### PR TITLE
Dashboard: recover from Google Translate DOM mutations instead of crashing

### DIFF
--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -10,6 +10,7 @@ import wpcom from 'calypso/lib/wp';
 import { AUTH_QUERY_KEY, initializeCurrentUser } from './auth';
 import { handleOAuthCallback } from './auth/oauth-callback';
 import { loadPreferencesHelper } from './dev-tools/preferences';
+import { installDomMutationGuard } from './dom-mutation-guard';
 import Layout from './layout';
 import { omnibarEvents } from './omnibar/events';
 import limitTotalSnackbars from './snackbars/limit-total-snackbars';
@@ -25,6 +26,8 @@ import './omnibar/style.scss';
 import '@automattic/omnibar/style.scss';
 
 function boot( config: AppConfig ) {
+	installDomMutationGuard();
+
 	if ( handleOAuthCallback() ) {
 		return;
 	}

--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -26,8 +26,6 @@ import './omnibar/style.scss';
 import '@automattic/omnibar/style.scss';
 
 function boot( config: AppConfig ) {
-	installDomMutationGuard();
-
 	if ( handleOAuthCallback() ) {
 		return;
 	}
@@ -37,6 +35,7 @@ function boot( config: AppConfig ) {
 	loadPreferencesHelper();
 	limitTotalSnackbars();
 	initSentry();
+	installDomMutationGuard();
 
 	const rootElement = document.getElementById( 'wpcom' );
 	if ( rootElement === null ) {

--- a/client/dashboard/app/dom-mutation-guard.ts
+++ b/client/dashboard/app/dom-mutation-guard.ts
@@ -5,7 +5,7 @@ let reported = false;
 function reportRecovery() {
 	if ( ! reported ) {
 		reported = true;
-		bumpStat( 'calypso_dashboard_dom_mutation_guard', 'recovered' );
+		bumpStat( 'dashboard_dom_guard', 'recovered' );
 	}
 }
 

--- a/client/dashboard/app/dom-mutation-guard.ts
+++ b/client/dashboard/app/dom-mutation-guard.ts
@@ -1,0 +1,46 @@
+import { bumpStat } from './analytics';
+
+let reported = false;
+
+function reportRecovery() {
+	if ( ! reported ) {
+		reported = true;
+		bumpStat( 'calypso_dashboard_dom_mutation_guard', 'recovered' );
+	}
+}
+
+/**
+ * Browser translation tools (Google Translate in particular) replace React-managed
+ * text nodes with `<font>` wrappers, so React's next commit throws NotFoundError
+ * when `insertBefore`/`removeChild` reference a node that is no longer where React
+ * left it (https://github.com/facebook/react/issues/11538). Recover instead of
+ * crashing the whole route: append when the reference node is gone, no-op when the
+ * child is already detached.
+ */
+export function installDomMutationGuard() {
+	if ( typeof Node !== 'function' || ! Node.prototype ) {
+		return;
+	}
+
+	const originalRemoveChild = Node.prototype.removeChild;
+	Node.prototype.removeChild = function < T extends Node >( this: Node, child: T ): T {
+		if ( child.parentNode !== this ) {
+			reportRecovery();
+			return child;
+		}
+		return originalRemoveChild.call( this, child ) as T;
+	};
+
+	const originalInsertBefore = Node.prototype.insertBefore;
+	Node.prototype.insertBefore = function < T extends Node >(
+		this: Node,
+		newNode: T,
+		referenceNode: Node | null
+	): T {
+		if ( referenceNode && referenceNode.parentNode !== this ) {
+			reportRecovery();
+			return originalInsertBefore.call( this, newNode, null ) as T;
+		}
+		return originalInsertBefore.call( this, newNode, referenceNode ) as T;
+	};
+}

--- a/client/dashboard/app/test/dom-mutation-guard.test.ts
+++ b/client/dashboard/app/test/dom-mutation-guard.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { bumpStat } from '../analytics';
+import { installDomMutationGuard } from '../dom-mutation-guard';
+
+jest.mock( '../analytics', () => ( {
+	bumpStat: jest.fn(),
+} ) );
+
+const mockedBumpStat = jest.mocked( bumpStat );
+
+installDomMutationGuard();
+
+describe( 'installDomMutationGuard', () => {
+	// Must run before any other recovery: the stat is bumped once per page load.
+	test( 'bumps a stat once no matter how many recoveries happen', () => {
+		const parent = document.createElement( 'div' );
+		parent.removeChild( document.createElement( 'span' ) );
+		parent.insertBefore( document.createElement( 'em' ), document.createElement( 'span' ) );
+
+		expect( mockedBumpStat ).toHaveBeenCalledTimes( 1 );
+		expect( mockedBumpStat ).toHaveBeenCalledWith(
+			'calypso_dashboard_dom_mutation_guard',
+			'recovered'
+		);
+	} );
+
+	test( 'removeChild still removes an actual child', () => {
+		const parent = document.createElement( 'div' );
+		const child = document.createElement( 'span' );
+		parent.appendChild( child );
+
+		expect( parent.removeChild( child ) ).toBe( child );
+		expect( parent.childNodes ).toHaveLength( 0 );
+	} );
+
+	test( 'removeChild no-ops instead of throwing when the child was detached', () => {
+		const parent = document.createElement( 'div' );
+		const child = document.createElement( 'span' );
+
+		expect( () => parent.removeChild( child ) ).not.toThrow();
+		expect( parent.removeChild( child ) ).toBe( child );
+	} );
+
+	test( 'insertBefore still inserts before an actual child', () => {
+		const parent = document.createElement( 'div' );
+		const reference = document.createElement( 'span' );
+		const newNode = document.createElement( 'em' );
+		parent.appendChild( reference );
+
+		parent.insertBefore( newNode, reference );
+
+		expect( Array.from( parent.childNodes ) ).toEqual( [ newNode, reference ] );
+	} );
+
+	test( 'insertBefore appends instead of throwing when the reference node was detached', () => {
+		const parent = document.createElement( 'div' );
+		const existing = document.createElement( 'span' );
+		const detachedReference = document.createElement( 'span' );
+		const newNode = document.createElement( 'em' );
+		parent.appendChild( existing );
+
+		expect( () => parent.insertBefore( newNode, detachedReference ) ).not.toThrow();
+		expect( Array.from( parent.childNodes ) ).toEqual( [ existing, newNode ] );
+	} );
+
+	test( 'insertBefore with a null reference still appends', () => {
+		const parent = document.createElement( 'div' );
+		const newNode = document.createElement( 'em' );
+
+		parent.insertBefore( newNode, null );
+
+		expect( Array.from( parent.childNodes ) ).toEqual( [ newNode ] );
+	} );
+} );


### PR DESCRIPTION
Fixes [CALYPSO-3G00](https://a8c.sentry.io/issues/7607898876/)

## Proposed Changes

* Patch `removeChild`/`insertBefore` at dashboard boot to recover (no-op / append) when the target node was detached by a browser translation tool, instead of throwing.
* Bump a stat once per page load on recovery, plus unit tests.

## Why are these changes being made?

* Google Translate rewraps React-managed text nodes in `<font>` tags; React's next commit then throws `NotFoundError` and crashes the route to the 500 page. ~360 events / ~250 users a month, mostly on the password form.
* React won't fix it upstream; this is the team-recommended workaround (facebook/react#11538). Unlike the original snippet, a lost insert appends instead of being skipped, so new UI stays visible for translated users.

## Testing Instructions

* `yarn test-client client/dashboard/app/test/dom-mutation-guard.test.ts`
* In Chrome, open `/me/security/password` on the v2 dashboard, translate the page, type in the password field, pause, then keep typing. Without the patch the route crashes to the 500 page; with it the form keeps working.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvFuYb6anxK7TKUaCp3fw2