### PR TITLE
Site Spec: point Calypso at 1.15.0

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -226,7 +226,7 @@
 	"blackbox_url": "https://blackbox-api.wp.com/v1/dist/v.js",
 	"blackbox_api_key": "1b4f123e7dae4d83bbd18170c4358f8e",
 	"site_spec": {
-		"script_url": "https://widgets.wp.com/site-spec/v1.13.3/index.js",
-		"css_url": "https://widgets.wp.com/site-spec/v1.13.3/style.css"
+		"script_url": "https://widgets.wp.com/site-spec/v1.15.0/index.js",
+		"css_url": "https://widgets.wp.com/site-spec/v1.15.0/style.css"
 	}
 }


### PR DESCRIPTION
Points Calypso's Site Spec widget at **1.15.0**, live on the CDN as of 234574-ghe-Automattic/wpcom

### Proposed Changes

* `config/_shared.json` — `site_spec.script_url` / `css_url` move from `v1.13.3` to `v1.15.0`.

Calypso had drifted behind the other consumers (Big Sky and the AI landing page were both on 1.14.0); this brings all three onto the same bundle.

### Why are these changes being made?

1.15.0 is the blueprint onboarding release (305-ghe-Automattic/site-spec). The widget forwards a blueprint identifier to the agent as `metadata.blueprint_id` so blueprint builds get an interview shaped by what the blueprint already provides, auto-starts that interview so the user lands on a question instead of an empty prompt, and opens with a static line explaining the site is already being built.

Calypso only sends that identifier on blueprint builds (`getBlueprintSiteSpecConfig`), so every other flow through the site-spec step is unaffected: same landing screen, no auto-start, no opening line.

Also included since 1.13.3: whatever shipped in 1.14.0, plus fixes in 1.15.0 for a `?prompt=` URL losing its prompt when a blueprint was also present, and onboarding funnel events recording completions without starts.

### Testing Instructions

1. `/setup/ai-site-builder-spec/site-spec` — the standard flow. Widget loads from `widgets.wp.com/site-spec/v1.15.0/`; landing screen, no auto-start, interview behaves as before.
2. CIAB and early-provision entries into the same step — unchanged.
3. Blueprint build (`?blueprint_archive_import=1&blueprint_slug=…`) — the agent opens the conversation with a blueprint-specific question, under a static intro line.
4. A URL carrying both a blueprint and `?prompt=` — the prompt is sent, and auto-start stands down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
