### PR TITLE
Backup restore: warn when a database restore may re-charge WooCommerce Subscriptions renewals

### DIFF
--- a/client/dashboard/sites/backup-restore/form.tsx
+++ b/client/dashboard/sites/backup-restore/form.tsx
@@ -9,6 +9,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
+import WooSubscriptionsNotice from './woo-subscriptions-notice';
 import type { RestoreConfig } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 
@@ -136,6 +137,12 @@ function SiteBackupRestoreForm( {
 				<Notice variant="info" title={ __( 'Important' ) }>
 					{ restoreWarning }
 				</Notice>
+
+				<WooSubscriptionsNotice
+					siteId={ siteId }
+					rewindId={ rewindId }
+					includesDatabase={ !! formData.sqls }
+				/>
 
 				<ButtonStack justify="flex-start">
 					<Button

--- a/client/dashboard/sites/backup-restore/granular-form.tsx
+++ b/client/dashboard/sites/backup-restore/granular-form.tsx
@@ -10,6 +10,7 @@ import { ButtonStack } from '../../components/button-stack';
 import Notice from '../../components/notice';
 import { Text } from '../../components/text';
 import FileSectionPanelBody from './file-section-panel-body';
+import WooSubscriptionsNotice from './woo-subscriptions-notice';
 
 function SiteBackupGranularRestoreForm( {
 	siteId,
@@ -100,6 +101,12 @@ function SiteBackupGranularRestoreForm( {
 				<Notice variant="info" title={ __( 'Important' ) }>
 					{ restoreWarning }
 				</Notice>
+
+				<WooSubscriptionsNotice
+					siteId={ siteId }
+					rewindId={ rewindId }
+					includesDatabase={ hasSelectedTables }
+				/>
 
 				<ButtonStack justify="flex-start">
 					<Button

--- a/client/dashboard/sites/backup-restore/woo-subscriptions-notice.tsx
+++ b/client/dashboard/sites/backup-restore/woo-subscriptions-notice.tsx
@@ -1,0 +1,55 @@
+import {
+	BACKUP_PLUGINS_PATH,
+	WOOCOMMERCE_SUBSCRIPTIONS_PLUGIN_SLUG,
+	selectBackupIncludesPlugin,
+	siteBackupContentsQuery,
+} from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { ExternalLink } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import Notice from '../../components/notice';
+
+const SUPPORT_URL = 'https://jetpack.com/support/getting-started-with-jetpack/known-issues/';
+
+/**
+ * Warns that restoring the database can re-run subscription renewals that were
+ * already charged after the restore point. See BACKUP-438.
+ *
+ * `includesDatabase` gates the notice: the duplicate-charge risk comes from
+ * reverting Action Scheduler tables and subscription postmeta, so a files-only
+ * restore is not affected.
+ */
+export default function WooSubscriptionsNotice( {
+	siteId,
+	rewindId,
+	includesDatabase,
+}: {
+	siteId: number;
+	rewindId: string;
+	includesDatabase: boolean;
+} ) {
+	const { data: hasWooSubscriptions } = useQuery( {
+		...siteBackupContentsQuery( siteId, Number( rewindId ), BACKUP_PLUGINS_PATH ),
+		select: selectBackupIncludesPlugin( WOOCOMMERCE_SUBSCRIPTIONS_PLUGIN_SLUG ),
+		enabled: !! siteId && !! rewindId && includesDatabase,
+	} );
+
+	if ( ! includesDatabase || ! hasWooSubscriptions ) {
+		return null;
+	}
+
+	return (
+		<Notice variant="warning" title={ __( 'This restore may charge your customers twice' ) }>
+			{ createInterpolateElement(
+				__(
+					'This backup includes WooCommerce Subscriptions. Renewals that were charged after the selected restore point will look unpaid again once the database is restored, and may be processed a second time. <link>Learn more</link>'
+				),
+				{
+					// @ts-expect-error children prop is injected by createInterpolateElement
+					link: <ExternalLink href={ SUPPORT_URL } />,
+				}
+			) }
+		</Notice>
+	);
+}

--- a/client/dashboard/sites/backup-restore/woo-subscriptions-notice.tsx
+++ b/client/dashboard/sites/backup-restore/woo-subscriptions-notice.tsx
@@ -10,7 +10,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import Notice from '../../components/notice';
 
-const SUPPORT_URL = 'https://jetpack.com/support/getting-started-with-jetpack/known-issues/';
+const SUPPORT_URL = 'https://jetpack.com/support/getting-started-with-jetpack/known-issues/#backup';
 
 /**
  * Warns that restoring the database can re-run subscription renewals that were

--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -47,6 +47,7 @@ import ProgressBar from './progress-bar';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
 import CheckYourEmail from './rewind-flow-notice/check-your-email';
 import MissingCredentials from './steps/missing-credentials';
+import WooSubscriptionsNotice from './woo-subscriptions-notice';
 import type { RestoreProgress } from 'calypso/state/data-layer/wpcom/activity-log/rewind/restore-status/type';
 import type { RewindState } from 'calypso/state/data-layer/wpcom/sites/rewind/type';
 
@@ -477,6 +478,11 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 					gridicon="notice"
 					title={ restoreWarning }
 					type={ RewindFlowNoticeLevel.WARNING }
+				/>
+				<WooSubscriptionsNotice
+					siteId={ siteId }
+					rewindId={ rewindId }
+					includesDatabase={ hasSelectedTables }
 				/>
 				<>
 					{ backupCurrentlyInProgress && (

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -47,6 +47,7 @@ import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
 import CheckYourEmail from './rewind-flow-notice/check-your-email';
 import MissingCredentials from './steps/missing-credentials';
 import { defaultRewindConfig, RewindConfig } from './types';
+import WooSubscriptionsNotice from './woo-subscriptions-notice';
 import type { RestoreProgress } from 'calypso/state/data-layer/wpcom/activity-log/rewind/restore-status/type';
 import type { RewindState } from 'calypso/state/data-layer/wpcom/sites/rewind/type';
 
@@ -296,6 +297,11 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					gridicon="notice"
 					title={ restoreWarning }
 					type={ RewindFlowNoticeLevel.WARNING }
+				/>
+				<WooSubscriptionsNotice
+					siteId={ siteId }
+					rewindId={ rewindId }
+					includesDatabase={ !! rewindConfig.sqls }
 				/>
 				<>
 					{ backupCurrentlyInProgress && (

--- a/client/my-sites/backup/rewind-flow/rewind-flow-notice/index.tsx
+++ b/client/my-sites/backup/rewind-flow/rewind-flow-notice/index.tsx
@@ -1,4 +1,5 @@
 import { Gridicon } from '@automattic/components';
+import clsx from 'clsx';
 import type { TranslateResult } from 'i18n-calypso';
 import type { FunctionComponent } from 'react';
 
@@ -35,6 +36,14 @@ const RewindFlowNotice: FunctionComponent< Props > = ( {
 		}
 	};
 
+	// The level also goes on the wrapper so the whole notice, not just its
+	// heading, can carry a tinted background.
+	const levelClassName = {
+		[ RewindFlowNoticeLevel.NOTICE ]: 'is-notice',
+		[ RewindFlowNoticeLevel.WARNING ]: 'is-warning',
+		[ RewindFlowNoticeLevel.REMINDER ]: 'is-reminder',
+	}[ type ];
+
 	const renderLink = () => (
 		<a className={ getTitleClassName() } href={ link } target="_blank" rel="noopener noreferrer">
 			<Gridicon icon={ gridicon } />
@@ -50,7 +59,7 @@ const RewindFlowNotice: FunctionComponent< Props > = ( {
 	);
 
 	return (
-		<div className="rewind-flow-notice">
+		<div className={ clsx( 'rewind-flow-notice', levelClassName ) }>
 			{ link ? renderLink() : renderNonLink() }
 			{ message && <p>{ message }</p> }
 		</div>

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -96,9 +96,7 @@ input.rewind-flow__rewind-config-editor-checkbox.form-checkbox {
 	margin-top: 24px;
 	padding: 16px;
 	border-radius: 4px;
-	// Tinted against whatever is behind it rather than a fixed color, so the
-	// notice follows the active color scheme instead of needing a dark override.
-	background-color: color-mix(in srgb, var(--color-neutral) 6%, transparent);
+	background-color: var(--color-neutral-0);
 
 	// Consecutive notices read as separate cards, so they need less room between
 	// them than the first one needs from the content above.
@@ -145,7 +143,7 @@ input.rewind-flow__rewind-config-editor-checkbox.form-checkbox {
 }
 
 .rewind-flow-notice.is-warning {
-	background-color: color-mix(in srgb, var(--color-warning) 8%, transparent);
+	background-color: var(--color-warning-5);
 }
 
 // when the reminder is default make the header more bold

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -93,10 +93,15 @@ input.rewind-flow__rewind-config-editor-checkbox.form-checkbox {
 }
 
 .rewind-flow-notice {
+	// Mirrors the Dashboard Notice: a 4% wash of the status color. The --dashboard__*
+	// tokens only exist on dashboard roots, so these use the Studio values behind them.
+	--rewind-flow-notice__status-color: var(--studio-gray-50);
+	--rewind-flow-notice__icon-color: var(--studio-gray-50);
+
 	margin-top: 24px;
 	padding: 16px;
 	border-radius: 4px;
-	background-color: var(--color-neutral-0);
+	background-color: color-mix(in srgb, var(--rewind-flow-notice__status-color) 4%, transparent);
 
 	// Consecutive notices read as separate cards, so they need less room between
 	// them than the first one needs from the content above.
@@ -143,7 +148,8 @@ input.rewind-flow__rewind-config-editor-checkbox.form-checkbox {
 }
 
 .rewind-flow-notice.is-warning {
-	background-color: var(--color-warning-5);
+	--rewind-flow-notice__status-color: var(--studio-orange-40);
+	--rewind-flow-notice__icon-color: var(--studio-orange-50);
 }
 
 // when the reminder is default make the header more bold
@@ -167,11 +173,11 @@ div.rewind-flow-notice__title-warning,
 a.rewind-flow-notice__title-warning,
 a.rewind-flow-notice__title-warning:visited {
 	.gridicon {
-		fill: var(--color-warning-dark);
+		fill: var(--rewind-flow-notice__icon-color);
 	}
 
 	&:hover {
-		fill: var(--color-warning-dark);
+		fill: var(--rewind-flow-notice__icon-color);
 	}
 }
 

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -93,18 +93,30 @@ input.rewind-flow__rewind-config-editor-checkbox.form-checkbox {
 }
 
 .rewind-flow-notice {
-	margin-top: 32px;
+	margin-top: 24px;
+	padding: 16px;
+	border-radius: 4px;
+	// Tinted against whatever is behind it rather than a fixed color, so the
+	// notice follows the active color scheme instead of needing a dark override.
+	background-color: color-mix(in srgb, var(--color-neutral) 6%, transparent);
 
-	.gridicon {
-		margin-right: 5px;
+	// Consecutive notices read as separate cards, so they need less room between
+	// them than the first one needs from the content above.
+	+ .rewind-flow-notice {
+		margin-top: 8px;
 	}
 
-	// the component renders a top-level a or div, depending on if it is a link or not
-	a,
-	div {
+	.gridicon {
+		margin-inline-end: 5px;
+		flex-shrink: 0;
+	}
+
+	// the component renders a top-level a or div, depending on if it is a link or not.
+	// Direct children only: a link inside the message must stay inline.
+	> a,
+	> div {
 		display: flex;
 		flex-direction: row;
-		margin-bottom: 16px;
 		width: fit-content;
 	}
 
@@ -118,14 +130,22 @@ input.rewind-flow__rewind-config-editor-checkbox.form-checkbox {
 	p {
 		margin: 0;
 	}
-	a {
+
+	> p {
+		margin-top: 4px;
+	}
+
+	> a {
 		align-items: center;
-		display: flex;
 	}
 
 	h4 {
 		text-wrap: wrap;
 	}
+}
+
+.rewind-flow-notice.is-warning {
+	background-color: color-mix(in srgb, var(--color-warning) 8%, transparent);
 }
 
 // when the reminder is default make the header more bold

--- a/client/my-sites/backup/rewind-flow/style.scss
+++ b/client/my-sites/backup/rewind-flow/style.scss
@@ -167,11 +167,11 @@ div.rewind-flow-notice__title-warning,
 a.rewind-flow-notice__title-warning,
 a.rewind-flow-notice__title-warning:visited {
 	.gridicon {
-		fill: var(--color-error);
+		fill: var(--color-warning-dark);
 	}
 
 	&:hover {
-		fill: var(--color-error-dark);
+		fill: var(--color-warning-dark);
 	}
 }
 

--- a/client/my-sites/backup/rewind-flow/woo-subscriptions-notice.tsx
+++ b/client/my-sites/backup/rewind-flow/woo-subscriptions-notice.tsx
@@ -1,0 +1,63 @@
+import {
+	BACKUP_PLUGINS_PATH,
+	WOOCOMMERCE_SUBSCRIPTIONS_PLUGIN_SLUG,
+	selectBackupIncludesPlugin,
+	siteBackupContentsQuery,
+} from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslate } from 'i18n-calypso';
+import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
+import type { FunctionComponent } from 'react';
+
+const SUPPORT_URL = 'https://jetpack.com/support/getting-started-with-jetpack/known-issues/';
+
+interface Props {
+	siteId: number;
+	rewindId: string;
+	/**
+	 * Whether the pending restore includes the database. The duplicate-charge
+	 * risk comes from reverting Action Scheduler tables and subscription
+	 * postmeta, so a files-only restore is not affected.
+	 */
+	includesDatabase: boolean;
+}
+
+/**
+ * Warns that restoring the database can re-run subscription renewals that were
+ * already charged after the restore point. See BACKUP-438.
+ */
+const WooSubscriptionsNotice: FunctionComponent< Props > = ( {
+	siteId,
+	rewindId,
+	includesDatabase,
+} ) => {
+	const translate = useTranslate();
+
+	const { data: hasWooSubscriptions } = useQuery( {
+		...siteBackupContentsQuery( siteId, Number( rewindId ), BACKUP_PLUGINS_PATH ),
+		select: selectBackupIncludesPlugin( WOOCOMMERCE_SUBSCRIPTIONS_PLUGIN_SLUG ),
+		enabled: !! siteId && !! rewindId && includesDatabase,
+	} );
+
+	if ( ! includesDatabase || ! hasWooSubscriptions ) {
+		return null;
+	}
+
+	return (
+		<RewindFlowNotice
+			gridicon="notice"
+			title={ translate( 'This restore may charge your customers twice.' ) }
+			message={ translate(
+				'This backup includes WooCommerce Subscriptions. Renewals that were charged after the selected restore point will look unpaid again once the database is restored, and may be processed a second time. {{a}}Learn more{{/a}}',
+				{
+					components: {
+						a: <a href={ SUPPORT_URL } target="_blank" rel="noopener noreferrer" />,
+					},
+				}
+			) }
+			type={ RewindFlowNoticeLevel.WARNING }
+		/>
+	);
+};
+
+export default WooSubscriptionsNotice;

--- a/client/my-sites/backup/rewind-flow/woo-subscriptions-notice.tsx
+++ b/client/my-sites/backup/rewind-flow/woo-subscriptions-notice.tsx
@@ -9,7 +9,7 @@ import { useTranslate } from 'i18n-calypso';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
 import type { FunctionComponent } from 'react';
 
-const SUPPORT_URL = 'https://jetpack.com/support/getting-started-with-jetpack/known-issues/';
+const SUPPORT_URL = 'https://jetpack.com/support/getting-started-with-jetpack/known-issues/#backup';
 
 interface Props {
 	siteId: number;

--- a/client/my-sites/backup/rewind-flow/woo-subscriptions-notice.tsx
+++ b/client/my-sites/backup/rewind-flow/woo-subscriptions-notice.tsx
@@ -46,7 +46,7 @@ const WooSubscriptionsNotice: FunctionComponent< Props > = ( {
 	return (
 		<RewindFlowNotice
 			gridicon="notice"
-			title={ translate( 'This restore may charge your customers twice.' ) }
+			title={ translate( 'This restore may charge your customers twice' ) }
 			message={ translate(
 				'This backup includes WooCommerce Subscriptions. Renewals that were charged after the selected restore point will look unpaid again once the database is restored, and may be processed a second time. {{a}}Learn more{{/a}}',
 				{

--- a/packages/api-queries/src/__tests__/site-backups.test.ts
+++ b/packages/api-queries/src/__tests__/site-backups.test.ts
@@ -70,4 +70,11 @@ describe( 'selectBackupIncludesPlugin', () => {
 			} )
 		).toBe( false );
 	} );
+
+	// The wpcom endpoint discards the VaultPress payload and returns a bare
+	// `array()` on any failure, so the client sees `[]` rather than `ok: false`.
+	// See sites-rewind-backup-ls.php::get_backup_contents().
+	it( 'returns false for the empty array wpcom returns on failure', () => {
+		expect( selectWooSubscriptions( [] as unknown as BackupContentsResponse ) ).toBe( false );
+	} );
 } );

--- a/packages/api-queries/src/__tests__/site-backups.test.ts
+++ b/packages/api-queries/src/__tests__/site-backups.test.ts
@@ -1,0 +1,73 @@
+import { selectBackupIncludesPlugin } from '../site-backups';
+import type { BackupContentsResponse } from '@automattic/api-core';
+
+const response = ( contents: BackupContentsResponse[ 'contents' ] ): BackupContentsResponse => ( {
+	ok: true,
+	error: '',
+	contents,
+} );
+
+const pluginEntry = ( label?: string ) => ( {
+	type: 'plugin' as const,
+	has_children: true,
+	...( label && { label } ),
+} );
+
+describe( 'selectBackupIncludesPlugin', () => {
+	const selectWooSubscriptions = selectBackupIncludesPlugin( 'woocommerce-subscriptions' );
+
+	it( 'matches the plugin directory slug', () => {
+		expect(
+			selectWooSubscriptions(
+				response( {
+					woocommerce: pluginEntry(),
+					'woocommerce-subscriptions': pluginEntry(),
+				} )
+			)
+		).toBe( true );
+	} );
+
+	it( 'matches on the slug even when the API supplies a display label', () => {
+		expect(
+			selectWooSubscriptions(
+				response( { 'woocommerce-subscriptions': pluginEntry( 'WooCommerce Subscriptions' ) } )
+			)
+		).toBe( true );
+	} );
+
+	it( 'does not match a display label that is not a key', () => {
+		expect(
+			selectWooSubscriptions( response( { akismet: pluginEntry( 'woocommerce-subscriptions' ) } ) )
+		).toBe( false );
+	} );
+
+	it( 'does not match a plugin whose slug merely contains the target', () => {
+		expect(
+			selectWooSubscriptions( response( { 'woocommerce-subscriptions-gifting': pluginEntry() } ) )
+		).toBe( false );
+	} );
+
+	it( 'ignores case', () => {
+		expect(
+			selectWooSubscriptions( response( { 'WooCommerce-Subscriptions': pluginEntry() } ) )
+		).toBe( true );
+	} );
+
+	it( 'returns false when the plugin is absent', () => {
+		expect( selectWooSubscriptions( response( { akismet: pluginEntry() } ) ) ).toBe( false );
+	} );
+
+	it( 'returns false for an empty listing', () => {
+		expect( selectWooSubscriptions( response( {} ) ) ).toBe( false );
+	} );
+
+	it( 'returns false when the request was not ok', () => {
+		expect(
+			selectWooSubscriptions( {
+				ok: false,
+				error: 'Backup not found',
+				contents: { 'woocommerce-subscriptions': pluginEntry() },
+			} )
+		).toBe( false );
+	} );
+} );

--- a/packages/api-queries/src/site-backups.ts
+++ b/packages/api-queries/src/site-backups.ts
@@ -17,17 +17,8 @@ export const BACKUP_PLUGINS_PATH = '/wp-content/plugins/';
 
 export const WOOCOMMERCE_SUBSCRIPTIONS_PLUGIN_SLUG = 'woocommerce-subscriptions';
 
-/**
- * Builds a `select` that reports whether a plugin directory is present in a
- * backup's plugin listing.
- *
- * Matches against the raw `contents` keys, which are the plugin directory
- * slugs. The file browser's parsed representation replaces those keys with the
- * API's display label ("WooCommerce Subscriptions"), so it can't be used for an
- * identity check.
- * @param slug - The plugin directory slug to look for.
- * @returns A `select` function for `siteBackupContentsQuery`.
- */
+// Matches on raw `contents` keys (directory slugs), not the API display labels
+// the file browser substitutes in their place.
 export const selectBackupIncludesPlugin =
 	( slug: string ) =>
 	( response: BackupContentsResponse ): boolean =>

--- a/packages/api-queries/src/site-backups.ts
+++ b/packages/api-queries/src/site-backups.ts
@@ -11,6 +11,30 @@ import {
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions } from '@tanstack/react-query';
 import { queryClient } from './query-client';
+import type { BackupContentsResponse } from '@automattic/api-core';
+
+export const BACKUP_PLUGINS_PATH = '/wp-content/plugins/';
+
+export const WOOCOMMERCE_SUBSCRIPTIONS_PLUGIN_SLUG = 'woocommerce-subscriptions';
+
+/**
+ * Builds a `select` that reports whether a plugin directory is present in a
+ * backup's plugin listing.
+ *
+ * Matches against the raw `contents` keys, which are the plugin directory
+ * slugs. The file browser's parsed representation replaces those keys with the
+ * API's display label ("WooCommerce Subscriptions"), so it can't be used for an
+ * identity check.
+ * @param slug - The plugin directory slug to look for.
+ * @returns A `select` function for `siteBackupContentsQuery`.
+ */
+export const selectBackupIncludesPlugin =
+	( slug: string ) =>
+	( response: BackupContentsResponse ): boolean =>
+		!! response?.ok &&
+		Object.keys( response.contents ?? {} ).some(
+			( name ) => name.toLowerCase() === slug.toLowerCase()
+		);
 
 export const siteLastBackupQuery = ( siteId: number ) =>
 	queryOptions( {


### PR DESCRIPTION
Part of BACKUP-438

## Proposed Changes

* Warn on the four restore confirmation screens (classic and Dashboard, full-site and granular) when the backup contains WooCommerce Subscriptions and the restore includes the database.
* Detect it by listing `/wp-content/plugins/` in the backup via the existing `siteBackupContentsQuery`, reusing the file browser's query key so the granular flow hits cache instead of refetching.

## Why are these changes being made?

A restore reverts Action Scheduler rows and subscription `_schedule_next_payment` postmeta to the snapshot state. Renewals that completed after the snapshot go back to `pending` with a past due time, so they re-run on restore and charge customers a second time for a period already paid.

It can't be fixed from the Subscriptions side — the evidence a renewal ran is exactly what the restore destroys. A durable fix needs an immutable "already charged" signal from Subscriptions (WOOSUBS-1896). This is the near-term guardrail.

Gated on the database being included, since a files-only restore can't revert Action Scheduler state.

## Testing Instructions

Needs a Backup-enabled site whose backup contains WooCommerce Subscriptions.

1. `/backup/<site-slug>/restore/<rewindId>` — with **Site database** checked the warning appears below the existing "Important" notice; unchecking it hides the warning.
2. Same on the Dashboard: `/sites/<site-slug>/backups/<rewindId>/restore`.
3. Granular equivalents (`/backup/<site-slug>/contents/<rewindId>`) warn when the selection includes tables.
4. On a site without the plugin, nothing changes from trunk.

Detection fails open: if the request is slow or fails the restore proceeds as before, and the button is never gated on it.

```
yarn test-packages packages/api-queries/src/__tests__/site-backups.test.ts
```

## Notes

* Not yet verified in a browser — no screenshots or dark-mode pass, pending a site that qualifies. Detection was confirmed against the VaultPress side (`vp-core/browser-functions.php` keys plugin entries by directory slug) rather than a live render.
* The one `@ts-expect-error` is the existing repo idiom for `createInterpolateElement` link children, same comment as in `site-reset-modal` and `settings-defensive-mode`.

<img width="1094" height="807" alt="Screenshot 2026-08-19 at 3 43 47 PM" src="https://github.com/user-attachments/assets/ed50079f-7dff-4e9a-9a1e-1c0580feadbd" />




## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

