### PR TITLE
Login: remove skeleton placeholder flash before 2FA screens

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -426,7 +426,13 @@ class Login extends Component {
 		const signupLink = this.getSignupLinkComponent();
 
 		if ( socialConnect ) {
-			return <AsyncLoad require={ loadSocialConnectPrompt } onSuccess={ this.handleValidLogin } />;
+			return (
+				<AsyncLoad
+					placeholder={ null }
+					require={ loadSocialConnectPrompt }
+					onSuccess={ this.handleValidLogin }
+				/>
+			);
 		}
 
 		if ( action === 'lostpassword' ) {
@@ -452,6 +458,7 @@ class Login extends Component {
 			return (
 				<Fragment>
 					<AsyncLoad
+						placeholder={ null }
 						require={ loadTwoFactorContent }
 						isBrowserSupported={ this.state.isBrowserSupported }
 						isJetpack={ isJetpack }


### PR DESCRIPTION
## Proposed Changes

* Pass `placeholder={ null }` to the lazy-loaded 2FA content and social-connect prompt in the login block, so nothing renders while their chunks download.

## Why are these changes being made?

* After submitting a password on an account with a security key, a small grey skeleton pill briefly flashes before the 2FA screen appears. It's the default `AsyncLoad` placeholder (80×8px, `margin: 0 16px`), which sits top-left while the rest of the login screen is centered, so it reads as a misaligned artifact rather than a loading state.
* The chunk loads in a few hundred ms; a brief blank state is less jarring than the misplaced skeleton.

## Testing Instructions

* Run Calypso locally and go to `/log-in` with an account that has 2FA enabled.
* In DevTools, throttle the network (e.g. Fast 4G) to make the chunk load visible.
* Log in with your password. Before: a small grey pulsing pill flashes near the top-left before the 2FA screen renders. After: no skeleton; the 2FA screen appears directly.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvFuYb6anxK7TKUaCp3fw2