### PR TITLE
Stats: keep the pricing grid away from all WordPress.com sites

### DIFF
--- a/client/my-sites/stats/pricing-grid/hooks/test/use-eligibility.test.ts
+++ b/client/my-sites/stats/pricing-grid/hooks/test/use-eligibility.test.ts
@@ -4,8 +4,7 @@
 
 import { renderHook } from '@testing-library/react';
 import { getPurchasesError } from 'calypso/state/purchases/selectors';
-import { getSiteOption } from 'calypso/state/sites/selectors';
-import getIsSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
+import { getSiteOption, isWpcomSite } from 'calypso/state/sites/selectors';
 import useStatsPurchases from '../../../hooks/use-stats-purchases';
 import useIsPricingGridEligible from '../use-eligibility';
 
@@ -14,7 +13,6 @@ jest.mock( 'calypso/state', () => ( {
 } ) );
 jest.mock( 'calypso/state/purchases/selectors' );
 jest.mock( 'calypso/state/sites/selectors' );
-jest.mock( 'calypso/state/sites/selectors/is-simple-site' );
 jest.mock( '../../../hooks/use-stats-purchases' );
 
 const SITE_ID = 123;
@@ -25,11 +23,11 @@ function mockSite( {
 	connectedAt = POST_LAUNCH_DATE as string | number | null,
 	hasAnyPlan = false,
 	isLoadingPurchases = false,
-	isSimpleSite = false,
+	isWpcom = false,
 	purchasesError = null as object | null,
 } = {} ) {
 	( getSiteOption as jest.Mock ).mockReturnValue( connectedAt );
-	( getIsSimpleSite as unknown as jest.Mock ).mockReturnValue( isSimpleSite );
+	( isWpcomSite as unknown as jest.Mock ).mockReturnValue( isWpcom );
 	( getPurchasesError as unknown as jest.Mock ).mockReturnValue( purchasesError );
 	( useStatsPurchases as jest.Mock ).mockReturnValue( {
 		hasAnyPlan,
@@ -63,8 +61,8 @@ describe( 'useIsPricingGridEligible', () => {
 		expect( result.current.isApplicable ).toBe( false );
 	} );
 
-	it( 'is not eligible for a WordPress.com Simple site', () => {
-		mockSite( { isSimpleSite: true } );
+	it( 'is not eligible for a WordPress.com site', () => {
+		mockSite( { isWpcom: true } );
 
 		const { result } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
 
@@ -118,10 +116,10 @@ describe( 'useIsPricingGridEligible', () => {
 
 		expect( preLaunch.current.isLoading ).toBe( false );
 
-		mockSite( { isSimpleSite: true, isLoadingPurchases: true } );
+		mockSite( { isWpcom: true, isLoadingPurchases: true } );
 
-		const { result: simple } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
+		const { result: wpcom } = renderHook( () => useIsPricingGridEligible( SITE_ID ) );
 
-		expect( simple.current.isLoading ).toBe( false );
+		expect( wpcom.current.isLoading ).toBe( false );
 	} );
 } );

--- a/client/my-sites/stats/pricing-grid/hooks/use-eligibility.ts
+++ b/client/my-sites/stats/pricing-grid/hooks/use-eligibility.ts
@@ -1,7 +1,6 @@
 import { useSelector } from 'calypso/state';
 import { getPurchasesError } from 'calypso/state/purchases/selectors';
-import { getSiteOption } from 'calypso/state/sites/selectors';
-import getIsSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
+import { getSiteOption, isWpcomSite } from 'calypso/state/sites/selectors';
 import useStatsPurchases from '../../hooks/use-stats-purchases';
 
 /**
@@ -12,18 +11,18 @@ const LAUNCH_DATE = Date.parse( '2026-08-07T00:00:00Z' );
 
 /**
  * Whether the pricing grid applies to this site: a newly connected site, other than a
- * WordPress.com Simple one, that hasn't picked a Stats plan yet. Bundled plans
- * (Complete, Growth, Business) count as having one, which is why this defers to
+ * WordPress.com one, that hasn't picked a Stats plan yet. Bundled plans (Complete,
+ * Growth, Business) count as having one, which is why this defers to
  * `useStatsPurchases` rather than scanning products.
  */
 export default function useIsPricingGridEligible( siteId: number | null ) {
 	const { hasAnyPlan, isLoading: isLoadingPurchases } = useStatsPurchases( siteId );
 
-	// Simple sites upgrade through WP.com plans, prompted inside the Stats dashboard
-	// itself, so the Jetpack Stats products this grid sells are not their upgrade path.
-	// Odyssey serves Simple Classic's wp-admin as well, so being an Odyssey route says
-	// nothing about the site type on its own.
-	const isSimpleSite = useSelector( ( state ) => !! getIsSimpleSite( state, siteId ) );
+	// WordPress.com sites — Simple and Atomic alike — upgrade through WP.com plans, prompted
+	// inside the Stats dashboard itself, so the Jetpack Stats products this grid sells are
+	// not their upgrade path. Odyssey serves their wp-admin as well, so being an Odyssey
+	// route says nothing about the site type on its own.
+	const isWpcom = useSelector( ( state ) => !! isWpcomSite( state, siteId ) );
 
 	// A failed purchases fetch reads as "loaded, no plan" upstream (FETCH_FAILED marks
 	// the store loaded with an empty list), which would show the grid to a site that
@@ -51,7 +50,7 @@ export default function useIsPricingGridEligible( siteId: number | null ) {
 
 	// Both checks read site data the store already holds, so ruling a site out here costs
 	// nothing — only an applicable site goes on to wait for its purchases.
-	const isApplicable = isNewConnection && ! isSimpleSite;
+	const isApplicable = isNewConnection && ! isWpcom;
 
 	return {
 		isEligible: isApplicable && ! hasAnyPlan && ! purchasesError,


### PR DESCRIPTION
Fixes STATS-436

Follow-up to #113515, which only excluded WordPress.com Simple sites.

## Proposed Changes

* Widen the Stats pricing grid's site-type exclusion from Simple sites to **all** WordPress.com sites.
* `useIsPricingGridEligible` swaps `isSimpleSite` for `isWpcomSite`, which covers Simple and Atomic alike. Self-hosted Jetpack sites are unaffected.
* Updated the hook's unit test to match.

## Why are these changes being made?

* The grid sells Jetpack Stats products. No WordPress.com-hosted site buys those — Simple and Atomic both upgrade through a WP.com plan, which the Stats dashboard already offers via its own "Unlock site growth analytics" CTA. #113515 kept the grid away from Simple sites, but Atomic sites have the same upgrade path and were still landing on it.
* Odyssey Stats serves WordPress.com wp-admin as well as self-hosted wp-admin, so mounting the gate on an Odyssey route says nothing about the site type on its own — the check has to be explicit.
* `isWpcomSite` is the existing canonical selector for "Simple or WoA", so this stays a one-line swap rather than a new site-type predicate.
* The check keeps its place alongside the connection-date test, so it stays free: both read site data already in the store, and a WordPress.com site falls straight through to the dashboard without the purchases fetch, the notice-visibility fetch, or the loading placeholder the gate would otherwise render.

## Testing Instructions

* On a WordPress.com **Atomic** site created after 2026-08-07 with no Stats plan, open `wp-admin` → Stats. Before this change the "Choose your Stats plan" grid appears; after it, the Stats dashboard loads directly.
* On a WordPress.com **Simple** site created after 2026-08-07, confirm behaviour is unchanged from #113515 — the dashboard still loads directly.
* On a self-hosted **Jetpack** site connected after 2026-08-07 with no Stats plan, open Stats in wp-admin and confirm the pricing grid still appears, and that choosing either option still dismisses it for subsequent visits.
* Unit tests: `yarn test-client client/my-sites/stats/pricing-grid`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
