### PR TITLE
Marketplace: Recover plugin install flow after page refresh

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-install-deadline.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-install-deadline.tsx
@@ -107,6 +107,7 @@ describe( 'useInstallDeadline', () => {
 		const { result } = renderDeadline();
 		await advance( 30000 );
 
+		expect( result.current.isTransferFresh ).toBe( true );
 		expect( result.current.hasTimedOut ).toBe( true );
 	} );
 

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -159,6 +159,19 @@ const simpleAtomicEligibleSite = {
 	},
 };
 
+const atomicSite = {
+	ui: { selectedSiteId: SITE_ID },
+	sites: {
+		items: {
+			[ SITE_ID ]: {
+				ID: SITE_ID,
+				URL: `https://${ SITE_SLUG }`,
+				options: { is_automated_transfer: true },
+			},
+		},
+	},
+};
+
 const THEME_SLUG = 'twentytwentyfour';
 const themeHandoff = {
 	marketplace: {
@@ -181,6 +194,7 @@ const beginAtomicPluginTransfer = async () => {
 	);
 	await waitFor( () => expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 ) );
 	rendered.unmount();
+	mockFetchLatestAtomicTransfer.mockClear();
 	initiatePluginTransfer.mockClear();
 };
 
@@ -322,9 +336,18 @@ describe( 'useProductInstall progression', () => {
 		expect( installPlugin ).not.toHaveBeenCalled();
 	} );
 
-	it( 'adopts an active transfer after refresh without initiating another one', async () => {
+	it.each( [
+		'pending',
+		'active',
+		'provisioned',
+		'relocating_switcheroo',
+		'renaming',
+		'exporting',
+		'importing',
+		'cleanup',
+	] )( 'adopts a %s transfer after refresh without initiating another one', async ( status ) => {
 		await beginAtomicPluginTransfer();
-		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'active' ) );
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( status ) );
 
 		const { result } = renderProgress(
 			{ pluginSlug: 'give' },
@@ -369,6 +392,24 @@ describe( 'useProductInstall progression', () => {
 			{ pluginSlug: 'give' },
 			{
 				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		await waitFor( () => expect( result.current.currentStep ).toBe( 2 ) );
+
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+		expect( installPlugin ).not.toHaveBeenCalled();
+	} );
+
+	it( 'adopts a completed transfer after refreshed site data reads Atomic', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'completed', 1000 ) );
+
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...marketplaceHandoff,
+				...atomicSite,
 				plugins: { wporg: { items: wporgItems } },
 			}
 		);
@@ -486,6 +527,124 @@ describe( 'useProductInstall progression', () => {
 		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
 		await advance( 1 );
 		expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not re-initiate a persisted attempt when the transfer lookup never settles', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockReturnValue( new Promise( () => undefined ) );
+
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...marketplaceHandoff,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+
+		await advance( INSTALL_DEADLINE_MS + 10000 );
+
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+		expect( result.current.error ).toEqual( { type: 'timeout' } );
+	} );
+
+	it( 'does not re-initiate a persisted attempt when the transfer lookup errors', async () => {
+		await beginAtomicPluginTransfer();
+
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...marketplaceHandoff,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+
+		await waitFor( () => expect( mockFetchLatestAtomicTransfer ).toHaveBeenCalled() );
+		await advance( INSTALL_DEADLINE_MS + 10000 );
+
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+		expect( result.current.error ).toEqual( { type: 'timeout' } );
+	} );
+
+	it( 're-initiates a persisted attempt after a successful lookup proves no match', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue(
+			latestTransfer( 'completed', INSTALL_DEADLINE_MS + 1000 )
+		);
+
+		renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...marketplaceHandoff,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+
+		await waitFor( () => expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 ) );
+	} );
+
+	it.each( [ 'error', 'reverted', 'reverting', 'relocating_revert' ] )(
+		'reports a persisted %s transfer as failed and stops polling',
+		async ( status ) => {
+			await beginAtomicPluginTransfer();
+			mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( status ) );
+
+			const { result } = renderProgress(
+				{ pluginSlug: 'give' },
+				{
+					...marketplaceHandoff,
+					...simpleAtomicEligibleSite,
+					plugins: { wporg: { items: wporgItems } },
+				}
+			);
+			await waitFor( () => expect( result.current.error ).toEqual( { type: 'transfer-failed' } ) );
+
+			expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+			await advance( 6000 );
+			expect( mockFetchLatestAtomicTransfer ).toHaveBeenCalledTimes( 1 );
+		}
+	);
+
+	it( 'clears the persisted attempt after successful installation', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'active' ) );
+		expect( window.sessionStorage ).toHaveLength( 1 );
+
+		const { result, store } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		await waitFor( () => expect( result.current.currentStep ).toBe( 1 ) );
+
+		await act( async () => {
+			store.dispatch(
+				receiveSitePlugins( SITE_ID, [ { slug: 'give', id: 'give/give', active: true } ] )
+			);
+		} );
+
+		await waitFor( () => expect( window.sessionStorage ).toHaveLength( 0 ) );
+	} );
+
+	it( 'clears the persisted attempt after a terminal transfer error', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'error' ) );
+		expect( window.sessionStorage ).toHaveLength( 1 );
+
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+
+		await waitFor( () => expect( result.current.error ).toEqual( { type: 'transfer-failed' } ) );
+		await waitFor( () => expect( window.sessionStorage ).toHaveLength( 0 ) );
 	} );
 
 	it( 'uploads a plugin and activates it once the upload completes', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { act } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { setAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import automatedTransferReducer from 'calypso/state/automated-transfer/reducer';
@@ -15,7 +15,15 @@ import { THEMES_REQUEST_SUCCESS } from 'calypso/state/themes/action-types';
 import themesReducer from 'calypso/state/themes/reducer';
 import uiReducer from 'calypso/state/ui/reducer';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
+import { INSTALL_DEADLINE_MS } from '../use-install-deadline';
 import { useProductInstall } from '../use-product-install';
+
+const mockFetchLatestAtomicTransfer = jest.fn();
+
+jest.mock( '@automattic/api-core', () => ( {
+	...jest.requireActual( '@automattic/api-core' ),
+	fetchLatestAtomicTransfer: ( siteId: number ) => mockFetchLatestAtomicTransfer( siteId ),
+} ) );
 
 // Keep the post-transfer site fetch off the network, leaving the rest of the package intact.
 jest.mock( '@automattic/api-queries', () => ( {
@@ -95,6 +103,16 @@ const reducers = {
 const SITE_ID = 1;
 const SITE_SLUG = 'example.com';
 
+const latestTransfer = ( status: string, agoMs = 0 ) => ( {
+	atomic_transfer_id: 10,
+	blog_id: SITE_ID,
+	status,
+	created_at: new Date( Date.now() - agoMs ).toISOString(),
+	is_stuck: false,
+	is_stuck_reset: false,
+	in_lossless_revert: false,
+} );
+
 const renderProgress = (
 	props: { pluginSlug?: string; themeSlug?: string },
 	initialState: object
@@ -152,9 +170,28 @@ const themeHandoff = {
 	},
 };
 
+const beginAtomicPluginTransfer = async () => {
+	const rendered = renderProgress(
+		{ pluginSlug: 'give' },
+		{
+			...marketplaceHandoff,
+			...simpleAtomicEligibleSite,
+			plugins: { wporg: { items: wporgItems } },
+		}
+	);
+	await waitFor( () => expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 ) );
+	rendered.unmount();
+	initiatePluginTransfer.mockClear();
+};
+
 describe( 'useProductInstall progression', () => {
 	beforeEach( () => {
 		jest.useFakeTimers();
+		window.sessionStorage.clear();
+		mockFetchLatestAtomicTransfer.mockReset();
+		mockFetchLatestAtomicTransfer.mockRejectedValue(
+			Object.assign( new Error( '404' ), { status: 404 } )
+		);
 		installPlugin.mockClear();
 		activatePlugin.mockClear();
 		initiatePluginTransfer.mockClear();
@@ -187,6 +224,17 @@ describe( 'useProductInstall progression', () => {
 		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
 		expect( activatePlugin ).toHaveBeenCalledWith( SITE_ID, { slug: 'give', id: 'give/give' } );
 		expect( result.current.currentStep ).toBe( 2 );
+	} );
+
+	it( 'installs in place despite an unrelated non-settled transfer record', async () => {
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'cleanup' ) );
+
+		renderProgress( { pluginSlug: 'give' }, { ...marketplaceHandoff, ...jetpackSite } );
+
+		expect( installPlugin ).toHaveBeenCalledTimes( 1 );
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+		await waitFor( () => expect( mockFetchLatestAtomicTransfer ).toHaveBeenCalled() );
+		expect( installPlugin ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'activates a plugin that is already present when the install step begins', async () => {
@@ -239,8 +287,8 @@ describe( 'useProductInstall progression', () => {
 				plugins: { wporg: { items: wporgItems } },
 			}
 		);
+		await waitFor( () => expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 ) );
 
-		expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 );
 		expect( initiatePluginTransfer ).toHaveBeenCalledWith(
 			SITE_ID,
 			null,
@@ -272,6 +320,172 @@ describe( 'useProductInstall progression', () => {
 		} );
 		expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 );
 		expect( installPlugin ).not.toHaveBeenCalled();
+	} );
+
+	it( 'adopts an active transfer after refresh without initiating another one', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'active' ) );
+
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		await waitFor( () => expect( result.current.currentStep ).toBe( 1 ) );
+
+		expect( mockFetchLatestAtomicTransfer ).toHaveBeenCalledWith( SITE_ID );
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+		expect( initiateAtomicTransfer ).not.toHaveBeenCalled();
+		expect( installPlugin ).not.toHaveBeenCalled();
+	} );
+
+	it( 'advances an adopted transfer when the durable status completes', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'active' ) );
+
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		await waitFor( () => expect( result.current.currentStep ).toBe( 1 ) );
+
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'completed' ) );
+		await advance( 6000 );
+
+		await waitFor( () => expect( result.current.currentStep ).toBe( 2 ) );
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+	} );
+
+	it( 'adopts a recently completed transfer after refresh', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'completed', 1000 ) );
+
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		await waitFor( () => expect( result.current.currentStep ).toBe( 2 ) );
+
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+		expect( installPlugin ).not.toHaveBeenCalled();
+	} );
+
+	it( 'starts a fresh authorized transfer instead of adopting a stale completion', async () => {
+		mockFetchLatestAtomicTransfer.mockResolvedValue(
+			latestTransfer( 'completed', INSTALL_DEADLINE_MS + 1000 )
+		);
+
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...marketplaceHandoff,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		await waitFor( () => expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 ) );
+
+		expect( result.current.currentStep ).toBe( 1 );
+		expect( installPlugin ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not advance from a recent completion that predates its new attempt', async () => {
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'completed', 1000 ) );
+
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...marketplaceHandoff,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		await waitFor( () => expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 ) );
+		await advance( 6000 );
+
+		expect( result.current.currentStep ).toBe( 1 );
+	} );
+
+	it( 'does not adopt a product-blind active transfer', async () => {
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'active' ) );
+
+		renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...marketplaceHandoff,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		await waitFor( () => expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 ) );
+	} );
+
+	it( 'adopts its persisted transfer when the handoff survives', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'active' ) );
+
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...marketplaceHandoff,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		await waitFor( () => expect( result.current.currentStep ).toBe( 1 ) );
+
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+	} );
+
+	it( 'waits for the latest-transfer lookup before initiating', async () => {
+		let rejectLookup: ( reason: unknown ) => void = () => {};
+		mockFetchLatestAtomicTransfer.mockReturnValue(
+			new Promise( ( _resolve, reject ) => {
+				rejectLookup = reject;
+			} )
+		);
+
+		renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...marketplaceHandoff,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+
+		await act( async () => {
+			rejectLookup( Object.assign( new Error( '404' ), { status: 404 } ) );
+		} );
+		await waitFor( () => expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 ) );
+	} );
+
+	it( 'initiates after the latest-transfer lookup grace period', async () => {
+		mockFetchLatestAtomicTransfer.mockReturnValue( new Promise( () => undefined ) );
+
+		renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...marketplaceHandoff,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+
+		await advance( 1999 );
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+		await advance( 1 );
+		expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'uploads a plugin and activates it once the upload completes', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
@@ -18,12 +18,27 @@ const reducers = {
 };
 
 // The deadline hook has its own suite; here we only assert how this hook arms it.
-type DeadlineArgs = { siteId: number; productSlug: string; enabled: boolean };
+type DeadlineArgs = { siteId: number; enabled: boolean };
+
+const diagnostics = {
+	has_transfer: false,
+	transfer_status: null,
+	transfer_age_seconds: null,
+	transfer_is_stuck: null,
+	transfer_in_lossless_revert: null,
+	waited_seconds: 0,
+	anchored_to: 'wait_start' as const,
+	deadline_seconds: 300,
+};
 
 const deadlineVerdict =
 	( verdict: { hasTimedOut: boolean; hasTransferFailed: boolean } ) => ( args: DeadlineArgs ) => ( {
 		...verdict,
 		receivedEnabled: args.enabled,
+		diagnostics,
+		transfer: undefined,
+		isTransferFresh: false,
+		isTransferLookupComplete: true,
 	} );
 
 const noDeadlineVerdict = deadlineVerdict( { hasTimedOut: false, hasTransferFailed: false } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
@@ -8,6 +8,7 @@ import themesReducer from 'calypso/state/themes/reducer';
 import uiReducer from 'calypso/state/ui/reducer';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
 import { useProductInstall } from '../use-product-install';
+import type { AtomicTransfer } from '@automattic/api-core';
 
 // useProductInstall reads several section-lazy slices that the bare test store doesn't register.
 const reducers = {
@@ -18,7 +19,11 @@ const reducers = {
 };
 
 // The deadline hook has its own suite; here we only assert how this hook arms it.
-type DeadlineArgs = { siteId: number; enabled: boolean };
+type DeadlineArgs = {
+	siteId: number;
+	enabled: boolean;
+	isTransferFromAttempt?: ( transfer: AtomicTransfer ) => boolean;
+};
 
 const diagnostics = {
 	has_transfer: false,

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-thank-you-redirect.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-thank-you-redirect.tsx
@@ -18,11 +18,12 @@ jest.mock( '../use-post-transfer-plugin-recovery', () => ( {
 
 // Control the post-transfer site fetch.
 let mockFreshSite: unknown;
+const mockFetchFreshSite = jest.fn( () => Promise.resolve( mockFreshSite ) );
 jest.mock( '@automattic/api-queries', () => ( {
 	...jest.requireActual( '@automattic/api-queries' ),
 	siteByIdQuery: () => ( {
 		queryKey: [ 'tyr-site' ],
-		queryFn: () => Promise.resolve( mockFreshSite ),
+		queryFn: () => mockFetchFreshSite(),
 	} ),
 } ) );
 
@@ -50,6 +51,7 @@ const baseProps: Props = {
 	pluginActive: false,
 	atomicFlow: true,
 	automatedTransferStatus: transferStates.COMPLETE,
+	durableTransferCompleted: false,
 	isTransferredUpload: false,
 };
 // A zip upload whose transfer is running: no product slug in the route, and no plugin in the store,
@@ -119,6 +121,38 @@ describe( 'useThankYouRedirect', () => {
 		mockFreshSite = ATOMIC_READY;
 		render( { atomicFlow: true, pluginActive: false } );
 		await waitFor( () => expect( mockRecoveryProps?.enabled ).toBe( true ) );
+	} );
+
+	it( 'enables recovery for the checkout-initiated activation window', async () => {
+		mockFreshSite = ATOMIC_READY;
+		render( { atomicFlow: false, currentStep: 0, pluginActive: false } );
+
+		await waitFor( () => expect( mockRecoveryProps?.enabled ).toBe( true ) );
+		expect( mockRecoveryProps?.ownsActivation ).toBe( true );
+	} );
+
+	it( 'enables recovery from a durable completion when the legacy status was lost', async () => {
+		mockFreshSite = ATOMIC_READY;
+		render( {
+			atomicFlow: true,
+			automatedTransferStatus: null,
+			durableTransferCompleted: true,
+		} );
+
+		await waitFor( () => expect( mockRecoveryProps?.canActivate ).toBe( true ) );
+		expect( mockFetchFreshSite ).toHaveBeenCalled();
+	} );
+
+	it( 'keeps the fresh-site query gated without either completion signal', () => {
+		mockFreshSite = ATOMIC_READY;
+		render( {
+			atomicFlow: true,
+			automatedTransferStatus: null,
+			durableTransferCompleted: false,
+		} );
+
+		expect( mockFetchFreshSite ).not.toHaveBeenCalled();
+		expect( mockRecoveryProps?.canActivate ).toBe( false );
 	} );
 
 	it( 'does not redirect after an atomic transfer while the plugin is still inactive', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-install-deadline.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-install-deadline.ts
@@ -58,6 +58,9 @@ export function useInstallDeadline( { siteId, enabled }: { siteId: number; enabl
 	hasTimedOut: boolean;
 	hasTransferFailed: boolean;
 	diagnostics: InstallWaitDiagnostics;
+	transfer: AtomicTransfer | undefined;
+	isTransferFresh: boolean;
+	isTransferLookupComplete: boolean;
 } {
 	const [ now, setNow ] = useState( () => Date.now() );
 	// Null while the wait is not running. The clock is stamped when it starts, never while it is
@@ -184,5 +187,8 @@ export function useInstallDeadline( { siteId, enabled }: { siteId: number; enabl
 		hasTimedOut: haltedOutcome === 'timeout' || isDeadlineExceeded,
 		hasTransferFailed: haltedOutcome === 'transfer-failed' || hasTransferFailed,
 		diagnostics,
+		transfer,
+		isTransferFresh: isFetchedAfterMount && isSuccess,
+		isTransferLookupComplete: isFetchedAfterMount,
 	};
 }

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-install-deadline.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-install-deadline.ts
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
 import {
 	createRevertedTransferWatcher,
+	isRevertedTransferStatus,
 	transferStates,
 } from 'calypso/landing/stepper/utils/atomic-transfer-outcome';
 import { useInterval } from 'calypso/lib/interval';
@@ -26,7 +27,7 @@ const SETTLED_STATUSES: string[] = [
 	transferStates.RELOCATING_REVERT,
 ];
 
-const isSettled = ( status?: string ) => !! status && SETTLED_STATUSES.includes( status );
+export const isSettled = ( status?: string ) => !! status && SETTLED_STATUSES.includes( status );
 
 type HaltedOutcome = 'timeout' | 'transfer-failed';
 
@@ -54,7 +55,15 @@ export type InstallWaitDiagnostics = {
  * we have watched that same transfer id in flight. An `error` is attributed the same way, or by
  * having started after this wait did.
  */
-export function useInstallDeadline( { siteId, enabled }: { siteId: number; enabled: boolean } ): {
+export function useInstallDeadline( {
+	siteId,
+	enabled,
+	isTransferFromAttempt,
+}: {
+	siteId: number;
+	enabled: boolean;
+	isTransferFromAttempt?: ( transfer: AtomicTransfer ) => boolean;
+} ): {
 	hasTimedOut: boolean;
 	hasTransferFailed: boolean;
 	diagnostics: InstallWaitDiagnostics;
@@ -110,8 +119,9 @@ export function useInstallDeadline( { siteId, enabled }: { siteId: number; enabl
 			// A settled record only ends the poll once it is this wait's. Otherwise it is the previous
 			// attempt's, still the site's latest because ours has not been created yet.
 			const isOurs =
-				latest?.atomic_transfer_id !== undefined &&
-				latest.atomic_transfer_id === seenInFlightId.current;
+				!! latest &&
+				( latest.atomic_transfer_id === seenInFlightId.current ||
+					isTransferFromAttempt?.( latest ) );
 			return isSettled( latest?.status ) && isOurs ? false : POLL_MS;
 		},
 		// A site that has never transferred answers 404, which is an answer rather than an outage.
@@ -131,11 +141,20 @@ export function useInstallDeadline( { siteId, enabled }: { siteId: number; enabl
 			return;
 		}
 		const startedDuringThisWait = Date.parse( transfer.created_at ) >= waitBeganAt;
-		const isOurs = transfer.atomic_transfer_id === seenInFlightId.current || startedDuringThisWait;
-		if ( reverted || ( transfer.status === transferStates.ERROR && isOurs ) ) {
+		const isKnownAttempt =
+			isFetchedAfterMount && isSuccess && !! isTransferFromAttempt?.( transfer );
+		const isOurs =
+			transfer.atomic_transfer_id === seenInFlightId.current ||
+			startedDuringThisWait ||
+			isKnownAttempt;
+		if (
+			reverted ||
+			( transfer.status === transferStates.ERROR && isOurs ) ||
+			( isRevertedTransferStatus( transfer.status ) && isKnownAttempt )
+		) {
 			setFailureSeen( true );
 		}
-	}, [ transfer, waitBeganAt ] );
+	}, [ transfer, waitBeganAt, isFetchedAfterMount, isSuccess, isTransferFromAttempt ] );
 
 	// A live transfer is the thing being waited on, so it owns the clock; its start survives a
 	// refresh where a mount-anchored timer would not.

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -2,9 +2,9 @@ import { marketplacePluginQuery } from '@automattic/api-queries';
 import { WPCOM_FEATURES_ATOMIC } from '@automattic/calypso-products';
 import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useState, useMemo, useRef } from 'react';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
-import { isAtomicTransferInProgress } from 'calypso/dashboard/utils/site-atomic-transfers';
+import { isRevertedTransferStatus } from 'calypso/landing/stepper/utils/atomic-transfer-outcome';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useWaitHeartbeat } from 'calypso/lib/analytics/wait-heartbeat';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -42,9 +42,10 @@ import {
 } from 'calypso/state/ui/selectors';
 import { chooseInstallStrategy } from './install-strategy';
 import { useDelayedCondition } from './use-delayed-condition';
-import { INSTALL_DEADLINE_MS, useInstallDeadline } from './use-install-deadline';
+import { INSTALL_DEADLINE_MS, isSettled, useInstallDeadline } from './use-install-deadline';
 import useMarketplaceAdditionalSteps from './use-marketplace-additional-steps';
 import { useThankYouRedirect } from './use-thank-you-redirect';
+import type { AtomicTransfer } from '@automattic/api-core';
 
 // The state authorizing an install is handed off asynchronously, so allow for it arriving late.
 const INSTALL_HANDOFF_GRACE_PERIOD_MS = 2000;
@@ -55,6 +56,7 @@ const TRANSFER_LOOKUP_GRACE_PERIOD_MS = 2000;
 // The plan's feature list is fetched asynchronously; allow for it arriving late.
 const PLAN_FEATURES_GRACE_PERIOD_MS = 2000;
 
+// Attempts older than the maximum install wait are no longer recoverable by this screen.
 const ADOPTABLE_TRANSFER_AGE_MS = INSTALL_DEADLINE_MS;
 const TRANSFER_ATTEMPT_CLOCK_SKEW_MS = 60 * 1000;
 const TRANSFER_ATTEMPT_KEY_PREFIX = 'marketplace-product-install-transfer';
@@ -84,6 +86,10 @@ const readTransferAttempt = ( key: string ): TransferAttempt | null => {
 };
 
 const clearTransferAttempt = ( key: string ) => {
+	if ( ! key || typeof window === 'undefined' ) {
+		return;
+	}
+
 	try {
 		window.sessionStorage.removeItem( key );
 	} catch {
@@ -92,6 +98,10 @@ const clearTransferAttempt = ( key: string ) => {
 };
 
 const writeTransferAttempt = ( key: string, attempt: TransferAttempt ) => {
+	if ( ! key || typeof window === 'undefined' ) {
+		return;
+	}
+
 	try {
 		window.sessionStorage.setItem( key, JSON.stringify( attempt ) );
 	} catch {
@@ -202,6 +212,24 @@ export function useProductInstall( {
 		!! persistedTransferAttempt &&
 		transferAttemptAge >= -TRANSFER_ATTEMPT_CLOCK_SKEW_MS &&
 		transferAttemptAge <= ADOPTABLE_TRANSFER_AGE_MS;
+	const isTransferFromAttempt = useCallback(
+		( candidate: AtomicTransfer ) => {
+			if ( ! persistedTransferAttempt || ! hasCurrentTransferAttempt ) {
+				return false;
+			}
+
+			const createdAt = Date.parse( candidate.created_at );
+			const age = Date.now() - createdAt;
+			return (
+				! Number.isNaN( createdAt ) &&
+				age >= -TRANSFER_ATTEMPT_CLOCK_SKEW_MS &&
+				age <= ADOPTABLE_TRANSFER_AGE_MS &&
+				candidate.atomic_transfer_id !== persistedTransferAttempt.previousTransferId &&
+				createdAt >= persistedTransferAttempt.initiatedAt - TRANSFER_ATTEMPT_CLOCK_SKEW_MS
+			);
+		},
+		[ hasCurrentTransferAttempt, persistedTransferAttempt ]
+	);
 
 	const pluginInstallStatus = useSelector( ( state ) =>
 		getStatusForPlugin( state, siteId, pluginSlug )
@@ -260,7 +288,7 @@ export function useProductInstall( {
 
 	// Flows that carry their own authorization never render this error, so don't arm the timer.
 	const noDirectAccessError = useDelayedCondition(
-		isInstallAuthorizationMissing && ! directInstallationAllowed && ! hasCurrentTransferAttempt,
+		isInstallAuthorizationMissing && ! directInstallationAllowed,
 		INSTALL_HANDOFF_GRACE_PERIOD_MS
 	);
 
@@ -316,29 +344,22 @@ export function useProductInstall( {
 	} = useInstallDeadline( {
 		siteId,
 		enabled: !! siteId && ! preflightError && ! isUploadStillSending,
+		isTransferFromAttempt,
 	} );
 	const latestTransfer = isTransferFresh ? transfer : undefined;
-	const latestTransferCreatedAt = latestTransfer ? Date.parse( latestTransfer.created_at ) : NaN;
-	const latestTransferAge = Date.now() - latestTransferCreatedAt;
-	const transferIsRecent =
-		!! latestTransfer &&
-		! Number.isNaN( latestTransferCreatedAt ) &&
-		latestTransferAge >= -TRANSFER_ATTEMPT_CLOCK_SKEW_MS &&
-		latestTransferAge <= ADOPTABLE_TRANSFER_AGE_MS;
-	const transferBelongsToAttempt =
-		!! latestTransfer &&
-		!! persistedTransferAttempt &&
-		hasCurrentTransferAttempt &&
-		transferIsRecent &&
-		latestTransfer.atomic_transfer_id !== persistedTransferAttempt.previousTransferId &&
-		latestTransferCreatedAt >=
-			persistedTransferAttempt.initiatedAt - TRANSFER_ATTEMPT_CLOCK_SKEW_MS;
-	const transferInFlight =
-		transferBelongsToAttempt && isAtomicTransferInProgress( latestTransfer.status );
+	const transferBelongsToAttempt = !! latestTransfer && isTransferFromAttempt( latestTransfer );
+	const transferInFlight = transferBelongsToAttempt && ! isSettled( latestTransfer.status );
 	const durableTransferCompleted =
 		transferBelongsToAttempt && latestTransfer.status === 'completed';
+	const durableTransferFailed =
+		transferBelongsToAttempt &&
+		( latestTransfer.status === 'error' || isRevertedTransferStatus( latestTransfer.status ) );
+	const transferHasFailed = hasTransferFailed || durableTransferFailed;
 	const transferLookupGraceElapsed = useDelayedCondition(
-		installStrategy === 'atomic-transfer' && !! pluginSlug && ! isTransferLookupComplete,
+		installStrategy === 'atomic-transfer' &&
+			!! pluginSlug &&
+			! hasCurrentTransferAttempt &&
+			! isTransferLookupComplete,
 		TRANSFER_LOOKUP_GRACE_PERIOD_MS
 	);
 
@@ -362,21 +383,25 @@ export function useProductInstall( {
 			return;
 		}
 
+		const shouldRecoverTransfer =
+			!! pluginSlug && ( transferInFlight || durableTransferCompleted || durableTransferFailed );
+
+		if ( shouldRecoverTransfer ) {
+			installFlowInitiatedRef.current = true;
+			setAtomicFlow( true );
+			if ( ! durableTransferFailed ) {
+				setCurrentStep( durableTransferCompleted ? 2 : 1 );
+			}
+			return;
+		}
+
 		// The site may not be installable yet — e.g. its feature data hasn't loaded. Leave the
 		// guard unset so a later update (features arriving) can still start the install.
 		if ( installStrategy === 'none' ) {
 			return;
 		}
 
-		const shouldAdoptTransfer =
-			!! pluginSlug &&
-			installStrategy === 'atomic-transfer' &&
-			( transferInFlight || durableTransferCompleted );
-
-		if ( shouldAdoptTransfer ) {
-			installFlowInitiatedRef.current = true;
-			setAtomicFlow( true );
-			setCurrentStep( durableTransferCompleted ? 2 : 1 );
+		if ( transferHasFailed || hasTimedOut || hasTransferTimedOut ) {
 			return;
 		}
 
@@ -384,8 +409,12 @@ export function useProductInstall( {
 			return;
 		}
 
-		// A transfer initiation must wait for this mount's latest-transfer lookup. Otherwise a fresh
-		// hook instance can dispatch again before it discovers the transfer already in progress.
+		// A persisted attempt must be resolved by a successful lookup before any install path starts.
+		if ( pluginSlug && hasCurrentTransferAttempt && ! isTransferFresh ) {
+			return;
+		}
+
+		// Without a marker, bound the initial lookup so an outage cannot block a newly authorized flow.
 		if (
 			installStrategy === 'atomic-transfer' &&
 			pluginSlug &&
@@ -430,6 +459,12 @@ export function useProductInstall( {
 		latestTransfer,
 		transferInFlight,
 		durableTransferCompleted,
+		durableTransferFailed,
+		transferHasFailed,
+		hasTimedOut,
+		hasTransferTimedOut,
+		hasCurrentTransferAttempt,
+		isTransferFresh,
 		isTransferLookupComplete,
 		transferLookupGraceElapsed,
 		transferAttemptKey,
@@ -477,7 +512,7 @@ export function useProductInstall( {
 	// Which error screen to show, in priority order, or null for none. The presentational mapping
 	// lives in ProductInstallErrorView; keeping this as data makes the branching testable.
 	let error: ProductInstallError | null = preflightError;
-	if ( ! error && hasTransferFailed ) {
+	if ( ! error && transferHasFailed ) {
 		error = { type: 'transfer-failed' };
 	}
 	if ( ! error && ( hasTimedOut || hasTransferTimedOut ) ) {
@@ -529,7 +564,7 @@ export function useProductInstall( {
 	diagnosticsRef.current = diagnostics;
 	useEffect( () => {
 		let outcome = null;
-		if ( hasTransferFailed ) {
+		if ( transferHasFailed ) {
 			outcome = 'transfer_failed';
 		} else if ( hasTimedOut || hasTransferTimedOut ) {
 			outcome = 'timeout';
@@ -553,7 +588,7 @@ export function useProductInstall( {
 	}, [
 		hasTimedOut,
 		hasTransferTimedOut,
-		hasTransferFailed,
+		transferHasFailed,
 		themeSlug,
 		installStrategy,
 		atomicFlow,

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useMemo, useRef } from 'react';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
+import { isAtomicTransferInProgress } from 'calypso/dashboard/utils/site-atomic-transfers';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useWaitHeartbeat } from 'calypso/lib/analytics/wait-heartbeat';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -41,15 +42,62 @@ import {
 } from 'calypso/state/ui/selectors';
 import { chooseInstallStrategy } from './install-strategy';
 import { useDelayedCondition } from './use-delayed-condition';
-import { useInstallDeadline } from './use-install-deadline';
+import { INSTALL_DEADLINE_MS, useInstallDeadline } from './use-install-deadline';
 import useMarketplaceAdditionalSteps from './use-marketplace-additional-steps';
 import { useThankYouRedirect } from './use-thank-you-redirect';
 
 // The state authorizing an install is handed off asynchronously, so allow for it arriving late.
 const INSTALL_HANDOFF_GRACE_PERIOD_MS = 2000;
 
+// Do not let a slow latest-transfer request block an authorized install indefinitely.
+const TRANSFER_LOOKUP_GRACE_PERIOD_MS = 2000;
+
 // The plan's feature list is fetched asynchronously; allow for it arriving late.
 const PLAN_FEATURES_GRACE_PERIOD_MS = 2000;
+
+const ADOPTABLE_TRANSFER_AGE_MS = INSTALL_DEADLINE_MS;
+const TRANSFER_ATTEMPT_CLOCK_SKEW_MS = 60 * 1000;
+const TRANSFER_ATTEMPT_KEY_PREFIX = 'marketplace-product-install-transfer';
+
+type TransferAttempt = {
+	initiatedAt: number;
+	previousTransferId: number | null;
+};
+
+const getTransferAttemptKey = ( siteId: number, pluginSlug: string ) =>
+	`${ TRANSFER_ATTEMPT_KEY_PREFIX }:${ siteId }:${ pluginSlug }`;
+
+const readTransferAttempt = ( key: string ): TransferAttempt | null => {
+	if ( ! key || typeof window === 'undefined' ) {
+		return null;
+	}
+
+	try {
+		const value = JSON.parse( window.sessionStorage.getItem( key ) ?? 'null' );
+		return Number.isFinite( value?.initiatedAt ) &&
+			( Number.isFinite( value.previousTransferId ) || value.previousTransferId === null )
+			? value
+			: null;
+	} catch {
+		return null;
+	}
+};
+
+const clearTransferAttempt = ( key: string ) => {
+	try {
+		window.sessionStorage.removeItem( key );
+	} catch {
+		// Nothing persisted, so there is nothing to recover or clear.
+	}
+};
+
+const writeTransferAttempt = ( key: string, attempt: TransferAttempt ) => {
+	try {
+		window.sessionStorage.setItem( key, JSON.stringify( attempt ) );
+	} catch {
+		// Recovery can still use the current mount's ref when storage is unavailable.
+	}
+};
 
 const installFlowName = ( {
 	themeSlug,
@@ -134,6 +182,26 @@ export function useProductInstall( {
 	const automatedTransferStatus = useSelector( ( state ) =>
 		getAutomatedTransferStatus( state, siteId )
 	);
+	const transferAttemptKey =
+		siteId && pluginSlug ? getTransferAttemptKey( siteId, pluginSlug ) : '';
+	const transferAttemptRef = useRef< { key: string; attempt: TransferAttempt | null } >( {
+		key: '',
+		attempt: null,
+	} );
+	if ( transferAttemptRef.current.key !== transferAttemptKey ) {
+		transferAttemptRef.current = {
+			key: transferAttemptKey,
+			attempt: readTransferAttempt( transferAttemptKey ),
+		};
+	}
+	const persistedTransferAttempt = transferAttemptRef.current.attempt;
+	const transferAttemptAge = persistedTransferAttempt
+		? Date.now() - persistedTransferAttempt.initiatedAt
+		: NaN;
+	const hasCurrentTransferAttempt =
+		!! persistedTransferAttempt &&
+		transferAttemptAge >= -TRANSFER_ATTEMPT_CLOCK_SKEW_MS &&
+		transferAttemptAge <= ADOPTABLE_TRANSFER_AGE_MS;
 
 	const pluginInstallStatus = useSelector( ( state ) =>
 		getStatusForPlugin( state, siteId, pluginSlug )
@@ -192,99 +260,9 @@ export function useProductInstall( {
 
 	// Flows that carry their own authorization never render this error, so don't arm the timer.
 	const noDirectAccessError = useDelayedCondition(
-		isInstallAuthorizationMissing && ! directInstallationAllowed,
+		isInstallAuthorizationMissing && ! directInstallationAllowed && ! hasCurrentTransferAttempt,
 		INSTALL_HANDOFF_GRACE_PERIOD_MS
 	);
-
-	// Upload flow startup
-	useEffect( () => {
-		if ( 100 !== pluginUploadProgress ) {
-			return;
-		}
-		// Let the upload step show briefly before advancing.
-		const id = setTimeout( () => setCurrentStep( 1 ), 1000 );
-		return () => clearTimeout( id );
-	}, [ pluginUploadProgress ] );
-
-	// Installing plugin flow startup
-	useEffect( () => {
-		if (
-			! ( marketplaceInstallationInProgress || directInstallationAllowed ) ||
-			isPluginUploadFlow ||
-			installFlowInitiatedRef.current ||
-			! ( wporgPlugin || wpOrgTheme )
-		) {
-			return;
-		}
-
-		// The site may not be installable yet — e.g. its feature data hasn't loaded. Leave the
-		// guard unset so a later update (features arriving) can still start the install.
-		if ( installStrategy === 'none' ) {
-			return;
-		}
-
-		installFlowInitiatedRef.current = true;
-
-		if ( installStrategy === 'in-place' ) {
-			if ( wpOrgTheme ) {
-				dispatch( installAndActivateTheme( wpOrgTheme.id, siteId ) );
-			} else {
-				dispatch( installPlugin( siteId, wporgPlugin, false ) );
-			}
-		} else if ( wpOrgTheme ) {
-			dispatch( initiateAtomicTransfer( siteId, { themeSlug, context: 'theme_install' } ) );
-		} else {
-			setAtomicFlow( true );
-			dispatch( initiateTransfer( siteId, null, pluginSlug, '', 'plugin_install' ) );
-		}
-		setCurrentStep( 1 );
-	}, [
-		marketplaceInstallationInProgress,
-		directInstallationAllowed,
-		isPluginUploadFlow,
-		siteId,
-		wporgPlugin,
-		wpOrgTheme,
-		pluginSlug,
-		themeSlug,
-		dispatch,
-		installStrategy,
-	] );
-
-	// Validate completion of atomic transfer flow
-	useEffect( () => {
-		if ( atomicFlow && currentStep === 1 && transferStates.COMPLETE === automatedTransferStatus ) {
-			setCurrentStep( 2 );
-		}
-	}, [ atomicFlow, automatedTransferStatus, currentStep ] );
-
-	// Activate once the plugin is installed and the installing step is reached. currentStep is a
-	// dependency so a plugin that appears before that step still activates when the step catches up.
-	useEffect( () => {
-		if (
-			installedPlugin &&
-			currentStep === 1 &&
-			( ! isPluginUploadFlow || pluginUploadComplete )
-		) {
-			if ( ! isTransferredUpload ) {
-				dispatch(
-					activatePlugin( siteId, {
-						slug: installedPlugin?.slug,
-						id: installedPlugin?.id,
-					} )
-				);
-			}
-			setCurrentStep( 2 );
-		}
-	}, [
-		installedPlugin,
-		currentStep,
-		isPluginUploadFlow,
-		isTransferredUpload,
-		pluginUploadComplete,
-		dispatch,
-		siteId,
-	] );
 
 	// Errors this page can tell apart before the wait even starts. They are also what says the wait
 	// is not really running, so the deadline below stays disarmed while one of them holds.
@@ -328,10 +306,173 @@ export function useProductInstall( {
 	const hasTransferTimedOut =
 		atomicFlow && automatedTransferStatus === transferStates.CLIENT_TIMEOUT;
 
-	const { hasTimedOut, hasTransferFailed, diagnostics } = useInstallDeadline( {
+	const {
+		hasTimedOut,
+		hasTransferFailed,
+		diagnostics,
+		transfer,
+		isTransferFresh,
+		isTransferLookupComplete,
+	} = useInstallDeadline( {
 		siteId,
 		enabled: !! siteId && ! preflightError && ! isUploadStillSending,
 	} );
+	const latestTransfer = isTransferFresh ? transfer : undefined;
+	const latestTransferCreatedAt = latestTransfer ? Date.parse( latestTransfer.created_at ) : NaN;
+	const latestTransferAge = Date.now() - latestTransferCreatedAt;
+	const transferIsRecent =
+		!! latestTransfer &&
+		! Number.isNaN( latestTransferCreatedAt ) &&
+		latestTransferAge >= -TRANSFER_ATTEMPT_CLOCK_SKEW_MS &&
+		latestTransferAge <= ADOPTABLE_TRANSFER_AGE_MS;
+	const transferBelongsToAttempt =
+		!! latestTransfer &&
+		!! persistedTransferAttempt &&
+		hasCurrentTransferAttempt &&
+		transferIsRecent &&
+		latestTransfer.atomic_transfer_id !== persistedTransferAttempt.previousTransferId &&
+		latestTransferCreatedAt >=
+			persistedTransferAttempt.initiatedAt - TRANSFER_ATTEMPT_CLOCK_SKEW_MS;
+	const transferInFlight =
+		transferBelongsToAttempt && isAtomicTransferInProgress( latestTransfer.status );
+	const durableTransferCompleted =
+		transferBelongsToAttempt && latestTransfer.status === 'completed';
+	const transferLookupGraceElapsed = useDelayedCondition(
+		installStrategy === 'atomic-transfer' && !! pluginSlug && ! isTransferLookupComplete,
+		TRANSFER_LOOKUP_GRACE_PERIOD_MS
+	);
+
+	// Upload flow startup
+	useEffect( () => {
+		if ( 100 !== pluginUploadProgress ) {
+			return;
+		}
+		// Let the upload step show briefly before advancing.
+		const id = setTimeout( () => setCurrentStep( 1 ), 1000 );
+		return () => clearTimeout( id );
+	}, [ pluginUploadProgress ] );
+
+	// Installing plugin flow startup
+	useEffect( () => {
+		if (
+			isPluginUploadFlow ||
+			installFlowInitiatedRef.current ||
+			! ( wporgPlugin || wpOrgTheme )
+		) {
+			return;
+		}
+
+		// The site may not be installable yet — e.g. its feature data hasn't loaded. Leave the
+		// guard unset so a later update (features arriving) can still start the install.
+		if ( installStrategy === 'none' ) {
+			return;
+		}
+
+		const shouldAdoptTransfer =
+			!! pluginSlug &&
+			installStrategy === 'atomic-transfer' &&
+			( transferInFlight || durableTransferCompleted );
+
+		if ( shouldAdoptTransfer ) {
+			installFlowInitiatedRef.current = true;
+			setAtomicFlow( true );
+			setCurrentStep( durableTransferCompleted ? 2 : 1 );
+			return;
+		}
+
+		if ( ! ( marketplaceInstallationInProgress || directInstallationAllowed ) ) {
+			return;
+		}
+
+		// A transfer initiation must wait for this mount's latest-transfer lookup. Otherwise a fresh
+		// hook instance can dispatch again before it discovers the transfer already in progress.
+		if (
+			installStrategy === 'atomic-transfer' &&
+			pluginSlug &&
+			! isTransferLookupComplete &&
+			! transferLookupGraceElapsed
+		) {
+			return;
+		}
+
+		installFlowInitiatedRef.current = true;
+
+		if ( installStrategy === 'in-place' ) {
+			if ( wpOrgTheme ) {
+				dispatch( installAndActivateTheme( wpOrgTheme.id, siteId ) );
+			} else {
+				dispatch( installPlugin( siteId, wporgPlugin, false ) );
+			}
+		} else if ( wpOrgTheme ) {
+			dispatch( initiateAtomicTransfer( siteId, { themeSlug, context: 'theme_install' } ) );
+		} else {
+			const attempt = {
+				initiatedAt: Date.now(),
+				previousTransferId: latestTransfer?.atomic_transfer_id ?? null,
+			};
+			transferAttemptRef.current = { key: transferAttemptKey, attempt };
+			writeTransferAttempt( transferAttemptKey, attempt );
+			setAtomicFlow( true );
+			dispatch( initiateTransfer( siteId, null, pluginSlug, '', 'plugin_install' ) );
+		}
+		setCurrentStep( 1 );
+	}, [
+		marketplaceInstallationInProgress,
+		directInstallationAllowed,
+		isPluginUploadFlow,
+		siteId,
+		wporgPlugin,
+		wpOrgTheme,
+		pluginSlug,
+		themeSlug,
+		dispatch,
+		installStrategy,
+		latestTransfer,
+		transferInFlight,
+		durableTransferCompleted,
+		isTransferLookupComplete,
+		transferLookupGraceElapsed,
+		transferAttemptKey,
+	] );
+
+	// Validate completion of atomic transfer flow
+	useEffect( () => {
+		if (
+			atomicFlow &&
+			currentStep === 1 &&
+			( transferStates.COMPLETE === automatedTransferStatus || durableTransferCompleted )
+		) {
+			setCurrentStep( 2 );
+		}
+	}, [ atomicFlow, automatedTransferStatus, currentStep, durableTransferCompleted ] );
+
+	// Activate once the plugin is installed and the installing step is reached. currentStep is a
+	// dependency so a plugin that appears before that step still activates when the step catches up.
+	useEffect( () => {
+		if (
+			installedPlugin &&
+			currentStep === 1 &&
+			( ! isPluginUploadFlow || pluginUploadComplete )
+		) {
+			if ( ! isTransferredUpload ) {
+				dispatch(
+					activatePlugin( siteId, {
+						slug: installedPlugin?.slug,
+						id: installedPlugin?.id,
+					} )
+				);
+			}
+			setCurrentStep( 2 );
+		}
+	}, [
+		installedPlugin,
+		currentStep,
+		isPluginUploadFlow,
+		isTransferredUpload,
+		pluginUploadComplete,
+		dispatch,
+		siteId,
+	] );
 
 	// Which error screen to show, in priority order, or null for none. The presentational mapping
 	// lives in ProductInstallErrorView; keeping this as data makes the branching testable.
@@ -354,6 +495,15 @@ export function useProductInstall( {
 	hasSucceededRef.current =
 		hasSucceededRef.current || ( themeSlug ? isThemeActive : !! installedPlugin && pluginActive );
 	const hasSucceeded = hasSucceededRef.current;
+	const transferAttemptEnded =
+		hasSucceeded || ( !! error && error.type !== 'non-installable-plan' );
+	useEffect( () => {
+		if ( ! transferAttemptEnded || ! transferAttemptRef.current.attempt ) {
+			return;
+		}
+		transferAttemptRef.current = { key: transferAttemptKey, attempt: null };
+		clearTransferAttempt( transferAttemptKey );
+	}, [ transferAttemptEnded, transferAttemptKey ] );
 
 	// Whether anyone is still watching. The wait stops being one the moment it resolves, either into
 	// an error screen or into a success on its way out.
@@ -426,6 +576,7 @@ export function useProductInstall( {
 		pluginActive,
 		atomicFlow,
 		automatedTransferStatus,
+		durableTransferCompleted,
 		isTransferredUpload,
 		halted: !! error,
 	} );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
@@ -26,6 +26,7 @@ export function useThankYouRedirect( {
 	pluginActive,
 	atomicFlow,
 	automatedTransferStatus,
+	durableTransferCompleted,
 	isTransferredUpload,
 	halted = false,
 }: {
@@ -41,6 +42,7 @@ export function useThankYouRedirect( {
 	pluginActive: boolean;
 	atomicFlow: boolean;
 	automatedTransferStatus: string | null;
+	durableTransferCompleted: boolean;
 	isTransferredUpload: boolean;
 	/** The wait has been called off — an error screen is up, so nothing here should keep polling. */
 	halted?: boolean;
@@ -53,7 +55,9 @@ export function useThankYouRedirect( {
 		enabled:
 			! halted &&
 			!! siteId &&
-			( ! atomicFlow || automatedTransferStatus === transferStates.COMPLETE ),
+			( ! atomicFlow ||
+				automatedTransferStatus === transferStates.COMPLETE ||
+				durableTransferCompleted ),
 		refetchInterval: ( query ) =>
 			query.state.data && isAtomicTransferredSite( query.state.data ) ? false : 2000,
 		staleTime: 0,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18174/marketplace-install-recover-flow-after-page-refresh

## Proposed Changes

**The marketplace install page now recovers an in-progress plugin install after a page refresh, instead of showing an error or kicking off a duplicate Atomic transfer.**

- When the page initiates an Atomic transfer it persists a per-site, per-plugin attempt marker (in `sessionStorage`) recording when the attempt started and which transfer existed before it.
- On mount, the page looks up the site’s latest Atomic transfer. If it belongs to the persisted attempt and is recent, the flow adopts it: resuming the progress UI while it’s in flight, or jumping straight to the install step if it already completed.
- Stale or unrelated transfers (old completions, transfers from other flows) are never adopted, and a new transfer is never dispatched before the latest-transfer lookup finishes (bounded by a 2-second grace period so a slow request can’t block an authorized install).
- The thank-you redirect also accepts this durable completion signal, so refreshing after the transfer finished still lands on the thank-you page.

## Why are these changes being made?

Buying a marketplace plugin on a site that isn’t Atomic yet triggers a server-side transfer that can take a few minutes. Until now, all the state that authorized and tracked that install lived only in the open tab: if the customer refreshed or lost the page mid-transfer, the install screen forgot everything — it would show a misleading “direct access” error, and in the worst case could try to start a second transfer for a site already being transferred. This makes the flow survive a refresh by letting the page re-attach to the transfer it started. See [DOTCOM-18174](https://linear.app/a8c/issue/DOTCOM-18174/marketplace-install-recover-flow-after-page-refresh).

## Testing Instructions

1. Run `yarn start`.
2. On a Simple site with a Business/Commerce plan (not yet Atomic), start a marketplace plugin install so you land on the install page and the Atomic transfer begins.
3. While the “transferring” step is running, refresh the page: progress should resume where it was, with no error and no second transfer initiated (check the network tab for a duplicate transfer request).
4. Once the transfer completes, refresh again: the page should skip ahead past the transfer step and end on the thank-you page.
5. Regression: open the install page directly (no purchase/authorization) on a site with no recent transfer — the no-direct-access error should still appear.
