### PR TITLE
Omnibar: track node clicks

### DIFF
--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -26,6 +26,7 @@ import { useShoppingCartPlugin } from './plugin-shopping-cart';
 import { buildSiteBadgeNode } from './plugin-site-badges';
 import { useStatsSparklinePlugin } from './plugin-stats-sparkline';
 import { buildWpcomAccountNode } from './plugin-wpcom-account';
+import { RESPONSIVE_MENU_NODE_ID, trackOmnibarNodes, useRecordOmnibarNodeClick } from './tracking';
 import type { AppConfig } from '../context';
 import type { User } from '@automattic/api-core';
 import type { OmnibarNodeBuilders } from '@automattic/omnibar';
@@ -76,6 +77,7 @@ export default function OmnibarContainer( {
 
 function ConnectedOmnibar( { user }: { user?: User } ) {
 	const { supports } = useAppContext();
+	const recordNodeClick = useRecordOmnibarNodeClick();
 	const [ hydrated, setHydrated ] = useState( false );
 	useEffect( () => {
 		setHydrated( true );
@@ -173,10 +175,18 @@ function ConnectedOmnibar( { user }: { user?: User } ) {
 		  ]
 		: [];
 
-	const omnibarNodes = {
-		...baseOmnibarNodes,
-		siteActions,
-		plugins,
+	const omnibarNodes = trackOmnibarNodes(
+		{
+			...baseOmnibarNodes,
+			siteActions,
+			plugins,
+		},
+		recordNodeClick
+	);
+
+	const handleClickResponsiveMenu = () => {
+		recordNodeClick( RESPONSIVE_MENU_NODE_ID );
+		onClickResponsiveMenu();
 	};
 
 	if ( ! hydrated ) {
@@ -186,7 +196,7 @@ function ConnectedOmnibar( { user }: { user?: User } ) {
 		<>
 			<Omnibar
 				nodes={ omnibarNodes }
-				onClickResponsiveMenu={ onClickResponsiveMenu }
+				onClickResponsiveMenu={ handleClickResponsiveMenu }
 				className={ isSupportSession() ? 'is-support-session' : undefined }
 			/>
 			{ shoppingCartPanel }

--- a/client/dashboard/app/omnibar/plugin-reader.tsx
+++ b/client/dashboard/app/omnibar/plugin-reader.tsx
@@ -1,6 +1,5 @@
 import { __ } from '@wordpress/i18n';
 import { wpcomLink } from '../../utils/link';
-import { useAnalytics } from '../analytics';
 import type { OmnibarNode } from '@automattic/omnibar';
 
 import './plugin-reader.scss';
@@ -20,14 +19,11 @@ function ReaderIcon() {
 }
 
 export function useReaderPlugin(): OmnibarNode {
-	const { recordTracksEvent } = useAnalytics();
-
 	return {
 		id: 'reader',
 		title: __( 'Reader' ),
 		icon: <ReaderIcon />,
 		className: 'omnibar__reader',
 		href: wpcomLink( '/reader' ),
-		onClick: () => recordTracksEvent( 'calypso_masterbar_reader_clicked' ),
 	};
 }

--- a/client/dashboard/app/omnibar/tracking.ts
+++ b/client/dashboard/app/omnibar/tracking.ts
@@ -1,0 +1,68 @@
+import { transformOmnibarNodes } from '@automattic/omnibar';
+import { useCallback } from 'react';
+import { useAnalytics } from '../analytics';
+import type { OmnibarNodes } from '@automattic/omnibar';
+
+export const RESPONSIVE_MENU_NODE_ID = 'responsive-menu';
+
+const LEGACY_MASTERBAR_EVENTS: Record< string, string > = {
+	[ RESPONSIVE_MENU_NODE_ID ]: 'calypso_masterbar_menu_clicked',
+	'wp-logo': 'calypso_masterbar_my_sites_clicked',
+	'wpcom-sites': 'calypso_masterbar_sites_clicked',
+	'wpcom-domains': 'calypso_masterbar_domains_clicked',
+	about: 'calypso_masterbar_about_wordpress_clicked',
+	contribute: 'calypso_masterbar_get_involved_clicked',
+	'view-site': 'calypso_masterbar_visit_site_clicked',
+	'wpcom-stats': 'calypso_masterbar_stats_clicked',
+	'site-plan-badge': 'calypso_masterbar_plan_clicked',
+	'new-post': 'calypso_masterbar_new_post_clicked',
+	'new-media': 'calypso_masterbar_new_media_clicked',
+	'new-page': 'calypso_masterbar_new_page_clicked',
+	'new-user': 'calypso_masterbar_new_user_clicked',
+	stats: 'calypso_masterbar_stats_sparkline_clicked',
+	reader: 'calypso_masterbar_reader_clicked',
+	'my-account': 'calypso_masterbar_me_clicked',
+	'user-info': 'calypso_masterbar_edit_profile_clicked',
+	logout: 'calypso_masterbar_log_out_clicked',
+	'my-wpcom-account': 'calypso_masterbar_wpcom_account_clicked',
+};
+
+export type RecordOmnibarNodeClick = ( nodeId: string ) => void;
+
+export function useRecordOmnibarNodeClick(): RecordOmnibarNodeClick {
+	const { recordTracksEvent } = useAnalytics();
+
+	return useCallback(
+		( nodeId: string ) => {
+			recordTracksEvent( 'calypso_omnibar_node_click', {
+				node_id: nodeId,
+			} );
+
+			const legacyEvent = LEGACY_MASTERBAR_EVENTS[ nodeId ];
+			if ( legacyEvent ) {
+				// Also fire old event to not lose old data.
+				recordTracksEvent( legacyEvent );
+			}
+		},
+		[ recordTracksEvent ]
+	);
+}
+
+export function trackOmnibarNodes(
+	nodes: OmnibarNodes,
+	recordNodeClick: RecordOmnibarNodeClick
+): OmnibarNodes {
+	return transformOmnibarNodes( nodes, ( node ) => {
+		if ( ! node.id ) {
+			return node;
+		}
+
+		return {
+			...node,
+			onClick: ( event: React.MouseEvent ) => {
+				recordNodeClick( node.id );
+				node.onClick?.( event );
+			},
+		};
+	} );
+}

--- a/packages/omnibar/src/components/omnibar-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-menu.tsx
@@ -161,6 +161,7 @@ export function OmnibarMenu( { node, className }: { node: OmnibarNode; className
 		<Menu open={ isOpen } onOpenChange={ handleOpenChange }>
 			<Menu.TriggerButton
 				ref={ triggerRef }
+				onClick={ node.onClick }
 				onMouseEnter={ () => setIsOpen( true ) }
 				onMouseLeave={ handleMouseLeave }
 				onTouchEnd={ handleTouchEnd }

--- a/packages/omnibar/src/index.ts
+++ b/packages/omnibar/src/index.ts
@@ -1,3 +1,4 @@
 export * from './components/omnibar';
 export * from './utils/admin-bar';
+export * from './utils/nodes';
 export type * from './types';

--- a/packages/omnibar/src/types/index.ts
+++ b/packages/omnibar/src/types/index.ts
@@ -3,6 +3,7 @@ export type {
 	OmnibarHrefResolver,
 	OmnibarNode,
 	OmnibarNodeBuilders,
+	OmnibarNodeTransformer,
 	OmnibarNodes,
 	OmnibarProps,
 } from './omnibar';

--- a/packages/omnibar/src/types/omnibar.ts
+++ b/packages/omnibar/src/types/omnibar.ts
@@ -23,6 +23,8 @@ export type OmnibarNodeBuilders = Record<
 
 export type OmnibarHrefResolver = ( href: string ) => string;
 
+export type OmnibarNodeTransformer = ( node: OmnibarNode ) => OmnibarNode;
+
 export interface SiteActionNodeMeta {
 	subtitle?: string;
 }

--- a/packages/omnibar/src/utils/nodes.ts
+++ b/packages/omnibar/src/utils/nodes.ts
@@ -1,0 +1,27 @@
+import type { OmnibarNode, OmnibarNodeTransformer, OmnibarNodes } from '../types';
+
+/**
+ * Applies `transform` to every node in the tree, including nested children, and
+ * returns a new `OmnibarNodes` — so callers don't have to know which sections
+ * hold a single node and which hold a list.
+ */
+export function transformOmnibarNodes(
+	nodes: OmnibarNodes,
+	transform: OmnibarNodeTransformer
+): OmnibarNodes {
+	const transformNode = ( node: OmnibarNode ): OmnibarNode => {
+		const transformed = transform( node );
+		return transformed.children
+			? { ...transformed, children: transformed.children.map( transformNode ) }
+			: transformed;
+	};
+
+	const entries = Object.entries( nodes ).map( ( [ section, value ] ) => {
+		if ( Array.isArray( value ) ) {
+			return [ section, value.map( transformNode ) ];
+		}
+		return [ section, value && transformNode( value ) ];
+	} );
+
+	return Object.fromEntries( entries ) as OmnibarNodes;
+}


### PR DESCRIPTION
## Proposed Changes

Fire `calypso_omnibar_node_click` Tracks event, with `node_id` prop, when we click any omnibar node.

We also fire an additional legacy event name is it was present before.

## Why are these changes being made?

We want to track node clicks.

## Testing Instructions

Test with the `dashboard/omnibar-radical` flag turned on.

1. Go to /sites
2. Click any node
3. Verify the event is fired, along with the existing one if any. For example, when clicking Reader:

<img width="637" height="271" alt="image" src="https://github.com/user-attachments/assets/deca167d-c96d-494f-8eda-58f33e96163a" />
