### PR TITLE
Omnibar: various tracking fixes

### DIFF
--- a/client/dashboard/app/omnibar/index.tsx
+++ b/client/dashboard/app/omnibar/index.tsx
@@ -29,6 +29,7 @@ export default function loadOmnibar( config: AppConfig ) {
 					<OmnibarContainer
 						user={ window.currentUser }
 						cartManagerClient={ shoppingCartManagerClient }
+						sectionName="dashboard"
 					/>
 				</AnalyticsProvider>
 			</QueryClientProvider>

--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -65,20 +65,30 @@ function createHrefResolver( adminUrl?: string ) {
 export default function OmnibarContainer( {
 	user,
 	cartManagerClient,
-	section,
+	sectionGroup,
+	sectionName,
 }: {
 	user?: User;
 	cartManagerClient: ShoppingCartManagerClient;
-	section?: string;
+	sectionGroup?: string;
+	sectionName?: string;
 } ) {
 	return (
 		<ShoppingCartProvider managerClient={ cartManagerClient }>
-			<ConnectedOmnibar user={ user } section={ section } />
+			<ConnectedOmnibar user={ user } sectionGroup={ sectionGroup } sectionName={ sectionName } />
 		</ShoppingCartProvider>
 	);
 }
 
-function ConnectedOmnibar( { user, section }: { user?: User; section?: string } ) {
+function ConnectedOmnibar( {
+	user,
+	sectionGroup,
+	sectionName,
+}: {
+	user?: User;
+	sectionGroup?: string;
+	sectionName?: string;
+} ) {
 	const { supports } = useAppContext();
 	const recordNodeClick = useRecordOmnibarNodeClick();
 	const [ hydrated, setHydrated ] = useState( false );
@@ -151,9 +161,9 @@ function ConnectedOmnibar( { user, section }: { user?: User; section?: string } 
 		return result;
 	}, [ dashboardNodes, siteNodes, site, supports, nodeBuilders ] );
 
-	const readerPluginNode = useReaderPlugin( { section } );
-	const helpCenterPluginNode = useHelpCenterPlugin();
-	const aiChatPluginNode = useAiChatPlugin();
+	const readerPluginNode = useReaderPlugin( { sectionGroup } );
+	const helpCenterPluginNode = useHelpCenterPlugin( { sectionName } );
+	const aiChatPluginNode = useAiChatPlugin( { sectionName } );
 	const notificationsPluginNode = useNotificationsPlugin( { user } );
 	const { node: languageSwitcherNode, panel: languageSwitcherPanel } = useLanguageSwitcherPlugin( {
 		user,
@@ -161,7 +171,7 @@ function ConnectedOmnibar( { user, section }: { user?: User; section?: string } 
 	const { node: shoppingCartNode, panel: shoppingCartPanel } = useShoppingCartPlugin( { site } );
 	const statsSparklineNode = useStatsSparklinePlugin( { site } );
 	const launchSiteNode = useLaunchSitePlugin( { site } );
-	const dashboardNode = useDashboardPlugin( { site, section } );
+	const dashboardNode = useDashboardPlugin( { site, sectionGroup } );
 	const siteNode = addDashboardNode( baseOmnibarNodes.site, dashboardNode );
 	const siteActions = [
 		...( baseOmnibarNodes.siteActions ?? [] ),

--- a/client/dashboard/app/omnibar/plugin-ai-chat.tsx
+++ b/client/dashboard/app/omnibar/plugin-ai-chat.tsx
@@ -24,7 +24,11 @@ function BigSkyIcon() {
 	);
 }
 
-export function useAiChatPlugin(): OmnibarNode | undefined {
+export function useAiChatPlugin( {
+	sectionName,
+}: {
+	sectionName?: string;
+} ): OmnibarNode | undefined {
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 	const { recordTracksEvent } = useAnalytics();
 
@@ -36,7 +40,7 @@ export function useAiChatPlugin(): OmnibarNode | undefined {
 		const isChatVisible = isAgentsManagerChatVisible();
 
 		recordTracksEvent( 'calypso_masterbar_agents_manager_ai_chat_clicked', {
-			section: 'dashboard',
+			section: sectionName,
 			action: isChatVisible ? 'close' : 'open',
 		} );
 

--- a/client/dashboard/app/omnibar/plugin-dashboard.tsx
+++ b/client/dashboard/app/omnibar/plugin-dashboard.tsx
@@ -6,12 +6,12 @@ import type { OmnibarNode } from '@automattic/omnibar';
 
 export function useDashboardPlugin( {
 	site,
-	section,
+	sectionGroup,
 }: {
 	site?: Site;
-	section?: string;
+	sectionGroup?: string;
 } ): OmnibarNode | undefined {
-	if ( ! site || section === 'sites' ) {
+	if ( ! site || sectionGroup === 'sites' ) {
 		return undefined;
 	}
 

--- a/client/dashboard/app/omnibar/plugin-help-center.tsx
+++ b/client/dashboard/app/omnibar/plugin-help-center.tsx
@@ -51,6 +51,7 @@ function handleMenuClick(
 	recordTracksEvent: RecordTracksEvent,
 	destination: string,
 	omnibarSiteId: number | null | undefined,
+	sectionName: string | undefined,
 	isExternal = false
 ) {
 	// Re-clicking the current route closes the chat; external links never do.
@@ -58,7 +59,7 @@ function handleMenuClick(
 		! isExternal && isAgentsManagerChatVisible() && getAgentsManagerChatRoute() === destination;
 
 	recordTracksEvent( 'calypso_dashboard_help_center_menu_panel_click', {
-		section: 'dashboard',
+		section: sectionName,
 		destination,
 		action: isClosing ? 'close' : 'open',
 	} );
@@ -74,7 +75,7 @@ function handleMenuClick(
 			withSiteContext(
 				{
 					location: 'help-center',
-					section: 'dashboard',
+					section: sectionName,
 				},
 				'omnibar',
 				omnibarSiteId
@@ -93,7 +94,7 @@ function handleMenuClick(
 		withSiteContext(
 			{
 				location: 'help-center',
-				section: 'dashboard',
+				section: sectionName,
 				destination,
 			},
 			'omnibar',
@@ -104,7 +105,8 @@ function handleMenuClick(
 
 function getAgentsManagerMenuNodes(
 	recordTracksEvent: RecordTracksEvent,
-	omnibarSiteId: number | null | undefined
+	omnibarSiteId: number | null | undefined,
+	sectionName: string | undefined
 ): OmnibarNode[] {
 	return [
 		{
@@ -115,13 +117,14 @@ function getAgentsManagerMenuNodes(
 					id: 'chat-support',
 					title: __( 'Chat support' ),
 					icon: menuIcon( comment ),
-					onClick: () => handleMenuClick( recordTracksEvent, '/chat', omnibarSiteId ),
+					onClick: () => handleMenuClick( recordTracksEvent, '/chat', omnibarSiteId, sectionName ),
 				},
 				{
 					id: 'chat-history',
 					title: __( 'Chat history' ),
 					icon: menuIcon( backup ),
-					onClick: () => handleMenuClick( recordTracksEvent, '/history', omnibarSiteId ),
+					onClick: () =>
+						handleMenuClick( recordTracksEvent, '/history', omnibarSiteId, sectionName ),
 				},
 			],
 		},
@@ -134,7 +137,8 @@ function getAgentsManagerMenuNodes(
 					id: 'support-guides',
 					title: __( 'Support guides' ),
 					icon: menuIcon( page ),
-					onClick: () => handleMenuClick( recordTracksEvent, '/support-guides', omnibarSiteId ),
+					onClick: () =>
+						handleMenuClick( recordTracksEvent, '/support-guides', omnibarSiteId, sectionName ),
 				},
 				{
 					id: 'courses',
@@ -145,6 +149,7 @@ function getAgentsManagerMenuNodes(
 							recordTracksEvent,
 							localizeUrl( 'https://wordpress.com/support/courses/' ),
 							omnibarSiteId,
+							sectionName,
 							true
 						),
 				},
@@ -157,6 +162,7 @@ function getAgentsManagerMenuNodes(
 							recordTracksEvent,
 							localizeUrl( 'https://wordpress.com/blog/category/product-features/' ),
 							omnibarSiteId,
+							sectionName,
 							true
 						),
 				},
@@ -165,7 +171,7 @@ function getAgentsManagerMenuNodes(
 	];
 }
 
-export function useHelpCenterPlugin(): OmnibarNode {
+export function useHelpCenterPlugin( { sectionName }: { sectionName?: string } ): OmnibarNode {
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 	const { isShown: isHelpCenterShown, setShowHelpCenter } = useHelpCenter();
 	const { recordTracksEvent } = useAnalytics();
@@ -176,7 +182,7 @@ export function useHelpCenterPlugin(): OmnibarNode {
 			id: 'help-center',
 			label: __( 'Help' ),
 			icon: <HelpIcon />,
-			children: getAgentsManagerMenuNodes( recordTracksEvent, omnibarSiteId ),
+			children: getAgentsManagerMenuNodes( recordTracksEvent, omnibarSiteId, sectionName ),
 		};
 	}
 

--- a/client/dashboard/app/omnibar/plugin-reader.tsx
+++ b/client/dashboard/app/omnibar/plugin-reader.tsx
@@ -18,13 +18,13 @@ function ReaderIcon() {
 	);
 }
 
-export function useReaderPlugin( { section }: { section?: string } ): OmnibarNode {
+export function useReaderPlugin( { sectionGroup }: { sectionGroup?: string } ): OmnibarNode {
 	return {
 		id: 'reader',
 		title: __( 'Reader' ),
 		icon: <ReaderIcon />,
 		className: 'omnibar__reader',
 		href: wpcomLink( '/reader' ),
-		active: section === 'reader',
+		active: sectionGroup === 'reader',
 	};
 }

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -299,6 +299,7 @@ class Layout extends Component {
 				<MasterbarComponent
 					siteId={ this.props.siteIdForLaunch }
 					section={ this.props.sectionGroup }
+					sectionGroup={ this.props.sectionGroup }
 					isCheckout={ this.props.sectionName === 'checkout' }
 					isCheckoutPending={ this.props.sectionName === 'checkout-pending' }
 					isCheckoutFailed={ isCheckoutFailed }

--- a/client/layout/masterbar/omnibar.tsx
+++ b/client/layout/masterbar/omnibar.tsx
@@ -13,7 +13,7 @@ import getIsNotificationsOpen from 'calypso/state/selectors/is-notifications-ope
 import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
 import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { AnalyticsClient } from 'calypso/dashboard/app/analytics';
 import type { AppConfig } from 'calypso/dashboard/app/context';
 
@@ -55,20 +55,21 @@ function useOmnibarBridge() {
 	} );
 
 	useOmnibarEvent( 'mobileMenu', () => {
-		recordTracksEvent( 'calypso_masterbar_menu_clicked' );
 		dispatch( setNextLayoutFocus( currentLayoutFocus === 'sidebar' ? 'content' : 'sidebar' ) );
 		dispatch( activateNextLayoutFocus() );
 	} );
 }
 
 export default function Omnibar( {
-	section,
+	sectionGroup,
 	loadHelpCenterIcon,
 }: {
-	section?: string;
+	sectionGroup?: string;
 	loadHelpCenterIcon?: boolean;
 } ) {
 	useOmnibarBridge();
+
+	const sectionName = useSelector( getSectionName );
 
 	const config: AppConfig = {
 		...APP_CONTEXT_DEFAULT_CONFIG,
@@ -89,7 +90,8 @@ export default function Omnibar( {
 						<OmnibarContainer
 							user={ window.currentUser }
 							cartManagerClient={ cartManagerClient }
-							section={ section }
+							sectionGroup={ sectionGroup }
+							sectionName={ sectionName ?? undefined }
 						/>
 					</div>
 				</AnalyticsProvider>


### PR DESCRIPTION
## Proposed Changes

Various fixes to the tracking mechanism in the new omnibar:

- Drop the duplicate `calypso_masterbar_menu_clicked` event firing.
- Split `OmnibarContainer`'s section prop into `sectionGroup` (behaviour) and `sectionName` (tracks attribution).
- Report the real section name on `calypso_dashboard_help_center_menu_panel_click`, `calypso_inlinehelp_show`, `calypso_inlinehelp_close` and `calypso_masterbar_agents_manager_ai_chat_clicked`, which were all hardcoded to 'dashboard'.

## Testing Instructions

Test with the `dashboard/omnibar-radical` flag turned on.

- On mobile view, the mobile hamburger menu and confirm `calypso_masterbar_menu_clicked` now fires once, not twice.
- Click Help Center → any menu item, and the Ask AI button, from a few different sections (Reader, My Sites, /me). Confirm the events carry that section's name rather than `dashboard`.
- Do the same on the Dashboard and confirm section is still `dashboard`.