### PR TITLE
Reader: restore the dark CTA hover on the scrolled nav

### DIFF
--- a/client/reader/style.scss
+++ b/client/reader/style.scss
@@ -601,6 +601,10 @@ body.is-section-reader {
 			.x-nav-link-chevron::before {
 				color: var( --studio-gray-100 );
 			}
+
+			// Back on the white band, the CTA hover flips to the default dark fill.
+			--x-nav-2026-cta-hover-fill: var( --studio-gray-100 );
+			--x-nav-2026-cta-hover-ink: var( --studio-white );
 		}
 	}
 }


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/MARTECH-2781/remove-the-global-nav-2026-experiment-infrastructure

## Proposed Changes

* On logged-out Reader pages (e.g. /discover), hovering the "Get started" button while the nav is scrolled now fills it dark with white text, matching wordpress.com.

## Why are these changes being made?

* The Reader header inverts the button's hover to a white fill so it reads over the dark hero, but never switched it back once the nav scrolls onto its white bar — so hovering there painted white-on-white and the button appeared dead.

## Testing Instructions

* Log out and open /discover. At the top of the page, hover "Get started": white fill, dark text (unchanged). Scroll down and hover it again: dark fill, white text — same as the button on https://wordpress.com/pricing/ when scrolled.
