### PR TITLE
FORNO-451: Add Redo for inline text edits

### DIFF
--- a/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
+++ b/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment node
+ */
+
+const path = require( 'path' );
+const postcss = require( 'postcss' );
+const sass = require( 'sass' );
+
+describe( 'Resolved edit action CSS contract', () => {
+	it( 'keeps icon paths on the surrounding action color', () => {
+		const stylesheet = path.resolve(
+			__dirname,
+			'../../../packages/agents-manager/src/components/agent-dock/style.scss'
+		);
+		const css = postcss.parse(
+			sass.compile( stylesheet, {
+				loadPaths: [ path.resolve( __dirname, '../../../node_modules' ) ],
+			} ).css
+		);
+		const selector = /\.agents-manager-resolved-edit-action__icon path$/;
+		const declarations = new Map();
+
+		css.walkRules( selector, ( rule ) => {
+			rule.walkDecls( ( declaration ) => {
+				declarations.set( declaration.prop, declaration.value );
+			} );
+		} );
+
+		expect( declarations.get( 'color' ) ).toBe( 'inherit' );
+		expect( declarations.get( 'fill' ) ).toBe( 'currentColor' );
+	} );
+} );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -1484,7 +1484,7 @@ describe( 'OrchestratorChat', () => {
 		);
 	} );
 
-	it( 'updates the checkpoint status after native Undo and exact native Redo', () => {
+	it( 'updates the checkpoint status when native Undo and Redo stores notify separately', () => {
 		const checkpointMessage = createCheckpointMessage(
 			'agent-native-undo',
 			'native-undo-checkpoint'
@@ -1519,8 +1519,15 @@ describe( 'OrchestratorChat', () => {
 		);
 
 		act( () => {
-			canSwapCheckpoint = false;
 			mockHasEditorRedo = true;
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe(
+			'Updated and Undo'
+		);
+
+		act( () => {
+			canSwapCheckpoint = false;
 			mockEditorBlocks = [ { clientId: 'native-undo-block' } ];
 			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
 		} );
@@ -1534,8 +1541,13 @@ describe( 'OrchestratorChat', () => {
 		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith( 'native-undo-checkpoint' );
 
 		act( () => {
-			canSwapCheckpoint = true;
 			mockHasEditorRedo = false;
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Reverted' );
+
+		act( () => {
+			canSwapCheckpoint = true;
 			mockEditorBlocks = [ { clientId: 'native-redo-block' } ];
 			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
 		} );
@@ -1547,6 +1559,152 @@ describe( 'OrchestratorChat', () => {
 			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
 		).not.toHaveProperty( 'onRedo' );
 		expect( mockInvalidateCheckpointAction ).toHaveBeenLastCalledWith( 'native-undo-checkpoint' );
+	} );
+
+	it( 'updates the checkpoint status when native Undo stores notify together', () => {
+		const checkpointMessage = createCheckpointMessage(
+			'agent-native-undo-combined',
+			'native-undo-combined-checkpoint'
+		);
+		let canSwapCheckpoint = true;
+		const checkpoint = {
+			getLastEditorState: jest.fn(),
+			setCheckpoint: jest.fn(),
+			addCheckpointKeys: jest.fn(),
+			restoreCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			canSwapCheckpoint: jest.fn( () => canSwapCheckpoint ),
+			swapCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			addNewPageToCheckpoint: jest.fn(),
+			addPageRenameToCheckpoint: jest.fn(),
+			addPageRemovalToCheckpoint: jest.fn(),
+			getLatestUserMessageId: jest.fn(),
+			clearCheckpoint: jest.fn(),
+			hasCheckpoint: jest.fn().mockReturnValue( true ),
+		};
+		const useCheckpoint = () => checkpoint;
+		mockCheckpointActions();
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, checkpointMessage ] } )
+		);
+		render( chat( { useCheckpoint } ) );
+
+		act( () => {
+			mockHasEditorRedo = true;
+			canSwapCheckpoint = false;
+			mockEditorBlocks = [ { clientId: 'native-undo-combined-block' } ];
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Reverted' );
+		expect( mockSetCheckpointActionReverted ).toHaveBeenCalledWith(
+			'native-undo-combined-checkpoint',
+			true
+		);
+	} );
+
+	it( 'keeps a source-drifted checkpoint Updated across later native history', () => {
+		const checkpointMessage = createCheckpointMessage(
+			'agent-source-drift-native-history',
+			'source-drift-native-history-checkpoint'
+		);
+		let canSwapCheckpoint = true;
+		const checkpoint = {
+			getLastEditorState: jest.fn(),
+			setCheckpoint: jest.fn(),
+			addCheckpointKeys: jest.fn(),
+			restoreCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			canSwapCheckpoint: jest.fn( () => canSwapCheckpoint ),
+			swapCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			addNewPageToCheckpoint: jest.fn(),
+			addPageRenameToCheckpoint: jest.fn(),
+			addPageRemovalToCheckpoint: jest.fn(),
+			getLatestUserMessageId: jest.fn(),
+			clearCheckpoint: jest.fn(),
+			hasCheckpoint: jest.fn().mockReturnValue( true ),
+		};
+		const useCheckpoint = () => checkpoint;
+		mockCheckpointActions();
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, checkpointMessage ] } )
+		);
+		const view = render( chat( { useCheckpoint } ) );
+
+		canSwapCheckpoint = false;
+		mockEditorBlocks = [ { clientId: 'manually-drifted-block' } ];
+		view.rerender( chat( { useCheckpoint } ) );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
+
+		mockHasEditorRedo = true;
+		view.rerender( chat( { useCheckpoint } ) );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
+
+		canSwapCheckpoint = true;
+		mockEditorBlocks = [ { clientId: 'restored-ai-state-block' } ];
+		view.rerender( chat( { useCheckpoint } ) );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
+
+		mockHasEditorRedo = false;
+		view.rerender( chat( { useCheckpoint } ) );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
+		expect( mockSetCheckpointActionReverted ).not.toHaveBeenCalledWith(
+			'source-drift-native-history-checkpoint',
+			true
+		);
+	} );
+
+	it( 'does not treat later source drift as a delayed native Undo', () => {
+		const checkpointMessage = createCheckpointMessage(
+			'agent-unrelated-native-history',
+			'unrelated-native-history-checkpoint'
+		);
+		let canSwapCheckpoint = true;
+		const checkpoint = {
+			getLastEditorState: jest.fn(),
+			setCheckpoint: jest.fn(),
+			addCheckpointKeys: jest.fn(),
+			restoreCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			canSwapCheckpoint: jest.fn( () => canSwapCheckpoint ),
+			swapCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			addNewPageToCheckpoint: jest.fn(),
+			addPageRenameToCheckpoint: jest.fn(),
+			addPageRemovalToCheckpoint: jest.fn(),
+			getLatestUserMessageId: jest.fn(),
+			clearCheckpoint: jest.fn(),
+			hasCheckpoint: jest.fn().mockReturnValue( true ),
+		};
+		const useCheckpoint = () => checkpoint;
+		mockCheckpointActions();
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, checkpointMessage ] } )
+		);
+		render( chat( { useCheckpoint } ) );
+
+		act( () => {
+			mockHasEditorRedo = true;
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe(
+			'Updated and Undo'
+		);
+
+		act( () => {
+			mockEditorBlocks = [ { clientId: 'unrelated-native-undo-block' } ];
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe(
+			'Updated and Undo'
+		);
+
+		act( () => {
+			canSwapCheckpoint = false;
+			mockEditorBlocks = [ { clientId: 'later-source-drift-block' } ];
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
+		expect( mockSetCheckpointActionReverted ).not.toHaveBeenCalledWith(
+			'unrelated-native-history-checkpoint',
+			true
+		);
 	} );
 
 	it( 'does not mark an unsupported checkpoint Reverted after native Undo', () => {
@@ -2004,6 +2162,104 @@ describe( 'OrchestratorChat', () => {
 		} >;
 		expect( regeneratedMessages[ 0 ].actions ).not.toEqual(
 			expect.arrayContaining( [ expect.objectContaining( { id: 'checkpoint' } ) ] )
+		);
+	} );
+
+	it( 'keeps a later-turn checkpoint action from a structured continuation result', async () => {
+		const firstCheckpoint = createCheckpointMessage(
+			'agent-first-structured-turn',
+			'first-structured-checkpoint'
+		);
+		const laterUserMessage = {
+			id: 'user-structured-continuation',
+			role: 'user',
+			content: [ { type: 'text', text: 'Make another edit' } ],
+			timestamp: 2,
+		};
+		const initialMessages = [ userMessage, firstCheckpoint, laterUserMessage ];
+		mockCheckpointActions();
+		mockUseAgentChat.mockReturnValue( agentChatReturn( { messages: initialMessages } ) );
+		const view = render( chat() );
+		const checkpointResult = JSON.stringify( {
+			tool_id: 'big_sky__apply_block_edits',
+			tool_call_id: 'tool-call-structured-continuation',
+			data: {
+				result: {
+					success: true,
+					outcome: 'updated',
+					changeType: 'text-content',
+				},
+			},
+		} );
+
+		await act( async () => {
+			await mockAgentChatConfig?.onTaskUpdate?.( {
+				id: 'task-structured-continuation',
+				status: {
+					state: 'working',
+					message: {
+						messageId: 'tool-result-structured-continuation',
+						role: 'agent',
+						kind: 'message',
+						parts: [
+							{
+								type: 'data',
+								data: {
+									toolCallId: 'tool-call-structured-continuation',
+									toolId: 'big_sky__apply_block_edits',
+									result: {
+										result: {
+											success: true,
+											outcome: 'updated',
+											changeType: 'text-content',
+										},
+										returnToAgent: true,
+										agentMessage: checkpointResult,
+									},
+								},
+							},
+						],
+					},
+				},
+				text: '',
+				final: false,
+				kind: 'status',
+			} );
+			await mockAgentChatConfig?.onTaskUpdate?.( {
+				id: 'task-structured-continuation',
+				status: {
+					state: 'completed',
+					message: {
+						messageId: 'agent-structured-final',
+						role: 'agent',
+						kind: 'message',
+						parts: [],
+					},
+				},
+				text: 'The paragraph has been updated again.',
+				final: true,
+				kind: 'status',
+			} );
+		} );
+
+		const finalMessage = {
+			id: 'agent-structured-final',
+			role: 'agent' as const,
+			content: [ { type: 'text' as const, text: 'The paragraph has been updated again.' } ],
+			timestamp: 3,
+			archived: false,
+			showIcon: true,
+		};
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ ...initialMessages, finalMessage ] } )
+		);
+		view.rerender( chat() );
+
+		expect( getDisplayedCheckpointAction( finalMessage.id ) ).toEqual(
+			expect.objectContaining( {
+				label: 'Updated and Undo',
+				componentProps: expect.objectContaining( { onUndo: expect.any( Function ) } ),
+			} )
 		);
 	} );
 

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -1736,10 +1736,26 @@ describe( 'OrchestratorChat', () => {
 		expect(
 			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
 		).not.toHaveProperty( 'onRedo' );
+		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith(
+			'unrelated-native-history-checkpoint'
+		);
 		expect( mockSetCheckpointActionReverted ).not.toHaveBeenCalledWith(
 			'unrelated-native-history-checkpoint',
 			true
 		);
+
+		act( () => {
+			canSwapCheckpoint = true;
+			mockEditorBlocks = [ { clientId: 'later-restored-ai-state-block' } ];
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onUndo' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onRedo' );
 	} );
 
 	it( 'does not mark an unsupported checkpoint Reverted after native Undo', () => {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -524,6 +524,18 @@ const getDisplayedCheckpointAction = ( messageId: string ) => {
 		?.actions?.find( ( action ) => action.id === 'checkpoint' );
 };
 
+const getDisplayedMessage = ( messageId: string ) => {
+	const messages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
+		disabled?: boolean;
+		id: string;
+	} >;
+	const message = messages.find( ( displayedMessage ) => displayedMessage.id === messageId );
+	if ( ! message ) {
+		throw new Error( `Expected message ${ messageId } to be displayed.` );
+	}
+	return message;
+};
+
 const countShowComponentMessages = () => {
 	const messages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
 		content?: Array< { text?: string } >;
@@ -1441,6 +1453,7 @@ describe( 'OrchestratorChat', () => {
 		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps ).toHaveProperty(
 			'onUndo'
 		);
+		expect( getDisplayedMessage( checkpointMessage.id ).disabled ).toBeUndefined();
 
 		const contextOnlyMessage = {
 			id: 'context-only',
@@ -1455,6 +1468,7 @@ describe( 'OrchestratorChat', () => {
 		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps ).toHaveProperty(
 			'onUndo'
 		);
+		expect( getDisplayedMessage( checkpointMessage.id ).disabled ).toBeUndefined();
 
 		const nextUserMessage = {
 			id: 'user-2',
@@ -1479,6 +1493,8 @@ describe( 'OrchestratorChat', () => {
 		expect(
 			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
 		).not.toHaveProperty( 'onRedo' );
+		expect( getDisplayedMessage( checkpointMessage.id ).disabled ).toBe( true );
+		expect( getDisplayedMessage( nextUserMessage.id ).disabled ).toBeUndefined();
 	} );
 
 	it( 'hides checkpoint controls in loaded conversation history', () => {
@@ -1652,6 +1668,7 @@ describe( 'OrchestratorChat', () => {
 		expect(
 			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
 		).not.toHaveProperty( 'onRedo' );
+		expect( getDisplayedMessage( checkpointMessage.id ).disabled ).toBeUndefined();
 		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith(
 			'pending-native-undo-checkpoint'
 		);
@@ -1823,6 +1840,7 @@ describe( 'OrchestratorChat', () => {
 		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith(
 			'unrelated-native-history-checkpoint'
 		);
+		expect( getDisplayedMessage( checkpointMessage.id ).disabled ).toBeUndefined();
 		expect( mockSetCheckpointActionReverted ).not.toHaveBeenCalledWith(
 			'unrelated-native-history-checkpoint',
 			true
@@ -2338,9 +2356,11 @@ describe( 'OrchestratorChat', () => {
 		expect( getDisplayedCheckpointAction( firstCheckpoint.id )?.componentProps ).not.toHaveProperty(
 			'onUndo'
 		);
+		expect( getDisplayedMessage( firstCheckpoint.id ).disabled ).toBe( true );
 		expect( getDisplayedCheckpointAction( secondCheckpoint.id )?.componentProps ).toHaveProperty(
 			'onUndo'
 		);
+		expect( getDisplayedMessage( secondCheckpoint.id ).disabled ).toBeUndefined();
 	} );
 
 	it( 'keeps streamed checkpoint actions through final prose and remounts', async () => {
@@ -2395,6 +2415,7 @@ describe( 'OrchestratorChat', () => {
 		expect( messages[ 0 ].actions ).toEqual( [
 			expect.objectContaining( { id: 'checkpoint', label: 'Updated and Undo' } ),
 		] );
+		expect( getDisplayedMessage( finalMessage.id ).disabled ).toBeUndefined();
 		view.unmount();
 
 		const remountedView = render( chat() );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -467,7 +467,11 @@ const createCheckpointMessage = (
 const getDisplayedCheckpointAction = ( messageId: string ) => {
 	const messages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
 		id: string;
-		actions?: Array< { id: string; componentProps?: Record< string, unknown > } >;
+		actions?: Array< {
+			id: string;
+			label?: string;
+			componentProps?: Record< string, unknown >;
+		} >;
 	} >;
 	return messages
 		.find( ( message ) => message.id === messageId )
@@ -1552,6 +1556,81 @@ describe( 'OrchestratorChat', () => {
 		expect(
 			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
 		).not.toHaveProperty( 'onUndo' );
+	} );
+
+	it( 'keeps checkpoint controls while Undo swaps the editor content', async () => {
+		const checkpointMessage = createCheckpointMessage(
+			'agent-checkpoint-swap',
+			'checkpoint-swap',
+			'text-content'
+		);
+		let canSwapCheckpoint = true;
+		let resolveSwap: ( () => void ) | undefined;
+		const checkpoint = {
+			getLastEditorState: jest.fn(),
+			setCheckpoint: jest.fn(),
+			addCheckpointKeys: jest.fn(),
+			restoreCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			canSwapCheckpoint: jest.fn( () => canSwapCheckpoint ),
+			swapCheckpoint: jest.fn(
+				() =>
+					new Promise< void >( ( resolve ) => {
+						canSwapCheckpoint = false;
+						mockEditorBlocks = [ { clientId: 'restored-block' } ];
+						mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+						resolveSwap = () => {
+							canSwapCheckpoint = true;
+							resolve();
+						};
+					} )
+			),
+			addNewPageToCheckpoint: jest.fn(),
+			addPageRenameToCheckpoint: jest.fn(),
+			addPageRemovalToCheckpoint: jest.fn(),
+			getLatestUserMessageId: jest.fn(),
+			clearCheckpoint: jest.fn(),
+			hasCheckpoint: jest.fn().mockReturnValue( true ),
+		};
+		const useCheckpoint = () => checkpoint;
+		const actualUseCheckpointAction = jest.requireActual(
+			'../../hooks/use-checkpoint-action'
+		).default;
+		mockUseCheckpointAction.mockImplementation( actualUseCheckpointAction );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, checkpointMessage ] } )
+		);
+		render( chat( { useCheckpoint } ) );
+
+		const onUndo = getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps?.onUndo;
+		if ( typeof onUndo !== 'function' ) {
+			throw new Error( 'Expected an Undo action.' );
+		}
+
+		let undoPromise!: Promise< boolean >;
+		act( () => {
+			undoPromise = onUndo() as Promise< boolean >;
+		} );
+		await act( async () => Promise.resolve() );
+
+		expect( mockInvalidateCheckpointAction ).not.toHaveBeenCalledWith( 'checkpoint-swap' );
+		await expect( onUndo() ).resolves.toBe( false );
+		expect( checkpoint.swapCheckpoint ).toHaveBeenCalledTimes( 1 );
+		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalled();
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps ).toHaveProperty(
+			'onUndo'
+		);
+
+		await act( async () => {
+			resolveSwap?.();
+			await undoPromise;
+		} );
+
+		await waitFor( () => {
+			const revertedAction = getDisplayedCheckpointAction( checkpointMessage.id );
+			expect( revertedAction?.label ).toBe( 'Reverted and Redo' );
+			expect( revertedAction?.componentProps ).toHaveProperty( 'onRedo' );
+		} );
+		expect( mockInvalidateCheckpointAction ).not.toHaveBeenCalledWith( 'checkpoint-swap' );
 	} );
 
 	it( 'invalidates a checkpoint that arrives after Gutenberg Undo', () => {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -1655,6 +1655,54 @@ describe( 'OrchestratorChat', () => {
 		).not.toHaveProperty( 'onUndo' );
 	} );
 
+	it( 'removes a stale rendered Undo when drift is detected on click', async () => {
+		const checkpointMessage = createCheckpointMessage(
+			'agent-stale-click',
+			'stale-click-checkpoint',
+			'text-content'
+		);
+		let canSwapCheckpoint = true;
+		const checkpoint = {
+			getLastEditorState: jest.fn(),
+			setCheckpoint: jest.fn(),
+			addCheckpointKeys: jest.fn(),
+			restoreCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			canSwapCheckpoint: jest.fn( () => canSwapCheckpoint ),
+			swapCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			addNewPageToCheckpoint: jest.fn(),
+			addPageRenameToCheckpoint: jest.fn(),
+			addPageRemovalToCheckpoint: jest.fn(),
+			getLatestUserMessageId: jest.fn(),
+			clearCheckpoint: jest.fn(),
+			hasCheckpoint: jest.fn().mockReturnValue( true ),
+		};
+		const useCheckpoint = () => checkpoint;
+		const actualUseCheckpointAction = jest.requireActual(
+			'../../hooks/use-checkpoint-action'
+		).default;
+		mockUseCheckpointAction.mockImplementation( actualUseCheckpointAction );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, checkpointMessage ] } )
+		);
+		render( chat( { useCheckpoint } ) );
+
+		const staleOnUndo = getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+			?.onUndo;
+		if ( typeof staleOnUndo !== 'function' ) {
+			throw new Error( 'Expected an Undo action.' );
+		}
+
+		canSwapCheckpoint = false;
+		await act( async () => staleOnUndo() );
+
+		expect( checkpoint.swapCheckpoint ).not.toHaveBeenCalled();
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onUndo' );
+		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalled();
+	} );
+
 	it( 'keeps checkpoint controls while Undo swaps the editor content', async () => {
 		const checkpointMessage = createCheckpointMessage(
 			'agent-checkpoint-swap',
@@ -1728,6 +1776,58 @@ describe( 'OrchestratorChat', () => {
 			expect( revertedAction?.componentProps ).toHaveProperty( 'onRedo' );
 		} );
 		expect( mockInvalidateCheckpointAction ).not.toHaveBeenCalledWith( 'checkpoint-swap' );
+	} );
+
+	it( 'keeps Redo when an inline Undo creates Gutenberg redo history', async () => {
+		const checkpointMessage = createCheckpointMessage(
+			'agent-inline-undo',
+			'inline-undo-checkpoint',
+			'text-content'
+		);
+		const checkpoint = {
+			getLastEditorState: jest.fn(),
+			setCheckpoint: jest.fn(),
+			addCheckpointKeys: jest.fn(),
+			restoreCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			canSwapCheckpoint: jest.fn().mockReturnValue( true ),
+			swapCheckpoint: jest.fn( () => {
+				mockHasEditorRedo = true;
+				mockEditorBlocks = [ { clientId: 'inline-undo-restored-block' } ];
+				mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+				return Promise.resolve();
+			} ),
+			addNewPageToCheckpoint: jest.fn(),
+			addPageRenameToCheckpoint: jest.fn(),
+			addPageRemovalToCheckpoint: jest.fn(),
+			getLatestUserMessageId: jest.fn(),
+			clearCheckpoint: jest.fn(),
+			hasCheckpoint: jest.fn().mockReturnValue( true ),
+		};
+		const useCheckpoint = () => checkpoint;
+		const actualUseCheckpointAction = jest.requireActual(
+			'../../hooks/use-checkpoint-action'
+		).default;
+		mockUseCheckpointAction.mockImplementation( actualUseCheckpointAction );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, checkpointMessage ] } )
+		);
+		render( chat( { useCheckpoint } ) );
+
+		const onUndo = getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps?.onUndo;
+		if ( typeof onUndo !== 'function' ) {
+			throw new Error( 'Expected an Undo action.' );
+		}
+
+		await act( async () => {
+			await onUndo();
+		} );
+
+		await waitFor( () => {
+			const revertedAction = getDisplayedCheckpointAction( checkpointMessage.id );
+			expect( revertedAction?.label ).toBe( 'Reverted and Redo' );
+			expect( revertedAction?.componentProps ).toHaveProperty( 'onRedo' );
+		} );
+		expect( mockInvalidateCheckpointAction ).not.toHaveBeenCalledWith( 'inline-undo-checkpoint' );
 	} );
 
 	it( 'invalidates a checkpoint that arrives after Gutenberg Undo', () => {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -31,6 +31,18 @@ const mockUseImageUpload = jest.fn();
 const mockIsReaderChatAgent = jest.fn();
 const mockInvalidateCheckpointAction = jest.fn();
 const mockInvalidatedCheckpointIds = new Set< string >();
+const mockRevertedCheckpointIds = new Set< string >();
+const mockSetCheckpointActionReverted = jest.fn(
+	( checkpointId: string, isReverted: boolean ): boolean => {
+		const wasReverted = mockRevertedCheckpointIds.has( checkpointId );
+		if ( isReverted ) {
+			mockRevertedCheckpointIds.add( checkpointId );
+		} else {
+			mockRevertedCheckpointIds.delete( checkpointId );
+		}
+		return wasReverted !== isReverted;
+	}
+);
 let mockSelectedBlockType: string | undefined;
 let mockBlockEditorStoreThrows = false;
 let mockHasEditorRedo = false;
@@ -81,13 +93,21 @@ const mockCheckpointActions = () => {
 		const canAct =
 			! mockInvalidatedCheckpointIds.has( checkpointId ) &&
 			( isCheckpointActionAvailable?.( checkpointId ) ?? true );
+		const isReverted = mockRevertedCheckpointIds.has( checkpointId );
+		let label = canAct ? 'Updated and Undo' : 'Updated';
+		if ( isReverted ) {
+			label = canAct ? 'Reverted and Redo' : 'Reverted';
+		}
 		return [
 			{
 				type: 'component',
 				id: 'checkpoint',
-				label: canAct ? 'Updated and Undo' : 'Updated',
+				label,
 				component: () => null,
-				componentProps: canAct ? { onUndo: jest.fn(), onRedo: jest.fn() } : {},
+				componentProps: {
+					initiallyReverted: isReverted,
+					...( canAct && { onUndo: jest.fn(), onRedo: jest.fn() } ),
+				},
 				order: 1,
 			},
 		];
@@ -310,10 +330,14 @@ jest.mock( '../../hooks/use-checkpoint-action', () => ( {
 	__esModule: true,
 	default: ( ...args: unknown[] ) => mockUseCheckpointAction( ...args ),
 	getCheckpointIdForMessage: mockGetCheckpointIdForMessage,
+	isCheckpointActionInvalidated: ( checkpointId: string ) =>
+		mockInvalidatedCheckpointIds.has( checkpointId ),
 	invalidateCheckpointAction: ( checkpointId: string ) => {
 		mockInvalidatedCheckpointIds.add( checkpointId );
 		mockInvalidateCheckpointAction( checkpointId );
 	},
+	setCheckpointActionReverted: ( checkpointId: string, isReverted: boolean ) =>
+		mockSetCheckpointActionReverted( checkpointId, isReverted ),
 } ) );
 jest.mock( '../../hooks/use-feedback-action', () => () => ( {
 	showFeedbackInput: false,
@@ -513,6 +537,7 @@ describe( 'OrchestratorChat', () => {
 		mockEditorBlocks = [];
 		mockDataStoreSubscribers.clear();
 		mockInvalidatedCheckpointIds.clear();
+		mockRevertedCheckpointIds.clear();
 		mockAgentChatConfig = undefined;
 		mockConversationConfig = undefined;
 	} );
@@ -1459,34 +1484,105 @@ describe( 'OrchestratorChat', () => {
 		);
 	} );
 
-	it( 'keeps checkpoint controls hidden after Gutenberg Undo and Redo', () => {
+	it( 'updates the checkpoint status after native Undo and exact native Redo', () => {
 		const checkpointMessage = createCheckpointMessage(
 			'agent-native-undo',
 			'native-undo-checkpoint'
 		);
+		let canSwapCheckpoint = true;
+		const checkpoint = {
+			getLastEditorState: jest.fn(),
+			setCheckpoint: jest.fn(),
+			addCheckpointKeys: jest.fn(),
+			restoreCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			canSwapCheckpoint: jest.fn( () => canSwapCheckpoint ),
+			swapCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			addNewPageToCheckpoint: jest.fn(),
+			addPageRenameToCheckpoint: jest.fn(),
+			addPageRemovalToCheckpoint: jest.fn(),
+			getLatestUserMessageId: jest.fn(),
+			clearCheckpoint: jest.fn(),
+			hasCheckpoint: jest.fn().mockReturnValue( true ),
+		};
+		const useCheckpoint = () => checkpoint;
 		mockCheckpointActions();
 		mockUseAgentChat.mockReturnValue(
 			agentChatReturn( { messages: [ userMessage, checkpointMessage ] } )
 		);
-		const view = render( chat() );
+		render( chat( { useCheckpoint } ) );
 
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe(
+			'Updated and Undo'
+		);
 		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps ).toHaveProperty(
 			'onUndo'
 		);
 
-		mockHasEditorRedo = true;
-		view.rerender( chat() );
+		act( () => {
+			canSwapCheckpoint = false;
+			mockHasEditorRedo = true;
+			mockEditorBlocks = [ { clientId: 'native-undo-block' } ];
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Reverted' );
 		expect(
 			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
 		).not.toHaveProperty( 'onUndo' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onRedo' );
 		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith( 'native-undo-checkpoint' );
 
-		mockHasEditorRedo = false;
-		view.rerender( chat() );
+		act( () => {
+			canSwapCheckpoint = true;
+			mockHasEditorRedo = false;
+			mockEditorBlocks = [ { clientId: 'native-redo-block' } ];
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
 		expect(
 			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
 		).not.toHaveProperty( 'onUndo' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onRedo' );
 		expect( mockInvalidateCheckpointAction ).toHaveBeenLastCalledWith( 'native-undo-checkpoint' );
+	} );
+
+	it( 'does not mark an unsupported checkpoint Reverted after native Undo', () => {
+		const checkpointMessage = createCheckpointMessage(
+			'agent-unsupported-native-undo',
+			'unsupported-native-undo-checkpoint'
+		);
+		const checkpoint = {
+			getLastEditorState: jest.fn(),
+			setCheckpoint: jest.fn(),
+			addCheckpointKeys: jest.fn(),
+			restoreCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			addNewPageToCheckpoint: jest.fn(),
+			addPageRenameToCheckpoint: jest.fn(),
+			addPageRemovalToCheckpoint: jest.fn(),
+			getLatestUserMessageId: jest.fn(),
+			clearCheckpoint: jest.fn(),
+			hasCheckpoint: jest.fn().mockReturnValue( true ),
+		};
+		const useCheckpoint = () => checkpoint;
+		mockCheckpointActions();
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, checkpointMessage ] } )
+		);
+		render( chat( { useCheckpoint } ) );
+
+		act( () => {
+			mockHasEditorRedo = true;
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
+		expect( mockSetCheckpointActionReverted ).not.toHaveBeenCalledWith(
+			'unsupported-native-undo-checkpoint',
+			true
+		);
 	} );
 
 	it( 'hides checkpoint controls when the editor content drifts without Gutenberg Undo', async () => {
@@ -1533,6 +1629,7 @@ describe( 'OrchestratorChat', () => {
 		expect( checkpoint.canSwapCheckpoint ).toHaveBeenLastCalledWith( 'editor-drift-checkpoint' );
 		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith( 'editor-drift-checkpoint' );
 		const actionAfterDrift = getDisplayedCheckpointAction( checkpointMessage.id );
+		expect( actionAfterDrift?.label ).toBe( 'Updated' );
 		const staleOnUndo = actionAfterDrift?.componentProps?.onUndo;
 		// Exercise the unfixed path so the failed-event assertion below is meaningful.
 		if ( typeof staleOnUndo === 'function' ) {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -3,12 +3,14 @@
  */
 /* eslint-disable import/order -- jest.mock calls must precede imports */
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { TaskUpdate } from '@automattic/agenttic-client';
 import type { Suggestion } from '@automattic/agenttic-ui';
 import type { ComponentProps } from 'react';
 
 const mockUseAgentChat = jest.fn();
 const mockUpdateSessionId = jest.fn();
 let mockManagerHasAgent = true;
+let mockAgentChatConfig: { onTaskUpdate?: ( update: TaskUpdate ) => Promise< void > } | undefined;
 const mockUseRegenerateAction = jest.fn();
 const mockUseCheckpointAction = jest.fn();
 const mockUseConversation = jest.fn();
@@ -152,7 +154,10 @@ jest.mock(
 			updateSessionId: mockUpdateSessionId,
 			hasAgent: () => mockManagerHasAgent,
 		} ),
-		useAgentChat: () => mockUseAgentChat(),
+		useAgentChat: ( config: typeof mockAgentChatConfig ) => {
+			mockAgentChatConfig = config;
+			return mockUseAgentChat();
+		},
 	} ),
 	{ virtual: true }
 );
@@ -348,6 +353,7 @@ describe( 'OrchestratorChat', () => {
 		mockBlockEditorStoreThrows = false;
 		sessionStorage.clear();
 		mockManagerHasAgent = true;
+		mockAgentChatConfig = undefined;
 	} );
 
 	it( 'ignores a conversation result for a discarded agent', () => {
@@ -1214,6 +1220,134 @@ describe( 'OrchestratorChat', () => {
 					} ),
 				] ),
 			} )
+		);
+	} );
+
+	it( 'keeps streamed checkpoint actions through final prose and remounts', async () => {
+		const checkpointAction = {
+			id: 'checkpoint',
+			label: 'Updated and Undo',
+			onClick: jest.fn(),
+			order: 1,
+		};
+		mockUseCheckpointAction.mockReturnValue(
+			( message: { content?: Array< { text?: string } > } ) =>
+				message.content?.[ 0 ]?.text?.includes( 'big_sky__apply_block_edits' )
+					? [ checkpointAction ]
+					: []
+		);
+		const view = render( chat() );
+		const checkpointResult = JSON.stringify( {
+			tool_id: 'big_sky__apply_block_edits',
+			tool_call_id: 'tool-call-streamed',
+			data: {
+				result: {
+					success: true,
+					outcome: 'updated',
+					changeType: 'text-content',
+				},
+			},
+		} );
+
+		await act( async () => {
+			await mockAgentChatConfig?.onTaskUpdate?.( {
+				id: 'task-streamed',
+				status: { state: 'working' },
+				text: checkpointResult,
+				final: false,
+				kind: 'status',
+			} );
+			await mockAgentChatConfig?.onTaskUpdate?.( {
+				id: 'task-streamed',
+				status: {
+					state: 'completed',
+					message: { messageId: 'agent-final', role: 'agent', kind: 'message', parts: [] },
+				},
+				text: 'The paragraph has been updated.',
+				final: true,
+				kind: 'status',
+			} );
+		} );
+
+		const finalMessage = {
+			id: 'agent-final',
+			role: 'agent' as const,
+			content: [ { type: 'text' as const, text: 'The paragraph has been updated.' } ],
+			timestamp: 1,
+			archived: false,
+			showIcon: true,
+		};
+		mockUseAgentChat.mockReturnValue( agentChatReturn( { messages: [ finalMessage ] } ) );
+		view.rerender( chat() );
+
+		const messages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
+			id: string;
+			actions?: Array< { id: string; label: string } >;
+		} >;
+		expect( messages[ 0 ].actions ).toEqual( [
+			expect.objectContaining( { id: 'checkpoint', label: 'Updated and Undo' } ),
+		] );
+		view.unmount();
+
+		const remountedView = render( chat() );
+		const remountedMessages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
+			actions?: Array< { id: string; label: string } >;
+		} >;
+		expect( remountedMessages[ 0 ].actions ).toEqual( [
+			expect.objectContaining( { id: 'checkpoint', label: 'Updated and Undo' } ),
+		] );
+
+		const regenerateConfig = mockUseRegenerateAction.mock.calls.at( -1 )![ 0 ] as {
+			getRegenerateHandler?: ( message: unknown ) => ( () => Promise< void > ) | null | undefined;
+		};
+		await act( async () => {
+			await regenerateConfig.getRegenerateHandler?.( finalMessage )?.();
+		} );
+		remountedView.rerender( chat() );
+
+		const restoredMessages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
+			actions?: Array< { id: string; label: string } >;
+		} >;
+		expect( restoredMessages[ 0 ].actions ).toEqual( [
+			expect.objectContaining( { id: 'checkpoint', label: 'Updated and Undo' } ),
+		] );
+
+		let resolveRegenerate!: () => void;
+		const regeneration = new Promise< void >( ( resolve ) => {
+			resolveRegenerate = resolve;
+		} );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				messages: [ finalMessage ],
+				getRegenerateHandler: jest.fn( () => () => regeneration ),
+			} )
+		);
+		remountedView.rerender( chat() );
+		const successfulRegenerateConfig = mockUseRegenerateAction.mock.calls.at( -1 )![ 0 ] as {
+			getRegenerateHandler?: ( message: unknown ) => ( () => Promise< void > ) | null | undefined;
+		};
+		await act( async () => {
+			const regenerate = successfulRegenerateConfig.getRegenerateHandler?.( finalMessage )?.();
+			await mockAgentChatConfig?.onTaskUpdate?.( {
+				id: 'task-regenerated',
+				status: {
+					state: 'completed',
+					message: { messageId: 'agent-final', role: 'agent', kind: 'message', parts: [] },
+				},
+				text: 'No edit was made.',
+				final: true,
+				kind: 'status',
+			} );
+			resolveRegenerate();
+			await regenerate;
+		} );
+		remountedView.rerender( chat() );
+
+		const regeneratedMessages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
+			actions?: Array< { id: string } >;
+		} >;
+		expect( regeneratedMessages[ 0 ].actions ).not.toEqual(
+			expect.arrayContaining( [ expect.objectContaining( { id: 'checkpoint' } ) ] )
 		);
 	} );
 

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -33,6 +33,8 @@ let mockAgentConfig: { agentId: string; sessionId?: string } = {
 	agentId: 'wp-orchestrator',
 };
 let mockTabSessionId: string | undefined = 'session-id';
+let mockSiteKey = 'site-1';
+let mockCurrentUserId: number | undefined = 1;
 const mockInvalidateCheckpointAction = jest.fn();
 const mockInvalidatedCheckpointIds = new Set< string >();
 const mockRevertedCheckpointIds = new Set< string >();
@@ -321,7 +323,8 @@ jest.mock( '../../contexts', () => {
 				onSessionIdChange: ( sessionId: string ) => saveSessionId( sessionId, 'wp-orchestrator' ),
 			},
 			getTabSessionId: () => mockTabSessionId ?? '',
-			siteKey: 'site-1',
+			siteKey: mockSiteKey,
+			currentUser: mockCurrentUserId === undefined ? undefined : { ID: mockCurrentUserId },
 		} ),
 	};
 } );
@@ -610,6 +613,8 @@ describe( 'OrchestratorChat', () => {
 		mockIsReaderChatAgent.mockReturnValue( false );
 		mockAgentConfig = { agentId: 'wp-orchestrator' };
 		mockTabSessionId = 'session-id';
+		mockSiteKey = 'site-1';
+		mockCurrentUserId = 1;
 		mockSelectedBlockType = undefined;
 		mockBlockEditorStoreThrows = false;
 		sessionStorage.clear();
@@ -2471,9 +2476,8 @@ describe( 'OrchestratorChat', () => {
 			'onUndo'
 		);
 		view.unmount();
-		mockUseAgentChat.mockReturnValue(
-			agentChatReturn( { messages: [ userMessage, finalMessage ] } )
-		);
+		const remountLoadMessages = jest.fn();
+		mockUseAgentChat.mockReturnValue( agentChatReturn( { loadMessages: remountLoadMessages } ) );
 		const remountedView = render( chat() );
 		act( () => {
 			mockConversationConfig?.onSuccess?.(
@@ -2488,6 +2492,10 @@ describe( 'OrchestratorChat', () => {
 				'server-session-promoted-after-completion'
 			);
 		} );
+		expect( remountLoadMessages ).toHaveBeenCalled();
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, finalMessage ] } )
+		);
 		remountedView.rerender( chat() );
 		expect( getDisplayedCheckpointAction( finalMessage.id )?.componentProps ).toHaveProperty(
 			'onUndo'
@@ -2546,6 +2554,29 @@ describe( 'OrchestratorChat', () => {
 		coldView.rerender( chat() );
 		expect( getDisplayedCheckpointAction( finalMessage.id ) ).toBeUndefined();
 		expect( getDisplayedMessage( finalMessage.id ).disabled ).toBeUndefined();
+
+		mockInvalidateCheckpointAction.mockClear();
+		mockAgentConfig = {
+			agentId: 'wp-orchestrator',
+			sessionId: 'server-session-promoted-after-completion',
+		};
+		coldView.rerender( chat() );
+		act( () => {
+			mockConversationConfig?.onSuccess?.(
+				[
+					{
+						messageId: finalMessage.id,
+						role: 'agent',
+						parts: [ { type: 'text', text: finalMessage.content[ 0 ].text } ],
+						kind: 'message',
+					},
+				],
+				'server-session-promoted-after-completion'
+			);
+		} );
+		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith(
+			'checkpoint-session-promoted-after-completion'
+		);
 	} );
 
 	it( 'keeps in-flight streamed checkpoints when a fresh session is promoted', async () => {
@@ -2624,6 +2655,51 @@ describe( 'OrchestratorChat', () => {
 				'onUndo'
 			);
 		}
+	} );
+
+	it( 'drops in-flight streamed checkpoints when the tab session scope changes', async () => {
+		mockAgentConfig = { agentId: 'wp-orchestrator', sessionId: '' };
+		mockTabSessionId = '';
+		mockCheckpointActions();
+		const view = render( chat() );
+		const onTaskUpdateBeforeScopeChange = mockAgentChatConfig?.onTaskUpdate;
+
+		await act( async () => {
+			await onTaskUpdateBeforeScopeChange?.(
+				createWorkingCheckpointUpdate(
+					'task-started-before-scope-change',
+					createJetpackCheckpointResult( 'checkpoint-started-before-scope-change' )
+				)
+			);
+		} );
+
+		mockSiteKey = 'site-2';
+		mockCurrentUserId = 2;
+		view.rerender( chat() );
+
+		await act( async () => {
+			await onTaskUpdateBeforeScopeChange?.(
+				createCompletedCheckpointUpdate(
+					'task-started-before-scope-change',
+					'agent-started-before-scope-change'
+				)
+			);
+		} );
+
+		const finalMessage = {
+			id: 'agent-started-before-scope-change',
+			role: 'agent' as const,
+			content: [ { type: 'text' as const, text: 'The paragraph has been updated.' } ],
+			timestamp: 2,
+			archived: false,
+			showIcon: true,
+		};
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, finalMessage ] } )
+		);
+		view.rerender( chat() );
+
+		expect( getDisplayedCheckpointAction( finalMessage.id ) ).toBeUndefined();
 	} );
 
 	it( 'keeps streamed checkpoint actions through final prose and remounts', async () => {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -271,6 +271,7 @@ jest.mock( '@wordpress/data', () => {
 	const { useEffect, useReducer, useRef } = jest.requireActual< typeof import('react') >( 'react' );
 
 	return {
+		select: ( storeName: string ) => mockSelectDataStore( storeName ),
 		useSelect: ( mapSelect: ( select: ( storeName: string ) => object ) => unknown ) => {
 			const selectorRef = useRef( mapSelect );
 			selectorRef.current = mapSelect;
@@ -486,6 +487,21 @@ const createCheckpointMessage = (
 		},
 	],
 	timestamp: 1,
+} );
+
+const createSwappableCheckpoint = () => ( {
+	getLastEditorState: jest.fn(),
+	setCheckpoint: jest.fn(),
+	addCheckpointKeys: jest.fn(),
+	restoreCheckpoint: jest.fn().mockResolvedValue( undefined ),
+	canSwapCheckpoint: jest.fn().mockReturnValue( true ),
+	swapCheckpoint: jest.fn().mockResolvedValue( undefined ),
+	addNewPageToCheckpoint: jest.fn(),
+	addPageRenameToCheckpoint: jest.fn(),
+	addPageRemovalToCheckpoint: jest.fn(),
+	getLatestUserMessageId: jest.fn(),
+	clearCheckpoint: jest.fn(),
+	hasCheckpoint: jest.fn().mockReturnValue( true ),
 } );
 
 const getDisplayedCheckpointAction = ( messageId: string ) => {
@@ -1522,9 +1538,14 @@ describe( 'OrchestratorChat', () => {
 			mockHasEditorRedo = true;
 			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
 		} );
-		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe(
-			'Updated and Undo'
-		);
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onUndo' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onRedo' );
+		expect( mockInvalidateCheckpointAction ).not.toHaveBeenCalledWith( 'native-undo-checkpoint' );
 
 		act( () => {
 			canSwapCheckpoint = false;
@@ -1681,18 +1702,26 @@ describe( 'OrchestratorChat', () => {
 
 		act( () => {
 			mockHasEditorRedo = true;
+			mockEditorBlocks = [ { clientId: 'unrelated-native-undo-block' } ];
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onUndo' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onRedo' );
+
+		act( () => {
+			mockEditorBlocks = [ { clientId: 'settled-unrelated-native-undo-block' } ];
 			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
 		} );
 		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe(
 			'Updated and Undo'
 		);
-
-		act( () => {
-			mockEditorBlocks = [ { clientId: 'unrelated-native-undo-block' } ];
-			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
-		} );
-		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe(
-			'Updated and Undo'
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps ).toHaveProperty(
+			'onUndo'
 		);
 
 		act( () => {
@@ -1701,6 +1730,12 @@ describe( 'OrchestratorChat', () => {
 			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
 		} );
 		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onUndo' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onRedo' );
 		expect( mockSetCheckpointActionReverted ).not.toHaveBeenCalledWith(
 			'unrelated-native-history-checkpoint',
 			true
@@ -1986,6 +2021,120 @@ describe( 'OrchestratorChat', () => {
 			expect( revertedAction?.componentProps ).toHaveProperty( 'onRedo' );
 		} );
 		expect( mockInvalidateCheckpointAction ).not.toHaveBeenCalledWith( 'inline-undo-checkpoint' );
+	} );
+
+	it( 'keeps an earlier Redo when Gutenberg history updates after inline Undo completes', async () => {
+		const checkpointMessage = createCheckpointMessage(
+			'agent-delayed-inline-undo',
+			'delayed-inline-undo-checkpoint',
+			'text-content'
+		);
+		const laterCheckpointMessage = createCheckpointMessage(
+			'agent-later-checkpoint',
+			'later-checkpoint',
+			'text-content'
+		);
+		const checkpoint = createSwappableCheckpoint();
+		checkpoint.swapCheckpoint.mockImplementation( () => {
+			mockHasEditorRedo = true;
+			return Promise.resolve();
+		} );
+		const useCheckpoint = () => checkpoint;
+		const actualUseCheckpointAction = jest.requireActual(
+			'../../hooks/use-checkpoint-action'
+		).default;
+		mockUseCheckpointAction.mockImplementation( actualUseCheckpointAction );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				messages: [ userMessage, checkpointMessage, laterCheckpointMessage ],
+			} )
+		);
+		render( chat( { useCheckpoint } ) );
+
+		const onUndo = getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps?.onUndo;
+		if ( typeof onUndo !== 'function' ) {
+			throw new Error( 'Expected an Undo action.' );
+		}
+
+		await act( async () => {
+			await onUndo();
+		} );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe(
+			'Reverted and Redo'
+		);
+
+		act( () => {
+			mockEditorBlocks = [ { clientId: 'delayed-inline-undo-restored-block' } ];
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+
+		const revertedAction = getDisplayedCheckpointAction( checkpointMessage.id );
+		expect( revertedAction?.label ).toBe( 'Reverted and Redo' );
+		expect( revertedAction?.componentProps ).toHaveProperty( 'onRedo' );
+		expect( getDisplayedCheckpointAction( laterCheckpointMessage.id )?.label ).toBe(
+			'Updated and Undo'
+		);
+		expect( mockInvalidateCheckpointAction ).not.toHaveBeenCalledWith(
+			'delayed-inline-undo-checkpoint'
+		);
+		expect( mockInvalidateCheckpointAction ).not.toHaveBeenCalledWith( 'later-checkpoint' );
+	} );
+
+	it( 'does not attribute a later native Undo to an inline Undo without editor history', async () => {
+		const checkpointMessage = createCheckpointMessage(
+			'agent-inline-undo-without-history',
+			'inline-undo-without-history-checkpoint',
+			'text-content'
+		);
+		const laterCheckpointMessage = createCheckpointMessage(
+			'agent-later-native-undo',
+			'later-native-undo-checkpoint',
+			'text-content'
+		);
+		let canSwapLaterCheckpoint = true;
+		const checkpoint = createSwappableCheckpoint();
+		checkpoint.canSwapCheckpoint.mockImplementation( ( checkpointId: string ) =>
+			checkpointId === 'later-native-undo-checkpoint' ? canSwapLaterCheckpoint : true
+		);
+		const useCheckpoint = () => checkpoint;
+		const actualUseCheckpointAction = jest.requireActual(
+			'../../hooks/use-checkpoint-action'
+		).default;
+		mockUseCheckpointAction.mockImplementation( actualUseCheckpointAction );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				messages: [ userMessage, checkpointMessage, laterCheckpointMessage ],
+			} )
+		);
+		render( chat( { useCheckpoint } ) );
+
+		const onUndo = getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps?.onUndo;
+		if ( typeof onUndo !== 'function' ) {
+			throw new Error( 'Expected an Undo action.' );
+		}
+		await act( async () => {
+			await onUndo();
+		} );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe(
+			'Reverted and Redo'
+		);
+
+		act( () => {
+			canSwapLaterCheckpoint = false;
+			mockHasEditorRedo = true;
+			mockEditorBlocks = [ { clientId: 'later-native-undo-block' } ];
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Reverted' );
+		expect( mockSetCheckpointActionReverted ).toHaveBeenCalledWith(
+			'later-native-undo-checkpoint',
+			true
+		);
+		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith(
+			'inline-undo-without-history-checkpoint'
+		);
+		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith( 'later-native-undo-checkpoint' );
 	} );
 
 	it( 'invalidates a checkpoint that arrives after Gutenberg Undo', () => {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -1547,6 +1547,63 @@ describe( 'OrchestratorChat', () => {
 		expect( getDisplayedMessage( nextUserMessage.id ).disabled ).toBeUndefined();
 	} );
 
+	it( 'dims a superseded streamed checkpoint message when its action is already hidden', async () => {
+		mockCheckpointActions();
+		const view = render( chat() );
+		const checkpointId = 'hidden-streamed-checkpoint';
+		const taskId = 'task-hidden-streamed-checkpoint';
+		const finalMessageId = 'agent-hidden-streamed-checkpoint';
+
+		await act( async () => {
+			await mockAgentChatConfig?.onTaskUpdate?.(
+				createWorkingCheckpointUpdate( taskId, createJetpackCheckpointResult( checkpointId ) )
+			);
+			await mockAgentChatConfig?.onTaskUpdate?.(
+				createCompletedCheckpointUpdate( taskId, finalMessageId )
+			);
+		} );
+
+		const finalMessage = {
+			id: finalMessageId,
+			role: 'agent' as const,
+			content: [ { type: 'text' as const, text: 'The paragraph has been updated.' } ],
+			timestamp: 2,
+		};
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, finalMessage ] } )
+		);
+		view.rerender( chat() );
+
+		expect( getDisplayedCheckpointAction( finalMessage.id )?.componentProps ).toHaveProperty(
+			'onUndo'
+		);
+		expect( getDisplayedMessage( finalMessage.id ).disabled ).toBeUndefined();
+		mockInvalidatedCheckpointIds.add( checkpointId );
+
+		const nextUserMessage = {
+			id: 'user-after-hidden-checkpoint',
+			role: 'user',
+			content: [ { type: 'text', text: 'What did you change?' } ],
+			timestamp: 3,
+		};
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				messages: [ userMessage, finalMessage, nextUserMessage ],
+			} )
+		);
+		view.rerender( chat() );
+
+		expect( getDisplayedCheckpointAction( finalMessage.id )?.label ).toBe( 'Updated' );
+		expect( getDisplayedCheckpointAction( finalMessage.id )?.componentProps ).not.toHaveProperty(
+			'disabled'
+		);
+		expect( getDisplayedCheckpointAction( finalMessage.id )?.componentProps ).not.toHaveProperty(
+			'onUndo'
+		);
+		expect( getDisplayedMessage( finalMessage.id ).disabled ).toBe( true );
+		expect( getDisplayedMessage( nextUserMessage.id ).disabled ).toBeUndefined();
+	} );
+
 	it( 'hides checkpoint controls in loaded conversation history', () => {
 		const checkpointMessage = createCheckpointMessage(
 			'agent-history',
@@ -1559,7 +1616,7 @@ describe( 'OrchestratorChat', () => {
 			agentChatReturn( { loadMessages, messages: [ checkpointMessage ] } )
 		);
 
-		render( chat() );
+		const view = render( chat() );
 		act( () => {
 			mockConversationConfig?.onSuccess?.(
 				[
@@ -1578,6 +1635,24 @@ describe( 'OrchestratorChat', () => {
 		expect( loadMessages ).toHaveBeenCalledWith(
 			expect.arrayContaining( [ expect.objectContaining( { messageId: checkpointMessage.id } ) ] )
 		);
+		view.rerender( chat() );
+		expect( getDisplayedMessage( checkpointMessage.id ).disabled ).toBeUndefined();
+
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				messages: [
+					checkpointMessage,
+					{
+						id: 'user-after-loaded-history',
+						role: 'user',
+						content: [ { type: 'text', text: 'Start a new request' } ],
+						timestamp: 2,
+					},
+				],
+			} )
+		);
+		view.rerender( chat() );
+		expect( getDisplayedMessage( checkpointMessage.id ).disabled ).toBe( true );
 	} );
 
 	it( 'updates the checkpoint status when native Undo and Redo stores notify separately', () => {
@@ -1662,7 +1737,7 @@ describe( 'OrchestratorChat', () => {
 		expect( mockInvalidateCheckpointAction ).toHaveBeenLastCalledWith( 'native-undo-checkpoint' );
 	} );
 
-	it( 'keeps a pending native Undo hidden after a later user message', () => {
+	it( 'keeps a pending native Undo hidden and dims it after a later user message', () => {
 		const checkpointMessage = createCheckpointMessage(
 			'agent-pending-native-undo',
 			'pending-native-undo-checkpoint'
@@ -1720,7 +1795,7 @@ describe( 'OrchestratorChat', () => {
 		expect(
 			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
 		).not.toHaveProperty( 'onRedo' );
-		expect( getDisplayedMessage( checkpointMessage.id ).disabled ).toBeUndefined();
+		expect( getDisplayedMessage( checkpointMessage.id ).disabled ).toBe( true );
 		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith(
 			'pending-native-undo-checkpoint'
 		);
@@ -1733,6 +1808,7 @@ describe( 'OrchestratorChat', () => {
 		expect(
 			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
 		).not.toHaveProperty( 'disabled' );
+		expect( getDisplayedMessage( checkpointMessage.id ).disabled ).toBe( true );
 	} );
 
 	it( 'updates the checkpoint status when native Undo stores notify together', () => {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -34,6 +34,24 @@ const mockInvalidatedCheckpointIds = new Set< string >();
 let mockSelectedBlockType: string | undefined;
 let mockBlockEditorStoreThrows = false;
 let mockHasEditorRedo = false;
+let mockEditorBlocks: unknown[] = [];
+const mockDataStoreSubscribers = new Set< () => void >();
+
+const mockSelectDataStore = ( storeName: string ) => {
+	if ( storeName === 'core/editor' ) {
+		return { hasEditorRedo: () => mockHasEditorRedo };
+	}
+	if ( storeName === 'core/block-editor' ) {
+		if ( mockBlockEditorStoreThrows ) {
+			throw new Error( 'Block editor store unavailable' );
+		}
+		return {
+			getSelectedBlock: () => ( mockSelectedBlockType ? { name: mockSelectedBlockType } : null ),
+			getBlocks: () => mockEditorBlocks,
+		};
+	}
+	return {};
+};
 
 function mockGetCheckpointIdForMessage( message: {
 	content?: Array< { text?: string } >;
@@ -229,24 +247,36 @@ jest.mock(
 	} ),
 	{ virtual: true }
 );
-jest.mock( '@wordpress/data', () => ( {
-	useSelect: ( mapSelect: ( select: ( storeName: string ) => object ) => unknown ) =>
-		mapSelect( ( storeName: string ) => {
-			if ( storeName === 'core/editor' ) {
-				return { hasEditorRedo: () => mockHasEditorRedo };
-			}
-			if ( storeName === 'core/block-editor' ) {
-				if ( mockBlockEditorStoreThrows ) {
-					throw new Error( 'Block editor store unavailable' );
-				}
-				return {
-					getSelectedBlock: () =>
-						mockSelectedBlockType ? { name: mockSelectedBlockType } : null,
+jest.mock( '@wordpress/data', () => {
+	const { useEffect, useReducer, useRef } = jest.requireActual< typeof import('react') >( 'react' );
+
+	return {
+		useSelect: ( mapSelect: ( select: ( storeName: string ) => object ) => unknown ) => {
+			const selectorRef = useRef( mapSelect );
+			selectorRef.current = mapSelect;
+			const selectedValue = mapSelect( mockSelectDataStore );
+			const selectedValueRef = useRef( selectedValue );
+			selectedValueRef.current = selectedValue;
+			const [ , forceRender ] = useReducer( ( count: number ) => count + 1, 0 );
+
+			useEffect( () => {
+				const updateSelectedValue = () => {
+					const nextValue = selectorRef.current( mockSelectDataStore );
+					if ( ! Object.is( selectedValueRef.current, nextValue ) ) {
+						selectedValueRef.current = nextValue;
+						forceRender();
+					}
 				};
-			}
-			return {};
-		} ),
-} ) );
+				mockDataStoreSubscribers.add( updateSelectedValue );
+				return () => {
+					mockDataStoreSubscribers.delete( updateSelectedValue );
+				};
+			}, [] );
+
+			return selectedValue;
+		},
+	};
+} );
 jest.mock( '@wordpress/element', () => jest.requireActual( 'react' ) );
 jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text } ) );
 jest.mock( 'react-router-dom', () => ( {
@@ -408,7 +438,11 @@ const showComponentMessage = ( id: string, content: string = SHOW_COMPONENT_CONT
 	showIcon: true,
 } );
 
-const createCheckpointMessage = ( id: string, checkpointId: string ) => ( {
+const createCheckpointMessage = (
+	id: string,
+	checkpointId: string,
+	changeType?: 'text-content'
+) => ( {
 	id,
 	role: 'agent',
 	content: [
@@ -417,7 +451,13 @@ const createCheckpointMessage = ( id: string, checkpointId: string ) => ( {
 			text: JSON.stringify( {
 				tool_id: 'big_sky__apply_block_edits',
 				tool_call_id: checkpointId,
-				data: { result: { success: true, outcome: 'updated' } },
+				data: {
+					result: {
+						success: true,
+						outcome: 'updated',
+						...( changeType && { changeType } ),
+					},
+				},
 			} ),
 		},
 	],
@@ -466,6 +506,8 @@ describe( 'OrchestratorChat', () => {
 		sessionStorage.clear();
 		mockManagerHasAgent = true;
 		mockHasEditorRedo = false;
+		mockEditorBlocks = [];
+		mockDataStoreSubscribers.clear();
 		mockInvalidatedCheckpointIds.clear();
 		mockAgentChatConfig = undefined;
 		mockConversationConfig = undefined;
@@ -1441,6 +1483,75 @@ describe( 'OrchestratorChat', () => {
 			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
 		).not.toHaveProperty( 'onUndo' );
 		expect( mockInvalidateCheckpointAction ).toHaveBeenLastCalledWith( 'native-undo-checkpoint' );
+	} );
+
+	it( 'hides checkpoint controls when the editor content drifts without Gutenberg Undo', async () => {
+		const checkpointMessage = createCheckpointMessage(
+			'agent-editor-drift',
+			'editor-drift-checkpoint',
+			'text-content'
+		);
+		let canSwapCheckpoint = true;
+		const checkpoint = {
+			getLastEditorState: jest.fn(),
+			setCheckpoint: jest.fn(),
+			addCheckpointKeys: jest.fn(),
+			restoreCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			canSwapCheckpoint: jest.fn( () => canSwapCheckpoint ),
+			swapCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			addNewPageToCheckpoint: jest.fn(),
+			addPageRenameToCheckpoint: jest.fn(),
+			addPageRemovalToCheckpoint: jest.fn(),
+			getLatestUserMessageId: jest.fn(),
+			clearCheckpoint: jest.fn(),
+			hasCheckpoint: jest.fn().mockReturnValue( true ),
+		};
+		const useCheckpoint = () => checkpoint;
+		const actualUseCheckpointAction = jest.requireActual(
+			'../../hooks/use-checkpoint-action'
+		).default;
+		mockUseCheckpointAction.mockImplementation( actualUseCheckpointAction );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, checkpointMessage ] } )
+		);
+		render( chat( { useCheckpoint } ) );
+
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps ).toHaveProperty(
+			'onUndo'
+		);
+
+		act( () => {
+			canSwapCheckpoint = false;
+			mockEditorBlocks = [ { clientId: 'edited-block' } ];
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+
+		expect( checkpoint.canSwapCheckpoint ).toHaveBeenLastCalledWith( 'editor-drift-checkpoint' );
+		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith( 'editor-drift-checkpoint' );
+		const actionAfterDrift = getDisplayedCheckpointAction( checkpointMessage.id );
+		const staleOnUndo = actionAfterDrift?.componentProps?.onUndo;
+		// Exercise the unfixed path so the failed-event assertion below is meaningful.
+		if ( typeof staleOnUndo === 'function' ) {
+			await act( async () => staleOnUndo() );
+		}
+		expect( actionAfterDrift?.componentProps ).not.toHaveProperty( 'onUndo' );
+		expect( actionAfterDrift?.componentProps ).not.toHaveProperty( 'onRedo' );
+		expect( checkpoint.swapCheckpoint ).not.toHaveBeenCalled();
+		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalledWith(
+			'restore_checkpoint_action',
+			expect.objectContaining( { id: 'editor-drift-checkpoint', outcome: 'failed' } )
+		);
+
+		const canSwapCallCount = checkpoint.canSwapCheckpoint.mock.calls.length;
+		act( () => {
+			canSwapCheckpoint = true;
+			mockEditorBlocks = [ { clientId: 'edited-again' } ];
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+		expect( checkpoint.canSwapCheckpoint ).toHaveBeenCalledTimes( canSwapCallCount );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onUndo' );
 	} );
 
 	it( 'invalidates a checkpoint that arrives after Gutenberg Undo', () => {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -1550,7 +1550,9 @@ describe( 'OrchestratorChat', () => {
 		const checkpointId = mockGetCheckpointIdForMessage( checkpointMessage )!;
 		const checkpointResult = checkpointMessage.content[ 0 ].text;
 		const loadMessages = jest.fn();
-		mockUseAgentChat.mockReturnValue( agentChatReturn( { loadMessages } ) );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { loadMessages, messages: [ checkpointMessage ] } )
+		);
 
 		render( chat() );
 		act( () => {
@@ -2469,6 +2471,27 @@ describe( 'OrchestratorChat', () => {
 			'onUndo'
 		);
 		view.unmount();
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, finalMessage ] } )
+		);
+		const remountedView = render( chat() );
+		act( () => {
+			mockConversationConfig?.onSuccess?.(
+				[
+					{
+						messageId: finalMessage.id,
+						role: 'agent',
+						parts: [ { type: 'text', text: finalMessage.content[ 0 ].text } ],
+						kind: 'message',
+					},
+				],
+				'server-session-promoted-after-completion'
+			);
+		} );
+		remountedView.rerender( chat() );
+		expect( getDisplayedCheckpointAction( finalMessage.id )?.componentProps ).toHaveProperty(
+			'onUndo'
+		);
 
 		const laterUserMessage = {
 			id: 'user-after-promoted-session',
@@ -2479,7 +2502,7 @@ describe( 'OrchestratorChat', () => {
 		mockUseAgentChat.mockReturnValue(
 			agentChatReturn( { messages: [ userMessage, finalMessage, laterUserMessage ] } )
 		);
-		const remountedView = render( chat() );
+		remountedView.rerender( chat() );
 
 		expect( getDisplayedCheckpointAction( finalMessage.id )?.label ).toBe( 'Updated' );
 		expect( getDisplayedCheckpointAction( finalMessage.id )?.componentProps ).toMatchObject( {
@@ -2490,12 +2513,37 @@ describe( 'OrchestratorChat', () => {
 		);
 		expect( getDisplayedMessage( finalMessage.id ).disabled ).toBe( true );
 		expect( getDisplayedMessage( laterUserMessage.id ).disabled ).toBeUndefined();
+		act( () => {
+			mockConversationConfig?.onSuccess?.(
+				[
+					{
+						messageId: finalMessage.id,
+						role: 'agent',
+						parts: [ { type: 'text', text: finalMessage.content[ 0 ].text } ],
+						kind: 'message',
+					},
+				],
+				'server-session-promoted-after-completion'
+			);
+		} );
+		remountedView.rerender( chat() );
+		expect( mockInvalidateCheckpointAction ).not.toHaveBeenCalled();
+		expect( getDisplayedCheckpointAction( finalMessage.id )?.componentProps ).toMatchObject( {
+			disabled: true,
+		} );
+		expect( getDisplayedMessage( finalMessage.id ).disabled ).toBe( true );
+		remountedView.unmount();
+		const coldView = render( chat() );
+		expect( getDisplayedCheckpointAction( finalMessage.id )?.componentProps ).toMatchObject( {
+			disabled: true,
+		} );
+		expect( getDisplayedMessage( finalMessage.id ).disabled ).toBe( true );
 
 		mockAgentConfig = {
 			agentId: 'wp-orchestrator',
 			sessionId: 'different-server-session',
 		};
-		remountedView.rerender( chat() );
+		coldView.rerender( chat() );
 		expect( getDisplayedCheckpointAction( finalMessage.id ) ).toBeUndefined();
 		expect( getDisplayedMessage( finalMessage.id ).disabled ).toBeUndefined();
 	} );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -1604,6 +1604,40 @@ describe( 'OrchestratorChat', () => {
 		expect( getDisplayedMessage( nextUserMessage.id ).disabled ).toBeUndefined();
 	} );
 
+	it( 'dims a persisted checkpoint message after a later user message', () => {
+		const persistedCheckpointMessage = {
+			id: 'agent-persisted-checkpoint',
+			role: 'agent' as const,
+			content: [ { type: 'text' as const, text: 'The paragraph has been updated.' } ],
+			timestamp: 2,
+			actions: [
+				{
+					type: 'component' as const,
+					id: 'checkpoint',
+					label: 'Updated',
+					component: () => null,
+					order: 1,
+				},
+			],
+		};
+		const nextUserMessage = {
+			id: 'user-after-persisted-checkpoint',
+			role: 'user',
+			content: [ { type: 'text', text: 'What did you change?' } ],
+			timestamp: 3,
+		};
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				messages: [ userMessage, persistedCheckpointMessage, nextUserMessage ],
+			} )
+		);
+
+		render( chat() );
+
+		expect( getDisplayedMessage( persistedCheckpointMessage.id ).disabled ).toBe( true );
+		expect( getDisplayedMessage( nextUserMessage.id ).disabled ).toBeUndefined();
+	} );
+
 	it( 'hides checkpoint controls in loaded conversation history', () => {
 		const checkpointMessage = createCheckpointMessage(
 			'agent-history',
@@ -1637,22 +1671,6 @@ describe( 'OrchestratorChat', () => {
 		);
 		view.rerender( chat() );
 		expect( getDisplayedMessage( checkpointMessage.id ).disabled ).toBeUndefined();
-
-		mockUseAgentChat.mockReturnValue(
-			agentChatReturn( {
-				messages: [
-					checkpointMessage,
-					{
-						id: 'user-after-loaded-history',
-						role: 'user',
-						content: [ { type: 'text', text: 'Start a new request' } ],
-						timestamp: 2,
-					},
-				],
-			} )
-		);
-		view.rerender( chat() );
-		expect( getDisplayedMessage( checkpointMessage.id ).disabled ).toBe( true );
 	} );
 
 	it( 'updates the checkpoint status when native Undo and Redo stores notify separately', () => {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -11,13 +11,81 @@ const mockUseAgentChat = jest.fn();
 const mockUpdateSessionId = jest.fn();
 let mockManagerHasAgent = true;
 let mockAgentChatConfig: { onTaskUpdate?: ( update: TaskUpdate ) => Promise< void > } | undefined;
+let mockConversationConfig:
+	| {
+			onSuccess?: (
+				messages: Array< {
+					messageId: string;
+					role: 'user' | 'agent';
+					parts: Array< { type: 'text'; text: string } >;
+					kind: 'message';
+				} >,
+				sessionId: string
+			) => void;
+	  }
+	| undefined;
 const mockUseRegenerateAction = jest.fn();
 const mockUseCheckpointAction = jest.fn();
 const mockUseConversation = jest.fn();
 const mockUseImageUpload = jest.fn();
 const mockIsReaderChatAgent = jest.fn();
+const mockInvalidateCheckpointAction = jest.fn();
+const mockInvalidatedCheckpointIds = new Set< string >();
 let mockSelectedBlockType: string | undefined;
 let mockBlockEditorStoreThrows = false;
+let mockHasEditorRedo = false;
+
+function mockGetCheckpointIdForMessage( message: {
+	content?: Array< { text?: string } >;
+} ): string | null {
+	try {
+		const parsed = JSON.parse( message.content?.[ 0 ]?.text ?? '' );
+		if (
+			parsed.tool_id !== 'big_sky__apply_block_edits' &&
+			parsed.tool_id !== 'wpcom__update_block_content'
+		) {
+			return null;
+		}
+		return parsed.data?.calypsoCheckpointId ?? parsed.tool_call_id ?? null;
+	} catch {
+		return null;
+	}
+}
+
+const mockCheckpointActions = () => {
+	let isCheckpointActionAvailable: ( ( checkpointId: string ) => boolean ) | undefined;
+	const getActions = ( message: { content?: Array< { text?: string } > } ) => {
+		const checkpointId = mockGetCheckpointIdForMessage( message );
+		if ( ! checkpointId ) {
+			return [];
+		}
+
+		const canAct =
+			! mockInvalidatedCheckpointIds.has( checkpointId ) &&
+			( isCheckpointActionAvailable?.( checkpointId ) ?? true );
+		return [
+			{
+				type: 'component',
+				id: 'checkpoint',
+				label: canAct ? 'Updated and Undo' : 'Updated',
+				component: () => null,
+				componentProps: canAct ? { onUndo: jest.fn(), onRedo: jest.fn() } : {},
+				order: 1,
+			},
+		];
+	};
+	mockUseCheckpointAction.mockImplementation(
+		(
+			_registerMessageActions: unknown,
+			_checkpoint: unknown,
+			nextIsCheckpointActionAvailable?: ( checkpointId: string ) => boolean
+		) => {
+			isCheckpointActionAvailable = nextIsCheckpointActionAvailable;
+			return getActions;
+		}
+	);
+};
+
 const mockAgentChat = jest.fn(
 	( {
 		onSuggestionClick,
@@ -164,6 +232,9 @@ jest.mock(
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: ( mapSelect: ( select: ( storeName: string ) => object ) => unknown ) =>
 		mapSelect( ( storeName: string ) => {
+			if ( storeName === 'core/editor' ) {
+				return { hasEditorRedo: () => mockHasEditorRedo };
+			}
 			if ( storeName === 'core/block-editor' ) {
 				if ( mockBlockEditorStoreThrows ) {
 					throw new Error( 'Block editor store unavailable' );
@@ -201,13 +272,18 @@ jest.mock( '../../utils/tracks', () => ( {
 	recordAgentsManagerTracksEvent: jest.fn(),
 } ) );
 jest.mock( '../../hooks/use-abilities-registration', () => () => {} );
-jest.mock(
-	'../../hooks/use-conversation',
-	() => ( config: unknown ) => mockUseConversation( config )
-);
+jest.mock( '../../hooks/use-conversation', () => ( config: typeof mockConversationConfig ) => {
+	mockConversationConfig = config;
+	return mockUseConversation( config );
+} );
 jest.mock( '../../hooks/use-checkpoint-action', () => ( {
 	__esModule: true,
 	default: ( ...args: unknown[] ) => mockUseCheckpointAction( ...args ),
+	getCheckpointIdForMessage: mockGetCheckpointIdForMessage,
+	invalidateCheckpointAction: ( checkpointId: string ) => {
+		mockInvalidatedCheckpointIds.add( checkpointId );
+		mockInvalidateCheckpointAction( checkpointId );
+	},
 } ) );
 jest.mock( '../../hooks/use-feedback-action', () => () => ( {
 	showFeedbackInput: false,
@@ -227,6 +303,16 @@ jest.mock( '../../hooks/use-sources-action', () => () => {} );
 jest.mock( '../../utils/convert-tool-messages-to-components', () => ( {
 	__esModule: true,
 	default: ( { messages }: { messages: unknown[] } ) => messages,
+	isContextOnlyMessage: ( message: {
+		context?: { flags?: { context_only?: boolean } };
+		content?: Array< { type?: string; data?: { flags?: { context_only?: boolean } } } >;
+	} ) =>
+		message.context?.flags?.context_only === true ||
+		message.content?.some(
+			( content ) =>
+				content.type === 'context' ||
+				( content.type === 'data' && content.data?.flags?.context_only === true )
+		),
 } ) );
 jest.mock( '../../utils/external-context', () => ( {
 	consumeNextMessageExternalContextEntries: jest.fn(),
@@ -322,6 +408,32 @@ const showComponentMessage = ( id: string, content: string = SHOW_COMPONENT_CONT
 	showIcon: true,
 } );
 
+const createCheckpointMessage = ( id: string, checkpointId: string ) => ( {
+	id,
+	role: 'agent',
+	content: [
+		{
+			type: 'text',
+			text: JSON.stringify( {
+				tool_id: 'big_sky__apply_block_edits',
+				tool_call_id: checkpointId,
+				data: { result: { success: true, outcome: 'updated' } },
+			} ),
+		},
+	],
+	timestamp: 1,
+} );
+
+const getDisplayedCheckpointAction = ( messageId: string ) => {
+	const messages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
+		id: string;
+		actions?: Array< { id: string; componentProps?: Record< string, unknown > } >;
+	} >;
+	return messages
+		.find( ( message ) => message.id === messageId )
+		?.actions?.find( ( action ) => action.id === 'checkpoint' );
+};
+
 const countShowComponentMessages = () => {
 	const messages = mockAgentChat.mock.calls.at( -1 )![ 0 ].messages as Array< {
 		content?: Array< { text?: string } >;
@@ -353,7 +465,10 @@ describe( 'OrchestratorChat', () => {
 		mockBlockEditorStoreThrows = false;
 		sessionStorage.clear();
 		mockManagerHasAgent = true;
+		mockHasEditorRedo = false;
+		mockInvalidatedCheckpointIds.clear();
 		mockAgentChatConfig = undefined;
+		mockConversationConfig = undefined;
 	} );
 
 	it( 'ignores a conversation result for a discarded agent', () => {
@@ -1223,19 +1338,174 @@ describe( 'OrchestratorChat', () => {
 		);
 	} );
 
-	it( 'keeps streamed checkpoint actions through final prose and remounts', async () => {
-		const checkpointAction = {
-			id: 'checkpoint',
-			label: 'Updated and Undo',
-			onClick: jest.fn(),
-			order: 1,
-		};
-		mockUseCheckpointAction.mockReturnValue(
-			( message: { content?: Array< { text?: string } > } ) =>
-				message.content?.[ 0 ]?.text?.includes( 'big_sky__apply_block_edits' )
-					? [ checkpointAction ]
-					: []
+	it( 'hides checkpoint controls after a later user message', () => {
+		const checkpointMessage = createCheckpointMessage( 'agent-checkpoint', 'history-checkpoint' );
+		mockCheckpointActions();
+		const initialMessages = [ userMessage, checkpointMessage ];
+		mockUseAgentChat.mockReturnValue( agentChatReturn( { messages: initialMessages } ) );
+		const view = render( chat() );
+
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps ).toHaveProperty(
+			'onUndo'
 		);
+
+		const contextOnlyMessage = {
+			id: 'context-only',
+			role: 'user',
+			content: [ { type: 'context' } ],
+			timestamp: 2,
+		};
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ ...initialMessages, contextOnlyMessage ] } )
+		);
+		view.rerender( chat() );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps ).toHaveProperty(
+			'onUndo'
+		);
+
+		const nextUserMessage = {
+			id: 'user-2',
+			role: 'user',
+			content: [ { type: 'text', text: 'Make another edit' } ],
+			timestamp: 3,
+		};
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ ...initialMessages, contextOnlyMessage, nextUserMessage ] } )
+		);
+		view.rerender( chat() );
+
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onUndo' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onRedo' );
+	} );
+
+	it( 'hides checkpoint controls in loaded conversation history', () => {
+		const checkpointMessage = createCheckpointMessage(
+			'agent-history',
+			`loaded-history-checkpoint-${ Date.now() }`
+		);
+		const checkpointId = mockGetCheckpointIdForMessage( checkpointMessage )!;
+		const checkpointResult = checkpointMessage.content[ 0 ].text;
+		const loadMessages = jest.fn();
+		mockUseAgentChat.mockReturnValue( agentChatReturn( { loadMessages } ) );
+
+		render( chat() );
+		act( () => {
+			mockConversationConfig?.onSuccess?.(
+				[
+					{
+						messageId: checkpointMessage.id,
+						role: 'agent',
+						parts: [ { type: 'text', text: checkpointResult } ],
+						kind: 'message',
+					},
+				],
+				'history-session'
+			);
+		} );
+
+		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith( checkpointId );
+		expect( loadMessages ).toHaveBeenCalledWith(
+			expect.arrayContaining( [ expect.objectContaining( { messageId: checkpointMessage.id } ) ] )
+		);
+	} );
+
+	it( 'keeps checkpoint controls hidden after Gutenberg Undo and Redo', () => {
+		const checkpointMessage = createCheckpointMessage(
+			'agent-native-undo',
+			'native-undo-checkpoint'
+		);
+		mockCheckpointActions();
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, checkpointMessage ] } )
+		);
+		const view = render( chat() );
+
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps ).toHaveProperty(
+			'onUndo'
+		);
+
+		mockHasEditorRedo = true;
+		view.rerender( chat() );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onUndo' );
+		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith( 'native-undo-checkpoint' );
+
+		mockHasEditorRedo = false;
+		view.rerender( chat() );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onUndo' );
+		expect( mockInvalidateCheckpointAction ).toHaveBeenLastCalledWith( 'native-undo-checkpoint' );
+	} );
+
+	it( 'invalidates a checkpoint that arrives after Gutenberg Undo', () => {
+		const checkpointMessage = createCheckpointMessage(
+			'agent-late-checkpoint',
+			'late-native-undo-checkpoint'
+		);
+		mockCheckpointActions();
+		mockUseAgentChat.mockReturnValue( agentChatReturn( { messages: [ userMessage ] } ) );
+		const view = render( chat() );
+
+		mockHasEditorRedo = true;
+		view.rerender( chat() );
+		mockHasEditorRedo = false;
+		view.rerender( chat() );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, checkpointMessage ] } )
+		);
+		view.rerender( chat() );
+
+		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith( 'late-native-undo-checkpoint' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onUndo' );
+	} );
+
+	it( 'allows checkpoint controls on a later user turn', () => {
+		const firstCheckpoint = createCheckpointMessage( 'agent-first-turn', 'first-turn-checkpoint' );
+		const secondCheckpoint = createCheckpointMessage(
+			'agent-second-turn',
+			'second-turn-checkpoint'
+		);
+		mockCheckpointActions();
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, firstCheckpoint ] } )
+		);
+		const view = render( chat() );
+
+		mockHasEditorRedo = true;
+		view.rerender( chat() );
+		mockHasEditorRedo = false;
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				messages: [
+					userMessage,
+					firstCheckpoint,
+					{
+						id: 'user-second-turn',
+						role: 'user',
+						content: [ { type: 'text', text: 'Make another edit' } ],
+						timestamp: 2,
+					},
+					secondCheckpoint,
+				],
+			} )
+		);
+		view.rerender( chat() );
+
+		expect( getDisplayedCheckpointAction( secondCheckpoint.id )?.componentProps ).toHaveProperty(
+			'onUndo'
+		);
+	} );
+
+	it( 'keeps streamed checkpoint actions through final prose and remounts', async () => {
+		mockCheckpointActions();
 		const view = render( chat() );
 		const checkpointResult = JSON.stringify( {
 			tool_id: 'big_sky__apply_block_edits',
@@ -1248,7 +1518,6 @@ describe( 'OrchestratorChat', () => {
 				},
 			},
 		} );
-
 		await act( async () => {
 			await mockAgentChatConfig?.onTaskUpdate?.( {
 				id: 'task-streamed',

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -1604,9 +1604,76 @@ describe( 'OrchestratorChat', () => {
 		expect( getDisplayedMessage( nextUserMessage.id ).disabled ).toBeUndefined();
 	} );
 
-	it( 'dims a persisted checkpoint message after a later user message', () => {
+	it( 'dims streamed final prose when its checkpoint action is unavailable', async () => {
+		mockUseCheckpointAction.mockReturnValue( () => [] );
+		const view = render( chat() );
+		const taskId = 'task-unavailable-streamed-checkpoint';
+		const finalMessageId = 'agent-unavailable-streamed-checkpoint';
+
+		await act( async () => {
+			await mockAgentChatConfig?.onTaskUpdate?.(
+				createWorkingCheckpointUpdate(
+					taskId,
+					createJetpackCheckpointResult( 'unavailable-streamed-checkpoint' )
+				)
+			);
+			await mockAgentChatConfig?.onTaskUpdate?.(
+				createCompletedCheckpointUpdate( taskId, finalMessageId )
+			);
+		} );
+
+		const finalMessage = {
+			id: finalMessageId,
+			role: 'agent' as const,
+			content: [ { type: 'text' as const, text: 'The paragraph has been updated.' } ],
+			timestamp: 2,
+		};
+		const nextUserMessage = {
+			id: 'user-after-unavailable-streamed-checkpoint',
+			role: 'user',
+			content: [ { type: 'text', text: 'What did you change?' } ],
+			timestamp: 3,
+		};
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, finalMessage, nextUserMessage ] } )
+		);
+		view.rerender( chat() );
+
+		expect( getDisplayedCheckpointAction( finalMessage.id ) ).toBeUndefined();
+		expect( getDisplayedMessage( finalMessage.id ).disabled ).toBe( true );
+		expect( getDisplayedMessage( nextUserMessage.id ).disabled ).toBeUndefined();
+	} );
+
+	it( 'dims a persisted raw checkpoint message after a later user message', () => {
 		const persistedCheckpointMessage = {
 			id: 'agent-persisted-checkpoint',
+			role: 'agent' as const,
+			content: [
+				{ type: 'text' as const, text: createJetpackCheckpointResult( 'persisted-checkpoint' ) },
+			],
+			timestamp: 2,
+		};
+		const nextUserMessage = {
+			id: 'user-after-persisted-checkpoint',
+			role: 'user',
+			content: [ { type: 'text', text: 'What did you change?' } ],
+			timestamp: 3,
+		};
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				messages: [ userMessage, persistedCheckpointMessage, nextUserMessage ],
+			} )
+		);
+
+		render( chat() );
+
+		expect( getDisplayedMessage( persistedCheckpointMessage.id ).disabled ).toBe( true );
+		expect( getDisplayedMessage( nextUserMessage.id ).disabled ).toBeUndefined();
+	} );
+
+	it( 'dims a persisted checkpoint action after a later user message', () => {
+		const persistedCheckpointMessage = {
+			id: 'agent-persisted-checkpoint-action',
 			role: 'agent' as const,
 			content: [ { type: 'text' as const, text: 'The paragraph has been updated.' } ],
 			timestamp: 2,
@@ -1621,7 +1688,7 @@ describe( 'OrchestratorChat', () => {
 			],
 		};
 		const nextUserMessage = {
-			id: 'user-after-persisted-checkpoint',
+			id: 'user-after-persisted-checkpoint-action',
 			role: 'user',
 			content: [ { type: 'text', text: 'What did you change?' } ],
 			timestamp: 3,

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -2450,6 +2450,24 @@ describe( 'OrchestratorChat', () => {
 		expect( getDisplayedCheckpointAction( finalMessage.id )?.componentProps ).toHaveProperty(
 			'onUndo'
 		);
+		act( () => {
+			mockConversationConfig?.onSuccess?.(
+				[
+					{
+						messageId: finalMessage.id,
+						role: 'agent',
+						parts: [ { type: 'text', text: finalMessage.content[ 0 ].text } ],
+						kind: 'message',
+					},
+				],
+				'server-session-promoted-after-completion'
+			);
+		} );
+		expect( mockInvalidateCheckpointAction ).not.toHaveBeenCalled();
+		view.rerender( chat() );
+		expect( getDisplayedCheckpointAction( finalMessage.id )?.componentProps ).toHaveProperty(
+			'onUndo'
+		);
 		view.unmount();
 
 		const laterUserMessage = {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -29,6 +29,10 @@ const mockUseCheckpointAction = jest.fn();
 const mockUseConversation = jest.fn();
 const mockUseImageUpload = jest.fn();
 const mockIsReaderChatAgent = jest.fn();
+let mockAgentConfig: { agentId: string; sessionId?: string } = {
+	agentId: 'wp-orchestrator',
+};
+let mockTabSessionId: string | undefined = 'session-id';
 const mockInvalidateCheckpointAction = jest.fn();
 const mockInvalidatedCheckpointIds = new Set< string >();
 const mockRevertedCheckpointIds = new Set< string >();
@@ -98,10 +102,9 @@ const mockCheckpointActions = () => {
 		const canAct = actionState === 'enabled';
 		const isReverted = mockRevertedCheckpointIds.has( checkpointId );
 		const showDisabledAction = actionState === 'disabled';
-		const showAction = canAct || showDisabledAction;
-		let label = showAction ? 'Updated and Undo' : 'Updated';
+		let label = canAct ? 'Updated and Undo' : 'Updated';
 		if ( isReverted ) {
-			label = showAction ? 'Reverted and Redo' : 'Reverted';
+			label = canAct ? 'Reverted and Redo' : 'Reverted';
 		}
 		return [
 			{
@@ -314,10 +317,11 @@ jest.mock( '../../contexts', () => {
 	return {
 		useAgentsManagerContext: () => ( {
 			agentConfig: {
-				agentId: 'wp-orchestrator',
+				...mockAgentConfig,
 				onSessionIdChange: ( sessionId: string ) => saveSessionId( sessionId, 'wp-orchestrator' ),
 			},
-			getTabSessionId: () => 'session-id',
+			getTabSessionId: () => mockTabSessionId ?? '',
+			siteKey: 'site-1',
 		} ),
 	};
 } );
@@ -495,6 +499,47 @@ const createCheckpointMessage = (
 	timestamp: 1,
 } );
 
+const createJetpackCheckpointResult = ( checkpointId: string ) =>
+	JSON.stringify( {
+		tool_id: 'wpcom__update_block_content',
+		tool_call_id: checkpointId,
+		data: {
+			result: {
+				success: true,
+				outcome: 'updated',
+				message: 'Updated the selected block.',
+			},
+			followUpTasks: false,
+		},
+	} );
+
+const createWorkingCheckpointUpdate = (
+	taskId: string,
+	checkpointResult: string
+): TaskUpdate => ( {
+	id: taskId,
+	status: { state: 'working' },
+	text: checkpointResult,
+	final: false,
+	kind: 'status',
+} );
+
+const createCompletedCheckpointUpdate = ( taskId: string, messageId: string ): TaskUpdate => ( {
+	id: taskId,
+	status: {
+		state: 'completed',
+		message: {
+			messageId,
+			role: 'agent',
+			kind: 'message',
+			parts: [],
+		},
+	},
+	text: 'The paragraph has been updated.',
+	final: true,
+	kind: 'status',
+} );
+
 const createSwappableCheckpoint = () => ( {
 	getLastEditorState: jest.fn(),
 	setCheckpoint: jest.fn(),
@@ -563,6 +608,8 @@ describe( 'OrchestratorChat', () => {
 		mockUseAgentChat.mockReturnValue( agentChatReturn() );
 		mockUseImageUpload.mockReturnValue( createImageUpload() );
 		mockIsReaderChatAgent.mockReturnValue( false );
+		mockAgentConfig = { agentId: 'wp-orchestrator' };
+		mockTabSessionId = 'session-id';
 		mockSelectedBlockType = undefined;
 		mockBlockEditorStoreThrows = false;
 		sessionStorage.clear();
@@ -1443,7 +1490,7 @@ describe( 'OrchestratorChat', () => {
 		);
 	} );
 
-	it( 'disables checkpoint controls after a later user message', () => {
+	it( 'hides checkpoint controls and dims the edit message after a later user message', () => {
 		const checkpointMessage = createCheckpointMessage( 'agent-checkpoint', 'history-checkpoint' );
 		mockCheckpointActions();
 		const initialMessages = [ userMessage, checkpointMessage ];
@@ -1481,9 +1528,7 @@ describe( 'OrchestratorChat', () => {
 		);
 		view.rerender( chat() );
 
-		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe(
-			'Updated and Undo'
-		);
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
 		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps ).toMatchObject( {
 			disabled: true,
 		} );
@@ -2317,7 +2362,7 @@ describe( 'OrchestratorChat', () => {
 		);
 	} );
 
-	it( 'disables an earlier checkpoint while enabling a later turn', () => {
+	it( 'dims an earlier checkpoint while enabling a later turn', () => {
 		const firstCheckpoint = createCheckpointMessage(
 			'agent-disabled-first-turn',
 			'disabled-first-turn-checkpoint'
@@ -2349,7 +2394,7 @@ describe( 'OrchestratorChat', () => {
 		);
 		view.rerender( chat() );
 
-		expect( getDisplayedCheckpointAction( firstCheckpoint.id )?.label ).toBe( 'Updated and Undo' );
+		expect( getDisplayedCheckpointAction( firstCheckpoint.id )?.label ).toBe( 'Updated' );
 		expect( getDisplayedCheckpointAction( firstCheckpoint.id )?.componentProps ).toMatchObject( {
 			disabled: true,
 		} );
@@ -2361,6 +2406,158 @@ describe( 'OrchestratorChat', () => {
 			'onUndo'
 		);
 		expect( getDisplayedMessage( secondCheckpoint.id ).disabled ).toBeUndefined();
+	} );
+
+	it( 'keeps a streamed checkpoint when a fresh session is promoted after completion', async () => {
+		mockAgentConfig = { agentId: 'wp-orchestrator', sessionId: '' };
+		mockTabSessionId = 'stale-session-that-must-not-own-the-checkpoint';
+		mockCheckpointActions();
+		const view = render( chat() );
+		const checkpointResult = createJetpackCheckpointResult(
+			'checkpoint-session-promoted-after-completion'
+		);
+
+		await act( async () => {
+			await mockAgentChatConfig?.onTaskUpdate?.(
+				createWorkingCheckpointUpdate( 'task-session-promoted-after-completion', checkpointResult )
+			);
+			await mockAgentChatConfig?.onTaskUpdate?.(
+				createCompletedCheckpointUpdate(
+					'task-session-promoted-after-completion',
+					'agent-session-promoted-after-completion'
+				)
+			);
+		} );
+
+		const finalMessage = {
+			id: 'agent-session-promoted-after-completion',
+			role: 'agent' as const,
+			content: [ { type: 'text' as const, text: 'The paragraph has been updated.' } ],
+			timestamp: 2,
+			archived: false,
+			showIcon: true,
+		};
+		mockAgentConfig = {
+			agentId: 'wp-orchestrator',
+			sessionId: 'server-session-promoted-after-completion',
+		};
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, finalMessage ] } )
+		);
+		view.rerender( chat() );
+
+		expect( getDisplayedCheckpointAction( finalMessage.id )?.label ).toBe( 'Updated and Undo' );
+		expect( getDisplayedCheckpointAction( finalMessage.id )?.componentProps ).toHaveProperty(
+			'onUndo'
+		);
+		view.unmount();
+
+		const laterUserMessage = {
+			id: 'user-after-promoted-session',
+			role: 'user',
+			content: [ { type: 'text', text: 'What did you change?' } ],
+			timestamp: 3,
+		};
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, finalMessage, laterUserMessage ] } )
+		);
+		const remountedView = render( chat() );
+
+		expect( getDisplayedCheckpointAction( finalMessage.id )?.label ).toBe( 'Updated' );
+		expect( getDisplayedCheckpointAction( finalMessage.id )?.componentProps ).toMatchObject( {
+			disabled: true,
+		} );
+		expect( getDisplayedCheckpointAction( finalMessage.id )?.componentProps ).not.toHaveProperty(
+			'onUndo'
+		);
+		expect( getDisplayedMessage( finalMessage.id ).disabled ).toBe( true );
+		expect( getDisplayedMessage( laterUserMessage.id ).disabled ).toBeUndefined();
+
+		mockAgentConfig = {
+			agentId: 'wp-orchestrator',
+			sessionId: 'different-server-session',
+		};
+		remountedView.rerender( chat() );
+		expect( getDisplayedCheckpointAction( finalMessage.id ) ).toBeUndefined();
+		expect( getDisplayedMessage( finalMessage.id ).disabled ).toBeUndefined();
+	} );
+
+	it( 'keeps in-flight streamed checkpoints when a fresh session is promoted', async () => {
+		mockAgentConfig = { agentId: 'wp-orchestrator', sessionId: '' };
+		mockTabSessionId = 'stale-session-that-must-not-own-the-in-flight-checkpoint';
+		mockCheckpointActions();
+		const view = render( chat() );
+		const onTaskUpdateBeforePromotion = mockAgentChatConfig?.onTaskUpdate;
+
+		await act( async () => {
+			await onTaskUpdateBeforePromotion?.(
+				createWorkingCheckpointUpdate(
+					'task-started-before-session-promotion',
+					createJetpackCheckpointResult( 'checkpoint-started-before-session-promotion' )
+				)
+			);
+		} );
+
+		mockAgentConfig = {
+			agentId: 'wp-orchestrator',
+			sessionId: 'server-session-promoted-in-flight',
+		};
+		view.rerender( chat() );
+
+		await act( async () => {
+			await onTaskUpdateBeforePromotion?.(
+				createWorkingCheckpointUpdate(
+					'task-delivered-after-session-promotion',
+					createJetpackCheckpointResult( 'checkpoint-delivered-after-session-promotion' )
+				)
+			);
+			await onTaskUpdateBeforePromotion?.(
+				createCompletedCheckpointUpdate(
+					'task-started-before-session-promotion',
+					'agent-started-before-session-promotion'
+				)
+			);
+			await onTaskUpdateBeforePromotion?.(
+				createCompletedCheckpointUpdate(
+					'task-delivered-after-session-promotion',
+					'agent-delivered-after-session-promotion'
+				)
+			);
+		} );
+
+		const finalMessageStartedBeforePromotion = {
+			id: 'agent-started-before-session-promotion',
+			role: 'agent' as const,
+			content: [ { type: 'text' as const, text: 'The paragraph has been updated.' } ],
+			timestamp: 2,
+			archived: false,
+			showIcon: true,
+		};
+		const finalMessageDeliveredAfterPromotion = {
+			...finalMessageStartedBeforePromotion,
+			id: 'agent-delivered-after-session-promotion',
+			timestamp: 3,
+		};
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				messages: [
+					userMessage,
+					finalMessageStartedBeforePromotion,
+					finalMessageDeliveredAfterPromotion,
+				],
+			} )
+		);
+		view.rerender( chat() );
+
+		for ( const finalMessage of [
+			finalMessageStartedBeforePromotion,
+			finalMessageDeliveredAfterPromotion,
+		] ) {
+			expect( getDisplayedCheckpointAction( finalMessage.id )?.label ).toBe( 'Updated and Undo' );
+			expect( getDisplayedCheckpointAction( finalMessage.id )?.componentProps ).toHaveProperty(
+				'onUndo'
+			);
+		}
 	} );
 
 	it( 'keeps streamed checkpoint actions through final prose and remounts', async () => {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -83,20 +83,25 @@ function mockGetCheckpointIdForMessage( message: {
 }
 
 const mockCheckpointActions = () => {
-	let isCheckpointActionAvailable: ( ( checkpointId: string ) => boolean ) | undefined;
+	let getCheckpointActionState:
+		| ( ( checkpointId: string ) => 'disabled' | 'enabled' | 'hidden' )
+		| undefined;
 	const getActions = ( message: { content?: Array< { text?: string } > } ) => {
 		const checkpointId = mockGetCheckpointIdForMessage( message );
 		if ( ! checkpointId ) {
 			return [];
 		}
 
-		const canAct =
-			! mockInvalidatedCheckpointIds.has( checkpointId ) &&
-			( isCheckpointActionAvailable?.( checkpointId ) ?? true );
+		const actionState = mockInvalidatedCheckpointIds.has( checkpointId )
+			? 'hidden'
+			: getCheckpointActionState?.( checkpointId ) ?? 'enabled';
+		const canAct = actionState === 'enabled';
 		const isReverted = mockRevertedCheckpointIds.has( checkpointId );
-		let label = canAct ? 'Updated and Undo' : 'Updated';
+		const showDisabledAction = actionState === 'disabled';
+		const showAction = canAct || showDisabledAction;
+		let label = showAction ? 'Updated and Undo' : 'Updated';
 		if ( isReverted ) {
-			label = canAct ? 'Reverted and Redo' : 'Reverted';
+			label = showAction ? 'Reverted and Redo' : 'Reverted';
 		}
 		return [
 			{
@@ -106,6 +111,7 @@ const mockCheckpointActions = () => {
 				component: () => null,
 				componentProps: {
 					initiallyReverted: isReverted,
+					...( showDisabledAction && { disabled: true } ),
 					...( canAct && { onUndo: jest.fn(), onRedo: jest.fn() } ),
 				},
 				order: 1,
@@ -116,9 +122,9 @@ const mockCheckpointActions = () => {
 		(
 			_registerMessageActions: unknown,
 			_checkpoint: unknown,
-			nextIsCheckpointActionAvailable?: ( checkpointId: string ) => boolean
+			nextGetCheckpointActionState?: ( checkpointId: string ) => 'disabled' | 'enabled' | 'hidden'
 		) => {
-			isCheckpointActionAvailable = nextIsCheckpointActionAvailable;
+			getCheckpointActionState = nextGetCheckpointActionState;
 			return getActions;
 		}
 	);
@@ -1425,7 +1431,7 @@ describe( 'OrchestratorChat', () => {
 		);
 	} );
 
-	it( 'hides checkpoint controls after a later user message', () => {
+	it( 'disables checkpoint controls after a later user message', () => {
 		const checkpointMessage = createCheckpointMessage( 'agent-checkpoint', 'history-checkpoint' );
 		mockCheckpointActions();
 		const initialMessages = [ userMessage, checkpointMessage ];
@@ -1461,6 +1467,12 @@ describe( 'OrchestratorChat', () => {
 		);
 		view.rerender( chat() );
 
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe(
+			'Updated and Undo'
+		);
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps ).toMatchObject( {
+			disabled: true,
+		} );
 		expect(
 			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
 		).not.toHaveProperty( 'onUndo' );
@@ -1580,6 +1592,78 @@ describe( 'OrchestratorChat', () => {
 			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
 		).not.toHaveProperty( 'onRedo' );
 		expect( mockInvalidateCheckpointAction ).toHaveBeenLastCalledWith( 'native-undo-checkpoint' );
+	} );
+
+	it( 'keeps a pending native Undo hidden after a later user message', () => {
+		const checkpointMessage = createCheckpointMessage(
+			'agent-pending-native-undo',
+			'pending-native-undo-checkpoint'
+		);
+		const checkpoint = {
+			getLastEditorState: jest.fn(),
+			setCheckpoint: jest.fn(),
+			addCheckpointKeys: jest.fn(),
+			restoreCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			canSwapCheckpoint: jest.fn().mockReturnValue( true ),
+			swapCheckpoint: jest.fn().mockResolvedValue( undefined ),
+			addNewPageToCheckpoint: jest.fn(),
+			addPageRenameToCheckpoint: jest.fn(),
+			addPageRemovalToCheckpoint: jest.fn(),
+			getLatestUserMessageId: jest.fn(),
+			clearCheckpoint: jest.fn(),
+			hasCheckpoint: jest.fn().mockReturnValue( true ),
+		};
+		const useCheckpoint = () => checkpoint;
+		mockCheckpointActions();
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, checkpointMessage ] } )
+		);
+		const view = render( chat( { useCheckpoint } ) );
+
+		act( () => {
+			mockHasEditorRedo = true;
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
+
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				messages: [
+					userMessage,
+					checkpointMessage,
+					{
+						id: 'user-after-pending-native-undo',
+						role: 'user',
+						content: [ { type: 'text', text: 'Make another edit' } ],
+						timestamp: 2,
+					},
+				],
+			} )
+		);
+		view.rerender( chat( { useCheckpoint } ) );
+
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'disabled' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onUndo' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'onRedo' );
+		expect( mockInvalidateCheckpointAction ).toHaveBeenCalledWith(
+			'pending-native-undo-checkpoint'
+		);
+
+		act( () => {
+			mockHasEditorRedo = false;
+			mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+		} );
+		expect( getDisplayedCheckpointAction( checkpointMessage.id )?.label ).toBe( 'Updated' );
+		expect(
+			getDisplayedCheckpointAction( checkpointMessage.id )?.componentProps
+		).not.toHaveProperty( 'disabled' );
 	} );
 
 	it( 'updates the checkpoint status when native Undo stores notify together', () => {
@@ -2209,6 +2293,51 @@ describe( 'OrchestratorChat', () => {
 		);
 		view.rerender( chat() );
 
+		expect( getDisplayedCheckpointAction( firstCheckpoint.id )?.label ).toBe( 'Updated' );
+		expect( getDisplayedCheckpointAction( secondCheckpoint.id )?.componentProps ).toHaveProperty(
+			'onUndo'
+		);
+	} );
+
+	it( 'disables an earlier checkpoint while enabling a later turn', () => {
+		const firstCheckpoint = createCheckpointMessage(
+			'agent-disabled-first-turn',
+			'disabled-first-turn-checkpoint'
+		);
+		const secondCheckpoint = createCheckpointMessage(
+			'agent-enabled-second-turn',
+			'enabled-second-turn-checkpoint'
+		);
+		mockCheckpointActions();
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { messages: [ userMessage, firstCheckpoint ] } )
+		);
+		const view = render( chat() );
+
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( {
+				messages: [
+					userMessage,
+					firstCheckpoint,
+					{
+						id: 'user-enabled-second-turn',
+						role: 'user',
+						content: [ { type: 'text', text: 'Make another edit' } ],
+						timestamp: 2,
+					},
+					secondCheckpoint,
+				],
+			} )
+		);
+		view.rerender( chat() );
+
+		expect( getDisplayedCheckpointAction( firstCheckpoint.id )?.label ).toBe( 'Updated and Undo' );
+		expect( getDisplayedCheckpointAction( firstCheckpoint.id )?.componentProps ).toMatchObject( {
+			disabled: true,
+		} );
+		expect( getDisplayedCheckpointAction( firstCheckpoint.id )?.componentProps ).not.toHaveProperty(
+			'onUndo'
+		);
 		expect( getDisplayedCheckpointAction( secondCheckpoint.id )?.componentProps ).toHaveProperty(
 			'onUndo'
 		);

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -134,6 +134,7 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 			}
 
 			&__icon {
+				color: inherit;
 				flex: 0 0 auto;
 				fill: currentColor;
 			}

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -94,6 +94,7 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 			}
 
 			&__status {
+				background: transparent;
 				color: #4ab866;
 				font-weight: 600;
 

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -137,6 +137,12 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 				color: inherit;
 				flex: 0 0 auto;
 				fill: currentColor;
+
+				// Agenttic sets `color` directly on every message descendant.
+				path {
+					color: inherit;
+					fill: currentColor;
+				}
 			}
 		}
 	}

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -94,8 +94,6 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 			}
 
 			&__status {
-				// Agenttic's success token is white in dark mode; match the Editorial Review treatment.
-				background: rgba( 74, 184, 102, 0.2 );
 				color: #4ab866;
 				font-weight: 600;
 

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -336,6 +336,7 @@ export default function OrchestratorChat( {
 		streamGeneration: Symbol(),
 		pendingByTaskId: new Map< string, UIMessage >(),
 		byFinalMessageId: getStreamedCheckpointMessages( checkpointSessionIdentity ),
+		liveFinalMessageIds: new Set< string >(),
 		regeneratingMessageId: undefined as string | undefined,
 	} );
 	if ( streamedCheckpointMessagesRef.current.sessionIdentity !== checkpointSessionIdentity ) {
@@ -367,6 +368,9 @@ export default function OrchestratorChat( {
 			streamGeneration: isSessionBootstrap ? previousStreamedMessages.streamGeneration : Symbol(),
 			pendingByTaskId: isSessionBootstrap ? previousStreamedMessages.pendingByTaskId : new Map(),
 			byFinalMessageId,
+			liveFinalMessageIds: isSessionBootstrap
+				? previousStreamedMessages.liveFinalMessageIds
+				: new Set(),
 			regeneratingMessageId: isSessionBootstrap
 				? previousStreamedMessages.regeneratingMessageId
 				: undefined,
@@ -410,12 +414,15 @@ export default function OrchestratorChat( {
 					const regeneratingMessageId = streamedMessages.regeneratingMessageId;
 					if ( completedSuccessfully && regeneratingMessageId ) {
 						streamedMessages.byFinalMessageId.delete( regeneratingMessageId );
+						streamedMessages.liveFinalMessageIds.delete( regeneratingMessageId );
 					}
 					if ( finalMessageId && completedSuccessfully && checkpointMessage ) {
 						streamedMessages.byFinalMessageId.set( finalMessageId, checkpointMessage );
+						streamedMessages.liveFinalMessageIds.add( finalMessageId );
 					} else if ( completedSuccessfully && regeneratingMessageId ) {
 						if ( finalMessageId ) {
 							streamedMessages.byFinalMessageId.delete( finalMessageId );
+							streamedMessages.liveFinalMessageIds.delete( finalMessageId );
 						}
 					}
 					streamedMessages.pendingByTaskId.delete( update.id );
@@ -604,7 +611,10 @@ export default function OrchestratorChat( {
 						.map( ( part ) => ( { type: 'text', text: part.text } ) ),
 				};
 				const checkpointId = getCheckpointIdForMessage( checkpointMessage );
-				if ( checkpointId ) {
+				const isLiveStreamedMessage = streamedCheckpointMessagesRef.current.liveFinalMessageIds.has(
+					message.messageId
+				);
+				if ( checkpointId && ! isLiveStreamedMessage ) {
 					invalidateCheckpointAction( checkpointId );
 				}
 			} );

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -21,6 +21,8 @@ import { useBroadcastConversationActivity } from '../../hooks/use-broadcast-conv
 import useCheckpointAction, {
 	getCheckpointIdForMessage,
 	invalidateCheckpointAction,
+	isCheckpointActionInvalidated,
+	setCheckpointActionReverted,
 } from '../../hooks/use-checkpoint-action';
 import useConversation from '../../hooks/use-conversation';
 import useCopyAction from '../../hooks/use-copy-action';
@@ -624,7 +626,9 @@ export default function OrchestratorChat( {
 	const hasPendingCheckpointSwap =
 		supportsCheckpointSwap &&
 		[ ...checkpointIdsByTurn.current ].some(
-			( checkpointId ) => ! sourceDriftInvalidatedCheckpointIds.has( checkpointId )
+			( checkpointId ) =>
+				! sourceDriftInvalidatedCheckpointIds.has( checkpointId ) &&
+				! isCheckpointActionInvalidated( checkpointId )
 		);
 	const checkpointEditorBlocks = useSelect(
 		( select ) => {
@@ -656,6 +660,7 @@ export default function OrchestratorChat( {
 		if ( supportsCheckpointSwap && currentCheckpoint ) {
 			for ( const checkpointId of checkpointIdsByTurn.current ) {
 				if (
+					! hasEditorRedo &&
 					! nextInvalidatedCheckpointIds.has( checkpointId ) &&
 					! pendingCheckpointActionIdsRef.current.has( checkpointId ) &&
 					currentCheckpoint.canSwapCheckpoint?.( checkpointId ) === false
@@ -674,6 +679,7 @@ export default function OrchestratorChat( {
 		checkpointEditorBlocks,
 		checkpointIdsByTurn,
 		checkpointSessionIdentity,
+		hasEditorRedo,
 		sourceDriftInvalidatedCheckpointIds,
 		supportsCheckpointSwap,
 		useCheckpoint,
@@ -682,6 +688,7 @@ export default function OrchestratorChat( {
 	const nativeUndoInvalidatedTurnRef = useRef(
 		hasEditorRedo ? checkpointIdsByTurn.userMessageId : undefined
 	);
+	const nativeUndoRevertedTurnRef = useRef< string | undefined >( undefined );
 	const getCheckpointActionsForMessage = useCheckpointAction(
 		registerMessageActions,
 		checkpoint,
@@ -695,12 +702,46 @@ export default function OrchestratorChat( {
 	);
 
 	useEffect( () => {
-		if ( previousHasEditorRedoRef.current === false && hasEditorRedo ) {
+		const currentCheckpointIds = [ ...checkpointIdsByTurn.current ];
+		const hasPendingCheckpointAction = currentCheckpointIds.some( ( checkpointId ) =>
+			pendingCheckpointActionIdsRef.current.has( checkpointId )
+		);
+		const didNativeUndo =
+			previousHasEditorRedoRef.current === false && hasEditorRedo && ! hasPendingCheckpointAction;
+		const didNativeRedo = previousHasEditorRedoRef.current === true && ! hasEditorRedo;
+		if ( didNativeUndo ) {
 			nativeUndoInvalidatedTurnRef.current = checkpointIdsByTurn.userMessageId;
+			nativeUndoRevertedTurnRef.current = checkpointIdsByTurn.userMessageId;
 		}
 		previousHasEditorRedoRef.current = hasEditorRedo;
 
-		for ( const checkpointId of checkpointIdsByTurn.current ) {
+		const latestCheckpointId = currentCheckpointIds[ currentCheckpointIds.length - 1 ];
+		let didChangeStatus = false;
+		let confirmedNativeRedo = false;
+		if (
+			didNativeRedo &&
+			latestCheckpointId &&
+			checkpointIdsByTurn.userMessageId &&
+			nativeUndoRevertedTurnRef.current === checkpointIdsByTurn.userMessageId &&
+			checkpointRef.current?.canSwapCheckpoint?.( latestCheckpointId ) === true
+		) {
+			didChangeStatus = setCheckpointActionReverted( latestCheckpointId, false );
+			nativeUndoRevertedTurnRef.current = undefined;
+			confirmedNativeRedo = true;
+		}
+		if (
+			! confirmedNativeRedo &&
+			latestCheckpointId &&
+			checkpointIdsByTurn.userMessageId &&
+			nativeUndoRevertedTurnRef.current === checkpointIdsByTurn.userMessageId &&
+			! sourceDriftInvalidatedCheckpointIds.has( latestCheckpointId ) &&
+			! isCheckpointActionInvalidated( latestCheckpointId ) &&
+			checkpointRef.current?.canSwapCheckpoint?.( latestCheckpointId ) === false
+		) {
+			didChangeStatus = setCheckpointActionReverted( latestCheckpointId, true );
+		}
+
+		for ( const checkpointId of currentCheckpointIds ) {
 			if (
 				checkpointIdsByTurn.userMessageId &&
 				nativeUndoInvalidatedTurnRef.current === checkpointIdsByTurn.userMessageId
@@ -708,7 +749,10 @@ export default function OrchestratorChat( {
 				invalidateCheckpointAction( checkpointId );
 			}
 		}
-	}, [ checkpointIdsByTurn, hasEditorRedo ] );
+		if ( didChangeStatus ) {
+			setCheckpointActionRevision( ( revision ) => revision + 1 );
+		}
+	}, [ checkpointIdsByTurn, hasEditorRedo, sourceDriftInvalidatedCheckpointIds ] );
 
 	// TODO (ability-migration): Remove once the last checkpoint-writing Big Sky
 	// ability migrates. Keeps the provider checkpoint store reachable for the

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -1412,11 +1412,25 @@ export default function OrchestratorChat( {
 		const latestAgentMessageId = getLatestAgentMessageId( currentMessages );
 
 		currentMessages = currentMessages.map( ( message ) => {
+			const checkpointActions = checkpointActionsByMessageId.get( message.id ) ?? [];
+			const hasDisabledCheckpointAction = checkpointActions.some(
+				( action ) =>
+					action.type === 'component' &&
+					action.id === 'checkpoint' &&
+					action.componentProps?.disabled === true
+			);
 			const traceId = getTraceIdForMessage( message.id );
-			const messageWithTraceId = traceId ? { ...message, traceId } : message;
+			const messageWithTraceId =
+				traceId || hasDisabledCheckpointAction
+					? {
+							...message,
+							...( traceId && { traceId } ),
+							...( hasDisabledCheckpointAction && { disabled: true } ),
+					  }
+					: message;
 
 			const directActions = [
-				...( checkpointActionsByMessageId.get( message.id ) ?? [] ),
+				...checkpointActions,
 				...getFeedbackActionsForMessage( message ),
 				...getCopyActionsForMessage( message ),
 				...getRegenerateActionsForMessage( message, {

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -791,7 +791,7 @@ export default function OrchestratorChat( {
 		} );
 
 		return {
-			current,
+			currentCheckpointIds: current,
 			userMessageIdByCheckpointId,
 			userMessageId: messages[ latestUserMessageIndex ]?.id,
 		};
@@ -812,7 +812,7 @@ export default function OrchestratorChat( {
 	const hasPendingCheckpointSwap =
 		supportsCheckpointSwap &&
 		( isWatchingNativeHistory ||
-			[ ...checkpointIdsByTurn.current ].some(
+			[ ...checkpointIdsByTurn.currentCheckpointIds ].some(
 				( checkpointId ) =>
 					! sourceDriftInvalidatedCheckpointIds.has( checkpointId ) &&
 					! isCheckpointActionInvalidated( checkpointId )
@@ -840,7 +840,7 @@ export default function OrchestratorChat( {
 		const currentCheckpoint = checkpointRef.current;
 		const nextInvalidatedCheckpointIds = new Set(
 			[ ...sourceDriftInvalidatedCheckpointIds ].filter( ( checkpointId ) =>
-				checkpointIdsByTurn.current.has( checkpointId )
+				checkpointIdsByTurn.currentCheckpointIds.has( checkpointId )
 			)
 		);
 		let didChange = nextInvalidatedCheckpointIds.size !== sourceDriftInvalidatedCheckpointIds.size;
@@ -851,7 +851,7 @@ export default function OrchestratorChat( {
 				pendingNativeUndoTurnRef.current === checkpointIdsByTurn.userMessageId ||
 				nativeUndoInvalidatedTurnRef.current === checkpointIdsByTurn.userMessageId );
 		if ( supportsCheckpointSwap && currentCheckpoint ) {
-			for ( const checkpointId of checkpointIdsByTurn.current ) {
+			for ( const checkpointId of checkpointIdsByTurn.currentCheckpointIds ) {
 				if (
 					! shouldDeferSourceDriftInvalidation &&
 					! nextInvalidatedCheckpointIds.has( checkpointId ) &&
@@ -893,7 +893,7 @@ export default function OrchestratorChat( {
 			) {
 				return 'hidden';
 			}
-			if ( ! checkpointIdsByTurn.current.has( checkpointId ) ) {
+			if ( ! checkpointIdsByTurn.currentCheckpointIds.has( checkpointId ) ) {
 				return 'disabled';
 			}
 			if ( hasEditorRedo && checkpointRef.current?.canSwapCheckpoint?.( checkpointId ) !== true ) {
@@ -914,7 +914,7 @@ export default function OrchestratorChat( {
 			checkpointEditorBlocks !== undefined &&
 			previousCheckpointEditorBlocksRef.current !== checkpointEditorBlocks;
 		previousCheckpointEditorBlocksRef.current = checkpointEditorBlocks;
-		const currentCheckpointIds = [ ...checkpointIdsByTurn.current ];
+		const currentCheckpointIds = [ ...checkpointIdsByTurn.currentCheckpointIds ];
 		const latestCheckpointId = currentCheckpointIds[ currentCheckpointIds.length - 1 ];
 		const latestCheckpointCanSwap = latestCheckpointId
 			? checkpointRef.current?.canSwapCheckpoint?.( latestCheckpointId )
@@ -930,7 +930,7 @@ export default function OrchestratorChat( {
 		const didInlineUndoCreateEditorRedo =
 			didEditorRedoBecomeAvailable &&
 			completedInlineUndoCheckpointIdRef.current !== undefined &&
-			checkpointIdsByTurn.current.has( completedInlineUndoCheckpointIdRef.current );
+			checkpointIdsByTurn.currentCheckpointIds.has( completedInlineUndoCheckpointIdRef.current );
 		const wasPendingNativeUndo =
 			!! checkpointIdsByTurn.userMessageId &&
 			pendingNativeUndoTurnRef.current === checkpointIdsByTurn.userMessageId;
@@ -1493,13 +1493,26 @@ export default function OrchestratorChat( {
 			);
 		}
 
+		const checkpointDetails = currentMessages.map( ( message ) => {
+			const checkpointMessage =
+				streamedCheckpointMessagesRef.current.byFinalMessageId.get( message.id ) ?? message;
+			return {
+				messageId: message.id,
+				actions: getCheckpointActionsForMessage( checkpointMessage ),
+				checkpointId: getCheckpointIdForMessage( checkpointMessage ),
+			};
+		} );
 		const checkpointActionsByMessageId = new Map(
-			currentMessages.map( ( message ) => [
-				message.id,
-				getCheckpointActionsForMessage(
-					streamedCheckpointMessagesRef.current.byFinalMessageId.get( message.id ) ?? message
-				),
-			] )
+			checkpointDetails.map( ( details ) => [ details.messageId, details.actions ] )
+		);
+		const supersededCheckpointMessageIds = new Set(
+			checkpointDetails
+				.filter(
+					( details ) =>
+						details.checkpointId &&
+						! checkpointIdsByTurn.currentCheckpointIds.has( details.checkpointId )
+				)
+				.map( ( details ) => details.messageId )
 		);
 
 		// Group site-build messages only when needed
@@ -1530,13 +1543,15 @@ export default function OrchestratorChat( {
 					action.id === 'checkpoint' &&
 					action.componentProps?.disabled === true
 			);
+			const shouldDisableCheckpointMessage =
+				hasDisabledCheckpointAction || supersededCheckpointMessageIds.has( message.id );
 			const traceId = getTraceIdForMessage( message.id );
 			const messageWithTraceId =
-				traceId || hasDisabledCheckpointAction
+				traceId || shouldDisableCheckpointMessage
 					? {
 							...message,
 							...( traceId && { traceId } ),
-							...( hasDisabledCheckpointAction && { disabled: true } ),
+							...( shouldDisableCheckpointMessage && { disabled: true } ),
 					  }
 					: message;
 
@@ -1575,6 +1590,7 @@ export default function OrchestratorChat( {
 		return currentMessages;
 	}, [
 		checkpointActionRevision,
+		checkpointIdsByTurn,
 		checkpointSessionIdentity,
 		currentPostId,
 		deletedMessageIds,

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -1,4 +1,9 @@
-import { getAgentManager, useAgentChat, type UIMessage } from '@automattic/agenttic-client';
+import {
+	getAgentManager,
+	useAgentChat,
+	type TaskUpdate,
+	type UIMessage,
+} from '@automattic/agenttic-client';
 import {
 	type Suggestion,
 	type MarkdownComponents,
@@ -37,6 +42,7 @@ import { getOrchestratorErrorMessage } from '../../utils/orchestrator-error-mess
 import { setProviderCheckpoints } from '../../utils/provider-checkpoints';
 import { getReaderChatErrorMessage } from '../../utils/reader-chat-error-message';
 import { isShowComponentTool } from '../../utils/show-component-tools';
+import { isBlockEditToolId } from '../../utils/tool-message-utils';
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import AgentChat from '../agent-chat';
 import { type Options as ChatHeaderOptions } from '../chat-header';
@@ -51,6 +57,19 @@ import type {
 	UseCheckpointHook,
 	ProviderCapabilities,
 } from '../../utils/load-external-providers';
+
+const streamedCheckpointMessagesBySession = new Map< string, Map< string, UIMessage > >();
+
+function getStreamedCheckpointMessages( sessionIdentity: string ): Map< string, UIMessage > {
+	const existing = streamedCheckpointMessagesBySession.get( sessionIdentity );
+	if ( existing ) {
+		return existing;
+	}
+
+	const messages = new Map< string, UIMessage >();
+	streamedCheckpointMessagesBySession.set( sessionIdentity, messages );
+	return messages;
+}
 
 function getLatestAgentMessageId( messages: UIMessage[] ): string | null {
 	for ( let index = messages.length - 1; index >= 0; index-- ) {
@@ -241,6 +260,75 @@ export default function OrchestratorChat( {
 		}
 	}, [] );
 	const { isPageOrSiteEditorSurface: groupWritingSuggestions } = usePageOrSiteEditorSurface();
+	const checkpointSessionIdentity = `${ agentConfig?.agentId ?? '' }:${
+		agentConfig?.sessionId ?? getActiveSessionId() ?? ''
+	}`;
+	const streamedCheckpointMessagesRef = useRef( {
+		sessionIdentity: checkpointSessionIdentity,
+		pendingByTaskId: new Map< string, UIMessage >(),
+		byFinalMessageId: getStreamedCheckpointMessages( checkpointSessionIdentity ),
+		regeneratingMessageId: undefined as string | undefined,
+	} );
+	if ( streamedCheckpointMessagesRef.current.sessionIdentity !== checkpointSessionIdentity ) {
+		streamedCheckpointMessagesRef.current = {
+			sessionIdentity: checkpointSessionIdentity,
+			pendingByTaskId: new Map(),
+			byFinalMessageId: getStreamedCheckpointMessages( checkpointSessionIdentity ),
+			regeneratingMessageId: undefined,
+		};
+	}
+	const agentChatConfig = useMemo( () => {
+		if ( ! agentConfig ) {
+			return null;
+		}
+
+		const { onTaskUpdate } = agentConfig;
+		return {
+			...agentConfig,
+			onTaskUpdate: async ( update: TaskUpdate ) => {
+				const streamedMessages = streamedCheckpointMessagesRef.current;
+				if ( streamedMessages.sessionIdentity === checkpointSessionIdentity && update.text ) {
+					const message: UIMessage = {
+						id: update.status.message?.messageId ?? update.agentMessage?.messageId ?? update.id,
+						role: 'agent',
+						content: [ { type: 'text', text: update.text } ],
+						timestamp: Date.now(),
+						archived: false,
+						showIcon: true,
+					};
+					if ( isBlockEditToolId( getToolMessageData( message )?.toolId ) ) {
+						streamedMessages.pendingByTaskId.set( update.id, message );
+					}
+				}
+
+				const isTerminal =
+					update.final === true ||
+					[ 'completed', 'canceled', 'failed' ].includes( update.status.state );
+				if ( isTerminal ) {
+					const finalMessageId = update.status.message?.messageId ?? update.agentMessage?.messageId;
+					const completedSuccessfully =
+						update.status.state === 'completed' ||
+						( update.final === true && ! [ 'canceled', 'failed' ].includes( update.status.state ) );
+					const checkpointMessage = streamedMessages.pendingByTaskId.get( update.id );
+					const regeneratingMessageId = streamedMessages.regeneratingMessageId;
+					if ( completedSuccessfully && regeneratingMessageId ) {
+						streamedMessages.byFinalMessageId.delete( regeneratingMessageId );
+					}
+					if ( finalMessageId && completedSuccessfully && checkpointMessage ) {
+						streamedMessages.byFinalMessageId.set( finalMessageId, checkpointMessage );
+					} else if ( completedSuccessfully && regeneratingMessageId ) {
+						if ( finalMessageId ) {
+							streamedMessages.byFinalMessageId.delete( finalMessageId );
+						}
+					}
+					streamedMessages.pendingByTaskId.delete( update.id );
+					streamedMessages.regeneratingMessageId = undefined;
+				}
+
+				await onTaskUpdate?.( update );
+			},
+		};
+	}, [ agentConfig, checkpointSessionIdentity ] );
 
 	const {
 		addMessage,
@@ -256,7 +344,7 @@ export default function OrchestratorChat( {
 		registerMessageActions,
 		getRegenerateHandler,
 		progressMessage,
-	} = useAgentChat( agentConfig! );
+	} = useAgentChat( agentChatConfig! );
 	const messagesRef = useRef( messages );
 	const getTraceIdForMessage = useAgentTraceIds( agentConfig );
 	const previousMessagesRef = useRef( messages );
@@ -296,11 +384,17 @@ export default function OrchestratorChat( {
 
 			return async () => {
 				setIsRegenerating( true );
+				streamedCheckpointMessagesRef.current.pendingByTaskId.clear();
+				streamedCheckpointMessagesRef.current.regeneratingMessageId = message?.id;
 				// Drop any retained placeholders up front; the turn is being
 				// rewound, so a leftover picker would otherwise reappear once
 				// regeneration settles if the new response omits the component.
 				clearRetainedShowComponentMessages();
-				await handler();
+				try {
+					await handler();
+				} finally {
+					streamedCheckpointMessagesRef.current.regeneratingMessageId = undefined;
+				}
 			};
 		},
 		[ clearRetainedShowComponentMessages, getRegenerateHandler ]
@@ -871,7 +965,9 @@ export default function OrchestratorChat( {
 		const checkpointActionsByMessageId = new Map(
 			currentMessages.map( ( message ) => [
 				message.id,
-				getCheckpointActionsForMessage( message ),
+				getCheckpointActionsForMessage(
+					streamedCheckpointMessagesRef.current.byFinalMessageId.get( message.id ) ?? message
+				),
 			] )
 		);
 

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -602,6 +602,9 @@ export default function OrchestratorChat( {
 		},
 		[]
 	);
+	const handleCheckpointActionInvalidated = useCallback( () => {
+		setCheckpointActionRevision( ( revision ) => revision + 1 );
+	}, [] );
 	const checkpointIdsByTurn = useMemo( () => {
 		const latestUserMessageIndex = getLatestUserMessageIndex( messages );
 		const current = new Set< string >();
@@ -693,21 +696,30 @@ export default function OrchestratorChat( {
 		registerMessageActions,
 		checkpoint,
 		( checkpointId ) =>
-			! hasEditorRedo &&
+			( ! hasEditorRedo || checkpointRef.current?.canSwapCheckpoint?.( checkpointId ) === true ) &&
 			! sourceDriftInvalidatedCheckpointIds.has( checkpointId ) &&
 			checkpointIdsByTurn.current.has( checkpointId ) &&
 			( ! checkpointIdsByTurn.userMessageId ||
 				nativeUndoInvalidatedTurnRef.current !== checkpointIdsByTurn.userMessageId ),
-		handleCheckpointActionPendingChange
+		handleCheckpointActionPendingChange,
+		handleCheckpointActionInvalidated
 	);
 
 	useEffect( () => {
 		const currentCheckpointIds = [ ...checkpointIdsByTurn.current ];
+		const latestCheckpointId = currentCheckpointIds[ currentCheckpointIds.length - 1 ];
+		const latestCheckpointCanSwap = latestCheckpointId
+			? checkpointRef.current?.canSwapCheckpoint?.( latestCheckpointId )
+			: undefined;
 		const hasPendingCheckpointAction = currentCheckpointIds.some( ( checkpointId ) =>
 			pendingCheckpointActionIdsRef.current.has( checkpointId )
 		);
+		// Inline swaps create redo history too, but remain swappable after their own editor update.
 		const didNativeUndo =
-			previousHasEditorRedoRef.current === false && hasEditorRedo && ! hasPendingCheckpointAction;
+			previousHasEditorRedoRef.current === false &&
+			hasEditorRedo &&
+			! hasPendingCheckpointAction &&
+			latestCheckpointCanSwap !== true;
 		const didNativeRedo = previousHasEditorRedoRef.current === true && ! hasEditorRedo;
 		if ( didNativeUndo ) {
 			nativeUndoInvalidatedTurnRef.current = checkpointIdsByTurn.userMessageId;
@@ -715,7 +727,6 @@ export default function OrchestratorChat( {
 		}
 		previousHasEditorRedoRef.current = hasEditorRedo;
 
-		const latestCheckpointId = currentCheckpointIds[ currentCheckpointIds.length - 1 ];
 		let didChangeStatus = false;
 		let confirmedNativeRedo = false;
 		if (

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -791,7 +791,7 @@ export default function OrchestratorChat( {
 		} );
 
 		return {
-			currentCheckpointIds: current,
+			current,
 			userMessageIdByCheckpointId,
 			userMessageId: messages[ latestUserMessageIndex ]?.id,
 		};
@@ -812,7 +812,7 @@ export default function OrchestratorChat( {
 	const hasPendingCheckpointSwap =
 		supportsCheckpointSwap &&
 		( isWatchingNativeHistory ||
-			[ ...checkpointIdsByTurn.currentCheckpointIds ].some(
+			[ ...checkpointIdsByTurn.current ].some(
 				( checkpointId ) =>
 					! sourceDriftInvalidatedCheckpointIds.has( checkpointId ) &&
 					! isCheckpointActionInvalidated( checkpointId )
@@ -840,7 +840,7 @@ export default function OrchestratorChat( {
 		const currentCheckpoint = checkpointRef.current;
 		const nextInvalidatedCheckpointIds = new Set(
 			[ ...sourceDriftInvalidatedCheckpointIds ].filter( ( checkpointId ) =>
-				checkpointIdsByTurn.currentCheckpointIds.has( checkpointId )
+				checkpointIdsByTurn.current.has( checkpointId )
 			)
 		);
 		let didChange = nextInvalidatedCheckpointIds.size !== sourceDriftInvalidatedCheckpointIds.size;
@@ -851,7 +851,7 @@ export default function OrchestratorChat( {
 				pendingNativeUndoTurnRef.current === checkpointIdsByTurn.userMessageId ||
 				nativeUndoInvalidatedTurnRef.current === checkpointIdsByTurn.userMessageId );
 		if ( supportsCheckpointSwap && currentCheckpoint ) {
-			for ( const checkpointId of checkpointIdsByTurn.currentCheckpointIds ) {
+			for ( const checkpointId of checkpointIdsByTurn.current ) {
 				if (
 					! shouldDeferSourceDriftInvalidation &&
 					! nextInvalidatedCheckpointIds.has( checkpointId ) &&
@@ -893,7 +893,7 @@ export default function OrchestratorChat( {
 			) {
 				return 'hidden';
 			}
-			if ( ! checkpointIdsByTurn.currentCheckpointIds.has( checkpointId ) ) {
+			if ( ! checkpointIdsByTurn.current.has( checkpointId ) ) {
 				return 'disabled';
 			}
 			if ( hasEditorRedo && checkpointRef.current?.canSwapCheckpoint?.( checkpointId ) !== true ) {
@@ -914,7 +914,7 @@ export default function OrchestratorChat( {
 			checkpointEditorBlocks !== undefined &&
 			previousCheckpointEditorBlocksRef.current !== checkpointEditorBlocks;
 		previousCheckpointEditorBlocksRef.current = checkpointEditorBlocks;
-		const currentCheckpointIds = [ ...checkpointIdsByTurn.currentCheckpointIds ];
+		const currentCheckpointIds = [ ...checkpointIdsByTurn.current ];
 		const latestCheckpointId = currentCheckpointIds[ currentCheckpointIds.length - 1 ];
 		const latestCheckpointCanSwap = latestCheckpointId
 			? checkpointRef.current?.canSwapCheckpoint?.( latestCheckpointId )
@@ -930,7 +930,7 @@ export default function OrchestratorChat( {
 		const didInlineUndoCreateEditorRedo =
 			didEditorRedoBecomeAvailable &&
 			completedInlineUndoCheckpointIdRef.current !== undefined &&
-			checkpointIdsByTurn.currentCheckpointIds.has( completedInlineUndoCheckpointIdRef.current );
+			checkpointIdsByTurn.current.has( completedInlineUndoCheckpointIdRef.current );
 		const wasPendingNativeUndo =
 			!! checkpointIdsByTurn.userMessageId &&
 			pendingNativeUndoTurnRef.current === checkpointIdsByTurn.userMessageId;
@@ -1493,26 +1493,24 @@ export default function OrchestratorChat( {
 			);
 		}
 
-		const checkpointDetails = currentMessages.map( ( message ) => {
-			const checkpointMessage =
-				streamedCheckpointMessagesRef.current.byFinalMessageId.get( message.id ) ?? message;
-			return {
-				messageId: message.id,
-				actions: getCheckpointActionsForMessage( checkpointMessage ),
-				checkpointId: getCheckpointIdForMessage( checkpointMessage ),
-			};
-		} );
 		const checkpointActionsByMessageId = new Map(
-			checkpointDetails.map( ( details ) => [ details.messageId, details.actions ] )
+			currentMessages.map( ( message ) => [
+				message.id,
+				getCheckpointActionsForMessage(
+					streamedCheckpointMessagesRef.current.byFinalMessageId.get( message.id ) ?? message
+				),
+			] )
 		);
+		const latestUserMessageIndex = getLatestUserMessageIndex( currentMessages );
 		const supersededCheckpointMessageIds = new Set(
-			checkpointDetails
+			currentMessages
 				.filter(
-					( details ) =>
-						details.checkpointId &&
-						! checkpointIdsByTurn.currentCheckpointIds.has( details.checkpointId )
+					( message, messageIndex ) =>
+						messageIndex < latestUserMessageIndex &&
+						( ( checkpointActionsByMessageId.get( message.id )?.length ?? 0 ) > 0 ||
+							message.actions?.some( ( action ) => action.id === 'checkpoint' ) )
 				)
-				.map( ( details ) => details.messageId )
+				.map( ( message ) => message.id )
 		);
 
 		// Group site-build messages only when needed
@@ -1590,7 +1588,6 @@ export default function OrchestratorChat( {
 		return currentMessages;
 	}, [
 		checkpointActionRevision,
-		checkpointIdsByTurn,
 		checkpointSessionIdentity,
 		currentPostId,
 		deletedMessageIds,

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -662,11 +662,19 @@ export default function OrchestratorChat( {
 	const checkpointIdsByTurn = useMemo( () => {
 		const latestUserMessageIndex = getLatestUserMessageIndex( messages );
 		const current = new Set< string >();
+		const userMessageIdByCheckpointId = new Map< string, string | undefined >();
+		let userMessageId: string | undefined;
 
 		messages.forEach( ( message, index ) => {
+			if ( message.role === 'user' && ! isContextOnlyMessage( message ) ) {
+				userMessageId = message.id;
+			}
 			const checkpointMessage =
 				streamedCheckpointMessagesRef.current.byFinalMessageId.get( message.id ) ?? message;
 			const checkpointId = getCheckpointIdForMessage( checkpointMessage );
+			if ( checkpointId ) {
+				userMessageIdByCheckpointId.set( checkpointId, userMessageId );
+			}
 			if ( checkpointId && index > latestUserMessageIndex ) {
 				current.add( checkpointId );
 			}
@@ -674,6 +682,7 @@ export default function OrchestratorChat( {
 
 		return {
 			current,
+			userMessageIdByCheckpointId,
 			userMessageId: messages[ latestUserMessageIndex ]?.id,
 		};
 	}, [ messages ] );
@@ -761,14 +770,28 @@ export default function OrchestratorChat( {
 	const getCheckpointActionsForMessage = useCheckpointAction(
 		registerMessageActions,
 		checkpoint,
-		( checkpointId ) =>
-			( ! hasEditorRedo || checkpointRef.current?.canSwapCheckpoint?.( checkpointId ) === true ) &&
-			! sourceDriftInvalidatedCheckpointIds.has( checkpointId ) &&
-			checkpointIdsByTurn.current.has( checkpointId ) &&
-			( ! checkpointIdsByTurn.userMessageId ||
-				pendingNativeUndoTurnRef.current !== checkpointIdsByTurn.userMessageId ) &&
-			( ! checkpointIdsByTurn.userMessageId ||
-				nativeUndoInvalidatedTurnRef.current !== checkpointIdsByTurn.userMessageId ),
+		( checkpointId ) => {
+			if ( sourceDriftInvalidatedCheckpointIds.has( checkpointId ) ) {
+				return 'hidden';
+			}
+			const checkpointUserMessageId =
+				checkpointIdsByTurn.userMessageIdByCheckpointId.get( checkpointId );
+			if (
+				checkpointUserMessageId &&
+				( pendingNativeUndoTurnRef.current === checkpointUserMessageId ||
+					nativeUndoInvalidatedTurnRef.current === checkpointUserMessageId )
+			) {
+				return 'hidden';
+			}
+			if ( ! checkpointIdsByTurn.current.has( checkpointId ) ) {
+				return 'disabled';
+			}
+			if ( hasEditorRedo && checkpointRef.current?.canSwapCheckpoint?.( checkpointId ) !== true ) {
+				return 'hidden';
+			}
+
+			return 'enabled';
+		},
 		handleCheckpointActionPendingChange,
 		handleCheckpointActionInvalidated
 	);
@@ -789,6 +812,7 @@ export default function OrchestratorChat( {
 		const hasPendingCheckpointAction = currentCheckpointIds.some( ( checkpointId ) =>
 			pendingCheckpointActionIdsRef.current.has( checkpointId )
 		);
+		let didInvalidateCheckpointAction = false;
 		const didEditorRedoBecomeAvailable =
 			previousHasEditorRedoRef.current === false && hasEditorRedo;
 		const didEditorRedoBecomeUnavailable =
@@ -802,6 +826,28 @@ export default function OrchestratorChat( {
 			pendingNativeUndoTurnRef.current === checkpointIdsByTurn.userMessageId;
 		let shouldConfirmNativeUndo = false;
 		let didCheckpointActionAvailabilityChange = false;
+		const supersededPendingNativeUndoTurn =
+			pendingNativeUndoTurnRef.current &&
+			pendingNativeUndoTurnRef.current !== checkpointIdsByTurn.userMessageId
+				? pendingNativeUndoTurnRef.current
+				: undefined;
+		if ( supersededPendingNativeUndoTurn ) {
+			pendingNativeUndoTurnRef.current = undefined;
+			nativeUndoInvalidatedTurnRef.current = supersededPendingNativeUndoTurn;
+			didCheckpointActionAvailabilityChange = true;
+			for ( const [
+				checkpointId,
+				userMessageId,
+			] of checkpointIdsByTurn.userMessageIdByCheckpointId ) {
+				if (
+					userMessageId === supersededPendingNativeUndoTurn &&
+					! isCheckpointActionInvalidated( checkpointId )
+				) {
+					invalidateCheckpointAction( checkpointId );
+					didInvalidateCheckpointAction = true;
+				}
+			}
+		}
 		if ( hasPendingCheckpointAction ) {
 			if ( pendingNativeUndoTurnRef.current !== undefined ) {
 				didCheckpointActionAvailabilityChange = true;
@@ -894,7 +940,6 @@ export default function OrchestratorChat( {
 			pendingNativeRedoTurnRef.current = undefined;
 		}
 
-		let didInvalidateCheckpointAction = false;
 		for ( const checkpointId of currentCheckpointIds ) {
 			if (
 				checkpointIdsByTurn.userMessageId &&

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -18,7 +18,10 @@ import { useRegisterCustomActions } from '../../hooks/custom-actions';
 import useAbilitiesRegistration from '../../hooks/use-abilities-registration';
 import useAgentTraceIds from '../../hooks/use-agent-trace-ids';
 import { useBroadcastConversationActivity } from '../../hooks/use-broadcast-conversation-activity';
-import useCheckpointAction from '../../hooks/use-checkpoint-action';
+import useCheckpointAction, {
+	getCheckpointIdForMessage,
+	invalidateCheckpointAction,
+} from '../../hooks/use-checkpoint-action';
 import useConversation from '../../hooks/use-conversation';
 import useCopyAction from '../../hooks/use-copy-action';
 import { usePageOrSiteEditorSurface } from '../../hooks/use-empty-view-suggestions';
@@ -28,6 +31,7 @@ import useRegenerateAction from '../../hooks/use-regenerate-action';
 import useSourcesAction from '../../hooks/use-sources-action';
 import convertToolMessagesToComponents, {
 	type AgentsManagerUIMessage,
+	isContextOnlyMessage,
 } from '../../utils/convert-tool-messages-to-components';
 import {
 	consumeNextMessageExternalContextEntries,
@@ -79,6 +83,16 @@ function getLatestAgentMessageId( messages: UIMessage[] ): string | null {
 	}
 
 	return null;
+}
+
+function getLatestUserMessageIndex( messages: UIMessage[] ): number {
+	for ( let index = messages.length - 1; index >= 0; index-- ) {
+		if ( messages[ index ].role === 'user' && ! isContextOnlyMessage( messages[ index ] ) ) {
+			return index;
+		}
+	}
+
+	return -1;
 }
 
 /**
@@ -257,6 +271,14 @@ export default function OrchestratorChat( {
 			return typeof blockName === 'string' && blockName ? blockName : undefined;
 		} catch {
 			return undefined;
+		}
+	}, [] );
+	const hasEditorRedo = useSelect( ( select ) => {
+		try {
+			const editor = select( 'core/editor' ) as { hasEditorRedo?: () => boolean };
+			return editor?.hasEditorRedo?.() ?? false;
+		} catch {
+			return false;
 		}
 	}, [] );
 	const { isPageOrSiteEditorSurface: groupWritingSuggestions } = usePageOrSiteEditorSurface();
@@ -496,6 +518,21 @@ export default function OrchestratorChat( {
 				return;
 			}
 
+			loadedMessages.forEach( ( message ) => {
+				const checkpointMessage = streamedCheckpointMessagesRef.current.byFinalMessageId.get(
+					message.messageId
+				) ?? {
+					id: message.messageId,
+					role: message.role,
+					content: message.parts
+						.filter( ( part ) => part.type === 'text' )
+						.map( ( part ) => ( { type: 'text', text: part.text } ) ),
+				};
+				const checkpointId = getCheckpointIdForMessage( checkpointMessage );
+				if ( checkpointId ) {
+					invalidateCheckpointAction( checkpointId );
+				}
+			} );
 			// Update the UI with the loaded messages
 			loadMessages( loadedMessages );
 			// Make sure future messages go to the right session
@@ -543,7 +580,53 @@ export default function OrchestratorChat( {
 
 	// Register an "Undo" action on agent messages with checkpoints.
 	const checkpoint = useCheckpoint?.();
-	const getCheckpointActionsForMessage = useCheckpointAction( registerMessageActions, checkpoint );
+	const checkpointIdsByTurn = useMemo( () => {
+		const latestUserMessageIndex = getLatestUserMessageIndex( messages );
+		const current = new Set< string >();
+
+		messages.forEach( ( message, index ) => {
+			const checkpointMessage =
+				streamedCheckpointMessagesRef.current.byFinalMessageId.get( message.id ) ?? message;
+			const checkpointId = getCheckpointIdForMessage( checkpointMessage );
+			if ( checkpointId && index > latestUserMessageIndex ) {
+				current.add( checkpointId );
+			}
+		} );
+
+		return {
+			current,
+			userMessageId: messages[ latestUserMessageIndex ]?.id,
+		};
+	}, [ messages ] );
+	const previousHasEditorRedoRef = useRef( hasEditorRedo );
+	const nativeUndoInvalidatedTurnRef = useRef(
+		hasEditorRedo ? checkpointIdsByTurn.userMessageId : undefined
+	);
+	const getCheckpointActionsForMessage = useCheckpointAction(
+		registerMessageActions,
+		checkpoint,
+		( checkpointId ) =>
+			! hasEditorRedo &&
+			checkpointIdsByTurn.current.has( checkpointId ) &&
+			( ! checkpointIdsByTurn.userMessageId ||
+				nativeUndoInvalidatedTurnRef.current !== checkpointIdsByTurn.userMessageId )
+	);
+
+	useEffect( () => {
+		if ( previousHasEditorRedoRef.current === false && hasEditorRedo ) {
+			nativeUndoInvalidatedTurnRef.current = checkpointIdsByTurn.userMessageId;
+		}
+		previousHasEditorRedoRef.current = hasEditorRedo;
+
+		for ( const checkpointId of checkpointIdsByTurn.current ) {
+			if (
+				checkpointIdsByTurn.userMessageId &&
+				nativeUndoInvalidatedTurnRef.current === checkpointIdsByTurn.userMessageId
+			) {
+				invalidateCheckpointAction( checkpointId );
+			}
+		}
+	}, [ checkpointIdsByTurn, hasEditorRedo ] );
 
 	// TODO (ability-migration): Remove once the last checkpoint-writing Big Sky
 	// ability migrates. Keeps the provider checkpoint store reachable for the
@@ -916,6 +999,8 @@ export default function OrchestratorChat( {
 	useAbilitiesRegistration();
 
 	const displayedMessages = useMemo< AgentsManagerUIMessage[] >( () => {
+		// The stable checkpoint getter reads this value through a ref.
+		void hasEditorRedo;
 		let currentMessages: AgentsManagerUIMessage[] = messages;
 
 		// Let the provider rewrite the transcript first, while the messages are
@@ -1038,6 +1123,7 @@ export default function OrchestratorChat( {
 		getFeedbackActionsForMessage,
 		getTraceIdForMessage,
 		getRegenerateActionsForMessage,
+		hasEditorRedo,
 		isBuildingSite,
 		isProcessing,
 		messages,

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -256,6 +256,8 @@ export default function OrchestratorChat( {
 	const [ sourceDriftInvalidatedCheckpointIds, setSourceDriftInvalidatedCheckpointIds ] = useState<
 		Set< string >
 	>( new Set() );
+	const pendingCheckpointActionIdsRef = useRef( new Set< string >() );
+	const [ checkpointActionRevision, setCheckpointActionRevision ] = useState( 0 );
 	const [ retainedShowComponentMessages, setRetainedShowComponentMessages ] = useState<
 		Map< string, UIMessage >
 	>( new Map() );
@@ -585,6 +587,19 @@ export default function OrchestratorChat( {
 	const checkpoint = useCheckpoint?.();
 	const checkpointRef = useRef( checkpoint );
 	checkpointRef.current = checkpoint;
+	const handleCheckpointActionPendingChange = useCallback(
+		( checkpointId: string, isPending: boolean ) => {
+			if ( isPending ) {
+				pendingCheckpointActionIdsRef.current.add( checkpointId );
+				return;
+			}
+
+			if ( pendingCheckpointActionIdsRef.current.delete( checkpointId ) ) {
+				setCheckpointActionRevision( ( revision ) => revision + 1 );
+			}
+		},
+		[]
+	);
 	const checkpointIdsByTurn = useMemo( () => {
 		const latestUserMessageIndex = getLatestUserMessageIndex( messages );
 		const current = new Set< string >();
@@ -627,6 +642,7 @@ export default function OrchestratorChat( {
 		[ checkpointIdsByTurn, checkpointSessionIdentity, hasPendingCheckpointSwap, useCheckpoint ]
 	);
 	useEffect( () => {
+		void checkpointActionRevision;
 		void checkpointEditorBlocks;
 		void checkpointSessionIdentity;
 		void useCheckpoint;
@@ -641,6 +657,7 @@ export default function OrchestratorChat( {
 			for ( const checkpointId of checkpointIdsByTurn.current ) {
 				if (
 					! nextInvalidatedCheckpointIds.has( checkpointId ) &&
+					! pendingCheckpointActionIdsRef.current.has( checkpointId ) &&
 					currentCheckpoint.canSwapCheckpoint?.( checkpointId ) === false
 				) {
 					nextInvalidatedCheckpointIds.add( checkpointId );
@@ -653,6 +670,7 @@ export default function OrchestratorChat( {
 			setSourceDriftInvalidatedCheckpointIds( nextInvalidatedCheckpointIds );
 		}
 	}, [
+		checkpointActionRevision,
 		checkpointEditorBlocks,
 		checkpointIdsByTurn,
 		checkpointSessionIdentity,
@@ -672,7 +690,8 @@ export default function OrchestratorChat( {
 			! sourceDriftInvalidatedCheckpointIds.has( checkpointId ) &&
 			checkpointIdsByTurn.current.has( checkpointId ) &&
 			( ! checkpointIdsByTurn.userMessageId ||
-				nativeUndoInvalidatedTurnRef.current !== checkpointIdsByTurn.userMessageId )
+				nativeUndoInvalidatedTurnRef.current !== checkpointIdsByTurn.userMessageId ),
+		handleCheckpointActionPendingChange
 	);
 
 	useEffect( () => {
@@ -1063,6 +1082,7 @@ export default function OrchestratorChat( {
 
 	const displayedMessages = useMemo< AgentsManagerUIMessage[] >( () => {
 		// The stable checkpoint getter reads this value through a ref.
+		void checkpointActionRevision;
 		void hasEditorRedo;
 		void sourceDriftInvalidatedCheckpointIds;
 		let currentMessages: AgentsManagerUIMessage[] = messages;
@@ -1178,6 +1198,7 @@ export default function OrchestratorChat( {
 
 		return currentMessages;
 	}, [
+		checkpointActionRevision,
 		currentPostId,
 		deletedMessageIds,
 		getChatComponent,

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -150,6 +150,41 @@ function getToolMessageData( message: Pick< UIMessage, 'content' > ):
 	}
 }
 
+function getBlockEditAgentMessageText( update: TaskUpdate ): string | undefined {
+	const candidateTexts = update.text ? [ update.text ] : [];
+
+	for ( const message of [ update.status.message, update.agentMessage ] ) {
+		for ( const part of message?.parts ?? [] ) {
+			if ( part.type !== 'data' || typeof part.data !== 'object' || part.data === null ) {
+				continue;
+			}
+
+			if ( ! ( 'result' in part.data ) ) {
+				continue;
+			}
+
+			const result = part.data.result;
+			if ( typeof result !== 'object' || result === null ) {
+				continue;
+			}
+
+			const agentMessage = ( result as { agentMessage?: unknown } ).agentMessage;
+			if ( typeof agentMessage === 'string' ) {
+				candidateTexts.push( agentMessage );
+			}
+		}
+	}
+
+	for ( const candidateText of candidateTexts ) {
+		const candidateMessage = { content: [ { type: 'text' as const, text: candidateText } ] };
+		if ( isBlockEditToolId( getToolMessageData( candidateMessage )?.toolId ) ) {
+			return candidateText;
+		}
+	}
+
+	return undefined;
+}
+
 function isShowComponentMessage( message: Pick< UIMessage, 'content' > ): boolean {
 	const toolData = getToolMessageData( message );
 	return isShowComponentTool( toolData?.toolId );
@@ -316,18 +351,20 @@ export default function OrchestratorChat( {
 			...agentConfig,
 			onTaskUpdate: async ( update: TaskUpdate ) => {
 				const streamedMessages = streamedCheckpointMessagesRef.current;
-				if ( streamedMessages.sessionIdentity === checkpointSessionIdentity && update.text ) {
+				const blockEditAgentMessageText = getBlockEditAgentMessageText( update );
+				if (
+					streamedMessages.sessionIdentity === checkpointSessionIdentity &&
+					blockEditAgentMessageText
+				) {
 					const message: UIMessage = {
 						id: update.status.message?.messageId ?? update.agentMessage?.messageId ?? update.id,
 						role: 'agent',
-						content: [ { type: 'text', text: update.text } ],
+						content: [ { type: 'text', text: blockEditAgentMessageText } ],
 						timestamp: Date.now(),
 						archived: false,
 						showIcon: true,
 					};
-					if ( isBlockEditToolId( getToolMessageData( message )?.toolId ) ) {
-						streamedMessages.pendingByTaskId.set( update.id, message );
-					}
+					streamedMessages.pendingByTaskId.set( update.id, message );
 				}
 
 				const isTerminal =
@@ -623,16 +660,27 @@ export default function OrchestratorChat( {
 			userMessageId: messages[ latestUserMessageIndex ]?.id,
 		};
 	}, [ messages ] );
+	const previousHasEditorRedoRef = useRef( hasEditorRedo );
+	const nativeUndoInvalidatedTurnRef = useRef(
+		hasEditorRedo ? checkpointIdsByTurn.userMessageId : undefined
+	);
+	const [ nativeUndoRevertedTurn, setNativeUndoRevertedTurn ] = useState< string | undefined >();
+	const pendingNativeUndoTurnRef = useRef< string | undefined >( undefined );
+	const pendingNativeRedoTurnRef = useRef< string | undefined >( undefined );
 	const supportsCheckpointSwap =
 		typeof checkpoint?.canSwapCheckpoint === 'function' &&
 		typeof checkpoint.swapCheckpoint === 'function';
+	const isWatchingNativeHistory =
+		!! checkpointIdsByTurn.userMessageId &&
+		nativeUndoRevertedTurn === checkpointIdsByTurn.userMessageId;
 	const hasPendingCheckpointSwap =
 		supportsCheckpointSwap &&
-		[ ...checkpointIdsByTurn.current ].some(
-			( checkpointId ) =>
-				! sourceDriftInvalidatedCheckpointIds.has( checkpointId ) &&
-				! isCheckpointActionInvalidated( checkpointId )
-		);
+		( isWatchingNativeHistory ||
+			[ ...checkpointIdsByTurn.current ].some(
+				( checkpointId ) =>
+					! sourceDriftInvalidatedCheckpointIds.has( checkpointId ) &&
+					! isCheckpointActionInvalidated( checkpointId )
+			) );
 	const checkpointEditorBlocks = useSelect(
 		( select ) => {
 			if ( ! hasPendingCheckpointSwap ) {
@@ -687,11 +735,6 @@ export default function OrchestratorChat( {
 		supportsCheckpointSwap,
 		useCheckpoint,
 	] );
-	const previousHasEditorRedoRef = useRef( hasEditorRedo );
-	const nativeUndoInvalidatedTurnRef = useRef(
-		hasEditorRedo ? checkpointIdsByTurn.userMessageId : undefined
-	);
-	const nativeUndoRevertedTurnRef = useRef< string | undefined >( undefined );
 	const getCheckpointActionsForMessage = useCheckpointAction(
 		registerMessageActions,
 		checkpoint,
@@ -704,8 +747,15 @@ export default function OrchestratorChat( {
 		handleCheckpointActionPendingChange,
 		handleCheckpointActionInvalidated
 	);
+	const previousCheckpointEditorBlocksRef = useRef( checkpointEditorBlocks );
 
 	useEffect( () => {
+		// Native history can notify before block content; a later or combined block change confirms Undo.
+		const didCheckpointEditorBlocksChange =
+			previousCheckpointEditorBlocksRef.current !== undefined &&
+			checkpointEditorBlocks !== undefined &&
+			previousCheckpointEditorBlocksRef.current !== checkpointEditorBlocks;
+		previousCheckpointEditorBlocksRef.current = checkpointEditorBlocks;
 		const currentCheckpointIds = [ ...checkpointIdsByTurn.current ];
 		const latestCheckpointId = currentCheckpointIds[ currentCheckpointIds.length - 1 ];
 		const latestCheckpointCanSwap = latestCheckpointId
@@ -714,42 +764,83 @@ export default function OrchestratorChat( {
 		const hasPendingCheckpointAction = currentCheckpointIds.some( ( checkpointId ) =>
 			pendingCheckpointActionIdsRef.current.has( checkpointId )
 		);
-		// Inline swaps create redo history too, but remain swappable after their own editor update.
-		const didNativeUndo =
-			previousHasEditorRedoRef.current === false &&
+		const didEditorRedoBecomeAvailable =
+			previousHasEditorRedoRef.current === false && hasEditorRedo;
+		const didEditorRedoBecomeUnavailable =
+			previousHasEditorRedoRef.current === true && ! hasEditorRedo;
+		let shouldConfirmNativeUndo = false;
+		if ( hasPendingCheckpointAction ) {
+			pendingNativeUndoTurnRef.current = undefined;
+			pendingNativeRedoTurnRef.current = undefined;
+		}
+		if ( didEditorRedoBecomeAvailable ) {
+			pendingNativeRedoTurnRef.current = undefined;
+			pendingNativeUndoTurnRef.current = undefined;
+			if (
+				! hasPendingCheckpointAction &&
+				! didCheckpointEditorBlocksChange &&
+				latestCheckpointId &&
+				latestCheckpointCanSwap === true
+			) {
+				pendingNativeUndoTurnRef.current = checkpointIdsByTurn.userMessageId;
+			} else if (
+				! hasPendingCheckpointAction &&
+				didCheckpointEditorBlocksChange &&
+				latestCheckpointId &&
+				latestCheckpointCanSwap === false
+			) {
+				shouldConfirmNativeUndo = true;
+			} else if ( latestCheckpointCanSwap === undefined ) {
+				nativeUndoInvalidatedTurnRef.current = checkpointIdsByTurn.userMessageId;
+			}
+		}
+		if (
 			hasEditorRedo &&
 			! hasPendingCheckpointAction &&
-			latestCheckpointCanSwap !== true;
-		const didNativeRedo = previousHasEditorRedoRef.current === true && ! hasEditorRedo;
-		if ( didNativeUndo ) {
+			didCheckpointEditorBlocksChange &&
+			latestCheckpointId &&
+			checkpointIdsByTurn.userMessageId &&
+			pendingNativeUndoTurnRef.current === checkpointIdsByTurn.userMessageId
+		) {
+			pendingNativeUndoTurnRef.current = undefined;
+			if ( latestCheckpointCanSwap === false ) {
+				shouldConfirmNativeUndo = true;
+			}
+		}
+		if ( shouldConfirmNativeUndo && latestCheckpointId && checkpointIdsByTurn.userMessageId ) {
 			nativeUndoInvalidatedTurnRef.current = checkpointIdsByTurn.userMessageId;
-			nativeUndoRevertedTurnRef.current = checkpointIdsByTurn.userMessageId;
+			if (
+				! sourceDriftInvalidatedCheckpointIds.has( latestCheckpointId ) &&
+				! isCheckpointActionInvalidated( latestCheckpointId )
+			) {
+				if ( setCheckpointActionReverted( latestCheckpointId, true ) ) {
+					setCheckpointActionRevision( ( revision ) => revision + 1 );
+				}
+				setNativeUndoRevertedTurn( checkpointIdsByTurn.userMessageId );
+			}
+		}
+		if (
+			didEditorRedoBecomeUnavailable &&
+			checkpointIdsByTurn.userMessageId &&
+			nativeUndoRevertedTurn === checkpointIdsByTurn.userMessageId
+		) {
+			// Exact checkpoint content confirms Updated, even when the user recreates it manually.
+			pendingNativeRedoTurnRef.current = checkpointIdsByTurn.userMessageId;
 		}
 		previousHasEditorRedoRef.current = hasEditorRedo;
 
-		let didChangeStatus = false;
-		let confirmedNativeRedo = false;
 		if (
-			didNativeRedo &&
+			! hasEditorRedo &&
 			latestCheckpointId &&
 			checkpointIdsByTurn.userMessageId &&
-			nativeUndoRevertedTurnRef.current === checkpointIdsByTurn.userMessageId &&
+			pendingNativeRedoTurnRef.current === checkpointIdsByTurn.userMessageId &&
 			checkpointRef.current?.canSwapCheckpoint?.( latestCheckpointId ) === true
 		) {
-			didChangeStatus = setCheckpointActionReverted( latestCheckpointId, false );
-			nativeUndoRevertedTurnRef.current = undefined;
-			confirmedNativeRedo = true;
-		}
-		if (
-			! confirmedNativeRedo &&
-			latestCheckpointId &&
-			checkpointIdsByTurn.userMessageId &&
-			nativeUndoRevertedTurnRef.current === checkpointIdsByTurn.userMessageId &&
-			! sourceDriftInvalidatedCheckpointIds.has( latestCheckpointId ) &&
-			! isCheckpointActionInvalidated( latestCheckpointId ) &&
-			checkpointRef.current?.canSwapCheckpoint?.( latestCheckpointId ) === false
-		) {
-			didChangeStatus = setCheckpointActionReverted( latestCheckpointId, true );
+			if ( setCheckpointActionReverted( latestCheckpointId, false ) ) {
+				setCheckpointActionRevision( ( revision ) => revision + 1 );
+			}
+			setNativeUndoRevertedTurn( undefined );
+			pendingNativeRedoTurnRef.current = undefined;
 		}
 
 		for ( const checkpointId of currentCheckpointIds ) {
@@ -760,10 +851,13 @@ export default function OrchestratorChat( {
 				invalidateCheckpointAction( checkpointId );
 			}
 		}
-		if ( didChangeStatus ) {
-			setCheckpointActionRevision( ( revision ) => revision + 1 );
-		}
-	}, [ checkpointIdsByTurn, hasEditorRedo, sourceDriftInvalidatedCheckpointIds ] );
+	}, [
+		checkpointEditorBlocks,
+		checkpointIdsByTurn,
+		hasEditorRedo,
+		nativeUndoRevertedTurn,
+		sourceDriftInvalidatedCheckpointIds,
+	] );
 
 	// TODO (ability-migration): Remove once the last checkpoint-writing Big Sky
 	// ability migrates. Keeps the provider checkpoint store reachable for the

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -1507,7 +1507,10 @@ export default function OrchestratorChat( {
 				.filter(
 					( message, messageIndex ) =>
 						messageIndex < latestUserMessageIndex &&
-						( ( checkpointActionsByMessageId.get( message.id )?.length ?? 0 ) > 0 ||
+						( getCheckpointIdForMessage(
+							streamedCheckpointMessagesRef.current.byFinalMessageId.get( message.id ) ?? message
+						) !== null ||
+							( checkpointActionsByMessageId.get( message.id )?.length ?? 0 ) > 0 ||
 							message.actions?.some( ( action ) => action.id === 'checkpoint' ) )
 				)
 				.map( ( message ) => message.id )

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -600,6 +600,9 @@ export default function OrchestratorChat( {
 				return;
 			}
 
+			const currentLiveMessageIds = new Set(
+				messagesRef.current.map( ( currentMessage ) => currentMessage.id )
+			);
 			loadedMessages.forEach( ( message ) => {
 				const checkpointMessage = streamedCheckpointMessagesRef.current.byFinalMessageId.get(
 					message.messageId
@@ -611,10 +614,11 @@ export default function OrchestratorChat( {
 						.map( ( part ) => ( { type: 'text', text: part.text } ) ),
 				};
 				const checkpointId = getCheckpointIdForMessage( checkpointMessage );
-				const isLiveStreamedMessage = streamedCheckpointMessagesRef.current.liveFinalMessageIds.has(
-					message.messageId
-				);
-				if ( checkpointId && ! isLiveStreamedMessage ) {
+				const isCurrentLiveMessage =
+					streamedCheckpointMessagesRef.current.liveFinalMessageIds.has( message.messageId ) ||
+					( streamedCheckpointMessagesRef.current.byFinalMessageId.has( message.messageId ) &&
+						currentLiveMessageIds.has( message.messageId ) );
+				if ( checkpointId && ! isCurrentLiveMessage ) {
 					invalidateCheckpointAction( checkpointId );
 				}
 			} );

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -10,7 +10,14 @@ import {
 	type MarkdownExtensions,
 } from '@automattic/agenttic-ui';
 import { select as selectDataStore, useSelect } from '@wordpress/data';
-import { useState, useCallback, useMemo, useEffect, useRef } from '@wordpress/element';
+import {
+	useState,
+	useCallback,
+	useMemo,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
 import { useAgentsManagerContext } from '../../contexts';
@@ -65,6 +72,14 @@ import type {
 } from '../../utils/load-external-providers';
 
 const streamedCheckpointMessagesBySession = new Map< string, Map< string, UIMessage > >();
+let activeStreamedCheckpointSession:
+	| {
+			scopeIdentity: string;
+			sessionId: string;
+			sessionIdentity: string;
+			liveFinalMessageIds: Set< string >;
+	  }
+	| undefined;
 
 function getStreamedCheckpointMessages( sessionIdentity: string ): Map< string, UIMessage > {
 	const existing = streamedCheckpointMessagesBySession.get( sessionIdentity );
@@ -75,6 +90,40 @@ function getStreamedCheckpointMessages( sessionIdentity: string ): Map< string, 
 	const messages = new Map< string, UIMessage >();
 	streamedCheckpointMessagesBySession.set( sessionIdentity, messages );
 	return messages;
+}
+
+function getLiveStreamedCheckpointMessageIds( sessionIdentity: string ): Set< string > {
+	return activeStreamedCheckpointSession?.sessionIdentity === sessionIdentity
+		? activeStreamedCheckpointSession.liveFinalMessageIds
+		: new Set< string >();
+}
+
+function activateLiveStreamedCheckpointSession(
+	scopeIdentity: string,
+	sessionId: string,
+	sessionIdentity: string,
+	liveFinalMessageIds: Set< string >
+): Set< string > {
+	const previousSession = activeStreamedCheckpointSession;
+	if ( previousSession?.sessionIdentity === sessionIdentity ) {
+		return previousSession.liveFinalMessageIds;
+	}
+
+	const isSessionBootstrap =
+		previousSession?.scopeIdentity === scopeIdentity &&
+		previousSession.sessionId === '' &&
+		sessionId !== '';
+	const nextLiveFinalMessageIds =
+		previousSession && isSessionBootstrap
+			? previousSession.liveFinalMessageIds
+			: liveFinalMessageIds;
+	activeStreamedCheckpointSession = {
+		scopeIdentity,
+		sessionId,
+		sessionIdentity,
+		liveFinalMessageIds: nextLiveFinalMessageIds,
+	};
+	return nextLiveFinalMessageIds;
 }
 
 function getLatestAgentMessageId( messages: UIMessage[] ): string | null {
@@ -283,7 +332,7 @@ export default function OrchestratorChat( {
 	isChatInputDisabled,
 	onHasMessagesChange,
 }: Props ) {
-	const { agentConfig, getTabSessionId } = useAgentsManagerContext();
+	const { agentConfig, getTabSessionId, siteKey, currentUser } = useAgentsManagerContext();
 
 	const [ inputValue, setInputValue ] = useState( '' );
 	const [ isThinking, setIsThinking ] = useState( false );
@@ -328,22 +377,33 @@ export default function OrchestratorChat( {
 	const { isPageOrSiteEditorSurface: groupWritingSuggestions } = usePageOrSiteEditorSurface();
 	const checkpointAgentId = agentConfig?.agentId ?? '';
 	const checkpointSessionId = agentConfig?.sessionId ?? getTabSessionId() ?? '';
-	const checkpointSessionIdentity = `${ checkpointAgentId }:${ checkpointSessionId }`;
+	const checkpointScopeIdentity = JSON.stringify( [
+		siteKey,
+		currentUser?.ID ?? null,
+		checkpointAgentId,
+	] );
+	const checkpointSessionIdentity = JSON.stringify( [
+		siteKey,
+		currentUser?.ID ?? null,
+		checkpointAgentId,
+		checkpointSessionId,
+	] );
+	const liveFinalMessageIds = getLiveStreamedCheckpointMessageIds( checkpointSessionIdentity );
 	const streamedCheckpointMessagesRef = useRef( {
-		agentId: checkpointAgentId,
+		scopeIdentity: checkpointScopeIdentity,
 		sessionId: checkpointSessionId,
 		sessionIdentity: checkpointSessionIdentity,
 		streamGeneration: Symbol(),
 		pendingByTaskId: new Map< string, UIMessage >(),
 		byFinalMessageId: getStreamedCheckpointMessages( checkpointSessionIdentity ),
-		liveFinalMessageIds: new Set< string >(),
+		liveFinalMessageIds,
 		regeneratingMessageId: undefined as string | undefined,
 	} );
 	if ( streamedCheckpointMessagesRef.current.sessionIdentity !== checkpointSessionIdentity ) {
 		const previousStreamedMessages = streamedCheckpointMessagesRef.current;
 		const byFinalMessageId = getStreamedCheckpointMessages( checkpointSessionIdentity );
 		const isSessionBootstrap =
-			previousStreamedMessages.agentId === checkpointAgentId &&
+			previousStreamedMessages.scopeIdentity === checkpointScopeIdentity &&
 			previousStreamedMessages.sessionId === '' &&
 			checkpointSessionId !== '';
 
@@ -362,7 +422,7 @@ export default function OrchestratorChat( {
 		}
 
 		streamedCheckpointMessagesRef.current = {
-			agentId: checkpointAgentId,
+			scopeIdentity: checkpointScopeIdentity,
 			sessionId: checkpointSessionId,
 			sessionIdentity: checkpointSessionIdentity,
 			streamGeneration: isSessionBootstrap ? previousStreamedMessages.streamGeneration : Symbol(),
@@ -370,12 +430,21 @@ export default function OrchestratorChat( {
 			byFinalMessageId,
 			liveFinalMessageIds: isSessionBootstrap
 				? previousStreamedMessages.liveFinalMessageIds
-				: new Set(),
+				: liveFinalMessageIds,
 			regeneratingMessageId: isSessionBootstrap
 				? previousStreamedMessages.regeneratingMessageId
 				: undefined,
 		};
 	}
+	useLayoutEffect( () => {
+		streamedCheckpointMessagesRef.current.liveFinalMessageIds =
+			activateLiveStreamedCheckpointSession(
+				checkpointScopeIdentity,
+				checkpointSessionId,
+				checkpointSessionIdentity,
+				streamedCheckpointMessagesRef.current.liveFinalMessageIds
+			);
+	}, [ checkpointScopeIdentity, checkpointSessionId, checkpointSessionIdentity ] );
 	const checkpointStreamGeneration = streamedCheckpointMessagesRef.current.streamGeneration;
 	const agentChatConfig = useMemo( () => {
 		if ( ! agentConfig ) {
@@ -600,9 +669,6 @@ export default function OrchestratorChat( {
 				return;
 			}
 
-			const currentLiveMessageIds = new Set(
-				messagesRef.current.map( ( currentMessage ) => currentMessage.id )
-			);
 			loadedMessages.forEach( ( message ) => {
 				const checkpointMessage = streamedCheckpointMessagesRef.current.byFinalMessageId.get(
 					message.messageId
@@ -614,10 +680,9 @@ export default function OrchestratorChat( {
 						.map( ( part ) => ( { type: 'text', text: part.text } ) ),
 				};
 				const checkpointId = getCheckpointIdForMessage( checkpointMessage );
-				const isCurrentLiveMessage =
-					streamedCheckpointMessagesRef.current.liveFinalMessageIds.has( message.messageId ) ||
-					( streamedCheckpointMessagesRef.current.byFinalMessageId.has( message.messageId ) &&
-						currentLiveMessageIds.has( message.messageId ) );
+				const isCurrentLiveMessage = streamedCheckpointMessagesRef.current.liveFinalMessageIds.has(
+					message.messageId
+				);
 				if ( checkpointId && ! isCurrentLiveMessage ) {
 					invalidateCheckpointAction( checkpointId );
 				}

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -9,7 +9,7 @@ import {
 	type MarkdownComponents,
 	type MarkdownExtensions,
 } from '@automattic/agenttic-ui';
-import { useSelect } from '@wordpress/data';
+import { select as selectDataStore, useSelect } from '@wordpress/data';
 import { useState, useCallback, useMemo, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
@@ -294,6 +294,7 @@ export default function OrchestratorChat( {
 		Set< string >
 	>( new Set() );
 	const pendingCheckpointActionIdsRef = useRef( new Set< string >() );
+	const completedInlineUndoCheckpointIdRef = useRef< string | undefined >( undefined );
 	const [ checkpointActionRevision, setCheckpointActionRevision ] = useState( 0 );
 	const [ retainedShowComponentMessages, setRetainedShowComponentMessages ] = useState<
 		Map< string, UIMessage >
@@ -323,6 +324,7 @@ export default function OrchestratorChat( {
 			return false;
 		}
 	}, [] );
+	const previousHasEditorRedoRef = useRef( hasEditorRedo );
 	const { isPageOrSiteEditorSurface: groupWritingSuggestions } = usePageOrSiteEditorSurface();
 	const checkpointSessionIdentity = `${ agentConfig?.agentId ?? '' }:${
 		agentConfig?.sessionId ?? getActiveSessionId() ?? ''
@@ -627,13 +629,28 @@ export default function OrchestratorChat( {
 	const checkpointRef = useRef( checkpoint );
 	checkpointRef.current = checkpoint;
 	const handleCheckpointActionPendingChange = useCallback(
-		( checkpointId: string, isPending: boolean ) => {
+		( checkpointId: string, isPending: boolean, completedAction?: 'undo' | 'redo' ) => {
 			if ( isPending ) {
+				completedInlineUndoCheckpointIdRef.current = undefined;
 				pendingCheckpointActionIdsRef.current.add( checkpointId );
 				return;
 			}
 
 			if ( pendingCheckpointActionIdsRef.current.delete( checkpointId ) ) {
+				let hasEditorRedoNow = false;
+				try {
+					const editor = selectDataStore( 'core/editor' ) as {
+						hasEditorRedo?: () => boolean;
+					};
+					hasEditorRedoNow = editor?.hasEditorRedo?.() ?? false;
+				} catch {
+					// The editor store is optional outside Gutenberg.
+				}
+				// The provider can settle after history renders but before the history effect processes it.
+				completedInlineUndoCheckpointIdRef.current =
+					completedAction === 'undo' && ! previousHasEditorRedoRef.current && hasEditorRedoNow
+						? checkpointId
+						: undefined;
 				setCheckpointActionRevision( ( revision ) => revision + 1 );
 			}
 		},
@@ -660,7 +677,6 @@ export default function OrchestratorChat( {
 			userMessageId: messages[ latestUserMessageIndex ]?.id,
 		};
 	}, [ messages ] );
-	const previousHasEditorRedoRef = useRef( hasEditorRedo );
 	const nativeUndoInvalidatedTurnRef = useRef(
 		hasEditorRedo ? checkpointIdsByTurn.userMessageId : undefined
 	);
@@ -672,7 +688,8 @@ export default function OrchestratorChat( {
 		typeof checkpoint.swapCheckpoint === 'function';
 	const isWatchingNativeHistory =
 		!! checkpointIdsByTurn.userMessageId &&
-		nativeUndoRevertedTurn === checkpointIdsByTurn.userMessageId;
+		( nativeUndoRevertedTurn === checkpointIdsByTurn.userMessageId ||
+			pendingNativeUndoTurnRef.current === checkpointIdsByTurn.userMessageId );
 	const hasPendingCheckpointSwap =
 		supportsCheckpointSwap &&
 		( isWatchingNativeHistory ||
@@ -743,6 +760,8 @@ export default function OrchestratorChat( {
 			! sourceDriftInvalidatedCheckpointIds.has( checkpointId ) &&
 			checkpointIdsByTurn.current.has( checkpointId ) &&
 			( ! checkpointIdsByTurn.userMessageId ||
+				pendingNativeUndoTurnRef.current !== checkpointIdsByTurn.userMessageId ) &&
+			( ! checkpointIdsByTurn.userMessageId ||
 				nativeUndoInvalidatedTurnRef.current !== checkpointIdsByTurn.userMessageId ),
 		handleCheckpointActionPendingChange,
 		handleCheckpointActionInvalidated
@@ -768,29 +787,48 @@ export default function OrchestratorChat( {
 			previousHasEditorRedoRef.current === false && hasEditorRedo;
 		const didEditorRedoBecomeUnavailable =
 			previousHasEditorRedoRef.current === true && ! hasEditorRedo;
+		const didInlineUndoCreateEditorRedo =
+			didEditorRedoBecomeAvailable &&
+			completedInlineUndoCheckpointIdRef.current !== undefined &&
+			checkpointIdsByTurn.current.has( completedInlineUndoCheckpointIdRef.current );
+		const wasPendingNativeUndo =
+			!! checkpointIdsByTurn.userMessageId &&
+			pendingNativeUndoTurnRef.current === checkpointIdsByTurn.userMessageId;
 		let shouldConfirmNativeUndo = false;
+		let didCheckpointActionAvailabilityChange = false;
 		if ( hasPendingCheckpointAction ) {
+			if ( pendingNativeUndoTurnRef.current !== undefined ) {
+				didCheckpointActionAvailabilityChange = true;
+			}
 			pendingNativeUndoTurnRef.current = undefined;
 			pendingNativeRedoTurnRef.current = undefined;
 		}
 		if ( didEditorRedoBecomeAvailable ) {
+			completedInlineUndoCheckpointIdRef.current = undefined;
 			pendingNativeRedoTurnRef.current = undefined;
+			if ( pendingNativeUndoTurnRef.current !== undefined ) {
+				didCheckpointActionAvailabilityChange = true;
+			}
 			pendingNativeUndoTurnRef.current = undefined;
 			if (
+				! didInlineUndoCreateEditorRedo &&
 				! hasPendingCheckpointAction &&
-				! didCheckpointEditorBlocksChange &&
 				latestCheckpointId &&
-				latestCheckpointCanSwap === true
+				checkpointIdsByTurn.userMessageId
 			) {
-				pendingNativeUndoTurnRef.current = checkpointIdsByTurn.userMessageId;
+				if ( didCheckpointEditorBlocksChange && latestCheckpointCanSwap === false ) {
+					shouldConfirmNativeUndo = true;
+				} else if ( latestCheckpointCanSwap !== undefined ) {
+					pendingNativeUndoTurnRef.current = checkpointIdsByTurn.userMessageId;
+					didCheckpointActionAvailabilityChange = true;
+				} else {
+					nativeUndoInvalidatedTurnRef.current = checkpointIdsByTurn.userMessageId;
+				}
 			} else if (
+				! didInlineUndoCreateEditorRedo &&
 				! hasPendingCheckpointAction &&
-				didCheckpointEditorBlocksChange &&
-				latestCheckpointId &&
-				latestCheckpointCanSwap === false
+				latestCheckpointCanSwap === undefined
 			) {
-				shouldConfirmNativeUndo = true;
-			} else if ( latestCheckpointCanSwap === undefined ) {
 				nativeUndoInvalidatedTurnRef.current = checkpointIdsByTurn.userMessageId;
 			}
 		}
@@ -800,9 +838,10 @@ export default function OrchestratorChat( {
 			didCheckpointEditorBlocksChange &&
 			latestCheckpointId &&
 			checkpointIdsByTurn.userMessageId &&
-			pendingNativeUndoTurnRef.current === checkpointIdsByTurn.userMessageId
+			wasPendingNativeUndo
 		) {
 			pendingNativeUndoTurnRef.current = undefined;
+			didCheckpointActionAvailabilityChange = true;
 			if ( latestCheckpointCanSwap === false ) {
 				shouldConfirmNativeUndo = true;
 			}
@@ -827,6 +866,12 @@ export default function OrchestratorChat( {
 			// Exact checkpoint content confirms Updated, even when the user recreates it manually.
 			pendingNativeRedoTurnRef.current = checkpointIdsByTurn.userMessageId;
 		}
+		if ( didEditorRedoBecomeUnavailable ) {
+			if ( pendingNativeUndoTurnRef.current !== undefined ) {
+				didCheckpointActionAvailabilityChange = true;
+			}
+			pendingNativeUndoTurnRef.current = undefined;
+		}
 		previousHasEditorRedoRef.current = hasEditorRedo;
 
 		if (
@@ -843,13 +888,19 @@ export default function OrchestratorChat( {
 			pendingNativeRedoTurnRef.current = undefined;
 		}
 
+		let didInvalidateCheckpointAction = false;
 		for ( const checkpointId of currentCheckpointIds ) {
 			if (
 				checkpointIdsByTurn.userMessageId &&
-				nativeUndoInvalidatedTurnRef.current === checkpointIdsByTurn.userMessageId
+				nativeUndoInvalidatedTurnRef.current === checkpointIdsByTurn.userMessageId &&
+				! isCheckpointActionInvalidated( checkpointId )
 			) {
 				invalidateCheckpointAction( checkpointId );
+				didInvalidateCheckpointAction = true;
 			}
+		}
+		if ( didInvalidateCheckpointAction || didCheckpointActionAvailabilityChange ) {
+			setCheckpointActionRevision( ( revision ) => revision + 1 );
 		}
 	}, [
 		checkpointEditorBlocks,

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -253,6 +253,9 @@ export default function OrchestratorChat( {
 	const [ thinkingMessage, setThinkingMessage ] = useState< string | null >( null );
 	const [ isBuildingSite, setIsBuildingSite ] = useState( false );
 	const [ deletedMessageIds, setDeletedMessageIds ] = useState< Set< string > >( new Set() );
+	const [ sourceDriftInvalidatedCheckpointIds, setSourceDriftInvalidatedCheckpointIds ] = useState<
+		Set< string >
+	>( new Set() );
 	const [ retainedShowComponentMessages, setRetainedShowComponentMessages ] = useState<
 		Map< string, UIMessage >
 	>( new Map() );
@@ -580,6 +583,8 @@ export default function OrchestratorChat( {
 
 	// Register an "Undo" action on agent messages with checkpoints.
 	const checkpoint = useCheckpoint?.();
+	const checkpointRef = useRef( checkpoint );
+	checkpointRef.current = checkpoint;
 	const checkpointIdsByTurn = useMemo( () => {
 		const latestUserMessageIndex = getLatestUserMessageIndex( messages );
 		const current = new Set< string >();
@@ -598,6 +603,63 @@ export default function OrchestratorChat( {
 			userMessageId: messages[ latestUserMessageIndex ]?.id,
 		};
 	}, [ messages ] );
+	const supportsCheckpointSwap =
+		typeof checkpoint?.canSwapCheckpoint === 'function' &&
+		typeof checkpoint.swapCheckpoint === 'function';
+	const hasPendingCheckpointSwap =
+		supportsCheckpointSwap &&
+		[ ...checkpointIdsByTurn.current ].some(
+			( checkpointId ) => ! sourceDriftInvalidatedCheckpointIds.has( checkpointId )
+		);
+	const checkpointEditorBlocks = useSelect(
+		( select ) => {
+			if ( ! hasPendingCheckpointSwap ) {
+				return undefined;
+			}
+
+			try {
+				const blockEditor = select( 'core/block-editor' ) as { getBlocks?: () => unknown[] };
+				return blockEditor?.getBlocks?.();
+			} catch {
+				return undefined;
+			}
+		},
+		[ checkpointIdsByTurn, checkpointSessionIdentity, hasPendingCheckpointSwap, useCheckpoint ]
+	);
+	useEffect( () => {
+		void checkpointEditorBlocks;
+		void checkpointSessionIdentity;
+		void useCheckpoint;
+		const currentCheckpoint = checkpointRef.current;
+		const nextInvalidatedCheckpointIds = new Set(
+			[ ...sourceDriftInvalidatedCheckpointIds ].filter( ( checkpointId ) =>
+				checkpointIdsByTurn.current.has( checkpointId )
+			)
+		);
+		let didChange = nextInvalidatedCheckpointIds.size !== sourceDriftInvalidatedCheckpointIds.size;
+		if ( supportsCheckpointSwap && currentCheckpoint ) {
+			for ( const checkpointId of checkpointIdsByTurn.current ) {
+				if (
+					! nextInvalidatedCheckpointIds.has( checkpointId ) &&
+					currentCheckpoint.canSwapCheckpoint?.( checkpointId ) === false
+				) {
+					nextInvalidatedCheckpointIds.add( checkpointId );
+					invalidateCheckpointAction( checkpointId );
+					didChange = true;
+				}
+			}
+		}
+		if ( didChange ) {
+			setSourceDriftInvalidatedCheckpointIds( nextInvalidatedCheckpointIds );
+		}
+	}, [
+		checkpointEditorBlocks,
+		checkpointIdsByTurn,
+		checkpointSessionIdentity,
+		sourceDriftInvalidatedCheckpointIds,
+		supportsCheckpointSwap,
+		useCheckpoint,
+	] );
 	const previousHasEditorRedoRef = useRef( hasEditorRedo );
 	const nativeUndoInvalidatedTurnRef = useRef(
 		hasEditorRedo ? checkpointIdsByTurn.userMessageId : undefined
@@ -607,6 +669,7 @@ export default function OrchestratorChat( {
 		checkpoint,
 		( checkpointId ) =>
 			! hasEditorRedo &&
+			! sourceDriftInvalidatedCheckpointIds.has( checkpointId ) &&
 			checkpointIdsByTurn.current.has( checkpointId ) &&
 			( ! checkpointIdsByTurn.userMessageId ||
 				nativeUndoInvalidatedTurnRef.current !== checkpointIdsByTurn.userMessageId )
@@ -1001,6 +1064,7 @@ export default function OrchestratorChat( {
 	const displayedMessages = useMemo< AgentsManagerUIMessage[] >( () => {
 		// The stable checkpoint getter reads this value through a ref.
 		void hasEditorRedo;
+		void sourceDriftInvalidatedCheckpointIds;
 		let currentMessages: AgentsManagerUIMessage[] = messages;
 
 		// Let the provider rewrite the transcript first, while the messages are
@@ -1129,6 +1193,7 @@ export default function OrchestratorChat( {
 		messages,
 		retainedShowComponentMessages,
 		siteBuildUtils,
+		sourceDriftInvalidatedCheckpointIds,
 		thinkingMessage,
 		transformMessages,
 	] );

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -326,23 +326,53 @@ export default function OrchestratorChat( {
 	}, [] );
 	const previousHasEditorRedoRef = useRef( hasEditorRedo );
 	const { isPageOrSiteEditorSurface: groupWritingSuggestions } = usePageOrSiteEditorSurface();
-	const checkpointSessionIdentity = `${ agentConfig?.agentId ?? '' }:${
-		agentConfig?.sessionId ?? getActiveSessionId() ?? ''
-	}`;
+	const checkpointAgentId = agentConfig?.agentId ?? '';
+	const checkpointSessionId = agentConfig?.sessionId ?? getTabSessionId() ?? '';
+	const checkpointSessionIdentity = `${ checkpointAgentId }:${ checkpointSessionId }`;
 	const streamedCheckpointMessagesRef = useRef( {
+		agentId: checkpointAgentId,
+		sessionId: checkpointSessionId,
 		sessionIdentity: checkpointSessionIdentity,
+		streamGeneration: Symbol(),
 		pendingByTaskId: new Map< string, UIMessage >(),
 		byFinalMessageId: getStreamedCheckpointMessages( checkpointSessionIdentity ),
 		regeneratingMessageId: undefined as string | undefined,
 	} );
 	if ( streamedCheckpointMessagesRef.current.sessionIdentity !== checkpointSessionIdentity ) {
+		const previousStreamedMessages = streamedCheckpointMessagesRef.current;
+		const byFinalMessageId = getStreamedCheckpointMessages( checkpointSessionIdentity );
+		const isSessionBootstrap =
+			previousStreamedMessages.agentId === checkpointAgentId &&
+			previousStreamedMessages.sessionId === '' &&
+			checkpointSessionId !== '';
+
+		if ( isSessionBootstrap ) {
+			previousStreamedMessages.byFinalMessageId.forEach( ( message, messageId ) => {
+				if ( ! byFinalMessageId.has( messageId ) ) {
+					byFinalMessageId.set( messageId, message );
+				}
+			} );
+			if (
+				streamedCheckpointMessagesBySession.get( previousStreamedMessages.sessionIdentity ) ===
+				previousStreamedMessages.byFinalMessageId
+			) {
+				streamedCheckpointMessagesBySession.delete( previousStreamedMessages.sessionIdentity );
+			}
+		}
+
 		streamedCheckpointMessagesRef.current = {
+			agentId: checkpointAgentId,
+			sessionId: checkpointSessionId,
 			sessionIdentity: checkpointSessionIdentity,
-			pendingByTaskId: new Map(),
-			byFinalMessageId: getStreamedCheckpointMessages( checkpointSessionIdentity ),
-			regeneratingMessageId: undefined,
+			streamGeneration: isSessionBootstrap ? previousStreamedMessages.streamGeneration : Symbol(),
+			pendingByTaskId: isSessionBootstrap ? previousStreamedMessages.pendingByTaskId : new Map(),
+			byFinalMessageId,
+			regeneratingMessageId: isSessionBootstrap
+				? previousStreamedMessages.regeneratingMessageId
+				: undefined,
 		};
 	}
+	const checkpointStreamGeneration = streamedCheckpointMessagesRef.current.streamGeneration;
 	const agentChatConfig = useMemo( () => {
 		if ( ! agentConfig ) {
 			return null;
@@ -353,11 +383,10 @@ export default function OrchestratorChat( {
 			...agentConfig,
 			onTaskUpdate: async ( update: TaskUpdate ) => {
 				const streamedMessages = streamedCheckpointMessagesRef.current;
+				const isCurrentStreamGeneration =
+					streamedMessages.streamGeneration === checkpointStreamGeneration;
 				const blockEditAgentMessageText = getBlockEditAgentMessageText( update );
-				if (
-					streamedMessages.sessionIdentity === checkpointSessionIdentity &&
-					blockEditAgentMessageText
-				) {
+				if ( isCurrentStreamGeneration && blockEditAgentMessageText ) {
 					const message: UIMessage = {
 						id: update.status.message?.messageId ?? update.agentMessage?.messageId ?? update.id,
 						role: 'agent',
@@ -372,7 +401,7 @@ export default function OrchestratorChat( {
 				const isTerminal =
 					update.final === true ||
 					[ 'completed', 'canceled', 'failed' ].includes( update.status.state );
-				if ( isTerminal ) {
+				if ( isTerminal && isCurrentStreamGeneration ) {
 					const finalMessageId = update.status.message?.messageId ?? update.agentMessage?.messageId;
 					const completedSuccessfully =
 						update.status.state === 'completed' ||
@@ -396,7 +425,7 @@ export default function OrchestratorChat( {
 				await onTaskUpdate?.( update );
 			},
 		};
-	}, [ agentConfig, checkpointSessionIdentity ] );
+	}, [ agentConfig, checkpointStreamGeneration ] );
 
 	const {
 		addMessage,
@@ -660,6 +689,8 @@ export default function OrchestratorChat( {
 		setCheckpointActionRevision( ( revision ) => revision + 1 );
 	}, [] );
 	const checkpointIdsByTurn = useMemo( () => {
+		// Session promotion changes the ref-backed messages without changing the raw message list.
+		void checkpointSessionIdentity;
 		const latestUserMessageIndex = getLatestUserMessageIndex( messages );
 		const current = new Set< string >();
 		const userMessageIdByCheckpointId = new Map< string, string | undefined >();
@@ -685,7 +716,7 @@ export default function OrchestratorChat( {
 			userMessageIdByCheckpointId,
 			userMessageId: messages[ latestUserMessageIndex ]?.id,
 		};
-	}, [ messages ] );
+	}, [ checkpointSessionIdentity, messages ] );
 	const nativeUndoInvalidatedTurnRef = useRef(
 		hasEditorRedo ? checkpointIdsByTurn.userMessageId : undefined
 	);
@@ -1332,8 +1363,9 @@ export default function OrchestratorChat( {
 	useAbilitiesRegistration();
 
 	const displayedMessages = useMemo< AgentsManagerUIMessage[] >( () => {
-		// The stable checkpoint getter reads this value through a ref.
+		// The stable checkpoint getter reads these values through refs.
 		void checkpointActionRevision;
+		void checkpointSessionIdentity;
 		void hasEditorRedo;
 		void sourceDriftInvalidatedCheckpointIds;
 		let currentMessages: AgentsManagerUIMessage[] = messages;
@@ -1464,6 +1496,7 @@ export default function OrchestratorChat( {
 		return currentMessages;
 	}, [
 		checkpointActionRevision,
+		checkpointSessionIdentity,
 		currentPostId,
 		deletedMessageIds,
 		getChatComponent,

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -725,10 +725,16 @@ export default function OrchestratorChat( {
 			)
 		);
 		let didChange = nextInvalidatedCheckpointIds.size !== sourceDriftInvalidatedCheckpointIds.size;
+		const shouldDeferSourceDriftInvalidation =
+			hasEditorRedo &&
+			!! checkpointIdsByTurn.userMessageId &&
+			( previousHasEditorRedoRef.current === false ||
+				pendingNativeUndoTurnRef.current === checkpointIdsByTurn.userMessageId ||
+				nativeUndoInvalidatedTurnRef.current === checkpointIdsByTurn.userMessageId );
 		if ( supportsCheckpointSwap && currentCheckpoint ) {
 			for ( const checkpointId of checkpointIdsByTurn.current ) {
 				if (
-					! hasEditorRedo &&
+					! shouldDeferSourceDriftInvalidation &&
 					! nextInvalidatedCheckpointIds.has( checkpointId ) &&
 					! pendingCheckpointActionIdsRef.current.has( checkpointId ) &&
 					currentCheckpoint.canSwapCheckpoint?.( checkpointId ) === false

--- a/packages/agents-manager/src/components/resolved-edit-action.tsx
+++ b/packages/agents-manager/src/components/resolved-edit-action.tsx
@@ -1,30 +1,37 @@
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { check, closeSmall, Icon, undo } from '@wordpress/icons';
+import { check, closeSmall, Icon, redo, undo } from '@wordpress/icons';
 
 type ResolvedEditActionProps = {
-	onUndo: () => Promise< boolean >;
+	initiallyReverted?: boolean;
+	onRedo?: () => Promise< boolean >;
+	onUndo?: () => Promise< boolean >;
 };
 
-export default function ResolvedEditAction( { onUndo }: ResolvedEditActionProps ) {
-	const [ undoState, setUndoState ] = useState< 'ready' | 'pending' | 'reverted' >( 'ready' );
-	const handleUndo = async () => {
-		if ( undoState !== 'ready' ) {
+export default function ResolvedEditAction( {
+	initiallyReverted = false,
+	onRedo,
+	onUndo,
+}: ResolvedEditActionProps ) {
+	const [ isReverted, setIsReverted ] = useState( initiallyReverted );
+	const [ isPending, setIsPending ] = useState( false );
+	const action = isReverted ? onRedo : onUndo;
+	const handleAction = async () => {
+		if ( ! action || isPending ) {
 			return;
 		}
 
-		setUndoState( 'pending' );
+		setIsPending( true );
 		try {
-			if ( await onUndo() ) {
-				setUndoState( 'reverted' );
-			} else {
-				setUndoState( 'ready' );
+			if ( await action() ) {
+				setIsReverted( ! isReverted );
 			}
 		} catch {
-			setUndoState( 'ready' );
+			return;
+		} finally {
+			setIsPending( false );
 		}
 	};
-	const isReverted = undoState === 'reverted';
 
 	return (
 		<div className="agents-manager-resolved-edit-action">
@@ -43,15 +50,21 @@ export default function ResolvedEditAction( { onUndo }: ResolvedEditActionProps 
 					? __( 'Reverted', __i18n_text_domain__ )
 					: __( 'Updated', __i18n_text_domain__ ) }
 			</span>
-			<button
-				type="button"
-				className="agents-manager-resolved-edit-action__undo"
-				onClick={ () => void handleUndo() }
-				disabled={ undoState !== 'ready' }
-			>
-				<Icon className="agents-manager-resolved-edit-action__icon" icon={ undo } size={ 20 } />
-				{ __( 'Undo', __i18n_text_domain__ ) }
-			</button>
+			{ action && (
+				<button
+					type="button"
+					className="agents-manager-resolved-edit-action__undo"
+					onClick={ () => void handleAction() }
+					disabled={ isPending }
+				>
+					<Icon
+						className="agents-manager-resolved-edit-action__icon"
+						icon={ isReverted ? redo : undo }
+						size={ 20 }
+					/>
+					{ isReverted ? __( 'Redo', __i18n_text_domain__ ) : __( 'Undo', __i18n_text_domain__ ) }
+				</button>
+			) }
 		</div>
 	);
 }

--- a/packages/agents-manager/src/components/resolved-edit-action.tsx
+++ b/packages/agents-manager/src/components/resolved-edit-action.tsx
@@ -1,4 +1,4 @@
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { check, closeSmall, Icon, redo, undo } from '@wordpress/icons';
 
@@ -15,6 +15,7 @@ export default function ResolvedEditAction( {
 }: ResolvedEditActionProps ) {
 	const [ isReverted, setIsReverted ] = useState( initiallyReverted );
 	const [ isPending, setIsPending ] = useState( false );
+	useEffect( () => setIsReverted( initiallyReverted ), [ initiallyReverted ] );
 	const action = isReverted ? onRedo : onUndo;
 	const handleAction = async () => {
 		if ( ! action || isPending ) {

--- a/packages/agents-manager/src/components/resolved-edit-action.tsx
+++ b/packages/agents-manager/src/components/resolved-edit-action.tsx
@@ -3,12 +3,14 @@ import { __ } from '@wordpress/i18n';
 import { check, closeSmall, Icon, redo, undo } from '@wordpress/icons';
 
 type ResolvedEditActionProps = {
+	disabled?: boolean;
 	initiallyReverted?: boolean;
 	onRedo?: () => Promise< boolean >;
 	onUndo?: () => Promise< boolean >;
 };
 
 export default function ResolvedEditAction( {
+	disabled = false,
 	initiallyReverted = false,
 	onRedo,
 	onUndo,
@@ -18,7 +20,7 @@ export default function ResolvedEditAction( {
 	useEffect( () => setIsReverted( initiallyReverted ), [ initiallyReverted ] );
 	const action = isReverted ? onRedo : onUndo;
 	const handleAction = async () => {
-		if ( ! action || isPending ) {
+		if ( ! action || disabled || isPending ) {
 			return;
 		}
 
@@ -51,12 +53,12 @@ export default function ResolvedEditAction( {
 					? __( 'Reverted', __i18n_text_domain__ )
 					: __( 'Updated', __i18n_text_domain__ ) }
 			</span>
-			{ action && (
+			{ ( action || disabled ) && (
 				<button
 					type="button"
 					className="agents-manager-resolved-edit-action__undo"
 					onClick={ () => void handleAction() }
-					disabled={ isPending }
+					disabled={ disabled || isPending }
 				>
 					<Icon
 						className="agents-manager-resolved-edit-action__icon"

--- a/packages/agents-manager/src/components/resolved-edit-action.tsx
+++ b/packages/agents-manager/src/components/resolved-edit-action.tsx
@@ -53,7 +53,7 @@ export default function ResolvedEditAction( {
 					? __( 'Reverted', __i18n_text_domain__ )
 					: __( 'Updated', __i18n_text_domain__ ) }
 			</span>
-			{ ( action || disabled ) && (
+			{ action && (
 				<button
 					type="button"
 					className="agents-manager-resolved-edit-action__undo"

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -12,7 +12,7 @@ import {
 } from '@testing-library/react';
 import { createElement } from '@wordpress/element';
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
-import useCheckpointAction from '../use-checkpoint-action';
+import useCheckpointAction, { invalidateCheckpointAction } from '../use-checkpoint-action';
 import type { UseCheckpointReturn } from '../../utils/load-external-providers';
 import type { UIMessage, UseAgentChatReturn } from '@automattic/agenttic-client';
 
@@ -320,6 +320,46 @@ describe( 'useCheckpointAction', () => {
 		expect( actions[ 0 ].componentProps ).not.toHaveProperty( 'onUndo' );
 		expect( actions[ 0 ].componentProps ).not.toHaveProperty( 'onRedo' );
 		expect( checkpoint.swapCheckpoint ).not.toHaveBeenCalled();
+	} );
+
+	it( 'hides unavailable and invalidated checkpoint controls', () => {
+		const registerMessageActions = jest.fn() as UseAgentChatReturn[ 'registerMessageActions' ];
+		const checkpoint = createCheckpoint();
+		checkpoint.canSwapCheckpoint = jest.fn().mockReturnValue( true );
+		checkpoint.swapCheckpoint = jest.fn().mockResolvedValue( undefined );
+		const message = createToolMessage( {
+			toolCallId: 'invalidated-tool-call',
+			data: {
+				result: {
+					success: true,
+					outcome: 'updated',
+					changeType: 'text-content',
+				},
+			},
+		} );
+		let isAvailable = false;
+		const { result, rerender } = renderHook( () =>
+			useCheckpointAction( registerMessageActions, checkpoint, () => isAvailable )
+		);
+
+		const unavailableAction = result.current( message )[ 0 ];
+		expect( unavailableAction ).toMatchObject( { label: 'Updated' } );
+		if ( unavailableAction?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		expect( unavailableAction.componentProps ).not.toHaveProperty( 'onUndo' );
+		expect( unavailableAction.componentProps ).not.toHaveProperty( 'onRedo' );
+
+		isAvailable = true;
+		rerender();
+		invalidateCheckpointAction( 'invalidated-tool-call' );
+		const invalidatedAction = result.current( message )[ 0 ];
+		expect( invalidatedAction ).toMatchObject( { label: 'Updated' } );
+		if ( invalidatedAction?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		expect( invalidatedAction.componentProps ).not.toHaveProperty( 'onUndo' );
+		expect( invalidatedAction.componentProps ).not.toHaveProperty( 'onRedo' );
 	} );
 
 	it( 'uses the Jetpack tool call id for its block edit checkpoint', async () => {

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -12,7 +12,10 @@ import {
 } from '@testing-library/react';
 import { createElement } from '@wordpress/element';
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
-import useCheckpointAction, { invalidateCheckpointAction } from '../use-checkpoint-action';
+import useCheckpointAction, {
+	invalidateCheckpointAction,
+	setCheckpointActionReverted,
+} from '../use-checkpoint-action';
 import type { UseCheckpointReturn } from '../../utils/load-external-providers';
 import type { UIMessage, UseAgentChatReturn } from '@automattic/agenttic-client';
 
@@ -170,6 +173,48 @@ describe( 'useCheckpointAction', () => {
 		expect( getActions( registration, message )[ 0 ] ).toMatchObject( {
 			label: 'Reverted',
 		} );
+	} );
+
+	it( 'updates a mounted resolved edit action from external checkpoint state', () => {
+		const registerMessageActions = jest.fn() as UseAgentChatReturn[ 'registerMessageActions' ];
+		const checkpoint = createCheckpoint();
+		const message = createToolMessage( {
+			toolCallId: 'native-status-tool-call',
+			data: {
+				result: {
+					success: true,
+					outcome: 'updated',
+					changeType: 'text-content',
+				},
+			},
+		} );
+		const { result } = renderHook( () =>
+			useCheckpointAction( registerMessageActions, checkpoint )
+		);
+		const updatedAction = result.current( message )[ 0 ];
+		if ( updatedAction?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		const view = render( createElement( updatedAction.component, updatedAction.componentProps ) );
+
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Updated' );
+		expect( screen.getByRole( 'button', { name: 'Undo' } ) ).toBeInTheDocument();
+
+		expect( setCheckpointActionReverted( 'native-status-tool-call', true ) ).toBe( true );
+		invalidateCheckpointAction( 'native-status-tool-call' );
+		const revertedAction = result.current( message )[ 0 ];
+		expect( revertedAction ).toMatchObject( { label: 'Reverted' } );
+		if ( revertedAction?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		view.rerender( createElement( revertedAction.component, revertedAction.componentProps ) );
+
+		const status = screen.getByRole( 'status' );
+		expect( status ).toHaveTextContent( 'Reverted' );
+		expect( within( status ).getByTestId( 'icon-closeSmall' ) ).toBeInTheDocument();
+		expect( status ).toHaveClass( 'agents-manager-resolved-edit-action__status--reverted' );
+		expect( screen.queryByRole( 'button', { name: 'Undo' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Redo' } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 're-enables Undo when restoring the checkpoint fails', async () => {

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -604,10 +604,14 @@ describe( 'useCheckpointAction', () => {
 			useCheckpointAction( registerMessageActions, checkpoint, () => actionState )
 		);
 		const activeAction = result.current( message )[ 0 ];
-		if ( activeAction?.type !== 'component' || ! activeAction.componentProps?.onUndo ) {
+		if ( activeAction?.type !== 'component' ) {
 			throw new Error( 'Expected an Undo action.' );
 		}
-		await expect( activeAction.componentProps.onUndo() ).resolves.toBe( true );
+		const onUndo = activeAction.componentProps?.onUndo;
+		if ( typeof onUndo !== 'function' ) {
+			throw new Error( 'Expected an Undo action.' );
+		}
+		await expect( onUndo() ).resolves.toBe( true );
 
 		actionState = 'disabled';
 		canSwapCheckpoint = undefined;

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -127,8 +127,11 @@ describe( 'useCheckpointAction', () => {
 				},
 			},
 		} );
+		let actionState: 'disabled' | 'enabled' = 'enabled';
 
-		renderHook( () => useCheckpointAction( registerMessageActions, checkpoint ) );
+		renderHook( () =>
+			useCheckpointAction( registerMessageActions, checkpoint, () => actionState )
+		);
 
 		const actions = getActions( registration, message );
 		expect( actions ).toHaveLength( 1 );
@@ -141,7 +144,7 @@ describe( 'useCheckpointAction', () => {
 		if ( actions[ 0 ]?.type !== 'component' ) {
 			throw new Error( 'Expected a component action.' );
 		}
-		render( createElement( actions[ 0 ].component, actions[ 0 ].componentProps ) );
+		const view = render( createElement( actions[ 0 ].component, actions[ 0 ].componentProps ) );
 		const status = screen.getByRole( 'status' );
 		expect( status ).toHaveTextContent( 'Updated' );
 		expect( within( status ).getByTestId( 'icon-check' ) ).toBeInTheDocument();
@@ -173,6 +176,22 @@ describe( 'useCheckpointAction', () => {
 		expect( getActions( registration, message )[ 0 ] ).toMatchObject( {
 			label: 'Reverted',
 		} );
+
+		actionState = 'disabled';
+		( checkpoint.hasCheckpoint as jest.Mock ).mockReturnValue( false );
+		const supersededAction = getActions( registration, message )[ 0 ];
+		expect( supersededAction ).toMatchObject( {
+			label: 'Reverted',
+			componentProps: { disabled: true, initiallyReverted: true },
+		} );
+		if ( supersededAction?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		expect( supersededAction.componentProps ).not.toHaveProperty( 'onUndo' );
+		expect( supersededAction.componentProps ).not.toHaveProperty( 'onRedo' );
+		view.rerender( createElement( supersededAction.component, supersededAction.componentProps ) );
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Reverted' );
+		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'updates a mounted resolved edit action from external checkpoint state', () => {
@@ -472,7 +491,7 @@ describe( 'useCheckpointAction', () => {
 		expect( checkpoint.swapCheckpoint ).not.toHaveBeenCalled();
 	} );
 
-	it( 'disables superseded checkpoint controls and hides invalidated controls', () => {
+	it( 'hides superseded and invalidated checkpoint controls', () => {
 		const registerMessageActions = jest.fn() as UseAgentChatReturn[ 'registerMessageActions' ];
 		const checkpoint = createCheckpoint();
 		checkpoint.canSwapCheckpoint = jest.fn().mockReturnValue( true );
@@ -494,7 +513,7 @@ describe( 'useCheckpointAction', () => {
 		);
 
 		const supersededAction = result.current( message )[ 0 ];
-		expect( supersededAction ).toMatchObject( { label: 'Updated and Undo' } );
+		expect( supersededAction ).toMatchObject( { label: 'Updated' } );
 		if ( supersededAction?.type !== 'component' ) {
 			throw new Error( 'Expected a component action.' );
 		}
@@ -504,9 +523,8 @@ describe( 'useCheckpointAction', () => {
 		const view = render(
 			createElement( supersededAction.component, supersededAction.componentProps )
 		);
-		const disabledUndo = screen.getByRole( 'button', { name: 'Undo' } );
-		expect( disabledUndo ).toBeDisabled();
-		fireEvent.click( disabledUndo );
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Updated' );
+		expect( screen.queryByRole( 'button', { name: 'Undo' } ) ).not.toBeInTheDocument();
 		expect( checkpoint.swapCheckpoint ).not.toHaveBeenCalled();
 		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalled();
 
@@ -574,7 +592,7 @@ describe( 'useCheckpointAction', () => {
 		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalled();
 		const disabledAction = getActions( registration, message )[ 0 ];
 		expect( disabledAction ).toMatchObject( {
-			label: 'Updated and Undo',
+			label: 'Updated',
 			componentProps: { disabled: true },
 		} );
 		if ( disabledAction?.type !== 'component' ) {
@@ -583,7 +601,7 @@ describe( 'useCheckpointAction', () => {
 		expect( disabledAction.componentProps ).not.toHaveProperty( 'onUndo' );
 	} );
 
-	it( 'keeps a successful Reverted action as a disabled Redo after its checkpoint clears', async () => {
+	it( 'keeps a successful Reverted status after its checkpoint clears', async () => {
 		const registerMessageActions = jest.fn() as UseAgentChatReturn[ 'registerMessageActions' ];
 		const checkpoint = createCheckpoint();
 		let canSwapCheckpoint: boolean | undefined = true;
@@ -619,7 +637,7 @@ describe( 'useCheckpointAction', () => {
 
 		const action = result.current( message )[ 0 ];
 		expect( action ).toMatchObject( {
-			label: 'Reverted and Redo',
+			label: 'Reverted',
 			componentProps: { disabled: true, initiallyReverted: true },
 		} );
 		if ( action?.type !== 'component' ) {
@@ -629,10 +647,9 @@ describe( 'useCheckpointAction', () => {
 		expect( action.componentProps ).not.toHaveProperty( 'onRedo' );
 		render( createElement( action.component, action.componentProps ) );
 
-		const disabledRedo = screen.getByRole( 'button', { name: 'Redo' } );
-		expect( disabledRedo ).toBeDisabled();
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Reverted' );
+		expect( screen.queryByRole( 'button', { name: 'Redo' } ) ).not.toBeInTheDocument();
 		const trackCalls = ( recordBigSkyTracksEvent as jest.Mock ).mock.calls.length;
-		fireEvent.click( disabledRedo );
 		expect( checkpoint.swapCheckpoint ).toHaveBeenCalledTimes( 1 );
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( trackCalls );
 	} );

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -344,6 +344,40 @@ describe( 'useCheckpointAction', () => {
 		expect( checkpoint.restoreCheckpoint ).not.toHaveBeenCalled();
 	} );
 
+	it( 'uses restore-based Undo when the merged provider cannot swap this checkpoint', async () => {
+		let registration: MessageActionsRegistration | undefined;
+		const registerMessageActions = jest.fn( ( nextRegistration ) => {
+			registration = nextRegistration;
+		} ) as UseAgentChatReturn[ 'registerMessageActions' ];
+		const checkpoint = createCheckpoint();
+		checkpoint.canSwapCheckpoint = jest.fn().mockReturnValue( undefined );
+		checkpoint.swapCheckpoint = jest.fn().mockResolvedValue( undefined );
+		const message = createToolMessage( {
+			toolCallId: 'restore-only-tool-call',
+			data: {
+				result: {
+					success: true,
+					outcome: 'updated',
+					changeType: 'text-content',
+				},
+			},
+		} );
+
+		renderHook( () => useCheckpointAction( registerMessageActions, checkpoint ) );
+
+		const action = getActions( registration, message )[ 0 ];
+		expect( action ).toMatchObject( { label: 'Updated and Undo' } );
+		if ( action?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		render( createElement( action.component, action.componentProps ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Undo' } ) );
+
+		await waitFor( () => expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Reverted' ) );
+		expect( checkpoint.restoreCheckpoint ).toHaveBeenCalledWith( 'restore-only-tool-call' );
+		expect( checkpoint.swapCheckpoint ).not.toHaveBeenCalled();
+	} );
+
 	it( 'invalidates a rendered Undo when the checkpoint drifts before the click', async () => {
 		let registration: MessageActionsRegistration | undefined;
 		const registerMessageActions = jest.fn( ( nextRegistration ) => {
@@ -438,7 +472,7 @@ describe( 'useCheckpointAction', () => {
 		expect( checkpoint.swapCheckpoint ).not.toHaveBeenCalled();
 	} );
 
-	it( 'hides unavailable and invalidated checkpoint controls', () => {
+	it( 'disables superseded checkpoint controls and hides invalidated controls', () => {
 		const registerMessageActions = jest.fn() as UseAgentChatReturn[ 'registerMessageActions' ];
 		const checkpoint = createCheckpoint();
 		checkpoint.canSwapCheckpoint = jest.fn().mockReturnValue( true );
@@ -453,20 +487,31 @@ describe( 'useCheckpointAction', () => {
 				},
 			},
 		} );
-		let isAvailable = false;
+		( checkpoint.hasCheckpoint as jest.Mock ).mockReturnValue( false );
+		let actionState: 'disabled' | 'enabled' | 'hidden' = 'disabled';
 		const { result, rerender } = renderHook( () =>
-			useCheckpointAction( registerMessageActions, checkpoint, () => isAvailable )
+			useCheckpointAction( registerMessageActions, checkpoint, () => actionState )
 		);
 
-		const unavailableAction = result.current( message )[ 0 ];
-		expect( unavailableAction ).toMatchObject( { label: 'Updated' } );
-		if ( unavailableAction?.type !== 'component' ) {
+		const supersededAction = result.current( message )[ 0 ];
+		expect( supersededAction ).toMatchObject( { label: 'Updated and Undo' } );
+		if ( supersededAction?.type !== 'component' ) {
 			throw new Error( 'Expected a component action.' );
 		}
-		expect( unavailableAction.componentProps ).not.toHaveProperty( 'onUndo' );
-		expect( unavailableAction.componentProps ).not.toHaveProperty( 'onRedo' );
+		expect( supersededAction.componentProps ).toMatchObject( { disabled: true } );
+		expect( supersededAction.componentProps ).not.toHaveProperty( 'onUndo' );
+		expect( supersededAction.componentProps ).not.toHaveProperty( 'onRedo' );
+		const view = render(
+			createElement( supersededAction.component, supersededAction.componentProps )
+		);
+		const disabledUndo = screen.getByRole( 'button', { name: 'Undo' } );
+		expect( disabledUndo ).toBeDisabled();
+		fireEvent.click( disabledUndo );
+		expect( checkpoint.swapCheckpoint ).not.toHaveBeenCalled();
+		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalled();
 
-		isAvailable = true;
+		( checkpoint.hasCheckpoint as jest.Mock ).mockReturnValue( true );
+		actionState = 'enabled';
 		rerender();
 		invalidateCheckpointAction( 'invalidated-tool-call' );
 		const invalidatedAction = result.current( message )[ 0 ];
@@ -474,9 +519,118 @@ describe( 'useCheckpointAction', () => {
 		if ( invalidatedAction?.type !== 'component' ) {
 			throw new Error( 'Expected a component action.' );
 		}
+		view.rerender( createElement( invalidatedAction.component, invalidatedAction.componentProps ) );
 		expect( invalidatedAction.componentProps ).not.toHaveProperty( 'onUndo' );
 		expect( invalidatedAction.componentProps ).not.toHaveProperty( 'onRedo' );
+		expect( screen.queryByRole( 'button', { name: 'Undo' } ) ).not.toBeInTheDocument();
 		expect( checkpoint.canSwapCheckpoint ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps a stale Undo inert when a later message disables it', async () => {
+		let registration: MessageActionsRegistration | undefined;
+		const registerMessageActions = jest.fn( ( nextRegistration ) => {
+			registration = nextRegistration;
+		} ) as UseAgentChatReturn[ 'registerMessageActions' ];
+		const checkpoint = createCheckpoint();
+		checkpoint.canSwapCheckpoint = jest.fn().mockReturnValue( true );
+		checkpoint.swapCheckpoint = jest.fn().mockResolvedValue( undefined );
+		const onCheckpointActionInvalidated = jest.fn();
+		const message = createToolMessage( {
+			toolCallId: 'superseded-stale-tool-call',
+			data: {
+				result: {
+					success: true,
+					outcome: 'updated',
+					changeType: 'text-content',
+				},
+			},
+		} );
+		let actionState: 'disabled' | 'enabled' | 'hidden' = 'enabled';
+
+		renderHook( () =>
+			useCheckpointAction(
+				registerMessageActions,
+				checkpoint,
+				() => actionState,
+				undefined,
+				onCheckpointActionInvalidated
+			)
+		);
+
+		const renderedAction = getActions( registration, message )[ 0 ];
+		if ( renderedAction?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		const staleOnUndo = renderedAction.componentProps?.onUndo;
+		if ( typeof staleOnUndo !== 'function' ) {
+			throw new Error( 'Expected an Undo action.' );
+		}
+
+		actionState = 'disabled';
+		await expect( staleOnUndo() ).resolves.toBe( false );
+
+		expect( checkpoint.swapCheckpoint ).not.toHaveBeenCalled();
+		expect( onCheckpointActionInvalidated ).not.toHaveBeenCalled();
+		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalled();
+		const disabledAction = getActions( registration, message )[ 0 ];
+		expect( disabledAction ).toMatchObject( {
+			label: 'Updated and Undo',
+			componentProps: { disabled: true },
+		} );
+		if ( disabledAction?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		expect( disabledAction.componentProps ).not.toHaveProperty( 'onUndo' );
+	} );
+
+	it( 'keeps a successful Reverted action as a disabled Redo after its checkpoint clears', async () => {
+		const registerMessageActions = jest.fn() as UseAgentChatReturn[ 'registerMessageActions' ];
+		const checkpoint = createCheckpoint();
+		let canSwapCheckpoint: boolean | undefined = true;
+		checkpoint.canSwapCheckpoint = jest.fn( () => canSwapCheckpoint );
+		checkpoint.swapCheckpoint = jest.fn().mockResolvedValue( undefined );
+		const message = createToolMessage( {
+			toolCallId: 'superseded-reverted-tool-call',
+			data: {
+				result: {
+					success: true,
+					outcome: 'updated',
+					changeType: 'text-content',
+				},
+			},
+		} );
+		let actionState: 'disabled' | 'enabled' | 'hidden' = 'enabled';
+		const { result } = renderHook( () =>
+			useCheckpointAction( registerMessageActions, checkpoint, () => actionState )
+		);
+		const activeAction = result.current( message )[ 0 ];
+		if ( activeAction?.type !== 'component' || ! activeAction.componentProps?.onUndo ) {
+			throw new Error( 'Expected an Undo action.' );
+		}
+		await expect( activeAction.componentProps.onUndo() ).resolves.toBe( true );
+
+		actionState = 'disabled';
+		canSwapCheckpoint = undefined;
+		( checkpoint.hasCheckpoint as jest.Mock ).mockReturnValue( false );
+
+		const action = result.current( message )[ 0 ];
+		expect( action ).toMatchObject( {
+			label: 'Reverted and Redo',
+			componentProps: { disabled: true, initiallyReverted: true },
+		} );
+		if ( action?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		expect( action.componentProps ).not.toHaveProperty( 'onUndo' );
+		expect( action.componentProps ).not.toHaveProperty( 'onRedo' );
+		render( createElement( action.component, action.componentProps ) );
+
+		const disabledRedo = screen.getByRole( 'button', { name: 'Redo' } );
+		expect( disabledRedo ).toBeDisabled();
+		const trackCalls = ( recordBigSkyTracksEvent as jest.Mock ).mock.calls.length;
+		fireEvent.click( disabledRedo );
+		expect( checkpoint.swapCheckpoint ).toHaveBeenCalledTimes( 1 );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( trackCalls );
 	} );
 
 	it( 'uses the Jetpack tool call id for its block edit checkpoint', async () => {

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -344,6 +344,64 @@ describe( 'useCheckpointAction', () => {
 		expect( checkpoint.restoreCheckpoint ).not.toHaveBeenCalled();
 	} );
 
+	it( 'invalidates a rendered Undo when the checkpoint drifts before the click', async () => {
+		let registration: MessageActionsRegistration | undefined;
+		const registerMessageActions = jest.fn( ( nextRegistration ) => {
+			registration = nextRegistration;
+		} ) as UseAgentChatReturn[ 'registerMessageActions' ];
+		const checkpoint = createCheckpoint();
+		let canSwapCheckpoint = true;
+		checkpoint.canSwapCheckpoint = jest.fn( () => canSwapCheckpoint );
+		checkpoint.swapCheckpoint = jest.fn().mockResolvedValue( undefined );
+		const onCheckpointActionInvalidated = jest.fn();
+		const message = createToolMessage( {
+			toolCallId: 'stale-rendered-tool-call',
+			data: {
+				result: {
+					success: true,
+					outcome: 'updated',
+					changeType: 'text-content',
+				},
+			},
+		} );
+
+		renderHook( () =>
+			useCheckpointAction(
+				registerMessageActions,
+				checkpoint,
+				undefined,
+				undefined,
+				onCheckpointActionInvalidated
+			)
+		);
+
+		const renderedAction = getActions( registration, message )[ 0 ];
+		if ( renderedAction?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		const staleOnUndo = renderedAction.componentProps?.onUndo;
+		if ( typeof staleOnUndo !== 'function' ) {
+			throw new Error( 'Expected an Undo action.' );
+		}
+
+		canSwapCheckpoint = false;
+		await expect( staleOnUndo() ).resolves.toBe( false );
+
+		expect( checkpoint.swapCheckpoint ).not.toHaveBeenCalled();
+		expect( onCheckpointActionInvalidated ).toHaveBeenCalledWith( 'stale-rendered-tool-call' );
+		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalled();
+		const refreshedAction = getActions( registration, message )[ 0 ];
+		if ( refreshedAction?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		expect( refreshedAction.componentProps ).not.toHaveProperty( 'onUndo' );
+		expect( refreshedAction.componentProps ).not.toHaveProperty( 'onRedo' );
+
+		await expect( staleOnUndo() ).resolves.toBe( false );
+		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalled();
+		expect( onCheckpointActionInvalidated ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'does not offer Undo when a swappable text checkpoint has drifted', () => {
 		let registration: MessageActionsRegistration | undefined;
 		const registerMessageActions = jest.fn( ( nextRegistration ) => {

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -159,6 +159,7 @@ describe( 'useCheckpointAction', () => {
 
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'restore_checkpoint_action', {
+			action: 'undo',
 			id: 'tool-call-1',
 			outcome: 'success',
 		} );
@@ -215,6 +216,7 @@ describe( 'useCheckpointAction', () => {
 
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'restore_checkpoint_action', {
+			action: 'undo',
 			id: 'tool-call-failure',
 			outcome: 'failed',
 		} );
@@ -233,6 +235,7 @@ describe( 'useCheckpointAction', () => {
 		expect( screen.queryByRole( 'button', { name: 'Undo' } ) ).not.toBeInTheDocument();
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 2 );
 		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'restore_checkpoint_action', {
+			action: 'undo',
 			id: 'tool-call-failure',
 			outcome: 'success',
 		} );
@@ -269,6 +272,11 @@ describe( 'useCheckpointAction', () => {
 		fireEvent.click( screen.getByRole( 'button', { name: 'Undo' } ) );
 		await waitFor( () => expect( screen.getByRole( 'button', { name: 'Redo' } ) ).toBeEnabled() );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Reverted' );
+		expect( recordBigSkyTracksEvent ).toHaveBeenNthCalledWith( 1, 'restore_checkpoint_action', {
+			action: 'undo',
+			id: 'swappable-tool-call',
+			outcome: 'success',
+		} );
 		( checkpoint.canSwapCheckpoint as jest.Mock ).mockReturnValue( false );
 		const driftedAction = getActions( registration, message )[ 0 ];
 		expect( driftedAction ).toMatchObject( { label: 'Reverted' } );
@@ -281,6 +289,11 @@ describe( 'useCheckpointAction', () => {
 		fireEvent.click( screen.getByRole( 'button', { name: 'Redo' } ) );
 		await waitFor( () => expect( screen.getByRole( 'button', { name: 'Undo' } ) ).toBeEnabled() );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Updated' );
+		expect( recordBigSkyTracksEvent ).toHaveBeenNthCalledWith( 2, 'restore_checkpoint_action', {
+			action: 'redo',
+			id: 'swappable-tool-call',
+			outcome: 'success',
+		} );
 		expect( checkpoint.swapCheckpoint ).toHaveBeenNthCalledWith( 1, 'swappable-tool-call' );
 		expect( checkpoint.swapCheckpoint ).toHaveBeenNthCalledWith( 2, 'swappable-tool-call' );
 		expect( checkpoint.restoreCheckpoint ).not.toHaveBeenCalled();
@@ -360,6 +373,7 @@ describe( 'useCheckpointAction', () => {
 		}
 		expect( invalidatedAction.componentProps ).not.toHaveProperty( 'onUndo' );
 		expect( invalidatedAction.componentProps ).not.toHaveProperty( 'onRedo' );
+		expect( checkpoint.canSwapCheckpoint ).not.toHaveBeenCalled();
 	} );
 
 	it( 'uses the Jetpack tool call id for its block edit checkpoint', async () => {

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -25,6 +25,7 @@ jest.mock( '@wordpress/icons', () => {
 	return {
 		check: 'check',
 		closeSmall: 'closeSmall',
+		redo: 'redo',
 		undo: 'undo',
 		Icon: ( { className, icon }: { className?: string; icon: unknown } ) => {
 			if ( typeof icon !== 'string' ) {
@@ -99,7 +100,7 @@ describe( 'useCheckpointAction', () => {
 		jest.restoreAllMocks();
 	} );
 
-	it( 'shows Reverted and disables Undo after restoring a successful block edit', async () => {
+	it( 'shows Reverted and removes Undo after restoring a successful block edit', async () => {
 		let registration: MessageActionsRegistration | undefined;
 		const registerMessageActions = jest.fn( ( nextRegistration ) => {
 			registration = nextRegistration;
@@ -119,6 +120,7 @@ describe( 'useCheckpointAction', () => {
 					success: true,
 					message: 'Corrected the grammar.',
 					outcome: 'updated',
+					changeType: 'text-content',
 				},
 			},
 		} );
@@ -160,10 +162,13 @@ describe( 'useCheckpointAction', () => {
 			id: 'tool-call-1',
 			outcome: 'success',
 		} );
-		expect( undoButton ).toBeDisabled();
+		expect( screen.queryByRole( 'button', { name: 'Undo' } ) ).not.toBeInTheDocument();
 		expect( status ).toHaveTextContent( 'Reverted' );
 		expect( within( status ).getByTestId( 'icon-closeSmall' ) ).toBeInTheDocument();
 		expect( status ).toHaveClass( 'agents-manager-resolved-edit-action__status--reverted' );
+		expect( getActions( registration, message )[ 0 ] ).toMatchObject( {
+			label: 'Reverted',
+		} );
 	} );
 
 	it( 're-enables Undo when restoring the checkpoint fails', async () => {
@@ -183,12 +188,13 @@ describe( 'useCheckpointAction', () => {
 			.mockResolvedValueOnce( undefined );
 		const consoleError = jest.spyOn( console, 'error' ).mockImplementation();
 		const message = createToolMessage( {
-			toolCallId: 'tool-call-1',
+			toolCallId: 'tool-call-failure',
 			data: {
 				result: {
 					success: true,
 					message: 'Corrected the grammar.',
 					outcome: 'updated',
+					changeType: 'text-content',
 				},
 			},
 		} );
@@ -209,7 +215,7 @@ describe( 'useCheckpointAction', () => {
 
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'restore_checkpoint_action', {
-			id: 'tool-call-1',
+			id: 'tool-call-failure',
 			outcome: 'failed',
 		} );
 		expect( undoButton ).toBeEnabled();
@@ -224,11 +230,96 @@ describe( 'useCheckpointAction', () => {
 		expect( checkpoint.restoreCheckpoint ).toHaveBeenCalledTimes( 2 );
 		expect( undoButton ).toBeDisabled();
 		await waitFor( () => expect( status ).toHaveTextContent( 'Reverted' ) );
+		expect( screen.queryByRole( 'button', { name: 'Undo' } ) ).not.toBeInTheDocument();
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 2 );
 		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'restore_checkpoint_action', {
-			id: 'tool-call-1',
+			id: 'tool-call-failure',
 			outcome: 'success',
 		} );
+	} );
+
+	it( 'swaps a text checkpoint between Undo and Redo', async () => {
+		let registration: MessageActionsRegistration | undefined;
+		const registerMessageActions = jest.fn( ( nextRegistration ) => {
+			registration = nextRegistration;
+		} ) as UseAgentChatReturn[ 'registerMessageActions' ];
+		const checkpoint = createCheckpoint();
+		checkpoint.canSwapCheckpoint = jest.fn().mockReturnValue( true );
+		checkpoint.swapCheckpoint = jest.fn().mockResolvedValue( undefined );
+		const message = createToolMessage( {
+			toolCallId: 'swappable-tool-call',
+			data: {
+				result: {
+					success: true,
+					message: 'Corrected the grammar.',
+					outcome: 'updated',
+					changeType: 'text-content',
+				},
+			},
+		} );
+
+		renderHook( () => useCheckpointAction( registerMessageActions, checkpoint ) );
+
+		const actions = getActions( registration, message );
+		if ( actions[ 0 ]?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		render( createElement( actions[ 0 ].component, actions[ 0 ].componentProps ) );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Undo' } ) );
+		await waitFor( () => expect( screen.getByRole( 'button', { name: 'Redo' } ) ).toBeEnabled() );
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Reverted' );
+		( checkpoint.canSwapCheckpoint as jest.Mock ).mockReturnValue( false );
+		const driftedAction = getActions( registration, message )[ 0 ];
+		expect( driftedAction ).toMatchObject( { label: 'Reverted' } );
+		if ( driftedAction?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		expect( driftedAction.componentProps ).not.toHaveProperty( 'onRedo' );
+		( checkpoint.canSwapCheckpoint as jest.Mock ).mockReturnValue( true );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Redo' } ) );
+		await waitFor( () => expect( screen.getByRole( 'button', { name: 'Undo' } ) ).toBeEnabled() );
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Updated' );
+		expect( checkpoint.swapCheckpoint ).toHaveBeenNthCalledWith( 1, 'swappable-tool-call' );
+		expect( checkpoint.swapCheckpoint ).toHaveBeenNthCalledWith( 2, 'swappable-tool-call' );
+		expect( checkpoint.restoreCheckpoint ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not offer Undo when a swappable text checkpoint has drifted', () => {
+		let registration: MessageActionsRegistration | undefined;
+		const registerMessageActions = jest.fn( ( nextRegistration ) => {
+			registration = nextRegistration;
+		} ) as UseAgentChatReturn[ 'registerMessageActions' ];
+		const checkpoint = createCheckpoint();
+		checkpoint.canSwapCheckpoint = jest.fn().mockReturnValue( false );
+		checkpoint.swapCheckpoint = jest.fn().mockResolvedValue( undefined );
+		const message = createToolMessage( {
+			toolCallId: 'drifted-tool-call',
+			data: {
+				result: {
+					success: true,
+					message: 'Corrected the grammar.',
+					outcome: 'updated',
+					changeType: 'text-content',
+				},
+			},
+		} );
+
+		renderHook( () => useCheckpointAction( registerMessageActions, checkpoint ) );
+
+		const actions = getActions( registration, message );
+		expect( actions[ 0 ] ).toMatchObject( {
+			type: 'component',
+			id: 'checkpoint',
+			label: 'Updated',
+		} );
+		if ( actions[ 0 ]?.type !== 'component' ) {
+			throw new Error( 'Expected a component action.' );
+		}
+		expect( actions[ 0 ].componentProps ).not.toHaveProperty( 'onUndo' );
+		expect( actions[ 0 ].componentProps ).not.toHaveProperty( 'onRedo' );
+		expect( checkpoint.swapCheckpoint ).not.toHaveBeenCalled();
 	} );
 
 	it( 'uses the Jetpack tool call id for its block edit checkpoint', async () => {
@@ -282,6 +373,30 @@ describe( 'useCheckpointAction', () => {
 					success: true,
 					message: 'No edits were necessary.',
 					outcome: 'no-changes',
+				},
+			},
+		} );
+
+		renderHook( () => useCheckpointAction( registerMessageActions, checkpoint ) );
+
+		expect( getActions( registration, message ) ).toEqual( [] );
+		expect( checkpoint.hasCheckpoint ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not show the resolved edit action for a structural block edit', () => {
+		let registration: MessageActionsRegistration | undefined;
+		const registerMessageActions = jest.fn( ( nextRegistration ) => {
+			registration = nextRegistration;
+		} ) as UseAgentChatReturn[ 'registerMessageActions' ];
+		const checkpoint = createCheckpoint();
+		const message = createToolMessage( {
+			toolCallId: 'structural-tool-call',
+			data: {
+				result: {
+					success: true,
+					message: 'Moved the block.',
+					outcome: 'updated',
+					changeType: 'other',
 				},
 			},
 		} );

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -263,14 +263,13 @@ export default function useCheckpointAction(
 
 		if ( checkpointInfo.showResolvedEditAction ) {
 			const canAct = isActionAvailable && ( ! supportsSwap || swapAvailability === true );
-			const showDisabledAction = actionState === 'disabled' && ( ! isReverted || supportsSwap );
-			const showAction = canAct || showDisabledAction;
-			let label: string = showAction
+			const showDisabledAction = actionState === 'disabled';
+			let label: string = canAct
 				? __( 'Updated and Undo', __i18n_text_domain__ )
 				: __( 'Updated', __i18n_text_domain__ );
 			if ( isReverted ) {
 				label =
-					showAction && supportsSwap
+					canAct && supportsSwap
 						? __( 'Reverted and Redo', __i18n_text_domain__ )
 						: __( 'Reverted', __i18n_text_domain__ );
 			}

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -2,12 +2,54 @@ import { createElement, useCallback, useEffect, useRef } from '@wordpress/elemen
 import { __ } from '@wordpress/i18n';
 import { undo, Icon } from '@wordpress/icons';
 import ResolvedEditAction from '../components/resolved-edit-action';
-import { getApplyBlockEditsOutcome } from '../utils/tool-message-utils';
+import {
+	APPLY_BLOCK_EDITS_TOOL_ID,
+	getApplyBlockEditsOutcome,
+	UPDATE_BLOCK_CONTENT_TOOL_ID,
+} from '../utils/tool-message-utils';
 import { recordBigSkyTracksEvent } from '../utils/tracks';
 import type { UseCheckpointReturn } from '../utils/load-external-providers';
 import type { UIMessage, UIMessageAction, UseAgentChatReturn } from '@automattic/agenttic-client';
 
 type RegisterMessageActions = UseAgentChatReturn[ 'registerMessageActions' ];
+
+const revertedCheckpointIds = new Set< string >();
+
+function isTextContentEdit( toolId: unknown, data: unknown ): boolean {
+	if ( toolId === UPDATE_BLOCK_CONTENT_TOOL_ID ) {
+		return true;
+	}
+
+	if ( toolId !== APPLY_BLOCK_EDITS_TOOL_ID || typeof data !== 'object' || data === null ) {
+		return false;
+	}
+
+	const toolData = data as {
+		calypsoCheckpointId?: unknown;
+		result?: {
+			changeType?: unknown;
+			details?: { attributeResults?: unknown };
+		};
+	};
+
+	if ( ! toolData.result ) {
+		return typeof toolData.calypsoCheckpointId === 'string' && !! toolData.calypsoCheckpointId;
+	}
+	if ( toolData.result.changeType !== undefined ) {
+		return toolData.result.changeType === 'text-content';
+	}
+
+	return (
+		Array.isArray( toolData.result.details?.attributeResults ) &&
+		toolData.result.details.attributeResults.some(
+			( result ) =>
+				typeof result === 'object' &&
+				result !== null &&
+				( result as { path?: unknown } ).path === 'content' &&
+				( result as { status?: unknown } ).status === 'changed'
+		)
+	);
+}
 
 /**
  * Gets checkpoint details embedded in a tool message.
@@ -24,7 +66,10 @@ function getCheckpointInfo(
 		const parsed = JSON.parse( firstPartText );
 		const blockEditOutcome = getApplyBlockEditsOutcome( parsed.tool_id, parsed.data );
 
-		if ( blockEditOutcome === 'no-changes' ) {
+		if (
+			blockEditOutcome === 'no-changes' ||
+			( blockEditOutcome === 'updated' && ! isTextContentEdit( parsed.tool_id, parsed.data ) )
+		) {
 			return undefined;
 		}
 
@@ -67,14 +112,41 @@ export default function useCheckpointAction(
 			return [];
 		}
 
-		const restoreCheckpoint = async (): Promise< boolean > => {
+		const swapAvailability =
+			typeof currentCheckpoint.canSwapCheckpoint === 'function' &&
+			typeof currentCheckpoint.swapCheckpoint === 'function'
+				? currentCheckpoint.canSwapCheckpoint( checkpointInfo.checkpointId )
+				: undefined;
+		const supportsSwap = swapAvailability !== undefined;
+		const isReverted = revertedCheckpointIds.has( checkpointInfo.checkpointId );
+		const applyCheckpointAction = async ( revert: boolean ): Promise< boolean > => {
 			let outcome: 'success' | 'failed' = 'failed';
 			try {
 				const checkpointToRestore = checkpointRef.current;
-				if ( ! checkpointToRestore ) {
+				if (
+					! checkpointToRestore ||
+					! checkpointToRestore.hasCheckpoint( checkpointInfo.checkpointId )
+				) {
 					return false;
 				}
-				await checkpointToRestore.restoreCheckpoint( checkpointInfo.checkpointId );
+
+				if ( supportsSwap ) {
+					if (
+						checkpointToRestore.canSwapCheckpoint?.( checkpointInfo.checkpointId ) !== true ||
+						! checkpointToRestore.swapCheckpoint
+					) {
+						return false;
+					}
+					await checkpointToRestore.swapCheckpoint( checkpointInfo.checkpointId );
+				} else {
+					await checkpointToRestore.restoreCheckpoint( checkpointInfo.checkpointId );
+				}
+
+				if ( revert ) {
+					revertedCheckpointIds.add( checkpointInfo.checkpointId );
+				} else {
+					revertedCheckpointIds.delete( checkpointInfo.checkpointId );
+				}
 				outcome = 'success';
 				return true;
 			} catch ( error ) {
@@ -90,13 +162,30 @@ export default function useCheckpointAction(
 		};
 
 		if ( checkpointInfo.showResolvedEditAction ) {
+			const canAct = ! supportsSwap || swapAvailability === true;
+			let label: string = canAct
+				? __( 'Updated and Undo', __i18n_text_domain__ )
+				: __( 'Updated', __i18n_text_domain__ );
+			if ( isReverted ) {
+				label =
+					canAct && supportsSwap
+						? __( 'Reverted and Redo', __i18n_text_domain__ )
+						: __( 'Reverted', __i18n_text_domain__ );
+			}
 			return [
 				{
 					type: 'component',
 					id: 'checkpoint',
-					label: __( 'Updated and Undo', __i18n_text_domain__ ),
+					label,
 					component: ResolvedEditAction,
-					componentProps: { onUndo: restoreCheckpoint },
+					componentProps: {
+						initiallyReverted: isReverted,
+						...( canAct && { onUndo: () => applyCheckpointAction( true ) } ),
+						...( canAct &&
+							supportsSwap && {
+								onRedo: () => applyCheckpointAction( false ),
+							} ),
+					},
 					order: 1,
 				},
 			];
@@ -111,7 +200,7 @@ export default function useCheckpointAction(
 					className: 'agents-manager-message-action-icon',
 				} ),
 				onClick: async () => {
-					await restoreCheckpoint();
+					await applyCheckpointAction( true );
 				},
 				order: 1,
 			},

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -100,6 +100,20 @@ export function invalidateCheckpointAction( checkpointId: string ): void {
 	invalidatedCheckpointIds.add( checkpointId );
 }
 
+export function isCheckpointActionInvalidated( checkpointId: string ): boolean {
+	return invalidatedCheckpointIds.has( checkpointId );
+}
+
+export function setCheckpointActionReverted( checkpointId: string, isReverted: boolean ): boolean {
+	const wasReverted = revertedCheckpointIds.has( checkpointId );
+	if ( isReverted ) {
+		revertedCheckpointIds.add( checkpointId );
+	} else {
+		revertedCheckpointIds.delete( checkpointId );
+	}
+	return wasReverted !== isReverted;
+}
+
 /**
  * Registers an undo action on agent messages that have a checkpoint.
  */
@@ -175,11 +189,7 @@ export default function useCheckpointAction(
 					await checkpointToRestore.restoreCheckpoint( checkpointInfo.checkpointId );
 				}
 
-				if ( revert ) {
-					revertedCheckpointIds.add( checkpointInfo.checkpointId );
-				} else {
-					revertedCheckpointIds.delete( checkpointInfo.checkpointId );
-				}
+				setCheckpointActionReverted( checkpointInfo.checkpointId, revert );
 				outcome = 'success';
 				return true;
 			} catch ( error ) {

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -14,6 +14,7 @@ import type { UIMessage, UIMessageAction, UseAgentChatReturn } from '@automattic
 type RegisterMessageActions = UseAgentChatReturn[ 'registerMessageActions' ];
 type IsCheckpointActionAvailable = ( checkpointId: string ) => boolean;
 type OnCheckpointActionPendingChange = ( checkpointId: string, isPending: boolean ) => void;
+type OnCheckpointActionInvalidated = ( checkpointId: string ) => void;
 
 const revertedCheckpointIds = new Set< string >();
 const invalidatedCheckpointIds = new Set< string >();
@@ -121,7 +122,8 @@ export default function useCheckpointAction(
 	registerMessageActions: RegisterMessageActions,
 	checkpoint?: UseCheckpointReturn,
 	isCheckpointActionAvailable?: IsCheckpointActionAvailable,
-	onCheckpointActionPendingChange?: OnCheckpointActionPendingChange
+	onCheckpointActionPendingChange?: OnCheckpointActionPendingChange,
+	onCheckpointActionInvalidated?: OnCheckpointActionInvalidated
 ): ( message: UIMessage ) => UIMessageAction[] {
 	// Refs avoid infinite re-renders caused by unstable provider values.
 	const checkpointRef = useRef( checkpoint );
@@ -130,6 +132,8 @@ export default function useCheckpointAction(
 	isCheckpointActionAvailableRef.current = isCheckpointActionAvailable;
 	const onCheckpointActionPendingChangeRef = useRef( onCheckpointActionPendingChange );
 	onCheckpointActionPendingChangeRef.current = onCheckpointActionPendingChange;
+	const onCheckpointActionInvalidatedRef = useRef( onCheckpointActionInvalidated );
+	onCheckpointActionInvalidatedRef.current = onCheckpointActionInvalidated;
 	const pendingSwapCheckpointIdsRef = useRef( new Set< string >() );
 	const getCheckpointActionsForMessage = useCallback( ( message: UIMessage ): UIMessageAction[] => {
 		const currentCheckpoint = checkpointRef.current;
@@ -163,6 +167,13 @@ export default function useCheckpointAction(
 
 			let outcome: 'success' | 'failed' = 'failed';
 			let didStartSwap = false;
+			let didAttemptAction = false;
+			const invalidateAction = () => {
+				if ( ! invalidatedCheckpointIds.has( checkpointInfo.checkpointId ) ) {
+					invalidateCheckpointAction( checkpointInfo.checkpointId );
+					onCheckpointActionInvalidatedRef.current?.( checkpointInfo.checkpointId );
+				}
+			};
 			try {
 				const checkpointToRestore = checkpointRef.current;
 				if (
@@ -171,6 +182,7 @@ export default function useCheckpointAction(
 					! checkpointToRestore ||
 					! checkpointToRestore.hasCheckpoint( checkpointInfo.checkpointId )
 				) {
+					invalidateAction();
 					return false;
 				}
 
@@ -179,13 +191,16 @@ export default function useCheckpointAction(
 						checkpointToRestore.canSwapCheckpoint?.( checkpointInfo.checkpointId ) !== true ||
 						! checkpointToRestore.swapCheckpoint
 					) {
+						invalidateAction();
 						return false;
 					}
 					pendingSwapCheckpointIdsRef.current.add( checkpointInfo.checkpointId );
 					onCheckpointActionPendingChangeRef.current?.( checkpointInfo.checkpointId, true );
 					didStartSwap = true;
+					didAttemptAction = true;
 					await checkpointToRestore.swapCheckpoint( checkpointInfo.checkpointId );
 				} else {
+					didAttemptAction = true;
 					await checkpointToRestore.restoreCheckpoint( checkpointInfo.checkpointId );
 				}
 
@@ -201,11 +216,13 @@ export default function useCheckpointAction(
 					pendingSwapCheckpointIdsRef.current.delete( checkpointInfo.checkpointId );
 					onCheckpointActionPendingChangeRef.current?.( checkpointInfo.checkpointId, false );
 				}
-				recordBigSkyTracksEvent( 'restore_checkpoint_action', {
-					action: revert ? 'undo' : 'redo',
-					id: checkpointInfo.checkpointId,
-					outcome,
-				} );
+				if ( didAttemptAction ) {
+					recordBigSkyTracksEvent( 'restore_checkpoint_action', {
+						action: revert ? 'undo' : 'redo',
+						id: checkpointInfo.checkpointId,
+						outcome,
+					} );
+				}
 			}
 		};
 

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -12,8 +12,10 @@ import type { UseCheckpointReturn } from '../utils/load-external-providers';
 import type { UIMessage, UIMessageAction, UseAgentChatReturn } from '@automattic/agenttic-client';
 
 type RegisterMessageActions = UseAgentChatReturn[ 'registerMessageActions' ];
+type IsCheckpointActionAvailable = ( checkpointId: string ) => boolean;
 
 const revertedCheckpointIds = new Set< string >();
+const invalidatedCheckpointIds = new Set< string >();
 
 function isTextContentEdit( toolId: unknown, data: unknown ): boolean {
 	if ( toolId === UPDATE_BLOCK_CONTENT_TOOL_ID ) {
@@ -58,7 +60,7 @@ function isTextContentEdit( toolId: unknown, data: unknown ): boolean {
  * state is session-only; `hasCheckpoint` filters out stale IDs.
  */
 function getCheckpointInfo(
-	message: UIMessage
+	message: Pick< UIMessage, 'content' >
 ): { checkpointId: string; showResolvedEditAction: boolean } | undefined {
 	const firstPartText = message.content?.[ 0 ]?.text ?? '';
 
@@ -89,16 +91,27 @@ function getCheckpointInfo(
 	return undefined;
 }
 
+export function getCheckpointIdForMessage( message: Pick< UIMessage, 'content' > ): string | null {
+	return getCheckpointInfo( message )?.checkpointId ?? null;
+}
+
+export function invalidateCheckpointAction( checkpointId: string ): void {
+	invalidatedCheckpointIds.add( checkpointId );
+}
+
 /**
  * Registers an undo action on agent messages that have a checkpoint.
  */
 export default function useCheckpointAction(
 	registerMessageActions: RegisterMessageActions,
-	checkpoint?: UseCheckpointReturn
+	checkpoint?: UseCheckpointReturn,
+	isCheckpointActionAvailable?: IsCheckpointActionAvailable
 ): ( message: UIMessage ) => UIMessageAction[] {
-	// Ref avoids infinite re-renders caused by unstable `checkpoint` reference.
+	// Refs avoid infinite re-renders caused by unstable provider values.
 	const checkpointRef = useRef( checkpoint );
 	checkpointRef.current = checkpoint;
+	const isCheckpointActionAvailableRef = useRef( isCheckpointActionAvailable );
+	isCheckpointActionAvailableRef.current = isCheckpointActionAvailable;
 	const getCheckpointActionsForMessage = useCallback( ( message: UIMessage ): UIMessageAction[] => {
 		const currentCheckpoint = checkpointRef.current;
 
@@ -119,11 +132,16 @@ export default function useCheckpointAction(
 				: undefined;
 		const supportsSwap = swapAvailability !== undefined;
 		const isReverted = revertedCheckpointIds.has( checkpointInfo.checkpointId );
+		const isActionAvailable =
+			! invalidatedCheckpointIds.has( checkpointInfo.checkpointId ) &&
+			( isCheckpointActionAvailableRef.current?.( checkpointInfo.checkpointId ) ?? true );
 		const applyCheckpointAction = async ( revert: boolean ): Promise< boolean > => {
 			let outcome: 'success' | 'failed' = 'failed';
 			try {
 				const checkpointToRestore = checkpointRef.current;
 				if (
+					invalidatedCheckpointIds.has( checkpointInfo.checkpointId ) ||
+					isCheckpointActionAvailableRef.current?.( checkpointInfo.checkpointId ) === false ||
 					! checkpointToRestore ||
 					! checkpointToRestore.hasCheckpoint( checkpointInfo.checkpointId )
 				) {
@@ -162,7 +180,7 @@ export default function useCheckpointAction(
 		};
 
 		if ( checkpointInfo.showResolvedEditAction ) {
-			const canAct = ! supportsSwap || swapAvailability === true;
+			const canAct = isActionAvailable && ( ! supportsSwap || swapAvailability === true );
 			let label: string = canAct
 				? __( 'Updated and Undo', __i18n_text_domain__ )
 				: __( 'Updated', __i18n_text_domain__ );
@@ -189,6 +207,10 @@ export default function useCheckpointAction(
 					order: 1,
 				},
 			];
+		}
+
+		if ( ! isActionAvailable ) {
+			return [];
 		}
 
 		return [

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -13,7 +13,11 @@ import type { UIMessage, UIMessageAction, UseAgentChatReturn } from '@automattic
 
 type RegisterMessageActions = UseAgentChatReturn[ 'registerMessageActions' ];
 type IsCheckpointActionAvailable = ( checkpointId: string ) => boolean;
-type OnCheckpointActionPendingChange = ( checkpointId: string, isPending: boolean ) => void;
+type OnCheckpointActionPendingChange = (
+	checkpointId: string,
+	isPending: boolean,
+	completedAction?: 'undo' | 'redo'
+) => void;
 type OnCheckpointActionInvalidated = ( checkpointId: string ) => void;
 
 const revertedCheckpointIds = new Set< string >();
@@ -214,7 +218,15 @@ export default function useCheckpointAction(
 			} finally {
 				if ( didStartSwap ) {
 					pendingSwapCheckpointIdsRef.current.delete( checkpointInfo.checkpointId );
-					onCheckpointActionPendingChangeRef.current?.( checkpointInfo.checkpointId, false );
+					let completedAction: 'undo' | 'redo' | undefined;
+					if ( outcome === 'success' ) {
+						completedAction = revert ? 'undo' : 'redo';
+					}
+					onCheckpointActionPendingChangeRef.current?.(
+						checkpointInfo.checkpointId,
+						false,
+						completedAction
+					);
 				}
 				if ( didAttemptAction ) {
 					recordBigSkyTracksEvent( 'restore_checkpoint_action', {

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -125,16 +125,17 @@ export default function useCheckpointAction(
 			return [];
 		}
 
+		const isReverted = revertedCheckpointIds.has( checkpointInfo.checkpointId );
+		const isActionAvailable =
+			! invalidatedCheckpointIds.has( checkpointInfo.checkpointId ) &&
+			( isCheckpointActionAvailableRef.current?.( checkpointInfo.checkpointId ) ?? true );
 		const swapAvailability =
+			isActionAvailable &&
 			typeof currentCheckpoint.canSwapCheckpoint === 'function' &&
 			typeof currentCheckpoint.swapCheckpoint === 'function'
 				? currentCheckpoint.canSwapCheckpoint( checkpointInfo.checkpointId )
 				: undefined;
 		const supportsSwap = swapAvailability !== undefined;
-		const isReverted = revertedCheckpointIds.has( checkpointInfo.checkpointId );
-		const isActionAvailable =
-			! invalidatedCheckpointIds.has( checkpointInfo.checkpointId ) &&
-			( isCheckpointActionAvailableRef.current?.( checkpointInfo.checkpointId ) ?? true );
 		const applyCheckpointAction = async ( revert: boolean ): Promise< boolean > => {
 			let outcome: 'success' | 'failed' = 'failed';
 			try {
@@ -173,6 +174,7 @@ export default function useCheckpointAction(
 				return false;
 			} finally {
 				recordBigSkyTracksEvent( 'restore_checkpoint_action', {
+					action: revert ? 'undo' : 'redo',
 					id: checkpointInfo.checkpointId,
 					outcome,
 				} );

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -12,7 +12,8 @@ import type { UseCheckpointReturn } from '../utils/load-external-providers';
 import type { UIMessage, UIMessageAction, UseAgentChatReturn } from '@automattic/agenttic-client';
 
 type RegisterMessageActions = UseAgentChatReturn[ 'registerMessageActions' ];
-type IsCheckpointActionAvailable = ( checkpointId: string ) => boolean;
+type CheckpointActionState = 'disabled' | 'enabled' | 'hidden';
+type GetCheckpointActionState = ( checkpointId: string ) => CheckpointActionState;
 type OnCheckpointActionPendingChange = (
 	checkpointId: string,
 	isPending: boolean,
@@ -22,6 +23,7 @@ type OnCheckpointActionInvalidated = ( checkpointId: string ) => void;
 
 const revertedCheckpointIds = new Set< string >();
 const invalidatedCheckpointIds = new Set< string >();
+const redoableCheckpointIds = new Set< string >();
 
 function isTextContentEdit( toolId: unknown, data: unknown ): boolean {
 	if ( toolId === UPDATE_BLOCK_CONTENT_TOOL_ID ) {
@@ -115,6 +117,7 @@ export function setCheckpointActionReverted( checkpointId: string, isReverted: b
 		revertedCheckpointIds.add( checkpointId );
 	} else {
 		revertedCheckpointIds.delete( checkpointId );
+		redoableCheckpointIds.delete( checkpointId );
 	}
 	return wasReverted !== isReverted;
 }
@@ -125,15 +128,15 @@ export function setCheckpointActionReverted( checkpointId: string, isReverted: b
 export default function useCheckpointAction(
 	registerMessageActions: RegisterMessageActions,
 	checkpoint?: UseCheckpointReturn,
-	isCheckpointActionAvailable?: IsCheckpointActionAvailable,
+	getCheckpointActionState?: GetCheckpointActionState,
 	onCheckpointActionPendingChange?: OnCheckpointActionPendingChange,
 	onCheckpointActionInvalidated?: OnCheckpointActionInvalidated
 ): ( message: UIMessage ) => UIMessageAction[] {
 	// Refs avoid infinite re-renders caused by unstable provider values.
 	const checkpointRef = useRef( checkpoint );
 	checkpointRef.current = checkpoint;
-	const isCheckpointActionAvailableRef = useRef( isCheckpointActionAvailable );
-	isCheckpointActionAvailableRef.current = isCheckpointActionAvailable;
+	const getCheckpointActionStateRef = useRef( getCheckpointActionState );
+	getCheckpointActionStateRef.current = getCheckpointActionState;
 	const onCheckpointActionPendingChangeRef = useRef( onCheckpointActionPendingChange );
 	onCheckpointActionPendingChangeRef.current = onCheckpointActionPendingChange;
 	const onCheckpointActionInvalidatedRef = useRef( onCheckpointActionInvalidated );
@@ -142,28 +145,42 @@ export default function useCheckpointAction(
 	const getCheckpointActionsForMessage = useCallback( ( message: UIMessage ): UIMessageAction[] => {
 		const currentCheckpoint = checkpointRef.current;
 
-		if ( ! currentCheckpoint || message.role !== 'agent' ) {
+		if ( message.role !== 'agent' ) {
 			return [];
 		}
 
 		const checkpointInfo = getCheckpointInfo( message );
 
-		if ( ! checkpointInfo || ! currentCheckpoint.hasCheckpoint( checkpointInfo.checkpointId ) ) {
+		if ( ! checkpointInfo ) {
+			return [];
+		}
+
+		const getCurrentActionState = (): CheckpointActionState =>
+			invalidatedCheckpointIds.has( checkpointInfo.checkpointId )
+				? 'hidden'
+				: getCheckpointActionStateRef.current?.( checkpointInfo.checkpointId ) ?? 'enabled';
+		const actionState = getCurrentActionState();
+		if (
+			actionState !== 'disabled' &&
+			( ! currentCheckpoint || ! currentCheckpoint.hasCheckpoint( checkpointInfo.checkpointId ) )
+		) {
 			return [];
 		}
 
 		const isReverted = revertedCheckpointIds.has( checkpointInfo.checkpointId );
-		const isActionAvailable =
-			! invalidatedCheckpointIds.has( checkpointInfo.checkpointId ) &&
-			( isCheckpointActionAvailableRef.current?.( checkpointInfo.checkpointId ) ?? true );
-		const swapAvailability =
-			isActionAvailable &&
+		const isActionAvailable = actionState === 'enabled';
+		const canCheckSwapAvailability =
+			!! currentCheckpoint &&
 			typeof currentCheckpoint.canSwapCheckpoint === 'function' &&
-			typeof currentCheckpoint.swapCheckpoint === 'function'
+			typeof currentCheckpoint.swapCheckpoint === 'function';
+		const swapAvailability =
+			canCheckSwapAvailability &&
+			( isActionAvailable || ( actionState === 'disabled' && isReverted ) )
 				? pendingSwapCheckpointIdsRef.current.has( checkpointInfo.checkpointId ) ||
-				  currentCheckpoint.canSwapCheckpoint( checkpointInfo.checkpointId )
+				  currentCheckpoint.canSwapCheckpoint?.( checkpointInfo.checkpointId )
 				: undefined;
-		const supportsSwap = swapAvailability !== undefined;
+		const supportsSwap =
+			swapAvailability !== undefined || redoableCheckpointIds.has( checkpointInfo.checkpointId );
 		const applyCheckpointAction = async ( revert: boolean ): Promise< boolean > => {
 			if ( pendingSwapCheckpointIdsRef.current.has( checkpointInfo.checkpointId ) ) {
 				return false;
@@ -180,9 +197,12 @@ export default function useCheckpointAction(
 			};
 			try {
 				const checkpointToRestore = checkpointRef.current;
+				const latestActionState = getCurrentActionState();
+				if ( latestActionState === 'disabled' ) {
+					return false;
+				}
 				if (
-					invalidatedCheckpointIds.has( checkpointInfo.checkpointId ) ||
-					isCheckpointActionAvailableRef.current?.( checkpointInfo.checkpointId ) === false ||
+					latestActionState === 'hidden' ||
 					! checkpointToRestore ||
 					! checkpointToRestore.hasCheckpoint( checkpointInfo.checkpointId )
 				) {
@@ -203,6 +223,9 @@ export default function useCheckpointAction(
 					didStartSwap = true;
 					didAttemptAction = true;
 					await checkpointToRestore.swapCheckpoint( checkpointInfo.checkpointId );
+					if ( revert ) {
+						redoableCheckpointIds.add( checkpointInfo.checkpointId );
+					}
 				} else {
 					didAttemptAction = true;
 					await checkpointToRestore.restoreCheckpoint( checkpointInfo.checkpointId );
@@ -240,12 +263,14 @@ export default function useCheckpointAction(
 
 		if ( checkpointInfo.showResolvedEditAction ) {
 			const canAct = isActionAvailable && ( ! supportsSwap || swapAvailability === true );
-			let label: string = canAct
+			const showDisabledAction = actionState === 'disabled' && ( ! isReverted || supportsSwap );
+			const showAction = canAct || showDisabledAction;
+			let label: string = showAction
 				? __( 'Updated and Undo', __i18n_text_domain__ )
 				: __( 'Updated', __i18n_text_domain__ );
 			if ( isReverted ) {
 				label =
-					canAct && supportsSwap
+					showAction && supportsSwap
 						? __( 'Reverted and Redo', __i18n_text_domain__ )
 						: __( 'Reverted', __i18n_text_domain__ );
 			}
@@ -257,6 +282,7 @@ export default function useCheckpointAction(
 					component: ResolvedEditAction,
 					componentProps: {
 						initiallyReverted: isReverted,
+						...( showDisabledAction && { disabled: true } ),
 						...( canAct && { onUndo: () => applyCheckpointAction( true ) } ),
 						...( canAct &&
 							supportsSwap && {

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -13,6 +13,7 @@ import type { UIMessage, UIMessageAction, UseAgentChatReturn } from '@automattic
 
 type RegisterMessageActions = UseAgentChatReturn[ 'registerMessageActions' ];
 type IsCheckpointActionAvailable = ( checkpointId: string ) => boolean;
+type OnCheckpointActionPendingChange = ( checkpointId: string, isPending: boolean ) => void;
 
 const revertedCheckpointIds = new Set< string >();
 const invalidatedCheckpointIds = new Set< string >();
@@ -105,13 +106,17 @@ export function invalidateCheckpointAction( checkpointId: string ): void {
 export default function useCheckpointAction(
 	registerMessageActions: RegisterMessageActions,
 	checkpoint?: UseCheckpointReturn,
-	isCheckpointActionAvailable?: IsCheckpointActionAvailable
+	isCheckpointActionAvailable?: IsCheckpointActionAvailable,
+	onCheckpointActionPendingChange?: OnCheckpointActionPendingChange
 ): ( message: UIMessage ) => UIMessageAction[] {
 	// Refs avoid infinite re-renders caused by unstable provider values.
 	const checkpointRef = useRef( checkpoint );
 	checkpointRef.current = checkpoint;
 	const isCheckpointActionAvailableRef = useRef( isCheckpointActionAvailable );
 	isCheckpointActionAvailableRef.current = isCheckpointActionAvailable;
+	const onCheckpointActionPendingChangeRef = useRef( onCheckpointActionPendingChange );
+	onCheckpointActionPendingChangeRef.current = onCheckpointActionPendingChange;
+	const pendingSwapCheckpointIdsRef = useRef( new Set< string >() );
 	const getCheckpointActionsForMessage = useCallback( ( message: UIMessage ): UIMessageAction[] => {
 		const currentCheckpoint = checkpointRef.current;
 
@@ -133,11 +138,17 @@ export default function useCheckpointAction(
 			isActionAvailable &&
 			typeof currentCheckpoint.canSwapCheckpoint === 'function' &&
 			typeof currentCheckpoint.swapCheckpoint === 'function'
-				? currentCheckpoint.canSwapCheckpoint( checkpointInfo.checkpointId )
+				? pendingSwapCheckpointIdsRef.current.has( checkpointInfo.checkpointId ) ||
+				  currentCheckpoint.canSwapCheckpoint( checkpointInfo.checkpointId )
 				: undefined;
 		const supportsSwap = swapAvailability !== undefined;
 		const applyCheckpointAction = async ( revert: boolean ): Promise< boolean > => {
+			if ( pendingSwapCheckpointIdsRef.current.has( checkpointInfo.checkpointId ) ) {
+				return false;
+			}
+
 			let outcome: 'success' | 'failed' = 'failed';
+			let didStartSwap = false;
 			try {
 				const checkpointToRestore = checkpointRef.current;
 				if (
@@ -156,6 +167,9 @@ export default function useCheckpointAction(
 					) {
 						return false;
 					}
+					pendingSwapCheckpointIdsRef.current.add( checkpointInfo.checkpointId );
+					onCheckpointActionPendingChangeRef.current?.( checkpointInfo.checkpointId, true );
+					didStartSwap = true;
 					await checkpointToRestore.swapCheckpoint( checkpointInfo.checkpointId );
 				} else {
 					await checkpointToRestore.restoreCheckpoint( checkpointInfo.checkpointId );
@@ -173,6 +187,10 @@ export default function useCheckpointAction(
 				console.error( '[useCheckpointAction] Failed to restore checkpoint:', error );
 				return false;
 			} finally {
+				if ( didStartSwap ) {
+					pendingSwapCheckpointIdsRef.current.delete( checkpointInfo.checkpointId );
+					onCheckpointActionPendingChangeRef.current?.( checkpointInfo.checkpointId, false );
+				}
 				recordBigSkyTracksEvent( 'restore_checkpoint_action', {
 					action: revert ? 'undo' : 'redo',
 					id: checkpointInfo.checkpointId,

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -800,6 +800,8 @@ describe( 'loadExternalProviders', () => {
 		} );
 		const secondReturn = createCheckpointReturn( {
 			hasCheckpoint: jest.fn( ( id: string ) => id === 'second-cp' ),
+			canSwapCheckpoint: jest.fn( ( id: string ) => id === 'second-cp' ),
+			swapCheckpoint: jest.fn( () => Promise.resolve() ),
 		} );
 		const firstHook = jest.fn( () => firstReturn );
 		const secondHook = jest.fn( () => secondReturn );
@@ -816,6 +818,9 @@ describe( 'loadExternalProviders', () => {
 		await checkpoint?.restoreCheckpoint( 'second-cp' );
 		expect( secondReturn.restoreCheckpoint ).toHaveBeenCalledWith( 'second-cp' );
 		expect( firstReturn.restoreCheckpoint ).not.toHaveBeenCalled();
+		expect( checkpoint?.canSwapCheckpoint?.( 'second-cp' ) ).toBe( true );
+		await checkpoint?.swapCheckpoint?.( 'second-cp' );
+		expect( secondReturn.swapCheckpoint ).toHaveBeenCalledWith( 'second-cp' );
 		checkpoint?.clearCheckpoint( 'second-cp' );
 		expect( secondReturn.clearCheckpoint ).toHaveBeenCalledWith( 'second-cp' );
 		expect( firstReturn.clearCheckpoint ).not.toHaveBeenCalled();

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -62,7 +62,7 @@ interface MessageWithContextFlags extends UIMessage {
 	};
 }
 
-function isContextOnlyMessage( message: UIMessage ): boolean {
+export function isContextOnlyMessage( message: UIMessage ): boolean {
 	return (
 		( message as MessageWithContextFlags ).context?.flags?.context_only === true ||
 		message.content?.some( ( content ) => {

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -127,6 +127,8 @@ export type UseCheckpointReturn = {
 	setCheckpoint: ( id: string, keys?: string[], metadata?: Record< string, unknown > ) => void;
 	addCheckpointKeys: ( id: string, keys: string[] ) => void;
 	restoreCheckpoint: ( id: string ) => Promise< void >;
+	canSwapCheckpoint?: ( id: string ) => boolean | undefined;
+	swapCheckpoint?: ( id: string ) => Promise< void >;
 	addNewPageToCheckpoint: ( pageId: string ) => void;
 	addPageRenameToCheckpoint: ( pageId: string, oldTitle: string, newTitle: string ) => void;
 	addPageRemovalToCheckpoint: (
@@ -280,6 +282,14 @@ export function mergeUseCheckpointHooks(
 				instances.some( ( instance ) => instance?.hasCheckpoint?.( id ) ),
 			restoreCheckpoint: async ( id: string ) => {
 				await findOwner( id )?.restoreCheckpoint?.( id );
+			},
+			canSwapCheckpoint: ( id: string ) => findOwner( id )?.canSwapCheckpoint?.( id ),
+			swapCheckpoint: async ( id: string ) => {
+				const owner = findOwner( id );
+				if ( owner?.canSwapCheckpoint?.( id ) !== true || ! owner.swapCheckpoint ) {
+					throw new Error( `Checkpoint "${ id }" does not support swapping.` );
+				}
+				await owner.swapCheckpoint( id );
 			},
 			clearCheckpoint: ( id: string ) => {
 				for ( const instance of instances ) {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -84,6 +84,15 @@ function appendBlockInRootLayout(
 	return { layout, block };
 }
 
+const mockSerializeBlocks = jest.fn( ( blocks: any[] ) => {
+	const normalize = ( block: any ): any => ( {
+		name: block.name,
+		attributes: block.attributes,
+		innerBlocks: ( block.innerBlocks ?? [] ).map( normalize ),
+	} );
+	return JSON.stringify( blocks.map( normalize ) );
+} );
+
 jest.mock( '@wordpress/block-editor', () => ( {
 	store: 'core/block-editor',
 	// BlockRef renders the block-type icon via BlockIcon; a stub keeps these
@@ -107,6 +116,7 @@ jest.mock( '@wordpress/blocks', () => ( {
 	// Nothing is registered in the test env, so block chips fall back to their
 	// prettified slug — which is all these tests assert about the block ref.
 	getBlockType: () => undefined,
+	serialize: ( blocks: any[] ) => mockSerializeBlocks( blocks ),
 } ) );
 
 jest.mock( '@wordpress/components', () => {
@@ -156,6 +166,10 @@ jest.mock( '@wordpress/data', () => ( {
 	} ),
 	select: jest.fn( ( store: string ) => {
 		if ( store === 'core/block-editor' ) {
+			const windowStore = ( globalThis as any ).wp?.data?.select?.( store );
+			if ( windowStore ) {
+				return windowStore;
+			}
 			return {
 				getSelectedBlockClientId: () => mockSelectedBlockClientId,
 			};
@@ -3077,6 +3091,112 @@ describe( 'toolProvider', () => {
 			);
 			expect( blockUpdates ).toHaveLength( 1 );
 			checkpoint.clearCheckpoint( 'call-stale-swap' );
+		} );
+
+		it( 'does not swap a block checkpoint after another block is added', async () => {
+			jest.useFakeTimers();
+			const { blockUpdates, blocks } = installWpDataMockWithBlockEditor();
+			const checkpoint = useCheckpoint();
+			const abilities = await toolProvider.getAbilities();
+			const updateBlock = abilities.find(
+				( ability: any ) => ability.name === 'wpcom/update-block-content'
+			);
+
+			const pending = updateBlock.callback( {
+				clientId: '550e8400-e29b-41d4-a716-446655440000',
+				content: 'Corrected block content.',
+				toolCallId: 'call-block-added-after-edit',
+				toolId: UPDATE_BLOCK_CONTENT_TOOL_ID,
+			} );
+			jest.advanceTimersByTime( 1000 );
+			await pending;
+
+			blocks[ 'new-paragraph-client-id' ] = {
+				name: 'core/paragraph',
+				attributes: { content: 'A new line.' },
+			};
+			expect( checkpoint.canSwapCheckpoint( 'call-block-added-after-edit' ) ).toBe( false );
+			await expect( checkpoint.swapCheckpoint( 'call-block-added-after-edit' ) ).rejects.toThrow(
+				'Failed to swap block edit checkpoint.'
+			);
+			await expect( checkpoint.restoreCheckpoint( 'call-block-added-after-edit' ) ).rejects.toThrow(
+				'Failed to restore block edit checkpoint.'
+			);
+			expect( blocks[ '550e8400-e29b-41d4-a716-446655440000' ].attributes.content ).toBe(
+				'Corrected block content.'
+			);
+			expect( blocks[ 'new-paragraph-client-id' ].attributes.content ).toBe( 'A new line.' );
+			expect( blockUpdates ).toHaveLength( 1 );
+			checkpoint.clearCheckpoint( 'call-block-added-after-edit' );
+		} );
+
+		it( 'does not swap a block checkpoint without a safe editor signature', async () => {
+			jest.useFakeTimers();
+			const { blockUpdates, blocks } = installWpDataMockWithBlockEditor();
+			const checkpoint = useCheckpoint();
+			const abilities = await toolProvider.getAbilities();
+			const updateBlock = abilities.find(
+				( ability: any ) => ability.name === 'wpcom/update-block-content'
+			);
+			mockSerializeBlocks.mockImplementationOnce( () => {
+				throw new Error( 'Block serialization failed.' );
+			} );
+
+			const pending = updateBlock.callback( {
+				clientId: '550e8400-e29b-41d4-a716-446655440000',
+				content: 'Corrected block content.',
+				toolCallId: 'call-unsafe-editor-signature',
+				toolId: UPDATE_BLOCK_CONTENT_TOOL_ID,
+			} );
+			jest.advanceTimersByTime( 1000 );
+			await pending;
+
+			expect( checkpoint.canSwapCheckpoint( 'call-unsafe-editor-signature' ) ).toBe( false );
+			await expect( checkpoint.swapCheckpoint( 'call-unsafe-editor-signature' ) ).rejects.toThrow(
+				'Failed to swap block edit checkpoint.'
+			);
+			expect( blocks[ '550e8400-e29b-41d4-a716-446655440000' ].attributes.content ).toBe(
+				'Corrected block content.'
+			);
+			expect( blockUpdates ).toHaveLength( 1 );
+			checkpoint.clearCheckpoint( 'call-unsafe-editor-signature' );
+		} );
+
+		it( 'does not redo a reverted block checkpoint after another block is added', async () => {
+			jest.useFakeTimers();
+			const { blockUpdates, blocks } = installWpDataMockWithBlockEditor();
+			const checkpoint = useCheckpoint();
+			const abilities = await toolProvider.getAbilities();
+			const updateBlock = abilities.find(
+				( ability: any ) => ability.name === 'wpcom/update-block-content'
+			);
+
+			const pending = updateBlock.callback( {
+				clientId: '550e8400-e29b-41d4-a716-446655440000',
+				content: 'Corrected block content.',
+				toolCallId: 'call-block-added-after-undo',
+				toolId: UPDATE_BLOCK_CONTENT_TOOL_ID,
+			} );
+			jest.advanceTimersByTime( 1000 );
+			await pending;
+			await checkpoint.swapCheckpoint( 'call-block-added-after-undo' );
+
+			blocks[ 'new-paragraph-after-undo' ] = {
+				name: 'core/paragraph',
+				attributes: { content: 'A new line after Undo.' },
+			};
+			expect( checkpoint.canSwapCheckpoint( 'call-block-added-after-undo' ) ).toBe( false );
+			await expect( checkpoint.swapCheckpoint( 'call-block-added-after-undo' ) ).rejects.toThrow(
+				'Failed to swap block edit checkpoint.'
+			);
+			expect( blocks[ '550e8400-e29b-41d4-a716-446655440000' ].attributes.content ).toBe(
+				'original block content'
+			);
+			expect( blocks[ 'new-paragraph-after-undo' ].attributes.content ).toBe(
+				'A new line after Undo.'
+			);
+			expect( blockUpdates ).toHaveLength( 2 );
+			checkpoint.clearCheckpoint( 'call-block-added-after-undo' );
 		} );
 
 		it( 'surfaces a failed block checkpoint restore', async () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -2967,6 +2967,59 @@ describe( 'toolProvider', () => {
 			checkpoint.clearCheckpoint( 'call-update-block' );
 		} );
 
+		it( 'checkpoints the re-resolved clientId after a delayed block reparse', async () => {
+			jest.useFakeTimers();
+			const { blockUpdates, blocks } = installWpDataMockWithBlockEditor( {
+				'first-live-client-id': {
+					name: 'core/paragraph',
+					attributes: { content: 'Teh quick fox jump over teh dog.' },
+				},
+			} );
+			const checkpoint = useCheckpoint();
+			const warn = jest.spyOn( console, 'warn' ).mockImplementation( () => undefined );
+			const abilities = await toolProvider.getAbilities();
+			const updateBlock = abilities.find(
+				( ability: any ) => ability.name === 'wpcom/update-block-content'
+			);
+
+			const pending = updateBlock.callback( {
+				clientId: 'stale-client-id',
+				content: 'A quick fox leaps over the dog.',
+				currentText: 'Teh quick fox jump over teh dog.',
+				toolCallId: 'call-reparsed-block',
+				toolId: UPDATE_BLOCK_CONTENT_TOOL_ID,
+			} );
+			blocks[ 'second-live-client-id' ] = {
+				...blocks[ 'first-live-client-id' ],
+				attributes: { ...blocks[ 'first-live-client-id' ].attributes },
+			};
+			delete blocks[ 'first-live-client-id' ];
+			jest.advanceTimersByTime( 1000 );
+			const result = await pending;
+
+			expect( result ).toMatchObject( {
+				success: true,
+				clientId: 'second-live-client-id',
+				contentBefore: 'Teh quick fox jump over teh dog.',
+				contentAfter: 'A quick fox leaps over the dog.',
+			} );
+			expect( warn ).toHaveBeenCalledWith( '[Jetpack AI] stale clientId matched by currentText', {
+				clientId: 'stale-client-id',
+				targetClientId: 'first-live-client-id',
+			} );
+			expect( blockUpdates[ 0 ] ).toEqual( {
+				clientId: 'second-live-client-id',
+				attrs: { content: 'A quick fox leaps over the dog.' },
+			} );
+			expect( checkpoint.canSwapCheckpoint( 'call-reparsed-block' ) ).toBe( true );
+			await checkpoint.swapCheckpoint( 'call-reparsed-block' );
+			expect( blocks[ 'second-live-client-id' ].attributes.content ).toBe(
+				'Teh quick fox jump over teh dog.'
+			);
+			checkpoint.clearCheckpoint( 'call-reparsed-block' );
+			warn.mockRestore();
+		} );
+
 		it( 'swaps a block checkpoint between the updated and original content', async () => {
 			jest.useFakeTimers();
 			const { blockUpdates, blocks } = installWpDataMockWithBlockEditor();
@@ -3096,6 +3149,46 @@ describe( 'toolProvider', () => {
 			} );
 			expect( blockUpdates ).toEqual( [] );
 			expect( checkpoint.hasCheckpoint( 'call-no-block-change' ) ).toBe( false );
+		} );
+
+		it( 'surfaces a delayed block update failure without checkpointing', async () => {
+			jest.useFakeTimers();
+			const { blocks } = installWpDataMockWithBlockEditor();
+			const checkpoint = useCheckpoint();
+			const abilities = await toolProvider.getAbilities();
+			const updateBlock = abilities.find(
+				( ability: any ) => ability.name === 'wpcom/update-block-content'
+			);
+
+			const pending = updateBlock.callback( {
+				clientId: '550e8400-e29b-41d4-a716-446655440000',
+				content: 'Corrected block content.',
+				currentText: 'original block content',
+				toolCallId: 'call-missing-target',
+				toolId: UPDATE_BLOCK_CONTENT_TOOL_ID,
+			} );
+			delete blocks[ '550e8400-e29b-41d4-a716-446655440000' ];
+			jest.advanceTimersByTime( 1000 );
+			const result = await pending;
+
+			expect( result ).toMatchObject( {
+				success: false,
+				error: 'block not found',
+				returnToAgent: false,
+			} );
+			expect( JSON.parse( result.agentMessage ) ).toEqual( {
+				tool_id: UPDATE_BLOCK_CONTENT_TOOL_ID,
+				tool_call_id: 'call-missing-target',
+				data: {
+					result: {
+						success: false,
+						message: 'I could not update the block. Please try again.',
+						error: 'block not found',
+					},
+					followUpTasks: false,
+				},
+			} );
+			expect( checkpoint.hasCheckpoint( 'call-missing-target' ) ).toBe( false );
 		} );
 
 		it( 'documents the completed-edit summary contract in the update-block-content schema', async () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -2967,6 +2967,65 @@ describe( 'toolProvider', () => {
 			checkpoint.clearCheckpoint( 'call-update-block' );
 		} );
 
+		it( 'swaps a block checkpoint between the updated and original content', async () => {
+			jest.useFakeTimers();
+			const { blockUpdates, blocks } = installWpDataMockWithBlockEditor();
+			const checkpoint = useCheckpoint();
+			const abilities = await toolProvider.getAbilities();
+			const updateBlock = abilities.find(
+				( ability: any ) => ability.name === 'wpcom/update-block-content'
+			);
+
+			const pending = updateBlock.callback( {
+				clientId: '550e8400-e29b-41d4-a716-446655440000',
+				content: 'Corrected block content.',
+				toolCallId: 'call-swap-block',
+				toolId: UPDATE_BLOCK_CONTENT_TOOL_ID,
+			} );
+			jest.advanceTimersByTime( 1000 );
+			await pending;
+
+			expect( checkpoint.canSwapCheckpoint( 'call-swap-block' ) ).toBe( true );
+			await checkpoint.swapCheckpoint( 'call-swap-block' );
+			expect( blocks[ '550e8400-e29b-41d4-a716-446655440000' ].attributes.content ).toBe(
+				'original block content'
+			);
+
+			await checkpoint.swapCheckpoint( 'call-swap-block' );
+			expect( blocks[ '550e8400-e29b-41d4-a716-446655440000' ].attributes.content ).toBe(
+				'Corrected block content.'
+			);
+			expect( blockUpdates ).toHaveLength( 3 );
+			checkpoint.clearCheckpoint( 'call-swap-block' );
+		} );
+
+		it( 'does not swap a block checkpoint after a later edit', async () => {
+			jest.useFakeTimers();
+			const { blockUpdates, blocks } = installWpDataMockWithBlockEditor();
+			const checkpoint = useCheckpoint();
+			const abilities = await toolProvider.getAbilities();
+			const updateBlock = abilities.find(
+				( ability: any ) => ability.name === 'wpcom/update-block-content'
+			);
+
+			const pending = updateBlock.callback( {
+				clientId: '550e8400-e29b-41d4-a716-446655440000',
+				content: 'Corrected block content.',
+				toolCallId: 'call-stale-swap',
+				toolId: UPDATE_BLOCK_CONTENT_TOOL_ID,
+			} );
+			jest.advanceTimersByTime( 1000 );
+			await pending;
+
+			blocks[ '550e8400-e29b-41d4-a716-446655440000' ].attributes.content = 'A later edit.';
+			expect( checkpoint.canSwapCheckpoint( 'call-stale-swap' ) ).toBe( false );
+			await expect( checkpoint.swapCheckpoint( 'call-stale-swap' ) ).rejects.toThrow(
+				'Failed to swap block edit checkpoint.'
+			);
+			expect( blockUpdates ).toHaveLength( 1 );
+			checkpoint.clearCheckpoint( 'call-stale-swap' );
+		} );
+
 		it( 'surfaces a failed block checkpoint restore', async () => {
 			jest.useFakeTimers();
 			const { blockUpdates, blocks } = installWpDataMockWithBlockEditor();

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -45,6 +45,7 @@ import {
 	rememberSelectedBlock,
 	clearRememberedSelectedBlock,
 	notifyBlockActionComplete,
+	canUndoBlockEdit,
 	undoBlockEdit,
 	BLOCK_ACTION_COMPLETE_EVENT,
 	SELECTED_BLOCK_CLEAR_EVENT,
@@ -944,8 +945,8 @@ export function getChatComponent( type: string ): ComponentType | null {
  * checkpoint must not clobber another field's later edits. Block-edit snapshots
  * are captured by `handleUpdateBlockContentForChat`; meta (SEO pickers) and
  * image alt text changes are not checkpointed. Stubs the rest of AM's
- * `UseCheckpointReturn` interface — only the three methods above are used on
- * this path.
+ * `UseCheckpointReturn` interface; block-edit checkpoints also support safe
+ * inline Undo and Redo through `canSwapCheckpoint` and `swapCheckpoint`.
  * @returns {Object} The checkpoint API AM consumes.
  */
 const postSnapshots: Map< string, Partial< Record< CheckpointField, string > > > = new Map();
@@ -962,6 +963,32 @@ export function useCheckpoint(): any {
 		},
 		hasCheckpoint( id: string ): boolean {
 			return postSnapshots.has( id ) || blockEditSnapshots.has( id );
+		},
+		canSwapCheckpoint( id: string ): boolean | undefined {
+			const snapshot = blockEditSnapshots.get( id );
+			return snapshot
+				? canUndoBlockEdit( snapshot.clientId, snapshot.contentAfter, snapshot.editableAttribute )
+				: undefined;
+		},
+		async swapCheckpoint( id: string ): Promise< void > {
+			const snapshot = blockEditSnapshots.get( id );
+			if (
+				! snapshot ||
+				! undoBlockEdit(
+					snapshot.clientId,
+					snapshot.contentBefore,
+					snapshot.contentAfter,
+					snapshot.editableAttribute
+				)
+			) {
+				throw new Error( 'Failed to swap block edit checkpoint.' );
+			}
+
+			blockEditSnapshots.set( id, {
+				...snapshot,
+				contentBefore: snapshot.contentAfter,
+				contentAfter: snapshot.contentBefore,
+			} );
 		},
 		async restoreCheckpoint( id: string ): Promise< void > {
 			const blockEditSnapshot = blockEditSnapshots.get( id );

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -9,7 +9,8 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { serialize } from '@wordpress/blocks';
+import { select as selectDataStore, useSelect } from '@wordpress/data';
 import { useState, useEffect, useMemo } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 /**
@@ -91,9 +92,59 @@ type BlockEditSnapshot = {
 	contentBefore: string;
 	contentAfter: string;
 	editableAttribute?: string;
+	editorBlocksSignatureAfter: string | undefined;
 };
 
 const blockEditSnapshots = new Map< string, BlockEditSnapshot >();
+const editorBlocksSignatures = new WeakMap< any[], string >();
+
+function getCurrentEditorBlocks(): any[] | undefined {
+	try {
+		const blockEditor = selectDataStore( 'core/block-editor' ) as {
+			getBlocks?: () => any[];
+		};
+		const blocks = blockEditor?.getBlocks?.();
+		return Array.isArray( blocks ) ? blocks : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function getEditorBlocksSignature( blocks: any[] | undefined ): string | undefined {
+	if ( ! blocks ) {
+		return undefined;
+	}
+	const cachedSignature = editorBlocksSignatures.get( blocks );
+	if ( cachedSignature !== undefined ) {
+		return cachedSignature;
+	}
+
+	try {
+		const signature = serialize( blocks );
+		editorBlocksSignatures.set( blocks, signature );
+		return signature;
+	} catch {
+		return undefined;
+	}
+}
+
+function canSwapBlockEditSnapshot( snapshot: BlockEditSnapshot ): boolean {
+	if (
+		! canUndoBlockEdit( snapshot.clientId, snapshot.contentAfter, snapshot.editableAttribute )
+	) {
+		return false;
+	}
+	if ( snapshot.editorBlocksSignatureAfter === undefined ) {
+		return false;
+	}
+
+	const currentEditorBlocks = getCurrentEditorBlocks();
+	return (
+		currentEditorBlocks !== undefined &&
+		getEditorBlocksSignature( currentEditorBlocks ) === snapshot.editorBlocksSignatureAfter
+	);
+}
+
 /** Default suggestion shown when no block is selected. */
 const OPTIMIZE_TITLE_SUGGESTION = {
 	id: 'optimize-title',
@@ -704,10 +755,12 @@ async function handleUpdateBlockContentForChat( input: any ): Promise< any > {
 			typeof result.contentBefore === 'string' &&
 			typeof result.contentAfter === 'string'
 		) {
+			const editorBlocksAfter = getCurrentEditorBlocks();
 			blockEditSnapshots.set( toolCallId, {
 				clientId: result.clientId,
 				contentBefore: result.contentBefore,
 				contentAfter: result.contentAfter,
+				editorBlocksSignatureAfter: getEditorBlocksSignature( editorBlocksAfter ),
 				...( typeof result.editableAttribute === 'string' && {
 					editableAttribute: result.editableAttribute,
 				} ),
@@ -987,14 +1040,13 @@ export function useCheckpoint(): any {
 		},
 		canSwapCheckpoint( id: string ): boolean | undefined {
 			const snapshot = blockEditSnapshots.get( id );
-			return snapshot
-				? canUndoBlockEdit( snapshot.clientId, snapshot.contentAfter, snapshot.editableAttribute )
-				: undefined;
+			return snapshot ? canSwapBlockEditSnapshot( snapshot ) : undefined;
 		},
 		async swapCheckpoint( id: string ): Promise< void > {
 			const snapshot = blockEditSnapshots.get( id );
 			if (
 				! snapshot ||
+				! canSwapBlockEditSnapshot( snapshot ) ||
 				! undoBlockEdit(
 					snapshot.clientId,
 					snapshot.contentBefore,
@@ -1005,15 +1057,20 @@ export function useCheckpoint(): any {
 				throw new Error( 'Failed to swap block edit checkpoint.' );
 			}
 
+			const editorBlocksAfter = getCurrentEditorBlocks();
 			blockEditSnapshots.set( id, {
 				...snapshot,
 				contentBefore: snapshot.contentAfter,
 				contentAfter: snapshot.contentBefore,
+				editorBlocksSignatureAfter: getEditorBlocksSignature( editorBlocksAfter ),
 			} );
 		},
 		async restoreCheckpoint( id: string ): Promise< void > {
 			const blockEditSnapshot = blockEditSnapshots.get( id );
 			if ( blockEditSnapshot ) {
+				if ( ! canSwapBlockEditSnapshot( blockEditSnapshot ) ) {
+					throw new Error( 'Failed to restore block edit checkpoint.' );
+				}
 				const didRestore = undoBlockEdit(
 					blockEditSnapshot.clientId,
 					blockEditSnapshot.contentBefore,

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -651,6 +651,20 @@ function isLegacyShowComponentTool( toolId: string ): boolean {
 	return toolId === LEGACY_SHOW_COMPONENT_TOOL_ID || toolId === LEGACY_SHOW_COMPONENT_ABILITY_NAME;
 }
 
+function createUpdateBlockContentAgentMessage(
+	toolCallId: string,
+	result: Record< string, unknown >
+): string {
+	return JSON.stringify( {
+		tool_id: UPDATE_BLOCK_CONTENT_AGENT_TOOL_ID,
+		tool_call_id: toolCallId,
+		data: {
+			result,
+			followUpTasks: false,
+		},
+	} );
+}
+
 async function handleUpdateBlockContentForChat( input: any ): Promise< any > {
 	const toolCallId =
 		typeof input?.toolCallId === 'string' && input.toolCallId ? input.toolCallId : undefined;
@@ -659,7 +673,21 @@ async function handleUpdateBlockContentForChat( input: any ): Promise< any > {
 		if ( toolCallId ) {
 			blockEditSnapshots.delete( toolCallId );
 		}
-		return result;
+		const error =
+			typeof result?.error === 'string' && result.error ? result.error : 'Block update failed';
+		const message = __( 'I could not update the block. Please try again.', __i18n_text_domain__ );
+		const agentMessage = toolCallId
+			? createUpdateBlockContentAgentMessage( toolCallId, {
+					success: false,
+					message,
+					error,
+			  } )
+			: result?.agentMessage;
+		return {
+			...result,
+			returnToAgent: false,
+			...( agentMessage && { agentMessage } ),
+		};
 	}
 
 	const outcome =
@@ -697,17 +725,10 @@ async function handleUpdateBlockContentForChat( input: any ): Promise< any > {
 				: __( 'No changes were needed.', __i18n_text_domain__ );
 	}
 	const agentMessage = toolCallId
-		? JSON.stringify( {
-				tool_id: UPDATE_BLOCK_CONTENT_AGENT_TOOL_ID,
-				tool_call_id: toolCallId,
-				data: {
-					result: {
-						success: true,
-						message,
-						outcome,
-					},
-					followUpTasks: false,
-				},
+		? createUpdateBlockContentAgentMessage( toolCallId, {
+				success: true,
+				message,
+				outcome,
 		  } )
 		: result.agentMessage;
 

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -25,6 +25,8 @@ export interface CheckpointApi {
 	setCheckpoint: ( id: string, fields?: CheckpointField[] ) => void;
 	hasCheckpoint: ( id: string ) => boolean;
 	restoreCheckpoint: ( id: string ) => Promise< void >;
+	canSwapCheckpoint?: ( id: string ) => boolean | undefined;
+	swapCheckpoint?: ( id: string ) => Promise< void >;
 }
 
 // ---------- Module state ----------
@@ -925,4 +927,13 @@ export function undoBlockEdit(
 	} catch {
 		return false;
 	}
+}
+
+export function canUndoBlockEdit(
+	clientId: string,
+	expectedContent: string,
+	editableAttribute?: string
+): boolean {
+	const snapshot = getBlockSnapshot( clientId, editableAttribute, undefined, expectedContent );
+	return !! snapshot?.attributeName && snapshot.content === expectedContent;
 }

--- a/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
+++ b/packages/jetpack-ai-sidebar/src/utils/block-actions.ts
@@ -716,6 +716,7 @@ export function handleUpdateBlockContent( input: any ): any {
 			returnToAgent: false,
 		};
 	}
+	const snapshotAttribute = snapshot.attributeName;
 
 	// Substring replace when currentText is a non-empty span present in the block.
 	// If that span no longer exists, fail rather than replacing the whole block
@@ -753,11 +754,7 @@ export function handleUpdateBlockContent( input: any ): any {
 	// Short delay so the shimmer is visible before content swaps
 	return new Promise< any >( ( resolve ) => {
 		setTimeout( () => {
-			const latestSnapshot = getBlockSnapshot(
-				targetClientId,
-				snapshot?.attributeName,
-				currentText
-			);
+			let latestSnapshot = getBlockSnapshot( targetClientId, snapshotAttribute, currentText );
 			const resolveFailure = ( error: string ) => {
 				if ( blockEl ) {
 					removeProcessingEffect( blockEl );
@@ -771,6 +768,25 @@ export function handleUpdateBlockContent( input: any ): any {
 				resolveFailure( 'context changed' );
 				return;
 			}
+
+			if ( ! latestSnapshot && hasCurrentText ) {
+				const fallback = findBlockSnapshotByCurrentText( currentText, snapshotAttribute );
+				if ( fallback.error ) {
+					resolveFailure( fallback.error );
+					return;
+				}
+				if ( fallback.snapshot ) {
+					latestSnapshot = getBlockSnapshot(
+						fallback.snapshot.clientId,
+						fallback.snapshot.attributeName,
+						currentText
+					);
+					if ( latestSnapshot ) {
+						targetClientId = latestSnapshot.clientId;
+					}
+				}
+			}
+
 			if ( ! latestSnapshot ) {
 				resolveFailure( 'block not found' );
 				return;


### PR DESCRIPTION
Part of FORNO-451

Partner PR: BigSky 6233
<img width="314" height="574" alt="Screenshot 2026-08-13 at 16 40 54" src="https://github.com/user-attachments/assets/9f42fdf8-d3b8-469d-a97b-6f52953a3b82" />
<img width="314" height="325" alt="Screenshot 2026-08-13 at 16 40 36" src="https://github.com/user-attachments/assets/c8185a48-e441-4cb1-a307-49e111d34144" />



## Proposed Changes

* Show `Updated` with inline Undo only for successful text-content edits.
* After Undo, show `Reverted` with Redo and swap the same provider-owned checkpoint for Big Sky and Jetpack.
* Hide the action for structural edits, CSS changes, and no-op outcomes.
* Preserve the action when Agenttic replaces the streamed tool result with final prose.
* Hide Undo and Redo after Gutenberg's native Undo (ctrl+Z) changes the editor history.
* Keep superseded Undo and Redo controls visible but disabled after a later user message, and dim the whole prior assistant message; keep loaded history and invalidated checkpoints hidden.
* Remove the background from `Updated` while keeping the green text.

## Why are these changes being made?

* This completes the inline text-edit action introduced in #113317 and keeps its controls limited to the current editor and chat state.

## Testing Instructions
* Install this PR with big-sky-plugin PR 6233

No. | Test case | Expected result
-- | -- | --
1 | Run Check grammar | Text is corrected. Guard block stays unchanged. Message shows Updated + enabled Undo.
2 | Click inline Undo | Original text returns. Status changes to Reverted. Redo appears.
3 | Click inline Redo | Corrected text returns. Status changes to Updated. Undo appears.
4 | Wait for final prose from the same response | Undo remains enabled. Final prose must not supersede the edit.
5 | Send a later real user message | Old message is dimmed completely. Updated/Reverted remains, but Undo/Redo disappears.
6 | Trigger a context-only continuation | Current Undo/Redo remains enabled. Hidden context must not supersede it.
7 | Add a newline or manually edit after Updated | Undo disappears. Manual content remains. Returning the content to its previous value must not bring Undo back.
8 | Inline Undo, then add a newline or edit | Redo disappears. Status remains Reverted. Manual content remains.
9 | Use native editor Undo | Chat Undo/Redo disappears immediately. When content reverts, status becomes Reverted.
10 | Use native editor Redo | AI content returns. Status becomes Updated, but chat Undo must not return.
11 | Press the shortcut while the chat input is focused | Only the chat input is affected. The editor and current checkpoint action remain unchanged.
12 | Race a stale Undo/Redo click after a manual edit | The click must not modify content or remove the manual change.
13 | Run another edit in a later turn | Older edit message stays dimmed with no action. Latest edit gets its own active Undo.
14 | Undo, then ask for another edit using the restored text | The agent uses the live reverted text and does not claim the old edit is still applied.
15 | Run a structural, styling, no-op, or failed edit | No false Undo/Redo action appears.

Automated checks:

* Focused checkpoint-action and OrchestratorChat suites pass: 75 tests.
* The full Agents Manager suite passes: 62 suites, 772 tests.
* The Agents Manager app suite passes: 7 suites, 78 tests.
* Four focused Agents Manager and Jetpack AI Sidebar suites pass: 288 tests.
* The full Jetpack AI Sidebar suite passes: 17 suites, 379 tests.
* Scoped ESLint, Stylelint, Prettier, and `git diff --check` pass.
* `@automattic/jetpack-ai-sidebar` typecheck and build pass.
* The Agents Manager production widget build passes with local source aliases.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks/using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?