### PR TITLE
Update Site Spec to v1.14.0

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -226,7 +226,7 @@
 	"blackbox_url": "https://blackbox-api.wp.com/v1/dist/v.js",
 	"blackbox_api_key": "1b4f123e7dae4d83bbd18170c4358f8e",
 	"site_spec": {
-		"script_url": "https://widgets.wp.com/site-spec/v1.13.3/index.js",
-		"css_url": "https://widgets.wp.com/site-spec/v1.13.3/style.css"
+		"script_url": "https://widgets.wp.com/site-spec/v1.14.0/index.js",
+		"css_url": "https://widgets.wp.com/site-spec/v1.14.0/style.css"
 	}
 }


### PR DESCRIPTION
Bumping Site Spec to 1.14.0 for the setup site builder flow.

See Site Spec repo for the Site Spec change.

## Testing

- Sandbox `widgets.wp.com`
- `yarn start`
- Visit http://calypso.localhost:3000/setup/ai-site-builder-spec/site-spec and confirm it loads Site Spec 1.14.0
- Confirm Site Spec functions as expected