### PR TITLE
Dashboard: open Odie chat from hosting activation modal's Need help button

### DIFF
--- a/client/dashboard/sites/hosting-feature-activation-modal/index.tsx
+++ b/client/dashboard/sites/hosting-feature-activation-modal/index.tsx
@@ -16,19 +16,20 @@ import {
 	ErrorContentInfo,
 } from './error-content-info';
 import { WarningContentInfo } from './warning-content-info';
+import type { Site } from '@automattic/api-core';
 
 import './style.scss';
 
 export default function HostingFeatureActivationModal( {
-	siteId,
+	site,
 	onProceed,
 }: {
-	siteId: number;
+	site: Site;
 	onProceed: ( options: { geo_affinity?: string } ) => void;
 } ) {
 	const { recordTracksEvent } = useAnalytics();
-	const { data } = useSuspenseQuery( siteAutomatedTransfersEligibilityQuery( siteId ) );
-	const { setShowHelpCenter } = useHelpCenter();
+	const { data } = useSuspenseQuery( siteAutomatedTransfersEligibilityQuery( site.ID ) );
+	const { setOpenOdieWithContext } = useHelpCenter();
 	const [ selectedGeoAffinity, setSelectedGeoAffinity ] = useState( '' );
 
 	if ( ! data ) {
@@ -43,7 +44,12 @@ export default function HostingFeatureActivationModal( {
 	const cannotActivate = ! isEligible && ! needsPlanUpgrade;
 
 	function handleGetHelp() {
-		setShowHelpCenter( true );
+		setOpenOdieWithContext( {
+			initialMessage: __( 'I need help activating hosting features on my site.' ),
+			section: 'hosting-activation',
+			siteUrl: site.URL,
+			siteId: site.ID,
+		} );
 		recordTracksEvent( 'calypso_dashboard_hosting_feature_activation_modal_help_center_click' );
 	}
 

--- a/client/dashboard/sites/hosting-feature-gated-with-callout/activation.tsx
+++ b/client/dashboard/sites/hosting-feature-gated-with-callout/activation.tsx
@@ -119,7 +119,7 @@ export default function ActivationCallout( {
 					onRequestClose={ () => setIsModalOpen( false ) }
 					size="medium"
 				>
-					<HostingFeatureActivationModal siteId={ site.ID } onProceed={ handleConfirm } />
+					<HostingFeatureActivationModal site={ site } onProceed={ handleConfirm } />
 				</Modal>
 			</Suspense>
 		);


### PR DESCRIPTION
## Summary
- The "Need help?" button in the hosting-feature-activation modal (Monitoring → Activate hosting features) called `setShowHelpCenter(true)`, which just opens the generic Help Center panel instead of Odie chat, unlike similar "Need help" affordances elsewhere in the dashboard (e.g. `EmailBlockNotice`).
- Switched it to `setOpenOdieWithContext(...)` so it opens Odie chat directly with a relevant initial message and site context, matching the existing pattern.
- `HostingFeatureActivationModal` now takes a `site: Site` prop instead of `siteId: number` so it has access to `site.URL` for the Odie context.

Fixes [DOTCOM-18105](https://linear.app/a8c/issue/DOTCOM-18105/site-transfer-modal-need-help-opens-help-center-instead-of-odie-chat).

## Test plan
- [ ] On a site eligible/ineligible for hosting-feature activation, go to Monitoring → Activate hosting features, click "Need help?", and confirm Odie chat opens directly (not the generic Help Center home) with the site context set.
- [ ] Confirm the "Activate hosting features" flow (proceed button, data center picker, errors/warnings) still works as before.