### PR TITLE
Stepper: Remove step-by-step from Onboarding - quick removal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/use-show-onboarding-progress.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/use-show-onboarding-progress.test.tsx
@@ -16,10 +16,10 @@ describe( 'useShowOnboardingProgress', () => {
 		mockViewport.mockReset();
 	} );
 
-	it( 'shows on desktop onboarding', () => {
+	it( 'hides on desktop onboarding while the indicator is disabled', () => {
 		mockViewport.mockReturnValue( true );
 		const { result } = renderHook( () => useShowOnboardingProgress( true ) );
-		expect( result.current ).toBe( true );
+		expect( result.current ).toBe( false );
 	} );
 
 	it( 'hides when not onboarding flow', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/use-show-onboarding-progress.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/use-show-onboarding-progress.ts
@@ -1,6 +1,11 @@
 import { useViewportMatch } from '@wordpress/compose';
 
 /**
+ * Temporarily disabled — flip to false to bring the indicator back.
+ */
+const IS_ONBOARDING_PROGRESS_DISABLED = true;
+
+/**
  * Single source of truth for whether the onboarding progress indicator shows.
  *
  * Desktop-only. Mobile keeps the existing top-bar step counter.
@@ -8,5 +13,5 @@ import { useViewportMatch } from '@wordpress/compose';
 export function useShowOnboardingProgress( isOnboardingFlow: boolean ): boolean {
 	const isDesktop = useViewportMatch( 'large' );
 
-	return isOnboardingFlow && isDesktop;
+	return ! IS_ONBOARDING_PROGRESS_DISABLED && isOnboardingFlow && isDesktop;
 }


### PR DESCRIPTION
Slack thread: p1786736229907649-slack-C06FCT6EEHH

**Note**: This is a safe removal for EOD on Friday. We'll properly remove the code next week.


## Proposed Changes

* Temporarily disable the onboarding progress indicator shown on the domains and plans steps of the onboarding flow.
* The change is contained to `useShowOnboardingProgress` — the single gate both consumers (`domain-search` and `unified-plans`) use — via an `IS_ONBOARDING_PROGRESS_DISABLED` constant. Re-enabling is a one-line flip; no component code or call sites were touched.
* Updated the hook's unit tests to reflect the disabled state.

Note: while the indicator showed, it replaced the back button in the top bar on those steps. With it disabled, the regular back button returns, which is the expected behavior.

## Why are these changes being made?

* We want to turn off the onboarding progress step indicator for now with the smallest possible change, keeping the component and its tests in place so it can be easily re-enabled (or fully removed) later.

## Testing Instructions

1. Start the onboarding flow at `/setup/onboarding` on a desktop-sized viewport.
2. On the domains step, verify the progress indicator ("Domains → Plans → …") no longer renders above the search, and the back button appears in the top bar.
3. Continue to the plans step and verify the same there.
4. Unit tests: `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)