### PR TITLE
Add WordPress Labs entry point and settings page in Preferences

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -1090,6 +1090,35 @@ export const hostingDashboardRoute = createRoute( {
 	)
 );
 
+export const wordpressLabsRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'WordPress Labs' ),
+			},
+		],
+	} ),
+	getParentRoute: () => preferencesRoute,
+	path: 'wordpress-labs',
+	beforeLoad: async () => {
+		if ( ! isEnabled( 'wordpress-labs' ) ) {
+			throw dashboardRedirect( { to: '/me/preferences', replace: true } );
+		}
+	},
+	loader: async () => {
+		await Promise.all( [
+			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
+			queryClient.prefetchQuery( allSitesQuery() ),
+		] );
+	},
+} ).lazy( () =>
+	import( '../../me/wordpress-labs' ).then( ( d ) =>
+		createLazyRoute( 'wordpress-labs' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const appearanceRoute = createRoute( {
 	head: () => ( {
 		meta: [
@@ -1364,6 +1393,9 @@ export const createMeRoutes = ( config: AppConfig ) => {
 	}
 	if ( config.optIn ) {
 		preferencesChildren.push( hostingDashboardRoute );
+	}
+	if ( isEnabled( 'wordpress-labs' ) ) {
+		preferencesChildren.push( wordpressLabsRoute );
 	}
 	if ( config.supports.darkMode && config.supports.colorScheme ) {
 		preferencesChildren.push( appearanceRoute );

--- a/client/dashboard/components/icons/index.tsx
+++ b/client/dashboard/components/icons/index.tsx
@@ -1,5 +1,20 @@
 import { SVG, Path, Circle } from '@wordpress/primitives';
 
+export const wordpressLabs = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+		<Path d="M9.75 3.75H14.25" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+		<Path
+			d="M10.5 4V9.6754C10.5 9.98903 10.4024 10.2949 10.2206 10.5503L6.94714 15.1435C6.09884 16.3346 6.95166 18 8.41442 18H15.5856C17.0483 18 17.9012 16.3346 17.0529 15.1435L13.7794 10.5503C13.5976 10.2949 13.5 9.98903 13.5 9.6754V4"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+		/>
+		<Path d="M8.5 14.25H15.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+		<Circle cx="12" cy="16.25" r="0.75" fill="currentColor" />
+	</SVG>
+);
+
 export const menuDot = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
 		<Circle cx="12" cy="12" r="2" fill="currentColor" />

--- a/client/dashboard/me/preferences-wordpress-labs/index.tsx
+++ b/client/dashboard/me/preferences-wordpress-labs/index.tsx
@@ -1,0 +1,30 @@
+import { userPreferenceQuery } from '@automattic/api-queries';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { wordpressLabs } from '../../components/icons';
+import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import type { Density } from '@automattic/components/src/summary-button/types';
+
+export default function PreferencesWordPressLabs( { density }: { density?: Density } ) {
+	const { data: optIn } = useSuspenseQuery( userPreferenceQuery( 'wordpress-labs-opt-in' ) );
+	const isOptedIn = optIn.value === 'opt-in';
+
+	const badges = [
+		{
+			text: isOptedIn ? __( 'Enabled' ) : __( 'Disabled' ),
+			intent: isOptedIn ? ( 'success' as const ) : undefined,
+		},
+	];
+
+	return (
+		<RouterLinkSummaryButton
+			density={ density }
+			to="/me/preferences/wordpress-labs"
+			title={ __( 'Early access' ) }
+			description={ __( 'Opt in for early access to new features and experiments.' ) }
+			decoration={ <Icon icon={ wordpressLabs } size={ 24 } /> }
+			badges={ badges }
+		/>
+	);
+}

--- a/client/dashboard/me/preferences-wordpress-labs/test/index.test.tsx
+++ b/client/dashboard/me/preferences-wordpress-labs/test/index.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { queryClient, rawUserPreferencesQuery } from '@automattic/api-queries';
+import '@testing-library/jest-dom';
+import { screen, waitFor } from '@testing-library/react';
+import PreferencesWordPressLabs from '..';
+import { render } from '../../../test-utils';
+
+beforeEach( () => {
+	queryClient.clear();
+	queryClient.setDefaultOptions( {
+		queries: { retry: false },
+	} );
+} );
+
+function renderWithOptIn( value: 'unset' | 'opt-in' | 'opt-out' = 'unset' ) {
+	queryClient.setQueryData( rawUserPreferencesQuery().queryKey, {
+		'wordpress-labs-opt-in': { value, updated_at: '2026-08-12T00:00:00.000Z' },
+	} );
+
+	return render( <PreferencesWordPressLabs />, { queryClient } );
+}
+
+test( 'links to the WordPress Labs settings page', async () => {
+	renderWithOptIn();
+
+	expect( await screen.findByRole( 'link', { name: /Early access/i } ) ).toHaveAttribute(
+		'href',
+		'/me/preferences/wordpress-labs'
+	);
+	expect(
+		screen.getByText( 'Opt in for early access to new features and experiments.' )
+	).toBeVisible();
+} );
+
+test( 'shows a disabled badge when the user has not opted in', async () => {
+	renderWithOptIn( 'unset' );
+
+	await waitFor( () => {
+		expect( screen.getByText( 'Disabled' ) ).toBeVisible();
+	} );
+} );
+
+test( 'shows an enabled badge when the user has opted in', async () => {
+	renderWithOptIn( 'opt-in' );
+
+	await waitFor( () => {
+		expect( screen.getByText( 'Enabled' ) ).toBeVisible();
+	} );
+} );

--- a/client/dashboard/me/preferences/index.tsx
+++ b/client/dashboard/me/preferences/index.tsx
@@ -11,6 +11,7 @@ import PreferencesDefaultsSummary from '../preferences-defaults/summary';
 import PreferencesLanguage from '../preferences-language';
 import PreferencesNewHostingDashboard from '../preferences-new-hosting-dashboard';
 import PreferencesPrivacy from '../preferences-privacy';
+import PreferencesWordPressLabs from '../preferences-wordpress-labs';
 
 export default function Preferences() {
 	const { optIn, supports } = useAppContext();
@@ -27,6 +28,7 @@ export default function Preferences() {
 		>
 			<SummaryButtonList>
 				{ optIn ? <PreferencesNewHostingDashboard /> : null }
+				{ isEnabled( 'wordpress-labs' ) ? <PreferencesWordPressLabs /> : null }
 				<PreferencesAppearance />
 				{ isEnabled( 'mcp-settings' ) ? <PreferencesAiMcp /> : null }
 				<PreferencesLanguage />

--- a/client/dashboard/me/wordpress-labs/index.tsx
+++ b/client/dashboard/me/wordpress-labs/index.tsx
@@ -1,0 +1,234 @@
+import { userPreferenceQuery, userPreferenceMutation } from '@automattic/api-queries';
+import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { Button, ToggleControl, __experimentalVStack as VStack } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
+import Breadcrumbs from '../../app/breadcrumbs';
+import { useAppContext } from '../../app/context';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
+import { ActionList } from '../../components/action-list';
+import { Card, CardBody } from '../../components/card';
+import ComponentViewTracker from '../../components/component-view-tracker';
+import { Notice } from '../../components/notice';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+import { SectionHeader } from '../../components/section-header';
+import SiteIcon from '../../components/site-icon';
+import { getSiteDisplayName } from '../../utils/site-name';
+import { getSiteDisplayUrl } from '../../utils/site-url';
+import PreferencesLoginSiteDropdown from '../preferences-defaults/site-dropdown';
+import type { Site } from '@automattic/api-core';
+
+export default function WordPressLabs() {
+	const { createErrorNotice } = useDispatch( noticesStore );
+	const { recordTracksEvent } = useAnalytics();
+	const { queries } = useAppContext();
+
+	const { data: optIn } = useSuspenseQuery( userPreferenceQuery( 'wordpress-labs-opt-in' ) );
+	const { data: excludedSiteIds } = useSuspenseQuery(
+		userPreferenceQuery( 'wordpress-labs-excluded-sites' )
+	);
+
+	const { mutate: saveOptInPreference, isPending: isSavingOptIn } = useMutation(
+		userPreferenceMutation( 'wordpress-labs-opt-in' )
+	);
+	const { mutate: saveExcludedSites, isPending: isSavingExceptions } = useMutation(
+		withSnackbar( userPreferenceMutation( 'wordpress-labs-excluded-sites' ), {
+			error: __( 'Failed to update site exceptions.' ),
+		} )
+	);
+
+	const sitesQueryResult = useQuery(
+		queries.sitesQuery( { site_visibility: 'visible', include_a8c_owned: false } )
+	);
+	const adminSites = ( ( sitesQueryResult.data as Site[] | undefined ) ?? [] ).filter(
+		( site ) => site.capabilities?.manage_options
+	);
+	const isSiteListLoading = sitesQueryResult.isLoading;
+
+	const [ selectedSiteId, setSelectedSiteId ] = useState< string | null >( null );
+
+	const isEnabled = optIn.value === 'opt-in';
+	const hasOptedOutBefore = optIn.value === 'opt-out' && optIn.updated_at !== '';
+
+	const excludedSites = excludedSiteIds
+		.map( ( siteId ) => adminSites.find( ( site ) => site.ID === siteId ) )
+		.filter( ( site ): site is Site => Boolean( site ) );
+
+	const availableSitesForPicker = adminSites.filter(
+		( site ) => ! excludedSiteIds.includes( site.ID )
+	);
+
+	const handleToggle = ( enabled: boolean ) => {
+		recordTracksEvent( 'calypso_dashboard_me_preferences_wordpress_labs_toggle_click', {
+			enabled,
+		} );
+
+		saveOptInPreference(
+			{
+				value: enabled ? 'opt-in' : 'opt-out',
+				updated_at: new Date().toISOString(),
+			},
+			{
+				onError() {
+					createErrorNotice(
+						enabled
+							? __( 'Failed to enable WordPress Labs.' )
+							: __( 'Failed to disable WordPress Labs.' ),
+						{ type: 'snackbar' }
+					);
+				},
+			}
+		);
+	};
+
+	const handleSiteExclude = ( siteId: number ) => {
+		saveExcludedSites( [ ...excludedSiteIds, siteId ], {
+			onSuccess: () => {
+				recordTracksEvent( 'calypso_dashboard_me_preferences_wordpress_labs_site_excluded', {
+					site_id: siteId,
+				} );
+			},
+		} );
+	};
+
+	const handleSiteRestore = ( siteId: number ) => {
+		saveExcludedSites(
+			excludedSiteIds.filter( ( id ) => id !== siteId ),
+			{
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_dashboard_me_preferences_wordpress_labs_site_restored', {
+						site_id: siteId,
+					} );
+				},
+			}
+		);
+	};
+
+	const handleSitePickerSelect = ( siteIdStr: string | null | undefined ) => {
+		if ( siteIdStr ) {
+			handleSiteExclude( parseInt( siteIdStr, 10 ) );
+			setSelectedSiteId( null );
+		}
+	};
+
+	return (
+		<PageLayout
+			size="small"
+			header={
+				<PageHeader
+					prefix={ <Breadcrumbs length={ 2 } /> }
+					title={ __( 'WordPress Labs' ) }
+					description={ __(
+						'Be the first to try the new features we’re building and help shape the future of WordPress.com.'
+					) }
+				/>
+			}
+		>
+			<ComponentViewTracker eventName="calypso_dashboard_me_preferences_wordpress_labs_view" />
+			<VStack spacing={ 8 }>
+				<VStack spacing={ 4 }>
+					<Card>
+						<CardBody>
+							<VStack spacing={ 4 } alignment="flex-start">
+								<SectionHeader title={ __( 'WordPress Labs' ) } level={ 3 } />
+								<ToggleControl
+									__nextHasNoMarginBottom
+									checked={ isEnabled }
+									label={ __( 'Enable WordPress Labs' ) }
+									disabled={ isSavingOptIn }
+									onChange={ handleToggle }
+								/>
+							</VStack>
+						</CardBody>
+					</Card>
+					{ isEnabled && (
+						<Notice variant="success" title={ __( 'You’re in!' ) }>
+							{ __(
+								'Every site for which you are an Administrator has been opted into WordPress Labs. You can find the list of current experiments below.'
+							) }
+						</Notice>
+					) }
+					{ ! isEnabled && hasOptedOutBefore && (
+						<Notice variant="info">
+							{ __(
+								'You’ve opted out of WordPress Labs. No experimental features will be added to your site.'
+							) }
+						</Notice>
+					) }
+				</VStack>
+
+				{ isEnabled && (
+					<VStack spacing={ 2 }>
+						<SectionHeader
+							level={ 3 }
+							title={ __( 'Current experiments' ) }
+							description={ __( 'Beta features and tools you can try will show up here.' ) }
+						/>
+						<Card>
+							<CardBody>{ __( 'No experiments are available yet. Check back soon.' ) }</CardBody>
+						</Card>
+					</VStack>
+				) }
+
+				{ isEnabled && (
+					<VStack spacing={ 4 }>
+						<Card>
+							<CardBody>
+								<VStack spacing={ 4 }>
+									<SectionHeader
+										level={ 3 }
+										title={ __( 'Add a site exception' ) }
+										description={ __(
+											'WordPress Labs is enabled for every site where you’re an Administrator. Remove specific sites here.'
+										) }
+									/>
+									<PreferencesLoginSiteDropdown
+										sites={ availableSitesForPicker }
+										isLoading={ isSiteListLoading || isSavingExceptions }
+										value={ selectedSiteId ?? '' }
+										onChange={ handleSitePickerSelect }
+										hideLabelFromVision
+									/>
+								</VStack>
+							</CardBody>
+						</Card>
+
+						{ excludedSites.length > 0 && (
+							<VStack spacing={ 2 }>
+								<SectionHeader
+									level={ 3 }
+									title={ __( 'Excluded sites' ) }
+									description={ __( 'WordPress Labs is disabled for these sites.' ) }
+								/>
+								<ActionList>
+									{ excludedSites.map( ( site ) => (
+										<ActionList.ActionItem
+											key={ site.ID }
+											title={ getSiteDisplayName( site ) }
+											description={ getSiteDisplayUrl( site ) || undefined }
+											decoration={ <SiteIcon site={ site } size={ 40 } /> }
+											actions={
+												<Button
+													variant="secondary"
+													size="compact"
+													disabled={ isSavingExceptions }
+													onClick={ () => handleSiteRestore( site.ID ) }
+												>
+													{ __( 'Restore' ) }
+												</Button>
+											}
+										/>
+									) ) }
+								</ActionList>
+							</VStack>
+						) }
+					</VStack>
+				) }
+			</VStack>
+		</PageLayout>
+	);
+}

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -63,6 +63,7 @@
 		"webauthn/related-origin-requests": true,
 		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
+		"wordpress-labs": true,
 		"wpcom-user-bootstrap": false
 	},
 	"enable_all_sections": false,

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -63,7 +63,7 @@
 		"webauthn/related-origin-requests": true,
 		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
-		"wordpress-labs": true,
+		"wordpress-labs": false,
 		"wpcom-user-bootstrap": false
 	},
 	"enable_all_sections": false,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -58,7 +58,7 @@
 		"webauthn/related-origin-requests": true,
 		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
-		"wordpress-labs": true,
+		"wordpress-labs": false,
 		"wpcom-user-bootstrap": true
 	},
 	"enable_all_sections": false,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -58,6 +58,7 @@
 		"webauthn/related-origin-requests": true,
 		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
+		"wordpress-labs": true,
 		"wpcom-user-bootstrap": true
 	},
 	"enable_all_sections": false,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -61,6 +61,7 @@
 		"webauthn/related-origin-requests": true,
 		"wordpress-agent-slack": false,
 		"wordpress-ai-tools": true,
+		"wordpress-labs": false,
 		"wpcom-user-bootstrap": true
 	},
 	"enable_all_sections": false,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -61,6 +61,7 @@
 		"webauthn/related-origin-requests": true,
 		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
+		"wordpress-labs": true,
 		"wpcom-user-bootstrap": true
 	},
 	"enable_all_sections": false,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -61,7 +61,7 @@
 		"webauthn/related-origin-requests": true,
 		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
-		"wordpress-labs": true,
+		"wordpress-labs": false,
 		"wpcom-user-bootstrap": true
 	},
 	"enable_all_sections": false,

--- a/config/development.json
+++ b/config/development.json
@@ -230,6 +230,7 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
+		"wordpress-labs": true,
 		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/development.json
+++ b/config/development.json
@@ -230,7 +230,7 @@
 		"upgrades/upcoming-renewals-notices": true,
 		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
-		"wordpress-labs": true,
+		"wordpress-labs": false,
 		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -146,7 +146,7 @@
 		"use-translation-chunks": true,
 		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
-		"wordpress-labs": true,
+		"wordpress-labs": false,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -146,6 +146,7 @@
 		"use-translation-chunks": true,
 		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
+		"wordpress-labs": true,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",

--- a/config/production.json
+++ b/config/production.json
@@ -182,6 +182,7 @@
 		"use-translation-chunks": true,
 		"wordpress-agent-slack": false,
 		"wordpress-ai-tools": true,
+		"wordpress-labs": false,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "a4f69f6759",

--- a/config/stage.json
+++ b/config/stage.json
@@ -181,6 +181,7 @@
 		"use-translation-chunks": true,
 		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
+		"wordpress-labs": true,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",

--- a/config/stage.json
+++ b/config/stage.json
@@ -181,7 +181,7 @@
 		"use-translation-chunks": true,
 		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
-		"wordpress-labs": true,
+		"wordpress-labs": false,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",

--- a/config/test.json
+++ b/config/test.json
@@ -124,6 +124,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"wordpress-agent-slack": true,
+		"wordpress-labs": true,
 		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/test.json
+++ b/config/test.json
@@ -124,7 +124,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"wordpress-agent-slack": true,
-		"wordpress-labs": true,
+		"wordpress-labs": false,
 		"wpcom-user-bootstrap": false
 	}
 }

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -183,7 +183,7 @@
 		"use-translation-chunks": true,
 		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
-		"wordpress-labs": true,
+		"wordpress-labs": false,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -183,6 +183,7 @@
 		"use-translation-chunks": true,
 		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
+		"wordpress-labs": true,
 		"wpcom-user-bootstrap": true
 	},
 	"siftscience_key": "e00e878351",

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -5,6 +5,11 @@ export interface HostingDashboardOptIn {
 	updated_at: string; // ISO date string
 }
 
+export interface WordPressLabsOptIn {
+	value: 'unset' | 'opt-in' | 'opt-out';
+	updated_at: string; // ISO date string
+}
+
 export interface LandingPagePreference {
 	updatedAt: number; // Result of Date.now()
 }
@@ -35,6 +40,8 @@ export interface UserPreferences {
 	[ key: `hosting-dashboard-time-mismatch-warning-dismissed-${ number }` ]: string | undefined; // Timestamp when the user dismissed the notice
 	[ key: `hosting-dashboard-wp-beta-notice-dismissed-${ number }` ]: string | undefined; // ISO timestamp when the user dismissed the beta notice for a site
 	'hosting-dashboard-welcome-notice-dismissed'?: string; // Timestamp when the user dismissed the notice
+	'wordpress-labs-opt-in'?: WordPressLabsOptIn;
+	'wordpress-labs-excluded-sites'?: number[]; // Site IDs excluded from an otherwise-opted-in account
 	'account-recovery-interstitial-snoozed-until'?: number; // Unix timestamp (seconds) until which the account-recovery interstitial is snoozed; 0/unset means "never snoozed"
 	'account-recovery-interstitial-dismiss-count'?: number; // How many times the user has dismissed the account-recovery interstitial; capped so we stop nudging after a few dismissals
 	'reader-landing-page'?: ReaderLandingPage;

--- a/packages/api-queries/src/__tests__/me-preferences.test.ts
+++ b/packages/api-queries/src/__tests__/me-preferences.test.ts
@@ -36,6 +36,15 @@ describe( 'user preference mutation meta', () => {
 		).toBe( 'user-pref-update.cncofr' );
 	} );
 
+	it( 'uses short codes for wordpress labs preferences', () => {
+		expect( getPreferenceMutationStatId( 'wordpress-labs-opt-in' ) ).toBe(
+			'user-pref-update.wplabin'
+		);
+		expect( getPreferenceOptimisticMutationStatId( 'wordpress-labs-excluded-sites' ) ).toBe(
+			'user-pref-opt-update.wplabex'
+		);
+	} );
+
 	it( 'uses an other bucket for unknown preference keys', () => {
 		expect(
 			getPreferenceMutationStatId( 'experimental-preference' as keyof UserPreferences )
@@ -53,6 +62,8 @@ describe( 'user preference mutation meta', () => {
 			'hosting-dashboard-overview-storage-notice-dismissed-123',
 			'hosting-dashboard-time-mismatch-warning-dismissed-123',
 			'cancellation-offer-accepted-notice-dismissed-123',
+			'wordpress-labs-opt-in',
+			'wordpress-labs-excluded-sites',
 			'experimental-preference' as keyof UserPreferences,
 		];
 

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -10,6 +10,8 @@ const defaultValues: Required< UserPreferences > = {
 	'hosting-dashboard-opt-in': { value: 'unset', updated_at: '' },
 	'hosting-dashboard-opt-in-welcome-modal-dismissed': '',
 	'hosting-dashboard-welcome-notice-dismissed': '',
+	'wordpress-labs-opt-in': { value: 'unset', updated_at: '' },
+	'wordpress-labs-excluded-sites': [],
 	'account-recovery-interstitial-snoozed-until': 0,
 	'account-recovery-interstitial-dismiss-count': 0,
 	'reader-landing-page': {
@@ -36,6 +38,8 @@ const staticPreferenceStatIds: Record< string, string > = {
 	'hosting-dashboard-opt-in': 'optin',
 	'hosting-dashboard-opt-in-welcome-modal-dismissed': 'optwelc',
 	'hosting-dashboard-welcome-notice-dismissed': 'welcome',
+	'wordpress-labs-opt-in': 'wplabin',
+	'wordpress-labs-excluded-sites': 'wplabex',
 	'account-recovery-interstitial-snoozed-until': 'acctrec',
 	'account-recovery-interstitial-dismiss-count': 'acrdis',
 	'reader-landing-page': 'rdland',


### PR DESCRIPTION
## Summary

Implements [DOTPROD-158](https://linear.app/a8c/issue/DOTPROD-158/add-wordpress-labs-entry-point-and-settings-page-in-preferences): a new "Early access" entry point in `/me/preferences` and a dedicated WordPress Labs settings page, per the initial opt-in scope of the [WordPress Labs opt-in](https://linear.app/a8c/project/wordpress-labs-opt-in-e861c61ee2e4/overview) project.

- **Entry point row** — "Early access" row in Preferences with a custom test-tube icon (per design feedback in the Linear thread — explicitly not the AI icon), badge shows Enabled/Disabled.
- **WordPress Labs page** — explains the purpose, an enable toggle, and the approved confirmation copy ("You're in! Every site for which you are an Administrator has been opted into WordPress Labs...").
- **Site exception list** — lets a user remove specific sites from an otherwise account-wide opt-in, following the same pattern as the existing "AI and MCP" site-exceptions UI.
- **Storage** — two new keys on the existing generic `/me/preferences` mechanism (`wordpress-labs-opt-in`, `wordpress-labs-excluded-sites`), no new backend endpoint needed, mirroring `hosting-dashboard-opt-in`.
- Gated behind a `wordpress-labs` feature flag (on in dev/wpcalypso/horizon/stage/test, off in production).

Out of scope for this PR (tracked separately): the actual Labs feature list/gating (DOTPROD-175), sunsetting the "I am a developer" checkbox (DOTPROD-177), and a backend user-attribute/list for opted-in users (parent project scope item #4, no linked issue yet).

## Test plan

- [x] `yarn typecheck-client` — clean (no `wordpress-labs`-related errors)
- [x] `yarn eslint` on all touched files — 0 errors
- [x] New unit tests for the Preferences entry-point component pass; existing `me-preferences` stat-id tests updated and pass
- [x] Manually verified locally: `/me/preferences` shows "Early access", opening it shows the toggle, confirmation message, and site exceptions list working as expected