### PR TITLE
A4A: Implement Plugins on MSD

### DIFF
--- a/client/dashboard/app-a4a/index.tsx
+++ b/client/dashboard/app-a4a/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import {
-	sitesQuery,
+	jetpackSitesQuery,
 	paginatedSitesQuery,
 	dashboardSiteFiltersQuery,
 	domainsQuery,
@@ -29,6 +29,7 @@ boot( {
 			learn: true,
 			mcp: true,
 			sites: true,
+			plugins: true,
 			team: true,
 			earn: true,
 		},
@@ -53,7 +54,8 @@ boot( {
 	optIn: false,
 	components: {},
 	queries: {
-		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => sitesQuery( 'all', fetchSiteOptions ),
+		// A4A only deals with Jetpack-connected sites, mirroring the classic app.
+		sitesQuery: ( fetchSiteOptions?: FetchSitesOptions ) => jetpackSitesQuery( fetchSiteOptions ),
 		paginatedSitesQuery: ( fetchSiteOptions?: FetchPaginatedSitesOptions ) =>
 			paginatedSitesQuery( 'all', fetchSiteOptions ),
 		dashboardSiteFiltersQuery: ( fields: FetchDashboardSiteFiltersParams[ 'fields' ] ) =>

--- a/client/dashboard/app/command-palette/commands.tsx
+++ b/client/dashboard/app/command-palette/commands.tsx
@@ -12,6 +12,7 @@ import {
 	receipt,
 	lock,
 } from '@wordpress/icons';
+import { PLUGINS_PATH } from '../../plugins/paths';
 import { useAppContext } from '../context';
 import type { AppConfig } from '../context';
 
@@ -57,7 +58,7 @@ export const navigationCommands: Command[] = [
 		name: 'dashboard-go-to-plugins',
 		label: __( 'Go to Plugins' ),
 		searchLabel: __( 'Navigate to Plugins management install plugins' ),
-		path: '/plugins',
+		path: PLUGINS_PATH,
 		icon: plugins,
 		isEnabled: ( supports ) => supports.plugins,
 	},

--- a/client/dashboard/app/context.tsx
+++ b/client/dashboard/app/context.tsx
@@ -22,6 +22,7 @@ export type AgencySupports = {
 	learn: boolean;
 	mcp: boolean;
 	sites: boolean;
+	plugins: boolean;
 	team: boolean;
 	earn: boolean;
 };

--- a/client/dashboard/app/responsive-sidebar/agency.tsx
+++ b/client/dashboard/app/responsive-sidebar/agency.tsx
@@ -6,6 +6,7 @@ import { SidebarExpandableMenuItem, SidebarMenuItem } from '../../components/sid
 import { useAppContext } from '../context';
 import {
 	agencyPartnerDirectoryRoute,
+	agencyPluginsRoute,
 	agencySitesRoute,
 	agencyTeamRoute,
 	agencyTiersRoute,
@@ -19,6 +20,7 @@ import {
 	learnRoute,
 	mcpRoute,
 } from '../router/agency';
+import PluginsMenu from './plugins-menu';
 import type { AnyRoute } from '@tanstack/react-router';
 
 export default function AgencySidebar() {
@@ -61,6 +63,7 @@ export default function AgencySidebar() {
 					{ __( 'Sites' ) }
 				</SidebarMenuItem>
 			) }
+			{ supports.agency.plugins && canAccess( agencyPluginsRoute ) && <PluginsMenu /> }
 			{ supports.agency.team && canAccess( agencyTeamRoute ) && (
 				<SidebarMenuItem icon={ people } to="/team">
 					{ __( 'Team' ) }

--- a/client/dashboard/app/responsive-sidebar/plugins-menu.tsx
+++ b/client/dashboard/app/responsive-sidebar/plugins-menu.tsx
@@ -1,0 +1,21 @@
+import { __ } from '@wordpress/i18n';
+import { plugins } from '@wordpress/icons';
+import { SidebarExpandableMenuItem, SidebarMenuItem } from '../../components/sidebar';
+import {
+	PLUGINS_MANAGE_PATH,
+	PLUGINS_PATH,
+	PLUGINS_SCHEDULED_UPDATES_PATH,
+} from '../../plugins/paths';
+import { wpcomLink } from '../../utils/link';
+
+export default function PluginsMenu() {
+	return (
+		<SidebarExpandableMenuItem label={ __( 'Plugins' ) } icon={ plugins } to={ PLUGINS_PATH }>
+			<SidebarMenuItem to={ PLUGINS_MANAGE_PATH }>{ __( 'Manage plugins' ) }</SidebarMenuItem>
+			<SidebarMenuItem to={ PLUGINS_SCHEDULED_UPDATES_PATH }>
+				{ __( 'Scheduled updates' ) }
+			</SidebarMenuItem>
+			<SidebarMenuItem href={ wpcomLink( '/plugins' ) }>{ __( 'Browse plugins' ) }</SidebarMenuItem>
+		</SidebarExpandableMenuItem>
+	);
+}

--- a/client/dashboard/app/responsive-sidebar/sidebar.tsx
+++ b/client/dashboard/app/responsive-sidebar/sidebar.tsx
@@ -1,19 +1,19 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { envelope, globe, layout, plugins } from '@wordpress/icons';
+import { envelope, globe, layout } from '@wordpress/icons';
 import { useRef } from 'react';
 import ReferralSidebar from '../../agency/earn/referrals/referral-sidebar';
 import AgencySiteSidebar from '../../agency/sites/site-sidebar';
 import RouterLinkButton from '../../components/router-link-button';
-import { SidebarExpandableMenuItem, SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
+import { SidebarMenu, SidebarMenuItem } from '../../components/sidebar';
 import SidebarNavigator from '../../components/sidebar-navigator';
 import DomainSidebar from '../../domains/domain-sidebar';
 import MeSidebar from '../../me/me-sidebar';
 import SiteSidebar from '../../sites/site-sidebar';
-import { wpcomLink } from '../../utils/link';
 import { useAnalytics } from '../analytics';
 import { useAppContext } from '../context';
 import AgencySidebar from './agency';
 import AgencyClientSidebar from './agency-client';
+import PluginsMenu from './plugins-menu';
 import { useSidebarScrollSync } from './use-sidebar-scroll-sync';
 
 import './sidebar.scss';
@@ -87,17 +87,7 @@ function PrimaryMenuSidebar() {
 					{ __( 'Emails' ) }
 				</SidebarMenuItem>
 			) }
-			{ supports.plugins && (
-				<SidebarExpandableMenuItem label={ __( 'Plugins' ) } icon={ plugins } to="/plugins">
-					<SidebarMenuItem to="/plugins/manage">{ __( 'Manage plugins' ) }</SidebarMenuItem>
-					<SidebarMenuItem to="/plugins/scheduled-updates">
-						{ __( 'Scheduled updates' ) }
-					</SidebarMenuItem>
-					<SidebarMenuItem href={ wpcomLink( '/plugins' ) }>
-						{ __( 'Browse plugins' ) }
-					</SidebarMenuItem>
-				</SidebarExpandableMenuItem>
-			) }
+			{ supports.plugins && <PluginsMenu /> }
 		</SidebarMenu>
 	);
 }

--- a/client/dashboard/app/responsive-sidebar/test/agency.test.tsx
+++ b/client/dashboard/app/responsive-sidebar/test/agency.test.tsx
@@ -17,6 +17,7 @@ const agencySupports: AgencySupports = {
 	learn: true,
 	mcp: true,
 	sites: true,
+	plugins: true,
 	team: true,
 	earn: true,
 };
@@ -67,6 +68,7 @@ describe( '<AgencySidebar>', () => {
 		] );
 
 		expect( screen.getByRole( 'link', { name: 'Sites' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Plugins' } ) ).toBeVisible();
 		expect( screen.getByRole( 'link', { name: 'Team' } ) ).toBeVisible();
 		expect( screen.getByRole( 'button', { name: 'Agency' } ) ).toBeVisible();
 		expect( screen.getByRole( 'button', { name: 'Marketplace' } ) ).toBeVisible();
@@ -78,6 +80,7 @@ describe( '<AgencySidebar>', () => {
 		await renderSidebar( [ 'a4a_read_managed_sites' ] );
 
 		expect( screen.getByRole( 'link', { name: 'Sites' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Plugins' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'link', { name: 'Team' } ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: 'Agency' } ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: 'Marketplace' } ) ).not.toBeInTheDocument();
@@ -90,6 +93,7 @@ describe( '<AgencySidebar>', () => {
 
 		expect( screen.getByRole( 'link', { name: 'Home' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'link', { name: 'Sites' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Plugins' } ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'keeps the Earn menu but drops the sub-items the user cannot reach', async () => {

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -6,7 +6,9 @@ import {
 	agencySiteQuery,
 	agencySitesWithPluginsQuery,
 	agencyWooPaymentsDataQuery,
+	marketplacePluginsQuery,
 	mcpSettingsQuery,
+	pluginsQuery,
 	queryClient,
 	rawUserPreferencesQuery,
 	siteApmAggregateRollingQuery,
@@ -25,6 +27,7 @@ import {
 import { isEnabled } from '@automattic/calypso-config';
 import { createRoute, createLazyRoute, notFound, Outlet } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
+import { PLUGINS_MANAGE_PATH } from '../../plugins/paths';
 import { getSiteTypeFeatureSupports } from '../../utils/site-type-feature-support';
 import { dashboardRedirect, redirectAsNotAllowed } from './redirect';
 import { rootRoute } from './root';
@@ -849,6 +852,127 @@ export const agencySiteMonitoringRoute = createRoute( {
 	)
 );
 
+// `/plugins` – manage plugins across the agency user's connected sites
+export const agencyPluginsRoute = createRoute( {
+	staticData: { requiresAgencyCapability: 'a4a_read_managed_sites' },
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Plugins' ),
+			},
+		],
+	} ),
+	getParentRoute: () => agencyRoute,
+	path: 'plugins',
+	component: Outlet,
+} );
+
+const agencyPluginsIndexRoute = createRoute( {
+	getParentRoute: () => agencyPluginsRoute,
+	path: '/',
+	beforeLoad: () => {
+		throw dashboardRedirect( { to: PLUGINS_MANAGE_PATH } );
+	},
+} );
+
+const agencyPluginsManageRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Manage plugins' ),
+			},
+		],
+	} ),
+	getParentRoute: () => agencyPluginsRoute,
+	path: 'manage',
+	loader: async () => {
+		queryClient.prefetchQuery( marketplacePluginsQuery() );
+		queryClient.prefetchQuery( pluginsQuery() );
+		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
+	},
+} );
+
+const agencyPluginsManageIndexRoute = createRoute( {
+	getParentRoute: () => agencyPluginsManageRoute,
+	path: '/',
+} ).lazy( () =>
+	import( '../../plugins/manage' ).then( ( d ) =>
+		createLazyRoute( 'agency-plugins-manage' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const agencyPluginRoute = createRoute( {
+	getParentRoute: () => agencyPluginsManageIndexRoute,
+	path: '$pluginId',
+} );
+
+const agencyPluginsScheduledUpdatesRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Scheduled updates' ),
+			},
+		],
+	} ),
+	getParentRoute: () => agencyPluginsRoute,
+	path: 'scheduled-updates',
+} );
+
+const agencyPluginsScheduledUpdatesIndexRoute = createRoute( {
+	getParentRoute: () => agencyPluginsScheduledUpdatesRoute,
+	path: '/',
+} ).lazy( () =>
+	import( '../../plugins/scheduled-updates' ).then( ( d ) =>
+		createLazyRoute( 'agency-plugins-scheduled-updates' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const agencyPluginsScheduledUpdatesNewRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'New schedule' ),
+			},
+		],
+	} ),
+	getParentRoute: () => agencyPluginsScheduledUpdatesRoute,
+	path: '/new',
+	loader: async ( { context } ) => {
+		queryClient.prefetchQuery( context.config.queries.sitesQuery() );
+	},
+} ).lazy( () =>
+	import( '../../plugins/scheduled-updates/new' ).then( ( d ) =>
+		createLazyRoute( 'agency-plugins-scheduled-updates-new' )( {
+			component: d.default,
+		} )
+	)
+);
+
+const agencyPluginsScheduledUpdatesEditRoute = createRoute( {
+	head: () => ( {
+		meta: [
+			{
+				title: __( 'Edit schedule' ),
+			},
+		],
+	} ),
+	getParentRoute: () => agencyPluginsScheduledUpdatesRoute,
+	path: '/edit/$scheduleId',
+	loader: async ( { context } ) => {
+		queryClient.prefetchQuery( context.config.queries.sitesQuery() );
+	},
+} ).lazy( () =>
+	import( '../../plugins/scheduled-updates/edit' ).then( ( d ) =>
+		createLazyRoute( 'agency-plugins-scheduled-updates-edit' )( {
+			component: d.default,
+		} )
+	)
+);
+
 export const createAgencyRoutes = () => [
 	agencyRoute.addChildren( [
 		agencyOverviewRoute,
@@ -863,6 +987,15 @@ export const createAgencyRoutes = () => [
 			mcpConnectRoute,
 		] ),
 		agencySitesRoute,
+		agencyPluginsRoute.addChildren( [
+			agencyPluginsIndexRoute,
+			agencyPluginsManageRoute.addChildren( [ agencyPluginsManageIndexRoute, agencyPluginRoute ] ),
+			agencyPluginsScheduledUpdatesRoute.addChildren( [
+				agencyPluginsScheduledUpdatesIndexRoute,
+				agencyPluginsScheduledUpdatesNewRoute,
+				agencyPluginsScheduledUpdatesEditRoute,
+			] ),
+		] ),
 		agencyTeamRoute,
 		earnOverviewRoute,
 		earnReferralsRoute,

--- a/client/dashboard/app/router/plugins.tsx
+++ b/client/dashboard/app/router/plugins.tsx
@@ -6,11 +6,12 @@ import {
 } from '@automattic/api-queries';
 import { createRoute, createLazyRoute, Outlet } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
+import { PLUGINS_MANAGE_PATH } from '../../plugins/paths';
 import { dashboardRedirect } from './redirect';
 import { rootRoute } from './root';
 import type { AnyRoute } from '@tanstack/react-router';
 
-export const pluginsRoute = createRoute( {
+const pluginsRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
@@ -23,7 +24,7 @@ export const pluginsRoute = createRoute( {
 	component: Outlet,
 } );
 
-export const pluginsIndexRoute = createRoute( {
+const pluginsIndexRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
@@ -34,11 +35,11 @@ export const pluginsIndexRoute = createRoute( {
 	getParentRoute: () => pluginsRoute,
 	path: '/',
 	beforeLoad: () => {
-		throw dashboardRedirect( { to: '/plugins/manage' } );
+		throw dashboardRedirect( { to: PLUGINS_MANAGE_PATH } );
 	},
 } );
 
-export const pluginsManageRoute = createRoute( {
+const pluginsManageRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
@@ -55,7 +56,7 @@ export const pluginsManageRoute = createRoute( {
 	},
 } );
 
-export const pluginsManageIndexRoute = createRoute( {
+const pluginsManageIndexRoute = createRoute( {
 	getParentRoute: () => pluginsManageRoute,
 	path: '/',
 } ).lazy( () =>
@@ -66,16 +67,12 @@ export const pluginsManageIndexRoute = createRoute( {
 	)
 );
 
-export const pluginRoute = createRoute( {
+const pluginRoute = createRoute( {
 	getParentRoute: () => pluginsManageIndexRoute,
 	path: '$pluginId',
-	loader: async () => {
-		queryClient.prefetchQuery( marketplacePluginsQuery() );
-		queryClient.prefetchQuery( pluginsQuery() );
-	},
 } );
 
-export const pluginsScheduledUpdatesRoute = createRoute( {
+const pluginsScheduledUpdatesRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
@@ -87,7 +84,7 @@ export const pluginsScheduledUpdatesRoute = createRoute( {
 	path: 'scheduled-updates',
 } );
 
-export const pluginsScheduledUpdatesIndexRoute = createRoute( {
+const pluginsScheduledUpdatesIndexRoute = createRoute( {
 	getParentRoute: () => pluginsScheduledUpdatesRoute,
 	path: '/',
 } ).lazy( () =>
@@ -98,7 +95,7 @@ export const pluginsScheduledUpdatesIndexRoute = createRoute( {
 	)
 );
 
-export const pluginsScheduledUpdatesNewRoute = createRoute( {
+const pluginsScheduledUpdatesNewRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{
@@ -119,7 +116,7 @@ export const pluginsScheduledUpdatesNewRoute = createRoute( {
 	)
 );
 
-export const pluginsScheduledUpdatesEditRoute = createRoute( {
+const pluginsScheduledUpdatesEditRoute = createRoute( {
 	head: () => ( {
 		meta: [
 			{

--- a/client/dashboard/app/router/test/plugins-route-parity.test.ts
+++ b/client/dashboard/app/router/test/plugins-route-parity.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { createAgencyRoutes } from '../agency';
+import { createPluginsRoutes } from '../plugins';
+
+type RouteNode = {
+	options?: { path?: string };
+	children?: RouteNode[];
+};
+
+function normalizeSegment( path?: string ) {
+	return ( path ?? '' ).replace( /^\/+|\/+$/g, '' );
+}
+
+function collectPaths( route: RouteNode, parentPath: string ): string[] {
+	const segment = normalizeSegment( route.options?.path );
+	const fullPath = [ parentPath, segment ].filter( Boolean ).join( '/' );
+	const children = Array.isArray( route.children ) ? route.children : [];
+
+	return children.reduce< string[] >(
+		( acc, child ) => acc.concat( collectPaths( child, fullPath ) ),
+		[ fullPath ]
+	);
+}
+
+function findPluginsSubtree( routes: RouteNode[] ): RouteNode | undefined {
+	for ( const route of routes ) {
+		if ( normalizeSegment( route.options?.path ) === 'plugins' ) {
+			return route;
+		}
+		const match = findPluginsSubtree( route.children ?? [] );
+		if ( match ) {
+			return match;
+		}
+	}
+	return undefined;
+}
+
+// The agency router deliberately owns its copy of the plugins route tree
+// (with its own capability gating) instead of reusing the dotcom one, and
+// shared screens navigate between the two trees via untyped path constants
+// from `client/dashboard/plugins/paths.ts`. Nothing type-checks that the
+// trees stay in sync, so a path added or renamed in one tree only would
+// surface as a runtime 404 in the other app. This test is that check.
+describe( 'plugins route parity', () => {
+	test( 'the agency plugins route tree exposes the same paths as the dotcom one', () => {
+		const dotcomSubtree = findPluginsSubtree( createPluginsRoutes() as RouteNode[] );
+		const agencySubtree = findPluginsSubtree( createAgencyRoutes() as RouteNode[] );
+
+		expect( dotcomSubtree ).toBeDefined();
+		expect( agencySubtree ).toBeDefined();
+
+		const dotcomPaths = [ ...new Set( collectPaths( dotcomSubtree as RouteNode, '' ) ) ].sort();
+		const agencyPaths = [ ...new Set( collectPaths( agencySubtree as RouteNode, '' ) ) ].sort();
+
+		expect( dotcomPaths ).toContain( 'plugins/manage' );
+		expect( agencyPaths ).toEqual( dotcomPaths );
+	} );
+} );

--- a/client/dashboard/plugins/manage/components/plugin-switcher.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.tsx
@@ -3,11 +3,11 @@ import { Field, View } from '@wordpress/dataviews';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { pluginRoute } from '../../../app/router/plugins';
 import { Card, CardBody } from '../../../components/card';
 import SwitcherContent from '../../../components/switcher/switcher-content';
 import SwitcherItem from '../../../components/switcher/switcher-item';
 import { Text } from '../../../components/text';
+import { getPluginManagePath } from '../../paths';
 import { PluginListRow } from '../types';
 import { PluginIcon } from './plugin-icon';
 import { PluginUpdatesFilter } from './plugin-updates-filter';
@@ -144,7 +144,7 @@ export const PluginSwitcher = ( {
 					onChangeView={ onChangeView }
 					items={ pluginsWithIcon }
 					resetScroll={ false }
-					getItemUrl={ ( item ) => pluginRoute.to.replace( '$pluginId', item.slug ) }
+					getItemUrl={ ( item ) => getPluginManagePath( item.slug ) }
 					renderItem={ renderItem }
 					searchableFields={ searchableFields }
 					noResultsText={ __( 'No plugins found.' ) }

--- a/client/dashboard/plugins/paths.ts
+++ b/client/dashboard/plugins/paths.ts
@@ -1,0 +1,10 @@
+export const PLUGINS_PATH = '/plugins';
+export const PLUGINS_MANAGE_PATH = `${ PLUGINS_PATH }/manage`;
+export const PLUGINS_SCHEDULED_UPDATES_PATH = `${ PLUGINS_PATH }/scheduled-updates`;
+export const PLUGINS_SCHEDULED_UPDATES_NEW_PATH = `${ PLUGINS_SCHEDULED_UPDATES_PATH }/new`;
+
+export const getPluginManagePath = ( pluginSlug: string ) =>
+	`${ PLUGINS_MANAGE_PATH }/${ pluginSlug }`;
+
+export const getScheduledUpdatesEditPath = ( scheduleId: string ) =>
+	`${ PLUGINS_SCHEDULED_UPDATES_PATH }/edit/${ scheduleId }`;

--- a/client/dashboard/plugins/scheduled-updates/edit/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/edit/index.tsx
@@ -1,14 +1,11 @@
-import { useNavigate } from '@tanstack/react-router';
+import { useNavigate, useParams } from '@tanstack/react-router';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
 import Breadcrumbs from '../../../app/breadcrumbs';
-import {
-	pluginsScheduledUpdatesEditRoute,
-	pluginsScheduledUpdatesRoute,
-} from '../../../app/router/plugins';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
+import { PLUGINS_SCHEDULED_UPDATES_PATH } from '../../paths';
 import {
 	ScheduledUpdatesForm,
 	type ScheduledUpdatesFormOnSubmit,
@@ -17,8 +14,8 @@ import { useLoadScheduleById } from '../hooks/use-load-schedule-by-id';
 import { useReconcileSchedules } from '../hooks/use-reconcile-schedules';
 
 export default function PluginsScheduledUpdatesEdit() {
-	const { scheduleId } = pluginsScheduledUpdatesEditRoute.useParams();
-	const navigate = useNavigate( { from: pluginsScheduledUpdatesEditRoute.fullPath } );
+	const { scheduleId = '' } = useParams( { strict: false } );
+	const navigate = useNavigate();
 
 	const { loading, error, initial } = useLoadScheduleById( scheduleId );
 	const [ selectedSiteIds, setSelectedSiteIds ] = useState< string[] >( [] );
@@ -42,7 +39,7 @@ export default function PluginsScheduledUpdatesEdit() {
 			weekday: inputs.weekday,
 			time: inputs.time,
 		} );
-		navigate( { to: pluginsScheduledUpdatesRoute.to } );
+		navigate( { to: PLUGINS_SCHEDULED_UPDATES_PATH } );
 	};
 
 	return (

--- a/client/dashboard/plugins/scheduled-updates/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/index.tsx
@@ -8,10 +8,6 @@ import { info } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState, useCallback } from 'react';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
-import {
-	pluginsScheduledUpdatesEditRoute,
-	pluginsScheduledUpdatesNewRoute,
-} from '../../app/router/plugins';
 import ConfirmModal from '../../components/confirm-modal';
 import { DataViewsCard } from '../../components/dataviews';
 import { PageHeader } from '../../components/page-header';
@@ -20,6 +16,7 @@ import RouterLinkButton from '../../components/router-link-button';
 import SiteIcon from '../../components/site-icon';
 import { SiteLink } from '../../sites/site-fields';
 import { formatDate } from '../../utils/datetime';
+import { getScheduledUpdatesEditPath, PLUGINS_SCHEDULED_UPDATES_NEW_PATH } from '../paths';
 import { prepareScheduleName } from './helpers';
 import { useDeleteSchedules } from './hooks/use-delete-schedules';
 import { useScheduledUpdates } from './hooks/use-scheduled-updates';
@@ -233,7 +230,7 @@ export default function PluginsScheduledUpdates() {
 						actions={
 							<RouterLinkButton
 								variant="primary"
-								to={ pluginsScheduledUpdatesNewRoute.to }
+								to={ PLUGINS_SCHEDULED_UPDATES_NEW_PATH }
 								__next40pxDefaultSize
 							>
 								{ __( 'New schedule' ) }
@@ -268,10 +265,9 @@ export default function PluginsScheduledUpdates() {
 								isPrimary: true,
 								callback: ( items ) => {
 									const item = items[ 0 ];
-									navigate( {
-										to: pluginsScheduledUpdatesEditRoute.fullPath,
-										params: { scheduleId: item?.scheduleId },
-									} );
+									if ( item ) {
+										navigate( { to: getScheduledUpdatesEditPath( item.scheduleId ) } );
+									}
 								},
 							},
 							{

--- a/client/dashboard/plugins/scheduled-updates/new/index.tsx
+++ b/client/dashboard/plugins/scheduled-updates/new/index.tsx
@@ -4,12 +4,9 @@ import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useCallback, useMemo, useState } from 'react';
 import Breadcrumbs from '../../../app/breadcrumbs';
-import {
-	pluginsScheduledUpdatesNewRoute,
-	pluginsScheduledUpdatesRoute,
-} from '../../../app/router/plugins';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
+import { PLUGINS_SCHEDULED_UPDATES_PATH } from '../../paths';
 import {
 	ScheduledUpdatesForm,
 	type ScheduledUpdatesFormOnSubmit,
@@ -17,7 +14,7 @@ import {
 import { useCreateSchedules } from '../hooks/use-create-schedules';
 
 function ScheduledUpdatesNew() {
-	const navigate = useNavigate( { from: pluginsScheduledUpdatesNewRoute.fullPath } );
+	const navigate = useNavigate();
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const [ selectedSiteIds, setSelectedSiteIds ] = useState< string[] >( [] );
 	const siteIdsAsNumbers = useMemo(
@@ -30,7 +27,7 @@ function ScheduledUpdatesNew() {
 		async ( inputs ) => {
 			await runCreate( inputs );
 			createSuccessNotice( __( 'Schedule created successfully.' ), { type: 'snackbar' } );
-			navigate( { to: pluginsScheduledUpdatesRoute.to } );
+			navigate( { to: PLUGINS_SCHEDULED_UPDATES_PATH } );
 		},
 		[ navigate, runCreate, createSuccessNotice ]
 	);

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -20,6 +20,7 @@ import { useInView } from 'react-intersection-observer';
 import { LAUNCHPAD_PERSONALIZATION_EXPERIMENT, normalizeVariation } from 'calypso/lib/ai-launchpad';
 import { useExperiment } from 'calypso/lib/explat';
 import { useAnalytics } from '../../app/analytics';
+import { useAppContext } from '../../app/context';
 import ComponentViewTracker from '../../components/component-view-tracker';
 import SiteIcon from '../../components/site-icon';
 import { Text } from '../../components/text';
@@ -73,6 +74,28 @@ export function SiteLink( {
 	expanded,
 	...props
 }: ComponentProps< typeof Link > & { site: Site; expanded?: boolean } ) {
+	const { supports } = useAppContext();
+
+	// Apps without the generic sites section (e.g. A4A) don't register
+	// `/sites/<slug>` for arbitrary user sites, so render plain text instead
+	// of a link.
+	if ( ! supports.sites ) {
+		const { children } = props;
+		return (
+			<span
+				style={ {
+					width: expanded ? '100%' : 'auto',
+					minWidth: 'unset',
+					...props.style,
+				} }
+			>
+				{ typeof children === 'function'
+					? children( { isActive: false, isTransitioning: false } )
+					: children }
+			</span>
+		);
+	}
+
 	return (
 		<Link
 			{ ...props }

--- a/client/dashboard/test-utils.tsx
+++ b/client/dashboard/test-utils.tsx
@@ -15,6 +15,14 @@ const defaultUser = {
 	language: 'en',
 } as User;
 
+// The screens under test are mounted in apps that support the generic sites
+// section, and components like SiteLink only render `/sites/<slug>` links
+// when the app does.
+const defaultConfig = {
+	...APP_CONTEXT_DEFAULT_CONFIG,
+	supports: { ...APP_CONTEXT_DEFAULT_CONFIG.supports, sites: true },
+};
+
 function createTestRouter( ui: React.ReactElement ) {
 	const Component = () => ui;
 
@@ -57,7 +65,7 @@ export function render( ui: React.ReactElement, options: RenderOptions = {} ): R
 
 	const testingLibraryResult = testingLibraryRender(
 		<QueryClientProvider client={ queryClient }>
-			<AppProvider config={ APP_CONTEXT_DEFAULT_CONFIG }>
+			<AppProvider config={ defaultConfig }>
 				<AnalyticsProvider client={ { recordTracksEvent, recordPageView } }>
 					<AuthContext.Provider value={ { user, logout: jest.fn() } }>
 						<RouterProvider router={ router } context={ { config: { basePath: '/' } } } />

--- a/packages/api-queries/src/sites.ts
+++ b/packages/api-queries/src/sites.ts
@@ -19,6 +19,20 @@ export const sitesQuery = (
 	} );
 };
 
+// Filters in the queryFn rather than via `select` or the endpoint's `filters`
+// param: consumers may provide their own `select`, and the server-side
+// `filters=jetpack` semantics don't exactly match `site.jetpack` (e.g. Atomic).
+export const jetpackSitesQuery = (
+	fetchSitesOptions: FetchSitesOptions = { site_visibility: 'visible', include_a8c_owned: false }
+) => {
+	const { source, ...fetchSitesOptionsKey } = fetchSitesOptions;
+	return queryOptions( {
+		queryKey: [ ...sitesQueryKey, 'jetpack-connected', fetchSitesOptionsKey ],
+		queryFn: async () =>
+			( await fetchSites( 'all', fetchSitesOptions ) ).filter( ( site ) => site.jetpack ),
+	} );
+};
+
 export const paginatedSitesQuery = (
 	siteFilters: FetchSiteTypes,
 	fetchSitesOptions: FetchPaginatedSitesOptions = {


### PR DESCRIPTION
Resolves A4A-2852

## Proposed Changes

* Enable the Plugins section on the A4A Multi-site Dashboard. It reuses the existing dashboard Plugins screens: Manage plugins, plugin details, and Scheduled updates.
* Add a "Plugins" entry to the A4A sidebar, right after "Sites" (same position as the classic A4A app).
* Apply the same access rule as the classic app: only agency members who can view managed sites see the menu entry, and opening `/plugins` directly without that permission redirects to the overview page. Client users are blocked as well.
* Limit the A4A dashboard's site list to Jetpack-connected sites, matching the classic app (personal WordPress.com Simple sites no longer appear as install targets or in the site switcher).

<img width="1920" height="923" alt="Screenshot 2026-08-18 at 10 48 10 AM" src="https://github.com/user-attachments/assets/d2025d40-9f71-4179-8997-e3e7af21bb23" />


## Why are these changes being made?

* Agencies should be able to manage plugins from the new dashboard without going back to the classic app. Reusing the existing dashboard Plugins screens gives A4A the same functionality with no duplicated UI code, while keeping the same data behavior as the classic Plugins page: the same plugin list, the same sites, and the same permissions.

## Testing Instructions

### A4A dashboard

* Open the Dashboard (A4A) live link.
* Confirm "Plugins" appears in the sidebar right after "Sites", with "Manage plugins", "Scheduled updates", and "Browse plugins" entries.
* Open Manage plugins. Compare the list with the classic A4A Plugins page (`/plugins/manage/sites` in the classic app): the same plugins should be listed for the same sites.
* Try activating/deactivating a plugin, toggling auto-updates, and updating a plugin with an available update.
* Open a plugin's details and check the site rows: site names should appear as plain text (not links), see the expected differences below.
* As a team member **without** the managed-sites permission: confirm the Plugins entry is not in the sidebar, and manually opening `/plugins` redirects to `/overview`.

#### Expected differences from the classic A4A Plugins page (intentional)

* **Scheduled updates and Browse plugins exist here but not in classic.** These come with the dashboard's Plugins section. Scheduled updates only works for WordPress.com-hosted sites; sites hosted elsewhere won't appear there.
* **For Automattician test accounts, totals can differ slightly from classic.** The dashboard excludes Automattic-owned sites and hidden sites from what it displays, while classic counts a slightly looser set. Regular agency accounts should see identical numbers in both apps. Relatedly, the plugin list's count can disagree with the "Installed on N sites" number in the detail panel on such accounts — that's a pre-existing dashboard bug being reported here: DOTMSD-1526.
* **Site names are plain text, not links.** The dashboard only has site pages for agency-managed sites, while the plugin list can include other sites connected to your account (like a personal site). Linking only some rows would be confusing and the rest would lead to dead ends, so site names on the plugin screens don't link anywhere in A4A. The WordPress.com dashboard keeps its links.

### WordPress.com dashboard (regression)

* Open the Dashboard (dotcom) live link and go to Plugins → Manage plugins.
* Confirm the list loads and plugin/site counts are unchanged from production.
* Click through to a plugin's details and switch between the "Installed on" and "Available on" tabs. Site names should still link to the site's dashboard page.
* Check Scheduled updates: the list loads, and creating and editing a schedule still navigates correctly.
* Confirm the sidebar Plugins menu (Manage plugins / Scheduled updates / Browse plugins) is unchanged.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)



