### PR TITLE
Purchases: clarify Google Workspace cancellation timing

### DIFF
--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -244,7 +244,9 @@ export default function CancellationMainContent( {
 				<BackupRetentionOptionOnCancelPurchase siteId={ purchase.blog_id } purchase={ purchase } />
 			) }
 
-			{ isGSuite && (
+			{ /* Cancel and auto-renew only: the message is worded around cancelling and counts
+			    the grace period from expiry, neither of which applies to an immediate removal. */ }
+			{ isGSuite && displayVariant !== 'remove' && (
 				<GSuiteAccessMessage purchase={ purchase } selectedDomain={ selectedDomain } />
 			) }
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/cancellation-main-content.tsx
@@ -244,7 +244,7 @@ export default function CancellationMainContent( {
 				<BackupRetentionOptionOnCancelPurchase siteId={ purchase.blog_id } purchase={ purchase } />
 			) }
 
-			{ isGSuite && ! isSplitCancelRemoveEnabled && (
+			{ isGSuite && (
 				<GSuiteAccessMessage purchase={ purchase } selectedDomain={ selectedDomain } />
 			) }
 

--- a/client/dashboard/me/billing-purchases/cancel-purchase/gsuite-access-message.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/gsuite-access-message.tsx
@@ -41,13 +41,14 @@ export default function GSuiteAccessMessage( {
 	return (
 		<p>
 			{ createInterpolateElement(
-				// Translators: <domainName /> is the name of the domain (e.g. example.com) and <googleMailService /> is either "G Suite" or "Google Workspace"
+				// Translators: <domainName /> is the name of the domain (e.g. example.com), <googleMailService /> is either "G Suite" or "Google Workspace", and <days /> is a number of days (usually '30')
 				__(
-					'If you cancel your subscription for <domainName /> now, <strong>you will lose access to all of your <googleMailService /> features 30 days after it expires</strong>. After that time, you will need to purchase a new subscription with Google if you wish to regain access to them.'
+					'If you cancel your subscription for <domainName /> now, <strong>you will lose access to all of your <googleMailService /> features <days /> days after it expires</strong>. After that time, you will need to purchase a new subscription with Google if you wish to regain access to them.'
 				),
 				{
 					domainName: <>{ domainName }</>,
 					googleMailService: <>{ googleMailService }</>,
+					days: <>{ 30 }</>,
 					strong: <strong />,
 				}
 			) }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/gsuite-access-message.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/gsuite-access-message.tsx
@@ -20,38 +20,37 @@ export default function GSuiteAccessMessage( {
 	const googleMailService = getGoogleMailServiceFamily( productSlug );
 	const googleSubscriptionStatus = getGSuiteSubscriptionStatus( selectedDomain );
 
+	// The `string` annotations below are load-bearing: `createInterpolateElement` derives
+	// the allowed conversion map keys from the string literal, and that inference skips a
+	// self-closing tag written with a space before the slash (`<tag />`).
 	if ( [ 'suspended', '' ].includes( googleSubscriptionStatus ) ) {
+		// Translators: <domainName /> is the name of the domain (e.g. example.com) and <googleMailService /> is either "G Suite" or "Google Workspace"
+		const message: string = __(
+			'If you cancel your subscription for <domainName /> now, <strong>you will lose access to all of your <googleMailService /> features immediately</strong>, and you will need to purchase a new subscription with Google if you wish to regain access to them.'
+		);
 		return (
 			<p>
-				{ createInterpolateElement(
-					// Translators: <domainName /> is the name of the domain (e.g. example.com) and <googleMailService /> is either "G Suite" or "Google Workspace"
-					__(
-						'If you cancel your subscription for <domainName /> now, <strong>you will lose access to all of your <googleMailService /> features immediately</strong>, and you will need to purchase a new subscription with Google if you wish to regain access to them.'
-					),
-					{
-						domainName: <>{ domainName }</>,
-						googleMailService: <>{ googleMailService }</>,
-						strong: <strong />,
-					}
-				) }
+				{ createInterpolateElement( message, {
+					domainName: <>{ domainName }</>,
+					googleMailService: <>{ googleMailService }</>,
+					strong: <strong />,
+				} ) }
 			</p>
 		);
 	}
 
+	// Translators: <domainName /> is the name of the domain (e.g. example.com), <googleMailService /> is either "G Suite" or "Google Workspace", and <days /> is a number of days (usually '30')
+	const message: string = __(
+		'If you cancel your subscription for <domainName /> now, <strong>you will lose access to all of your <googleMailService /> features <days /> days after it expires</strong>. After that time, you will need to purchase a new subscription with Google if you wish to regain access to them.'
+	);
 	return (
 		<p>
-			{ createInterpolateElement(
-				// Translators: <domainName /> is the name of the domain (e.g. example.com), <googleMailService /> is either "G Suite" or "Google Workspace", and <days /> is a number of days (usually '30')
-				__(
-					'If you cancel your subscription for <domainName /> now, <strong>you will lose access to all of your <googleMailService /> features <days /> days after it expires</strong>. After that time, you will need to purchase a new subscription with Google if you wish to regain access to them.'
-				),
-				{
-					domainName: <>{ domainName }</>,
-					googleMailService: <>{ googleMailService }</>,
-					days: <>{ 30 }</>,
-					strong: <strong />,
-				}
-			) }
+			{ createInterpolateElement( message, {
+				domainName: <>{ domainName }</>,
+				googleMailService: <>{ googleMailService }</>,
+				days: <>{ 30 }</>,
+				strong: <strong />,
+			} ) }
 		</p>
 	);
 }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/gsuite-access-message.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/gsuite-access-message.tsx
@@ -48,7 +48,7 @@ export default function GSuiteAccessMessage( {
 				sprintf(
 					// Translators: %(domainName)s is the name of the domain (e.g. example.com), %(googleMailService)s can be either "G Suite" or "Google Workspace", and %(days)d is a number of days (usually '30')
 					__(
-						'If you cancel your subscription for %(domainName)s now, <strong>you will lose access to all of your %(googleMailService)s features in %(days)d days</strong>. After that time, you will need to purchase a new subscription with Google if you wish to regain access to them.'
+						'If you cancel your subscription for %(domainName)s now, <strong>you will lose access to all of your %(googleMailService)s features %(days)d days after it expires</strong>. After that time, you will need to purchase a new subscription with Google if you wish to regain access to them.'
 					),
 					{
 						domainName,

--- a/client/dashboard/me/billing-purchases/cancel-purchase/gsuite-access-message.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/gsuite-access-message.tsx
@@ -1,5 +1,5 @@
 import { createInterpolateElement } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { getGSuiteSubscriptionStatus, getGoogleMailServiceFamily } from '../../../utils/gsuite';
 import type { Purchase, Domain } from '@automattic/api-core';
 
@@ -24,17 +24,13 @@ export default function GSuiteAccessMessage( {
 		return (
 			<p>
 				{ createInterpolateElement(
-					sprintf(
-						// Translators: %(domainName)s is the name of the domain (e.g. example.com) and %(googleMailService)s can be either "G Suite" or "Google Workspace"
-						__(
-							'If you cancel your subscription for %(domainName)s now, <strong>you will lose access to all of your %(googleMailService)s features immediately</strong>, and you will need to purchase a new subscription with Google if you wish to regain access to them.'
-						),
-						{
-							domainName,
-							googleMailService,
-						}
+					// Translators: <domainName /> is the name of the domain (e.g. example.com) and <googleMailService /> is either "G Suite" or "Google Workspace"
+					__(
+						'If you cancel your subscription for <domainName /> now, <strong>you will lose access to all of your <googleMailService /> features immediately</strong>, and you will need to purchase a new subscription with Google if you wish to regain access to them.'
 					),
 					{
+						domainName: <>{ domainName }</>,
+						googleMailService: <>{ googleMailService }</>,
 						strong: <strong />,
 					}
 				) }
@@ -45,18 +41,13 @@ export default function GSuiteAccessMessage( {
 	return (
 		<p>
 			{ createInterpolateElement(
-				sprintf(
-					// Translators: %(domainName)s is the name of the domain (e.g. example.com), %(googleMailService)s can be either "G Suite" or "Google Workspace", and %(days)d is a number of days (usually '30')
-					__(
-						'If you cancel your subscription for %(domainName)s now, <strong>you will lose access to all of your %(googleMailService)s features %(days)d days after it expires</strong>. After that time, you will need to purchase a new subscription with Google if you wish to regain access to them.'
-					),
-					{
-						domainName,
-						googleMailService,
-						days: 30,
-					}
+				// Translators: <domainName /> is the name of the domain (e.g. example.com) and <googleMailService /> is either "G Suite" or "Google Workspace"
+				__(
+					'If you cancel your subscription for <domainName /> now, <strong>you will lose access to all of your <googleMailService /> features 30 days after it expires</strong>. After that time, you will need to purchase a new subscription with Google if you wish to regain access to them.'
 				),
 				{
+					domainName: <>{ domainName }</>,
+					googleMailService: <>{ googleMailService }</>,
 					strong: <strong />,
 				}
 			) }

--- a/client/dashboard/me/billing-purchases/cancel-purchase/test/cancellation-main-content.test.tsx
+++ b/client/dashboard/me/billing-purchases/cancel-purchase/test/cancellation-main-content.test.tsx
@@ -258,6 +258,90 @@ describe( '<CancellationMainContent />', () => {
 		expect( screen.queryByText( /will also be removed/ ) ).not.toBeInTheDocument();
 	} );
 
+	describe( 'Google Workspace access message', () => {
+		const googleWorkspacePurchase = makePurchase( {
+			product_name: 'Google Workspace Business Starter',
+			product_slug: 'wp_google_workspace_business_starter_yearly',
+			is_plan: false,
+			meta: 'mydomain.com',
+		} );
+		const activeGoogleDomain = {
+			google_apps_subscription: { status: 'active' },
+		} as Domain;
+
+		test.each( [ [ 'cancel' ], [ 'auto-renew' ] ] as const )(
+			'grace period message appears on the %s variant',
+			( displayVariant ) => {
+				render(
+					<CancellationMainContent
+						{ ...defaultProps }
+						displayVariant={ displayVariant }
+						purchase={ googleWorkspacePurchase }
+						selectedDomain={ activeGoogleDomain }
+					/>
+				);
+
+				expect(
+					screen.getByText( /If you cancel your subscription for mydomain\.com now/ )
+				).toBeVisible();
+				expect(
+					screen.getByText(
+						'you will lose access to all of your Google Workspace features 30 days after it expires'
+					)
+				).toBeVisible();
+			}
+		);
+
+		test( 'grace period message does not appear on the remove variant', () => {
+			render(
+				<CancellationMainContent
+					{ ...defaultProps }
+					displayVariant="remove"
+					purchase={ googleWorkspacePurchase }
+					selectedDomain={ activeGoogleDomain }
+				/>
+			);
+
+			expect(
+				screen.queryByText( /If you cancel your subscription for mydomain\.com now/ )
+			).not.toBeInTheDocument();
+		} );
+
+		test( 'grace period message appears regardless of the split-cancel-remove flag', () => {
+			mockedIsEnabled.mockImplementation( ( flag ) => flag === 'purchases/split-cancel-remove' );
+
+			render(
+				<CancellationMainContent
+					{ ...defaultProps }
+					purchase={ googleWorkspacePurchase }
+					selectedDomain={ activeGoogleDomain }
+				/>
+			);
+
+			expect(
+				screen.getByText( /you will lose access to all of your Google Workspace features 30 days/ )
+			).toBeVisible();
+		} );
+
+		test( 'suspended subscriptions keep the immediate-loss wording', () => {
+			render(
+				<CancellationMainContent
+					{ ...defaultProps }
+					purchase={ googleWorkspacePurchase }
+					selectedDomain={
+						{ google_apps_subscription: { status: 'suspended' } } as unknown as Domain
+					}
+				/>
+			);
+
+			expect(
+				screen.getByText(
+					/you will lose access to all of your Google Workspace features immediately/
+				)
+			).toBeVisible();
+		} );
+	} );
+
 	test( 'Atomic items still render regardless of flag', () => {
 		mockedIsEnabled.mockImplementation( () => false );
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-476/

## Proposed Changes

This clarifies the Google Workspace cancellation message so it describes when access is actually lost — 30 days *after* the subscription expires (once Google's grace period ends) — and makes that message visible on both cancellation screens rather than only the legacy one.

## Why are these changes being made?

The cancellation screen presented three timings that contradicted each other. The top notice (`getTopNoticeCopy`, `case 'email'`) says "Your email will remain active for another *[duration]*", the losses list intro (`getCancelLossIntro`) says "On *[date]*, your email will expire", and the Google Workspace message said access ends "in 30 days" — counted from the moment the user clicks Cancel. None of those described the real behaviour: the subscription stays active until its expiry date, transfers to Google, and only then does Google's 30-day grace period run out. Customers read the "30 days" line as an immediate countdown and abandoned the cancellation, generating support tickets.

## Testing Instructions

TC:
```
yarn test-client client/dashboard/me/billing-purchases/cancel-purchase/test/cancellation-main-content.test.tsx
```

Manual testing:
* Use a site with an active Google Workspace subscription that is not suspended.
* Go to `/me/purchases`, select the Google Workspace subscription, and click **Cancel subscription**.
* Confirm the message reads "…you will lose access to all of your Google Workspace features **30 days after it expires**." and no longer says "in 30 days".
* Repeat with `purchases/split-cancel-remove` both enabled and disabled — the message should appear in both cases (previously it only appeared with the flag off).
* For a suspended Google Workspace subscription, confirm the "immediately" variant of the message is unchanged.
