### PR TITLE
Omnibar: add Dashboard/My Home node on non-site-level screens

### DIFF
--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -16,6 +16,7 @@ import { useAppContext } from '../context';
 import { omnibarEvents } from './events';
 import { OmnibarHomeIcon } from './home';
 import { useAiChatPlugin } from './plugin-ai-chat';
+import { addDashboardNode, useDashboardPlugin } from './plugin-dashboard';
 import { useHelpCenterPlugin } from './plugin-help-center';
 import { useLanguageSwitcherPlugin } from './plugin-language-switcher';
 import { useLaunchSitePlugin } from './plugin-launch-site';
@@ -64,18 +65,26 @@ function createHrefResolver( adminUrl?: string ) {
 export default function OmnibarContainer( {
 	user,
 	cartManagerClient,
+	isWithinSiteContext,
 }: {
 	user?: User;
 	cartManagerClient: ShoppingCartManagerClient;
+	isWithinSiteContext?: boolean;
 } ) {
 	return (
 		<ShoppingCartProvider managerClient={ cartManagerClient }>
-			<ConnectedOmnibar user={ user } />
+			<ConnectedOmnibar user={ user } isWithinSiteContext={ isWithinSiteContext } />
 		</ShoppingCartProvider>
 	);
 }
 
-function ConnectedOmnibar( { user }: { user?: User } ) {
+function ConnectedOmnibar( {
+	user,
+	isWithinSiteContext,
+}: {
+	user?: User;
+	isWithinSiteContext?: boolean;
+} ) {
 	const { supports } = useAppContext();
 	const recordNodeClick = useRecordOmnibarNodeClick();
 	const [ hydrated, setHydrated ] = useState( false );
@@ -158,6 +167,8 @@ function ConnectedOmnibar( { user }: { user?: User } ) {
 	const { node: shoppingCartNode, panel: shoppingCartPanel } = useShoppingCartPlugin( { site } );
 	const statsSparklineNode = useStatsSparklinePlugin( { site } );
 	const launchSiteNode = useLaunchSitePlugin( { site } );
+	const dashboardNode = useDashboardPlugin( { site, isWithinSiteContext } );
+	const siteNode = addDashboardNode( baseOmnibarNodes.site, dashboardNode );
 	const siteActions = [
 		...( baseOmnibarNodes.siteActions ?? [] ),
 		statsSparklineNode,
@@ -178,6 +189,7 @@ function ConnectedOmnibar( { user }: { user?: User } ) {
 	const omnibarNodes = trackOmnibarNodes(
 		{
 			...baseOmnibarNodes,
+			site: siteNode,
 			siteActions,
 			plugins,
 		},

--- a/client/dashboard/app/omnibar/plugin-dashboard.tsx
+++ b/client/dashboard/app/omnibar/plugin-dashboard.tsx
@@ -1,0 +1,41 @@
+import { __ } from '@wordpress/i18n';
+import { wpcomLink } from '../../utils/link';
+import { usesWpAdminInterface } from '../../utils/site-types';
+import type { Site } from '@automattic/api-core';
+import type { OmnibarNode } from '@automattic/omnibar';
+
+export function useDashboardPlugin( {
+	site,
+	isWithinSiteContext,
+}: {
+	site?: Site;
+	isWithinSiteContext?: boolean;
+} ): OmnibarNode | undefined {
+	if ( ! site || isWithinSiteContext ) {
+		return undefined;
+	}
+
+	if ( usesWpAdminInterface( site ) ) {
+		const adminUrl = site.options?.admin_url;
+		return adminUrl ? { id: 'dashboard', title: __( 'Dashboard' ), href: adminUrl } : undefined;
+	}
+
+	return {
+		id: 'my-home',
+		title: __( 'My Home' ),
+		href: wpcomLink( `/home/${ site.slug }` ),
+	};
+}
+
+// Add the new node below the view-site node.
+export function addDashboardNode( siteNode?: OmnibarNode, dashboardNode?: OmnibarNode ) {
+	if ( ! siteNode || ! dashboardNode ) {
+		return siteNode;
+	}
+
+	const children = [ ...( siteNode.children ?? [] ) ];
+	const viewSiteIndex = children.findIndex( ( child ) => child.id === 'view-site' );
+	children.splice( viewSiteIndex + 1, 0, dashboardNode );
+
+	return { ...siteNode, children };
+}

--- a/client/dashboard/app/omnibar/tracking.ts
+++ b/client/dashboard/app/omnibar/tracking.ts
@@ -13,6 +13,8 @@ const LEGACY_MASTERBAR_EVENTS: Record< string, string > = {
 	about: 'calypso_masterbar_about_wordpress_clicked',
 	contribute: 'calypso_masterbar_get_involved_clicked',
 	'view-site': 'calypso_masterbar_visit_site_clicked',
+	dashboard: 'calypso_masterbar_dashboard_clicked',
+	'my-home': 'calypso_masterbar_my_home_clicked',
 	'wpcom-stats': 'calypso_masterbar_stats_clicked',
 	'site-plan-badge': 'calypso_masterbar_plan_clicked',
 	'new-post': 'calypso_masterbar_new_post_clicked',

--- a/client/dashboard/utils/site-types.ts
+++ b/client/dashboard/utils/site-types.ts
@@ -21,3 +21,9 @@ export function isCommerceGarden( site: Site ) {
 export function isStagingSite( site: Site ) {
 	return site.is_wpcom_staging_site;
 }
+
+export function usesWpAdminInterface( site: Site ) {
+	return (
+		( site.jetpack && ! site.is_wpcom_atomic ) || site.options?.wpcom_admin_interface === 'wp-admin'
+	);
+}

--- a/client/layout/masterbar/omnibar.tsx
+++ b/client/layout/masterbar/omnibar.tsx
@@ -80,7 +80,11 @@ export default function Omnibar( { loadHelpCenterIcon }: { loadHelpCenterIcon?: 
 			<QueryClientProvider client={ queryClient }>
 				<AnalyticsProvider client={ analyticsClient }>
 					<div id="wpcom-omnibar">
-						<OmnibarContainer user={ window.currentUser } cartManagerClient={ cartManagerClient } />
+						<OmnibarContainer
+							user={ window.currentUser }
+							cartManagerClient={ cartManagerClient }
+							isWithinSiteContext
+						/>
 					</div>
 				</AnalyticsProvider>
 			</QueryClientProvider>

--- a/packages/api-core/src/site/fetchers.ts
+++ b/packages/api-core/src/site/fetchers.ts
@@ -66,6 +66,7 @@ export const SITE_OPTIONS = [
 	'software_version',
 	'updated_at',
 	'woocommerce_is_active',
+	'wpcom_admin_interface',
 	'wpcom_ai_launchpad_enabled',
 	'wpcom_ai_launchpad_dismissed',
 	'wpcom_ai_launchpad_completed',

--- a/packages/api-core/src/site/types.ts
+++ b/packages/api-core/src/site/types.ts
@@ -58,6 +58,7 @@ export interface SiteOptions {
 	unmapped_url?: string;
 	wordads?: boolean;
 	woocommerce_is_active?: boolean;
+	wpcom_admin_interface?: string;
 	wpcom_ai_launchpad_enabled?: boolean;
 	wpcom_ai_launchpad_dismissed?: boolean;
 	wpcom_ai_launchpad_completed?: boolean;


### PR DESCRIPTION

## Proposed Changes

Adds a new `Dashboard` node on non-site-level (nav-unification) screens so that the user can return to the wp-admin dashboard. 

<img width="268" height="191" alt="image" src="https://github.com/user-attachments/assets/9f465401-80df-4ae9-bae8-bafe25e27530" />

On sites with Default admin interface style, the node is My Home.

## Why are these changes being made?

Parity with the existing masterbar behavior.

## Testing Instructions

1. Go to `/sites/:siteSlug` of a site with Classic admin interface style; verify you can see the new Dashboard node.
1. Go to `/sites/:siteSlug` of a site with Default admin interface style; verify you can see the new My Home node.
1. Go to `/home/:siteSlug` of the above sites; verify you DON'T see the new node.