### PR TITLE
Omnibar: make it work on Reader

### DIFF
--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -65,26 +65,20 @@ function createHrefResolver( adminUrl?: string ) {
 export default function OmnibarContainer( {
 	user,
 	cartManagerClient,
-	isWithinSiteContext,
+	section,
 }: {
 	user?: User;
 	cartManagerClient: ShoppingCartManagerClient;
-	isWithinSiteContext?: boolean;
+	section?: string;
 } ) {
 	return (
 		<ShoppingCartProvider managerClient={ cartManagerClient }>
-			<ConnectedOmnibar user={ user } isWithinSiteContext={ isWithinSiteContext } />
+			<ConnectedOmnibar user={ user } section={ section } />
 		</ShoppingCartProvider>
 	);
 }
 
-function ConnectedOmnibar( {
-	user,
-	isWithinSiteContext,
-}: {
-	user?: User;
-	isWithinSiteContext?: boolean;
-} ) {
+function ConnectedOmnibar( { user, section }: { user?: User; section?: string } ) {
 	const { supports } = useAppContext();
 	const recordNodeClick = useRecordOmnibarNodeClick();
 	const [ hydrated, setHydrated ] = useState( false );
@@ -157,7 +151,7 @@ function ConnectedOmnibar( {
 		return result;
 	}, [ dashboardNodes, siteNodes, site, supports, nodeBuilders ] );
 
-	const readerPluginNode = useReaderPlugin();
+	const readerPluginNode = useReaderPlugin( { section } );
 	const helpCenterPluginNode = useHelpCenterPlugin();
 	const aiChatPluginNode = useAiChatPlugin();
 	const notificationsPluginNode = useNotificationsPlugin( { user } );
@@ -167,7 +161,7 @@ function ConnectedOmnibar( {
 	const { node: shoppingCartNode, panel: shoppingCartPanel } = useShoppingCartPlugin( { site } );
 	const statsSparklineNode = useStatsSparklinePlugin( { site } );
 	const launchSiteNode = useLaunchSitePlugin( { site } );
-	const dashboardNode = useDashboardPlugin( { site, isWithinSiteContext } );
+	const dashboardNode = useDashboardPlugin( { site, section } );
 	const siteNode = addDashboardNode( baseOmnibarNodes.site, dashboardNode );
 	const siteActions = [
 		...( baseOmnibarNodes.siteActions ?? [] ),

--- a/client/dashboard/app/omnibar/plugin-dashboard.tsx
+++ b/client/dashboard/app/omnibar/plugin-dashboard.tsx
@@ -6,12 +6,12 @@ import type { OmnibarNode } from '@automattic/omnibar';
 
 export function useDashboardPlugin( {
 	site,
-	isWithinSiteContext,
+	section,
 }: {
 	site?: Site;
-	isWithinSiteContext?: boolean;
+	section?: string;
 } ): OmnibarNode | undefined {
-	if ( ! site || isWithinSiteContext ) {
+	if ( ! site || section === 'sites' ) {
 		return undefined;
 	}
 

--- a/client/dashboard/app/omnibar/plugin-reader.scss
+++ b/client/dashboard/app/omnibar/plugin-reader.scss
@@ -57,7 +57,7 @@ $omnibar-reader-active-radius: 4px;
 		@include omnibar-reader-active-corner( 100% );
 	}
 
-	body.rtl & {
+	[dir="rtl"] & {
 		&::before {
 			@include omnibar-reader-active-corner( 100% );
 		}

--- a/client/dashboard/app/omnibar/plugin-reader.scss
+++ b/client/dashboard/app/omnibar/plugin-reader.scss
@@ -1,3 +1,13 @@
+$omnibar-reader-active-radius: 4px;
+
+@mixin omnibar-reader-active-corner( $x ) {
+	mask: radial-gradient(
+		circle at $x 0,
+		transparent $omnibar-reader-active-radius,
+		var( --color-sidebar-background ) $omnibar-reader-active-radius
+	);
+}
+
 .omnibar .omnibar__reader {
 	@media ( max-width: 360px ) {
 		display: none;
@@ -10,5 +20,50 @@
 
 	@media ( min-width: 782px ) {
 		width: 24px;
+	}
+}
+
+.omnibar .omnibar__menu.omnibar__reader.is-active {
+	position: relative;
+	background: var( --color-masterbar-item-active-background );
+}
+
+.is-global-sidebar-visible .omnibar .omnibar__menu.omnibar__reader.is-active {
+	--omnibar-text-color: var( --color-sidebar-menu-selected-text );
+	--omnibar-highlight-color: var( --color-sidebar-menu-selected-text );
+
+	background: var( --color-sidebar-background );
+	border-start-start-radius: $omnibar-reader-active-radius;
+	border-start-end-radius: $omnibar-reader-active-radius;
+
+	&::before,
+	&::after {
+		content: '';
+		position: absolute;
+		bottom: 0;
+		width: $omnibar-reader-active-radius;
+		height: $omnibar-reader-active-radius;
+		background-color: var( --color-sidebar-background );
+		pointer-events: none;
+	}
+
+	&::before {
+		inset-inline-start: -$omnibar-reader-active-radius;
+		@include omnibar-reader-active-corner( 0 );
+	}
+
+	&::after {
+		inset-inline-end: -$omnibar-reader-active-radius;
+		@include omnibar-reader-active-corner( 100% );
+	}
+
+	body.rtl & {
+		&::before {
+			@include omnibar-reader-active-corner( 100% );
+		}
+
+		&::after {
+			@include omnibar-reader-active-corner( 0 );
+		}
 	}
 }

--- a/client/dashboard/app/omnibar/plugin-reader.tsx
+++ b/client/dashboard/app/omnibar/plugin-reader.tsx
@@ -18,12 +18,13 @@ function ReaderIcon() {
 	);
 }
 
-export function useReaderPlugin(): OmnibarNode {
+export function useReaderPlugin( { section }: { section?: string } ): OmnibarNode {
 	return {
 		id: 'reader',
 		title: __( 'Reader' ),
 		icon: <ReaderIcon />,
 		className: 'omnibar__reader',
 		href: wpcomLink( '/reader' ),
+		active: section === 'reader',
 	};
 }

--- a/client/layout/masterbar/omnibar.tsx
+++ b/client/layout/masterbar/omnibar.tsx
@@ -61,7 +61,13 @@ function useOmnibarBridge() {
 	} );
 }
 
-export default function Omnibar( { loadHelpCenterIcon }: { loadHelpCenterIcon?: boolean } ) {
+export default function Omnibar( {
+	section,
+	loadHelpCenterIcon,
+}: {
+	section?: string;
+	loadHelpCenterIcon?: boolean;
+} ) {
 	useOmnibarBridge();
 
 	const config: AppConfig = {
@@ -83,7 +89,7 @@ export default function Omnibar( { loadHelpCenterIcon }: { loadHelpCenterIcon?: 
 						<OmnibarContainer
 							user={ window.currentUser }
 							cartManagerClient={ cartManagerClient }
-							isWithinSiteContext
+							section={ section }
 						/>
 					</div>
 				</AnalyticsProvider>

--- a/packages/omnibar/src/components/omnibar-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-menu.tsx
@@ -88,7 +88,7 @@ function OmnibarMenuContent( { nodes }: { nodes: OmnibarNode[] } ) {
 
 export function OmnibarMenu( { node, className }: { node: OmnibarNode; className?: string } ) {
 	const label = node.title || node.label || '';
-	const menuClassName = [ 'omnibar__menu', className, node.className ]
+	const menuClassName = [ 'omnibar__menu', className, node.className, node.active && 'is-active' ]
 		.filter( Boolean )
 		.join( ' ' );
 	const [ isOpen, setIsOpen ] = useState( false );

--- a/packages/omnibar/src/types/omnibar.ts
+++ b/packages/omnibar/src/types/omnibar.ts
@@ -10,6 +10,7 @@ export interface OmnibarNode {
 	href?: string;
 	onClick?: ( event: React.MouseEvent ) => void;
 	disabled?: boolean;
+	active?: boolean;
 	className?: string;
 	meta?: SiteActionNodeMeta & UserInfoNodeMeta;
 	render?: ( node: OmnibarNode ) => React.ReactNode;


### PR DESCRIPTION
## Proposed Changes

Apply the existing styling to the omnibar node on Reader screens:

<img width="1026" height="166" alt="image" src="https://github.com/user-attachments/assets/9e5bd1ce-10d7-4a67-8478-f64dd967bc9e" />

## Why are these changes being made?

Parity between existing Calypso masterbar and new omnibar.

## Testing Instructions

Test with the `dashboard/omnibar-radical` flag turned on:

1. Go to /reader
2. Verify the active state is as shown in the screenshot above.
3. Go to Discover, Search etc from the sidebar; verify the active state still stays.
