### PR TITLE
Marketplace thank-you: end the endless waits

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/marketplace/get-thank-you-error.ts
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/get-thank-you-error.ts
@@ -1,0 +1,27 @@
+import { transferFailureStates, transferStates } from 'calypso/state/automated-transfer/constants';
+
+export type ThankYouError = 'transfer-failed' | 'timeout' | null;
+
+export function getThankYouError( {
+	transferStatus,
+	hasTimedOut,
+	isPageReady,
+}: {
+	transferStatus: string | null;
+	hasTimedOut: boolean;
+	isPageReady: boolean;
+} ): ThankYouError {
+	if ( isPageReady ) {
+		return null;
+	}
+
+	if ( transferFailureStates.includes( transferStatus ) ) {
+		return 'transfer-failed';
+	}
+
+	if ( transferStatus === transferStates.CLIENT_TIMEOUT || hasTimedOut ) {
+		return 'timeout';
+	}
+
+	return null;
+}

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -59,7 +59,7 @@ const MarketplaceThankYou = ( {
 	const {
 		isInitialized: isDeadlineInitialized,
 		hasTimedOut,
-		waitedSeconds,
+		getWaitedSeconds,
 		restart: restartDeadline,
 		complete: completeWait,
 	} = useThankYouDeadline( {
@@ -124,6 +124,7 @@ const MarketplaceThankYou = ( {
 		showProgressBar,
 		setShowProgressBar,
 		isRetryingTransferStatus,
+		trustedTransferStatus,
 		retry: retryAtomicTransfer,
 	} = useAtomicTransfer( isAtomicNeeded, hasTimedOut, isDeadlineInitialized );
 
@@ -137,7 +138,7 @@ const MarketplaceThankYou = ( {
 
 	const transferStatus = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
 	const thankYouError = getThankYouError( {
-		transferStatus: isRetryingTransferStatus ? null : transferStatus,
+		transferStatus: isRetryingTransferStatus ? null : trustedTransferStatus,
 		hasTimedOut,
 		isPageReady,
 	} );
@@ -181,11 +182,11 @@ const MarketplaceThankYou = ( {
 		reportedErrorRef.current = thankYouError;
 		recordTracksEvent( 'calypso_marketplace_thank_you_wait_ended', {
 			error: thankYouError,
-			transfer_status: transferStatus,
-			waited_seconds: waitedSeconds,
+			transfer_status: trustedTransferStatus,
+			waited_seconds: getWaitedSeconds(),
 			plugin_slugs: pluginSlugs.join( ',' ),
 		} );
-	}, [ pluginSlugs, thankYouError, transferStatus, waitedSeconds ] );
+	}, [ getWaitedSeconds, pluginSlugs, thankYouError, trustedTransferStatus ] );
 
 	const retry = useCallback( () => {
 		restartDeadline();

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -14,7 +14,6 @@ import { useSelector, useDispatch } from 'calypso/state';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
 import { transferCompleteStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
-import { isRequesting } from 'calypso/state/plugins/installed/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
@@ -46,9 +45,6 @@ const MarketplaceThankYou = ( {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
-	const isRequestingPlugins = useSelector( ( state ) =>
-		siteId ? isRequesting( state, siteId ) : false
-	);
 	const productKey = useMemo(
 		() =>
 			`plugins:${ [ ...pluginSlugs ].sort().join( ',' ) };themes:${ [ ...themeSlugs ]
@@ -161,7 +157,7 @@ const MarketplaceThankYou = ( {
 			dispatch( requestAdminMenu( siteId ) );
 			return;
 		}
-	}, [ isRequestingPlugins, isPageReady, dispatch, siteId, transferStatus, isJetpackSelfHosted ] );
+	}, [ isPageReady, dispatch, siteId, transferStatus, isJetpackSelfHosted ] );
 
 	useEffect( () => {
 		if ( isPageReady ) {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you.tsx
@@ -1,6 +1,8 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button } from '@automattic/components';
 import { ThemeProvider, Global, css } from '@emotion/react';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
@@ -10,17 +12,19 @@ import MarketplaceProgressBar from 'calypso/my-sites/marketplace/components/prog
 import theme from 'calypso/my-sites/marketplace/theme';
 import { useSelector, useDispatch } from 'calypso/state';
 import { requestAdminMenu } from 'calypso/state/admin-menu/actions';
-import { transferStates } from 'calypso/state/automated-transfer/constants';
+import { transferCompleteStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { isRequesting } from 'calypso/state/plugins/installed/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { getSiteAdminUrl, isJetpackSite } from 'calypso/state/sites/selectors';
 import { setThemePreviewOptions } from 'calypso/state/themes/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getThankYouError, type ThankYouError } from './get-thank-you-error';
 import { MarketplaceGoBackSection } from './marketplace-go-back-section';
 import { useAtomicTransfer } from './use-atomic-transfer';
 import { usePageTexts } from './use-page-texts';
 import usePluginsThankYouData from './use-plugins-thank-you-data';
+import { useThankYouDeadline } from './use-thank-you-deadline';
 import { useThankYouFoooter } from './use-thank-you-footer';
 import { useThankYouSteps } from './use-thank-you-steps';
 import { useThemesThankYouData } from './use-themes-thank-you-data';
@@ -45,29 +49,49 @@ const MarketplaceThankYou = ( {
 	const isRequestingPlugins = useSelector( ( state ) =>
 		siteId ? isRequesting( state, siteId ) : false
 	);
+	const productKey = useMemo(
+		() =>
+			`plugins:${ [ ...pluginSlugs ].sort().join( ',' ) };themes:${ [ ...themeSlugs ]
+				.sort()
+				.join( ',' ) }`,
+		[ pluginSlugs, themeSlugs ]
+	);
+	const {
+		isInitialized: isDeadlineInitialized,
+		hasTimedOut,
+		waitedSeconds,
+		restart: restartDeadline,
+		complete: completeWait,
+	} = useThankYouDeadline( {
+		siteId,
+		productKey,
+		enabled: pluginSlugs.length > 0 || themeSlugs.length > 0,
+	} );
 
-	const [
+	const {
 		pluginsSection,
 		allPluginsFetched,
 		allPluginsActivated,
 		pluginTitle,
 		pluginSubtitle,
 		pluginsProgressbarSteps,
-		isAtomicNeededForPlugins,
-		thankYouHeaderActionForPlugins,
-		isLoadedPlugins,
-	] = usePluginsThankYouData( pluginSlugs );
-	const [
+		isAtomicNeeded: isAtomicNeededForPlugins,
+		thankYouHeaderAction: thankYouHeaderActionForPlugins,
+		isLoaded: isLoadedPlugins,
+		retry: retryPlugins,
+	} = usePluginsThankYouData( pluginSlugs, hasTimedOut );
+	const {
 		firstTheme,
 		themesSection,
 		allThemesFetched,
 		themeTitle,
 		themeSubtitle,
 		themesProgressbarSteps,
-		isAtomicNeededForThemes,
-		thankYouHeaderActionForThemes,
-		isLoadedThemes,
-	] = useThemesThankYouData( themeSlugs, isOnboardingFlow, continueWithPluginBundle );
+		isAtomicNeeded: isAtomicNeededForThemes,
+		thankYouHeaderAction: thankYouHeaderActionForThemes,
+		isLoaded: isLoadedThemes,
+		retry: retryThemes,
+	} = useThemesThankYouData( themeSlugs, isOnboardingFlow, continueWithPluginBundle );
 
 	useEffect( () => {
 		if ( firstTheme && styleVariationSlug ) {
@@ -94,8 +118,14 @@ const MarketplaceThankYou = ( {
 	} );
 
 	const isAtomicNeeded = isAtomicNeededForPlugins || isAtomicNeededForThemes || ! allThemesFetched;
-	const [ isAtomicTransferCheckComplete, currentStep, showProgressBar, setShowProgressBar ] =
-		useAtomicTransfer( isAtomicNeeded );
+	const {
+		isAtomicTransferCheckComplete,
+		currentStep,
+		showProgressBar,
+		setShowProgressBar,
+		isRetryingTransferStatus,
+		retry: retryAtomicTransfer,
+	} = useAtomicTransfer( isAtomicNeeded, hasTimedOut, isDeadlineInitialized );
 
 	const isPageReady =
 		allPluginsFetched &&
@@ -106,7 +136,11 @@ const MarketplaceThankYou = ( {
 		( ! hasThemes || isLoadedThemes );
 
 	const transferStatus = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
-	const isTransferTimedOut = transferStatus === transferStates.CLIENT_TIMEOUT;
+	const thankYouError = getThankYouError( {
+		transferStatus: isRetryingTransferStatus ? null : transferStatus,
+		hasTimedOut,
+		isPageReady,
+	} );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 	const isJetpackSelfHosted = isJetpack && ! isAtomic;
@@ -114,7 +148,10 @@ const MarketplaceThankYou = ( {
 	// Site is already Atomic (or just transferred).
 	// Poll the plugin installation status.
 	useEffect( () => {
-		if ( ! siteId || ( ! isJetpackSelfHosted && transferStatus !== transferStates.COMPLETE ) ) {
+		if (
+			! siteId ||
+			( ! isJetpackSelfHosted && ! transferCompleteStates.includes( transferStatus ) )
+		) {
 			return;
 		}
 
@@ -125,13 +162,53 @@ const MarketplaceThankYou = ( {
 		}
 	}, [ isRequestingPlugins, isPageReady, dispatch, siteId, transferStatus, isJetpackSelfHosted ] );
 
+	useEffect( () => {
+		if ( isPageReady ) {
+			completeWait();
+		}
+	}, [ completeWait, isPageReady ] );
+
+	const reportedErrorRef = useRef< ThankYouError >( null );
+	useEffect( () => {
+		if ( ! thankYouError ) {
+			reportedErrorRef.current = null;
+			return;
+		}
+		if ( reportedErrorRef.current === thankYouError ) {
+			return;
+		}
+
+		reportedErrorRef.current = thankYouError;
+		recordTracksEvent( 'calypso_marketplace_thank_you_wait_ended', {
+			error: thankYouError,
+			transfer_status: transferStatus,
+			waited_seconds: waitedSeconds,
+			plugin_slugs: pluginSlugs.join( ',' ),
+		} );
+	}, [ pluginSlugs, thankYouError, transferStatus, waitedSeconds ] );
+
+	const retry = useCallback( () => {
+		restartDeadline();
+		retryAtomicTransfer();
+		retryPlugins();
+		retryThemes();
+		setShowProgressBar( true );
+	}, [ restartDeadline, retryAtomicTransfer, retryPlugins, retryThemes, setShowProgressBar ] );
+
 	const pluginsUrl = useSelector( ( state ) => {
 		return getSiteAdminUrl( state, siteId, 'plugins.php?activate=true&plugin_status=active' );
 	} );
 	// Set progressbar (currentStep) depending on transfer/plugin status.
+	const previousThankYouErrorRef = useRef< ThankYouError >( null );
 	useEffect( () => {
-		if ( isTransferTimedOut ) {
+		if ( thankYouError ) {
+			previousThankYouErrorRef.current = thankYouError;
 			setShowProgressBar( false );
+			return;
+		}
+		if ( previousThankYouErrorRef.current ) {
+			previousThankYouErrorRef.current = null;
+			setShowProgressBar( ! isPageReady );
 			return;
 		}
 
@@ -150,7 +227,7 @@ const MarketplaceThankYou = ( {
 	}, [
 		setShowProgressBar,
 		showProgressBar,
-		isTransferTimedOut,
+		thankYouError,
 		isPageReady,
 		pluginSlugs.length,
 		themeSlugs.length,
@@ -185,7 +262,7 @@ const MarketplaceThankYou = ( {
 				` }
 			/>
 			<MarketplaceGoBackSection pluginSlugs={ pluginSlugs } themeSlugs={ themeSlugs } />
-			{ showProgressBar && ! isTransferTimedOut && (
+			{ showProgressBar && ! thankYouError && (
 				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 				<div className="marketplace-plugin-install__root">
 					<MarketplaceProgressBar
@@ -195,16 +272,23 @@ const MarketplaceThankYou = ( {
 					/>
 				</div>
 			) }
-			{ isTransferTimedOut && (
+			{ thankYouError && (
 				<Main className="marketplace-thank-you__container">
 					<Notice
 						status="is-error"
 						showDismiss={ false }
-						text={ translate( 'Setting up your site is taking longer than expected.' ) }
+						text={
+							thankYouError === 'transfer-failed'
+								? translate( "Sorry, we couldn't process your transfer. Please try again later." )
+								: translate( 'Setting up your site is taking longer than expected.' )
+						}
 					/>
+					<Button className="marketplace-thank-you__retry-button" onClick={ retry }>
+						{ translate( 'Check again' ) }
+					</Button>
 				</Main>
 			) }
-			{ ! showProgressBar && ! isTransferTimedOut && (
+			{ ! showProgressBar && ! thankYouError && (
 				<Main className="marketplace-thank-you__container">
 					<ThankYouV2
 						title={ title }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/style.scss
@@ -1,7 +1,11 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "@wordpress/base-styles/mixins";
+@import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/mixins';
 
 .marketplace-thank-you__container {
 	max-width: 750px;
 	padding: 16px 24px 0;
+}
+
+.marketplace-thank-you__retry-button {
+	margin-block-start: 16px;
 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/get-thank-you-error.ts
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/get-thank-you-error.ts
@@ -1,0 +1,51 @@
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import { getThankYouError } from '../get-thank-you-error';
+
+const defaults = {
+	transferStatus: transferStates.ACTIVE,
+	hasTimedOut: false,
+	isPageReady: false,
+};
+
+describe( 'getThankYouError', () => {
+	test.each( [
+		transferStates.ERROR,
+		transferStates.FAILURE,
+		transferStates.CONFLICTS,
+		transferStates.REVERTED,
+	] )( 'reports transfer failure for %s', ( transferStatus ) => {
+		expect( getThankYouError( { ...defaults, transferStatus } ) ).toBe( 'transfer-failed' );
+	} );
+
+	test.each( [
+		[ 'client timeout', { transferStatus: transferStates.CLIENT_TIMEOUT } ],
+		[ 'page deadline', { hasTimedOut: true } ],
+	] )( 'reports timeout for %s', ( _label, overrides ) => {
+		expect( getThankYouError( { ...defaults, ...overrides } ) ).toBe( 'timeout' );
+	} );
+
+	it( 'prioritizes transfer failure over timeout', () => {
+		expect(
+			getThankYouError( {
+				...defaults,
+				transferStatus: transferStates.FAILURE,
+				hasTimedOut: true,
+			} )
+		).toBe( 'transfer-failed' );
+	} );
+
+	it( 'suppresses stale errors once the page is ready', () => {
+		expect(
+			getThankYouError( {
+				...defaults,
+				transferStatus: transferStates.FAILURE,
+				hasTimedOut: true,
+				isPageReady: true,
+			} )
+		).toBeNull();
+	} );
+
+	it( 'returns null while work remains in progress', () => {
+		expect( getThankYouError( defaults ) ).toBeNull();
+	} );
+} );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/marketplace-thank-you.tsx
@@ -1,0 +1,177 @@
+/**
+ * @jest-environment jsdom
+ */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import MarketplaceThankYou from '../marketplace-thank-you';
+
+const mockRestart = jest.fn();
+const mockComplete = jest.fn();
+const mockRetryAtomic = jest.fn();
+const mockRetryPlugins = jest.fn();
+const mockRetryThemes = jest.fn();
+const mockSetShowProgressBar = jest.fn();
+let mockState = {
+	siteId: 1,
+	transferStatus: transferStates.ACTIVE as string | null,
+};
+let mockWait = {
+	isInitialized: true,
+	hasTimedOut: false,
+	waitedSeconds: 0,
+	restart: mockRestart,
+	complete: mockComplete,
+};
+
+jest.mock( '@automattic/calypso-analytics', () => ( { recordTracksEvent: jest.fn() } ) );
+jest.mock( '@automattic/components', () => ( {
+	Button: ( { children, ...props }: React.ButtonHTMLAttributes< HTMLButtonElement > ) => (
+		<button { ...props }>{ children }</button>
+	),
+} ) );
+jest.mock( '@emotion/react', () => ( {
+	ThemeProvider: ( { children }: { children: React.ReactNode } ) => children,
+	Global: () => null,
+	css: () => null,
+} ) );
+jest.mock( 'i18n-calypso', () => ( { useTranslate: () => ( text: string ) => text } ) );
+jest.mock( 'calypso/components/data/document-head', () => () => null );
+jest.mock( 'calypso/components/main', () => ( { children }: { children: React.ReactNode } ) => (
+	<main>{ children }</main>
+) );
+jest.mock( 'calypso/components/notice', () => ( { text }: { text: React.ReactNode } ) => (
+	<div role="alert">{ text }</div>
+) );
+jest.mock( 'calypso/components/thank-you-v2', () => () => null );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => () => null );
+jest.mock( 'calypso/my-sites/marketplace/components/progressbar', () => () => null );
+jest.mock( 'calypso/my-sites/marketplace/theme', () => ( {} ) );
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => jest.fn(),
+	useSelector: ( selector: ( state: typeof mockState ) => unknown ) => selector( mockState ),
+} ) );
+jest.mock( 'calypso/state/admin-menu/actions', () => ( { requestAdminMenu: jest.fn() } ) );
+jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
+	getAutomatedTransferStatus: ( state: typeof mockState ) => state.transferStatus,
+} ) );
+jest.mock( 'calypso/state/plugins/installed/selectors', () => ( { isRequesting: () => false } ) );
+jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
+	__esModule: true,
+	default: () => false,
+} ) );
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	getSiteAdminUrl: () => null,
+	isJetpackSite: () => false,
+} ) );
+jest.mock( 'calypso/state/themes/actions', () => ( { setThemePreviewOptions: jest.fn() } ) );
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSiteId: ( state: typeof mockState ) => state.siteId,
+} ) );
+jest.mock( '../marketplace-go-back-section', () => ( { MarketplaceGoBackSection: () => null } ) );
+jest.mock( '../use-page-texts', () => ( { usePageTexts: () => [ '', '' ] } ) );
+jest.mock( '../use-thank-you-footer', () => ( { useThankYouFoooter: () => null } ) );
+jest.mock( '../use-thank-you-steps', () => ( {
+	useThankYouSteps: () => ( { steps: [], additionalSteps: [] } ),
+} ) );
+jest.mock( '../use-thank-you-deadline', () => ( {
+	useThankYouDeadline: () => mockWait,
+} ) );
+jest.mock( '../use-plugins-thank-you-data', () => ( {
+	__esModule: true,
+	default: () => ( {
+		pluginsSection: [],
+		allPluginsFetched: false,
+		allPluginsActivated: false,
+		pluginTitle: '',
+		pluginSubtitle: '',
+		pluginsProgressbarSteps: [],
+		isAtomicNeeded: true,
+		thankYouHeaderAction: null,
+		isLoaded: true,
+		retry: mockRetryPlugins,
+	} ),
+} ) );
+jest.mock( '../use-atomic-transfer', () => ( {
+	useAtomicTransfer: () => ( {
+		isAtomicTransferCheckComplete: false,
+		currentStep: 0,
+		showProgressBar: false,
+		setShowProgressBar: mockSetShowProgressBar,
+		isRetryingTransferStatus: false,
+		retry: mockRetryAtomic,
+	} ),
+} ) );
+jest.mock( '../use-themes-thank-you-data', () => ( {
+	useThemesThankYouData: () => ( {
+		firstTheme: null,
+		themesSection: [],
+		allThemesFetched: true,
+		themeTitle: '',
+		themeSubtitle: '',
+		themesProgressbarSteps: [],
+		isAtomicNeeded: false,
+		thankYouHeaderAction: null,
+		isLoaded: true,
+		retry: mockRetryThemes,
+	} ),
+} ) );
+
+const renderPage = () =>
+	render(
+		<MarketplaceThankYou
+			pluginSlugs={ [ 'sensei-pro' ] }
+			themeSlugs={ [] }
+			isOnboardingFlow={ false }
+			styleVariationSlug={ null }
+			continueWithPluginBundle={ null }
+		/>
+	);
+
+describe( 'MarketplaceThankYou errors', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockState = { siteId: 1, transferStatus: transferStates.ACTIVE };
+		mockWait = {
+			isInitialized: true,
+			hasTimedOut: false,
+			waitedSeconds: 0,
+			restart: mockRestart,
+			complete: mockComplete,
+		};
+	} );
+
+	it( 'renders and reports a transfer failure', () => {
+		mockState.transferStatus = transferStates.FAILURE;
+		renderPage();
+
+		expect(
+			screen.getByText( "Sorry, we couldn't process your transfer. Please try again later." )
+		).toBeVisible();
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_marketplace_thank_you_wait_ended',
+			expect.objectContaining( {
+				error: 'transfer-failed',
+				transfer_status: transferStates.FAILURE,
+				plugin_slugs: 'sensei-pro',
+			} )
+		);
+	} );
+
+	it( 'renders a timeout and lets the customer retry', async () => {
+		mockWait = { ...mockWait, hasTimedOut: true, waitedSeconds: 300 };
+		renderPage();
+
+		expect(
+			screen.getByText( 'Setting up your site is taking longer than expected.' )
+		).toBeVisible();
+		await userEvent.click( screen.getByRole( 'button', { name: 'Check again' } ) );
+
+		expect( mockRestart ).toHaveBeenCalledTimes( 1 );
+		expect( mockRetryAtomic ).toHaveBeenCalledTimes( 1 );
+		expect( mockRetryPlugins ).toHaveBeenCalledTimes( 1 );
+		expect( mockRetryThemes ).toHaveBeenCalledTimes( 1 );
+		expect( mockSetShowProgressBar ).toHaveBeenCalledWith( true );
+	} );
+} );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/marketplace-thank-you.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/marketplace-thank-you.tsx
@@ -20,7 +20,7 @@ let mockState = {
 let mockWait = {
 	isInitialized: true,
 	hasTimedOut: false,
-	waitedSeconds: 0,
+	getWaitedSeconds: () => 0,
 	restart: mockRestart,
 	complete: mockComplete,
 };
@@ -100,6 +100,7 @@ jest.mock( '../use-atomic-transfer', () => ( {
 		showProgressBar: false,
 		setShowProgressBar: mockSetShowProgressBar,
 		isRetryingTransferStatus: false,
+		trustedTransferStatus: mockState.transferStatus,
 		retry: mockRetryAtomic,
 	} ),
 } ) );
@@ -136,7 +137,7 @@ describe( 'MarketplaceThankYou errors', () => {
 		mockWait = {
 			isInitialized: true,
 			hasTimedOut: false,
-			waitedSeconds: 0,
+			getWaitedSeconds: () => 0,
 			restart: mockRestart,
 			complete: mockComplete,
 		};
@@ -160,7 +161,7 @@ describe( 'MarketplaceThankYou errors', () => {
 	} );
 
 	it( 'renders a timeout and lets the customer retry', async () => {
-		mockWait = { ...mockWait, hasTimedOut: true, waitedSeconds: 300 };
+		mockWait = { ...mockWait, hasTimedOut: true, getWaitedSeconds: () => 300 };
 		renderPage();
 
 		expect(

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-atomic-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-atomic-transfer.tsx
@@ -5,7 +5,7 @@ import { act, renderHook } from '@testing-library/react';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { requestSite } from 'calypso/state/sites/actions';
-import { useAtomicTransfer } from '../use-atomic-transfer';
+import { FAILURE_CONFIRM_ATTEMPTS, useAtomicTransfer } from '../use-atomic-transfer';
 import { THANK_YOU_RECOVERY_INTERVAL_MS } from '../use-thank-you-deadline';
 
 const mockDispatch = jest.fn();
@@ -24,11 +24,15 @@ jest.mock( 'calypso/state', () => ( {
 } ) );
 jest.mock( 'calypso/state/automated-transfer/actions', () => ( {
 	fetchAutomatedTransferStatus: jest.fn(
-		( siteId: number, { resetPolling = false, singleCheck = false } = {} ) => ( {
+		(
+			siteId: number,
+			{ resetPolling = false, singleCheck = false, retryOnFailure = false } = {}
+		) => ( {
 			type: 'FETCH_AUTOMATED_TRANSFER_STATUS',
 			siteId,
 			...( resetPolling ? { resetPolling: true } : {} ),
 			...( singleCheck ? { singleCheck: true } : {} ),
+			...( retryOnFailure ? { retryOnFailure: true } : {} ),
 		} )
 	),
 } ) );
@@ -73,7 +77,7 @@ describe( 'useAtomicTransfer', () => {
 	it( 'starts one transfer-status polling chain for the selected site', () => {
 		const { rerender } = renderAtomic();
 
-		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1 );
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, { retryOnFailure: true } );
 		mockState.transferStatus = transferStates.PROVISIONED;
 		rerender();
 
@@ -91,7 +95,7 @@ describe( 'useAtomicTransfer', () => {
 		mockState.transferStatus = transferStatus;
 		renderAtomic();
 
-		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1 );
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, { retryOnFailure: true } );
 	} );
 
 	it( 'polls site data for either completed spelling', () => {
@@ -155,7 +159,10 @@ describe( 'useAtomicTransfer', () => {
 
 		act( () => result.current.retry() );
 
-		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, { resetPolling: true } );
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, {
+			resetPolling: true,
+			retryOnFailure: true,
+		} );
 		expect( result.current.isRetryingTransferStatus ).toBe( true );
 
 		mockState.isFetchingTransferStatus = true;
@@ -164,6 +171,76 @@ describe( 'useAtomicTransfer', () => {
 		mockState.transferStatus = transferStates.ACTIVE;
 		rerender();
 		expect( result.current.isRetryingTransferStatus ).toBe( false );
+	} );
+
+	it( 'does not trust a settled failure before this wait confirms it', () => {
+		const { result, rerender } = renderAtomic();
+
+		mockState.isFetchingTransferStatus = true;
+		rerender();
+		mockState.isFetchingTransferStatus = false;
+		mockState.transferStatus = transferStates.ERROR;
+		rerender();
+
+		expect( result.current.trustedTransferStatus ).toBeNull();
+
+		jest.clearAllMocks();
+		act( () => jest.advanceTimersByTime( 3000 ) );
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, {
+			resetPolling: true,
+			retryOnFailure: true,
+		} );
+	} );
+
+	it( 'trusts a settled failure once every confirmation attempt still reports it', () => {
+		const { result, rerender } = renderAtomic();
+
+		for ( let attempt = 0; attempt <= FAILURE_CONFIRM_ATTEMPTS; attempt++ ) {
+			mockState.isFetchingTransferStatus = true;
+			rerender();
+			mockState.isFetchingTransferStatus = false;
+			mockState.transferStatus = transferStates.ERROR;
+			rerender();
+			act( () => jest.advanceTimersByTime( 3000 ) );
+		}
+
+		expect( result.current.trustedTransferStatus ).toBe( transferStates.ERROR );
+	} );
+
+	it( 'trusts a failure immediately once this wait has seen the transfer progress', () => {
+		const { result, rerender } = renderAtomic();
+
+		mockState.isFetchingTransferStatus = true;
+		rerender();
+		mockState.isFetchingTransferStatus = false;
+		mockState.transferStatus = transferStates.ACTIVE;
+		rerender();
+		expect( result.current.trustedTransferStatus ).toBe( transferStates.ACTIVE );
+
+		mockState.isFetchingTransferStatus = true;
+		rerender();
+		mockState.isFetchingTransferStatus = false;
+		mockState.transferStatus = transferStates.ERROR;
+		rerender();
+		expect( result.current.trustedTransferStatus ).toBe( transferStates.ERROR );
+	} );
+
+	it( 'queues a retry clicked while a status request is in flight', () => {
+		mockState.transferStatus = transferStates.CLIENT_TIMEOUT;
+		mockState.isFetchingTransferStatus = true;
+		const { result, rerender } = renderAtomic();
+		jest.clearAllMocks();
+
+		act( () => result.current.retry() );
+		expect( fetchAutomatedTransferStatus ).not.toHaveBeenCalled();
+		expect( result.current.isRetryingTransferStatus ).toBe( true );
+
+		mockState.isFetchingTransferStatus = false;
+		rerender();
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, {
+			resetPolling: true,
+			retryOnFailure: true,
+		} );
 	} );
 
 	it( 'completes immediately once the site reports Atomic', () => {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-atomic-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-atomic-transfer.tsx
@@ -61,6 +61,15 @@ jest.mock( 'calypso/state/ui/selectors', () => ( {
 const defaultState = { ...mockState };
 const renderAtomic = ( isRecoveryMode = false ) =>
 	renderHook( () => useAtomicTransfer( true, isRecoveryMode, true ) );
+const INITIAL_FETCH_OPTIONS = { resetPolling: true, retryOnFailure: true };
+// Simulate a status response cycle so the hook observes the status from this wait.
+const observeStatus = ( rerender: () => void, status: string ) => {
+	mockState.isFetchingTransferStatus = true;
+	rerender();
+	mockState.isFetchingTransferStatus = false;
+	mockState.transferStatus = status;
+	rerender();
+};
 
 describe( 'useAtomicTransfer', () => {
 	beforeEach( () => {
@@ -77,7 +86,7 @@ describe( 'useAtomicTransfer', () => {
 	it( 'starts one transfer-status polling chain for the selected site', () => {
 		const { rerender } = renderAtomic();
 
-		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, { retryOnFailure: true } );
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, INITIAL_FETCH_OPTIONS );
 		mockState.transferStatus = transferStates.PROVISIONED;
 		rerender();
 
@@ -95,12 +104,12 @@ describe( 'useAtomicTransfer', () => {
 		mockState.transferStatus = transferStatus;
 		renderAtomic();
 
-		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, { retryOnFailure: true } );
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, INITIAL_FETCH_OPTIONS );
 	} );
 
 	it( 'polls site data for either completed spelling', () => {
-		mockState.transferStatus = transferStates.COMPLETED;
-		const { result } = renderAtomic();
+		const { result, rerender } = renderAtomic();
+		observeStatus( rerender, transferStates.COMPLETED );
 
 		act( () => jest.advanceTimersByTime( 2000 ) );
 
@@ -108,8 +117,16 @@ describe( 'useAtomicTransfer', () => {
 		expect( result.current.currentStep ).toBe( 3 );
 	} );
 
-	it( 'does not overlap site-data requests', async () => {
+	it( 'does not start the atomic-flag poll from a stale persisted complete status', () => {
 		mockState.transferStatus = transferStates.COMPLETE;
+		renderAtomic();
+
+		act( () => jest.advanceTimersByTime( 10000 ) );
+
+		expect( requestSite ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not overlap site-data requests', async () => {
 		let resolveRequest: () => void = () => {};
 		const pendingRequest = new Promise< void >( ( resolve ) => {
 			resolveRequest = resolve;
@@ -117,7 +134,8 @@ describe( 'useAtomicTransfer', () => {
 		mockDispatch.mockImplementation( ( action ) =>
 			action.type === 'REQUEST_SITE' ? pendingRequest : undefined
 		);
-		renderAtomic();
+		const { rerender } = renderAtomic();
+		observeStatus( rerender, transferStates.COMPLETE );
 
 		act( () => jest.advanceTimersByTime( 10000 ) );
 		expect( requestSite ).toHaveBeenCalledTimes( 1 );
@@ -128,8 +146,8 @@ describe( 'useAtomicTransfer', () => {
 	} );
 
 	it( 'uses slow background checks after the page deadline', () => {
-		mockState.transferStatus = transferStates.COMPLETE;
-		renderAtomic( true );
+		const { rerender } = renderAtomic( true );
+		observeStatus( rerender, transferStates.COMPLETE );
 
 		act( () => jest.advanceTimersByTime( THANK_YOU_RECOVERY_INTERVAL_MS - 1 ) );
 		expect( requestSite ).not.toHaveBeenCalled();

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-atomic-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-atomic-transfer.tsx
@@ -61,7 +61,7 @@ jest.mock( 'calypso/state/ui/selectors', () => ( {
 const defaultState = { ...mockState };
 const renderAtomic = ( isRecoveryMode = false ) =>
 	renderHook( () => useAtomicTransfer( true, isRecoveryMode, true ) );
-const INITIAL_FETCH_OPTIONS = { resetPolling: true, retryOnFailure: true };
+const INITIAL_FETCH_OPTIONS = 'start';
 // Simulate a status response cycle so the hook observes the status from this wait.
 const observeStatus = ( rerender: () => void, status: string ) => {
 	mockState.isFetchingTransferStatus = true;
@@ -161,7 +161,7 @@ describe( 'useAtomicTransfer', () => {
 
 		expect( fetchAutomatedTransferStatus ).not.toHaveBeenCalled();
 		act( () => jest.advanceTimersByTime( THANK_YOU_RECOVERY_INTERVAL_MS ) );
-		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, { singleCheck: true } );
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, 'single' );
 	} );
 
 	it( 'waits for the durable deadline to initialize before starting status polling', () => {
@@ -177,10 +177,7 @@ describe( 'useAtomicTransfer', () => {
 
 		act( () => result.current.retry() );
 
-		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, {
-			resetPolling: true,
-			retryOnFailure: true,
-		} );
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, 'start' );
 		expect( result.current.isRetryingTransferStatus ).toBe( true );
 
 		mockState.isFetchingTransferStatus = true;
@@ -204,10 +201,7 @@ describe( 'useAtomicTransfer', () => {
 
 		jest.clearAllMocks();
 		act( () => jest.advanceTimersByTime( 3000 ) );
-		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, {
-			resetPolling: true,
-			retryOnFailure: true,
-		} );
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, 'start' );
 	} );
 
 	it( 'trusts a settled failure once every confirmation attempt still reports it', () => {
@@ -225,7 +219,7 @@ describe( 'useAtomicTransfer', () => {
 		expect( result.current.trustedTransferStatus ).toBe( transferStates.ERROR );
 	} );
 
-	it( 'trusts a failure immediately once this wait has seen the transfer progress', () => {
+	it( 'confirms a failure even after the transfer was seen progressing', () => {
 		const { result, rerender } = renderAtomic();
 
 		mockState.isFetchingTransferStatus = true;
@@ -240,6 +234,15 @@ describe( 'useAtomicTransfer', () => {
 		mockState.isFetchingTransferStatus = false;
 		mockState.transferStatus = transferStates.ERROR;
 		rerender();
+		expect( result.current.trustedTransferStatus ).toBe( transferStates.ACTIVE );
+
+		for ( let attempt = 0; attempt < FAILURE_CONFIRM_ATTEMPTS; attempt++ ) {
+			act( () => jest.advanceTimersByTime( 3000 ) );
+			mockState.isFetchingTransferStatus = true;
+			rerender();
+			mockState.isFetchingTransferStatus = false;
+			rerender();
+		}
 		expect( result.current.trustedTransferStatus ).toBe( transferStates.ERROR );
 	} );
 
@@ -255,10 +258,7 @@ describe( 'useAtomicTransfer', () => {
 
 		mockState.isFetchingTransferStatus = false;
 		rerender();
-		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, {
-			resetPolling: true,
-			retryOnFailure: true,
-		} );
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, 'start' );
 	} );
 
 	it( 'completes immediately once the site reports Atomic', () => {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-atomic-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-atomic-transfer.tsx
@@ -1,0 +1,180 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react';
+import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import { requestSite } from 'calypso/state/sites/actions';
+import { useAtomicTransfer } from '../use-atomic-transfer';
+import { THANK_YOU_RECOVERY_INTERVAL_MS } from '../use-thank-you-deadline';
+
+const mockDispatch = jest.fn();
+let mockState = {
+	siteId: 1 as number | null,
+	isSiteAtomic: false,
+	isJetpack: false,
+	isAtomic: false,
+	isFetchingTransferStatus: false,
+	transferStatus: transferStates.ACTIVE as string | null,
+};
+
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+	useSelector: ( selector: ( state: typeof mockState ) => unknown ) => selector( mockState ),
+} ) );
+jest.mock( 'calypso/state/automated-transfer/actions', () => ( {
+	fetchAutomatedTransferStatus: jest.fn(
+		( siteId: number, { resetPolling = false, singleCheck = false } = {} ) => ( {
+			type: 'FETCH_AUTOMATED_TRANSFER_STATUS',
+			siteId,
+			...( resetPolling ? { resetPolling: true } : {} ),
+			...( singleCheck ? { singleCheck: true } : {} ),
+		} )
+	),
+} ) );
+jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
+	getAutomatedTransferStatus: ( state: typeof mockState ) => state.transferStatus,
+	isFetchingAutomatedTransferStatus: ( state: typeof mockState ) => state.isFetchingTransferStatus,
+} ) );
+jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
+	__esModule: true,
+	default: ( state: typeof mockState ) => state.isAtomic,
+} ) );
+jest.mock( 'calypso/state/selectors/is-site-wpcom-atomic', () => ( {
+	__esModule: true,
+	default: ( state: typeof mockState ) => state.isSiteAtomic,
+} ) );
+jest.mock( 'calypso/state/sites/actions', () => ( {
+	requestSite: jest.fn( ( siteId: number ) => ( { type: 'REQUEST_SITE', siteId } ) ),
+} ) );
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	isJetpackSite: ( state: typeof mockState ) => state.isJetpack,
+} ) );
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSiteId: ( state: typeof mockState ) => state.siteId,
+} ) );
+
+const defaultState = { ...mockState };
+const renderAtomic = ( isRecoveryMode = false ) =>
+	renderHook( () => useAtomicTransfer( true, isRecoveryMode, true ) );
+
+describe( 'useAtomicTransfer', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		jest.clearAllMocks();
+		mockDispatch.mockReset();
+		mockState = { ...defaultState };
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'starts one transfer-status polling chain for the selected site', () => {
+		const { rerender } = renderAtomic();
+
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1 );
+		mockState.transferStatus = transferStates.PROVISIONED;
+		rerender();
+
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test.each( [
+		transferStates.COMPLETE,
+		transferStates.COMPLETED,
+		transferStates.FAILURE,
+		transferStates.ERROR,
+		transferStates.CONFLICTS,
+		transferStates.REVERTED,
+	] )( 'refreshes a possibly stale persisted status at mount: %s', ( transferStatus ) => {
+		mockState.transferStatus = transferStatus;
+		renderAtomic();
+
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1 );
+	} );
+
+	it( 'polls site data for either completed spelling', () => {
+		mockState.transferStatus = transferStates.COMPLETED;
+		const { result } = renderAtomic();
+
+		act( () => jest.advanceTimersByTime( 2000 ) );
+
+		expect( requestSite ).toHaveBeenCalledWith( 1 );
+		expect( result.current.currentStep ).toBe( 3 );
+	} );
+
+	it( 'does not overlap site-data requests', async () => {
+		mockState.transferStatus = transferStates.COMPLETE;
+		let resolveRequest: () => void = () => {};
+		const pendingRequest = new Promise< void >( ( resolve ) => {
+			resolveRequest = resolve;
+		} );
+		mockDispatch.mockImplementation( ( action ) =>
+			action.type === 'REQUEST_SITE' ? pendingRequest : undefined
+		);
+		renderAtomic();
+
+		act( () => jest.advanceTimersByTime( 10000 ) );
+		expect( requestSite ).toHaveBeenCalledTimes( 1 );
+
+		await act( async () => resolveRequest() );
+		act( () => jest.advanceTimersByTime( 2000 ) );
+		expect( requestSite ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'uses slow background checks after the page deadline', () => {
+		mockState.transferStatus = transferStates.COMPLETE;
+		renderAtomic( true );
+
+		act( () => jest.advanceTimersByTime( THANK_YOU_RECOVERY_INTERVAL_MS - 1 ) );
+		expect( requestSite ).not.toHaveBeenCalled();
+		act( () => jest.advanceTimersByTime( 1 ) );
+		expect( requestSite ).toHaveBeenCalledWith( 1 );
+	} );
+
+	it( 'uses one-shot status checks while recovering from a transfer timeout', () => {
+		mockState.transferStatus = transferStates.CLIENT_TIMEOUT;
+		renderAtomic( true );
+
+		expect( fetchAutomatedTransferStatus ).not.toHaveBeenCalled();
+		act( () => jest.advanceTimersByTime( THANK_YOU_RECOVERY_INTERVAL_MS ) );
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, { singleCheck: true } );
+	} );
+
+	it( 'waits for the durable deadline to initialize before starting status polling', () => {
+		renderHook( () => useAtomicTransfer( true, false, false ) );
+
+		expect( fetchAutomatedTransferStatus ).not.toHaveBeenCalled();
+	} );
+
+	it( 'restarts a failed status poll on explicit retry', () => {
+		mockState.transferStatus = transferStates.REQUEST_FAILURE;
+		const { result, rerender } = renderAtomic();
+		jest.clearAllMocks();
+
+		act( () => result.current.retry() );
+
+		expect( fetchAutomatedTransferStatus ).toHaveBeenCalledWith( 1, { resetPolling: true } );
+		expect( result.current.isRetryingTransferStatus ).toBe( true );
+
+		mockState.isFetchingTransferStatus = true;
+		rerender();
+		mockState.isFetchingTransferStatus = false;
+		mockState.transferStatus = transferStates.ACTIVE;
+		rerender();
+		expect( result.current.isRetryingTransferStatus ).toBe( false );
+	} );
+
+	it( 'completes immediately once the site reports Atomic', () => {
+		mockState.transferStatus = transferStates.COMPLETED;
+		mockState.isSiteAtomic = true;
+
+		const { result } = renderAtomic();
+
+		expect( result.current.isAtomicTransferCheckComplete ).toBe( true );
+		act( () => jest.advanceTimersByTime( THANK_YOU_RECOVERY_INTERVAL_MS ) );
+		expect( requestSite ).not.toHaveBeenCalled();
+		expect( fetchAutomatedTransferStatus ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-plugins-thank-you-data.tsx
@@ -1,0 +1,168 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
+import usePluginsThankYouData from '../use-plugins-thank-you-data';
+import { THANK_YOU_RECOVERY_INTERVAL_MS } from '../use-thank-you-deadline';
+
+const PLUGIN_SLUG = 'sensei-pro';
+const mockDispatch = jest.fn();
+let mockState = {
+	siteId: 1 as number | null,
+	siteSlug: 'example.wordpress.com',
+	pluginsOnSite: [ { slug: PLUGIN_SLUG, fetched: true, wporg: true, icon: '' } ] as Array< {
+		slug: string;
+		fetched: boolean;
+		wporg: boolean;
+		icon: string;
+	} >,
+	wporgPlugins: [ { slug: PLUGIN_SLUG } ],
+	wporgFetched: [ true ],
+	wporgFetching: [ false ],
+	activePluginSlugs: new Set< string >(),
+	transferStatus: transferStates.COMPLETE as string | null,
+	isJetpack: false,
+	isAtomic: true,
+};
+
+jest.mock( '@automattic/calypso-analytics', () => ( { recordTracksEvent: jest.fn() } ) );
+jest.mock( '@automattic/components', () => ( { Button: () => null } ) );
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( text: string ) => text,
+} ) );
+jest.mock( 'calypso/data/marketplace/use-wpcom-plugins-query', () => ( {
+	useWPCOMPlugins: ( slugs: string[] ) =>
+		slugs.map( ( slug ) => ( { data: { software_slug: slug } } ) ),
+} ) );
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+	useSelector: ( selector: ( state: typeof mockState ) => unknown ) => selector( mockState ),
+} ) );
+jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
+	getAutomatedTransferStatus: ( state: typeof mockState ) => state.transferStatus,
+} ) );
+jest.mock( 'calypso/state/marketplace/purchase-flow/actions', () => ( {
+	pluginInstallationStateChange: jest.fn( () => ( { type: 'PLUGIN_INSTALLATION_STATE_CHANGE' } ) ),
+} ) );
+jest.mock( 'calypso/state/plugins/installed/actions', () => ( {
+	fetchSitePlugins: jest.fn( ( siteId: number ) => ( { type: 'FETCH_SITE_PLUGINS', siteId } ) ),
+} ) );
+jest.mock( 'calypso/state/plugins/installed/selectors', () => ( {
+	getPluginsOnSite: ( state: typeof mockState ) => state.pluginsOnSite,
+} ) );
+jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
+	isPluginActive: ( state: typeof mockState, _siteId: number, slug: string ) =>
+		state.activePluginSlugs.has( slug ),
+} ) );
+jest.mock( 'calypso/state/plugins/wporg/actions', () => ( {
+	fetchPluginData: jest.fn( ( slug: string ) => ( { type: 'FETCH_PLUGIN_DATA', slug } ) ),
+} ) );
+jest.mock( 'calypso/state/plugins/wporg/selectors', () => ( {
+	areFetched: ( state: typeof mockState ) => state.wporgFetched,
+	areFetching: ( state: typeof mockState ) => state.wporgFetching,
+	getPlugins: ( state: typeof mockState ) => state.wporgPlugins,
+} ) );
+jest.mock( 'calypso/state/selectors/is-site-automated-transfer', () => ( {
+	__esModule: true,
+	default: ( state: typeof mockState ) => state.isAtomic,
+} ) );
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	isJetpackSite: ( state: typeof mockState ) => state.isJetpack,
+} ) );
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSiteId: ( state: typeof mockState ) => state.siteId,
+	getSelectedSiteSlug: ( state: typeof mockState ) => state.siteSlug,
+} ) );
+jest.mock( '../marketplace-thank-you-plugin-section', () => ( {
+	ThankYouPluginSection: () => null,
+} ) );
+
+const defaultState = { ...mockState };
+const renderPlugins = ( pluginSlugs: string[] = [ PLUGIN_SLUG ], isRecoveryMode = false ) =>
+	renderHook( ( { slugs, recovery } ) => usePluginsThankYouData( slugs, recovery ), {
+		initialProps: { slugs: pluginSlugs, recovery: isRecoveryMode },
+	} );
+
+describe( 'usePluginsThankYouData', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		jest.setSystemTime( new Date( '2026-08-13T12:00:00Z' ) );
+		jest.clearAllMocks();
+		mockState = {
+			...defaultState,
+			pluginsOnSite: [ ...defaultState.pluginsOnSite ],
+			wporgPlugins: [ ...defaultState.wporgPlugins ],
+			wporgFetched: [ ...defaultState.wporgFetched ],
+			wporgFetching: [ ...defaultState.wporgFetching ],
+			activePluginSlugs: new Set(),
+		};
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'polls installed plugins every three seconds after transfer completion', () => {
+		renderPlugins();
+		expect( fetchSitePlugins ).toHaveBeenCalledTimes( 1 );
+
+		act( () => jest.advanceTimersByTime( 3000 ) );
+
+		expect( fetchSitePlugins ).toHaveBeenCalledTimes( 2 );
+		expect( fetchSitePlugins ).toHaveBeenLastCalledWith( 1 );
+	} );
+
+	it( 'does not poll before transfer completion', () => {
+		mockState.transferStatus = transferStates.ACTIVE;
+		renderPlugins();
+
+		act( () => jest.advanceTimersByTime( 10000 ) );
+
+		expect( fetchSitePlugins ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not poll when all plugins are active', () => {
+		mockState.activePluginSlugs.add( PLUGIN_SLUG );
+		renderPlugins();
+
+		act( () => jest.advanceTimersByTime( 10000 ) );
+
+		expect( fetchSitePlugins ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not poll when no plugins were purchased', () => {
+		renderPlugins( [] );
+
+		act( () => jest.advanceTimersByTime( 10000 ) );
+
+		expect( fetchSitePlugins ).not.toHaveBeenCalled();
+	} );
+
+	it( 'accepts the completed status spelling', () => {
+		mockState.transferStatus = transferStates.COMPLETED;
+		renderPlugins();
+
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( 1 );
+	} );
+
+	it( 'uses slow background checks after the page deadline', () => {
+		renderPlugins( [ PLUGIN_SLUG ], true );
+		jest.mocked( fetchSitePlugins ).mockClear();
+
+		act( () => jest.advanceTimersByTime( THANK_YOU_RECOVERY_INTERVAL_MS - 1 ) );
+		expect( fetchSitePlugins ).not.toHaveBeenCalled();
+		act( () => jest.advanceTimersByTime( 1 ) );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( 1 );
+	} );
+
+	it( 'offers an immediate plugin refresh for explicit retry', () => {
+		const { result } = renderPlugins();
+		jest.mocked( fetchSitePlugins ).mockClear();
+
+		act( () => result.current.retry() );
+
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( 1 );
+	} );
+} );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-plugins-thank-you-data.tsx
@@ -25,6 +25,7 @@ let mockState = {
 	transferStatus: transferStates.COMPLETE as string | null,
 	isJetpack: false,
 	isAtomic: true,
+	isRequestingPlugins: false,
 };
 
 jest.mock( '@automattic/calypso-analytics', () => ( { recordTracksEvent: jest.fn() } ) );
@@ -51,6 +52,7 @@ jest.mock( 'calypso/state/plugins/installed/actions', () => ( {
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors', () => ( {
 	getPluginsOnSite: ( state: typeof mockState ) => state.pluginsOnSite,
+	isRequesting: ( state: typeof mockState ) => state.isRequestingPlugins,
 } ) );
 jest.mock( 'calypso/state/plugins/installed/selectors-ts', () => ( {
 	isPluginActive: ( state: typeof mockState, _siteId: number, slug: string ) =>
@@ -112,6 +114,21 @@ describe( 'usePluginsThankYouData', () => {
 
 		expect( fetchSitePlugins ).toHaveBeenCalledTimes( 2 );
 		expect( fetchSitePlugins ).toHaveBeenLastCalledWith( 1 );
+	} );
+
+	it( 'skips a poll tick while a plugin request is in flight', () => {
+		const { rerender } = renderPlugins();
+		jest.clearAllMocks();
+
+		mockState.isRequestingPlugins = true;
+		rerender( { slugs: [ PLUGIN_SLUG ], recovery: false } );
+		act( () => jest.advanceTimersByTime( 3000 ) );
+		expect( fetchSitePlugins ).not.toHaveBeenCalled();
+
+		mockState.isRequestingPlugins = false;
+		rerender( { slugs: [ PLUGIN_SLUG ], recovery: false } );
+		act( () => jest.advanceTimersByTime( 3000 ) );
+		expect( fetchSitePlugins ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'does not poll before transfer completion', () => {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-thank-you-deadline.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-thank-you-deadline.tsx
@@ -1,0 +1,66 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react';
+import { THANK_YOU_WAIT_DEADLINE_MS, useThankYouDeadline } from '../use-thank-you-deadline';
+
+const renderDeadline = () =>
+	renderHook( () =>
+		useThankYouDeadline( {
+			siteId: 1,
+			productKey: 'sensei-pro',
+			enabled: true,
+		} )
+	);
+
+describe( 'useThankYouDeadline', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		jest.setSystemTime( 1000000 );
+		window.sessionStorage.clear();
+	} );
+
+	afterEach( () => jest.useRealTimers() );
+
+	it( 'bounds the whole page wait to five minutes', () => {
+		const { result } = renderDeadline();
+
+		act( () => jest.advanceTimersByTime( THANK_YOU_WAIT_DEADLINE_MS - 1000 ) );
+		expect( result.current.hasTimedOut ).toBe( false );
+
+		act( () => jest.advanceTimersByTime( 1000 ) );
+		expect( result.current.hasTimedOut ).toBe( true );
+	} );
+
+	it( 'keeps the original deadline across a remount', () => {
+		const first = renderDeadline();
+		act( () => jest.advanceTimersByTime( THANK_YOU_WAIT_DEADLINE_MS - 1000 ) );
+		first.unmount();
+
+		act( () => jest.advanceTimersByTime( 1000 ) );
+		const second = renderDeadline();
+
+		expect( second.result.current.hasTimedOut ).toBe( true );
+	} );
+
+	it( 'starts a fresh budget on explicit retry', () => {
+		const { result } = renderDeadline();
+		act( () => jest.advanceTimersByTime( THANK_YOU_WAIT_DEADLINE_MS ) );
+		expect( result.current.hasTimedOut ).toBe( true );
+
+		act( () => result.current.restart() );
+
+		expect( result.current.hasTimedOut ).toBe( false );
+	} );
+
+	it( 'clears the durable deadline after success', () => {
+		const first = renderDeadline();
+		act( () => jest.advanceTimersByTime( THANK_YOU_WAIT_DEADLINE_MS ) );
+		act( () => first.result.current.complete() );
+		first.unmount();
+
+		const second = renderDeadline();
+
+		expect( second.result.current.hasTimedOut ).toBe( false );
+	} );
+} );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-themes-thank-you-data.tsx
@@ -107,8 +107,10 @@ describe( 'useThemesThankYouData retry', () => {
 		expect( requestTheme ).not.toHaveBeenCalled();
 	} );
 
-	test( 'refetches site purchases when they never loaded', () => {
-		mockState.hasLoadedSitePurchases = false;
+	test( 'refetches site purchases even when a failed fetch marked them loaded', () => {
+		// The purchases reducer sets hasLoadedSitePurchasesFromServer on failure too, so the
+		// flag cannot gate the retry — only an in-flight request should.
+		mockState.hasLoadedSitePurchases = true;
 		const { result } = renderThemes();
 
 		act( () => result.current.retry() );
@@ -116,17 +118,27 @@ describe( 'useThemesThankYouData retry', () => {
 		expect( fetchSitePurchases ).toHaveBeenCalledWith( 1 );
 	} );
 
-	test( 'leaves loaded purchases and in-flight requests alone', () => {
+	test( 'skips the purchases refetch while one is in flight', () => {
+		mockState.isRequestingSitePurchases = true;
 		const { result } = renderThemes();
 
 		act( () => result.current.retry() );
 		expect( fetchSitePurchases ).not.toHaveBeenCalled();
+	} );
 
+	test( 'reports loaded once purchases arrive for a plain theme purchase', () => {
+		mockState.dotComThemes = [ { id: THEME_SLUG } ];
+		mockState.hasLoadedSitePurchases = true;
+		mockState.isRequestingSitePurchases = false;
+		const { result } = renderThemes();
+
+		expect( result.current.isLoaded ).toBe( true );
+	} );
+
+	test( 'stays loading while purchases have not loaded yet', () => {
 		mockState.hasLoadedSitePurchases = false;
-		mockState.isRequestingSitePurchases = true;
-		const { result: fetching } = renderThemes();
+		const { result } = renderThemes();
 
-		act( () => fetching.current.retry() );
-		expect( fetchSitePurchases ).not.toHaveBeenCalled();
+		expect( result.current.isLoaded ).toBe( false );
 	} );
 } );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/test/use-themes-thank-you-data.tsx
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react';
+import { fetchSitePurchases } from 'calypso/state/purchases/actions';
+import { requestTheme } from 'calypso/state/themes/actions';
+import { useThemesThankYouData } from '../use-themes-thank-you-data';
+
+const THEME_SLUG = 'twentytwentyfour';
+const mockDispatch = jest.fn();
+let mockState = {
+	siteId: 1,
+	siteSlug: 'example.wordpress.com',
+	themeSlug: 'pub/other-theme',
+	dotComThemes: [ null ] as Array< { id: string } | null >,
+	dotOrgThemes: [ null ] as Array< { id: string } | null >,
+	isRequestingSitePurchases: false,
+	hasLoadedSitePurchases: true,
+	isJetpack: false,
+	subscribedThemes: [] as string[],
+	hasExternallyManagedThemes: false,
+};
+
+jest.mock( '@automattic/calypso-router', () => jest.fn() );
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( text: string ) => text,
+} ) );
+jest.mock( 'calypso/components/data/query-site-purchases', () => ( {
+	useQuerySitePurchases: jest.fn(),
+} ) );
+jest.mock( 'calypso/components/data/query-theme', () => ( {
+	useQueryThemes: jest.fn(),
+} ) );
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+	useSelector: ( selector: ( state: typeof mockState ) => unknown ) => selector( mockState ),
+} ) );
+jest.mock( 'calypso/state/purchases/actions', () => ( {
+	fetchSitePurchases: jest.fn( ( siteId: number ) => ( {
+		type: 'FETCH_SITE_PURCHASES',
+		siteId,
+	} ) ),
+} ) );
+jest.mock( 'calypso/state/purchases/selectors', () => ( {
+	hasLoadedSitePurchasesFromServer: ( state: typeof mockState ) => state.hasLoadedSitePurchases,
+	isFetchingSitePurchases: ( state: typeof mockState ) => state.isRequestingSitePurchases,
+} ) );
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	isJetpackSite: ( state: typeof mockState ) => state.isJetpack,
+	getSiteOption: ( state: typeof mockState ) => state.themeSlug,
+} ) );
+jest.mock( 'calypso/state/themes/actions', () => ( {
+	clearActivated: jest.fn( ( siteId: number ) => ( { type: 'THEMES_CLEAR_ACTIVATED', siteId } ) ),
+	requestTheme: jest.fn( ( themeId: string, siteId: string ) => ( {
+		type: 'THEME_REQUEST',
+		themeId,
+		siteId,
+	} ) ),
+} ) );
+jest.mock( 'calypso/state/themes/selectors', () => ( {
+	getThemes: ( state: typeof mockState, source: string ) =>
+		source === 'wpcom' ? state.dotComThemes : state.dotOrgThemes,
+	isMarketplaceThemeSubscribed: ( state: typeof mockState, themeId: string ) =>
+		state.subscribedThemes.includes( themeId ),
+} ) );
+jest.mock( 'calypso/state/themes/selectors/is-externally-managed-theme', () => ( {
+	hasExternallyManagedThemes: ( state: typeof mockState ) => state.hasExternallyManagedThemes,
+} ) );
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSiteId: ( state: typeof mockState ) => state.siteId,
+	getSelectedSiteSlug: ( state: typeof mockState ) => state.siteSlug,
+} ) );
+jest.mock( '../marketplace-thank-you-theme-section', () => ( {
+	ThankYouThemeSection: () => null,
+} ) );
+
+const defaultState = { ...mockState };
+const renderThemes = ( themeSlugs: string[] = [ THEME_SLUG ] ) =>
+	renderHook( () => useThemesThankYouData( themeSlugs, false, null ) );
+
+describe( 'useThemesThankYouData retry', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockState = { ...defaultState };
+	} );
+
+	test( 'refetches a missing theme from both sources', () => {
+		const { result } = renderThemes();
+
+		act( () => result.current.retry() );
+
+		expect( requestTheme ).toHaveBeenCalledWith( THEME_SLUG, 'wpcom' );
+		expect( requestTheme ).toHaveBeenCalledWith( THEME_SLUG, 'wporg' );
+		expect( mockDispatch ).toHaveBeenCalledWith( {
+			type: 'THEME_REQUEST',
+			themeId: THEME_SLUG,
+			siteId: 'wpcom',
+		} );
+	} );
+
+	test( 'does not refetch a theme that already loaded from either source', () => {
+		mockState.dotComThemes = [ { id: THEME_SLUG } ];
+		const { result } = renderThemes();
+
+		act( () => result.current.retry() );
+
+		expect( requestTheme ).not.toHaveBeenCalled();
+	} );
+
+	test( 'refetches site purchases when they never loaded', () => {
+		mockState.hasLoadedSitePurchases = false;
+		const { result } = renderThemes();
+
+		act( () => result.current.retry() );
+
+		expect( fetchSitePurchases ).toHaveBeenCalledWith( 1 );
+	} );
+
+	test( 'leaves loaded purchases and in-flight requests alone', () => {
+		const { result } = renderThemes();
+
+		act( () => result.current.retry() );
+		expect( fetchSitePurchases ).not.toHaveBeenCalled();
+
+		mockState.hasLoadedSitePurchases = false;
+		mockState.isRequestingSitePurchases = true;
+		const { result: fetching } = renderThemes();
+
+		act( () => fetching.current.retry() );
+		expect( fetchSitePurchases ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
@@ -2,7 +2,11 @@ import { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } fr
 import { useInterval } from 'calypso/lib/interval';
 import { useSelector, useDispatch } from 'calypso/state';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
-import { transferCompleteStates, transferStates } from 'calypso/state/automated-transfer/constants';
+import {
+	transferCompleteStates,
+	transferFailureStates,
+	transferStates,
+} from 'calypso/state/automated-transfer/constants';
 import {
 	getAutomatedTransferStatus,
 	isFetchingAutomatedTransferStatus,
@@ -16,12 +20,20 @@ import { THANK_YOU_RECOVERY_INTERVAL_MS } from './use-thank-you-deadline';
 
 const ATOMIC_FLAG_POLL_INTERVAL_MS = 2000;
 
+// The status endpoint returns the site's *latest* transfer, so right after a purchase a
+// settled failure can belong to a previous transfer whose record has not been superseded
+// yet. Until this wait has seen the transfer progress, a failure is only trusted after a
+// few confirmations spaced far enough apart for the new record to appear.
+export const FAILURE_CONFIRM_ATTEMPTS = 3;
+const FAILURE_CONFIRM_INTERVAL_MS = 3000;
+
 type AtomicTransferData = {
 	isAtomicTransferCheckComplete: boolean;
 	currentStep: number;
 	showProgressBar: boolean;
 	setShowProgressBar: Dispatch< SetStateAction< boolean > >;
 	isRetryingTransferStatus: boolean;
+	trustedTransferStatus: string | null;
 	retry: () => void;
 };
 
@@ -49,13 +61,30 @@ export function useAtomicTransfer(
 	);
 	const [ currentStep, setCurrentStep ] = useState( 0 );
 	const [ isRetryingTransferStatus, setIsRetryingTransferStatus ] = useState( false );
+	// Redux already holds a transfer status when this page mounts — possibly a stale one from
+	// earlier in the SPA session. Only statuses observed from a response of this wait are safe
+	// to act on.
+	const [ trustedTransferStatus, setTrustedTransferStatus ] = useState< string | null >( null );
 	const statusRequestSiteIdRef = useRef< number | null >( null );
 	const atomicFlagRequestSiteIdRef = useRef< number | null >( null );
-	const retryObservedFetchingRef = useRef( false );
+	const wasFetchingStatusRef = useRef( false );
+	const sawProgressRef = useRef( false );
+	const failureConfirmAttemptsRef = useRef( 0 );
+	const pendingRetryRef = useRef( false );
+	const confirmTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
 
 	useEffect( () => {
 		setIsAtomicTransferCheckComplete( ! isAtomicNeeded );
 	}, [ isAtomicNeeded ] );
+
+	useEffect(
+		() => () => {
+			if ( confirmTimeoutRef.current ) {
+				clearTimeout( confirmTimeoutRef.current );
+			}
+		},
+		[]
+	);
 
 	useEffect( () => {
 		if ( siteId && isSiteAtomic ) {
@@ -76,7 +105,7 @@ export function useAtomicTransfer(
 		}
 
 		statusRequestSiteIdRef.current = siteId;
-		dispatch( fetchAutomatedTransferStatus( siteId ) );
+		dispatch( fetchAutomatedTransferStatus( siteId, { retryOnFailure: true } ) );
 	}, [
 		dispatch,
 		isAtomicNeeded,
@@ -87,6 +116,60 @@ export function useAtomicTransfer(
 		isSiteAtomic,
 		siteId,
 	] );
+
+	const performStatusRetry = useCallback(
+		( targetSiteId: number ) => {
+			statusRequestSiteIdRef.current = targetSiteId;
+			dispatch(
+				fetchAutomatedTransferStatus( targetSiteId, { resetPolling: true, retryOnFailure: true } )
+			);
+		},
+		[ dispatch ]
+	);
+
+	useEffect( () => {
+		if ( isFetchingTransferStatus ) {
+			wasFetchingStatusRef.current = true;
+			return;
+		}
+		if ( ! wasFetchingStatusRef.current ) {
+			return;
+		}
+		wasFetchingStatusRef.current = false;
+
+		// A "Check again" click that arrived while a request was in flight: that response is
+		// stale, so discard it and run the queued reset now.
+		if ( pendingRetryRef.current ) {
+			pendingRetryRef.current = false;
+			if ( siteId ) {
+				performStatusRetry( siteId );
+			}
+			return;
+		}
+
+		const isFailure = transferFailureStates.includes( transferStatus );
+		if (
+			isFailure &&
+			! sawProgressRef.current &&
+			failureConfirmAttemptsRef.current < FAILURE_CONFIRM_ATTEMPTS
+		) {
+			failureConfirmAttemptsRef.current += 1;
+			confirmTimeoutRef.current = setTimeout( () => {
+				if ( siteId ) {
+					dispatch(
+						fetchAutomatedTransferStatus( siteId, { resetPolling: true, retryOnFailure: true } )
+					);
+				}
+			}, FAILURE_CONFIRM_INTERVAL_MS );
+			return;
+		}
+
+		if ( ! isFailure ) {
+			sawProgressRef.current = true;
+		}
+		setTrustedTransferStatus( transferStatus );
+		setIsRetryingTransferStatus( false );
+	}, [ dispatch, isFetchingTransferStatus, performStatusRetry, siteId, transferStatus ] );
 
 	const requestAtomicSite = useCallback( () => {
 		if ( ! siteId || atomicFlagRequestSiteIdRef.current === siteId ) {
@@ -133,18 +216,6 @@ export function useAtomicTransfer(
 			: null
 	);
 
-	useEffect( () => {
-		if ( ! isRetryingTransferStatus ) {
-			return;
-		}
-		if ( isFetchingTransferStatus ) {
-			retryObservedFetchingRef.current = true;
-		} else if ( retryObservedFetchingRef.current ) {
-			retryObservedFetchingRef.current = false;
-			setIsRetryingTransferStatus( false );
-		}
-	}, [ isFetchingTransferStatus, isRetryingTransferStatus ] );
-
 	const retry = useCallback( () => {
 		if ( ! siteId ) {
 			return;
@@ -152,12 +223,27 @@ export function useAtomicTransfer(
 
 		if ( isTransferComplete ) {
 			requestAtomicSite();
-		} else if ( ! isFetchingTransferStatus ) {
-			statusRequestSiteIdRef.current = siteId;
-			setIsRetryingTransferStatus( true );
-			dispatch( fetchAutomatedTransferStatus( siteId, { resetPolling: true } ) );
+			return;
 		}
-	}, [ dispatch, isFetchingTransferStatus, isTransferComplete, requestAtomicSite, siteId ] );
+
+		if ( confirmTimeoutRef.current ) {
+			clearTimeout( confirmTimeoutRef.current );
+		}
+		failureConfirmAttemptsRef.current = 0;
+		sawProgressRef.current = false;
+		setIsRetryingTransferStatus( true );
+		if ( isFetchingTransferStatus ) {
+			pendingRetryRef.current = true;
+			return;
+		}
+		performStatusRetry( siteId );
+	}, [
+		isFetchingTransferStatus,
+		isTransferComplete,
+		performStatusRetry,
+		requestAtomicSite,
+		siteId,
+	] );
 
 	useEffect( () => {
 		if ( ! showProgressBar || isJetpack ) {
@@ -181,6 +267,7 @@ export function useAtomicTransfer(
 		showProgressBar,
 		setShowProgressBar,
 		isRetryingTransferStatus,
+		trustedTransferStatus,
 		retry,
 	};
 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
@@ -22,8 +22,8 @@ const ATOMIC_FLAG_POLL_INTERVAL_MS = 2000;
 
 // The status endpoint returns the site's *latest* transfer, so right after a purchase a
 // settled failure can belong to a previous transfer whose record has not been superseded
-// yet. Until this wait has seen the transfer progress, a failure is only trusted after a
-// few confirmations spaced far enough apart for the new record to appear.
+// yet. A failure is only trusted after a few confirmations spaced far enough apart for
+// the new record to appear.
 export const FAILURE_CONFIRM_ATTEMPTS = 3;
 const FAILURE_CONFIRM_INTERVAL_MS = 3000;
 
@@ -68,7 +68,6 @@ export function useAtomicTransfer(
 	const statusRequestSiteIdRef = useRef< number | null >( null );
 	const atomicFlagRequestSiteIdRef = useRef< number | null >( null );
 	const wasFetchingStatusRef = useRef( false );
-	const sawProgressRef = useRef( false );
 	const failureConfirmAttemptsRef = useRef( 0 );
 	const pendingRetryRef = useRef( false );
 	const confirmTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >( null );
@@ -105,11 +104,7 @@ export function useAtomicTransfer(
 		}
 
 		statusRequestSiteIdRef.current = siteId;
-		// resetPolling: a new wait owns a new deadline window — never inherit one left behind
-		// by an earlier wait or another surface's polling chain.
-		dispatch(
-			fetchAutomatedTransferStatus( siteId, { resetPolling: true, retryOnFailure: true } )
-		);
+		dispatch( fetchAutomatedTransferStatus( siteId, 'start' ) );
 	}, [
 		dispatch,
 		isAtomicNeeded,
@@ -124,9 +119,7 @@ export function useAtomicTransfer(
 	const performStatusRetry = useCallback(
 		( targetSiteId: number ) => {
 			statusRequestSiteIdRef.current = targetSiteId;
-			dispatch(
-				fetchAutomatedTransferStatus( targetSiteId, { resetPolling: true, retryOnFailure: true } )
-			);
+			dispatch( fetchAutomatedTransferStatus( targetSiteId, 'start' ) );
 		},
 		[ dispatch ]
 	);
@@ -152,31 +145,18 @@ export function useAtomicTransfer(
 		}
 
 		const isFailure = transferFailureStates.includes( transferStatus );
-		if (
-			isFailure &&
-			! sawProgressRef.current &&
-			failureConfirmAttemptsRef.current < FAILURE_CONFIRM_ATTEMPTS
-		) {
+		if ( isFailure && failureConfirmAttemptsRef.current < FAILURE_CONFIRM_ATTEMPTS ) {
 			failureConfirmAttemptsRef.current += 1;
 			confirmTimeoutRef.current = setTimeout( () => {
 				if ( siteId ) {
-					dispatch(
-						fetchAutomatedTransferStatus( siteId, { resetPolling: true, retryOnFailure: true } )
-					);
+					dispatch( fetchAutomatedTransferStatus( siteId, 'start' ) );
 				}
 			}, FAILURE_CONFIRM_INTERVAL_MS );
 			return;
 		}
 
-		// Only genuine transfer activity proves there is no stale failure to confirm away —
-		// a failed request or an expired wait says nothing about which record the backend has.
-		if (
-			! isFailure &&
-			transferStatus &&
-			transferStatus !== transferStates.REQUEST_FAILURE &&
-			transferStatus !== transferStates.CLIENT_TIMEOUT
-		) {
-			sawProgressRef.current = true;
+		if ( ! isFailure ) {
+			failureConfirmAttemptsRef.current = 0;
 		}
 		setTrustedTransferStatus( transferStatus );
 		setIsRetryingTransferStatus( false );
@@ -216,7 +196,7 @@ export function useAtomicTransfer(
 	useInterval(
 		() => {
 			if ( siteId && ! isFetchingTransferStatus ) {
-				dispatch( fetchAutomatedTransferStatus( siteId, { singleCheck: true } ) );
+				dispatch( fetchAutomatedTransferStatus( siteId, 'single' ) );
 			}
 		},
 		isRecoveryMode &&
@@ -243,7 +223,6 @@ export function useAtomicTransfer(
 			clearTimeout( confirmTimeoutRef.current );
 		}
 		failureConfirmAttemptsRef.current = 0;
-		sawProgressRef.current = false;
 		setIsRetryingTransferStatus( true );
 		if ( isFetchingTransferStatus ) {
 			pendingRetryRef.current = true;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
@@ -105,7 +105,11 @@ export function useAtomicTransfer(
 		}
 
 		statusRequestSiteIdRef.current = siteId;
-		dispatch( fetchAutomatedTransferStatus( siteId, { retryOnFailure: true } ) );
+		// resetPolling: a new wait owns a new deadline window — never inherit one left behind
+		// by an earlier wait or another surface's polling chain.
+		dispatch(
+			fetchAutomatedTransferStatus( siteId, { resetPolling: true, retryOnFailure: true } )
+		);
 	}, [
 		dispatch,
 		isAtomicNeeded,
@@ -164,7 +168,14 @@ export function useAtomicTransfer(
 			return;
 		}
 
-		if ( ! isFailure ) {
+		// Only genuine transfer activity proves there is no stale failure to confirm away —
+		// a failed request or an expired wait says nothing about which record the backend has.
+		if (
+			! isFailure &&
+			transferStatus &&
+			transferStatus !== transferStates.REQUEST_FAILURE &&
+			transferStatus !== transferStates.CLIENT_TIMEOUT
+		) {
 			sawProgressRef.current = true;
 		}
 		setTrustedTransferStatus( transferStatus );
@@ -188,7 +199,9 @@ export function useAtomicTransfer(
 		);
 	}, [ dispatch, siteId ] );
 
-	const isTransferComplete = transferCompleteStates.includes( transferStatus );
+	// Gate on the trusted status, not the raw shared one: a stale persisted COMPLETE from an
+	// earlier transfer must not start the atomic-flag poll or short-circuit "Check again".
+	const isTransferComplete = transferCompleteStates.includes( trustedTransferStatus );
 	const isWaitingForAtomicFlag =
 		!! siteId && isTransferComplete && ! isSiteAtomic && ! isJetpackSelfHosted && isAtomicNeeded;
 	let atomicFlagPollInterval: number | null = null;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-atomic-transfer.tsx
@@ -1,8 +1,8 @@
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { waitFor } from 'calypso/my-sites/marketplace/util';
+import { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } from 'react';
+import { useInterval } from 'calypso/lib/interval';
 import { useSelector, useDispatch } from 'calypso/state';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
-import { transferStates } from 'calypso/state/automated-transfer/constants';
+import { transferCompleteStates, transferStates } from 'calypso/state/automated-transfer/constants';
 import {
 	getAutomatedTransferStatus,
 	isFetchingAutomatedTransferStatus,
@@ -12,15 +12,27 @@ import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { requestSite } from 'calypso/state/sites/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { THANK_YOU_RECOVERY_INTERVAL_MS } from './use-thank-you-deadline';
+
+const ATOMIC_FLAG_POLL_INTERVAL_MS = 2000;
+
+type AtomicTransferData = {
+	isAtomicTransferCheckComplete: boolean;
+	currentStep: number;
+	showProgressBar: boolean;
+	setShowProgressBar: Dispatch< SetStateAction< boolean > >;
+	isRetryingTransferStatus: boolean;
+	retry: () => void;
+};
 
 export function useAtomicTransfer(
-	isAtomicNeeded: boolean
-): [ boolean, number, boolean, Dispatch< SetStateAction< boolean > > ] {
+	isAtomicNeeded: boolean,
+	isRecoveryMode: boolean,
+	isDeadlineInitialized: boolean
+): AtomicTransferData {
 	const dispatch = useDispatch();
 	const siteId = useSelector( getSelectedSiteId );
-
 	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId as number ) );
-
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 	const isJetpackSelfHosted = isJetpack && ! isAtomic;
@@ -36,56 +48,119 @@ export function useAtomicTransfer(
 		! new URLSearchParams( document.location.search ).has( 'hide-progress-bar' )
 	);
 	const [ currentStep, setCurrentStep ] = useState( 0 );
+	const [ isRetryingTransferStatus, setIsRetryingTransferStatus ] = useState( false );
+	const statusRequestSiteIdRef = useRef< number | null >( null );
+	const atomicFlagRequestSiteIdRef = useRef< number | null >( null );
+	const retryObservedFetchingRef = useRef( false );
 
 	useEffect( () => {
 		setIsAtomicTransferCheckComplete( ! isAtomicNeeded );
 	}, [ isAtomicNeeded ] );
 
-	// Site is transferring to Atomic.
-	// Poll the transfer status.
 	useEffect( () => {
-		// Check the transfer status through the isSiteAtomic selector.
-		// This uses the `is_wpcom_atomic` flag returned by the sites endpoint.
 		if ( siteId && isSiteAtomic ) {
 			setIsAtomicTransferCheckComplete( true );
 		}
 
-		if ( ! siteId || isSiteAtomic || isJetpackSelfHosted || ! isAtomicNeeded ) {
+		if (
+			! siteId ||
+			isSiteAtomic ||
+			isJetpackSelfHosted ||
+			! isAtomicNeeded ||
+			! isDeadlineInitialized ||
+			isRecoveryMode ||
+			isFetchingTransferStatus ||
+			statusRequestSiteIdRef.current === siteId
+		) {
 			return;
 		}
 
-		if (
-			! isFetchingTransferStatus &&
-			transferStatus !== transferStates.COMPLETE &&
-			transferStatus !== transferStates.CLIENT_TIMEOUT
-		) {
-			waitFor( 2 ).then( () => dispatch( fetchAutomatedTransferStatus( siteId ) ) );
-		}
-
-		// Once the transferStatus is reported complete, query the sites endpoint
-		// until the `is_wpcom_atomic` = true is returned
-		if ( transferStatus === transferStates.COMPLETE && ! isSiteAtomic ) {
-			waitFor( 2 ).then( () => dispatch( requestSite( siteId ) ) );
-		}
+		statusRequestSiteIdRef.current = siteId;
+		dispatch( fetchAutomatedTransferStatus( siteId ) );
 	}, [
-		siteId,
 		dispatch,
-		transferStatus,
+		isAtomicNeeded,
+		isDeadlineInitialized,
 		isFetchingTransferStatus,
 		isJetpackSelfHosted,
-		isAtomicNeeded,
+		isRecoveryMode,
 		isSiteAtomic,
+		siteId,
 	] );
 
-	// Set progressbar (currentStep) depending on transfer/plugin status.
-	useEffect( () => {
-		// We don't want to show the progress bar again when it is hidden.
-		if ( ! showProgressBar ) {
+	const requestAtomicSite = useCallback( () => {
+		if ( ! siteId || atomicFlagRequestSiteIdRef.current === siteId ) {
 			return;
 		}
 
-		// Sites already transferred to Atomic or self-hosted Jetpack sites no longer need to change the current step.
-		if ( isJetpack ) {
+		atomicFlagRequestSiteIdRef.current = siteId;
+		const clearInFlightRequest = () => {
+			if ( atomicFlagRequestSiteIdRef.current === siteId ) {
+				atomicFlagRequestSiteIdRef.current = null;
+			}
+		};
+		Promise.resolve( dispatch( requestSite( siteId ) ) ).then(
+			clearInFlightRequest,
+			clearInFlightRequest
+		);
+	}, [ dispatch, siteId ] );
+
+	const isTransferComplete = transferCompleteStates.includes( transferStatus );
+	const isWaitingForAtomicFlag =
+		!! siteId && isTransferComplete && ! isSiteAtomic && ! isJetpackSelfHosted && isAtomicNeeded;
+	let atomicFlagPollInterval: number | null = null;
+	if ( isWaitingForAtomicFlag ) {
+		atomicFlagPollInterval = isRecoveryMode
+			? THANK_YOU_RECOVERY_INTERVAL_MS
+			: ATOMIC_FLAG_POLL_INTERVAL_MS;
+	}
+
+	useInterval( requestAtomicSite, atomicFlagPollInterval );
+
+	useInterval(
+		() => {
+			if ( siteId && ! isFetchingTransferStatus ) {
+				dispatch( fetchAutomatedTransferStatus( siteId, { singleCheck: true } ) );
+			}
+		},
+		isRecoveryMode &&
+			siteId &&
+			! isTransferComplete &&
+			! isSiteAtomic &&
+			! isJetpackSelfHosted &&
+			isAtomicNeeded
+			? THANK_YOU_RECOVERY_INTERVAL_MS
+			: null
+	);
+
+	useEffect( () => {
+		if ( ! isRetryingTransferStatus ) {
+			return;
+		}
+		if ( isFetchingTransferStatus ) {
+			retryObservedFetchingRef.current = true;
+		} else if ( retryObservedFetchingRef.current ) {
+			retryObservedFetchingRef.current = false;
+			setIsRetryingTransferStatus( false );
+		}
+	}, [ isFetchingTransferStatus, isRetryingTransferStatus ] );
+
+	const retry = useCallback( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		if ( isTransferComplete ) {
+			requestAtomicSite();
+		} else if ( ! isFetchingTransferStatus ) {
+			statusRequestSiteIdRef.current = siteId;
+			setIsRetryingTransferStatus( true );
+			dispatch( fetchAutomatedTransferStatus( siteId, { resetPolling: true } ) );
+		}
+	}, [ dispatch, isFetchingTransferStatus, isTransferComplete, requestAtomicSite, siteId ] );
+
+	useEffect( () => {
+		if ( ! showProgressBar || isJetpack ) {
 			return;
 		}
 
@@ -95,10 +170,17 @@ export function useAtomicTransfer(
 			setCurrentStep( 1 );
 		} else if ( transferStatus === transferStates.RELOCATING ) {
 			setCurrentStep( 2 );
-		} else if ( transferStatus === transferStates.COMPLETE ) {
+		} else if ( transferCompleteStates.includes( transferStatus ) ) {
 			setCurrentStep( 3 );
 		}
 	}, [ transferStatus, showProgressBar, isJetpack ] );
 
-	return [ isAtomicTransferCheckComplete, currentStep, showProgressBar, setShowProgressBar ];
+	return {
+		isAtomicTransferCheckComplete,
+		currentStep,
+		showProgressBar,
+		setShowProgressBar,
+		isRetryingTransferStatus,
+		retry,
+	};
 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -10,7 +10,7 @@ import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/sel
 import { pluginInstallationStateChange } from 'calypso/state/marketplace/purchase-flow/actions';
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
-import { getPluginsOnSite } from 'calypso/state/plugins/installed/selectors';
+import { getPluginsOnSite, isRequesting } from 'calypso/state/plugins/installed/selectors';
 import { isPluginActive } from 'calypso/state/plugins/installed/selectors-ts';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { areFetched, areFetching, getPlugins } from 'calypso/state/plugins/wporg/selectors';
@@ -139,6 +139,10 @@ export default function usePluginsThankYouData(
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ areAllWporgPluginsFetched, areWporgPluginsFetched, pluginSlugs, dispatch, wporgPlugins ] );
 
+	const isRequestingPlugins = useSelector( ( state ) =>
+		siteId ? isRequesting( state, siteId ) : false
+	);
+
 	const isPluginPollActive =
 		!! siteId &&
 		pluginSlugs.length > 0 &&
@@ -158,16 +162,16 @@ export default function usePluginsThankYouData(
 	}
 
 	useInterval( () => {
-		if ( siteId ) {
+		if ( siteId && ! isRequestingPlugins ) {
 			dispatch( fetchSitePlugins( siteId ) );
 		}
 	}, pluginPollInterval );
 
 	const retry = useCallback( () => {
-		if ( siteId && pluginSlugs.length > 0 ) {
+		if ( siteId && pluginSlugs.length > 0 && ! isRequestingPlugins ) {
 			dispatch( fetchSitePlugins( siteId ) );
 		}
-	}, [ dispatch, pluginSlugs.length, siteId ] );
+	}, [ dispatch, isRequestingPlugins, pluginSlugs.length, siteId ] );
 
 	const pluginsSection = pluginsInformationList.map( ( plugin: any ) => {
 		return <ThankYouPluginSection plugin={ plugin } key={ `plugin_${ plugin.slug }` } />;

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-plugins-thank-you-data.tsx
@@ -3,13 +3,10 @@ import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useMemo } from 'react';
 import { useWPCOMPlugins } from 'calypso/data/marketplace/use-wpcom-plugins-query';
+import { useInterval } from 'calypso/lib/interval';
 import { useSelector, useDispatch } from 'calypso/state';
-import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
-import { transferStates } from 'calypso/state/automated-transfer/constants';
-import {
-	getAutomatedTransferStatus,
-	isFetchingAutomatedTransferStatus,
-} from 'calypso/state/automated-transfer/selectors';
+import { transferCompleteStates } from 'calypso/state/automated-transfer/constants';
+import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { pluginInstallationStateChange } from 'calypso/state/marketplace/purchase-flow/actions';
 import { MARKETPLACE_ASYNC_PROCESS_STATUS } from 'calypso/state/marketplace/types';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
@@ -21,20 +18,27 @@ import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-t
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { ThankYouPluginSection } from './marketplace-thank-you-plugin-section';
+import { THANK_YOU_RECOVERY_INTERVAL_MS } from './use-thank-you-deadline';
 
-type ThankYouData = [
-	React.ReactElement[],
-	boolean,
-	boolean,
-	string,
-	string,
-	string[],
-	boolean,
-	React.ReactElement | null,
-	boolean,
-];
+type ThankYouData = {
+	pluginsSection: React.ReactElement[];
+	allPluginsFetched: boolean;
+	allPluginsActivated: boolean;
+	pluginTitle: string;
+	pluginSubtitle: string;
+	pluginsProgressbarSteps: string[];
+	isAtomicNeeded: boolean;
+	thankYouHeaderAction: React.ReactElement | null;
+	isLoaded: boolean;
+	retry: () => void;
+};
 
-export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYouData {
+const PLUGIN_POLL_INTERVAL_MS = 3000;
+
+export default function usePluginsThankYouData(
+	pluginSlugs: string[],
+	isRecoveryMode: boolean
+): ThankYouData {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
@@ -94,9 +98,6 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 	const isJetpackSelfHosted = isJetpack && ! isAtomic;
 
-	const isFetchingTransferStatus = useSelector( ( state ) =>
-		isFetchingAutomatedTransferStatus( state, siteId )
-	);
 	// Consolidate the plugin information from the .org and .com sources in a single list
 	const pluginsInformationList = useMemo( () => {
 		return pluginsOnSite.reduce(
@@ -138,53 +139,35 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ areAllWporgPluginsFetched, areWporgPluginsFetched, pluginSlugs, dispatch, wporgPlugins ] );
 
-	useEffect( () => {
-		if (
-			! isFetchingTransferStatus &&
-			transferStatus !== transferStates.COMPLETE &&
-			transferStatus !== transferStates.CLIENT_TIMEOUT
-		) {
-			dispatch( fetchAutomatedTransferStatus( siteId as number ) );
-		}
-	}, [ dispatch, isFetchingTransferStatus, siteId, transferStatus ] );
+	const isPluginPollActive =
+		!! siteId &&
+		pluginSlugs.length > 0 &&
+		( isJetpackSelfHosted || transferCompleteStates.includes( transferStatus ) ) &&
+		! ( allPluginsFetched && allPluginsActivated );
 
-	// Site is already Atomic (or just transferred).
-	// Poll the plugin installation status.
 	useEffect( () => {
-		if (
-			! siteId ||
-			( ! isJetpackSelfHosted && transferStatus !== transferStates.COMPLETE ) ||
-			( allPluginsFetched && allPluginsActivated ) ||
-			pluginSlugs.length === 0
-		) {
+		if ( ! isPluginPollActive || ! siteId ) {
 			return;
 		}
 
-		const abortController = new AbortController();
+		dispatch( fetchSitePlugins( siteId ) );
+	}, [ dispatch, isPluginPollActive, siteId ] );
+	let pluginPollInterval: number | null = null;
+	if ( isPluginPollActive ) {
+		pluginPollInterval = isRecoveryMode ? THANK_YOU_RECOVERY_INTERVAL_MS : PLUGIN_POLL_INTERVAL_MS;
+	}
 
-		async function fetchPlugins() {
-			if ( abortController.signal.aborted ) {
-				return;
-			}
-
-			await dispatch( fetchSitePlugins( siteId ) );
-			fetchPlugins();
+	useInterval( () => {
+		if ( siteId ) {
+			dispatch( fetchSitePlugins( siteId ) );
 		}
+	}, pluginPollInterval );
 
-		fetchPlugins();
-
-		return () => {
-			abortController.abort();
-		};
-	}, [
-		dispatch,
-		siteId,
-		transferStatus,
-		isJetpackSelfHosted,
-		allPluginsFetched,
-		allPluginsActivated,
-		pluginSlugs,
-	] );
+	const retry = useCallback( () => {
+		if ( siteId && pluginSlugs.length > 0 ) {
+			dispatch( fetchSitePlugins( siteId ) );
+		}
+	}, [ dispatch, pluginSlugs.length, siteId ] );
 
 	const pluginsSection = pluginsInformationList.map( ( plugin: any ) => {
 		return <ThankYouPluginSection plugin={ plugin } key={ `plugin_${ plugin.slug }` } />;
@@ -232,17 +215,18 @@ export default function usePluginsThankYouData( pluginSlugs: string[] ): ThankYo
 	// so atomic is always needed as long as we have plugins
 	const isAtomicNeeded = pluginSlugs.length > 0;
 
-	return [
+	return {
 		pluginsSection,
 		allPluginsFetched,
 		allPluginsActivated,
-		title,
-		subtitle,
-		thankyouSteps,
+		pluginTitle: title,
+		pluginSubtitle: subtitle,
+		pluginsProgressbarSteps: thankyouSteps,
 		isAtomicNeeded,
 		thankYouHeaderAction,
-		true,
-	];
+		isLoaded: true,
+		retry,
+	};
 }
 
 type Plugin = {

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-deadline.ts
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-deadline.ts
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useInterval } from 'calypso/lib/interval';
+
+export const THANK_YOU_WAIT_DEADLINE_MS = 5 * 60 * 1000;
+export const THANK_YOU_RECOVERY_INTERVAL_MS = 30 * 1000;
+
+const CLOCK_TICK_MS = 1000;
+const STORAGE_PREFIX = 'marketplace-thank-you-wait';
+
+const readStartedAt = ( key: string ): number | null => {
+	try {
+		const startedAt = Number( window.sessionStorage.getItem( key ) );
+		return Number.isFinite( startedAt ) && startedAt > 0 ? startedAt : null;
+	} catch {
+		return null;
+	}
+};
+
+const writeStartedAt = ( key: string, startedAt: number ) => {
+	try {
+		window.sessionStorage.setItem( key, String( startedAt ) );
+	} catch {}
+};
+
+const removeStartedAt = ( key: string ) => {
+	try {
+		window.sessionStorage.removeItem( key );
+	} catch {}
+};
+
+export function useThankYouDeadline( {
+	siteId,
+	productKey,
+	enabled,
+}: {
+	siteId: number | null;
+	productKey: string;
+	enabled: boolean;
+} ) {
+	const storageKey = useMemo(
+		() => ( siteId ? `${ STORAGE_PREFIX }:${ siteId }:${ productKey }` : null ),
+		[ productKey, siteId ]
+	);
+	const [ deadlineState, setDeadlineState ] = useState< {
+		storageKey: string;
+		startedAt: number;
+	} | null >( () => {
+		if ( ! enabled || ! storageKey ) {
+			return null;
+		}
+		const startedAt = readStartedAt( storageKey ) ?? Date.now();
+		writeStartedAt( storageKey, startedAt );
+		return { storageKey, startedAt };
+	} );
+	const [ now, setNow ] = useState( () => Date.now() );
+
+	useEffect( () => {
+		if ( ! enabled || ! storageKey ) {
+			setDeadlineState( null );
+			return;
+		}
+
+		const startedAt = readStartedAt( storageKey ) ?? Date.now();
+		writeStartedAt( storageKey, startedAt );
+		setNow( Date.now() );
+		setDeadlineState( { storageKey, startedAt } );
+	}, [ enabled, storageKey ] );
+
+	const isCurrentWait = deadlineState?.storageKey === storageKey;
+	const startedAt = isCurrentWait ? deadlineState.startedAt : null;
+	const hasTimedOut =
+		enabled && startedAt !== null && now - startedAt >= THANK_YOU_WAIT_DEADLINE_MS;
+
+	useInterval( () => setNow( Date.now() ), enabled && startedAt !== null ? CLOCK_TICK_MS : null );
+
+	const restart = useCallback( () => {
+		if ( ! storageKey ) {
+			return;
+		}
+
+		const nextStartedAt = Date.now();
+		writeStartedAt( storageKey, nextStartedAt );
+		setNow( nextStartedAt );
+		setDeadlineState( { storageKey, startedAt: nextStartedAt } );
+	}, [ storageKey ] );
+
+	const complete = useCallback( () => {
+		if ( storageKey ) {
+			removeStartedAt( storageKey );
+		}
+		setDeadlineState( null );
+	}, [ storageKey ] );
+
+	return {
+		isInitialized: ! enabled || ( !! storageKey && isCurrentWait ),
+		hasTimedOut,
+		waitedSeconds: startedAt === null ? 0 : Math.round( ( now - startedAt ) / 1000 ),
+		restart,
+		complete,
+	};
+}

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-deadline.ts
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-thank-you-deadline.ts
@@ -1,10 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useInterval } from 'calypso/lib/interval';
 
 export const THANK_YOU_WAIT_DEADLINE_MS = 5 * 60 * 1000;
 export const THANK_YOU_RECOVERY_INTERVAL_MS = 30 * 1000;
 
-const CLOCK_TICK_MS = 1000;
 const STORAGE_PREFIX = 'marketplace-thank-you-wait';
 
 const readStartedAt = ( key: string ): number | null => {
@@ -48,11 +46,9 @@ export function useThankYouDeadline( {
 		if ( ! enabled || ! storageKey ) {
 			return null;
 		}
-		const startedAt = readStartedAt( storageKey ) ?? Date.now();
-		writeStartedAt( storageKey, startedAt );
-		return { storageKey, startedAt };
+		return { storageKey, startedAt: readStartedAt( storageKey ) ?? Date.now() };
 	} );
-	const [ now, setNow ] = useState( () => Date.now() );
+	const [ hasTimedOut, setHasTimedOut ] = useState( false );
 
 	useEffect( () => {
 		if ( ! enabled || ! storageKey ) {
@@ -62,16 +58,35 @@ export function useThankYouDeadline( {
 
 		const startedAt = readStartedAt( storageKey ) ?? Date.now();
 		writeStartedAt( storageKey, startedAt );
-		setNow( Date.now() );
 		setDeadlineState( { storageKey, startedAt } );
 	}, [ enabled, storageKey ] );
 
 	const isCurrentWait = deadlineState?.storageKey === storageKey;
 	const startedAt = isCurrentWait ? deadlineState.startedAt : null;
-	const hasTimedOut =
-		enabled && startedAt !== null && now - startedAt >= THANK_YOU_WAIT_DEADLINE_MS;
 
-	useInterval( () => setNow( Date.now() ), enabled && startedAt !== null ? CLOCK_TICK_MS : null );
+	// A single timer at the deadline instead of a ticking clock: the only state transition
+	// anyone renders on is the deadline crossing.
+	useEffect( () => {
+		if ( ! enabled || startedAt === null ) {
+			setHasTimedOut( false );
+			return;
+		}
+
+		const remainingMs = startedAt + THANK_YOU_WAIT_DEADLINE_MS - Date.now();
+		if ( remainingMs <= 0 ) {
+			setHasTimedOut( true );
+			return;
+		}
+
+		setHasTimedOut( false );
+		const id = setTimeout( () => setHasTimedOut( true ), remainingMs );
+		return () => clearTimeout( id );
+	}, [ enabled, startedAt ] );
+
+	const getWaitedSeconds = useCallback(
+		() => ( startedAt === null ? 0 : Math.round( ( Date.now() - startedAt ) / 1000 ) ),
+		[ startedAt ]
+	);
 
 	const restart = useCallback( () => {
 		if ( ! storageKey ) {
@@ -80,7 +95,6 @@ export function useThankYouDeadline( {
 
 		const nextStartedAt = Date.now();
 		writeStartedAt( storageKey, nextStartedAt );
-		setNow( nextStartedAt );
 		setDeadlineState( { storageKey, startedAt: nextStartedAt } );
 	}, [ storageKey ] );
 
@@ -93,8 +107,8 @@ export function useThankYouDeadline( {
 
 	return {
 		isInitialized: ! enabled || ( !! storageKey && isCurrentWait ),
-		hasTimedOut,
-		waitedSeconds: startedAt === null ? 0 : Math.round( ( now - startedAt ) / 1000 ),
+		hasTimedOut: enabled && hasTimedOut,
+		getWaitedSeconds,
 		restart,
 		complete,
 	};

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -1,16 +1,17 @@
 import page from '@automattic/calypso-router';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import { useQueryThemes } from 'calypso/components/data/query-theme';
 import { useDispatch, useSelector } from 'calypso/state';
+import { fetchSitePurchases } from 'calypso/state/purchases/actions';
 import {
 	hasLoadedSitePurchasesFromServer,
 	isFetchingSitePurchases,
 } from 'calypso/state/purchases/selectors';
 import { isJetpackSite, getSiteOption } from 'calypso/state/sites/selectors';
-import { clearActivated } from 'calypso/state/themes/actions';
+import { clearActivated, requestTheme } from 'calypso/state/themes/actions';
 import {
 	getThemes,
 	isMarketplaceThemeSubscribed as getIsMarketplaceThemeSubscribed,
@@ -20,17 +21,18 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import { Theme } from 'calypso/types';
 import { ThankYouThemeSection } from './marketplace-thank-you-theme-section';
 
-type ThankYouThemeData = [
-	Theme,
-	React.ReactElement[],
-	boolean,
-	string,
-	string,
-	string[],
-	boolean,
-	React.ReactElement | null,
-	boolean,
-];
+type ThankYouThemeData = {
+	firstTheme: Theme;
+	themesSection: React.ReactElement[];
+	allThemesFetched: boolean;
+	themeTitle: string;
+	themeSubtitle: string;
+	themesProgressbarSteps: string[];
+	isAtomicNeeded: boolean;
+	thankYouHeaderAction: React.ReactElement | null;
+	isLoaded: boolean;
+	retry: () => void;
+};
 
 export function useThemesThankYouData(
 	themeSlugs: string[],
@@ -171,19 +173,44 @@ export function useThemesThankYouData(
 		}
 	}, [ firstTheme, isAtomicNeeded, isJetpack, isOnboardingFlow, siteSlug ] );
 
-	return [
+	// The query hooks above request each source only once per mount, and the purchases hook
+	// suppresses re-requests for the same site, so a failed request would otherwise leave
+	// "Check again" unable to fill in whatever this page is still missing.
+	const retry = useCallback( () => {
+		themeSlugs.forEach( ( slug, index ) => {
+			if ( ! dotComThemes[ index ] && ! dotOrgThemes[ index ] ) {
+				dispatch( requestTheme( slug, 'wpcom' ) );
+				dispatch( requestTheme( slug, 'wporg' ) );
+			}
+		} );
+
+		if ( ! hasLoadedSitePurchases && ! isRequestingSitePurchases ) {
+			dispatch( fetchSitePurchases( siteId ) );
+		}
+	}, [
+		dispatch,
+		dotComThemes,
+		dotOrgThemes,
+		hasLoadedSitePurchases,
+		isRequestingSitePurchases,
+		siteId,
+		themeSlugs,
+	] );
+
+	return {
 		firstTheme,
 		themesSection,
 		allThemesFetched,
-		title,
-		subtitle,
-		thankyouSteps,
+		themeTitle: title,
+		themeSubtitle: subtitle,
+		themesProgressbarSteps: thankyouSteps,
 		isAtomicNeeded,
-		null,
+		thankYouHeaderAction: null,
 		// Always display the loading screen for the following situations:
 		// - Redirect to the plugin-bundle flow after the theme is activated for Woo themes.
 		// - Redirect to the Theme Details page after the atomic transfer if it's required.
 		// - Redirect to the /home page if the user removed the externally managed theme from checkout.
-		! ( continueWithPluginBundle || isAtomicNeeded || ! isRequestingSitePurchases ),
-	];
+		isLoaded: ! ( continueWithPluginBundle || isAtomicNeeded || ! isRequestingSitePurchases ),
+		retry,
+	};
 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -184,18 +184,13 @@ export function useThemesThankYouData(
 			}
 		} );
 
-		if ( ! hasLoadedSitePurchases && ! isRequestingSitePurchases ) {
+		// Unconditional on purpose: `hasLoadedSitePurchasesFromServer` is set even when the
+		// fetch failed, so it cannot distinguish "loaded" from "failed" — and a manual retry
+		// after a failure is exactly when a refetch is needed.
+		if ( ! isRequestingSitePurchases ) {
 			dispatch( fetchSitePurchases( siteId ) );
 		}
-	}, [
-		dispatch,
-		dotComThemes,
-		dotOrgThemes,
-		hasLoadedSitePurchases,
-		isRequestingSitePurchases,
-		siteId,
-		themeSlugs,
-	] );
+	}, [ dispatch, dotComThemes, dotOrgThemes, isRequestingSitePurchases, siteId, themeSlugs ] );
 
 	return {
 		firstTheme,
@@ -206,11 +201,13 @@ export function useThemesThankYouData(
 		themesProgressbarSteps: thankyouSteps,
 		isAtomicNeeded,
 		thankYouHeaderAction: null,
-		// Always display the loading screen for the following situations:
-		// - Redirect to the plugin-bundle flow after the theme is activated for Woo themes.
-		// - Redirect to the Theme Details page after the atomic transfer if it's required.
-		// - Redirect to the /home page if the user removed the externally managed theme from checkout.
-		isLoaded: ! ( continueWithPluginBundle || isAtomicNeeded || ! isRequestingSitePurchases ),
+		// Keep the loading screen up for the flows that redirect away from this page:
+		// - the plugin-bundle flow after the theme is activated for Woo themes;
+		// - the Theme Details page after the atomic transfer, if one is required.
+		// Otherwise the page is loaded once purchases have been fetched — the previous
+		// `isRequestingSitePurchases` form was only true *while* fetching, so a slow theme
+		// request could leave this false forever and time the page out.
+		isLoaded: ! continueWithPluginBundle && ! isAtomicNeeded && hasLoadedSitePurchases,
 		retry,
 	};
 }

--- a/client/state/automated-transfer/actions.js
+++ b/client/state/automated-transfer/actions.js
@@ -35,12 +35,13 @@ export const initiateAutomatedTransferWithPluginZip = ( siteId, pluginZip ) => (
  */
 export const fetchAutomatedTransferStatus = (
 	siteId,
-	{ resetPolling = false, singleCheck = false } = {}
+	{ resetPolling = false, singleCheck = false, retryOnFailure = false } = {}
 ) => ( {
 	type: AUTOMATED_TRANSFER_STATUS_REQUEST,
 	siteId,
 	...( resetPolling ? { resetPolling: true } : {} ),
 	...( singleCheck ? { singleCheck: true } : {} ),
+	...( retryOnFailure ? { retryOnFailure: true } : {} ),
 } );
 
 /**

--- a/client/state/automated-transfer/actions.js
+++ b/client/state/automated-transfer/actions.js
@@ -30,18 +30,22 @@ export const initiateAutomatedTransferWithPluginZip = ( siteId, pluginZip ) => (
 
 /**
  * Query the automated transfer status of a given site.
+ *
+ * `pollingMode` opts the fetch into the data layer's managed polling:
+ * - 'start': begins a new wait — resets the site's poll deadline and retries failed
+ *   requests until it expires.
+ * - 'continue': a poll belonging to an already-started wait (used by the data layer's
+ *   own polling chain).
+ * - 'single': one isolated check — no polling chain, no deadline interaction.
+ * - null (default): a plain fetch that fails once and stops, as it always did.
  * @param {number} siteId The id of the site to query.
+ * @param {'start'|'continue'|'single'|null} [pollingMode] See above.
  * @returns {Object} An action object
  */
-export const fetchAutomatedTransferStatus = (
-	siteId,
-	{ resetPolling = false, singleCheck = false, retryOnFailure = false } = {}
-) => ( {
+export const fetchAutomatedTransferStatus = ( siteId, pollingMode = null ) => ( {
 	type: AUTOMATED_TRANSFER_STATUS_REQUEST,
 	siteId,
-	...( resetPolling ? { resetPolling: true } : {} ),
-	...( singleCheck ? { singleCheck: true } : {} ),
-	...( retryOnFailure ? { retryOnFailure: true } : {} ),
+	...( pollingMode ? { pollingMode } : {} ),
 } );
 
 /**

--- a/client/state/automated-transfer/actions.js
+++ b/client/state/automated-transfer/actions.js
@@ -33,9 +33,14 @@ export const initiateAutomatedTransferWithPluginZip = ( siteId, pluginZip ) => (
  * @param {number} siteId The id of the site to query.
  * @returns {Object} An action object
  */
-export const fetchAutomatedTransferStatus = ( siteId ) => ( {
+export const fetchAutomatedTransferStatus = (
+	siteId,
+	{ resetPolling = false, singleCheck = false } = {}
+) => ( {
 	type: AUTOMATED_TRANSFER_STATUS_REQUEST,
 	siteId,
+	...( resetPolling ? { resetPolling: true } : {} ),
+	...( singleCheck ? { singleCheck: true } : {} ),
 } );
 
 /**

--- a/client/state/automated-transfer/constants.ts
+++ b/client/state/automated-transfer/constants.ts
@@ -1,6 +1,13 @@
+/**
+ * Error message the status endpoint returns when the site has no transfer record.
+ * Maps to `transferStates.NONE`.
+ * TODO : [MARKETPLACE] rely on a tangible status from the backend instead of this message
+ */
+export const NO_TRANSFER_RECORD_ERROR = 'An invalid transfer ID was passed.';
+
 export const transferStates = {
 	/**
-	 * This is when the request to fetch the transfer returns the error 'An invalid transfer ID was passed.'
+	 * This is when the request to fetch the transfer returns the error `NO_TRANSFER_RECORD_ERROR`.
 	 */
 	NONE: 'none',
 	PENDING: 'pending',
@@ -33,6 +40,25 @@ export const transferStates = {
 	CLIENT_TIMEOUT: 'client_timeout',
 } as const;
 
+export type TransferStates = ( typeof transferStates )[ keyof typeof transferStates ];
+
+export const transferCompleteStates: ReadonlyArray< string | null > = [
+	transferStates.COMPLETE,
+	transferStates.COMPLETED,
+];
+
+export const transferFailureStates: ReadonlyArray< string | null > = [
+	transferStates.ERROR,
+	transferStates.FAILURE,
+	transferStates.CONFLICTS,
+	transferStates.REVERTED,
+];
+
+export const transferSettledStates: ReadonlyArray< string | null > = [
+	...transferCompleteStates,
+	...transferFailureStates,
+];
+
 export const transferInProgress = [
 	transferStates.START,
 	transferStates.PENDING,
@@ -41,8 +67,6 @@ export const transferInProgress = [
 ] as const;
 
 export const transferRevertingInProgress = [ transferStates.RELOCATING_REVERT ] as const;
-
-export type TransferStates = ( typeof transferStates )[ keyof typeof transferStates ];
 
 export const eligibilityHolds = {
 	BLOCKED_ATOMIC_TRANSFER: 'BLOCKED_ATOMIC_TRANSFER',

--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -16,7 +16,7 @@ import {
 	withSchemaValidation,
 	withPersistence,
 } from 'calypso/state/utils';
-import { transferStates } from './constants';
+import { NO_TRANSFER_RECORD_ERROR, transferStates } from './constants';
 import eligibility from './eligibility/reducer';
 import { automatedTransfer as schema } from './schema';
 
@@ -34,8 +34,7 @@ export const status = withPersistence(
 			case TRANSFER_UPDATE:
 				return 'complete' === action.status ? transferStates.COMPLETE : state;
 			case REQUEST_STATUS_FAILURE:
-				// TODO : [MARKETPLACE] rely on a tangible status from the backend instead of this message
-				return action.error === 'An invalid transfer ID was passed.'
+				return action.error === NO_TRANSFER_RECORD_ERROR
 					? transferStates.NONE
 					: transferStates.REQUEST_FAILURE;
 		}
@@ -43,9 +42,8 @@ export const status = withPersistence(
 		return state;
 	},
 	{
-		// CLIENT_TIMEOUT is client-only. Persisting it would render a stale error on screens that
-		// stop polling once they see it, leaving nothing able to clear it.
-		serialize: ( state ) => ( state === transferStates.CLIENT_TIMEOUT ? null : state ),
+		serialize: () => null,
+		deserialize: () => null,
 	}
 );
 

--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -42,8 +42,9 @@ export const status = withPersistence(
 		return state;
 	},
 	{
-		serialize: () => null,
-		deserialize: () => null,
+		// CLIENT_TIMEOUT is client-only. Persisting it would render a stale error on screens that
+		// stop polling once they see it, leaving nothing able to clear it.
+		serialize: ( state ) => ( state === transferStates.CLIENT_TIMEOUT ? null : state ),
 	}
 );
 

--- a/client/state/automated-transfer/test/reducer.js
+++ b/client/state/automated-transfer/test/reducer.js
@@ -39,7 +39,7 @@ describe( 'state', () => {
 				} );
 			} );
 
-			test( 'should persist eligibility but not live transfer status or fetching state', () => {
+			test( 'should persist all state keys except fetchingStatus', () => {
 				const SITE_ID = 12345;
 				const AT_STATE = {
 					[ SITE_ID ]: {
@@ -54,12 +54,12 @@ describe( 'state', () => {
 				};
 
 				const serialized = serialize( reducer, AT_STATE ).root();
-				expect( serialized[ SITE_ID ] ).toHaveProperty( 'status', null );
+				expect( serialized[ SITE_ID ] ).toHaveProperty( 'status' );
 				expect( serialized[ SITE_ID ] ).toHaveProperty( 'eligibility' );
 				expect( serialized[ SITE_ID ] ).not.toHaveProperty( 'fetchingStatus' );
 
 				const deserialized = deserialize( reducer, AT_STATE );
-				expect( deserialized[ SITE_ID ] ).toHaveProperty( 'status', null );
+				expect( deserialized[ SITE_ID ] ).toHaveProperty( 'status', transferStates.BACKFILLING );
 				expect( deserialized[ SITE_ID ] ).toHaveProperty( 'eligibility' );
 				// The non-persisted property has default value, persisted value is ignored
 				expect( deserialized[ SITE_ID ] ).toHaveProperty( 'fetchingStatus', false );

--- a/client/state/automated-transfer/test/reducer.js
+++ b/client/state/automated-transfer/test/reducer.js
@@ -39,7 +39,7 @@ describe( 'state', () => {
 				} );
 			} );
 
-			test( 'should persist all state keys except fetchingStatus', () => {
+			test( 'should persist eligibility but not live transfer status or fetching state', () => {
 				const SITE_ID = 12345;
 				const AT_STATE = {
 					[ SITE_ID ]: {
@@ -54,12 +54,12 @@ describe( 'state', () => {
 				};
 
 				const serialized = serialize( reducer, AT_STATE ).root();
-				expect( serialized[ SITE_ID ] ).toHaveProperty( 'status' );
+				expect( serialized[ SITE_ID ] ).toHaveProperty( 'status', null );
 				expect( serialized[ SITE_ID ] ).toHaveProperty( 'eligibility' );
 				expect( serialized[ SITE_ID ] ).not.toHaveProperty( 'fetchingStatus' );
 
 				const deserialized = deserialize( reducer, AT_STATE );
-				expect( deserialized[ SITE_ID ] ).toHaveProperty( 'status', transferStates.BACKFILLING );
+				expect( deserialized[ SITE_ID ] ).toHaveProperty( 'status', null );
 				expect( deserialized[ SITE_ID ] ).toHaveProperty( 'eligibility' );
 				// The non-persisted property has default value, persisted value is ignored
 				expect( deserialized[ SITE_ID ] ).toHaveProperty( 'fetchingStatus', false );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -43,16 +43,12 @@ const getOrCreatePollDeadline = ( siteId ) => {
 };
 
 export const requestStatus = ( action ) => {
-	// A single recovery check must not touch the deadline state: a regular chain may be
-	// running for the same site, and deleting or reviving its entry would either kill its
-	// timeout or let it mint a fresh five-minute window. Only an explicit new wait
-	// (resetPolling + retryOnFailure) mints an entry: plain fetches would orphan one, and a
-	// chain re-dispatch minting one could resurrect a wait that has already settled.
-	if ( ! action.singleCheck && action.resetPolling ) {
+	// Only an explicit new wait touches the deadline state. Plain and 'single' fetches would
+	// orphan an entry (handing a later wait an already-expired window), and a 'continue' poll
+	// minting one could resurrect a wait that has already settled.
+	if ( action.pollingMode === 'start' ) {
 		pollDeadlines.delete( action.siteId );
-		if ( action.retryOnFailure ) {
-			getOrCreatePollDeadline( action.siteId );
-		}
+		getOrCreatePollDeadline( action.siteId );
 	}
 	return http(
 		{
@@ -65,10 +61,7 @@ export const requestStatus = ( action ) => {
 };
 
 export const receiveStatus =
-	(
-		{ siteId, singleCheck, retryOnFailure },
-		{ status, uploaded_plugin_slug, transfer_id: transferId }
-	) =>
+	( { siteId, pollingMode }, { status, uploaded_plugin_slug, transfer_id: transferId } ) =>
 	( dispatch ) => {
 		const pluginId = uploaded_plugin_slug;
 		const isSettled = transferSettledStates.includes( status );
@@ -86,7 +79,7 @@ export const receiveStatus =
 
 		dispatch( setAutomatedTransferStatus( siteId, status, pluginId ) );
 
-		if ( singleCheck ) {
+		if ( pollingMode === 'single' ) {
 			// Inert with respect to the deadline state, and no polling chain of its own.
 		} else if ( isSettled ) {
 			pollDeadlines.delete( siteId );
@@ -95,13 +88,13 @@ export const receiveStatus =
 
 			if ( Date.now() < deadline ) {
 				pollDeadlines.set( siteId, { transferId, deadline } );
-				// The retry policy belongs to the wait, so it travels on the polling chain's own
-				// actions rather than on the shared deadline entry — a concurrent fetch from
-				// another surface must not inherit it, and a transfer_id change must not drop it.
+				// The wait's polling mode travels on the chain's own actions rather than on the
+				// shared deadline entry — a concurrent fetch from another surface must not inherit
+				// it, and a transfer_id change must not drop it.
 				setTimeout(
 					dispatch,
 					POLL_INTERVAL_MS,
-					fetchAutomatedTransferStatus( siteId, { retryOnFailure } )
+					fetchAutomatedTransferStatus( siteId, pollingMode ? 'continue' : null )
 				);
 			} else {
 				pollDeadlines.set( siteId, { transferId, deadline, hasTimedOut: true } );
@@ -116,27 +109,25 @@ export const receiveStatus =
 	};
 
 export const requestingStatusFailure = ( response ) => ( dispatch ) => {
-	const { siteId, singleCheck, retryOnFailure } = response;
+	const { siteId, pollingMode } = response;
 	const message = response.meta?.dataLayer?.error?.message;
 	dispatch( automatedTransferStatusFetchingFailure( { siteId, error: message } ) );
 
 	// Retrying failures — and eventually reporting CLIENT_TIMEOUT — is behavior only waits
-	// that asked for it (on this very action) should get. Other dispatchers expect a failed
-	// request to fail once and stop, exactly as it did before the retry logic existed — and
-	// they must not leave any deadline state behind for a later wait to inherit.
-	if ( singleCheck || ! retryOnFailure ) {
+	// get. Plain and 'single' fetches fail once and stop, exactly as they always did.
+	if ( pollingMode !== 'start' && pollingMode !== 'continue' ) {
 		return;
 	}
 
 	// No entry means the wait has ended (a settled response deletes it) or never started.
-	// A stale failure must not resurrect it — the retry flag on the action alone is not
-	// proof the wait is still alive.
+	// A stale failure must not resurrect it — the mode on the action alone is not proof
+	// the wait is still alive.
 	const recorded = pollDeadlines.get( siteId );
 	if ( ! recorded ) {
 		return;
 	}
 
-	const retryFetch = fetchAutomatedTransferStatus( siteId, { retryOnFailure: true } );
+	const retryFetch = fetchAutomatedTransferStatus( siteId, 'continue' );
 
 	// The reducer maps a missing record to the terminal NONE status, so once the retries run
 	// out the chain must end there — letting the deadline fire would replace a real "this site

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -4,7 +4,11 @@ import {
 	setAutomatedTransferStatus,
 	automatedTransferStatusFetchingFailure,
 } from 'calypso/state/automated-transfer/actions';
-import { transferStates } from 'calypso/state/automated-transfer/constants';
+import {
+	NO_TRANSFER_RECORD_ERROR,
+	transferSettledStates,
+	transferStates,
+} from 'calypso/state/automated-transfer/constants';
 import { registerHandlers } from 'calypso/state/data-layer/handler-registry';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { dispatchRequest } from 'calypso/state/data-layer/wpcom-http/utils';
@@ -14,17 +18,10 @@ export const TRANSFER_STATUS_POLL_DEADLINE_MS = 5 * 60 * 1000;
 
 const POLL_INTERVAL_MS = 3000;
 
-// Statuses the backend will not move away from on its own. Polling past one of these would
-// keep asking about a transfer that has already ended, and letting the deadline fire on one
-// would overwrite a real outcome with a generic timeout.
-const settledStates = [
-	transferStates.COMPLETE,
-	transferStates.COMPLETED,
-	transferStates.ERROR,
-	transferStates.FAILURE,
-	transferStates.CONFLICTS,
-	transferStates.REVERTED,
-];
+// A missing transfer record right after a purchase can mean the backend simply hasn't created
+// it yet, so it deserves a few retries — but it is also the terminal answer for a site that
+// has no transfer at all, so it must not be retried for the full deadline window.
+export const MISSING_RECORD_ATTEMPTS = 6;
 
 // The deadline belongs to the wait, not to a single request: consumers re-dispatch a fetch
 // every time the status changes, and each of those would otherwise open a fresh window. It
@@ -34,8 +31,23 @@ const pollDeadlines = new Map();
 
 export const clearPollDeadlines = () => pollDeadlines.clear();
 
-export const requestStatus = ( action ) =>
-	http(
+const getOrCreatePollDeadline = ( siteId ) => {
+	const stored = pollDeadlines.get( siteId );
+	if ( stored ) {
+		return stored;
+	}
+
+	const created = { deadline: Date.now() + TRANSFER_STATUS_POLL_DEADLINE_MS };
+	pollDeadlines.set( siteId, created );
+	return created;
+};
+
+export const requestStatus = ( action ) => {
+	if ( action.resetPolling ) {
+		pollDeadlines.delete( action.siteId );
+	}
+	getOrCreatePollDeadline( action.siteId );
+	return http(
 		{
 			method: 'GET',
 			path: `/sites/${ action.siteId }/automated-transfers/status`,
@@ -43,14 +55,16 @@ export const requestStatus = ( action ) =>
 		},
 		action
 	);
+};
 
 export const receiveStatus =
-	( { siteId }, { status, uploaded_plugin_slug, transfer_id: transferId } ) =>
+	( { siteId, singleCheck }, { status, uploaded_plugin_slug, transfer_id: transferId } ) =>
 	( dispatch ) => {
 		const pluginId = uploaded_plugin_slug;
-		const isSettled = settledStates.includes( status );
+		const isSettled = transferSettledStates.includes( status );
 		const stored = pollDeadlines.get( siteId );
-		const recorded = stored?.transferId === transferId ? stored : undefined;
+		const recorded =
+			stored?.transferId === undefined || stored?.transferId === transferId ? stored : undefined;
 
 		// Once a wait has run out of time it stays that way until the transfer actually ends.
 		// Otherwise the next status fetch — and several screens keep fetching — would replace
@@ -63,6 +77,8 @@ export const receiveStatus =
 		dispatch( setAutomatedTransferStatus( siteId, status, pluginId ) );
 
 		if ( isSettled ) {
+			pollDeadlines.delete( siteId );
+		} else if ( singleCheck ) {
 			pollDeadlines.delete( siteId );
 		} else {
 			const deadline = recorded?.deadline ?? Date.now() + TRANSFER_STATUS_POLL_DEADLINE_MS;
@@ -82,11 +98,39 @@ export const receiveStatus =
 		}
 	};
 
-export const requestingStatusFailure = ( response ) => {
-	return automatedTransferStatusFetchingFailure( {
-		siteId: response.siteId,
-		error: response.meta?.dataLayer?.error?.message,
-	} );
+export const requestingStatusFailure = ( response ) => ( dispatch ) => {
+	const { siteId } = response;
+	const message = response.meta?.dataLayer?.error?.message;
+	const recorded = getOrCreatePollDeadline( siteId );
+	dispatch( automatedTransferStatusFetchingFailure( { siteId, error: message } ) );
+
+	if ( response.singleCheck ) {
+		pollDeadlines.delete( siteId );
+		return;
+	}
+
+	// The reducer maps a missing record to the terminal NONE status, so once the retries run
+	// out the chain must end there — letting the deadline fire would replace a real "this site
+	// has no transfer" answer with a timeout.
+	if ( message === NO_TRANSFER_RECORD_ERROR ) {
+		const missingRecordAttempts = ( recorded.missingRecordAttempts ?? 0 ) + 1;
+		if ( missingRecordAttempts >= MISSING_RECORD_ATTEMPTS ) {
+			pollDeadlines.delete( siteId );
+			return;
+		}
+
+		pollDeadlines.set( siteId, { ...recorded, missingRecordAttempts } );
+		setTimeout( dispatch, POLL_INTERVAL_MS, fetchAutomatedTransferStatus( siteId ) );
+		return;
+	}
+
+	if ( Date.now() < recorded.deadline ) {
+		setTimeout( dispatch, POLL_INTERVAL_MS, fetchAutomatedTransferStatus( siteId ) );
+		return;
+	}
+
+	pollDeadlines.set( siteId, { ...recorded, hasTimedOut: true } );
+	dispatch( setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT ) );
 };
 
 registerHandlers( 'state/data-layer/wpcom/sites/automated-transfer/status/index.js', {

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -45,14 +45,13 @@ const getOrCreatePollDeadline = ( siteId ) => {
 export const requestStatus = ( action ) => {
 	// A single recovery check must not touch the deadline state: a regular chain may be
 	// running for the same site, and deleting or reviving its entry would either kill its
-	// timeout or let it mint a fresh five-minute window.
-	if ( ! action.singleCheck ) {
-		if ( action.resetPolling ) {
-			pollDeadlines.delete( action.siteId );
-		}
-		const recorded = getOrCreatePollDeadline( action.siteId );
-		if ( action.retryOnFailure && ! recorded.retryOnFailure ) {
-			pollDeadlines.set( action.siteId, { ...recorded, retryOnFailure: true } );
+	// timeout or let it mint a fresh five-minute window. Only an explicit new wait
+	// (resetPolling + retryOnFailure) mints an entry: plain fetches would orphan one, and a
+	// chain re-dispatch minting one could resurrect a wait that has already settled.
+	if ( ! action.singleCheck && action.resetPolling ) {
+		pollDeadlines.delete( action.siteId );
+		if ( action.retryOnFailure ) {
+			getOrCreatePollDeadline( action.siteId );
 		}
 	}
 	return http(
@@ -66,7 +65,10 @@ export const requestStatus = ( action ) => {
 };
 
 export const receiveStatus =
-	( { siteId, singleCheck }, { status, uploaded_plugin_slug, transfer_id: transferId } ) =>
+	(
+		{ siteId, singleCheck, retryOnFailure },
+		{ status, uploaded_plugin_slug, transfer_id: transferId }
+	) =>
 	( dispatch ) => {
 		const pluginId = uploaded_plugin_slug;
 		const isSettled = transferSettledStates.includes( status );
@@ -90,13 +92,19 @@ export const receiveStatus =
 			pollDeadlines.delete( siteId );
 		} else {
 			const deadline = recorded?.deadline ?? Date.now() + TRANSFER_STATUS_POLL_DEADLINE_MS;
-			const retryOnFailure = recorded?.retryOnFailure;
 
 			if ( Date.now() < deadline ) {
-				pollDeadlines.set( siteId, { transferId, deadline, retryOnFailure } );
-				setTimeout( dispatch, POLL_INTERVAL_MS, fetchAutomatedTransferStatus( siteId ) );
+				pollDeadlines.set( siteId, { transferId, deadline } );
+				// The retry policy belongs to the wait, so it travels on the polling chain's own
+				// actions rather than on the shared deadline entry — a concurrent fetch from
+				// another surface must not inherit it, and a transfer_id change must not drop it.
+				setTimeout(
+					dispatch,
+					POLL_INTERVAL_MS,
+					fetchAutomatedTransferStatus( siteId, { retryOnFailure } )
+				);
 			} else {
-				pollDeadlines.set( siteId, { transferId, deadline, retryOnFailure, hasTimedOut: true } );
+				pollDeadlines.set( siteId, { transferId, deadline, hasTimedOut: true } );
 				dispatch( setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, pluginId ) );
 			}
 		}
@@ -108,21 +116,27 @@ export const receiveStatus =
 	};
 
 export const requestingStatusFailure = ( response ) => ( dispatch ) => {
-	const { siteId } = response;
+	const { siteId, singleCheck, retryOnFailure } = response;
 	const message = response.meta?.dataLayer?.error?.message;
 	dispatch( automatedTransferStatusFetchingFailure( { siteId, error: message } ) );
 
-	if ( response.singleCheck ) {
+	// Retrying failures — and eventually reporting CLIENT_TIMEOUT — is behavior only waits
+	// that asked for it (on this very action) should get. Other dispatchers expect a failed
+	// request to fail once and stop, exactly as it did before the retry logic existed — and
+	// they must not leave any deadline state behind for a later wait to inherit.
+	if ( singleCheck || ! retryOnFailure ) {
 		return;
 	}
 
-	// Retrying failures — and eventually reporting CLIENT_TIMEOUT — is behavior only waits
-	// that asked for it should get. Other dispatchers of this action expect a failed request
-	// to fail once and stop, exactly as it did before the retry logic existed.
+	// No entry means the wait has ended (a settled response deletes it) or never started.
+	// A stale failure must not resurrect it — the retry flag on the action alone is not
+	// proof the wait is still alive.
 	const recorded = pollDeadlines.get( siteId );
-	if ( ! recorded?.retryOnFailure ) {
+	if ( ! recorded ) {
 		return;
 	}
+
+	const retryFetch = fetchAutomatedTransferStatus( siteId, { retryOnFailure: true } );
 
 	// The reducer maps a missing record to the terminal NONE status, so once the retries run
 	// out the chain must end there — letting the deadline fire would replace a real "this site
@@ -135,12 +149,12 @@ export const requestingStatusFailure = ( response ) => ( dispatch ) => {
 		}
 
 		pollDeadlines.set( siteId, { ...recorded, missingRecordAttempts } );
-		setTimeout( dispatch, POLL_INTERVAL_MS, fetchAutomatedTransferStatus( siteId ) );
+		setTimeout( dispatch, POLL_INTERVAL_MS, retryFetch );
 		return;
 	}
 
 	if ( Date.now() < recorded.deadline ) {
-		setTimeout( dispatch, POLL_INTERVAL_MS, fetchAutomatedTransferStatus( siteId ) );
+		setTimeout( dispatch, POLL_INTERVAL_MS, retryFetch );
 		return;
 	}
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -43,10 +43,18 @@ const getOrCreatePollDeadline = ( siteId ) => {
 };
 
 export const requestStatus = ( action ) => {
-	if ( action.resetPolling ) {
-		pollDeadlines.delete( action.siteId );
+	// A single recovery check must not touch the deadline state: a regular chain may be
+	// running for the same site, and deleting or reviving its entry would either kill its
+	// timeout or let it mint a fresh five-minute window.
+	if ( ! action.singleCheck ) {
+		if ( action.resetPolling ) {
+			pollDeadlines.delete( action.siteId );
+		}
+		const recorded = getOrCreatePollDeadline( action.siteId );
+		if ( action.retryOnFailure && ! recorded.retryOnFailure ) {
+			pollDeadlines.set( action.siteId, { ...recorded, retryOnFailure: true } );
+		}
 	}
-	getOrCreatePollDeadline( action.siteId );
 	return http(
 		{
 			method: 'GET',
@@ -76,18 +84,19 @@ export const receiveStatus =
 
 		dispatch( setAutomatedTransferStatus( siteId, status, pluginId ) );
 
-		if ( isSettled ) {
-			pollDeadlines.delete( siteId );
-		} else if ( singleCheck ) {
+		if ( singleCheck ) {
+			// Inert with respect to the deadline state, and no polling chain of its own.
+		} else if ( isSettled ) {
 			pollDeadlines.delete( siteId );
 		} else {
 			const deadline = recorded?.deadline ?? Date.now() + TRANSFER_STATUS_POLL_DEADLINE_MS;
+			const retryOnFailure = recorded?.retryOnFailure;
 
 			if ( Date.now() < deadline ) {
-				pollDeadlines.set( siteId, { transferId, deadline } );
+				pollDeadlines.set( siteId, { transferId, deadline, retryOnFailure } );
 				setTimeout( dispatch, POLL_INTERVAL_MS, fetchAutomatedTransferStatus( siteId ) );
 			} else {
-				pollDeadlines.set( siteId, { transferId, deadline, hasTimedOut: true } );
+				pollDeadlines.set( siteId, { transferId, deadline, retryOnFailure, hasTimedOut: true } );
 				dispatch( setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, pluginId ) );
 			}
 		}
@@ -101,11 +110,17 @@ export const receiveStatus =
 export const requestingStatusFailure = ( response ) => ( dispatch ) => {
 	const { siteId } = response;
 	const message = response.meta?.dataLayer?.error?.message;
-	const recorded = getOrCreatePollDeadline( siteId );
 	dispatch( automatedTransferStatusFetchingFailure( { siteId, error: message } ) );
 
 	if ( response.singleCheck ) {
-		pollDeadlines.delete( siteId );
+		return;
+	}
+
+	// Retrying failures — and eventually reporting CLIENT_TIMEOUT — is behavior only waits
+	// that asked for it should get. Other dispatchers of this action expect a failed request
+	// to fail once and stop, exactly as it did before the retry logic existed.
+	const recorded = pollDeadlines.get( siteId );
+	if ( ! recorded?.retryOnFailure ) {
 		return;
 	}
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -64,12 +64,12 @@ describe( 'requestStatus', () => {
 	test( 'should restart the polling deadline when requested', () => {
 		const start = 1000000;
 		jest.setSystemTime( start );
-		requestStatus( { siteId, retryOnFailure: true } );
+		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
 		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
 
 		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
 		const dispatch = jest.fn();
-		requestingStatusFailure( { siteId } )( dispatch );
+		requestingStatusFailure( { siteId, retryOnFailure: true } )( dispatch );
 
 		expect( dispatch ).not.toHaveBeenCalledWith(
 			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
@@ -87,9 +87,10 @@ describe( 'requestingStatusFailure', () => {
 	test( 'should retry failed requests at the polling cadence when the wait opted in', () => {
 		const response = {
 			siteId,
+			retryOnFailure: true,
 			meta: { dataLayer: { error: { message: 'Service unavailable' } } },
 		};
-		requestStatus( { siteId, retryOnFailure: true } );
+		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
 		const dispatch = jest.fn();
 
 		requestingStatusFailure( response )( dispatch );
@@ -101,7 +102,9 @@ describe( 'requestingStatusFailure', () => {
 				error: 'Service unavailable',
 			} )
 		);
-		expect( dispatch ).toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
+		expect( dispatch ).toHaveBeenCalledWith(
+			fetchAutomatedTransferStatus( siteId, { retryOnFailure: true } )
+		);
 	} );
 
 	test( 'should not retry or time out a failure when the wait did not opt in', () => {
@@ -129,11 +132,11 @@ describe( 'requestingStatusFailure', () => {
 	test( 'should time out repeated request failures against the original request', () => {
 		const start = 1000000;
 		jest.setSystemTime( start );
-		requestStatus( { siteId, retryOnFailure: true } );
+		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
 		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
 		const dispatch = jest.fn();
 
-		requestingStatusFailure( { siteId } )( dispatch );
+		requestingStatusFailure( { siteId, retryOnFailure: true } )( dispatch );
 
 		expect( dispatch ).toHaveBeenLastCalledWith(
 			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
@@ -143,9 +146,10 @@ describe( 'requestingStatusFailure', () => {
 	test( 'should stop retrying a missing transfer record after a few attempts', () => {
 		const response = {
 			siteId,
+			retryOnFailure: true,
 			meta: { dataLayer: { error: { message: NO_TRANSFER_RECORD_ERROR } } },
 		};
-		requestStatus( { siteId, retryOnFailure: true } );
+		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
 		const dispatch = jest.fn();
 
 		for ( let attempt = 0; attempt < MISSING_RECORD_ATTEMPTS; attempt++ ) {
@@ -157,6 +161,7 @@ describe( 'requestingStatusFailure', () => {
 			( [ action ] ) => action?.type === fetchAutomatedTransferStatus( siteId ).type
 		);
 		expect( retries ).toHaveLength( MISSING_RECORD_ATTEMPTS - 1 );
+		retries.forEach( ( [ action ] ) => expect( action.retryOnFailure ).toBe( true ) );
 		expect( dispatch ).not.toHaveBeenCalledWith(
 			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
 		);
@@ -165,16 +170,76 @@ describe( 'requestingStatusFailure', () => {
 	test( 'should not turn a missing transfer record into a client timeout at the deadline', () => {
 		const start = 1000000;
 		jest.setSystemTime( start );
-		requestStatus( { siteId, retryOnFailure: true } );
+		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
 		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
 		const dispatch = jest.fn();
 
 		requestingStatusFailure( {
 			siteId,
+			retryOnFailure: true,
 			meta: { dataLayer: { error: { message: NO_TRANSFER_RECORD_ERROR } } },
 		} )( dispatch );
 
 		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
+		);
+	} );
+
+	test( 'should not leave deadline state behind after a fail-once request', () => {
+		const start = 1000000;
+		jest.setSystemTime( start );
+		requestStatus( { siteId } );
+		const dispatch = jest.fn();
+		requestingStatusFailure( {
+			siteId,
+			meta: { dataLayer: { error: { message: 'Service unavailable' } } },
+		} )( dispatch );
+
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS + 60000 );
+		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
+		const waitDispatch = jest.fn();
+		receiveStatus( { siteId, retryOnFailure: true }, IN_PROGRESS_RESPONSE )( waitDispatch );
+
+		expect( waitDispatch ).not.toHaveBeenCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
+		);
+		expect( waitDispatch ).toHaveBeenCalledWith(
+			setAutomatedTransferStatus( siteId, 'uploading', 'hello-dolly' )
+		);
+	} );
+
+	test( 'should not let a concurrent wait opt other dispatchers into retries', () => {
+		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
+		const dispatch = jest.fn();
+
+		requestingStatusFailure( {
+			siteId,
+			meta: { dataLayer: { error: { message: 'Service unavailable' } } },
+		} )( dispatch );
+		jest.runAllTimers();
+
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { type: fetchAutomatedTransferStatus( siteId ).type } )
+		);
+	} );
+
+	test( 'should not let a stale failure resurrect a wait that has settled', () => {
+		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
+		const dispatch = jest.fn();
+		receiveStatus( { siteId, retryOnFailure: true }, settledResponse( 'complete' ) )( dispatch );
+
+		const staleDispatch = jest.fn();
+		requestingStatusFailure( {
+			siteId,
+			retryOnFailure: true,
+			meta: { dataLayer: { error: { message: 'Service unavailable' } } },
+		} )( staleDispatch );
+		jest.runAllTimers();
+
+		expect( staleDispatch ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { type: fetchAutomatedTransferStatus( siteId ).type } )
+		);
+		expect( staleDispatch ).not.toHaveBeenCalledWith(
 			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
 		);
 	} );
@@ -253,6 +318,23 @@ describe( 'receiveStatus', () => {
 		expect( dispatch ).toHaveBeenLastCalledWith(
 			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
 		);
+	} );
+
+	test( 'should keep the retry opt-in when the transfer record changes mid-wait', () => {
+		const dispatch = jest.fn();
+
+		receiveStatus( { siteId, retryOnFailure: true }, IN_PROGRESS_RESPONSE )( dispatch );
+		receiveStatus(
+			{ siteId, retryOnFailure: true },
+			{ ...IN_PROGRESS_RESPONSE, transfer_id: 2 }
+		)( dispatch );
+		jest.runAllTimers();
+
+		const scheduled = dispatch.mock.calls.filter(
+			( [ action ] ) => action?.type === fetchAutomatedTransferStatus( siteId ).type
+		);
+		expect( scheduled.length ).toBeGreaterThan( 0 );
+		scheduled.forEach( ( [ action ] ) => expect( action.retryOnFailure ).toBe( true ) );
 	} );
 
 	test( 'should keep polling until the deadline arrives', () => {

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -64,10 +64,10 @@ describe( 'requestStatus', () => {
 	test( 'should restart the polling deadline when requested', () => {
 		const start = 1000000;
 		jest.setSystemTime( start );
-		requestStatus( { siteId } );
+		requestStatus( { siteId, retryOnFailure: true } );
 		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
 
-		requestStatus( { siteId, resetPolling: true } );
+		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
 		const dispatch = jest.fn();
 		requestingStatusFailure( { siteId } )( dispatch );
 
@@ -84,12 +84,12 @@ describe( 'requestingStatusFailure', () => {
 	} );
 	afterEach( () => jest.useRealTimers() );
 
-	test( 'should retry failed requests at the polling cadence', () => {
+	test( 'should retry failed requests at the polling cadence when the wait opted in', () => {
 		const response = {
 			siteId,
 			meta: { dataLayer: { error: { message: 'Service unavailable' } } },
 		};
-		requestStatus( { siteId } );
+		requestStatus( { siteId, retryOnFailure: true } );
 		const dispatch = jest.fn();
 
 		requestingStatusFailure( response )( dispatch );
@@ -104,10 +104,32 @@ describe( 'requestingStatusFailure', () => {
 		expect( dispatch ).toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
 	} );
 
-	test( 'should time out repeated request failures against the original request', () => {
+	test( 'should not retry or time out a failure when the wait did not opt in', () => {
 		const start = 1000000;
 		jest.setSystemTime( start );
 		requestStatus( { siteId } );
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
+		const dispatch = jest.fn();
+
+		requestingStatusFailure( {
+			siteId,
+			meta: { dataLayer: { error: { message: 'Service unavailable' } } },
+		} )( dispatch );
+		jest.runAllTimers();
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			automatedTransferStatusFetchingFailure( { siteId, error: 'Service unavailable' } )
+		);
+		expect( dispatch ).not.toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
+		);
+	} );
+
+	test( 'should time out repeated request failures against the original request', () => {
+		const start = 1000000;
+		jest.setSystemTime( start );
+		requestStatus( { siteId, retryOnFailure: true } );
 		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
 		const dispatch = jest.fn();
 
@@ -123,7 +145,7 @@ describe( 'requestingStatusFailure', () => {
 			siteId,
 			meta: { dataLayer: { error: { message: NO_TRANSFER_RECORD_ERROR } } },
 		};
-		requestStatus( { siteId } );
+		requestStatus( { siteId, retryOnFailure: true } );
 		const dispatch = jest.fn();
 
 		for ( let attempt = 0; attempt < MISSING_RECORD_ATTEMPTS; attempt++ ) {
@@ -143,7 +165,7 @@ describe( 'requestingStatusFailure', () => {
 	test( 'should not turn a missing transfer record into a client timeout at the deadline', () => {
 		const start = 1000000;
 		jest.setSystemTime( start );
-		requestStatus( { siteId } );
+		requestStatus( { siteId, retryOnFailure: true } );
 		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
 		const dispatch = jest.fn();
 
@@ -212,6 +234,25 @@ describe( 'receiveStatus', () => {
 		jest.runAllTimers();
 
 		expect( dispatch ).not.toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
+	} );
+
+	test( 'should not let a single recovery check clobber a running chain deadline', () => {
+		const start = 1000000;
+		jest.setSystemTime( start );
+		const dispatch = jest.fn();
+
+		requestStatus( { siteId } );
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS - 1000 );
+		receiveStatus( { siteId, singleCheck: true }, IN_PROGRESS_RESPONSE )( dispatch );
+
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
+		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
+
+		expect( dispatch ).toHaveBeenLastCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
+		);
 	} );
 
 	test( 'should keep polling until the deadline arrives', () => {

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -1,14 +1,20 @@
 import { SITE_REQUEST } from 'calypso/state/action-types';
 import {
+	automatedTransferStatusFetchingFailure,
 	fetchAutomatedTransferStatus,
 	setAutomatedTransferStatus,
 } from 'calypso/state/automated-transfer/actions';
-import { transferStates } from 'calypso/state/automated-transfer/constants';
+import {
+	NO_TRANSFER_RECORD_ERROR,
+	transferStates,
+} from 'calypso/state/automated-transfer/constants';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import {
 	requestStatus,
 	receiveStatus,
+	requestingStatusFailure,
 	clearPollDeadlines,
+	MISSING_RECORD_ATTEMPTS,
 	TRANSFER_STATUS_POLL_DEADLINE_MS,
 } from '../';
 
@@ -36,6 +42,12 @@ const settledResponse = ( status ) => ( {
 } );
 
 describe( 'requestStatus', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		clearPollDeadlines();
+	} );
+	afterEach( () => jest.useRealTimers() );
+
 	test( 'should dispatch an http request', () => {
 		expect( requestStatus( { siteId } ) ).toEqual(
 			http(
@@ -47,6 +59,112 @@ describe( 'requestStatus', () => {
 				{ siteId }
 			)
 		);
+	} );
+
+	test( 'should restart the polling deadline when requested', () => {
+		const start = 1000000;
+		jest.setSystemTime( start );
+		requestStatus( { siteId } );
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
+
+		requestStatus( { siteId, resetPolling: true } );
+		const dispatch = jest.fn();
+		requestingStatusFailure( { siteId } )( dispatch );
+
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
+		);
+	} );
+} );
+
+describe( 'requestingStatusFailure', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		clearPollDeadlines();
+	} );
+	afterEach( () => jest.useRealTimers() );
+
+	test( 'should retry failed requests at the polling cadence', () => {
+		const response = {
+			siteId,
+			meta: { dataLayer: { error: { message: 'Service unavailable' } } },
+		};
+		requestStatus( { siteId } );
+		const dispatch = jest.fn();
+
+		requestingStatusFailure( response )( dispatch );
+		jest.runAllTimers();
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			automatedTransferStatusFetchingFailure( {
+				siteId,
+				error: 'Service unavailable',
+			} )
+		);
+		expect( dispatch ).toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
+	} );
+
+	test( 'should time out repeated request failures against the original request', () => {
+		const start = 1000000;
+		jest.setSystemTime( start );
+		requestStatus( { siteId } );
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
+		const dispatch = jest.fn();
+
+		requestingStatusFailure( { siteId } )( dispatch );
+
+		expect( dispatch ).toHaveBeenLastCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
+		);
+	} );
+
+	test( 'should stop retrying a missing transfer record after a few attempts', () => {
+		const response = {
+			siteId,
+			meta: { dataLayer: { error: { message: NO_TRANSFER_RECORD_ERROR } } },
+		};
+		requestStatus( { siteId } );
+		const dispatch = jest.fn();
+
+		for ( let attempt = 0; attempt < MISSING_RECORD_ATTEMPTS; attempt++ ) {
+			requestingStatusFailure( response )( dispatch );
+			jest.runAllTimers();
+		}
+
+		const retries = dispatch.mock.calls.filter(
+			( [ action ] ) => action?.type === fetchAutomatedTransferStatus( siteId ).type
+		);
+		expect( retries ).toHaveLength( MISSING_RECORD_ATTEMPTS - 1 );
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
+		);
+	} );
+
+	test( 'should not turn a missing transfer record into a client timeout at the deadline', () => {
+		const start = 1000000;
+		jest.setSystemTime( start );
+		requestStatus( { siteId } );
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
+		const dispatch = jest.fn();
+
+		requestingStatusFailure( {
+			siteId,
+			meta: { dataLayer: { error: { message: NO_TRANSFER_RECORD_ERROR } } },
+		} )( dispatch );
+
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
+		);
+	} );
+
+	test( 'should not retry a failed single recovery check', () => {
+		requestStatus( { siteId, singleCheck: true } );
+		const dispatch = jest.fn();
+
+		requestingStatusFailure( { siteId, singleCheck: true } )( dispatch );
+		jest.runAllTimers();
+
+		expect( dispatch ).not.toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
 	} );
 } );
 
@@ -86,6 +204,14 @@ describe( 'receiveStatus', () => {
 
 		expect( dispatch ).toHaveBeenCalledTimes( 2 );
 		expect( dispatch ).toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
+	} );
+
+	test( 'should not open a polling chain for a single recovery check', () => {
+		const dispatch = jest.fn();
+		receiveStatus( { siteId, singleCheck: true }, IN_PROGRESS_RESPONSE )( dispatch );
+		jest.runAllTimers();
+
+		expect( dispatch ).not.toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
 	} );
 
 	test( 'should keep polling until the deadline arrives', () => {

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -64,12 +64,12 @@ describe( 'requestStatus', () => {
 	test( 'should restart the polling deadline when requested', () => {
 		const start = 1000000;
 		jest.setSystemTime( start );
-		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
+		requestStatus( { siteId, pollingMode: 'start' } );
 		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
 
-		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
+		requestStatus( { siteId, pollingMode: 'start' } );
 		const dispatch = jest.fn();
-		requestingStatusFailure( { siteId, retryOnFailure: true } )( dispatch );
+		requestingStatusFailure( { siteId, pollingMode: 'start' } )( dispatch );
 
 		expect( dispatch ).not.toHaveBeenCalledWith(
 			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
@@ -87,10 +87,10 @@ describe( 'requestingStatusFailure', () => {
 	test( 'should retry failed requests at the polling cadence when the wait opted in', () => {
 		const response = {
 			siteId,
-			retryOnFailure: true,
+			pollingMode: 'start',
 			meta: { dataLayer: { error: { message: 'Service unavailable' } } },
 		};
-		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
+		requestStatus( { siteId, pollingMode: 'start' } );
 		const dispatch = jest.fn();
 
 		requestingStatusFailure( response )( dispatch );
@@ -102,9 +102,7 @@ describe( 'requestingStatusFailure', () => {
 				error: 'Service unavailable',
 			} )
 		);
-		expect( dispatch ).toHaveBeenCalledWith(
-			fetchAutomatedTransferStatus( siteId, { retryOnFailure: true } )
-		);
+		expect( dispatch ).toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId, 'continue' ) );
 	} );
 
 	test( 'should not retry or time out a failure when the wait did not opt in', () => {
@@ -132,11 +130,11 @@ describe( 'requestingStatusFailure', () => {
 	test( 'should time out repeated request failures against the original request', () => {
 		const start = 1000000;
 		jest.setSystemTime( start );
-		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
+		requestStatus( { siteId, pollingMode: 'start' } );
 		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
 		const dispatch = jest.fn();
 
-		requestingStatusFailure( { siteId, retryOnFailure: true } )( dispatch );
+		requestingStatusFailure( { siteId, pollingMode: 'start' } )( dispatch );
 
 		expect( dispatch ).toHaveBeenLastCalledWith(
 			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
@@ -146,10 +144,10 @@ describe( 'requestingStatusFailure', () => {
 	test( 'should stop retrying a missing transfer record after a few attempts', () => {
 		const response = {
 			siteId,
-			retryOnFailure: true,
+			pollingMode: 'start',
 			meta: { dataLayer: { error: { message: NO_TRANSFER_RECORD_ERROR } } },
 		};
-		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
+		requestStatus( { siteId, pollingMode: 'start' } );
 		const dispatch = jest.fn();
 
 		for ( let attempt = 0; attempt < MISSING_RECORD_ATTEMPTS; attempt++ ) {
@@ -161,7 +159,7 @@ describe( 'requestingStatusFailure', () => {
 			( [ action ] ) => action?.type === fetchAutomatedTransferStatus( siteId ).type
 		);
 		expect( retries ).toHaveLength( MISSING_RECORD_ATTEMPTS - 1 );
-		retries.forEach( ( [ action ] ) => expect( action.retryOnFailure ).toBe( true ) );
+		retries.forEach( ( [ action ] ) => expect( action.pollingMode ).toBe( 'continue' ) );
 		expect( dispatch ).not.toHaveBeenCalledWith(
 			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
 		);
@@ -170,13 +168,13 @@ describe( 'requestingStatusFailure', () => {
 	test( 'should not turn a missing transfer record into a client timeout at the deadline', () => {
 		const start = 1000000;
 		jest.setSystemTime( start );
-		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
+		requestStatus( { siteId, pollingMode: 'start' } );
 		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
 		const dispatch = jest.fn();
 
 		requestingStatusFailure( {
 			siteId,
-			retryOnFailure: true,
+			pollingMode: 'start',
 			meta: { dataLayer: { error: { message: NO_TRANSFER_RECORD_ERROR } } },
 		} )( dispatch );
 
@@ -196,9 +194,9 @@ describe( 'requestingStatusFailure', () => {
 		} )( dispatch );
 
 		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS + 60000 );
-		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
+		requestStatus( { siteId, pollingMode: 'start' } );
 		const waitDispatch = jest.fn();
-		receiveStatus( { siteId, retryOnFailure: true }, IN_PROGRESS_RESPONSE )( waitDispatch );
+		receiveStatus( { siteId, pollingMode: 'start' }, IN_PROGRESS_RESPONSE )( waitDispatch );
 
 		expect( waitDispatch ).not.toHaveBeenCalledWith(
 			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT, 'hello-dolly' )
@@ -209,7 +207,7 @@ describe( 'requestingStatusFailure', () => {
 	} );
 
 	test( 'should not let a concurrent wait opt other dispatchers into retries', () => {
-		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
+		requestStatus( { siteId, pollingMode: 'start' } );
 		const dispatch = jest.fn();
 
 		requestingStatusFailure( {
@@ -224,14 +222,14 @@ describe( 'requestingStatusFailure', () => {
 	} );
 
 	test( 'should not let a stale failure resurrect a wait that has settled', () => {
-		requestStatus( { siteId, resetPolling: true, retryOnFailure: true } );
+		requestStatus( { siteId, pollingMode: 'start' } );
 		const dispatch = jest.fn();
-		receiveStatus( { siteId, retryOnFailure: true }, settledResponse( 'complete' ) )( dispatch );
+		receiveStatus( { siteId, pollingMode: 'continue' }, settledResponse( 'complete' ) )( dispatch );
 
 		const staleDispatch = jest.fn();
 		requestingStatusFailure( {
 			siteId,
-			retryOnFailure: true,
+			pollingMode: 'start',
 			meta: { dataLayer: { error: { message: 'Service unavailable' } } },
 		} )( staleDispatch );
 		jest.runAllTimers();
@@ -245,10 +243,10 @@ describe( 'requestingStatusFailure', () => {
 	} );
 
 	test( 'should not retry a failed single recovery check', () => {
-		requestStatus( { siteId, singleCheck: true } );
+		requestStatus( { siteId, pollingMode: 'single' } );
 		const dispatch = jest.fn();
 
-		requestingStatusFailure( { siteId, singleCheck: true } )( dispatch );
+		requestingStatusFailure( { siteId, pollingMode: 'single' } )( dispatch );
 		jest.runAllTimers();
 
 		expect( dispatch ).not.toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
@@ -295,7 +293,7 @@ describe( 'receiveStatus', () => {
 
 	test( 'should not open a polling chain for a single recovery check', () => {
 		const dispatch = jest.fn();
-		receiveStatus( { siteId, singleCheck: true }, IN_PROGRESS_RESPONSE )( dispatch );
+		receiveStatus( { siteId, pollingMode: 'single' }, IN_PROGRESS_RESPONSE )( dispatch );
 		jest.runAllTimers();
 
 		expect( dispatch ).not.toHaveBeenCalledWith( fetchAutomatedTransferStatus( siteId ) );
@@ -310,7 +308,7 @@ describe( 'receiveStatus', () => {
 		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
 
 		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS - 1000 );
-		receiveStatus( { siteId, singleCheck: true }, IN_PROGRESS_RESPONSE )( dispatch );
+		receiveStatus( { siteId, pollingMode: 'single' }, IN_PROGRESS_RESPONSE )( dispatch );
 
 		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
 		receiveStatus( { siteId }, IN_PROGRESS_RESPONSE )( dispatch );
@@ -320,12 +318,12 @@ describe( 'receiveStatus', () => {
 		);
 	} );
 
-	test( 'should keep the retry opt-in when the transfer record changes mid-wait', () => {
+	test( 'should keep the wait polling mode when the transfer record changes mid-wait', () => {
 		const dispatch = jest.fn();
 
-		receiveStatus( { siteId, retryOnFailure: true }, IN_PROGRESS_RESPONSE )( dispatch );
+		receiveStatus( { siteId, pollingMode: 'start' }, IN_PROGRESS_RESPONSE )( dispatch );
 		receiveStatus(
-			{ siteId, retryOnFailure: true },
+			{ siteId, pollingMode: 'continue' },
 			{ ...IN_PROGRESS_RESPONSE, transfer_id: 2 }
 		)( dispatch );
 		jest.runAllTimers();
@@ -334,7 +332,7 @@ describe( 'receiveStatus', () => {
 			( [ action ] ) => action?.type === fetchAutomatedTransferStatus( siteId ).type
 		);
 		expect( scheduled.length ).toBeGreaterThan( 0 );
-		scheduled.forEach( ( [ action ] ) => expect( action.retryOnFailure ).toBe( true ) );
+		scheduled.forEach( ( [ action ] ) => expect( action.pollingMode ).toBe( 'continue' ) );
 	} );
 
 	test( 'should keep polling until the deadline arrives', () => {

--- a/client/state/themes/actions/request-theme.js
+++ b/client/state/themes/actions/request-theme.js
@@ -19,8 +19,8 @@ import 'calypso/state/themes/init';
 /**
  * Triggers a network request to fetch a specific theme from a site.
  * @param  {string}   themeId Theme ID
- * @param  {number}   siteId  Site ID
- * @param  {string}   locale  Locale slug
+ * @param  {number|'wpcom'|'wporg'}   siteId  Site ID, or a theme source
+ * @param  {string}   [locale]  Locale slug
  * @returns {Function}         Action thunk
  */
 export function requestTheme( themeId, siteId, locale ) {


### PR DESCRIPTION
Fixes DOTCOM-17963

## Proposed Changes

Buying a plugin or theme lands you on a thank-you page that waits for the Atomic transfer and the install to finish. That wait had no exit: a failed transfer kept the page refetching the status every two seconds forever, and the plugin check was an uncapped self-calling loop. People just stared at a progress bar until they gave up.

Now the page gets one five-minute budget, stored in `sessionStorage` so reloading doesn't restart the clock:

* Polling runs on fixed intervals owned by the data layer, with in-flight guards. Once the budget expires, it drops to a 30-second background check.
* When the budget runs out — or the transfer genuinely failed — the spinner is replaced by a clear error with a **Check again** button that restarts the whole wait, including the theme and purchase data the query hooks only fetch once per mount.
* The page only acts on statuses it observed itself. The endpoint returns the site's *latest* transfer, which right after a purchase can still be the previous one — so a settled failure is confirmed a few times before it's shown.
* Failure retries and the client-side timeout are opt-in per fetch (`pollingMode` on the action); every other screen that requests transfer status behaves exactly as before.
* A `calypso_marketplace_thank_you_wait_ended` Tracks event records how each wait ended (error kind, transfer status, seconds waited).

## Why are these changes being made?

The marketplace thank-you page is the most common surface where users sit through an Atomic transfer, and it offered no way out when the transfer failed or stalled. Every wait needs a deadline, a truthful outcome, a recovery path, and telemetry.

## Testing Instructions

1. Buy a marketplace plugin on a Simple site — the transfer progresses through the steps and ends on the thank-you content.
2. Block `/automated-transfers/status` in DevTools: after 5 minutes the timeout notice appears with **Check again**; clicking it restarts the wait. Reloading mid-wait keeps the clock running.
3. Mock the status response to `error`: the failure notice appears instead of an endless spinner.
4. `yarn test-client client/my-sites/checkout/checkout-thank-you/marketplace client/state/automated-transfer client/state/data-layer/wpcom/sites/automated-transfer`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
