### PR TITLE
Stats: align the Emails card Opens column with the Clicks fallback rules

### DIFF
--- a/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx
@@ -1,6 +1,5 @@
 import { StatsCard } from '@automattic/components';
 import { mail } from '@automattic/components/src/icons';
-import { formatNumber } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import QuerySiteStats from 'calypso/components/data/query-site-stats';
@@ -22,8 +21,8 @@ import {
 	TooltipWrapper,
 	OpensTooltipContent,
 	ClicksTooltipContent,
-	hasUniqueMetrics,
 	getClicksDisplayValue,
+	getOpensDisplayValue,
 	EmailStatsItem,
 } from './tooltips';
 import type { StatsDefaultModuleProps, StatsStateProps } from '../types';
@@ -88,26 +87,13 @@ const StatsEmails: React.FC< StatsDefaultModuleProps > = ( {
 					}
 					additionalColumns={ {
 						header: <span>{ translate( 'Opens' ) }</span>,
-						body: ( item: EmailStatsItem ) => {
-							const opensUnique = parseInt( String( item.unique_opens ), 10 );
-							const opens = parseInt( String( item.opens ), 10 );
-							const hasUniques = hasUniqueMetrics( opensUnique, opens );
-							return (
-								<TooltipWrapper
-									value={
-										hasUniques
-											? `${ formatNumber( item.opens_rate, {
-													numberFormatOptions: {
-														maximumFractionDigits: 2,
-													},
-											  } ) }%`
-											: '—'
-									}
-									item={ item }
-									TooltipContent={ OpensTooltipContent }
-								/>
-							);
-						},
+						body: ( item: EmailStatsItem ) => (
+							<TooltipWrapper
+								value={ getOpensDisplayValue( item ) }
+								item={ item }
+								TooltipContent={ OpensTooltipContent }
+							/>
+						),
 					} }
 					moduleStrings={ moduleStrings }
 					period={ forcedDailyPeriodForStatsModule }

--- a/client/my-sites/stats/features/modules/stats-emails/test/tooltips.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/test/tooltips.tsx
@@ -1,4 +1,36 @@
-import { getClicksDisplayValue } from '../tooltips';
+import { getClicksDisplayValue, getOpensDisplayValue } from '../tooltips';
+
+describe( 'getOpensDisplayValue', () => {
+	it( 'shows total opens when unique open data is unavailable', () => {
+		expect(
+			getOpensDisplayValue( {
+				opens: 13,
+				unique_opens: 0,
+				opens_rate: 0,
+			} )
+		).toBe( '13' );
+	} );
+
+	it( 'keeps showing open rate when unique open data is available', () => {
+		expect(
+			getOpensDisplayValue( {
+				opens: 10,
+				unique_opens: 5,
+				opens_rate: 50,
+			} )
+		).toBe( '50%' );
+	} );
+
+	it( 'shows a dash when there are no opens', () => {
+		expect(
+			getOpensDisplayValue( {
+				opens: 0,
+				unique_opens: 0,
+				opens_rate: 0,
+			} )
+		).toBe( '—' );
+	} );
+} );
 
 describe( 'getClicksDisplayValue', () => {
 	it( 'shows total clicks when unique click data is unavailable', () => {

--- a/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
+++ b/client/my-sites/stats/features/modules/stats-emails/tooltips.tsx
@@ -48,6 +48,28 @@ export const hasUniqueMetrics = ( uniqueValue: number, totalValue: number ) => {
 	return uniqueValue > 0 && totalValue > 0;
 };
 
+export const getOpensDisplayValue = (
+	item: Pick< EmailStatsItem, 'unique_opens' | 'opens' | 'opens_rate' >
+) => {
+	const opensUnique = parseInt( String( item.unique_opens ), 10 );
+	const opens = parseInt( String( item.opens ), 10 );
+	const hasUniques = hasUniqueMetrics( opensUnique, opens );
+
+	if ( hasUniques ) {
+		return `${ formatNumber( item.opens_rate, {
+			numberFormatOptions: {
+				maximumFractionDigits: 2,
+			},
+		} ) }%`;
+	}
+
+	if ( opens > 0 ) {
+		return formatNumber( item.opens );
+	}
+
+	return '—';
+};
+
 export const getClicksDisplayValue = (
 	item: Pick< EmailStatsItem, 'unique_clicks' | 'clicks' | 'clicks_rate' >
 ) => {


### PR DESCRIPTION
Part of STATS-440

## Proposed Changes

* Align the Subscribers > Emails card's **Opens** column with the **Clicks** column's display rules from #110760: show the unique-based open rate when unique-open metrics are available, and fall back to the formatted total opens when they are not — instead of the current `—`.
* Extract the Opens cell logic into a `getOpensDisplayValue()` helper next to the existing `getClicksDisplayValue()`, replacing the inline logic in `stats-emails.tsx`, so both columns share one shape.
* Add unit coverage mirroring the clicks tests (total-open fallback, percentage behavior, no-open dash).

## Why are these changes being made?

* The Emails card could show a dash in the Opens column even when the row had total open data — legacy sends predate unique-open tracking, so their `unique_opens` / `opens_rate` are 0 while `opens` is not (the STATS-440 row had `opens: 13`, shown as `—`, while Clicks correctly showed its total on the same row).
* #110760 (DOTCOM-12613) already established this fallback for the Clicks column; this aligns Opens with it so the two columns follow the same rules.

## Known trade-off: mixed units within a column

The rate is unique-based (`opens_rate = unique_opens / total_sends`), so rows missing unique data fall back to a raw count while neighbouring rows show a percentage — one column can then mix `17.1%` and `107`, distinguished only by the `%` sign. This is already the shipped Clicks behavior (visible today on sites whose older sends lack `unique_clicks`), and the fallback is still more honest than a dash that reads as "no data". The mixed-unit column itself, and candidate treatments (labeled fallback units, totals-primary with rate in tooltip, or `null` rates from the API so "0%" and "unknown" are distinguishable), are recorded in STATS-442 for a product/design decision — deliberately out of scope here.

## Screenshots

Stats > Subscribers > Emails, on a site with legacy sends (`opens > 0`, `unique_opens: 0`).

| Before | After |
| --- | --- |
|<img width="628" height="600" alt="截圖 2026-08-15 凌晨12 20 55" src="https://github.com/user-attachments/assets/5dd19d88-48b3-41cb-b22e-264bf8b84f1e" />|<img width="635" height="598" alt="截圖 2026-08-15 凌晨12 21 13" src="https://github.com/user-attachments/assets/6ce889e5-2fdb-4396-9f8b-4e12762b7493" />|

## Testing Instructions

* `node .yarn/releases/yarn-4.0.2.cjs test-client client/my-sites/stats/features/modules/stats-emails/test/tooltips.tsx`
* `node .yarn/releases/yarn-4.0.2.cjs eslint client/my-sites/stats/features/modules/stats-emails/stats-emails.tsx client/my-sites/stats/features/modules/stats-emails/tooltips.tsx client/my-sites/stats/features/modules/stats-emails/test/tooltips.tsx`
* In Stats > Subscribers > Emails, find a legacy email whose row shows a value in Clicks but `—` in Opens (its API row has `opens > 0` with `unique_opens: 0`): the Opens cell now shows the total opens count, and the tooltip still shows the total with `Unique opens: -`.
* Rows with unique-open data keep showing the open-rate percentage; rows with no opens at all keep showing `—`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

