### PR TITLE
Reader: enable reader/shelves feature flag in non-production envs

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -188,7 +188,7 @@
 		"push-notifications": true,
 		"resurrected-users/90-day-eligibility": true,
 		"reader/social": true,
-		"reader/shelves": false,
+		"reader/shelves": true,
 		"reader/full-errors": true,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -111,7 +111,7 @@
 		"purchases/split-cancel-remove": false,
 		"resurrected-users/90-day-eligibility": true,
 		"reader/social": true,
-		"reader/shelves": false,
+		"reader/shelves": true,
 		"reader/full-errors": false,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -140,7 +140,7 @@
 		"push-notifications": true,
 		"resurrected-users/90-day-eligibility": true,
 		"reader/social": true,
-		"reader/shelves": false,
+		"reader/shelves": true,
 		"reader/full-errors": false,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": true,

--- a/config/test.json
+++ b/config/test.json
@@ -100,7 +100,7 @@
 		"purchases/split-cancel-remove": false,
 		"resurrected-users/90-day-eligibility": true,
 		"reader/social": true,
-		"reader/shelves": false,
+		"reader/shelves": true,
 		"reader/full-errors": true,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -142,7 +142,7 @@
 		"purchases/split-cancel-remove": false,
 		"resurrected-users/90-day-eligibility": true,
 		"reader/social": true,
-		"reader/shelves": false,
+		"reader/shelves": true,
 		"reader/full-errors": true,
 		"reader/msd-enabled": true,
 		"reader/onboarding-rsm": true,


### PR DESCRIPTION
## Proposed Changes

* Flip the `reader/shelves` feature flag from `false` to `true` in `config/development.json`, `config/test.json`, `config/wpcalypso.json`, `config/stage.json`, and `config/horizon.json`.
* `config/production.json` is left untouched (still `false`).

## Why are these changes being made?

* The Reader Shelves feature (dark-shipped behind `reader/shelves`) needs to be testable in dev and staging-like environments ahead of a production rollout.

## Testing Instructions

### Scenario 1 - Shelves visible in the Reader sidebar:
- Go to `/reader`
- Check if you can see the Shelves entry point in the Reader sidebar

### Scenario 2 - Shelves subscribe flow:
- Go to `/reader/shelves`
- Check if the shelf page loads instead of redirecting away

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?