### PR TITLE
Omnibar: support site-level with applied color scheme

### DIFF
--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -8,7 +8,7 @@ import { isSupportSession } from '@automattic/calypso-support-session';
 import { AdminBarNode, Omnibar, buildOmnibarNodesFromAdminBarNodes } from '@automattic/omnibar';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
-import { wpcomLink } from '../../utils/link';
+import { dashboardLink, wpcomLink } from '../../utils/link';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { AUTH_QUERY_KEY, initializeCurrentUser } from '../auth';
 import { useAppContext } from '../context';
@@ -48,7 +48,7 @@ function createHrefResolver( adminUrl?: string ) {
 		const path = url.pathname + url.search + url.hash;
 
 		if ( url.host === 'my.wordpress.com' ) {
-			return path;
+			return dashboardLink( path );
 		}
 		if ( url.host === 'wordpress.com' ) {
 			return wpcomLink( path );

--- a/client/dashboard/app/omnibar/plugin-launch-site.scss
+++ b/client/dashboard/app/omnibar/plugin-launch-site.scss
@@ -1,15 +1,15 @@
-// Keep the button in blueberry whatever the bar's palette is, as wp-admin does.
 .omnibar .omnibar__menu.omnibar__launch-site {
-	background-color: var( --studio-wordpress-blue-50, #3858e9 );
+	background-color: var( --wp-admin-theme-color, #3858e9 );
+	color: var( --studio-white, #fff );
 
 	&:hover:not( [aria-disabled='true'] ),
 	&:focus-visible:not( [aria-disabled='true'] ),
 	&:active:not( [aria-disabled='true'] ) {
 		background-color: var( --wp-admin-theme-color-darker-10, #2145e6 );
-		color: var( --omnibar-text-color );
+		color: var( --studio-white, #fff );
 
 		svg {
-			color: var( --omnibar-text-color );
+			color: var( --studio-white, #fff );
 		}
 	}
 

--- a/client/dashboard/app/omnibar/plugin-launch-site.tsx
+++ b/client/dashboard/app/omnibar/plugin-launch-site.tsx
@@ -56,7 +56,7 @@ export function useLaunchSitePlugin( { site }: { site?: Site } ): OmnibarNode | 
 		id: 'launch-site',
 		title: __( 'Launch site' ),
 		icon: <LaunchRocketIcon />,
-		className: 'omnibar__launch-site',
+		className: 'omnibar__launch-site color-scheme is-global',
 		disabled,
 		href,
 		onClick,

--- a/client/dashboard/app/omnibar/plugin-notifications.tsx
+++ b/client/dashboard/app/omnibar/plugin-notifications.tsx
@@ -42,6 +42,7 @@ export function useNotificationsPlugin( { user }: { user?: User } ): OmnibarNode
 
 	return {
 		id: 'notifications',
+		className: 'omnibar__notifications',
 		label: __( 'Notifications' ),
 		icon: (
 			<span ref={ bellRef } className="omnibar__notifications-icon">

--- a/client/dashboard/app/omnibar/plugin-stats-sparkline.scss
+++ b/client/dashboard/app/omnibar/plugin-stats-sparkline.scss
@@ -2,7 +2,7 @@
 	vertical-align: middle;
 }
 
-.omnibar .omnibar__stats-sparkline {
+.omnibar .omnibar__menu.omnibar__stats-sparkline {
 	@media ( max-width: 781px ) {
 		display: none;
 	}

--- a/client/dashboard/app/omnibar/plugin-wpcom-account.scss
+++ b/client/dashboard/app/omnibar/plugin-wpcom-account.scss
@@ -8,7 +8,7 @@
 		margin-block: 6px;
 		border-radius: 2px;
 		background-color: var( --studio-wordpress-blue-50, #3858e9 );
-		color: var( --omnibar-text-color );
+		color: var( --studio-white, #fff );
 		line-height: 32px;
 		text-align: center;
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -76,6 +76,7 @@ import '@automattic/components/src/button/style.scss';
 import '@automattic/components/src/card/style.scss';
 
 import 'calypso/reader/color-scheme/dark-mode.scss';
+import './masterbar/omnibar.scss';
 import './style.scss';
 
 const loadWooCoreProfiler = () =>
@@ -132,10 +133,22 @@ const loadLegalUpdatesBanner = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-blocks-legal-updates-banner" */ 'calypso/blocks/legal-updates-banner'
 	);
+const loadOmnibar = () =>
+	import(
+		/* webpackChunkName: "async-load-calypso-layout-masterbar-omnibar" */ './masterbar/omnibar'
+	);
 const loadGlobalNotifications = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-layout-global-notifications" */ 'calypso/layout/global-notifications'
 	);
+
+const Omnibar = ( props ) => (
+	<AsyncLoad
+		require={ loadOmnibar }
+		placeholder={ <div id="wpcom-omnibar" className="masterbar-omnibar-placeholder" /> }
+		{ ...props }
+	/>
+);
 
 const READER_DARK_MODE_BODY_CLASS = 'is-reader-dark-mode';
 
@@ -260,9 +273,16 @@ class Layout extends Component {
 			return null;
 		}
 
-		const MasterbarComponent = config.isEnabled( 'jetpack-cloud' )
-			? JetpackCloudMasterbar
-			: MasterbarLoggedIn;
+		let MasterbarComponent = MasterbarLoggedIn;
+		if ( config.isEnabled( 'jetpack-cloud' ) ) {
+			MasterbarComponent = JetpackCloudMasterbar;
+		} else if (
+			config.isEnabled( 'dashboard/omnibar-radical' ) &&
+			this.props.sectionName !== 'checkout' &&
+			this.props.sectionName !== 'checkout-pending'
+		) {
+			MasterbarComponent = Omnibar;
+		}
 
 		const isCheckoutFailed =
 			this.props.sectionName === 'checkout' &&

--- a/client/layout/masterbar/omnibar.scss
+++ b/client/layout/masterbar/omnibar.scss
@@ -1,0 +1,36 @@
+@import 'calypso/assets/stylesheets/shared/functions/z-index';
+
+body #wpcom-omnibar {
+	position: fixed;
+	top: 0;
+	inset-inline: 0;
+	z-index: z-index( 'root', '.masterbar' );
+}
+
+body:has( .omnibar:not( .is-support-session ) ) {
+	--omnibar-background: var( --color-masterbar-background );
+	--omnibar-menu-active-background: var( --color-masterbar-item-hover-background );
+	--omnibar-submenu-background: var( --color-masterbar-item-hover-background );
+	--omnibar-text-color: var( --color-masterbar-text );
+	--omnibar-submenu-text-color: var( --color-masterbar-submenu-text );
+	--omnibar-highlight-color: var( --color-masterbar-highlight );
+	--omnibar-submenu-highlight-color: var(
+		--color-masterbar-submenu-hover-text,
+		var( --color-masterbar-highlight )
+	);
+	--omnibar-avatar-ring-color: var( --color-masterbar-border );
+	--omnibar-secondary-group-background: var( --color-masterbar-submenu-group-background );
+}
+
+.omnibar:not( .is-support-session ) .omnibar__notifications-unread-dot {
+	fill: var( --color-masterbar-unread-dot-background );
+}
+
+.omnibar__popover a:visited {
+	color: var( --omnibar-submenu-text-color );
+}
+
+.masterbar-omnibar-placeholder {
+	height: var( --masterbar-height );
+	background: var( --color-masterbar-background, #1e1e1e );
+}

--- a/client/layout/masterbar/omnibar.tsx
+++ b/client/layout/masterbar/omnibar.tsx
@@ -1,0 +1,85 @@
+import { omnibarSiteIdQuery, queryClient } from '@automattic/api-queries';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { AnalyticsProvider } from 'calypso/dashboard/app/analytics';
+import { APP_CONTEXT_DEFAULT_CONFIG, AppProvider } from 'calypso/dashboard/app/context';
+import { omnibarEvents, useOmnibarEvent } from 'calypso/dashboard/app/omnibar/events';
+import OmnibarContainer from 'calypso/dashboard/app/omnibar/omnibar';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useDispatch, useSelector } from 'calypso/state';
+import getUnseenCount from 'calypso/state/selectors/get-notification-unseen-count';
+import getIsNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
+import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
+import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { AnalyticsClient } from 'calypso/dashboard/app/analytics';
+import type { AppConfig } from 'calypso/dashboard/app/context';
+
+import 'calypso/dashboard/app/omnibar/style.scss';
+import '@automattic/omnibar/style.scss';
+
+const analyticsClient: AnalyticsClient = {
+	recordTracksEvent,
+	recordPageView: () => {},
+};
+
+function useOmnibarBridge() {
+	const dispatch = useDispatch();
+	const siteId = useSelector( getSelectedSiteId );
+	const unseenCount = useSelector( getUnseenCount );
+	const isNotificationsOpen = useSelector( getIsNotificationsOpen );
+	const currentLayoutFocus = useSelector( getCurrentLayoutFocus );
+
+	useEffect( () => {
+		queryClient.cancelQueries( { queryKey: omnibarSiteIdQuery().queryKey } );
+		queryClient.setQueryData( omnibarSiteIdQuery().queryKey, siteId ?? null );
+	}, [ siteId ] );
+
+	useEffect( () => {
+		if ( unseenCount !== null ) {
+			omnibarEvents.notificationsUnseenCount.emit( unseenCount );
+		}
+	}, [ unseenCount ] );
+
+	useEffect( () => {
+		omnibarEvents.notificationsOpen.emit( isNotificationsOpen );
+	}, [ isNotificationsOpen ] );
+
+	useOmnibarEvent( 'notifications', () => {
+		dispatch( toggleNotificationsPanel() );
+	} );
+
+	useOmnibarEvent( 'mobileMenu', () => {
+		recordTracksEvent( 'calypso_masterbar_menu_clicked' );
+		dispatch( setNextLayoutFocus( currentLayoutFocus === 'sidebar' ? 'content' : 'sidebar' ) );
+		dispatch( activateNextLayoutFocus() );
+	} );
+}
+
+export default function Omnibar( { loadHelpCenterIcon }: { loadHelpCenterIcon?: boolean } ) {
+	useOmnibarBridge();
+
+	const config: AppConfig = {
+		...APP_CONTEXT_DEFAULT_CONFIG,
+		name: 'WordPress.com',
+		supports: {
+			...APP_CONTEXT_DEFAULT_CONFIG.supports,
+			reader: true,
+			notifications: true,
+			help: !! loadHelpCenterIcon,
+		},
+	};
+
+	return (
+		<AppProvider config={ config }>
+			<QueryClientProvider client={ queryClient }>
+				<AnalyticsProvider client={ analyticsClient }>
+					<div id="wpcom-omnibar">
+						<OmnibarContainer user={ window.currentUser } />
+					</div>
+				</AnalyticsProvider>
+			</QueryClientProvider>
+		</AppProvider>
+	);
+}

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -76,7 +76,8 @@ const refreshNotes = () => notificationAppModule?.then( ( module ) => module.ref
 
 const debug = debugFactory( 'notifications:panel' );
 
-const getMasterbarBell = () => document.querySelector( '.masterbar-notifications' );
+const getMasterbarBell = () =>
+	document.querySelector( '.masterbar-notifications, .omnibar__notifications' );
 
 const Notifications3PCNotice = ( { className } ) => {
 	const translate = useTranslate();


### PR DESCRIPTION
## Proposed Changes

Renders the omnibar at site level / nav unification pages (`wordpress.com/home/<site>`) under the `dashboard/omnibar-radical` flag, with the color scheme applied:

<img width="2024" height="64" alt="image" src="https://github.com/user-attachments/assets/ec97b6a0-1d1b-4f16-a40f-51fd6226ccb9" />


## Why are these changes being made?

We want to migrate to the new `packages/omnibar`.

## Testing Instructions

Test with the `dashboard/omnibar-radical` flag turned on.

1. Go to `/home/site`
2. Verify the omnibar is shown without any regression.
4. Verify it is shown with the current color scheme.
3. Try clicking around.