### PR TITLE
Pattern Library: stop the infinite image-reload loop in pattern previews

### DIFF
--- a/client/my-sites/patterns/components/pattern-preview/index.tsx
+++ b/client/my-sites/patterns/components/pattern-preview/index.tsx
@@ -29,10 +29,12 @@ export const ASPECT_RATIO = 7 / 4;
 
 // This style is injected into pattern preview iframes to prevent users from navigating away from
 // the pattern preview page and from submitting forms.
-const noClickStyle = {
-	css: 'a[href], button, input, textarea { pointer-events: none; }',
-	isGlobalStyles: true,
-};
+const noClickStyles = [
+	{
+		css: 'a[href], button, input, textarea { pointer-events: none; }',
+		isGlobalStyles: true,
+	},
+];
 
 // Firefox and Safari have trouble rendering elements in iframes with `writing-mode` styles. This
 // hacky script is injected into pattern preview iframes to force rerender those elements.
@@ -305,7 +307,7 @@ function PatternPreviewFragment( {
 					minHeight={ nodeSize.width ? nodeSize.width / ASPECT_RATIO : undefined }
 					patternId={ patternId }
 					scripts={ redrawScript }
-					styles={ [ noClickStyle ] }
+					styles={ noClickStyles }
 					viewportWidth={ viewportWidth }
 				/>
 			</div>

--- a/packages/block-renderer/src/components/block-renderer-container.tsx
+++ b/packages/block-renderer/src/components/block-renderer-container.tsx
@@ -99,8 +99,14 @@ const ScaledBlockRendererContainer = ( {
 
 	const scriptAssets = useParsedAssets( scripts );
 
+	// Memoized so the `dangerouslySetInnerHTML` objects keep a stable identity; React 19
+	// reassigns `innerHTML` whenever that object identity changes, even for identical markup.
 	const svgFilters = useMemo( () => {
-		return [ ...( duotone?.default ?? [] ), ...( duotone?.theme ?? [] ) ];
+		const presets = [ ...( duotone?.default ?? [] ), ...( duotone?.theme ?? [] ) ];
+		return presets.map( ( preset ) => ( {
+			slug: preset.slug,
+			markup: { __html: getDuotoneFilter( `wp-duotone-${ preset.slug }`, preset.colors ) },
+		} ) );
 	}, [ duotone ] );
 
 	const contentRef = useRefEffect< HTMLBodyElement >( ( bodyElement ) => {
@@ -163,13 +169,11 @@ const ScaledBlockRendererContainer = ( {
 				{ isLoaded ? contentResizeListener : null }
 				{
 					/* Filters need to be rendered before children to avoid Safari rendering issues. */
-					svgFilters.map( ( preset ) => (
+					svgFilters.map( ( filter ) => (
 						<div
-							key={ preset.slug }
+							key={ filter.slug }
 							// eslint-disable-next-line react/no-danger
-							dangerouslySetInnerHTML={ {
-								__html: getDuotoneFilter( `wp-duotone-${ preset.slug }`, preset.colors ),
-							} }
+							dangerouslySetInnerHTML={ filter.markup }
 						/>
 					) )
 				}

--- a/packages/block-renderer/src/components/pattern-renderer.tsx
+++ b/packages/block-renderer/src/components/pattern-renderer.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 import { normalizeMinHeight } from '../html-transformers';
 import { shufflePosts } from '../styles-transformers';
 import BlockRendererContainer from './block-renderer-container';
@@ -37,13 +37,21 @@ const PatternRenderer = ( {
 		patternHtml = transformHtml( patternHtml );
 	}
 
-	let patternStyles = [ ...styles, ...( pattern?.styles ?? [] ) ];
-	if ( shouldShufflePosts ) {
-		const css = shufflePosts( patternId, patternHtml );
-		patternStyles = [ ...patternStyles, { css } as RenderedStyle ];
-	}
+	const patternStyles = useMemo( () => {
+		let mergedStyles = [ ...styles, ...( pattern?.styles ?? [] ) ];
+		if ( shouldShufflePosts ) {
+			const css = shufflePosts( patternId, patternHtml );
+			mergedStyles = [ ...mergedStyles, { css } as RenderedStyle ];
+		}
+		return mergedStyles;
+	}, [ styles, pattern?.styles, shouldShufflePosts, patternId, patternHtml ] );
 
 	const patternScripts = [ pattern?.scripts ?? '', scripts ];
+
+	// React 19 reassigns `innerHTML` whenever the `dangerouslySetInnerHTML` object identity
+	// changes, even when `__html` holds the same string. An inline object here would wipe and
+	// re-parse the pattern on every render, re-fetching all of its images in a loop.
+	const patternHtmlMarkup = useMemo( () => ( { __html: patternHtml } ), [ patternHtml ] );
 
 	return (
 		<BlockRendererContainer
@@ -56,7 +64,7 @@ const PatternRenderer = ( {
 		>
 			<div
 				// eslint-disable-next-line react/no-danger
-				dangerouslySetInnerHTML={ { __html: patternHtml } }
+				dangerouslySetInnerHTML={ patternHtmlMarkup }
 			/>
 		</BlockRendererContainer>
 	);

--- a/packages/block-renderer/src/hooks/use-rendered-patterns.ts
+++ b/packages/block-renderer/src/hooks/use-rendered-patterns.ts
@@ -1,7 +1,8 @@
 import { useLocale } from '@automattic/i18n-utils';
 import { useQueries } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
-import type { RenderedPattern, RenderedPatterns, SiteInfo } from '../types';
+import type { RenderedPatterns, SiteInfo } from '../types';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 const fetchRenderedPatterns = (
 	siteId: number | string,
@@ -34,6 +35,14 @@ const fetchRenderedPatterns = (
 	} );
 };
 
+// Defined outside the hook and passed via `combine` so react-query can memoize the merged
+// object; rebuilding it on every render would invalidate every consumer of the context.
+const combineRenderedPatterns = ( results: Array< UseQueryResult< RenderedPatterns > > ) =>
+	results.reduce< RenderedPatterns >(
+		( acc, { data } ) => ( data ? Object.assign( acc, data ) : acc ),
+		{}
+	);
+
 const useRenderedPatterns = (
 	siteId: number | string,
 	stylesheet: string,
@@ -50,19 +59,10 @@ const useRenderedPatterns = (
 		refetchOnWindowFocus: false,
 	} ) );
 
-	const result = useQueries< RenderedPattern[] >( {
+	return useQueries( {
 		queries,
+		combine: combineRenderedPatterns,
 	} );
-
-	return result
-		.filter( ( query ) => !! query.data )
-		.reduce(
-			( acc, cur ) => ( {
-				...acc,
-				...( cur.data as RenderedPattern[] ),
-			} ),
-			{}
-		);
 };
 
 export default useRenderedPatterns;


### PR DESCRIPTION
Fixes DOTOBRD-588

## Proposed Changes

* Memoize the `dangerouslySetInnerHTML` objects in `@automattic/block-renderer` (`PatternRenderer`'s pattern markup and the duotone SVG filter divs in `ScaledBlockRendererContainer`) so their identity only changes when the markup string actually changes.
* Stabilize the `renderedPatterns` object returned by `useRenderedPatterns` using `useQueries`' `combine` option (react-query memoizes the combined result), so `PatternsRendererProvider`'s context value stops changing identity on every render and `memo( PatternRenderer )` is effective again.
* Memoize the merged `patternStyles` array in `PatternRenderer` and hoist the static `styles` array in `PatternPreview` to a module constant, so `EditorStyles` isn't re-evaluated on every render.

## Why are these changes being made?

The Pattern Library (`/patterns/gallery` and sibling category pages) loads indefinitely: every pattern preview keeps flashing and re-downloading its images. Profiling the production page showed ~740 image requests in 15 seconds, with the same image fetched 500+ times, and each preview iframe's HTML being wiped and re-parsed 20–40 times per second.

Root cause: React 19 diffs host-element props by object identity, and its `dangerouslySetInnerHTML` commit path reassigns `innerHTML` without comparing the `__html` strings (React 18 compared the strings). Since `PatternRenderer` passed a fresh inline `{ __html: patternHtml }` object on every render, each re-render wiped and re-parsed the entire pattern inside the preview iframe, recreating every `<img>` and re-fetching its image. That fed a loop: images refetch → iframe body height changes as they load → the content resize observer in `ScaledBlockRendererContainer` triggers a state update → re-render → HTML wiped again.

Verified against the production page by injecting a guard that skips identical-value `innerHTML` assignments (the exact effect of the stable `__html` objects): image requests dropped from ~740 to ~23 in the same 15-second window and the loop disappeared.

`@automattic/block-renderer` is only consumed by the Pattern Library screens, so the blast radius matches the affected surface.

## Testing Instructions

1. Run `yarn start` and open `/patterns/gallery`.
2. Open the Network tab, filter by `Img`.
3. Before this change: image requests to `dotcompatterns.wordpress.com/...` repeat continuously for ~25 seconds (hundreds of requests for the same file) and previews keep flashing.
4. After this change: each pattern image loads once (a handful of requests total) and previews render steadily.
5. Optionally, run this in the DevTools console of a preview iframe to confirm the DOM is no longer churning — it should log a low, quickly-settling count:
   ```js
   let n = 0;
   new MutationObserver( ( m ) => ( n += m.length ) ).observe( document.documentElement, {
   	childList: true,
   	subtree: true,
   } );
   setInterval( () => console.log( 'mutations:', n ), 2000 );
   ```

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
