### PR TITLE
Login: support OAuth 2.1 client branding via oauth2_1_client_id

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -187,6 +187,7 @@ class Login extends Component {
 				locale: this.props.locale,
 				twoFactorAuthType: 'link',
 				oauth2ClientId: this.props.currentQuery?.client_id,
+				oauth21ClientId: this.props.currentQuery?.oauth2_1_client_id,
 				redirectTo: this.props.redirectTo,
 				usernameOnly: true,
 			};

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -510,6 +510,7 @@ export class LoginForm extends Component {
 							locale: this.props.locale,
 							action: this.props.isWooJPC ? 'jetpack/lostpassword' : 'lostpassword',
 							oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
+							oauth21ClientId: this.props.currentQuery?.oauth2_1_client_id,
 							from: this.props.currentQuery?.from,
 						} )
 					);
@@ -554,6 +555,7 @@ export class LoginForm extends Component {
 			currentRoute: this.props.currentRoute,
 			signupUrl: this.props.currentQuery?.signup_url,
 			oauth2ClientId: this.props.oauth2Client?.id,
+			oauth21ClientId: this.props.currentQuery?.oauth2_1_client_id,
 			emailAddress: usernameOrEmail || query?.email_address || this.state.usernameOrEmail,
 			redirectTo: this.props.redirectTo,
 			from: this.props.currentQuery?.from,

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -10,6 +10,7 @@ import {
 	isJetpackCloudOAuth2Client,
 	isWooOAuth2Client,
 	isIntenseDebateOAuth2Client,
+	isOAuth2_1Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 
@@ -130,7 +131,9 @@ export function getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, 
 		return `/start/wpcc?${ oauth2Params.toString() }`;
 	}
 
-	if ( oauth2Client ) {
+	// OAuth 2.1 clients have no 2.0 client ID, so there is no wpcc signup flow for
+	// them; fall through to the generic account signup with the same redirect_to.
+	if ( oauth2Client && ! isOAuth2_1Client( oauth2Client ) ) {
 		const oauth2Params = new URLSearchParams( {
 			oauth2_client_id: oauth2Client.id,
 			oauth2_redirect: redirectTo,

--- a/client/lib/login/test/index.js
+++ b/client/lib/login/test/index.js
@@ -154,6 +154,25 @@ describe( 'getSignupUrl', () => {
 		);
 	} );
 
+	test( 'should fall through to the generic account signup for OAuth 2.1 clients', () => {
+		// 2.1 clients have no 2.0 client ID, so there is no wpcc signup flow for them.
+		const currentQuery = {
+			oauth2_1_client_id: '7',
+			redirect_to:
+				'https://public-api.wordpress.com/oauth2-1/authorize/?client_id=7&response_type=code&redirect_uri=https%3A%2F%2Fchatgpt.com%2Fconnector_platform_oauth_redirect&from-calypso=1',
+		};
+		const currentRoute = '/log-in';
+		const oauth2Client = {
+			id: 'oauth2-1:7',
+			name: 'chatgpt',
+			title: 'ChatGPT',
+			icon: 'https://example.com/chatgpt.svg',
+		};
+		expect( getSignupUrl( currentQuery, currentRoute, oauth2Client, 'en', '' ) ).toEqual(
+			'/start/account?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2-1%2Fauthorize%2F%3Fclient_id%3D7%26response_type%3Dcode%26redirect_uri%3Dhttps%253A%252F%252Fchatgpt.com%252Fconnector_platform_oauth_redirect%26from-calypso%3D1'
+		);
+	} );
+
 	test( 'signup_flow modifies /start base', () => {
 		expect( getSignupUrl( { signup_flow: 'test' }, '/log-in', null, 'en', '' ) ).toEqual(
 			'/start/test'

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -1,5 +1,16 @@
 import { getQueryArg } from '@wordpress/url';
 
+// OAuth 2.1 (MCP) client IDs are issued from `oauth2_1_clients`, a separate
+// namespace to the OAuth 2.0 `oauth2_clients` table, and both count from 1. 2.1
+// client data is stored under a prefixed key so the two namespaces can never
+// collide in the Redux store.
+export const OAUTH2_1_CLIENT_ID_PREFIX = 'oauth2-1:';
+
+export const getOAuth2_1ClientKey = ( clientId ) => `${ OAUTH2_1_CLIENT_ID_PREFIX }${ clientId }`;
+
+export const isOAuth2_1Client = ( oauth2Client ) =>
+	typeof oauth2Client?.id === 'string' && oauth2Client.id.startsWith( OAUTH2_1_CLIENT_ID_PREFIX );
+
 // The WordPress and Jetpack mobile apps share the same OAuth2 client IDs; the app
 // identity is not encoded in the client_id. Distinguish the Jetpack app from the
 // WordPress app by the redirect_uri scheme (jetpack:// vs wordpress://).

--- a/client/lib/partner-branding.tsx
+++ b/client/lib/partner-branding.tsx
@@ -48,7 +48,7 @@ export interface PartnerConfig {
 	/** Domains that identify this partner in redirect URLs (e.g., ['my.woo.ai']) */
 	domains?: string[];
 	/** Callback to check if an OAuth2 client belongs to this partner */
-	isOAuth2Client?: ( oauth2Client: { id: number } | null ) => boolean;
+	isOAuth2Client?: ( oauth2Client: { id: number | string } | null ) => boolean;
 	/** Window title suffix used on branded auth flows */
 	windowTitleSuffix?: string;
 }
@@ -333,7 +333,7 @@ export function getPartnerConfigFromRedirectUrl(
  * Get partner config by matching an OAuth2 client against partner configs.
  */
 export function getPartnerConfigFromOAuth2Client(
-	oauth2Client: { id: number } | null | undefined
+	oauth2Client: { id: number | string } | null | undefined
 ): PartnerConfig | null {
 	if ( ! oauth2Client ) {
 		return null;
@@ -373,7 +373,11 @@ function getSearchParam( name: string ): string | null {
  *   4. redirect_to        — hostname inside ?redirect_to= URL
  *   5. session storage    — persisted partner from a previous detection in this session
  */
-export function detectPartnerConfig( oauth2Client?: { id: number } | null ): PartnerConfig | null {
+export function detectPartnerConfig(
+	oauth2Client?: {
+		id: number | string;
+	} | null
+): PartnerConfig | null {
 	const detected =
 		getPartnerConfigFromCurrentDomain() ??
 		getPartnerConfigFromBrandingCode() ??

--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -11,6 +11,7 @@ import { addQueryArgs } from 'calypso/lib/url';
 	emailAddress?: string;
 	socialService?: string;
 	oauth2ClientId?: string | number;
+	oauth21ClientId?: string | number;
 	wccomFrom?: string;
 	site?: string;
 	useMagicLink?: boolean;
@@ -32,6 +33,7 @@ export function login( {
 	emailAddress = undefined,
 	socialService = undefined,
 	oauth2ClientId = undefined,
+	oauth21ClientId = undefined,
 	wccomFrom = undefined,
 	site = undefined,
 	useMagicLink = undefined,
@@ -87,6 +89,10 @@ export function login( {
 
 	if ( oauth2ClientId && ! isNaN( oauth2ClientId ) ) {
 		url = addQueryArgs( { client_id: oauth2ClientId }, url );
+	}
+
+	if ( oauth21ClientId ) {
+		url = addQueryArgs( { oauth2_1_client_id: oauth21ClientId }, url );
 	}
 
 	if ( wccomFrom ) {

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -28,6 +28,11 @@ describe( 'login', () => {
 		expect( url ).toBe( '/log-in?client_id=12345' );
 	} );
 
+	test( 'should return the login url with encoded OAuth 2.1 client ID param', () => {
+		const url = login( { oauth21ClientId: 7 } );
+		expect( url ).toBe( '/log-in?oauth2_1_client_id=7' );
+	} );
+
 	test( 'should return the login url for Jetpack specific login', () => {
 		const url = login( { isJetpack: true } );
 		expect( url ).toBe( '/log-in/jetpack' );

--- a/client/lib/test/oauth2-clients.js
+++ b/client/lib/test/oauth2-clients.js
@@ -4,6 +4,8 @@ import {
 	isSharedMobileAppOAuth2Client,
 	getOAuth2RedirectUri,
 	isJetpackAppRedirectUri,
+	getOAuth2_1ClientKey,
+	isOAuth2_1Client,
 } from 'calypso/lib/oauth2-clients';
 
 describe( 'oauth2-clients mobile app helpers', () => {
@@ -88,6 +90,26 @@ describe( 'oauth2-clients mobile app helpers', () => {
 			expect( isJetpackAppRedirectUri( '' ) ).toBe( false );
 			expect( isJetpackAppRedirectUri( null ) ).toBe( false );
 			expect( isJetpackAppRedirectUri( undefined ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'getOAuth2_1ClientKey', () => {
+		test( 'prefixes the client id with the 2.1 namespace', () => {
+			expect( getOAuth2_1ClientKey( 7 ) ).toBe( 'oauth2-1:7' );
+			expect( getOAuth2_1ClientKey( '7' ) ).toBe( 'oauth2-1:7' );
+		} );
+	} );
+
+	describe( 'isOAuth2_1Client', () => {
+		test( 'is true for clients stored under a namespaced key', () => {
+			expect( isOAuth2_1Client( { id: 'oauth2-1:7' } ) ).toBe( true );
+		} );
+
+		test( 'is false for OAuth 2.0 clients and empty values', () => {
+			expect( isOAuth2_1Client( { id: 1854 } ) ).toBe( false );
+			expect( isOAuth2_1Client( { id: '1854' } ) ).toBe( false );
+			expect( isOAuth2_1Client( null ) ).toBe( false );
+			expect( isOAuth2_1Client( undefined ) ).toBe( false );
 		} );
 	} );
 } );

--- a/client/login/controller.jsx
+++ b/client/login/controller.jsx
@@ -1,11 +1,14 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
-import { isGravPoweredOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { isGravPoweredOAuth2Client, getOAuth2_1ClientKey } from 'calypso/lib/oauth2-clients';
 import { DesktopLoginStart, DesktopLoginFinalize } from 'calypso/login/desktop-login';
 import { SOCIAL_HANDOFF_CONNECT_ACCOUNT } from 'calypso/state/action-types';
 import { isUserLoggedIn, getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
+import {
+	fetchOAuth2ClientData,
+	fetchOAuth2_1ClientData,
+} from 'calypso/state/oauth2-clients/actions';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
 import { LocalizedMagicLogin } from './magic-login';
 import HandleEmailedLinkForm from './magic-login/handle-emailed-link-form';
@@ -74,7 +77,7 @@ const enhanceContextWithLogin = ( context ) => {
 
 export async function login( context, next ) {
 	const {
-		query: { client_id, redirect_to },
+		query: { client_id, oauth2_1_client_id, redirect_to },
 	} = context;
 
 	// Remove id_token from the address bar and push social connect args into the state instead
@@ -114,6 +117,34 @@ export async function login( context, next ) {
 				await context.store.dispatch( fetchOAuth2ClientData( client_id ) );
 			} catch ( error ) {
 				return next( error );
+			}
+		}
+	}
+
+	if ( oauth2_1_client_id ) {
+		if ( ! redirect_to ) {
+			const error = new Error( 'The `redirect_to` query parameter is missing.' );
+			error.status = 401;
+			return next( error );
+		}
+
+		// The authorize URL inside redirect_to carries the OAuth 2.1 client_id.
+		const { searchParams: redirectParams } = getUrlParts( redirect_to );
+
+		if ( oauth2_1_client_id !== redirectParams.get( 'client_id' ) ) {
+			const error = new Error(
+				'The `redirect_to` query parameter is invalid with the given `oauth2_1_client_id`.'
+			);
+			error.status = 401;
+			return next( error );
+		}
+
+		const clientKey = getOAuth2_1ClientKey( oauth2_1_client_id );
+		if ( ! getOAuth2Client( context.store.getState(), clientKey ) ) {
+			try {
+				await context.store.dispatch( fetchOAuth2_1ClientData( oauth2_1_client_id ) );
+			} catch {
+				// The endpoint 404s for unknown or untrusted clients; render unbranded.
 			}
 		}
 	}

--- a/client/login/ssr.js
+++ b/client/login/ssr.js
@@ -3,7 +3,7 @@ import { ssrSetupLocale } from 'calypso/controller';
 import { setDocumentHeadMeta } from 'calypso/state/document-head/actions';
 import { getDocumentHeadMeta } from 'calypso/state/document-head/selectors';
 
-const VALID_QUERY_KEYS = [ 'client_id', 'signup_flow', 'redirect_to' ];
+const VALID_QUERY_KEYS = [ 'client_id', 'oauth2_1_client_id', 'signup_flow', 'redirect_to' ];
 
 /**
  * A middleware that enables (or disables) server side rendering for the /log-in page.

--- a/client/login/test/controller.js
+++ b/client/login/test/controller.js
@@ -1,10 +1,12 @@
 import page from '@automattic/calypso-router';
+import { fetchOAuth2_1ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
 import { redirectJetpack, login } from '../controller';
 
 jest.mock( 'calypso/state/oauth2-clients/actions', () => ( {
 	...jest.requireActual( 'calypso/state/oauth2-clients/actions' ),
 	fetchOAuth2ClientData: jest.fn(),
+	fetchOAuth2_1ClientData: jest.fn(),
 } ) );
 
 jest.mock( 'calypso/state/oauth2-clients/selectors', () => ( {
@@ -123,5 +125,69 @@ describe( 'login', () => {
 
 		expect( getOAuth2Client ).toHaveBeenCalledWith( state, '1234' );
 		expect( next ).toHaveBeenCalled();
+	} );
+
+	describe( 'oauth2_1_client_id', () => {
+		beforeEach( () => {
+			jest.clearAllMocks();
+		} );
+
+		it( 'should throw an error if oauth2_1_client_id exists but redirect_to does not', async () => {
+			context.query.oauth2_1_client_id = '7';
+
+			await login( context, next );
+
+			expect( next ).toHaveBeenCalledWith( expect.objectContaining( { status: 401 } ) );
+		} );
+
+		it( 'should throw an error if oauth2_1_client_id does not match the client_id in redirect_to', async () => {
+			context.query.oauth2_1_client_id = '7';
+			context.query.redirect_to =
+				'https://public-api.wordpress.com/oauth2-1/authorize/?client_id=8';
+
+			await login( context, next );
+
+			expect( next ).toHaveBeenCalledWith( expect.objectContaining( { status: 401 } ) );
+		} );
+
+		it( 'should fetch the OAuth 2.1 client data when the id matches redirect_to', async () => {
+			context.query.oauth2_1_client_id = '7';
+			context.query.redirect_to =
+				'https://public-api.wordpress.com/oauth2-1/authorize/?client_id=7';
+			getOAuth2Client.mockReturnValueOnce( null );
+
+			await login( context, next );
+
+			expect( getOAuth2Client ).toHaveBeenCalledWith( state, 'oauth2-1:7' );
+			expect( fetchOAuth2_1ClientData ).toHaveBeenCalledWith( '7' );
+			expect( next ).toHaveBeenCalledWith();
+		} );
+
+		it( 'should not fetch when the OAuth 2.1 client data is already in the store', async () => {
+			context.query.oauth2_1_client_id = '7';
+			context.query.redirect_to =
+				'https://public-api.wordpress.com/oauth2-1/authorize/?client_id=7';
+			getOAuth2Client.mockReturnValueOnce( { id: 'oauth2-1:7', title: 'ChatGPT' } );
+
+			await login( context, next );
+
+			expect( fetchOAuth2_1ClientData ).not.toHaveBeenCalled();
+			expect( next ).toHaveBeenCalledWith();
+		} );
+
+		it( 'should continue unbranded when the OAuth 2.1 client data fetch fails', async () => {
+			context.query.oauth2_1_client_id = '7';
+			context.query.redirect_to =
+				'https://public-api.wordpress.com/oauth2-1/authorize/?client_id=7';
+			getOAuth2Client.mockReturnValueOnce( null );
+			context.store.dispatch.mockImplementationOnce( ( thunk ) => thunk );
+			fetchOAuth2_1ClientData.mockImplementationOnce( () =>
+				Promise.reject( new Error( 'not found' ) )
+			);
+
+			await login( context, next );
+
+			expect( next ).toHaveBeenCalledWith();
+		} );
 	} );
 } );

--- a/client/login/test/ssr.js
+++ b/client/login/test/ssr.js
@@ -90,6 +90,15 @@ describe( 'setShouldServerSideRenderLogin', () => {
 		expect( next ).toHaveBeenCalledTimes( 5 ); // because we have 5 tests and we did not check for each of them
 	} );
 
+	test( 'when query has oauth2_1_client_id, then sets context.serverSideRender to TRUE - and calls next()', () => {
+		const next = jest.fn();
+		const contextWithQueryKeys = getSomeCleanLoginContext( { oauth2_1_client_id: '7' } );
+
+		setShouldServerSideRenderLogin( contextWithQueryKeys, next );
+		expect( contextWithQueryKeys.serverSideRender ).toBe( true );
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	test( 'when query has redirect_to, then only the ones starting with the prefix make SSR true', () => {
 		const contextWithThemePrefix = getSomeCleanLoginContext( {
 			redirect_to: 'https://wordpress.com/theme/something',

--- a/client/login/wp-login/hooks/get-header-text.tsx
+++ b/client/login/wp-login/hooks/get-header-text.tsx
@@ -10,6 +10,7 @@ import {
 	isVIPOAuth2Client,
 	isSharedMobileAppOAuth2Client,
 	isIosOAuth2Client,
+	isOAuth2_1Client,
 } from 'calypso/lib/oauth2-clients';
 import { getOAuth2Client } from 'calypso/state/oauth2-clients/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
@@ -73,7 +74,7 @@ export function getMobileAppClientName( {
 	isJetpackApp,
 	translate,
 }: {
-	oauth2Client: { id: number } | null | undefined;
+	oauth2Client: { id: number | string } | null | undefined;
 	isJetpackApp?: boolean;
 	translate: Props[ 'translate' ];
 } ): TranslateResult | null {
@@ -175,6 +176,10 @@ export function getHeaderText( {
 				clientName = 'Woo';
 			} else if ( isVIPOAuth2Client( oauth2Client ) ) {
 				clientName = 'VIP';
+			} else if ( isOAuth2_1Client( oauth2Client ) ) {
+				// 2.1 branding is curated server-side by the client's registered
+				// redirect_uri origin, so the fetched title is authoritative.
+				clientName = oauth2Client?.title;
 			}
 
 			/**

--- a/client/login/wp-login/hooks/test/get-header-text.test.tsx
+++ b/client/login/wp-login/hooks/test/get-header-text.test.tsx
@@ -52,7 +52,7 @@ describe( 'getHeaderText client-name casing', () => {
 	// authoritative and opt out via `is-exact-case`; only the raw client slug keeps
 	// the default title-casing.
 	const renderClientName = (
-		oauth2Client: { id: number; name?: string },
+		oauth2Client: { id: number | string; name?: string; title?: string },
 		isJetpackApp?: boolean
 	) => {
 		const headerText = getHeaderText( {
@@ -96,5 +96,13 @@ describe( 'getHeaderText client-name casing', () => {
 		expect( clientName ).toBeVisible();
 		expect( clientName ).not.toHaveClass( 'is-exact-case' );
 		expect( clientName ).toHaveTextContent( 'crowdsignal' );
+	} );
+
+	test( 'renders an OAuth 2.1 client title verbatim (is-exact-case)', () => {
+		// 2.1 branding is curated server-side, so the fetched title wins over the slug.
+		const clientName = renderClientName( { id: 'oauth2-1:7', name: 'chatgpt', title: 'ChatGPT' } );
+		expect( clientName ).toBeVisible();
+		expect( clientName ).toHaveClass( 'is-exact-case' );
+		expect( clientName ).toHaveTextContent( 'ChatGPT' );
 	} );
 } );

--- a/client/state/oauth2-clients/actions.js
+++ b/client/state/oauth2-clients/actions.js
@@ -1,4 +1,5 @@
 import LRU from 'lru';
+import { getOAuth2_1ClientKey } from 'calypso/lib/oauth2-clients';
 import wpcom from 'calypso/lib/wp';
 import { OAUTH2_CLIENT_DATA_RECEIVE } from 'calypso/state/action-types';
 
@@ -26,6 +27,28 @@ export const fetchOAuth2ClientData = ( clientId ) => async ( dispatch ) => {
 			data = await wpcom.req.get( `/oauth2/client-data/${ clientId }`, {
 				apiNamespace: 'wpcom/v2',
 			} );
+			cache.set( cacheKey, data );
+		}
+
+		dispatch( { type: OAUTH2_CLIENT_DATA_RECEIVE, data } );
+		return data;
+	} catch ( error ) {
+		throw convertWpcomError( error );
+	}
+};
+
+// OAuth 2.1 clients resolve against a separate endpoint and namespace. The
+// endpoint only returns curated branding for trusted clients and 404s otherwise.
+export const fetchOAuth2_1ClientData = ( clientId ) => async ( dispatch ) => {
+	const cacheKey = getOAuth2_1ClientKey( clientId );
+
+	try {
+		let data = cache.get( cacheKey );
+		if ( data === undefined ) {
+			data = await wpcom.req.get( `/oauth2-1/client-data/${ clientId }`, {
+				apiNamespace: 'wpcom/v2',
+			} );
+			data = { ...data, id: cacheKey };
 			cache.set( cacheKey, data );
 		}
 

--- a/client/state/oauth2-clients/selectors.js
+++ b/client/state/oauth2-clients/selectors.js
@@ -3,8 +3,8 @@ import 'calypso/state/oauth2-clients/init';
 /**
  * Gets the OAuth2 client data.
  * @param  {Object}   state  Global state tree
- * @param  {number} clientId OAuth2 Client ID
- * @returns {{ id: number; title: string; icon: string; name: string; } | null} OAuth2 client data
+ * @param  {number | string} clientId OAuth2 Client ID, or the namespaced key for an OAuth 2.1 client
+ * @returns {{ id: number | string; title: string; icon: string; name: string; } | null} OAuth2 client data
  */
 export const getOAuth2Client = ( state, clientId ) => {
 	return state?.oauth2Clients?.clients?.[ clientId ] ?? null;

--- a/client/state/oauth2-clients/test/actions.js
+++ b/client/state/oauth2-clients/test/actions.js
@@ -1,0 +1,56 @@
+import wpcom from 'calypso/lib/wp';
+import { OAUTH2_CLIENT_DATA_RECEIVE } from 'calypso/state/action-types';
+import { fetchOAuth2_1ClientData } from '../actions';
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: { get: jest.fn() },
+} ) );
+
+describe( 'fetchOAuth2_1ClientData', () => {
+	beforeEach( () => {
+		wpcom.req.get.mockReset();
+	} );
+
+	test( 'fetches from the OAuth 2.1 endpoint and dispatches the data under a namespaced key', async () => {
+		wpcom.req.get.mockResolvedValue( {
+			id: 7,
+			name: 'chatgpt',
+			title: 'ChatGPT',
+			icon: 'https://example.com/icon.svg',
+		} );
+		const dispatch = jest.fn();
+
+		const data = await fetchOAuth2_1ClientData( 7 )( dispatch );
+
+		expect( wpcom.req.get ).toHaveBeenCalledWith( '/oauth2-1/client-data/7', {
+			apiNamespace: 'wpcom/v2',
+		} );
+		expect( data.id ).toBe( 'oauth2-1:7' );
+		expect( dispatch ).toHaveBeenCalledWith( {
+			type: OAUTH2_CLIENT_DATA_RECEIVE,
+			data: expect.objectContaining( { id: 'oauth2-1:7', title: 'ChatGPT' } ),
+		} );
+	} );
+
+	test( 'serves repeat fetches of the same client from the cache', async () => {
+		wpcom.req.get.mockResolvedValue( { id: 8, title: 'ChatGPT' } );
+		const dispatch = jest.fn();
+
+		await fetchOAuth2_1ClientData( 8 )( dispatch );
+		await fetchOAuth2_1ClientData( 8 )( dispatch );
+
+		expect( wpcom.req.get ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	test( 'converts wpcom errors', async () => {
+		wpcom.req.get.mockRejectedValue( { message: 'not found', error: 'rest_no_route' } );
+		const dispatch = jest.fn();
+
+		await expect( fetchOAuth2_1ClientData( 404 )( dispatch ) ).rejects.toEqual( {
+			message: 'not found',
+			code: 'rest_no_route',
+		} );
+		expect( dispatch ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/state/oauth2-clients/ui/reducer.js
+++ b/client/state/oauth2-clients/ui/reducer.js
@@ -1,3 +1,4 @@
+import { getOAuth2_1ClientKey } from 'calypso/lib/oauth2-clients';
 import { ROUTE_SET } from 'calypso/state/action-types';
 import { combineReducers } from 'calypso/state/utils';
 
@@ -5,11 +6,13 @@ export const currentClientId = ( state = null, action ) => {
 	switch ( action.type ) {
 		case ROUTE_SET: {
 			const { path, query } = action;
-			if (
-				( path.startsWith( '/log-in' ) || path.startsWith( '/oauth2/authorize' ) ) &&
-				query.client_id
-			) {
-				return Number( query.client_id );
+			if ( path.startsWith( '/log-in' ) || path.startsWith( '/oauth2/authorize' ) ) {
+				if ( query.oauth2_1_client_id ) {
+					return getOAuth2_1ClientKey( query.oauth2_1_client_id );
+				}
+				if ( query.client_id ) {
+					return Number( query.client_id );
+				}
 			}
 
 			if (

--- a/client/state/oauth2-clients/ui/selectors.js
+++ b/client/state/oauth2-clients/ui/selectors.js
@@ -5,7 +5,7 @@ import 'calypso/state/oauth2-clients/init';
 /**
  * Returns the ID of the current OAuth2 client.
  * @param  {Object}  state  Global state tree
- * @returns {?number}        Current OAuth2 client ID
+ * @returns {?number | string} Current OAuth2 client ID, or the namespaced key for an OAuth 2.1 client
  */
 export function getCurrentOAuth2ClientId( state ) {
 	return state.oauth2Clients?.ui.currentClientId;
@@ -14,7 +14,7 @@ export function getCurrentOAuth2ClientId( state ) {
 /**
  * Gets the OAuth2 client data.
  * @param  {Object}   state  Global state tree
- * @returns {{ id: number; title: string; icon: string; name: string; } | null} OAuth2 client data
+ * @returns {{ id: number | string; title: string; icon: string; name: string; } | null} OAuth2 client data
  */
 export const getCurrentOAuth2Client = ( state ) => {
 	const currentClientId = getCurrentOAuth2ClientId( state );

--- a/client/state/oauth2-clients/ui/test/reducer.js
+++ b/client/state/oauth2-clients/ui/test/reducer.js
@@ -27,5 +27,40 @@ describe( 'reducer', () => {
 
 			expect( state ).toEqual( 42 );
 		} );
+
+		test( 'should store the namespaced key on ROUTE_SET with oauth2_1_client_id', () => {
+			const state = currentClientId( undefined, {
+				type: ROUTE_SET,
+				path: '/log-in',
+				query: {
+					oauth2_1_client_id: '7',
+				},
+			} );
+
+			expect( state ).toEqual( 'oauth2-1:7' );
+		} );
+
+		test( 'should prefer oauth2_1_client_id over client_id when both are present', () => {
+			const state = currentClientId( undefined, {
+				type: ROUTE_SET,
+				path: '/log-in',
+				query: {
+					client_id: 42,
+					oauth2_1_client_id: '7',
+				},
+			} );
+
+			expect( state ).toEqual( 'oauth2-1:7' );
+		} );
+
+		test( 'should keep the current state when neither client id is present', () => {
+			const state = currentClientId( 'oauth2-1:7', {
+				type: ROUTE_SET,
+				path: '/log-in/link',
+				query: {},
+			} );
+
+			expect( state ).toEqual( 'oauth2-1:7' );
+		} );
 	} );
 } );


### PR DESCRIPTION
Part of AIINT-601

## Proposed Changes

* Add support for an `oauth2_1_client_id` query parameter on `/log-in`, identifying an OAuth 2.1 (MCP) client. It is validated against the `client_id` inside `redirect_to` (the authorize URL), mirroring the existing `client_id` validation.
* Fetch branding for these clients from the new `wpcom/v2/oauth2-1/client-data/<id>` endpoint (wpcom side lands separately), which returns curated branding only for clients whose registered `redirect_uri` origin is trusted, and 404s otherwise. A failed fetch renders the login screen unbranded rather than erroring — unlike the 2.0 path, deliberately.
* Store 2.1 client data under a namespaced key (`oauth2-1:<id>`) so 2.1 IDs can never collide with OAuth 2.0 client IDs in the Redux store — both namespaces count from 1.
* Render the curated `title` verbatim (e.g. "Log in to ChatGPT with WordPress.com") instead of title-casing the client slug.
* Guard `getSignupUrl()` so 2.1 clients fall through to the generic `/start/account?redirect_to=...` signup — a 2.1 ID has no meaning in the wpcc signup flow.
* Propagate the parameter to magic-link and lost-password URLs built during the flow, and add it to the login SSR query-key allowlist.

## Why are these changes being made?

* AIINT-599 moved logged-out OAuth 2.1 (MCP) users to the Calypso login screen without any `client_id`, so the screen is currently unbranded. Simply forwarding the 2.1 `client_id` would brand the page with an unrelated OAuth 2.0 app, since Calypso resolves `?client_id=` against the 2.0 table.
* The wpcom side binds branding to the client's registered `redirect_uri` origin rather than its self-asserted `client_name`; this PR is the Calypso half that asks the new 2.1 endpoint for that curated branding. Until the wpcom change that emits `oauth2_1_client_id` ships, no URLs carry the parameter and this is a no-op in production.

## Testing Instructions

* Unit tests: `yarn test-client client/state/oauth2-clients client/login/test client/login/wp-login/hooks/test client/lib/paths/login client/lib/login client/lib/test/oauth2-clients.js client/blocks/login`
* With the wpcom endpoint sandboxed:
  * `/log-in?oauth2_1_client_id=<id>&redirect_to=<authorize URL with matching client_id>` renders the curated branding (title in the header, icon in the masterbar).
  * An unknown or untrusted `oauth2_1_client_id` renders the unbranded login screen (no error).
  * A mismatched `redirect_to` returns a 401 error page.
* Without the sandboxed endpoint, verify that `/log-in?oauth2_1_client_id=7&redirect_to=...` falls back to the unbranded screen (the fetch 404s and is swallowed).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?