### PR TITLE
WPCOM Siteless purchases: Fix broken manage purchase link on the post-checkout thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/generic.tsx
@@ -3,6 +3,7 @@ import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import ThankYouV2 from 'calypso/components/thank-you-v2';
 import ThankYouProduct from 'calypso/components/thank-you-v2/product';
+import { purchasesRoot } from 'calypso/me/purchases/paths';
 import { useSelector } from 'calypso/state';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -25,6 +26,10 @@ export default function GenericThankYou( { purchases, emailAddress }: GenericTha
 	const siteId = useSelector( getSelectedSiteId );
 	const currentRoute = useSelector( getCurrentRoute );
 	const [ , predicate ] = getDomainPurchaseTypeAndPredicate( purchases );
+
+	// Siteless checkout (e.g. `/checkout/wpcom/:productSlug`) has no site in context, so the
+	// site-scoped subscriptions route would resolve to a nonexistent site.
+	const managePurchaseUrl = siteSlug ? `/purchases/subscriptions/${ siteSlug }` : purchasesRoot;
 
 	// When users purchase a domain registration, we'll have two separate purchase items in the list,
 	// one for domain registration and one for domain mapping. This filter ensures we exclude the redundant
@@ -68,11 +73,7 @@ export default function GenericThankYou( { purchases, emailAddress }: GenericTha
 			<ThankYouProduct
 				key={ purchase.productSlug }
 				name={ purchase.productName }
-				actions={
-					<Button href={ `/purchases/subscriptions/${ siteSlug }` }>
-						{ translate( 'Manage purchase' ) }
-					</Button>
-				}
+				actions={ <Button href={ managePurchaseUrl }>{ translate( 'Manage purchase' ) }</Button> }
 			/>
 		);
 	} );

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/test/generic.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/test/generic.tsx
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+import { PRODUCT_STUDIO_CODE_AI_CREDITS } from '@automattic/api-core';
+import { render, screen } from '@testing-library/react';
+import GenericThankYou from '../pages/generic';
+import type { ReceiptPurchase } from 'calypso/state/receipts/types';
+
+let mockSelectedSiteSlug: string | null = null;
+
+jest.mock( 'calypso/state', () => ( {
+	useSelector: ( selector: () => unknown ) => selector(),
+} ) );
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSiteSlug: () => mockSelectedSiteSlug,
+	getSelectedSiteId: () => null,
+} ) );
+jest.mock( 'calypso/state/selectors/get-current-route', () => () => '/checkout/thank-you' );
+
+// A product with no thank-you page of its own, which is what falls through to the generic
+// "Manage purchase" button.
+const purchase = {
+	productSlug: PRODUCT_STUDIO_CODE_AI_CREDITS,
+	productName: 'Studio Code AI Credits',
+} as ReceiptPurchase;
+
+describe( 'GenericThankYou', () => {
+	it( 'points "Manage purchase" at the site subscriptions page when a site is selected', () => {
+		mockSelectedSiteSlug = 'example.wordpress.com';
+
+		render( <GenericThankYou purchases={ [ purchase ] } /> );
+
+		expect( screen.getByRole( 'link', { name: 'Manage purchase' } ) ).toHaveAttribute(
+			'href',
+			'/purchases/subscriptions/example.wordpress.com'
+		);
+	} );
+
+	it( 'points "Manage purchase" at the account purchases list for siteless checkout', () => {
+		mockSelectedSiteSlug = null;
+
+		render( <GenericThankYou purchases={ [ purchase ] } /> );
+
+		expect( screen.getByRole( 'link', { name: 'Manage purchase' } ) ).toHaveAttribute(
+			'href',
+			'/me/purchases'
+		);
+	} );
+} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2416/wpcom-siteless-purchases-fix-broken-manage-purchase-link-on-the-post

## Proposed Changes

When you make a siteless purchase on WordPress.com (currently only Studio Code AI Credits) the "Manage purchase" link on the post-checkout thank you page is currently broken -- it tries to take you to the page for managing all purchases on the site, but since the purchase isn't associated with a real site, it basically just links to `/purchases/subscriptions/null` instead.

This pull request fixes it by changing the link to point to the user-level purchase management page instead.

## Testing Instructions

Go to `/checkout/wpcom/studio-code-ai-credits:-q-11000` and proceed with making a purchase.  Make sure that clicking on the "Manage purchase" link on the thank you page takes you to a sensible place.