### PR TITLE
A4A-904: Fix the double post-checkout message resizing between screens

### DIFF
--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/mixins";
+@import "@automattic/typography/styles/variables";
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 
 // custom properties for a8c-for-agencies
@@ -444,6 +445,13 @@
 		border: none;
 		background: var(--color-surface);
 	}
+}
+
+// A4A checkout finishes on the wordpress.com pending page, which ships its own 24px rule for this title. That
+// stylesheet belongs to the checkout section and is never loaded here, so without this the title would jump from
+// 32px to 24px as the browser crosses over.
+.theme-a8c-for-agencies .checkout__pending-content .wpcom__loading-title {
+	font-size: $font-title-medium;
 }
 
 // Universal Text Styles


### PR DESCRIPTION
Linear: [A4A-904](https://linear.app/a8c/issue/A4A-904/fix-double-post-checkout-message)

## Proposed Changes

* Make the "finalizing your order" title the same size on both post-checkout screens in A4A.

## Why are these changes being made?

When an A4A checkout finishes, you see the "finalizing your order" message twice and the second one is smaller, so it looks like the page loaded twice.

Both screens use the same loading component. The smaller size comes from a stylesheet that only loads on the wordpress.com side, so the A4A screen ends up bigger. This sets A4A to match.

The second screen isn't going away, since checkout has to hand off to wordpress.com to check the order status. But with the sizes matching it should read as one screen instead of two.

## Testing Instructions

* Finish an A4A checkout on a desktop-width window.
* Watch the handoff after payment. Before, the title shrinks after the page load. After, it stays the same size.

Screen 1
<img width="1952" height="1041" alt="Screenshot 2026-08-14 at 12 02 29 PM" src="https://github.com/user-attachments/assets/ed1db63a-3ebf-42c3-bdcf-67ef58c7dd10" />

Screen 2
<img width="1948" height="1040" alt="Screenshot 2026-08-14 at 12 02 42 PM" src="https://github.com/user-attachments/assets/fe61611a-74cf-493b-8103-7bbaf309368e" />

Old screen 1
<img width="1938" height="1028" alt="Screenshot 2026-08-14 at 12 26 02 PM" src="https://github.com/user-attachments/assets/ce48eb95-fd2f-4414-946b-891b0b67f6d2" />





## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Crafted by Travbot (Claude-powered)
