### PR TITLE
Atomic transfer: recognize the no-transfer-record error by code, not prose

### DIFF
--- a/client/state/automated-transfer/actions.js
+++ b/client/state/automated-transfer/actions.js
@@ -75,10 +75,11 @@ export const setAutomatedTransferStatus = ( siteId, status, uploadedPluginId ) =
  * @param {string} param.error The error string received
  * @returns {Object} An action object
  */
-export const automatedTransferStatusFetchingFailure = ( { siteId, error } ) => ( {
+export const automatedTransferStatusFetchingFailure = ( { siteId, error, errorCode } ) => ( {
 	type: AUTOMATED_TRANSFER_STATUS_REQUEST_FAILURE,
 	siteId,
 	error,
+	errorCode,
 } );
 
 /**

--- a/client/state/automated-transfer/constants.ts
+++ b/client/state/automated-transfer/constants.ts
@@ -1,9 +1,19 @@
 /**
  * Error message the status endpoint returns when the site has no transfer record.
  * Maps to `transferStates.NONE`.
- * TODO : [MARKETPLACE] rely on a tangible status from the backend instead of this message
+ * Legacy fallback — matching on prose is fragile. The backend is gaining a proper
+ * `no_transfer_record` error code; once it has been deployed for a while this message
+ * match can be removed (tracked in DOTCOM-18223).
  */
 export const NO_TRANSFER_RECORD_ERROR = 'An invalid transfer ID was passed.';
+
+export const NO_TRANSFER_RECORD_ERROR_CODE = 'no_transfer_record';
+
+export const isNoTransferRecordError = ( error: {
+	error?: string | null;
+	message?: string | null;
+} ): boolean =>
+	error.error === NO_TRANSFER_RECORD_ERROR_CODE || error.message === NO_TRANSFER_RECORD_ERROR;
 
 export const transferStates = {
 	/**

--- a/client/state/automated-transfer/reducer.js
+++ b/client/state/automated-transfer/reducer.js
@@ -16,7 +16,7 @@ import {
 	withSchemaValidation,
 	withPersistence,
 } from 'calypso/state/utils';
-import { NO_TRANSFER_RECORD_ERROR, transferStates } from './constants';
+import { isNoTransferRecordError, transferStates } from './constants';
 import eligibility from './eligibility/reducer';
 import { automatedTransfer as schema } from './schema';
 
@@ -34,7 +34,7 @@ export const status = withPersistence(
 			case TRANSFER_UPDATE:
 				return 'complete' === action.status ? transferStates.COMPLETE : state;
 			case REQUEST_STATUS_FAILURE:
-				return action.error === NO_TRANSFER_RECORD_ERROR
+				return isNoTransferRecordError( { error: action.errorCode, message: action.error } )
 					? transferStates.NONE
 					: transferStates.REQUEST_FAILURE;
 		}

--- a/client/state/automated-transfer/test/reducer.js
+++ b/client/state/automated-transfer/test/reducer.js
@@ -5,7 +5,11 @@ import {
 	AUTOMATED_TRANSFER_STATUS_SET as SET_STATUS,
 } from 'calypso/state/action-types';
 import { serialize, deserialize } from 'calypso/state/utils';
-import { transferStates } from '../constants';
+import {
+	NO_TRANSFER_RECORD_ERROR,
+	NO_TRANSFER_RECORD_ERROR_CODE,
+	transferStates,
+} from '../constants';
 import reducer, { status, fetchingStatus } from '../reducer';
 
 describe( 'state', () => {
@@ -20,6 +24,37 @@ describe( 'state', () => {
 
 				test( 'should not overwrite the status when a valid state already exists', () => {
 					expect( status( transferStates.START, update ) ).toEqual( transferStates.START );
+				} );
+			} );
+
+			describe( 'status request failure', () => {
+				test( 'should map the no-transfer-record error code to NONE', () => {
+					expect(
+						status( null, {
+							type: REQUEST_STATUS_FAILURE,
+							errorCode: NO_TRANSFER_RECORD_ERROR_CODE,
+							error: 'This site has no automated transfer.',
+						} )
+					).toBe( transferStates.NONE );
+				} );
+
+				test( 'should map the legacy no-transfer-record message to NONE', () => {
+					expect(
+						status( null, {
+							type: REQUEST_STATUS_FAILURE,
+							error: NO_TRANSFER_RECORD_ERROR,
+						} )
+					).toBe( transferStates.NONE );
+				} );
+
+				test( 'should map any other failure to REQUEST_FAILURE', () => {
+					expect(
+						status( null, {
+							type: REQUEST_STATUS_FAILURE,
+							errorCode: 'bad_request',
+							error: 'Service unavailable',
+						} )
+					).toBe( transferStates.REQUEST_FAILURE );
 				} );
 			} );
 

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/index.js
@@ -5,7 +5,7 @@ import {
 	automatedTransferStatusFetchingFailure,
 } from 'calypso/state/automated-transfer/actions';
 import {
-	NO_TRANSFER_RECORD_ERROR,
+	isNoTransferRecordError,
 	transferSettledStates,
 	transferStates,
 } from 'calypso/state/automated-transfer/constants';
@@ -110,8 +110,14 @@ export const receiveStatus =
 
 export const requestingStatusFailure = ( response ) => ( dispatch ) => {
 	const { siteId, pollingMode } = response;
-	const message = response.meta?.dataLayer?.error?.message;
-	dispatch( automatedTransferStatusFetchingFailure( { siteId, error: message } ) );
+	const error = response.meta?.dataLayer?.error;
+	dispatch(
+		automatedTransferStatusFetchingFailure( {
+			siteId,
+			error: error?.message,
+			errorCode: error?.error,
+		} )
+	);
 
 	// Retrying failures — and eventually reporting CLIENT_TIMEOUT — is behavior only waits
 	// get. Plain and 'single' fetches fail once and stop, exactly as they always did.
@@ -132,7 +138,7 @@ export const requestingStatusFailure = ( response ) => ( dispatch ) => {
 	// The reducer maps a missing record to the terminal NONE status, so once the retries run
 	// out the chain must end there — letting the deadline fire would replace a real "this site
 	// has no transfer" answer with a timeout.
-	if ( message === NO_TRANSFER_RECORD_ERROR ) {
+	if ( isNoTransferRecordError( error ?? {} ) ) {
 		const missingRecordAttempts = ( recorded.missingRecordAttempts ?? 0 ) + 1;
 		if ( missingRecordAttempts >= MISSING_RECORD_ATTEMPTS ) {
 			pollDeadlines.delete( siteId );

--- a/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/status/test/index.js
@@ -6,6 +6,7 @@ import {
 } from 'calypso/state/automated-transfer/actions';
 import {
 	NO_TRANSFER_RECORD_ERROR,
+	NO_TRANSFER_RECORD_ERROR_CODE,
 	transferStates,
 } from 'calypso/state/automated-transfer/constants';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
@@ -162,6 +163,38 @@ describe( 'requestingStatusFailure', () => {
 		retries.forEach( ( [ action ] ) => expect( action.pollingMode ).toBe( 'continue' ) );
 		expect( dispatch ).not.toHaveBeenCalledWith(
 			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
+		);
+	} );
+
+	test( 'should recognize a missing transfer record by its error code alone', () => {
+		const start = 1000000;
+		jest.setSystemTime( start );
+		requestStatus( { siteId, pollingMode: 'start' } );
+		jest.setSystemTime( start + TRANSFER_STATUS_POLL_DEADLINE_MS );
+		const dispatch = jest.fn();
+
+		requestingStatusFailure( {
+			siteId,
+			pollingMode: 'start',
+			meta: {
+				dataLayer: {
+					error: {
+						error: NO_TRANSFER_RECORD_ERROR_CODE,
+						message: 'This site has no automated transfer.',
+					},
+				},
+			},
+		} )( dispatch );
+
+		expect( dispatch ).not.toHaveBeenCalledWith(
+			setAutomatedTransferStatus( siteId, transferStates.CLIENT_TIMEOUT )
+		);
+		expect( dispatch ).toHaveBeenCalledWith(
+			automatedTransferStatusFetchingFailure( {
+				siteId,
+				error: 'This site has no automated transfer.',
+				errorCode: NO_TRANSFER_RECORD_ERROR_CODE,
+			} )
 		);
 	} );
 


### PR DESCRIPTION
Part of DOTCOM-18223

## Proposed Changes

* Add `NO_TRANSFER_RECORD_ERROR_CODE = 'no_transfer_record'` and an `isNoTransferRecordError( error )` helper to `client/state/automated-transfer/constants.ts`, matching the upcoming backend error code **or** the legacy message `An invalid transfer ID was passed.`.
* Route both consumers through the helper: the `automated-transfer` status reducer (maps the error to the terminal `NONE` state) and the status poller's bounded missing-record retry path.
* Pass the response's error code through `automatedTransferStatusFetchingFailure` as `errorCode` so the reducer can see it (previously only the message string reached it).
* Tests: reducer maps code → `NONE`, legacy message → `NONE`, anything else → `REQUEST_FAILURE`; poller recognizes the missing record by code alone and never converts it into `client_timeout`.

## Why are these changes being made?

The status endpoint signals "this site has no transfer record" only through human-readable prose — the error code is a generic `bad_request`, so Calypso string-matches the English sentence to tell a terminal "no transfer exists" apart from a transient request failure. Any rewording of that message silently degrades "no transfer" into "transient failure": retry-opted waits would poll for the full five minutes and end in a bogus `client_timeout` instead of settling on `NONE` within seconds.

The backend is gaining a distinct `no_transfer_record` error code for the missing-record case (DOTCOM-18223). This shim must ship **first** — it accepts the new code while keeping the legacy message as a fallback, so the backend rename cannot break detection in production. Once the backend change has been deployed for a safe interval, the message fallback and the 2021 `TODO : [MARKETPLACE]` comment can be deleted.

## Testing Instructions

1. `yarn test-client client/state/automated-transfer client/state/data-layer/wpcom/sites/automated-transfer` — 6 suites, 72 tests.
2. No behavior change today: the backend still sends the legacy shape, which the fallback matches byte-for-byte.
