### PR TITLE
Refuse canvas writes aimed at a page the editor has left

### DIFF
--- a/packages/agents-manager/src/abilities/ability-name.ts
+++ b/packages/agents-manager/src/abilities/ability-name.ts
@@ -1,7 +1,13 @@
 import type { Ability } from './types';
 
-// The agent routes tool calls with `/` → `__` and `-` → `_`.
-const normalizeAbilityName = ( name: string ) => name.replace( /\//g, '__' ).replace( /-/g, '_' );
+/**
+ * The agent routes tool calls with `/` → `__` and `-` → `_`, so an ability
+ * registered as `big-sky/apply-block-edits` is invoked as
+ * `big_sky__apply_block_edits`. Anything matching an ability by name — execution,
+ * ownership checks, the editor-target guard — has to normalize both sides.
+ */
+export const normalizeAbilityName = ( name: string ) =>
+	name.replace( /\//g, '__' ).replace( /-/g, '_' );
 
 /**
  * Finds an ability by its raw or agent-normalized name — the one matching

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -230,6 +230,12 @@ jest.mock( '../agent-chat', () => ( {
 	default: ( props: unknown ) => mockAgentChat( props as Parameters< typeof mockAgentChat >[ 0 ] ),
 } ) );
 
+import {
+	blockCurrentRequest,
+	getTargetViolation,
+	recordReportedTarget,
+	startNewUserRequest,
+} from '../../utils/editor-target-binding';
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import OrchestratorChat from '../orchestrator-chat';
 
@@ -283,6 +289,16 @@ const createImageUpload = ( overrides: Record< string, unknown > = {} ) => ( {
 const renderWithImageUpload = ( imageUpload: ReturnType< typeof createImageUpload > ) => {
 	mockUseImageUpload.mockReturnValue( imageUpload );
 	return render( chat() );
+};
+
+// The host's canvas-change event, as Big Sky dispatches it when the editor
+// opens a different page.
+const dispatchEditorTargetChange = ( target: unknown ) => {
+	act( () => {
+		window.dispatchEvent(
+			new CustomEvent( 'big-sky-editor-target-change', { detail: { target } } )
+		);
+	} );
 };
 
 // Show-component fixtures shared by the retention tests.
@@ -1405,5 +1421,96 @@ describe( 'OrchestratorChat', () => {
 		rerender( chat() );
 
 		expect( countShowComponentMessages() ).toBe( 1 );
+	} );
+
+	describe( 'editor canvas binding', () => {
+		const ABOUT_PAGE = { available: true, key: 'page:4', label: 'About' };
+		const CONTACT_PAGE = { available: true, key: 'page:9', label: 'Contact' };
+
+		beforeEach( () => {
+			// The binding is module-level state, so each test has to start from the
+			// unbound, unblocked position a fresh page load would give it.
+			startNewUserRequest();
+		} );
+
+		it( 'aborts and blocks the request when the canvas moves mid-request', () => {
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { abortCurrentRequest } = mockUseAgentChat();
+
+			render( chat() );
+			// The canvas the model was looking at when it decided what to do.
+			recordReportedTarget( ABOUT_PAGE );
+
+			dispatchEditorTargetChange( CONTACT_PAGE );
+
+			expect( abortCurrentRequest ).toHaveBeenCalledTimes( 1 );
+			// Blocked as well as aborted, and carrying the pages it was blocked
+			// for: a tool call already in flight when the abort loses the race must
+			// still be refused, with a message that names the page it was meant for.
+			expect( getTargetViolation() ).toEqual( {
+				code: 'moved',
+				from: 'About',
+				to: 'Contact',
+			} );
+		} );
+
+		it( 'leaves the request running when the canvas has not moved', () => {
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { abortCurrentRequest } = mockUseAgentChat();
+
+			render( chat() );
+			recordReportedTarget( ABOUT_PAGE );
+
+			// The host re-announces the canvas on editor changes that do not move it.
+			dispatchEditorTargetChange( ABOUT_PAGE );
+
+			expect( abortCurrentRequest ).not.toHaveBeenCalled();
+			expect( getTargetViolation() ).toBeNull();
+		} );
+
+		it( 'does not abort when no request is running', () => {
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: false } ) );
+			const { abortCurrentRequest } = mockUseAgentChat();
+
+			render( chat() );
+			recordReportedTarget( ABOUT_PAGE );
+
+			dispatchEditorTargetChange( CONTACT_PAGE );
+
+			expect( abortCurrentRequest ).not.toHaveBeenCalled();
+		} );
+
+		it( 'stops listening for canvas moves once unmounted', () => {
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { abortCurrentRequest } = mockUseAgentChat();
+
+			const { unmount } = render( chat() );
+			recordReportedTarget( ABOUT_PAGE );
+			unmount();
+
+			dispatchEditorTargetChange( CONTACT_PAGE );
+
+			expect( abortCurrentRequest ).not.toHaveBeenCalled();
+		} );
+
+		it( 'lifts the block when the composer submits the next message', async () => {
+			// The rebind has to sit on the callback the composer is wired to. In
+			// `submitChatMessage` — which only serves custom actions and context
+			// cards — one canvas-move abort would latch the block for the rest of
+			// the page session, refusing every canvas write until a reload.
+			const { onSubmit } = mockUseAgentChat();
+
+			render( chat() );
+			recordReportedTarget( ABOUT_PAGE );
+			blockCurrentRequest( { code: 'moved', from: 'About', to: 'Contact' } );
+			expect( getTargetViolation() ).not.toBeNull();
+
+			await act( async () => {
+				fireEvent.click( screen.getByText( 'Submit message' ) );
+			} );
+
+			expect( onSubmit ).toHaveBeenCalledWith( 'Describe these images' );
+			expect( getTargetViolation() ).toBeNull();
+		} );
 	} );
 } );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -233,6 +233,7 @@ jest.mock( '../agent-chat', () => ( {
 import {
 	blockCurrentRequest,
 	getTargetViolation,
+	recordLiveTarget,
 	recordReportedTarget,
 	startNewUserRequest,
 } from '../../utils/editor-target-binding';
@@ -1493,6 +1494,32 @@ describe( 'OrchestratorChat', () => {
 			expect( abortCurrentRequest ).not.toHaveBeenCalled();
 		} );
 
+		it( 'does not abort again on a canvas event that moved nothing', () => {
+			// The abort keys off the live move, not the block. Keying it off the
+			// block would abort on every later canvas event for the rest of the page
+			// session — including events that re-announce the canvas the request is
+			// now bound to, and including a later, unrelated request.
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { abortCurrentRequest } = mockUseAgentChat();
+
+			render( chat() );
+			recordReportedTarget( ABOUT_PAGE );
+			dispatchEditorTargetChange( CONTACT_PAGE );
+			expect( abortCurrentRequest ).toHaveBeenCalledTimes( 1 );
+
+			// The refused tool call's continuation rebinds to the page now open.
+			recordReportedTarget( CONTACT_PAGE );
+			dispatchEditorTargetChange( CONTACT_PAGE );
+
+			expect( abortCurrentRequest ).toHaveBeenCalledTimes( 1 );
+			// The block is untouched by any of that: the refused write stays refused.
+			expect( getTargetViolation() ).toEqual( {
+				code: 'moved',
+				from: 'About',
+				to: 'Contact',
+			} );
+		} );
+
 		it( 'lifts the block when the composer submits the next message', async () => {
 			// The rebind has to sit on the callback the composer is wired to. In
 			// `submitChatMessage` — which only serves custom actions and context
@@ -1502,7 +1529,8 @@ describe( 'OrchestratorChat', () => {
 
 			render( chat() );
 			recordReportedTarget( ABOUT_PAGE );
-			blockCurrentRequest( { code: 'moved', from: 'About', to: 'Contact' } );
+			recordLiveTarget( CONTACT_PAGE );
+			blockCurrentRequest();
 			expect( getTargetViolation() ).not.toBeNull();
 
 			await act( async () => {
@@ -1510,6 +1538,28 @@ describe( 'OrchestratorChat', () => {
 			} );
 
 			expect( onSubmit ).toHaveBeenCalledWith( 'Describe these images' );
+			expect( getTargetViolation() ).toBeNull();
+		} );
+
+		it( 'lifts the block when the turn is regenerated', async () => {
+			// A regeneration is a fresh dispatch that rebinds on its own outbound
+			// message, so it is a new request for the binding too. It goes through
+			// agenttic's own handler rather than the composer, so without this the
+			// block would survive into a request it has nothing to do with.
+			render( chat() );
+			recordReportedTarget( ABOUT_PAGE );
+			recordLiveTarget( CONTACT_PAGE );
+			blockCurrentRequest();
+			expect( getTargetViolation() ).not.toBeNull();
+
+			const config = mockUseRegenerateAction.mock.calls.at( -1 )![ 0 ] as {
+				getRegenerateHandler?: ( message: unknown ) => ( () => Promise< void > ) | null | undefined;
+			};
+			const wrappedHandler = config.getRegenerateHandler?.( showComponentMessage( 'agent-1' ) );
+			await act( async () => {
+				await wrappedHandler?.();
+			} );
+
 			expect( getTargetViolation() ).toBeNull();
 		} );
 	} );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -1455,6 +1455,38 @@ describe( 'OrchestratorChat', () => {
 			} );
 		} );
 
+		it( 'explains the cancellation in the thread, without sending it to the server', () => {
+			// An aborted turn otherwise stops mid-sentence and reads as a failure.
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { addMessage } = mockUseAgentChat();
+
+			render( chat() );
+			recordReportedTarget( ABOUT_PAGE );
+
+			dispatchEditorTargetChange( CONTACT_PAGE );
+
+			expect( addMessage ).toHaveBeenCalledTimes( 1 );
+
+			const message = addMessage.mock.calls[ 0 ][ 0 ];
+			expect( message.role ).toBe( 'agent' );
+			expect( message.content[ 0 ].text ).toContain( 'switched pages' );
+			// `addMessage` only touches the UI list. Anything that dispatched to the
+			// agent would restart the request the abort just stopped.
+			expect( mockUseAgentChat().onSubmit ).not.toHaveBeenCalled();
+		} );
+
+		it( 'says nothing when the canvas has not moved', () => {
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { addMessage } = mockUseAgentChat();
+
+			render( chat() );
+			recordReportedTarget( ABOUT_PAGE );
+
+			dispatchEditorTargetChange( ABOUT_PAGE );
+
+			expect( addMessage ).not.toHaveBeenCalled();
+		} );
+
 		it( 'leaves the request running when the canvas has not moved', () => {
 			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
 			const { abortCurrentRequest } = mockUseAgentChat();

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -303,13 +303,15 @@ export default function OrchestratorChat( {
 		const handleEditorTargetChange = ( event: Event ) => {
 			recordLiveTarget( ( event as CustomEvent ).detail?.target );
 
-			if ( ! isProcessing || ! getTargetViolation() ) {
+			const violation = getTargetViolation();
+
+			if ( ! isProcessing || ! violation ) {
 				return;
 			}
 
 			// Blocked as well as aborted: an abort that loses the race to an
 			// in-flight tool call must not let that call land on the new page.
-			blockCurrentRequest();
+			blockCurrentRequest( violation );
 			abortCurrentRequest();
 		};
 

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -28,6 +28,12 @@ import convertToolMessagesToComponents, {
 	type AgentsManagerUIMessage,
 } from '../../utils/convert-tool-messages-to-components';
 import {
+	blockCurrentRequest,
+	getTargetViolation,
+	recordLiveTarget,
+	startNewUserRequest,
+} from '../../utils/editor-target-binding';
+import {
 	consumeNextMessageExternalContextEntries,
 	removeExternalContextCard,
 	removeExternalContextEntry,
@@ -288,6 +294,31 @@ export default function OrchestratorChat( {
 			setIsRegenerating( false );
 		}
 	}, [ isProcessing, isRegenerating ] );
+
+	// Stop a request the moment the canvas it was made for goes away. The guard
+	// in `load-external-providers` would refuse the eventual write anyway, but
+	// only once the model got there — the user would sit and watch a request run
+	// against a page they have already left.
+	useEffect( () => {
+		const handleEditorTargetChange = ( event: Event ) => {
+			recordLiveTarget( ( event as CustomEvent ).detail?.target );
+
+			if ( ! isProcessing || ! getTargetViolation() ) {
+				return;
+			}
+
+			// Blocked as well as aborted: an abort that loses the race to an
+			// in-flight tool call must not let that call land on the new page.
+			blockCurrentRequest();
+			abortCurrentRequest();
+		};
+
+		window.addEventListener( 'big-sky-editor-target-change', handleEditorTargetChange );
+
+		return () => {
+			window.removeEventListener( 'big-sky-editor-target-change', handleEditorTargetChange );
+		};
+	}, [ isProcessing, abortCurrentRequest ] );
 
 	// While a regeneration runs, the component being regenerated is deliberately
 	// dropped from the live messages (Agenttic sends `preserveUiOnlyMessages:
@@ -594,6 +625,13 @@ export default function OrchestratorChat( {
 				// unrelated draft in it).
 				setInputValue( ( currentValue ) => ( currentValue === message ? '' : currentValue ) );
 			}
+
+			// A new user message is a new intent: rebind to whatever canvas is open
+			// now, and lift any block left by a previous request. This sits on the
+			// dispatch path rather than in `submitChatMessage` — the composer calls
+			// this callback directly, and the sends above that bail out early must
+			// not disturb a binding that still belongs to a running request.
+			startNewUserRequest();
 
 			submitDispatchedRef.current = true;
 			try {

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -28,8 +28,9 @@ import convertToolMessagesToComponents, {
 	type AgentsManagerUIMessage,
 } from '../../utils/convert-tool-messages-to-components';
 import {
+	EDITOR_TARGET_CHANGE_EVENT,
 	blockCurrentRequest,
-	getTargetViolation,
+	getLiveTargetMove,
 	recordLiveTarget,
 	startNewUserRequest,
 } from '../../utils/editor-target-binding';
@@ -303,22 +304,23 @@ export default function OrchestratorChat( {
 		const handleEditorTargetChange = ( event: Event ) => {
 			recordLiveTarget( ( event as CustomEvent ).detail?.target );
 
-			const violation = getTargetViolation();
-
-			if ( ! isProcessing || ! violation ) {
+			// Keyed off the live move rather than `getTargetViolation()`: a request
+			// already blocked would otherwise abort on every later canvas event,
+			// including ones where the canvas did not move at all.
+			if ( ! isProcessing || ! getLiveTargetMove() ) {
 				return;
 			}
 
 			// Blocked as well as aborted: an abort that loses the race to an
 			// in-flight tool call must not let that call land on the new page.
-			blockCurrentRequest( violation );
+			blockCurrentRequest();
 			abortCurrentRequest();
 		};
 
-		window.addEventListener( 'big-sky-editor-target-change', handleEditorTargetChange );
+		window.addEventListener( EDITOR_TARGET_CHANGE_EVENT, handleEditorTargetChange );
 
 		return () => {
-			window.removeEventListener( 'big-sky-editor-target-change', handleEditorTargetChange );
+			window.removeEventListener( EDITOR_TARGET_CHANGE_EVENT, handleEditorTargetChange );
 		};
 	}, [ isProcessing, abortCurrentRequest ] );
 
@@ -338,6 +340,11 @@ export default function OrchestratorChat( {
 				// rewound, so a leftover picker would otherwise reappear once
 				// regeneration settles if the new response omits the component.
 				clearRetainedShowComponentMessages();
+				// A regeneration is a fresh dispatch that rebinds via
+				// `getClientContext()` on its own outbound message, so it starts a
+				// new request for the binding too — carrying a previous request's
+				// block into it would refuse writes the new canvas is bound to.
+				startNewUserRequest();
 				await handler();
 			};
 		},

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -41,6 +41,7 @@ import {
 	type ExternalContextCard,
 	type ExternalContextCardAction,
 } from '../../utils/external-context';
+import { generateUUID } from '../../utils/generate-uuid';
 import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
 import { mergeEmptyViewSuggestions } from '../../utils/merge-empty-view-suggestions';
 import { getOrchestratorErrorMessage } from '../../utils/orchestrator-error-message';
@@ -315,6 +316,27 @@ export default function OrchestratorChat( {
 			// in-flight tool call must not let that call land on the new page.
 			blockCurrentRequest();
 			abortCurrentRequest();
+
+			// Say why, or the reply just stops mid-sentence and reads as a failure.
+			// UI-only: the message carries an id the agent's client history does not
+			// have, so `filterUiOnlyMessages` keeps it on screen and it is never sent
+			// back to the server as conversation history.
+			addMessage( {
+				id: `editor-target-abort-${ generateUUID() }`,
+				role: 'agent',
+				content: [
+					{
+						type: 'text',
+						text: __(
+							'You switched pages, so I stopped that request before it changed the wrong one. Ask again to apply it here.',
+							__i18n_text_domain__
+						),
+					},
+				],
+				timestamp: Date.now(),
+				archived: false,
+				showIcon: true,
+			} );
 		};
 
 		window.addEventListener( EDITOR_TARGET_CHANGE_EVENT, handleEditorTargetChange );
@@ -322,7 +344,7 @@ export default function OrchestratorChat( {
 		return () => {
 			window.removeEventListener( EDITOR_TARGET_CHANGE_EVENT, handleEditorTargetChange );
 		};
-	}, [ isProcessing, abortCurrentRequest ] );
+	}, [ isProcessing, abortCurrentRequest, addMessage ] );
 
 	// While a regeneration runs, the component being regenerated is deliberately
 	// dropped from the live messages (Agenttic sends `preserveUiOnlyMessages:

--- a/packages/agents-manager/src/utils/__tests__/editor-target-binding.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/editor-target-binding.test.ts
@@ -4,6 +4,7 @@
 import {
 	blockCurrentRequest,
 	clearTargetBinding,
+	getLiveTargetMove,
 	getTargetViolation,
 	parseEditorTarget,
 	recordLiveTarget,
@@ -65,16 +66,19 @@ describe( 'getTargetViolation', () => {
 		// The fail-open branch sits *under* the block check, so a request blocked
 		// on a host that never implemented the contract would refuse every canvas
 		// write over a deploy-order mismatch neither side controls.
-		// `blockCurrentRequest` takes the violation rather than a bare flag
+		// `blockCurrentRequest` latches the live move rather than accepting one,
 		// precisely so it cannot be reached without one — and on this host there
-		// is never one to pass, however far the canvas moves.
+		// is never one to latch, however far the canvas moves.
 		recordReportedTarget( undefined );
+		expect( blockCurrentRequest() ).toBe( false );
 		expect( getTargetViolation() ).toBeNull();
 
 		recordLiveTarget( { available: false } );
+		expect( blockCurrentRequest() ).toBe( false );
 		expect( getTargetViolation() ).toBeNull();
 
 		recordLiveTarget( { available: true, key: 'page:9', label: 'Contact' } );
+		expect( blockCurrentRequest() ).toBe( false );
 		expect( getTargetViolation() ).toBeNull();
 	} );
 
@@ -147,8 +151,7 @@ describe( 'getTargetViolation', () => {
 		// attempt write the user's request onto the page they moved to.
 		recordReportedTarget( { available: true, key: 'page:4', label: 'About' } );
 		recordLiveTarget( { available: true, key: 'page:9', label: 'Contact' } );
-		const violation = getTargetViolation();
-		blockCurrentRequest( violation! );
+		expect( blockCurrentRequest() ).toBe( true );
 
 		recordReportedTarget( { available: true, key: 'page:9', label: 'Contact' } );
 
@@ -169,7 +172,7 @@ describe( 'getTargetViolation', () => {
 		// wrong thing to say about a request made with no page open at all.
 		recordReportedTarget( { available: true, key: 'page:4', label: 'About' } );
 		recordLiveTarget( { available: false } );
-		blockCurrentRequest( { code: 'no-editor' } );
+		blockCurrentRequest();
 
 		recordReportedTarget( { available: true, key: 'page:9', label: 'Contact' } );
 
@@ -178,7 +181,8 @@ describe( 'getTargetViolation', () => {
 
 	it( 'unblocks on the next user message', () => {
 		recordReportedTarget( { available: true, key: 'page:4' } );
-		blockCurrentRequest( { code: 'moved', from: 'page:4', to: 'page:9' } );
+		recordLiveTarget( { available: true, key: 'page:9' } );
+		blockCurrentRequest();
 		startNewUserRequest();
 		recordReportedTarget( { available: true, key: 'page:9' } );
 
@@ -198,7 +202,8 @@ describe( 'getTargetViolation', () => {
 		// binding, and if that also lifted the block the model could navigate and
 		// then write the refused change onto the page it navigated to.
 		recordReportedTarget( { available: true, key: 'page:4', label: 'About' } );
-		blockCurrentRequest( { code: 'moved', from: 'About', to: 'Contact' } );
+		recordLiveTarget( { available: true, key: 'page:9', label: 'Contact' } );
+		blockCurrentRequest();
 
 		clearTargetBinding();
 
@@ -207,5 +212,63 @@ describe( 'getTargetViolation', () => {
 			from: 'About',
 			to: 'Contact',
 		} );
+	} );
+} );
+
+describe( 'getLiveTargetMove', () => {
+	it( 'stops reporting a move once the canvas is back in agreement', () => {
+		// The latch-free reading, which is what the abort keys off. After a
+		// refusal the model's continuation re-reports the new canvas, so the two
+		// agree again — and a host event that re-announces that same canvas is not
+		// a move, however long the request stays blocked.
+		recordReportedTarget( { available: true, key: 'page:4', label: 'About' } );
+		recordLiveTarget( { available: true, key: 'page:9', label: 'Contact' } );
+		blockCurrentRequest();
+
+		recordReportedTarget( { available: true, key: 'page:9', label: 'Contact' } );
+		recordLiveTarget( { available: true, key: 'page:9', label: 'Contact' } );
+
+		expect( getLiveTargetMove() ).toBeNull();
+		// The block itself is untouched: the write still may not proceed.
+		expect( getTargetViolation() ).toEqual( {
+			code: 'moved',
+			from: 'About',
+			to: 'Contact',
+		} );
+	} );
+
+	it( 'keeps reporting a move while the canvas is still away', () => {
+		recordReportedTarget( { available: true, key: 'page:4', label: 'About' } );
+		recordLiveTarget( { available: true, key: 'page:9', label: 'Contact' } );
+
+		expect( getLiveTargetMove() ).toEqual( {
+			code: 'moved',
+			from: 'About',
+			to: 'Contact',
+		} );
+	} );
+} );
+
+describe( 'blockCurrentRequest', () => {
+	it( 'latches nothing when the canvas has not moved', () => {
+		// A block is only ever created from a real live move, so a caller cannot
+		// refuse writes the binding has no basis to refuse.
+		recordReportedTarget( { available: true, key: 'page:4', label: 'About' } );
+
+		expect( blockCurrentRequest() ).toBe( false );
+		expect( getTargetViolation() ).toBeNull();
+	} );
+
+	it( 'keeps the first block rather than replacing it', () => {
+		recordReportedTarget( { available: true, key: 'page:4', label: 'About' } );
+		recordLiveTarget( { available: false } );
+		expect( blockCurrentRequest() ).toBe( true );
+
+		// A second call once the canvas has mounted elsewhere must not overwrite
+		// the original cause — the refusal message is chosen from its code.
+		recordLiveTarget( { available: true, key: 'page:9', label: 'Contact' } );
+		expect( blockCurrentRequest() ).toBe( true );
+
+		expect( getTargetViolation() ).toEqual( { code: 'no-editor' } );
 	} );
 } );

--- a/packages/agents-manager/src/utils/__tests__/editor-target-binding.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/editor-target-binding.test.ts
@@ -1,0 +1,160 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	blockCurrentRequest,
+	clearTargetBinding,
+	getTargetViolation,
+	parseEditorTarget,
+	recordLiveTarget,
+	recordReportedTarget,
+	startNewUserRequest,
+} from '../editor-target-binding';
+
+beforeEach( () => {
+	startNewUserRequest();
+} );
+
+describe( 'parseEditorTarget', () => {
+	it.each( [ undefined, null, 'page:4', 42, {}, { available: 'yes' } ] )(
+		'returns null for an unrecognised value: %p',
+		( value ) => {
+			expect( parseEditorTarget( value ) ).toBeNull();
+		}
+	);
+
+	it( 'parses the no-canvas shape', () => {
+		expect( parseEditorTarget( { available: false } ) ).toEqual( { available: false } );
+	} );
+
+	it( 'parses a mounting canvas', () => {
+		expect( parseEditorTarget( { available: true, key: null } ) ).toEqual( {
+			available: true,
+			key: null,
+		} );
+	} );
+
+	it( 'parses a resolved canvas with its label', () => {
+		expect( parseEditorTarget( { available: true, key: 'page:4', label: 'About' } ) ).toEqual( {
+			available: true,
+			key: 'page:4',
+			label: 'About',
+		} );
+	} );
+
+	it( 'drops a non-string key rather than trusting it', () => {
+		// The value crosses a repo boundary from an untyped runtime module, so a
+		// wrong-typed key must degrade to "mounting" (permissive) rather than
+		// being stringified into a key that matches nothing (refuses everything).
+		expect( parseEditorTarget( { available: true, key: 4 } ) ).toEqual( {
+			available: true,
+			key: null,
+		} );
+	} );
+} );
+
+describe( 'getTargetViolation', () => {
+	it( 'is null when the host never reported a target', () => {
+		// An older Big Sky plugin against a newer Calypso. The guard disables
+		// itself rather than refusing every canvas write on the site.
+		recordReportedTarget( undefined );
+		expect( getTargetViolation() ).toBeNull();
+	} );
+
+	it( 'is null when the canvas has not moved', () => {
+		recordReportedTarget( { available: true, key: 'page:4', label: 'About' } );
+		expect( getTargetViolation() ).toBeNull();
+	} );
+
+	it( 'reports no-editor when the live canvas is gone', () => {
+		recordReportedTarget( { available: true, key: 'page:4' } );
+		recordLiveTarget( { available: false } );
+		expect( getTargetViolation() ).toEqual( { code: 'no-editor' } );
+	} );
+
+	it( 'reports no-editor when the request itself was made without a canvas', () => {
+		recordReportedTarget( { available: false } );
+		expect( getTargetViolation() ).toEqual( { code: 'no-editor' } );
+	} );
+
+	it( 'reports a move, naming both pages', () => {
+		recordReportedTarget( { available: true, key: 'page:4', label: 'About' } );
+		recordLiveTarget( { available: true, key: 'page:9', label: 'Contact' } );
+		expect( getTargetViolation() ).toEqual( {
+			code: 'moved',
+			from: 'About',
+			to: 'Contact',
+		} );
+	} );
+
+	it( 'falls back to the key when a page has no label', () => {
+		recordReportedTarget( { available: true, key: 'page:4' } );
+		recordLiveTarget( { available: true, key: 'page:9' } );
+		expect( getTargetViolation() ).toEqual( {
+			code: 'moved',
+			from: 'page:4',
+			to: 'page:9',
+		} );
+	} );
+
+	it( 'reports a move when a canvas appears after a canvas-less request', () => {
+		// The model decided what to write with no page content in front of it.
+		// That output belongs to no canvas, so the one that has since mounted
+		// must not receive it.
+		recordReportedTarget( { available: false } );
+		recordLiveTarget( { available: true, key: 'page:9', label: 'Contact' } );
+		expect( getTargetViolation() ).toEqual( {
+			code: 'moved',
+			from: null,
+			to: 'Contact',
+		} );
+	} );
+
+	it( 'lets a mounting live canvas through', () => {
+		// The write abilities do their own readiness handling and retry; refusing
+		// here would break ordinary editor startup.
+		recordReportedTarget( { available: true, key: 'page:4' } );
+		recordLiveTarget( { available: true, key: null } );
+		expect( getTargetViolation() ).toBeNull();
+	} );
+
+	it( 'lets a write through when the request was reported mid-mount', () => {
+		recordReportedTarget( { available: true, key: null } );
+		recordLiveTarget( { available: true, key: 'page:4' } );
+		expect( getTargetViolation() ).toBeNull();
+	} );
+
+	it( 'stays blocked for the rest of the request once the canvas has moved', () => {
+		// Otherwise the model can simply retry: the refusal's own tool result
+		// re-reports the new canvas, which would rebind and let the second
+		// attempt write the user's request onto the page they moved to.
+		recordReportedTarget( { available: true, key: 'page:4', label: 'About' } );
+		recordLiveTarget( { available: true, key: 'page:9', label: 'Contact' } );
+		blockCurrentRequest();
+
+		recordReportedTarget( { available: true, key: 'page:9', label: 'Contact' } );
+
+		expect( getTargetViolation() ).toEqual( {
+			code: 'moved',
+			from: 'Contact',
+			to: 'Contact',
+		} );
+	} );
+
+	it( 'unblocks on the next user message', () => {
+		recordReportedTarget( { available: true, key: 'page:4' } );
+		blockCurrentRequest();
+		startNewUserRequest();
+		recordReportedTarget( { available: true, key: 'page:9' } );
+
+		expect( getTargetViolation() ).toBeNull();
+	} );
+
+	it( 'is null after the binding is cleared for an agent-driven move', () => {
+		recordReportedTarget( { available: true, key: 'page:4' } );
+		clearTargetBinding();
+		recordLiveTarget( { available: true, key: 'page:9' } );
+
+		expect( getTargetViolation() ).toBeNull();
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/editor-target-binding.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/editor-target-binding.test.ts
@@ -61,6 +61,23 @@ describe( 'getTargetViolation', () => {
 		expect( getTargetViolation() ).toBeNull();
 	} );
 
+	it( 'never yields a violation to block with when the host reports no target', () => {
+		// The fail-open branch sits *under* the block check, so a request blocked
+		// on a host that never implemented the contract would refuse every canvas
+		// write over a deploy-order mismatch neither side controls.
+		// `blockCurrentRequest` takes the violation rather than a bare flag
+		// precisely so it cannot be reached without one — and on this host there
+		// is never one to pass, however far the canvas moves.
+		recordReportedTarget( undefined );
+		expect( getTargetViolation() ).toBeNull();
+
+		recordLiveTarget( { available: false } );
+		expect( getTargetViolation() ).toBeNull();
+
+		recordLiveTarget( { available: true, key: 'page:9', label: 'Contact' } );
+		expect( getTargetViolation() ).toBeNull();
+	} );
+
 	it( 'is null when the canvas has not moved', () => {
 		recordReportedTarget( { available: true, key: 'page:4', label: 'About' } );
 		expect( getTargetViolation() ).toBeNull();
@@ -130,20 +147,38 @@ describe( 'getTargetViolation', () => {
 		// attempt write the user's request onto the page they moved to.
 		recordReportedTarget( { available: true, key: 'page:4', label: 'About' } );
 		recordLiveTarget( { available: true, key: 'page:9', label: 'Contact' } );
-		blockCurrentRequest();
+		const violation = getTargetViolation();
+		blockCurrentRequest( violation! );
 
 		recordReportedTarget( { available: true, key: 'page:9', label: 'Contact' } );
 
+		// Still naming both real pages after the rebind. Re-deriving them from the
+		// rebound binding would name Contact twice, so the refusal would tell the
+		// user — and the model — nothing about which page the work was meant for.
 		expect( getTargetViolation() ).toEqual( {
 			code: 'moved',
-			from: 'Contact',
+			from: 'About',
 			to: 'Contact',
 		} );
 	} );
 
+	it( 'keeps the original violation code once blocked', () => {
+		// A block caused by the editor closing must keep reporting `no-editor`
+		// even after a canvas mounts and rebinds: the refusal message is chosen
+		// from the code, and "the page you asked for is no longer open" is the
+		// wrong thing to say about a request made with no page open at all.
+		recordReportedTarget( { available: true, key: 'page:4', label: 'About' } );
+		recordLiveTarget( { available: false } );
+		blockCurrentRequest( { code: 'no-editor' } );
+
+		recordReportedTarget( { available: true, key: 'page:9', label: 'Contact' } );
+
+		expect( getTargetViolation() ).toEqual( { code: 'no-editor' } );
+	} );
+
 	it( 'unblocks on the next user message', () => {
 		recordReportedTarget( { available: true, key: 'page:4' } );
-		blockCurrentRequest();
+		blockCurrentRequest( { code: 'moved', from: 'page:4', to: 'page:9' } );
 		startNewUserRequest();
 		recordReportedTarget( { available: true, key: 'page:9' } );
 
@@ -156,5 +191,21 @@ describe( 'getTargetViolation', () => {
 		recordLiveTarget( { available: true, key: 'page:9' } );
 
 		expect( getTargetViolation() ).toBeNull();
+	} );
+
+	it( 'keeps a block in place when the agent navigates mid-request', () => {
+		// Only a new user message lifts a block. An agent-driven move clears the
+		// binding, and if that also lifted the block the model could navigate and
+		// then write the refused change onto the page it navigated to.
+		recordReportedTarget( { available: true, key: 'page:4', label: 'About' } );
+		blockCurrentRequest( { code: 'moved', from: 'About', to: 'Contact' } );
+
+		clearTargetBinding();
+
+		expect( getTargetViolation() ).toEqual( {
+			code: 'moved',
+			from: 'About',
+			to: 'Contact',
+		} );
 	} );
 } );

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -933,9 +933,12 @@ describe( 'editor target guard', () => {
 	const APPLY_BLOCK_EDITS = 'big_sky__apply_block_edits';
 	const RESTORE_CHECKPOINT = 'big_sky__restore_checkpoint';
 	const UPDATE_THEME = 'big_sky__apply_update_theme';
+	const EDIT_ENTITY_RECORD = 'big_sky__edit_entity_record';
 	const EDITOR_NAVIGATE = 'big_sky__editor_navigate';
+	const WP_ADMIN_NAVIGATE = 'wp_admin__navigate';
 
 	const OPEN_PAGE = { available: true, key: 'page:4', label: 'About' };
+	const CONTACT_PAGE = { available: true, key: 'page:9', label: 'Contact' };
 
 	// Asks `setUpProvider` to leave `editorTarget` out of the client context. A
 	// sentinel rather than `undefined`, because passing `undefined` to a parameter
@@ -953,7 +956,8 @@ describe( 'editor target guard', () => {
 	} );
 
 	// Registers one external provider serving `abilityNames`, reporting `About`
-	// (page 4) as the open canvas.
+	// (page 4) as the open canvas. `editorTarget` may be a function, for hosts
+	// whose reported canvas changes between messages.
 	function setUpProvider(
 		abilityNames: string[],
 		executeAbility = jest.fn( () => Promise.resolve( { ok: true } ) ),
@@ -964,13 +968,17 @@ describe( 'editor target guard', () => {
 			executeAbility,
 		};
 		const contextProvider = {
-			getClientContext: () => ( {
-				url: '',
-				pathname: '',
-				search: '',
-				environment: 'wp-admin',
-				...( editorTarget === NO_EDITOR_TARGET ? {} : { editorTarget } ),
-			} ),
+			getClientContext: () => {
+				const target = typeof editorTarget === 'function' ? editorTarget() : editorTarget;
+
+				return {
+					url: '',
+					pathname: '',
+					search: '',
+					environment: 'wp-admin',
+					...( target === NO_EDITOR_TARGET ? {} : { editorTarget: target } ),
+				};
+			},
 		};
 
 		setAgentsManagerData( { agentProviders: [ { toolProvider, contextProvider } ] } );
@@ -1067,6 +1075,103 @@ describe( 'editor target guard', () => {
 		expect( executeAbility ).toHaveBeenCalled();
 	} );
 
+	it( 'does not guard an ability that names its own target', async () => {
+		// `edit-entity-record` addresses records explicitly (`entityType` /
+		// `entityName` / `recordId`), and most of them — site metadata, navigation
+		// menus — are not page-scoped at all. Moving the canvas cannot redirect its
+		// write, so guarding it would only refuse legitimate site-level edits from
+		// screens that have no canvas, such as a list view.
+		const { executeAbility } = setUpProvider( [ 'big-sky/edit-entity-record' ] );
+		const providers = await loadExternalProviders();
+
+		providers.contextProvider?.getClientContext();
+		recordLiveTarget( { available: false } );
+
+		await providers.toolProvider?.executeAbility( EDIT_ENTITY_RECORD, {} );
+
+		expect( executeAbility ).toHaveBeenCalledWith( EDIT_ENTITY_RECORD, {} );
+	} );
+
+	it( 'stays refused for the rest of the request once a write has been refused', async () => {
+		// The refusal goes back to the model as a tool result, and agenttic asks
+		// for the client context again on that continuation — which rebinds to the
+		// page the user moved to. Without the latch, the retry would then write the
+		// original request onto the new page.
+		let reportedTarget: unknown = OPEN_PAGE;
+		const { executeAbility } = setUpProvider(
+			[ 'big-sky/apply-block-edits' ],
+			jest.fn( () => Promise.resolve( { ok: true } ) ),
+			() => reportedTarget
+		);
+		const providers = await loadExternalProviders();
+
+		providers.contextProvider?.getClientContext();
+		recordLiveTarget( CONTACT_PAGE );
+
+		const first: any = await providers.toolProvider?.executeAbility( APPLY_BLOCK_EDITS, {} );
+		expect( first.result.error ).toBe( 'editor_target_moved' );
+
+		// The continuation: the host now reports Contact, so the binding agrees
+		// with the live canvas again.
+		reportedTarget = CONTACT_PAGE;
+		providers.contextProvider?.getClientContext();
+
+		const second: any = await providers.toolProvider?.executeAbility( APPLY_BLOCK_EDITS, {} );
+
+		expect( second.result.error ).toBe( 'editor_target_moved' );
+		// Still naming the page the work was meant for, not Contact twice.
+		expect( second.result.message ).toContain( 'About' );
+		expect( executeAbility ).not.toHaveBeenCalled();
+	} );
+
+	it( 'binds through a merged context provider that only one host reports on', async () => {
+		// The binding wraps the *merged* provider. Wrapping each external one would
+		// let a provider that reports no canvas overwrite the reading from one that
+		// does, depending on registration order — here the non-reporting provider
+		// is registered first, and is also the one serving the write.
+		const executeAbility = jest.fn( () => Promise.resolve( { ok: true } ) );
+		setAgentsManagerData( {
+			agentProviders: [
+				{
+					toolProvider: {
+						getAbilities: jest.fn( () =>
+							Promise.resolve( [ createAbility( 'big-sky/apply-block-edits' ) ] )
+						),
+						executeAbility,
+					},
+					contextProvider: {
+						getClientContext: () => ( {
+							url: '',
+							pathname: '',
+							search: '',
+							environment: 'wp-admin',
+						} ),
+					},
+				},
+				{
+					contextProvider: {
+						getClientContext: () => ( {
+							url: '',
+							pathname: '',
+							search: '',
+							environment: 'wp-admin',
+							editorTarget: OPEN_PAGE,
+						} ),
+					},
+				},
+			],
+		} );
+		const providers = await loadExternalProviders();
+
+		providers.contextProvider?.getClientContext();
+		recordLiveTarget( CONTACT_PAGE );
+
+		const result: any = await providers.toolProvider?.executeAbility( APPLY_BLOCK_EDITS, {} );
+
+		expect( executeAbility ).not.toHaveBeenCalled();
+		expect( result.result.error ).toBe( 'editor_target_moved' );
+	} );
+
 	it( 'clears the binding before a navigation ability runs, not after', async () => {
 		// The navigation itself makes the canvas move, so a binding still in
 		// place while it executes would abort the agent's own request.
@@ -1083,6 +1188,27 @@ describe( 'editor target guard', () => {
 
 		await providers.toolProvider?.executeAbility( EDITOR_NAVIGATE, {} );
 
+		expect( violationDuringExecution ).toBeNull();
+	} );
+
+	it( 'clears the binding before a wp-admin navigation runs', async () => {
+		// The other canvas-moving ability: leaving for a wp-admin screen takes the
+		// canvas away entirely, so a binding still in place would read as
+		// `no-editor` and abort the agent's own request.
+		let violationDuringExecution: unknown = 'not captured';
+		const executeAbility = jest.fn( () => {
+			violationDuringExecution = getTargetViolation();
+			return Promise.resolve( { ok: true } );
+		} );
+		setUpProvider( [ 'wp-admin/navigate' ], executeAbility );
+		const providers = await loadExternalProviders();
+
+		providers.contextProvider?.getClientContext();
+		recordLiveTarget( { available: false } );
+
+		await providers.toolProvider?.executeAbility( WP_ADMIN_NAVIGATE, {} );
+
+		expect( executeAbility ).toHaveBeenCalledWith( WP_ADMIN_NAVIGATE, {} );
 		expect( violationDuringExecution ).toBeNull();
 	} );
 

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -6,6 +6,11 @@ import { restoreCheckpointAbility } from '../../abilities/restore-checkpoint';
 import { showComponentAbility } from '../../abilities/show-component';
 import { getAvailableCheckpoints } from '../checkpoints';
 import {
+	getTargetViolation,
+	recordLiveTarget,
+	startNewUserRequest,
+} from '../editor-target-binding';
+import {
 	loadExternalProviders,
 	mergeCapabilitiesInto,
 	mergeUseSuggestionsHooks,
@@ -917,5 +922,185 @@ describe( 'mergeUseSuggestionsHooks', () => {
 			suggestions: [ { id: 'second', label: 'Second', prompt: 'Second prompt.' } ],
 			replaceEmptyViewSuggestions: true,
 		} );
+	} );
+} );
+
+describe( 'editor target guard', () => {
+	// Every ability name below is in the agent's tool-id form (`/` → `__`,
+	// `-` → `_`), which is what actually reaches `executeAbility`. Writing these
+	// in the registered form would pass against a guard that never fires in
+	// production.
+	const APPLY_BLOCK_EDITS = 'big_sky__apply_block_edits';
+	const RESTORE_CHECKPOINT = 'big_sky__restore_checkpoint';
+	const UPDATE_THEME = 'big_sky__apply_update_theme';
+	const EDITOR_NAVIGATE = 'big_sky__editor_navigate';
+
+	const OPEN_PAGE = { available: true, key: 'page:4', label: 'About' };
+
+	// Asks `setUpProvider` to leave `editorTarget` out of the client context. A
+	// sentinel rather than `undefined`, because passing `undefined` to a parameter
+	// that has a default re-triggers the default — the key would still be there
+	// and the version-skew test would silently assert the opposite of its name.
+	const NO_EDITOR_TARGET = Symbol( 'host reports no editorTarget' );
+
+	beforeEach( () => {
+		startNewUserRequest();
+	} );
+
+	afterEach( () => {
+		delete ( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData;
+		delete ( window as typeof window & { agentsManagerData?: unknown } ).agentsManagerData;
+	} );
+
+	// Registers one external provider serving `abilityNames`, reporting `About`
+	// (page 4) as the open canvas.
+	function setUpProvider(
+		abilityNames: string[],
+		executeAbility = jest.fn( () => Promise.resolve( { ok: true } ) ),
+		editorTarget: unknown = OPEN_PAGE
+	) {
+		const toolProvider = {
+			getAbilities: jest.fn( () => Promise.resolve( abilityNames.map( createAbility ) ) ),
+			executeAbility,
+		};
+		const contextProvider = {
+			getClientContext: () => ( {
+				url: '',
+				pathname: '',
+				search: '',
+				environment: 'wp-admin',
+				...( editorTarget === NO_EDITOR_TARGET ? {} : { editorTarget } ),
+			} ),
+		};
+
+		setAgentsManagerData( { agentProviders: [ { toolProvider, contextProvider } ] } );
+
+		return { executeAbility };
+	}
+
+	it( 'refuses a provider-owned canvas write after the canvas moves', async () => {
+		const { executeAbility } = setUpProvider( [ 'big-sky/apply-block-edits' ] );
+		const providers = await loadExternalProviders();
+
+		// The model saw page 4 when it decided to call the tool.
+		providers.contextProvider?.getClientContext();
+		recordLiveTarget( { available: true, key: 'page:9', label: 'Contact' } );
+
+		const result: any = await providers.toolProvider?.executeAbility( APPLY_BLOCK_EDITS, {} );
+
+		expect( executeAbility ).not.toHaveBeenCalled();
+		expect( result.result.success ).toBe( false );
+		expect( result.result.error ).toBe( 'editor_target_moved' );
+		expect( result.result.message ).toContain( 'Contact' );
+		expect( result.returnToAgent ).toBe( true );
+	} );
+
+	it( 'refuses an AM-owned canvas write after the canvas moves', async () => {
+		// `restore-checkpoint` has already migrated to AM, so it executes through
+		// `amToolProvider` and never reaches the external provider. A guard placed
+		// in the external provider would not fire here — this is the case that
+		// breaks silently as each remaining ability migrates.
+		setUpProvider( [ 'big-sky/apply-block-edits' ] );
+		const providers = await loadExternalProviders();
+
+		providers.contextProvider?.getClientContext();
+		recordLiveTarget( { available: false } );
+
+		const result: any = await providers.toolProvider?.executeAbility( RESTORE_CHECKPOINT, {} );
+
+		expect( result.result.success ).toBe( false );
+		expect( result.result.error ).toBe( 'editor_target_no_editor' );
+	} );
+
+	it( 'guards the path where AM is the only tool provider', async () => {
+		// No external provider serves tools, so `mergedToolProvider` is assigned
+		// straight from `allToolProviders[ 0 ]` and never enters the merging
+		// closure. A guard applied inside that closure would not exist here.
+		setAgentsManagerData( {
+			agentProviders: [
+				{
+					contextProvider: {
+						getClientContext: () => ( {
+							url: '',
+							pathname: '',
+							search: '',
+							environment: 'wp-admin',
+							editorTarget: OPEN_PAGE,
+						} ),
+					},
+				},
+			],
+		} );
+		const providers = await loadExternalProviders();
+
+		providers.contextProvider?.getClientContext();
+		recordLiveTarget( { available: false } );
+
+		const result: any = await providers.toolProvider?.executeAbility( RESTORE_CHECKPOINT, {} );
+
+		expect( result.result.success ).toBe( false );
+		expect( result.result.error ).toBe( 'editor_target_no_editor' );
+	} );
+
+	it( 'lets a canvas write through when the canvas has not moved', async () => {
+		const { executeAbility } = setUpProvider( [ 'big-sky/apply-block-edits' ] );
+		const providers = await loadExternalProviders();
+
+		providers.contextProvider?.getClientContext();
+
+		await providers.toolProvider?.executeAbility( APPLY_BLOCK_EDITS, {} );
+
+		expect( executeAbility ).toHaveBeenCalledWith( APPLY_BLOCK_EDITS, {} );
+	} );
+
+	it( 'does not guard site-wide abilities', async () => {
+		// Global styles and the site logo are not page-scoped, so moving between
+		// pages does not make them wrong.
+		const { executeAbility } = setUpProvider( [ 'big-sky/apply-update-theme' ] );
+		const providers = await loadExternalProviders();
+
+		providers.contextProvider?.getClientContext();
+		recordLiveTarget( { available: false } );
+
+		await providers.toolProvider?.executeAbility( UPDATE_THEME, {} );
+
+		expect( executeAbility ).toHaveBeenCalled();
+	} );
+
+	it( 'clears the binding before a navigation ability runs, not after', async () => {
+		// The navigation itself makes the canvas move, so a binding still in
+		// place while it executes would abort the agent's own request.
+		let violationDuringExecution: unknown = 'not captured';
+		const executeAbility = jest.fn( () => {
+			violationDuringExecution = getTargetViolation();
+			return Promise.resolve( { ok: true } );
+		} );
+		setUpProvider( [ 'big-sky/editor-navigate' ], executeAbility );
+		const providers = await loadExternalProviders();
+
+		providers.contextProvider?.getClientContext();
+		recordLiveTarget( { available: true, key: 'page:9' } );
+
+		await providers.toolProvider?.executeAbility( EDITOR_NAVIGATE, {} );
+
+		expect( violationDuringExecution ).toBeNull();
+	} );
+
+	it( 'stays disabled when the host reports no editorTarget', async () => {
+		// An older Big Sky plugin against a newer Calypso: refusing here would
+		// break every canvas write on the site over a deploy-order mismatch.
+		const { executeAbility } = setUpProvider(
+			[ 'big-sky/apply-block-edits' ],
+			jest.fn( () => Promise.resolve( { ok: true } ) ),
+			NO_EDITOR_TARGET
+		);
+		const providers = await loadExternalProviders();
+
+		providers.contextProvider?.getClientContext();
+		recordLiveTarget( { available: false } );
+
+		await providers.toolProvider?.executeAbility( APPLY_BLOCK_EDITS, {} );
+
+		expect( executeAbility ).toHaveBeenCalled();
 	} );
 } );

--- a/packages/agents-manager/src/utils/editor-target-binding.ts
+++ b/packages/agents-manager/src/utils/editor-target-binding.ts
@@ -1,0 +1,176 @@
+/**
+ * Binds an agent request to the editor canvas it was made for.
+ *
+ * The host reports the open canvas in its client context, and agenttic-client
+ * asks for that context on every outgoing message — including the tool-result
+ * continuations within a single request. So the last reported target is, by
+ * construction, the canvas the model was looking at when it decided to call the
+ * tool that is now executing. If the live canvas differs, the canvas moved in
+ * the gap, and the pending write belongs to a page that is no longer on screen.
+ *
+ * The binding is deliberately not keyed by request id: nothing in the pipeline
+ * carries one to the ability layer, and the report-then-execute ordering above
+ * makes one unnecessary.
+ *
+ * Module-level state, matching `provider-checkpoints.ts` — there is one chat per
+ * page load and the wrappers that read this are themselves module-level.
+ */
+
+/**
+ * The canvas a request is bound to.
+ *
+ * Mirrors Big Sky's `src/ai/wp-orchestrator/editor-target.ts`. The two cannot
+ * share a module across repos, so `parseEditorTarget` validates every field
+ * rather than trusting the runtime shape.
+ */
+export type EditorTarget =
+	| { available: false }
+	| { available: true; key: string | null; label?: string };
+
+export type TargetViolation =
+	| { code: 'no-editor' }
+	| { code: 'moved'; from: string | null; to: string | null };
+
+// `null` means the host never reported a target — an older plugin, or a host
+// that does not implement the contract. The guard disables itself rather than
+// refusing writes it has no basis to refuse.
+let reportedTarget: EditorTarget | null = null;
+let liveTarget: EditorTarget | null = null;
+
+// Set once a request has been refused or aborted for moving off its canvas, so
+// the model cannot simply retry onto the page the user moved to.
+let requestBlocked = false;
+
+/**
+ * Validate a client-context `editorTarget` value.
+ *
+ * @param value The raw value from the merged client context.
+ * @returns The parsed target, or null when the value is not one this build understands.
+ */
+export function parseEditorTarget( value: unknown ): EditorTarget | null {
+	if ( ! value || typeof value !== 'object' ) {
+		return null;
+	}
+
+	const { available, key, label } = value as Record< string, unknown >;
+
+	if ( available === false ) {
+		return { available: false };
+	}
+
+	if ( available !== true ) {
+		return null;
+	}
+
+	// A wrong-typed key degrades to "mounting", which is permissive. Coercing it
+	// to a string instead would produce a key that matches nothing and would
+	// therefore refuse every write.
+	const parsedKey = typeof key === 'string' && key ? key : null;
+
+	return {
+		available: true,
+		key: parsedKey,
+		...( typeof label === 'string' && label ? { label } : {} ),
+	};
+}
+
+/**
+ * Record the target the host reported on an outgoing message.
+ *
+ * This is both the newest binding and the freshest live reading, so it sets both.
+ *
+ * @param value The raw `editorTarget` from the client context.
+ */
+export function recordReportedTarget( value: unknown ): void {
+	const target = parseEditorTarget( value );
+	reportedTarget = target;
+	liveTarget = target;
+}
+
+/**
+ * Record a live canvas reading that did not come from an outgoing message.
+ *
+ * @param value The raw target from the host's change event.
+ */
+export function recordLiveTarget( value: unknown ): void {
+	liveTarget = parseEditorTarget( value );
+}
+
+/**
+ * Drop the binding because the agent itself is moving the canvas.
+ *
+ * Called before a navigation ability runs, not after: the navigation dispatches
+ * the host's change event while it executes, and a binding still in place at
+ * that moment would read as a violation and abort the agent's own request.
+ */
+export function clearTargetBinding(): void {
+	reportedTarget = null;
+	liveTarget = null;
+}
+
+/**
+ * Refuse canvas writes for the remainder of the current request.
+ */
+export function blockCurrentRequest(): void {
+	requestBlocked = true;
+}
+
+/**
+ * Start a fresh binding for a new user message.
+ */
+export function startNewUserRequest(): void {
+	clearTargetBinding();
+	requestBlocked = false;
+}
+
+function describeTarget( target: EditorTarget | null ): string | null {
+	if ( ! target?.available ) {
+		return null;
+	}
+
+	return target.label ?? target.key;
+}
+
+/**
+ * Whether the pending canvas write would land somewhere it was not meant to.
+ *
+ * @returns The violation, or null when the write may proceed.
+ */
+export function getTargetViolation(): TargetViolation | null {
+	if ( requestBlocked ) {
+		return {
+			code: 'moved',
+			from: describeTarget( reportedTarget ),
+			to: describeTarget( liveTarget ),
+		};
+	}
+
+	// No contract from this host, or no reading yet: nothing to enforce against.
+	if ( ! reportedTarget || ! liveTarget ) {
+		return null;
+	}
+
+	if ( ! liveTarget.available ) {
+		return { code: 'no-editor' };
+	}
+
+	// A canvas that is still mounting is not a wrong canvas. The write abilities
+	// handle their own readiness and retry.
+	if ( liveTarget.key === null ) {
+		return null;
+	}
+
+	if ( ! reportedTarget.available ) {
+		return { code: 'moved', from: null, to: describeTarget( liveTarget ) };
+	}
+
+	if ( reportedTarget.key === null || reportedTarget.key === liveTarget.key ) {
+		return null;
+	}
+
+	return {
+		code: 'moved',
+		from: describeTarget( reportedTarget ),
+		to: describeTarget( liveTarget ),
+	};
+}

--- a/packages/agents-manager/src/utils/editor-target-binding.ts
+++ b/packages/agents-manager/src/utils/editor-target-binding.ts
@@ -37,9 +37,16 @@ export type TargetViolation =
 let reportedTarget: EditorTarget | null = null;
 let liveTarget: EditorTarget | null = null;
 
-// Set once a request has been refused or aborted for moving off its canvas, so
-// the model cannot simply retry onto the page the user moved to.
-let requestBlocked = false;
+// The violation that caused the current request to be blocked, if any. Set once
+// a request has been refused or aborted for moving off its canvas, so the model
+// cannot simply retry onto the page the user moved to.
+//
+// Storing the cause rather than a bare flag makes "blocked without a violation"
+// unrepresentable. That matters because the fail-open branch below sits *under*
+// this check: a flag could be set on a host that never reported a target, and
+// would then refuse canvas writes there is no basis to refuse. Requiring the
+// violation means only a real one can get here.
+let blockedViolation: TargetViolation | null = null;
 
 /**
  * Validate a client-context `editorTarget` value.
@@ -110,9 +117,12 @@ export function clearTargetBinding(): void {
 
 /**
  * Refuse canvas writes for the remainder of the current request.
+ *
+ * @param violation The violation that caused the block. Required so a block can
+ *                  never outrun an actual violation — see `blockedViolation`.
  */
-export function blockCurrentRequest(): void {
-	requestBlocked = true;
+export function blockCurrentRequest( violation: TargetViolation ): void {
+	blockedViolation = violation;
 }
 
 /**
@@ -120,7 +130,7 @@ export function blockCurrentRequest(): void {
  */
 export function startNewUserRequest(): void {
 	clearTargetBinding();
-	requestBlocked = false;
+	blockedViolation = null;
 }
 
 function describeTarget( target: EditorTarget | null ): string | null {
@@ -137,12 +147,11 @@ function describeTarget( target: EditorTarget | null ): string | null {
  * @returns The violation, or null when the write may proceed.
  */
 export function getTargetViolation(): TargetViolation | null {
-	if ( requestBlocked ) {
-		return {
-			code: 'moved',
-			from: describeTarget( reportedTarget ),
-			to: describeTarget( liveTarget ),
-		};
+	// Every refusal after the first names the pages from the violation that
+	// caused the block, rather than re-deriving them from a binding that has
+	// since rebound to the page the user moved to.
+	if ( blockedViolation ) {
+		return blockedViolation;
 	}
 
 	// No contract from this host, or no reading yet: nothing to enforce against.

--- a/packages/agents-manager/src/utils/editor-target-binding.ts
+++ b/packages/agents-manager/src/utils/editor-target-binding.ts
@@ -31,6 +31,15 @@ export type TargetViolation =
 	| { code: 'no-editor' }
 	| { code: 'moved'; from: string | null; to: string | null };
 
+/**
+ * The host's canvas-change event.
+ *
+ * Must stay byte-identical to Big Sky's `EDITOR_TARGET_CHANGE_EVENT` in
+ * `src/ai/wp-orchestrator/editor-target.ts` — with the shape parser above, this
+ * is the whole cross-repo seam, so both halves of it live in this module.
+ */
+export const EDITOR_TARGET_CHANGE_EVENT = 'big-sky-editor-target-change';
+
 // `null` means the host never reported a target — an older plugin, or a host
 // that does not implement the contract. The guard disables itself rather than
 // refusing writes it has no basis to refuse.
@@ -42,10 +51,11 @@ let liveTarget: EditorTarget | null = null;
 // cannot simply retry onto the page the user moved to.
 //
 // Storing the cause rather than a bare flag makes "blocked without a violation"
-// unrepresentable. That matters because the fail-open branch below sits *under*
-// this check: a flag could be set on a host that never reported a target, and
-// would then refuse canvas writes there is no basis to refuse. Requiring the
-// violation means only a real one can get here.
+// unrepresentable, and `blockCurrentRequest()` can only ever fill it from a live
+// move. That matters because the fail-open branch below sits *under* this check:
+// a flag could be set on a host that never reported a target, and would then
+// refuse canvas writes there is no basis to refuse. Deriving the violation from
+// the live reading means only a real one can get here.
 let blockedViolation: TargetViolation | null = null;
 
 /**
@@ -118,11 +128,21 @@ export function clearTargetBinding(): void {
 /**
  * Refuse canvas writes for the remainder of the current request.
  *
- * @param violation The violation that caused the block. Required so a block can
- *                  never outrun an actual violation — see `blockedViolation`.
+ * Latches whatever move is live right now rather than accepting one, so a block
+ * can never outrun an actual violation — on a host that reports no target there
+ * is nothing to latch, and the fail-open guarantee holds by construction.
+ * Idempotent: an existing block is kept, never replaced or cleared.
+ *
+ * @returns Whether a block is in place.
  */
-export function blockCurrentRequest( violation: TargetViolation ): void {
-	blockedViolation = violation;
+export function blockCurrentRequest(): boolean {
+	if ( blockedViolation ) {
+		return true;
+	}
+
+	blockedViolation = getLiveTargetMove();
+
+	return null !== blockedViolation;
 }
 
 /**
@@ -142,18 +162,14 @@ function describeTarget( target: EditorTarget | null ): string | null {
 }
 
 /**
- * Whether the pending canvas write would land somewhere it was not meant to.
+ * Whether the live canvas differs from the one the model last saw.
  *
- * @returns The violation, or null when the write may proceed.
+ * The latch-free reading. Use it to decide whether something just moved; use
+ * `getTargetViolation()` to decide whether a write may proceed.
+ *
+ * @returns The violation, or null when the live canvas still matches.
  */
-export function getTargetViolation(): TargetViolation | null {
-	// Every refusal after the first names the pages from the violation that
-	// caused the block, rather than re-deriving them from a binding that has
-	// since rebound to the page the user moved to.
-	if ( blockedViolation ) {
-		return blockedViolation;
-	}
-
+export function getLiveTargetMove(): TargetViolation | null {
 	// No contract from this host, or no reading yet: nothing to enforce against.
 	if ( ! reportedTarget || ! liveTarget ) {
 		return null;
@@ -182,4 +198,16 @@ export function getTargetViolation(): TargetViolation | null {
 		from: describeTarget( reportedTarget ),
 		to: describeTarget( liveTarget ),
 	};
+}
+
+/**
+ * Whether the pending canvas write would land somewhere it was not meant to.
+ *
+ * @returns The violation, or null when the write may proceed.
+ */
+export function getTargetViolation(): TargetViolation | null {
+	// Every refusal after the first names the pages from the violation that
+	// caused the block, rather than re-deriving them from a binding that has
+	// since rebound to the page the user moved to.
+	return blockedViolation ?? getLiveTargetMove();
 }

--- a/packages/agents-manager/src/utils/editor-target-guard.ts
+++ b/packages/agents-manager/src/utils/editor-target-guard.ts
@@ -1,0 +1,132 @@
+/**
+ * Enforces the editor-target binding on the merged providers.
+ *
+ * `editor-target-binding` owns the state machine; this module owns the policy —
+ * which abilities are bound to the open canvas, which ones legitimately move it,
+ * and what a refusal says. The ability lists live next to the state machine they
+ * encode against rather than in the provider loader, which only composes them.
+ */
+
+import { normalizeAbilityName } from '../abilities/ability-name';
+import {
+	blockCurrentRequest,
+	clearTargetBinding,
+	getTargetViolation,
+	recordReportedTarget,
+	type TargetViolation,
+} from './editor-target-binding';
+import type { AbilityResult } from '../abilities/types';
+import type { ContextProvider, ToolProvider } from '../types';
+
+// Abilities that write to the page open in the editor. Deliberately excludes
+// `big-sky/apply-update-theme` and `big-sky/set-site-logo` (site-wide — moving
+// between pages does not make them wrong) and `big-sky/show-component` (not a
+// write). Ownership is irrelevant here: this list is checked on the merged
+// provider, so it covers abilities that have migrated to AM and abilities still
+// served by an external provider alike.
+//
+// `edit-entity-record` is deliberately absent: it names its target explicitly
+// (`entityType`/`entityName`/`recordId`, often site-level like `root`/`site` or
+// `wp_navigation`), so moving the canvas cannot redirect its write. Guarding it
+// would refuse legitimate site-level edits from any screen without a canvas.
+//
+// Normalized, because the agent invokes `big-sky/apply-block-edits` as
+// `big_sky__apply_block_edits`. Matching the registered form against the name
+// that actually arrives would never hit, leaving the guard inert in production.
+const CANVAS_BOUND_ABILITIES = new Set(
+	[ 'big-sky/apply-block-edits', 'big-sky/stream-page-design', 'big-sky/restore-checkpoint' ].map(
+		normalizeAbilityName
+	)
+);
+
+// Abilities whose whole job is to move the canvas. The binding is dropped before
+// they run, so the move they cause does not read as a violation.
+const CANVAS_MOVING_ABILITIES = new Set(
+	[ 'big-sky/editor-navigate', 'wp-admin/navigate' ].map( normalizeAbilityName )
+);
+
+function buildTargetRefusal( violation: TargetViolation ): AbilityResult {
+	// Untranslated on purpose: `returnToAgent: true` means these strings are read
+	// by the model, not shown to the user, unlike neighbouring abilities' messages.
+	const message =
+		violation.code === 'no-editor'
+			? 'No page is open in the editor, so nothing was changed. Ask the user to open the page they want changed in the editor, then try again. Do not describe or design a page you cannot read.'
+			: `Nothing was changed: this was requested for ${
+					violation.from ?? 'a page that is no longer open'
+			  }, but the editor now has ${
+					violation.to ?? 'a different page'
+			  } open. Do not retry it here — tell the user what happened and ask whether they want the same change on the page they are now viewing.`;
+
+	return {
+		result: {
+			success: false,
+			message,
+			error: `editor_target_${ violation.code.replace( '-', '_' ) }`,
+		},
+		returnToAgent: true,
+	};
+}
+
+/**
+ * Records the canvas the host reports on every outgoing message.
+ *
+ * Wraps the merged provider rather than each external one so a host that reports
+ * a target cannot be shadowed by one that does not.
+ * @param contextProvider The merged context provider, if any.
+ * @returns The wrapped provider, or undefined when there is nothing to wrap.
+ */
+export function withEditorTargetBinding(
+	contextProvider: ContextProvider | undefined
+): ContextProvider | undefined {
+	if ( ! contextProvider ) {
+		return undefined;
+	}
+
+	return {
+		getClientContext: () => {
+			const context = contextProvider.getClientContext();
+			recordReportedTarget( ( context as Record< string, unknown > ).editorTarget );
+			return context;
+		},
+	};
+}
+
+/**
+ * Refuses a canvas write whose canvas has moved since the model asked for it.
+ *
+ * Applied to the merged tool provider, so it is indifferent to which provider
+ * owns a given ability — including after an ability migrates into AM.
+ * @param toolProvider The merged tool provider, if any.
+ * @returns The wrapped provider, or undefined when there is nothing to wrap.
+ */
+export function withEditorTargetGuard(
+	toolProvider: ToolProvider | undefined
+): ToolProvider | undefined {
+	if ( ! toolProvider ) {
+		return undefined;
+	}
+
+	return {
+		getAbilities: () => toolProvider.getAbilities(),
+		executeAbility: async ( name: string, args: unknown ) => {
+			// Normalize the incoming name too: it may arrive in either form
+			// (`findAbilityByName` accepts both), and normalizing an already
+			// normalized name is a no-op.
+			const normalizedName = normalizeAbilityName( name );
+
+			if ( CANVAS_BOUND_ABILITIES.has( normalizedName ) ) {
+				const violation = getTargetViolation();
+				if ( violation ) {
+					blockCurrentRequest();
+					return buildTargetRefusal( violation );
+				}
+			}
+
+			if ( CANVAS_MOVING_ABILITIES.has( normalizedName ) ) {
+				clearTargetBinding();
+			}
+
+			return toolProvider.executeAbility( name, args );
+		},
+	};
+}

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -13,14 +13,8 @@
 
 import { getAgentManager, UIMessage } from '@automattic/agenttic-client';
 import { amToolProvider, getAmCheckpointContext } from '../abilities';
-import { findAbilityByName, normalizeAbilityName } from '../abilities/ability-name';
-import {
-	blockCurrentRequest,
-	clearTargetBinding,
-	getTargetViolation,
-	recordReportedTarget,
-	type TargetViolation,
-} from './editor-target-binding';
+import { findAbilityByName } from '../abilities/ability-name';
+import { withEditorTargetBinding, withEditorTargetGuard } from './editor-target-guard';
 import { getAgentsManagerInlineData } from './get-agents-manager-inline-data';
 import { isReaderChatAgent } from './is-reader-chat-agent';
 import {
@@ -454,108 +448,6 @@ function withAmCheckpoints(
 					checkpointIndex: index,
 				} ) ),
 			};
-		},
-	};
-}
-
-// Abilities that write to the page open in the editor. Deliberately excludes
-// `big-sky/apply-update-theme` and `big-sky/set-site-logo` (site-wide — moving
-// between pages does not make them wrong) and `big-sky/show-component` (not a
-// write). Ownership is irrelevant here: this list is checked on the merged
-// provider, so it covers abilities that have migrated to AM and abilities still
-// served by an external provider alike.
-// Normalized, because the agent invokes `big-sky/apply-block-edits` as
-// `big_sky__apply_block_edits`. Matching the registered form against the name
-// that actually arrives would never hit, leaving the guard inert in production.
-const CANVAS_BOUND_ABILITIES = new Set(
-	[
-		'big-sky/apply-block-edits',
-		'big-sky/stream-page-design',
-		'big-sky/edit-entity-record',
-		'big-sky/restore-checkpoint',
-	].map( normalizeAbilityName )
-);
-
-// Abilities whose whole job is to move the canvas. The binding is dropped before
-// they run, so the move they cause does not read as a violation.
-const CANVAS_MOVING_ABILITIES = new Set(
-	[ 'big-sky/editor-navigate', 'wp-admin/navigate' ].map( normalizeAbilityName )
-);
-
-function buildTargetRefusal( violation: TargetViolation ) {
-	const message =
-		violation.code === 'no-editor'
-			? 'No page is open in the editor, so nothing was changed. Ask the user to open the page they want changed in the editor, then try again. Do not describe or design a page you cannot read.'
-			: `Nothing was changed: this was requested for ${
-					violation.from ?? 'a page that is no longer open'
-			  }, but the editor now has ${
-					violation.to ?? 'a different page'
-			  } open. Do not retry it here — tell the user what happened and ask whether they want the same change on the page they are now viewing.`;
-
-	return {
-		result: {
-			success: false,
-			message,
-			error: `editor_target_${ violation.code.replace( '-', '_' ) }`,
-		},
-		returnToAgent: true,
-	};
-}
-
-/**
- * Records the canvas the host reports on every outgoing message.
- *
- * Wraps the merged provider rather than each external one so a host that reports
- * a target cannot be shadowed by one that does not.
- */
-function withEditorTargetBinding(
-	contextProvider: ContextProvider | undefined
-): ContextProvider | undefined {
-	if ( ! contextProvider ) {
-		return undefined;
-	}
-
-	return {
-		getClientContext: () => {
-			const context = contextProvider.getClientContext();
-			recordReportedTarget( ( context as Record< string, unknown > ).editorTarget );
-			return context;
-		},
-	};
-}
-
-/**
- * Refuses a canvas write whose canvas has moved since the model asked for it.
- *
- * Applied to the merged tool provider, so it is indifferent to which provider
- * owns a given ability — including after an ability migrates into AM.
- */
-function withEditorTargetGuard( toolProvider: ToolProvider | undefined ): ToolProvider | undefined {
-	if ( ! toolProvider ) {
-		return undefined;
-	}
-
-	return {
-		getAbilities: () => toolProvider.getAbilities(),
-		executeAbility: async ( name: string, args: unknown ) => {
-			// Normalize the incoming name too: it may arrive in either form
-			// (`findAbilityByName` accepts both), and normalizing an already
-			// normalized name is a no-op.
-			const normalizedName = normalizeAbilityName( name );
-
-			if ( CANVAS_BOUND_ABILITIES.has( normalizedName ) ) {
-				const violation = getTargetViolation();
-				if ( violation ) {
-					blockCurrentRequest( violation );
-					return buildTargetRefusal( violation );
-				}
-			}
-
-			if ( CANVAS_MOVING_ABILITIES.has( normalizedName ) ) {
-				clearTargetBinding();
-			}
-
-			return toolProvider.executeAbility( name, args );
 		},
 	};
 }

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -13,7 +13,14 @@
 
 import { getAgentManager, UIMessage } from '@automattic/agenttic-client';
 import { amToolProvider, getAmCheckpointContext } from '../abilities';
-import { findAbilityByName } from '../abilities/ability-name';
+import { findAbilityByName, normalizeAbilityName } from '../abilities/ability-name';
+import {
+	blockCurrentRequest,
+	clearTargetBinding,
+	getTargetViolation,
+	recordReportedTarget,
+	type TargetViolation,
+} from './editor-target-binding';
 import { getAgentsManagerInlineData } from './get-agents-manager-inline-data';
 import { isReaderChatAgent } from './is-reader-chat-agent';
 import {
@@ -451,6 +458,108 @@ function withAmCheckpoints(
 	};
 }
 
+// Abilities that write to the page open in the editor. Deliberately excludes
+// `big-sky/apply-update-theme` and `big-sky/set-site-logo` (site-wide — moving
+// between pages does not make them wrong) and `big-sky/show-component` (not a
+// write). Ownership is irrelevant here: this list is checked on the merged
+// provider, so it covers abilities that have migrated to AM and abilities still
+// served by an external provider alike.
+// Normalized, because the agent invokes `big-sky/apply-block-edits` as
+// `big_sky__apply_block_edits`. Matching the registered form against the name
+// that actually arrives would never hit, leaving the guard inert in production.
+const CANVAS_BOUND_ABILITIES = new Set(
+	[
+		'big-sky/apply-block-edits',
+		'big-sky/stream-page-design',
+		'big-sky/edit-entity-record',
+		'big-sky/restore-checkpoint',
+	].map( normalizeAbilityName )
+);
+
+// Abilities whose whole job is to move the canvas. The binding is dropped before
+// they run, so the move they cause does not read as a violation.
+const CANVAS_MOVING_ABILITIES = new Set(
+	[ 'big-sky/editor-navigate', 'wp-admin/navigate' ].map( normalizeAbilityName )
+);
+
+function buildTargetRefusal( violation: TargetViolation ) {
+	const message =
+		violation.code === 'no-editor'
+			? 'No page is open in the editor, so nothing was changed. Ask the user to open the page they want changed in the editor, then try again. Do not describe or design a page you cannot read.'
+			: `Nothing was changed: this was requested for ${
+					violation.from ?? 'a page that is no longer open'
+			  }, but the editor now has ${
+					violation.to ?? 'a different page'
+			  } open. Do not retry it here — tell the user what happened and ask whether they want the same change on the page they are now viewing.`;
+
+	return {
+		result: {
+			success: false,
+			message,
+			error: `editor_target_${ violation.code.replace( '-', '_' ) }`,
+		},
+		returnToAgent: true,
+	};
+}
+
+/**
+ * Records the canvas the host reports on every outgoing message.
+ *
+ * Wraps the merged provider rather than each external one so a host that reports
+ * a target cannot be shadowed by one that does not.
+ */
+function withEditorTargetBinding(
+	contextProvider: ContextProvider | undefined
+): ContextProvider | undefined {
+	if ( ! contextProvider ) {
+		return undefined;
+	}
+
+	return {
+		getClientContext: () => {
+			const context = contextProvider.getClientContext();
+			recordReportedTarget( ( context as Record< string, unknown > ).editorTarget );
+			return context;
+		},
+	};
+}
+
+/**
+ * Refuses a canvas write whose canvas has moved since the model asked for it.
+ *
+ * Applied to the merged tool provider, so it is indifferent to which provider
+ * owns a given ability — including after an ability migrates into AM.
+ */
+function withEditorTargetGuard( toolProvider: ToolProvider | undefined ): ToolProvider | undefined {
+	if ( ! toolProvider ) {
+		return undefined;
+	}
+
+	return {
+		getAbilities: () => toolProvider.getAbilities(),
+		executeAbility: async ( name: string, args: unknown ) => {
+			// Normalize the incoming name too: it may arrive in either form
+			// (`findAbilityByName` accepts both), and normalizing an already
+			// normalized name is a no-op.
+			const normalizedName = normalizeAbilityName( name );
+
+			if ( CANVAS_BOUND_ABILITIES.has( normalizedName ) ) {
+				const violation = getTargetViolation();
+				if ( violation ) {
+					blockCurrentRequest();
+					return buildTargetRefusal( violation );
+				}
+			}
+
+			if ( CANVAS_MOVING_ABILITIES.has( normalizedName ) ) {
+				clearTargetBinding();
+			}
+
+			return toolProvider.executeAbility( name, args );
+		},
+	};
+}
+
 export function mergeContextProviders(
 	contextProviders: ContextProvider[]
 ): ContextProvider | undefined {
@@ -710,7 +819,9 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		}
 	}
 
-	const mergedContextProvider = withAmCheckpoints( mergeContextProviders( allContextProviders ) );
+	const mergedContextProvider = withEditorTargetBinding(
+		withAmCheckpoints( mergeContextProviders( allContextProviders ) )
+	);
 	const mergedMarkdownComponents = mergeMarkdownComponentsFromProviders( allMarkdownComponents );
 	const mergedMarkdownExtensions = mergeMarkdownExtensionsFromProviders( allMarkdownExtensions );
 
@@ -776,6 +887,11 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 			},
 		};
 	}
+
+	// After the branch, deliberately: the single-provider path above assigns
+	// `allToolProviders[ 0 ]` straight through, so a guard applied inside the
+	// multi-provider closure would silently not exist on those surfaces.
+	mergedToolProvider = withEditorTargetGuard( mergedToolProvider );
 
 	// Merge transformMessages: compose in registration order, so each provider
 	// rewrites what the previous one produced. Unlike the singleton exports this

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -546,7 +546,7 @@ function withEditorTargetGuard( toolProvider: ToolProvider | undefined ): ToolPr
 			if ( CANVAS_BOUND_ABILITIES.has( normalizedName ) ) {
 				const violation = getTargetViolation();
 				if ( violation ) {
-					blockCurrentRequest();
+					blockCurrentRequest( violation );
 					return buildTargetRefusal( violation );
 				}
 			}


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/AI-1129/prevent-agent-requests-from-writing-to-a-different-canvas

Agent requests could write to the wrong page. If you asked for a change and then navigated away, the edit landed on whatever canvas was mounted by the time the tool ran.

The Big Sky plugin now reports which canvas is open (`editorTarget`, refreshed on every outgoing message). This PR binds each request to it.

## What this adds

**`utils/editor-target-binding.ts`** — records the canvas the model last saw and reports when the live canvas differs from it.

**`utils/editor-target-guard.ts`** — wraps the merged tool provider and refuses `apply-block-edits`, `stream-page-design` and `restore-checkpoint` when the canvas has moved or none is open. The refusal is a tool result, so the agent can relay it and ask the user. Wrapping the *merged* provider means the guard keeps working as abilities migrate from Big Sky into AM.

**Abort** — an in-flight request is stopped when the canvas moves, and further canvas writes are blocked until the next user message or regenerate.

Abilities that name their own target (`edit-entity-record`) are deliberately not guarded — moving the canvas cannot redirect them.

Hosts that don't send `editorTarget` are unaffected; the guard disables itself.

## Testing

`yarn test-packages packages/agents-manager` — 791 tests.

## Manual testing

- With all 3 PRs deployed to sandbox, try starting an agent request and navigate while the request is running, and check that it is aborted and a message to explain this is displayed in chat
- Try an `add a new page for ...` prompt and make sure this is still able to navigate mid request

## Related

Needs all three to land together:

- Big Sky plugin — reports `editorTarget`: https://github.com/Automattic/big-sky-plugin/pull/6271
- wpcom — `#234746`
