### PR TITLE
E2E: fix the two faults behind the Jetpack Forms block smoke failures

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -7,6 +7,8 @@ import {
 } from './shared';
 import { BlockFlow, EditorContext, PublishedPostContext } from '.';
 
+const FORM_PATTERN_NAME = 'Contact';
+
 interface ConfigurationData {
 	labelPrefix: string;
 }
@@ -104,20 +106,22 @@ export class FormPatternsFlow implements BlockFlow {
 		await context.addedBlockLocator.getByRole( 'button', { name: 'Browse form patterns' } ).click();
 
 		const editorParent = await context.editorPage.getEditorParent();
-		const firstOption = editorParent
+		// Name the pattern rather than taking whichever option renders first: the library also
+		// serves Newsletter and Subscription patterns, which build on the Subscribe block and
+		// carry no Email field for `configure` to label or the assertions to find.
+		const option = editorParent
 			.getByRole( 'dialog', { name: 'Choose a pattern' } )
-			.getByRole( 'option' )
-			.first();
+			.getByRole( 'option', { name: FORM_PATTERN_NAME, exact: true } );
 		// Wait for the dialog to settle before clicking; the patterns load in via an
 		// iframe and a `block-editor-block-preview__container` overlay intercepts
 		// pointer events while previews hydrate. The remote pattern library can be
 		// slow to load on loaded CI agents, so allow a generous timeout here.
-		await firstOption.waitFor( { state: 'visible', timeout: 40 * 1000 } );
+		await option.waitFor( { state: 'visible', timeout: 40 * 1000 } );
 		// Force the click: on slower CI agents the preview container occasionally
 		// continues to intercept pointer events even after the option reports as
 		// visible, enabled and stable. The option still carries the selection
 		// handler — clicking it directly is what the keyboard-activated path does.
-		await firstOption.click( { force: true } );
+		await option.click( { force: true } );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/form-patterns.ts
@@ -111,12 +111,17 @@ export class FormPatternsFlow implements BlockFlow {
 		// carry no Email field for `configure` to label or the assertions to find.
 		const option = editorParent
 			.getByRole( 'dialog', { name: 'Choose a pattern' } )
-			.getByRole( 'option', { name: FORM_PATTERN_NAME, exact: true } );
+			.getByRole( 'option', { name: FORM_PATTERN_NAME, exact: true } )
+			.first();
 		// Wait for the dialog to settle before clicking; the patterns load in via an
 		// iframe and a `block-editor-block-preview__container` overlay intercepts
 		// pointer events while previews hydrate. The remote pattern library can be
 		// slow to load on loaded CI agents, so allow a generous timeout here.
 		await option.waitFor( { state: 'visible', timeout: 40 * 1000 } );
+		// The option sits partway down the list and previews above it hydrate late, so
+		// settle its position before taking a point: a forced click skips the stability
+		// check and would otherwise land on whichever pattern shifted into place.
+		await option.scrollIntoViewIfNeeded();
 		// Force the click: on slower CI agents the preview container occasionally
 		// continues to intercept pointer events even after the option reports as
 		// visible, enabled and stable. The option still carries the selection

--- a/packages/calypso-e2e/src/lib/blocks/block-flows/shared/block-helpers.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/shared/block-helpers.ts
@@ -88,9 +88,18 @@ export async function labelFormFieldBlock(
 	if ( isRefactor && parentBlockName ) {
 		scope = scope.locator( makeSelectorFromBlockName( parentBlockName ) );
 	}
-	await scope
-		.locator( makeSelectorFromBlockName( blockName ) )
-		.getByRole( 'textbox', { name: accessibleLabelName } )
-		.first()
-		.fill( labelText );
+	const fieldBlock = scope.locator( makeSelectorFromBlockName( blockName ) );
+	const labelInput = fieldBlock.getByRole( 'textbox', { name: accessibleLabelName } ).first();
+	// The editor re-renders the field after the fill and can drop what was typed without the
+	// fill itself reporting anything. Read the label back and type it once more; left
+	// unchecked the flow publishes an unlabelled field and fails a minute later, on an
+	// assertion that cannot say which step lost the label.
+	const labelled = fieldBlock.getByText( labelText, { exact: true } ).first();
+	await labelInput.fill( labelText );
+	try {
+		await labelled.waitFor( { timeout: 5 * 1000 } );
+	} catch {
+		await labelInput.fill( labelText );
+		await labelled.waitFor( { timeout: 5 * 1000 } );
+	}
 }

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -33,9 +33,10 @@ export function createBlockTests(
 		] );
 
 		test( `${ specName }: smoke test blocks`, async ( { page, pageEditor } ) => {
-			// One test adds, configures and validates every flow in the list, so the budget covers a
-			// fixed cost (authenticate, load the editor, publish) plus a share per flow.
-			test.setTimeout( 120_000 + blockFlows.length * 60_000 );
+			// One test adds, configures and validates every flow in the list. The fixed cost —
+			// authenticate, load the editor on Atomic, publish — dominates and is what overruns the
+			// default, so most of the budget sits in the base and each flow adds a smaller share.
+			test.setTimeout( 180_000 + blockFlows.length * 45_000 );
 
 			let editorContext: EditorContext;
 			let publishedPostContext: PublishedPostContext;

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -33,6 +33,10 @@ export function createBlockTests(
 		] );
 
 		test( `${ specName }: smoke test blocks`, async ( { page, pageEditor } ) => {
+			// One test adds, configures and validates every flow in the list, so the budget covers a
+			// fixed cost (authenticate, load the editor, publish) plus a share per flow.
+			test.setTimeout( 120_000 + blockFlows.length * 60_000 );
+
 			let editorContext: EditorContext;
 			let publishedPostContext: PublishedPostContext;
 


### PR DESCRIPTION
Fixes #

Reported in p1786636284527309-slack-jetpack-alerts

## Proposed Changes

* Scale the block smoke test timeout with the number of block flows instead of taking the
  120s default.
* Insert the Contact form pattern by name instead of clicking whichever option renders first.

## Why are these changes being made?

Two independent faults, which happened to land in the same attempt of one build and read as
one problem.

### The timeout

Every block flow runs inside a single `test()`, so the whole sequence — authenticate, load
the editor, then add/configure/verify each flow, publish, validate each flow — shares one
budget. Jetpack Forms passes on CI with only a few seconds to spare against the 120s cap, so
any slowness on the Atomic side tips it over. `blocks__jetpack-earn.spec.ts` and
`editor__post-basic-flow.spec.ts` have hit the same cap.

### The pattern selection

`FormPatternsFlow` clicked `getByRole( 'option' ).first()`. The library's 42 options are
served in a stable order, but their previews hydrate in a different order each run, so the
click landed on a different pattern between runs. The first five options are Newsletter and
Subscription patterns built on the Subscribe block, which has no Email field — leaving
`configure` nothing to label and `validateAfterPublish` nothing to find:

    TimeoutError: locator.waitFor: Timeout 10000ms exceeded.
      - waiting for getByRole('textbox', { name: 'Form Patterns Email field' }).first()

The aria snapshot of a failing run shows the Form Patterns block published as
`heading "Subscribe"` + `textbox "Enter your email…"` + `button "Subscribe"`, while the other
three blocks in the same post rendered their fields correctly.

## Testing Instructions

Run the spec the way the failing build does, pinned to the variation that fails most:

    yarn workspace @automattic/calypso-e2e build

    TEST_ON_ATOMIC=true \
    ATOMIC_VARIATION=ecomm-plan \
    JETPACK_TARGET=wpcom-deployment \
    VIEWPORT_NAME=desktop \
    CALYPSO_BASE_URL=<the default Test URL parameter> \
    LOCALE=en \
    NODE_CONFIG_ENV=test \
    CI=true \
    AUTHENTICATE_ACCOUNTS= \
    yarn workspace wp-e2e-tests test:pw:desktop \
        specs/blocks/blocks__jetpack-forms.spec.ts --retries=0

The build sets `ATOMIC_VARIATION=mixed` with `ATOMIC_VARIATION_KEY=<commit sha>`; pinning it
to `ecomm-plan` picks the variation directly. `--retries=0` is added so a first-attempt
failure is not masked by the retry. The build's `PLAYWRIGHT_BROWSERS_PATH=0` and
`PW_WORKERS=14` are dropped: the first points at the docker image's browser directory, the
second only matters when the whole tag is running. `calypso-e2e` has to be rebuilt first —
the specs load it from `dist`.

Five sequential runs before the pattern fix failed twice on `Form Patterns Email field`; five
after passed every time.

The timeout change cannot be exercised this way — the same spec runs at roughly half the CI
duration locally, well clear of the cap. It needs a CI run to verify.

* Reviewer check: the budget must stay above the observed pass time for the largest suite.
  `blocks__jetpack-grow.spec.ts` has 5 flows so gets 420s; `blocks__jetpack-writing.spec.ts`
  has 1 and gets 180s against a pass time close to the old default.
* Reviewer check: `exact: true` on the pattern name matters — without it the locator also
  matches `Contact 1`, `Contact 2` and `Contact 3`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
