### PR TITLE
Agents Manager: bump agenttic dependencies to 0.1.89

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.87",
+		"@automattic/agenttic-ui": "^0.1.89",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.87",
-		"@automattic/agenttic-ui": "^0.1.87",
+		"@automattic/agenttic-client": "^0.1.89",
+		"@automattic/agenttic-ui": "^0.1.89",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -51,8 +51,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.87",
-		"@automattic/agenttic-ui": "^0.1.87",
+		"@automattic/agenttic-client": "^0.1.89",
+		"@automattic/agenttic-ui": "^0.1.89",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -44,7 +44,7 @@
 		"typecheck": "tsc --build --dry"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.87",
+		"@automattic/agenttic-client": "^0.1.89",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/components": "workspace:^",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.87",
+		"@automattic/agenttic-ui": "^0.1.89",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -36,7 +36,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.87",
+		"@automattic/agenttic-ui": "^0.1.89",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,8 +182,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.87"
-    "@automattic/agenttic-ui": "npm:^0.1.87"
+    "@automattic/agenttic-client": "npm:^0.1.89"
+    "@automattic/agenttic-ui": "npm:^0.1.89"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -230,9 +230,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.87":
-  version: 0.1.87
-  resolution: "@automattic/agenttic-client@npm:0.1.87"
+"@automattic/agenttic-client@npm:^0.1.89":
+  version: 0.1.89
+  resolution: "@automattic/agenttic-client@npm:0.1.89"
   dependencies:
     "@types/react": "npm:^18.0.0 || ^19.0.0"
     marked: "npm:^16.2.1"
@@ -245,13 +245,13 @@ __metadata:
   peerDependenciesMeta:
     "@wordpress/api-fetch":
       optional: true
-  checksum: 97b710151694fb4cbc339edf32d81cf025cd18290e1194b19c2e4038d47f57b6df8b75e74b2aba189ba2b71de2f643000acd32ec88930a25003e3ca09dc646f8
+  checksum: 4cac4119dd28f042e1e71f14ae3f16fdc61583f804fc260c4bc1b54f41e3987233ab3ef04d72666e38b0f203e6c8c25d68aba652dc72219154dbdb615e37fde3
   languageName: node
   linkType: hard
 
-"@automattic/agenttic-ui@npm:^0.1.87":
-  version: 0.1.87
-  resolution: "@automattic/agenttic-ui@npm:0.1.87"
+"@automattic/agenttic-ui@npm:^0.1.89":
+  version: 0.1.89
+  resolution: "@automattic/agenttic-ui@npm:0.1.89"
   dependencies:
     "@automattic/charts": "npm:^1.10.0"
     "@radix-ui/react-popover": "npm:^1.1.15"
@@ -274,7 +274,7 @@ __metadata:
   dependenciesMeta:
     marked:
       optional: true
-  checksum: 647f89fe20cfe36614534b1a847fe1f472b23fedb90ff6c6091b130ad87bbda2a619415e04e9bcb2058b1628bd4b8640f5cff8dea757b8203a12febd7ee563e1
+  checksum: 68eee5766e2ef691ab8efa5c5e99503a6ce1bab52585a5c7a9bd351b1483da4e9a0916b38df21dd7d0b7a8d63ae054df874142a6ff347e551a95a8114cfb5c3d
   languageName: node
   linkType: hard
 
@@ -1521,8 +1521,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.87"
-    "@automattic/agenttic-ui": "npm:^0.1.87"
+    "@automattic/agenttic-client": "npm:^0.1.89"
+    "@automattic/agenttic-ui": "npm:^0.1.89"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1610,7 +1610,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.87"
+    "@automattic/agenttic-client": "npm:^0.1.89"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
@@ -1877,7 +1877,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.87"
+    "@automattic/agenttic-ui": "npm:^0.1.89"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -2720,7 +2720,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/zendesk-client@workspace:packages/zendesk-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.87"
+    "@automattic/agenttic-ui": "npm:^0.1.89"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
@@ -14433,7 +14433,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.87"
+    "@automattic/agenttic-ui": "npm:^0.1.89"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"


### PR DESCRIPTION
## Proposed Changes

* Bump `@automattic/agenttic-client` and `@automattic/agenttic-ui` from `^0.1.87` to `^0.1.89` across every workspace package that declares them, and regenerate `yarn.lock`.

## Why are these changes being made?

The Agents Manager app needs the fix from agenttic#415, which ships in `agenttic` 0.1.89.

## Testing Instructions

This is a dependency-version change with no source changes, so the checks are that everything still builds and behaves as before in all the agenttic app usages.

1. `yarn install` — confirm `yarn.lock` shows a single resolution for each package at `0.1.89` and no duplicate entries:
   ```
   grep -n "agenttic" yarn.lock
   ```
2. `yarn typecheck-client` and `yarn typecheck-packages` — both should pass.
3. Build and sync the app to a sandbox:
   ```
   cd apps/agents-manager && yarn dev --sync
   ```
   (Sandbox `widgets.wp.com`; the sites themselves do not need sandboxing.)
4. Open the Agents Manager on a Simple and Atomic sites and confirm chat still loads, sends, and renders agent responses.
5. Check the other surfaces that pull in the same packages, since they share the bump:
   - Image Studio (Media Library and Block Editor entry points)
   - Jetpack AI sidebar in the block editor
   - Help Center / Odie chat, and Zendesk handoff
6. Watch the browser console for errors in each surface.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
