### PR TITLE
Jetpack AI sidebar: hide Generate Featured Image where the post type cannot store one

### DIFF
--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -262,12 +262,48 @@ function installWpDataMock(
 	return state;
 }
 
+interface PostTypeMockOptions {
+	supportsExcerpt?: boolean;
+	postTypeRecordResolved?: boolean;
+	/** add_post_type_support with arguments stores an array instead of true. */
+	supportsThumbnail?: boolean | unknown[];
+	/** Mirrors the theme support, which is a boolean or a list of post types. */
+	themeSupportsThumbnails?: boolean | string[];
+	/** core-data returns an empty object until the active theme resolves. */
+	themeSupportsResolved?: boolean;
+	/** Whole getThemeSupports return value, for a store that returns something else. */
+	themeSupportsReturnValue?: unknown;
+}
+
 function installPostTypeMock(
 	postType?: string,
 	postId: EditorPostId | null = 123,
-	supportsExcerpt: boolean = postType === 'post',
-	postTypeRecordResolved = true
+	options: PostTypeMockOptions = {}
 ) {
+	const {
+		supportsExcerpt = postType === 'post',
+		postTypeRecordResolved = true,
+		themeSupportsThumbnails = true,
+		themeSupportsResolved = true,
+	} = options;
+
+	// remove_post_type_support unsets the key, so an explicit undefined omits it.
+	const supportsThumbnail =
+		'supportsThumbnail' in options
+			? options.supportsThumbnail
+			: postType === 'post' || postType === 'page';
+	const supports: Record< string, unknown > = { excerpt: supportsExcerpt };
+	if ( supportsThumbnail !== undefined ) {
+		supports.thumbnail = supportsThumbnail;
+	}
+
+	const getThemeSupports = () => {
+		if ( 'themeSupportsReturnValue' in options ) {
+			return options.themeSupportsReturnValue;
+		}
+		return themeSupportsResolved ? { 'post-thumbnails': themeSupportsThumbnails } : {};
+	};
+
 	( window as any ).wp = {
 		data: {
 			select: ( store: string ) => {
@@ -287,9 +323,8 @@ function installPostTypeMock(
 				if ( store === 'core' ) {
 					return {
 						getPostType: ( name: string ) =>
-							postTypeRecordResolved && name === postType
-								? { supports: { excerpt: supportsExcerpt } }
-								: undefined,
+							postTypeRecordResolved && name === postType ? { supports } : undefined,
+						getThemeSupports,
 					};
 				}
 				return undefined;
@@ -1886,7 +1921,7 @@ describe( 'getEmptyViewSuggestions', () => {
 			excerptSuggestion: true,
 			proofreadContent: true,
 		} );
-		installPostTypeMock( 'page', 123, true );
+		installPostTypeMock( 'page', 123, { supportsExcerpt: true } );
 
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
@@ -1908,7 +1943,7 @@ describe( 'getEmptyViewSuggestions', () => {
 				proofreadContent: true,
 				seoSuggestions: true,
 			} );
-			installPostTypeMock( postType, postId, true );
+			installPostTypeMock( postType, postId, { supportsExcerpt: true } );
 
 			const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
@@ -2067,7 +2102,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		installAiEditorialReviewData( { excerptSuggestion: true } );
 		// WordPress.com Simple / any site with the Jetpack SEO Tools module adds
 		// excerpt support to pages — the legacy AI Excerpt panel shows there too.
-		installPostTypeMock( 'page', 123, true );
+		installPostTypeMock( 'page', 123, { supportsExcerpt: true } );
 
 		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
 
@@ -2076,7 +2111,7 @@ describe( 'getEmptyViewSuggestions', () => {
 
 	it( 'hides Generate Excerpt for site editor templates that support excerpts', () => {
 		installAiEditorialReviewData( { excerptSuggestion: true } );
-		installPostTypeMock( 'wp_template', 123, true );
+		installPostTypeMock( 'wp_template', 123, { supportsExcerpt: true } );
 
 		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
 
@@ -2087,7 +2122,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		installAiEditorialReviewData( { excerptSuggestion: true } );
 		// Core registers excerpt support for wp_block (patterns), but the excerpt
 		// field acts as a description there — the chip still excludes patterns.
-		installPostTypeMock( 'wp_block', 123, true );
+		installPostTypeMock( 'wp_block', 123, { supportsExcerpt: true } );
 
 		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
 
@@ -2096,7 +2131,10 @@ describe( 'getEmptyViewSuggestions', () => {
 
 	it( 'shows Generate Excerpt for posts while the post type record is still resolving', () => {
 		installAiEditorialReviewData( { excerptSuggestion: true } );
-		installPostTypeMock( 'post', 123, true, false );
+		installPostTypeMock( 'post', 123, {
+			supportsExcerpt: true,
+			postTypeRecordResolved: false,
+		} );
 
 		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
 
@@ -2105,7 +2143,10 @@ describe( 'getEmptyViewSuggestions', () => {
 
 	it( 'hides Generate Excerpt for pages while the post type record is still resolving', () => {
 		installAiEditorialReviewData( { excerptSuggestion: true } );
-		installPostTypeMock( 'page', 123, false, false );
+		installPostTypeMock( 'page', 123, {
+			supportsExcerpt: false,
+			postTypeRecordResolved: false,
+		} );
 
 		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
 
@@ -2141,6 +2182,112 @@ describe( 'getEmptyViewSuggestions', () => {
 		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
 
 		expect( ids ).not.toContain( 'generate-featured-image' );
+	} );
+
+	it( 'hides Generate Featured Image when the post type has no thumbnail support', () => {
+		// What remove_post_type_support leaves behind: the key is gone.
+		installPostTypeMock( 'post', 123, { supportsThumbnail: undefined } );
+		mockImageStudioActions = { openImageStudio: jest.fn() };
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).not.toContain( 'generate-featured-image' );
+	} );
+
+	it( 'hides Generate Featured Image on pages that dropped thumbnail support', () => {
+		installPostTypeMock( 'page', 123, { supportsThumbnail: undefined } );
+		mockImageStudioActions = { openImageStudio: jest.fn() };
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).not.toContain( 'generate-featured-image' );
+	} );
+
+	it( 'shows Generate Featured Image on pages that support featured images', () => {
+		installPostTypeMock( 'page', 123, { supportsThumbnail: true } );
+		mockImageStudioActions = { openImageStudio: jest.fn() };
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).toContain( 'generate-featured-image' );
+	} );
+
+	it( 'shows Generate Featured Image when thumbnail support was registered with arguments', () => {
+		// add_post_type_support( 'post', 'thumbnail', $args ) stores the arguments,
+		// so the REST route reports an array. The editor treats that as supported.
+		installPostTypeMock( 'post', 123, { supportsThumbnail: [ [ 'custom' ] ] } );
+		mockImageStudioActions = { openImageStudio: jest.fn() };
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).toContain( 'generate-featured-image' );
+	} );
+
+	it( 'hides Generate Featured Image when the theme does not support post thumbnails', () => {
+		// The post type keeps thumbnail support; the theme is what is missing.
+		installPostTypeMock( 'post', 123, { themeSupportsThumbnails: false } );
+		mockImageStudioActions = { openImageStudio: jest.fn() };
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).not.toContain( 'generate-featured-image' );
+	} );
+
+	it( 'hides Generate Featured Image when the theme limits thumbnails to other post types', () => {
+		// add_theme_support( 'post-thumbnails', array( 'post' ) ) leaves pages out.
+		installPostTypeMock( 'page', 123, { themeSupportsThumbnails: [ 'post' ] } );
+		mockImageStudioActions = { openImageStudio: jest.fn() };
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).not.toContain( 'generate-featured-image' );
+	} );
+
+	it( 'shows Generate Featured Image when the theme lists this post type', () => {
+		installPostTypeMock( 'page', 123, { themeSupportsThumbnails: [ 'post', 'page' ] } );
+		mockImageStudioActions = { openImageStudio: jest.fn() };
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).toContain( 'generate-featured-image' );
+	} );
+
+	it( 'hides Generate Featured Image when the theme lists no post types', () => {
+		installPostTypeMock( 'post', 123, { themeSupportsThumbnails: [] } );
+		mockImageStudioActions = { openImageStudio: jest.fn() };
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).not.toContain( 'generate-featured-image' );
+	} );
+
+	it( 'shows Generate Featured Image while the post type record is still resolving', () => {
+		installPostTypeMock( 'post', 123, { postTypeRecordResolved: false } );
+		mockImageStudioActions = { openImageStudio: jest.fn() };
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).toContain( 'generate-featured-image' );
+	} );
+
+	it( 'shows Generate Featured Image when the theme supports are not an object', () => {
+		// core-data always returns an object, but the chip reads whichever store
+		// the page registered as 'core', so reading the key must not throw.
+		installPostTypeMock( 'post', 123, { themeSupportsReturnValue: true } );
+		mockImageStudioActions = { openImageStudio: jest.fn() };
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).toContain( 'generate-featured-image' );
+	} );
+
+	it( 'shows Generate Featured Image while the theme supports are still resolving', () => {
+		installPostTypeMock( 'post', 123, { themeSupportsResolved: false } );
+		mockImageStudioActions = { openImageStudio: jest.fn() };
+
+		const ids = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+
+		expect( ids ).toContain( 'generate-featured-image' );
 	} );
 
 	it( "invoking the suggestion's action opens Image Studio and does not submit a prompt", () => {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -327,6 +327,66 @@ function currentPostTypeSupportsExcerpt(
 }
 
 /**
+ * Unresolved counts as supported: only posts and pages reach this chip, and
+ * both register it. Registering a support with arguments stores those
+ * arguments, so match the editor and treat any truthy value as support.
+ * @see checkSupport in @wordpress/editor
+ */
+function postTypeRecordSupportsThumbnail(
+	postTypeRecord: { supports?: Record< string, unknown > } | undefined
+): boolean {
+	if ( ! postTypeRecord ) {
+		return true;
+	}
+	return !! postTypeRecord.supports?.thumbnail;
+}
+
+/**
+ * Themes can pass a list of post types to add_theme_support, so the support is
+ * a boolean or a list.
+ * @see PostFeaturedImageCheck in @wordpress/editor
+ */
+function themeSupportsThumbnail(
+	currentPostType: string,
+	themeSupports: { 'post-thumbnails'?: boolean | string[] } | undefined
+): boolean {
+	// core-data returns {} until the theme resolves; a resolved theme always has the key.
+	const support = themeSupports?.[ 'post-thumbnails' ];
+	if ( support === undefined ) {
+		return true;
+	}
+	return Array.isArray( support ) ? support.includes( currentPostType ) : !! support;
+}
+
+/**
+ * The post type and theme checks the editor makes before it renders the
+ * featured image panel. The editor hides the panel while either one is still
+ * resolving; the chip shows instead, so a slow read never hides it for good.
+ */
+function currentPostTypeSupportsFeaturedImage(
+	currentPostType: string | undefined = getCurrentEditorPostType()
+): boolean {
+	if ( ! currentPostType ) {
+		return false;
+	}
+	const coreStore = ( window as any ).wp?.data?.select?.( 'core' );
+	return (
+		postTypeRecordSupportsThumbnail( coreStore?.getPostType?.( currentPostType ) ) &&
+		themeSupportsThumbnail( currentPostType, coreStore?.getThemeSupports?.() )
+	);
+}
+
+function isFeaturedImageSuggestionAvailable(
+	currentPostType: string | undefined = getCurrentEditorPostType()
+): boolean {
+	// Image Studio first: the core-store reads can trigger a REST resolution.
+	if ( ! isImageStudioAvailable() ) {
+		return false;
+	}
+	return currentPostTypeSupportsFeaturedImage( currentPostType );
+}
+
+/**
  * Editor entities that support whole-content Jetpack AI suggestions.
  */
 const EDITOR_LEVEL_SUGGESTION_POST_TYPES = new Set( [ 'post', 'page' ] );
@@ -397,7 +457,9 @@ function getPostLevelSuggestions(
 	}
 
 	return [
-		...( isImageStudioAvailable() ? [ GENERATE_FEATURED_IMAGE_SUGGESTION ] : [] ),
+		...( isFeaturedImageSuggestionAvailable( currentPostType )
+			? [ GENERATE_FEATURED_IMAGE_SUGGESTION ]
+			: [] ),
 		...( isOptimizeTitleSuggestionEnabled() ? [ OPTIMIZE_TITLE_SUGGESTION ] : [] ),
 		...( isExcerptSuggestionAvailable( currentPostType, supportsExcerpt )
 			? [ GENERATE_EXCERPT_SUGGESTION ]


### PR DESCRIPTION
## Proposed Changes

* Hide the "Generate featured image" chip unless the post type supports `thumbnail` and the theme allows post thumbnails for it.

## Why are these changes being made?

* The chip only checked that Image Studio had loaded, so you could generate an image with nowhere to put it. These are the two checks the editor's `PostFeaturedImageCheck` already makes.

## Testing Instructions

Ask your agent to spin up a JN site with Jetpack connected (the `jetpack-test-jurassic-ninja` skill in the Jetpack monorepo, or the `jurassic-ninja` MCP provider directly). Sandbox `widgets.wp.com`, then run `yarn dev --sync` from `apps/agents-manager` on this branch.

Have the agent add this mu-plugin to turn the sidebar on:

```php
<?php
// wp-content/mu-plugins/zz-thumbnail-test.php
add_filter( 'jetpack_ai_sidebar_enabled', '__return_true' );
```

Open a post. The "Generate featured image" chip shows.

Add this to the same file. The chip goes on pages and stays on posts:

```php
add_action( 'after_setup_theme', function () {
	remove_theme_support( 'post-thumbnails' );
	add_theme_support( 'post-thumbnails', array( 'post' ) );
}, 20 );
```

Swap that block for this. The chip goes on posts:

```php
add_action( 'init', function () {
	remove_post_type_support( 'post', 'thumbnail' );
}, 20 );
```

Delete the file. The chip comes back.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
