### PR TITLE
Agents Manager: gate the selected-block chip on the provider capability

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -244,13 +244,20 @@ describe( 'AgentChat', () => {
 
 	it( 'renders the selected-block chip only on editor pages', async () => {
 		document.body.classList.add( 'post-php', 'post-type-post' );
-		renderAgentChat();
+		renderAgentChat( { showSelectedBlock: true } );
 		await waitFor( () => expect( mockSelectedBlock ).toHaveBeenCalled() );
 
 		mockSelectedBlock.mockClear();
 		document.body.className = '';
-		renderAgentChat();
+		renderAgentChat( { showSelectedBlock: true } );
 		// The lazy chunk resolves in a microtask — flush before asserting absence.
+		await act( () => Promise.resolve() );
+		expect( mockSelectedBlock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'hides the selected-block chip when the host does not forward the selection', async () => {
+		document.body.classList.add( 'post-php', 'post-type-post' );
+		renderAgentChat();
 		await act( () => Promise.resolve() );
 		expect( mockSelectedBlock ).not.toHaveBeenCalled();
 	} );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -35,6 +35,7 @@ const mockAgentChat = jest.fn(
 		inputValue?: string;
 		onInputChange?: ( value: string ) => void;
 		emptyViewSuggestions?: Suggestion[];
+		showSelectedBlock?: boolean;
 	} ) => (
 		<>
 			<button
@@ -1033,6 +1034,14 @@ describe( 'OrchestratorChat', () => {
 		fireEvent.click( screen.getByText( 'Stop' ) );
 
 		expect( abortCurrentRequest ).toHaveBeenCalled();
+	} );
+
+	it( 'shows the selected-block chip only when a provider forwards the block selection', () => {
+		render( chat( { capabilities: { forwardsBlockSelection: true } } ) );
+		expect( mockAgentChat.mock.calls.at( -1 )![ 0 ].showSelectedBlock ).toBe( true );
+
+		render( chat() );
+		expect( mockAgentChat.mock.calls.at( -1 )![ 0 ].showSelectedBlock ).toBe( false );
 	} );
 
 	it( 'drops a same-tick duplicate send before upload state propagates', async () => {

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -110,6 +110,11 @@ interface Props {
 	onContextCardAction?: ( card: ExternalContextCard, action: ExternalContextCardAction ) => void;
 	/** Called when a context card's dismiss button is clicked. */
 	onContextCardDismiss?: ( card: ExternalContextCard ) => void;
+	/**
+	 * Shows the selected-block chip above the input. Only hosts whose context
+	 * provider forwards the block selection should enable it.
+	 */
+	showSelectedBlock?: boolean;
 }
 
 // Carries the block-editor stack, so it loads on demand — and only on editor
@@ -191,6 +196,7 @@ export default function AgentChat( {
 	complianceDisclosure,
 	onContextCardAction,
 	onContextCardDismiss,
+	showSelectedBlock = false,
 }: Props ) {
 	const { setFloatingPosition, setFreeDragPosition, setFloatingSize } =
 		useDispatch( AGENTS_MANAGER_STORE );
@@ -372,7 +378,7 @@ export default function AgentChat( {
 								dropZoneRef={ conversationViewRef as RefObject< HTMLElement > }
 							/>
 						) }
-						{ isEditorPage() && <SelectedBlock /> }
+						{ showSelectedBlock && isEditorPage() && <SelectedBlock /> }
 						{ /* `readOnly` (not `disabled`) so the stop button stays active while a batch uploads. */ }
 						{ /* Disabling the input takes BOTH props: agenttic forwards `readOnly` to the
 						     textarea but consumes `disabled` only to gate the submit button and

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -1081,6 +1081,7 @@ export default function OrchestratorChat( {
 			onCancelFeedback={ resetFeedback }
 			onContextCardAction={ handleContextCardAction }
 			onContextCardDismiss={ dismissContextCard }
+			showSelectedBlock={ capabilities?.forwardsBlockSelection === true }
 		/>
 	);
 }

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -90,14 +90,15 @@ describe( 'mergeCapabilitiesInto', () => {
 		}
 	);
 
-	it.each( [ 'supportsSplitScreen', 'supportsRegenerateAction' ] as const )(
-		'sets %s when the provider declares it',
-		( flag ) => {
-			const merged: ProviderCapabilities = {};
-			mergeCapabilitiesInto( merged, { [ flag ]: true } );
-			expect( merged[ flag ] ).toBe( true );
-		}
-	);
+	it.each( [
+		'supportsSplitScreen',
+		'supportsRegenerateAction',
+		'forwardsBlockSelection',
+	] as const )( 'sets %s when the provider declares it', ( flag ) => {
+		const merged: ProviderCapabilities = {};
+		mergeCapabilitiesInto( merged, { [ flag ]: true } );
+		expect( merged[ flag ] ).toBe( true );
+	} );
 
 	it( 'leaves supportsSplitScreen unset when the provider declares false', () => {
 		const merged: ProviderCapabilities = {};

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -149,6 +149,12 @@ export interface ProviderCapabilities {
 	supportsSplitScreen?: boolean;
 	/** Adds Agenttic's built-in regenerate action to agent messages when true. */
 	supportsRegenerateAction?: boolean;
+	/**
+	 * Shows the selected-block chip above the chat input when true. Declare it
+	 * only if `contextProvider.getClientContext()` forwards the block selection;
+	 * otherwise the chip promises the agent context that is never sent.
+	 */
+	forwardsBlockSelection?: boolean;
 }
 
 /**
@@ -167,6 +173,9 @@ export function mergeCapabilitiesInto( merged: ProviderCapabilities, capabilitie
 	}
 	if ( caps.supportsRegenerateAction === true ) {
 		merged.supportsRegenerateAction = true;
+	}
+	if ( caps.forwardsBlockSelection === true ) {
+		merged.forwardsBlockSelection = true;
 	}
 }
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -1226,6 +1226,9 @@ export const capabilities = {
 	supportsSplitScreen: true,
 	// Flip to `true` to enable regenerate in the Jetpack AI sidebar.
 	supportsRegenerateAction: false,
+	// `contextProvider.getClientContext()` sends `selectedBlockClientId` and the
+	// `selected-block-content` context entry.
+	forwardsBlockSelection: true,
 };
 
 /**


### PR DESCRIPTION
## Proposed Changes

* Add a `forwardsBlockSelection` flag to `ProviderCapabilities` in `packages/agents-manager/src/utils/load-external-providers.ts`, OR-merged across providers like the existing capability flags.
* `AgentChat` renders the selected-block chip only when the new `showSelectedBlock` prop is true; `OrchestratorChat` passes `capabilities?.forwardsBlockSelection === true`. The existing `isEditorPage()` gate still applies.
* `packages/jetpack-ai-sidebar` declares the capability, so its chip behavior is unchanged.

## Why are these changes being made?

**Symptom:** in the post editor, the AI chat sidebar showed a "selected block" chip above the message input while the agent answered that no block was selected. Confirmed from request traces.

**Root cause:** the chip (`components/selected-block`) reads the block editor directly via `select( blockEditorStore ).getSelectedBlock()`, so it renders whenever any block is selected, regardless of the active host provider. What actually sends the selection is the host's `contextProvider.getClientContext()`. jetpack-ai-sidebar sends `selectedBlockClientId` and a `selected-block-content` context entry; other providers (for example the WooCommerce AI provider, which lives in another repo) return `environment: 'wp-admin'` with no Gutenberg data and feed page context through the separate `setExternalContextEntry()` registry. Chip visible, payload empty.

**Why a capability flag rather than probing the provider at render time:** the chat components do not receive the context provider, and `getClientContext()` is not safe to call speculatively — the jetpack-ai-sidebar implementation serializes the whole block tree and consumes a one-shot "suppress current page content" flag as a side effect. Capabilities already flow to the chat components (`supportsSplitScreen`, `supportsRegenerateAction`), so gating on one adds no new plumbing.

Whether the WooCommerce AI provider should forward the block selection at all is a separate product decision, left to that team. Once a provider does forward it, it declares `forwardsBlockSelection: true` and the chip returns.

## Testing Instructions

* Post editor or site editor with the Jetpack AI / Big Sky sidebar: select a block. The chip appears above the input as before, the clear button still clears the selection, and the agent still acts on the selected block.
* Any host whose provider does not declare the capability: select a block in the editor; no chip is rendered. You can try it with a self-hosted Woo AI site.