### PR TITLE
Omnibar: support shopping cart node

### DIFF
--- a/client/dashboard/.eslintrc.js
+++ b/client/dashboard/.eslintrc.js
@@ -74,6 +74,7 @@ module.exports = {
 							'!@automattic/languages',
 							'!@automattic/language-picker',
 							'!@automattic/load-script',
+							'!@automattic/mini-cart',
 							'!@automattic/number-formatters',
 							'!@automattic/search',
 							'!@automattic/calypso-stripe',

--- a/client/dashboard/app/omnibar/index.tsx
+++ b/client/dashboard/app/omnibar/index.tsx
@@ -5,6 +5,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { hydrateRoot } from 'react-dom/client';
 import { AnalyticsProvider } from '../analytics';
 import { AppProvider } from '../context';
+import { shoppingCartManagerClient } from '../shopping-cart';
 import OmnibarContainer from './omnibar';
 import type { AnalyticsClient } from '../analytics';
 import type { AppConfig } from '../context';
@@ -25,7 +26,10 @@ export default function loadOmnibar( config: AppConfig ) {
 		<AppProvider config={ config }>
 			<QueryClientProvider client={ queryClient }>
 				<AnalyticsProvider client={ analyticsClient }>
-					<OmnibarContainer user={ window.currentUser } />
+					<OmnibarContainer
+						user={ window.currentUser }
+						cartManagerClient={ shoppingCartManagerClient }
+					/>
 				</AnalyticsProvider>
 			</QueryClientProvider>
 		</AppProvider>

--- a/client/dashboard/app/omnibar/omnibar-shopping-cart-panel.scss
+++ b/client/dashboard/app/omnibar/omnibar-shopping-cart-panel.scss
@@ -1,0 +1,19 @@
+@import '@automattic/calypso-color-schemes/root-only';
+
+.omnibar__cart-popover {
+	button {
+		appearance: none;
+		border: 0;
+		font-family: inherit;
+	}
+
+	.mini-cart__close-button {
+		background: transparent;
+		padding: 0;
+	}
+
+	.mini-cart__title {
+		margin-block-start: 0;
+		font-weight: inherit;
+	}
+}

--- a/client/dashboard/app/omnibar/omnibar-shopping-cart-panel.tsx
+++ b/client/dashboard/app/omnibar/omnibar-shopping-cart-panel.tsx
@@ -1,0 +1,45 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
+import { MiniCart } from '@automattic/mini-cart';
+import { wpcomLink } from '../../utils/link';
+import { useAnalytics } from '../analytics';
+
+import './omnibar-shopping-cart-panel.scss';
+
+export default function OmnibarShoppingCartPanel( {
+	siteId,
+	siteSlug,
+	onClose,
+}: {
+	siteId: number;
+	siteSlug: string;
+	onClose: () => void;
+} ) {
+	const { recordTracksEvent } = useAnalytics();
+
+	const recordRemoval = ( uuid = 'coupon' ) =>
+		recordTracksEvent( 'calypso_masterbar_cart_remove_product', { uuid } );
+
+	return (
+		<CheckoutErrorBoundary errorMessage="Error">
+			<MiniCart
+				selectedSiteSlug={ siteSlug }
+				cartKey={ siteId }
+				goToCheckout={ ( slug ) => {
+					recordTracksEvent( 'calypso_masterbar_cart_go_to_checkout' );
+					window.location.href = wpcomLink( `/checkout/${ slug }` );
+				} }
+				closeCart={ onClose }
+				onRemoveProduct={ recordRemoval }
+				onRemoveCoupon={ recordRemoval }
+				onRemoveBundle={ ( groupId, memberCount ) =>
+					recordTracksEvent( 'calypso_domain_bundle_removed_from_cart', {
+						domain_bundle_group_id: groupId,
+						domain_count: memberCount,
+					} )
+				}
+				showBundleGrouping={ isEnabled( 'domain-bundling' ) }
+			/>
+		</CheckoutErrorBoundary>
+	);
+}

--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -6,6 +6,7 @@ import {
 } from '@automattic/api-queries';
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { AdminBarNode, Omnibar, buildOmnibarNodesFromAdminBarNodes } from '@automattic/omnibar';
+import { ShoppingCartProvider } from '@automattic/shopping-cart';
 import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 import { dashboardLink, wpcomLink } from '../../utils/link';
@@ -21,12 +22,14 @@ import { useLaunchSitePlugin } from './plugin-launch-site';
 import { createLogoutNodeBuilder } from './plugin-logout';
 import { useNotificationsPlugin } from './plugin-notifications';
 import { useReaderPlugin } from './plugin-reader';
+import { useShoppingCartPlugin } from './plugin-shopping-cart';
 import { buildSiteBadgeNode } from './plugin-site-badges';
 import { useStatsSparklinePlugin } from './plugin-stats-sparkline';
 import { buildWpcomAccountNode } from './plugin-wpcom-account';
 import type { AppConfig } from '../context';
 import type { User } from '@automattic/api-core';
 import type { OmnibarNodeBuilders } from '@automattic/omnibar';
+import type { ShoppingCartManagerClient } from '@automattic/shopping-cart';
 
 const onClickResponsiveMenu = () => omnibarEvents.mobileMenu.emit();
 
@@ -57,7 +60,21 @@ function createHrefResolver( adminUrl?: string ) {
 	};
 }
 
-export default function OmnibarContainer( { user }: { user?: User } ) {
+export default function OmnibarContainer( {
+	user,
+	cartManagerClient,
+}: {
+	user?: User;
+	cartManagerClient: ShoppingCartManagerClient;
+} ) {
+	return (
+		<ShoppingCartProvider managerClient={ cartManagerClient }>
+			<ConnectedOmnibar user={ user } />
+		</ShoppingCartProvider>
+	);
+}
+
+function ConnectedOmnibar( { user }: { user?: User } ) {
 	const { supports } = useAppContext();
 	const [ hydrated, setHydrated ] = useState( false );
 	useEffect( () => {
@@ -134,6 +151,7 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 	const aiChatPluginNode = useAiChatPlugin();
 	const notificationsPluginNode = useNotificationsPlugin( { user } );
 	const languageSwitcherNode = useLanguageSwitcherPlugin( { user } );
+	const { node: shoppingCartNode, panel: shoppingCartPanel } = useShoppingCartPlugin( { site } );
 	const statsSparklineNode = useStatsSparklinePlugin( { site } );
 	const launchSiteNode = useLaunchSitePlugin( { site } );
 	const siteActions = [
@@ -145,6 +163,7 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 	const plugins = baseOmnibarNodes.user
 		? [
 				...( languageSwitcherNode ? [ languageSwitcherNode ] : [] ),
+				...( shoppingCartNode ? [ shoppingCartNode ] : [] ),
 				...( supports.reader ? [ readerPluginNode ] : [] ),
 				...( supports.help ? [ helpCenterPluginNode ] : [] ),
 				...( supports.help && aiChatPluginNode ? [ aiChatPluginNode ] : [] ),
@@ -162,11 +181,14 @@ export default function OmnibarContainer( { user }: { user?: User } ) {
 		return <InitialOmnibar user={ user } />;
 	}
 	return (
-		<Omnibar
-			nodes={ omnibarNodes }
-			onClickResponsiveMenu={ onClickResponsiveMenu }
-			className={ isSupportSession() ? 'is-support-session' : undefined }
-		/>
+		<>
+			<Omnibar
+				nodes={ omnibarNodes }
+				onClickResponsiveMenu={ onClickResponsiveMenu }
+				className={ isSupportSession() ? 'is-support-session' : undefined }
+			/>
+			{ shoppingCartPanel }
+		</>
 	);
 }
 

--- a/client/dashboard/app/omnibar/plugin-shopping-cart.scss
+++ b/client/dashboard/app/omnibar/plugin-shopping-cart.scss
@@ -1,0 +1,26 @@
+.omnibar .omnibar__secondary .omnibar__menu.omnibar__cart {
+	@media ( min-width: 782px ) {
+		padding-inline: 6px;
+	}
+}
+
+.omnibar__cart-icon {
+	display: flex;
+}
+
+.omnibar .omnibar__cart-dot {
+	fill: var( --studio-wordpress-blue-20, #3858e9 );
+	stroke: var( --omnibar-background );
+	stroke-width: 6%;
+}
+
+.omnibar .omnibar__menu:hover .omnibar__cart-dot,
+.omnibar .omnibar__menu:focus-visible .omnibar__cart-dot,
+.omnibar .omnibar__menu:active .omnibar__cart-dot {
+	stroke: var( --omnibar-menu-active-background );
+}
+
+.omnibar__cart-popover .components-popover__content {
+	width: max-content;
+	max-width: calc( 100vw - 32px );
+}

--- a/client/dashboard/app/omnibar/plugin-shopping-cart.tsx
+++ b/client/dashboard/app/omnibar/plugin-shopping-cart.tsx
@@ -1,0 +1,110 @@
+import { useShoppingCart } from '@automattic/shopping-cart';
+import { Popover } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
+import { useAnalytics } from '../analytics';
+import type { Site } from '@automattic/api-core';
+import type { OmnibarNode } from '@automattic/omnibar';
+
+import './plugin-shopping-cart.scss';
+
+const OmnibarShoppingCartPanel = lazy(
+	() =>
+		import( /* webpackChunkName: "async-omnibar-shopping-cart" */ './omnibar-shopping-cart-panel' )
+);
+
+function CartIcon() {
+	return (
+		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+			<path d="M9,20c0,1.1-0.9,2-2,2s-2-0.9-2-2s0.9-2,2-2S9,18.9,9,20z M17,18c-1.1,0-2,0.9-2,2s0.9,2,2,2s2-0.9,2-2S18.1,18,17,18z M17.4,13c0.9,0,1.7-0.7,2-1.6L21,5H7V4c0-1.1-0.9-2-2-2H3v2h2v1v8v2c0,1.1,0.9,2,2,2h12c0-1.1-0.9-2-2-2H7v-2H17.4z" />
+			<circle className="omnibar__cart-dot" cx="20" cy="3" r="3.7" />
+		</svg>
+	);
+}
+
+function ShoppingCartPanel( {
+	siteId,
+	siteSlug,
+	anchor,
+	onClose,
+}: {
+	siteId: number;
+	siteSlug: string;
+	anchor: HTMLElement;
+	onClose: () => void;
+} ) {
+	return (
+		<Popover
+			className="omnibar__cart-popover"
+			anchor={ anchor }
+			placement="bottom-end"
+			offset={ 0 }
+			onClose={ onClose }
+			onFocusOutside={ () => {
+				const omnibar = document.getElementById( 'wpcom-omnibar' );
+				if ( ! omnibar?.contains( document.activeElement ) ) {
+					onClose();
+				}
+			} }
+		>
+			<Suspense fallback={ null }>
+				<OmnibarShoppingCartPanel siteId={ siteId } siteSlug={ siteSlug } onClose={ onClose } />
+			</Suspense>
+		</Popover>
+	);
+}
+
+export function useShoppingCartPlugin( { site }: { site?: Site } ): {
+	node?: OmnibarNode;
+	panel?: React.ReactNode;
+} {
+	const { recordTracksEvent } = useAnalytics();
+	const { responseCart, reloadFromServer } = useShoppingCart( site?.ID );
+	const [ isOpen, setIsOpen ] = useState( false );
+	const [ anchor, setAnchor ] = useState< HTMLElement | null >( null );
+	const hasProducts = responseCart.products.length > 0;
+
+	const anchorRef = useCallback( ( icon: HTMLSpanElement | null ) => {
+		setAnchor( icon?.closest( 'button' ) ?? null );
+	}, [] );
+
+	useEffect( () => {
+		if ( hasProducts ) {
+			recordTracksEvent( 'calypso_masterbar_cart_shown' );
+		} else {
+			setIsOpen( false );
+		}
+	}, [ hasProducts, recordTracksEvent ] );
+
+	if ( ! hasProducts || ! site ) {
+		return {};
+	}
+
+	return {
+		node: {
+			id: 'shopping-cart',
+			className: 'omnibar__cart',
+			label: __( 'My shopping cart' ),
+			icon: (
+				<span ref={ anchorRef } className="omnibar__cart-icon">
+					<CartIcon />
+				</span>
+			),
+			onClick: () => {
+				if ( ! isOpen ) {
+					recordTracksEvent( 'calypso_masterbar_cart_open' );
+					reloadFromServer().catch( () => {} );
+				}
+				setIsOpen( ! isOpen );
+			},
+		},
+		panel: isOpen && anchor && (
+			<ShoppingCartPanel
+				siteId={ site.ID }
+				siteSlug={ site.slug }
+				anchor={ anchor }
+				onClose={ () => setIsOpen( false ) }
+			/>
+		),
+	};
+}

--- a/client/layout/masterbar/omnibar.tsx
+++ b/client/layout/masterbar/omnibar.tsx
@@ -6,6 +6,7 @@ import { APP_CONTEXT_DEFAULT_CONFIG, AppProvider } from 'calypso/dashboard/app/c
 import { omnibarEvents, useOmnibarEvent } from 'calypso/dashboard/app/omnibar/events';
 import OmnibarContainer from 'calypso/dashboard/app/omnibar/omnibar';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { cartManagerClient } from 'calypso/my-sites/checkout/cart-manager-client';
 import { useDispatch, useSelector } from 'calypso/state';
 import getUnseenCount from 'calypso/state/selectors/get-notification-unseen-count';
 import getIsNotificationsOpen from 'calypso/state/selectors/is-notifications-open';
@@ -76,7 +77,7 @@ export default function Omnibar( { loadHelpCenterIcon }: { loadHelpCenterIcon?: 
 			<QueryClientProvider client={ queryClient }>
 				<AnalyticsProvider client={ analyticsClient }>
 					<div id="wpcom-omnibar">
-						<OmnibarContainer user={ window.currentUser } />
+						<OmnibarContainer user={ window.currentUser } cartManagerClient={ cartManagerClient } />
 					</div>
 				</AnalyticsProvider>
 			</QueryClientProvider>


### PR DESCRIPTION
## Proposed Changes

This PR implements the shopping cart node and panel in the new omnibar:

<img width="955" height="361" alt="image" src="https://github.com/user-attachments/assets/869f9833-e877-4cc0-9d09-08ccd75dfad5" />


## Why are these changes being made?

Parity between the old Calypso masterbar and the new omnibar.

## Testing Instructions

1. Go to /home/:siteSlug of a free site
2. Try to purchase an upgrade (plan / add-on)
3. Don't finalize the checkout; go back to My Home
4. Verify the cart node is shown
5. Click it; verify the panel is shown as above.
6. Verify you can still complete the checkout