### PR TITLE
Switch agenttic consumers to the workspace packages

### DIFF
--- a/bin/build-packages-web.sh
+++ b/bin/build-packages-web.sh
@@ -12,9 +12,15 @@ set -e
 #   server config at runtime, not bundled by webpack.
 # - languages (conditional): pre-builds translation chunk manifests when
 #   BUILD_TRANSLATION_CHUNKS or use-translation-chunks is enabled.
+# - agenttic-client / agenttic-ui: consumed via dist/ (no `calypso:src` —
+#   their source relies on vite-only features like import.meta.glob that
+#   webpack can't parse). The ui build downloads translation files from
+#   translate.wordpress.com.
 #
 yarn workspace @automattic/calypso-color-schemes run prepare
 yarn workspace @automattic/create-calypso-config run prepare
+yarn workspace @automattic/agenttic-client run prepare
+yarn workspace @automattic/agenttic-ui run prepare
 
 if [ "${BUILD_TRANSLATION_CHUNKS:-}" = "true" ] || [ "${ENABLE_FEATURES:-}" = "use-translation-chunks" ]; then
 	yarn workspace @automattic/languages run prepare

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@automattic/accessible-focus": "workspace:^",
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-ui": "^0.1.89",
+		"@automattic/agenttic-ui": "workspace:^",
 		"@automattic/api-core": "workspace:^",
 		"@automattic/api-queries": "workspace:^",
 		"@automattic/block-renderer": "workspace:^",

--- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -41,8 +41,8 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.89",
-		"@automattic/agenttic-ui": "^0.1.89",
+		"@automattic/agenttic-client": "workspace:^",
+		"@automattic/agenttic-ui": "workspace:^",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/agents-manager/tsconfig.json
+++ b/packages/agents-manager/tsconfig.json
@@ -9,5 +9,10 @@
 		"types": [ "jest", "@testing-library/jest-dom" ]
 	},
 	"include": [ "src", "src/*.json", "types" ],
-	"references": [ { "path": "../viewport" }, { "path": "../support-articles" } ]
+	"references": [
+		{ "path": "../agenttic-client" },
+		{ "path": "../agenttic-ui" },
+		{ "path": "../viewport" },
+		{ "path": "../support-articles" }
+	]
 }

--- a/packages/agenttic-client/package.json
+++ b/packages/agenttic-client/package.json
@@ -22,7 +22,7 @@
 	},
 	"files": [
 		"dist",
-		"README.md"
+		"!dist/tsconfig.tsbuildinfo"
 	],
 	"scripts": {
 		"build": "yarn run clean && vite build && tsc --project tsconfig.json --emitDeclarationOnly",

--- a/packages/agenttic-client/package.json
+++ b/packages/agenttic-client/package.json
@@ -26,6 +26,7 @@
 	],
 	"scripts": {
 		"build": "yarn run clean && vite build && tsc --project tsconfig.json --emitDeclarationOnly",
+		"prepare": "yarn run build",
 		"dev": "vite build --watch",
 		"clean": "rm -rf dist",
 		"type-check": "tsc --noEmit",

--- a/packages/agenttic-client/tsconfig.json
+++ b/packages/agenttic-client/tsconfig.json
@@ -19,6 +19,11 @@
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,
 		"outDir": "dist",
+		// With a flat outDir the default buildinfo path is the package root, where it
+		// survives `rm -rf dist` and makes `tsc --build` skip re-emitting the deleted
+		// declarations. Keep it in dist so wiping dist forces a rebuild. Obsolete if
+		// the package ever moves to the standard dist/esm + dist/cjs layout.
+		"tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
 		"rootDir": "src",
 		"declaration": true,
 		"declarationMap": true,

--- a/packages/agenttic-ui/package.json
+++ b/packages/agenttic-ui/package.json
@@ -21,7 +21,7 @@
 	},
 	"files": [
 		"dist",
-		"README.md"
+		"!dist/tsconfig.tsbuildinfo"
 	],
 	"scripts": {
 		"build": "yarn run clean && yarn run i18n:download-json && vite build && tsc --project tsconfig.json --emitDeclarationOnly",

--- a/packages/agenttic-ui/package.json
+++ b/packages/agenttic-ui/package.json
@@ -25,6 +25,7 @@
 	],
 	"scripts": {
 		"build": "yarn run clean && yarn run i18n:download-json && vite build && tsc --project tsconfig.json --emitDeclarationOnly",
+		"prepare": "yarn run build",
 		"dev": "vite",
 		"clean": "rm -rf dist",
 		"type-check": "tsc --noEmit",
@@ -72,7 +73,6 @@
 		"@types/react": "^18.0.0 || ^19.0.0",
 		"@types/react-dom": "^18.0.0 || ^19.0.0",
 		"@vitejs/plugin-react": "^4.0.0",
-		"@wordpress/prettier-config": "^4.2.0",
 		"autoprefixer": "^10.4.0",
 		"jsdom": "^24.0.0",
 		"postcss": "^8.4.0",

--- a/packages/agenttic-ui/tsconfig.json
+++ b/packages/agenttic-ui/tsconfig.json
@@ -19,6 +19,11 @@
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,
 		"outDir": "dist",
+		// With a flat outDir the default buildinfo path is the package root, where it
+		// survives `rm -rf dist` and makes `tsc --build` skip re-emitting the deleted
+		// declarations. Keep it in dist so wiping dist forces a rebuild. Obsolete if
+		// the package ever moves to the standard dist/esm + dist/cjs layout.
+		"tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo",
 		"rootDir": "src",
 		"declaration": true,
 		"declarationMap": true,

--- a/packages/image-studio/package.json
+++ b/packages/image-studio/package.json
@@ -51,8 +51,8 @@
 	},
 	"dependencies": {
 		"@automattic/agents-manager": "workspace:^",
-		"@automattic/agenttic-client": "^0.1.89",
-		"@automattic/agenttic-ui": "^0.1.89",
+		"@automattic/agenttic-client": "workspace:^",
+		"@automattic/agenttic-ui": "workspace:^",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/oauth-token": "workspace:^",
 		"@wordpress/abilities": "^0.14.0",

--- a/packages/jetpack-ai-sidebar/package.json
+++ b/packages/jetpack-ai-sidebar/package.json
@@ -44,7 +44,7 @@
 		"typecheck": "tsc --build --dry"
 	},
 	"dependencies": {
-		"@automattic/agenttic-client": "^0.1.89",
+		"@automattic/agenttic-client": "workspace:^",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/components": "workspace:^",

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -41,7 +41,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.89",
+		"@automattic/agenttic-ui": "workspace:^",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/odie-client/tsconfig.json
+++ b/packages/odie-client/tsconfig.json
@@ -8,5 +8,9 @@
 	},
 	"include": [ "src", "src/*.json", "src/types/index.d.ts", "types" ],
 	"exclude": [ "**/__tests__/*" ],
-	"references": [ { "path": "../components" }, { "path": "../zendesk-client" } ]
+	"references": [
+		{ "path": "../agenttic-ui" },
+		{ "path": "../components" },
+		{ "path": "../zendesk-client" }
+	]
 }

--- a/packages/zendesk-client/package.json
+++ b/packages/zendesk-client/package.json
@@ -36,7 +36,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"@automattic/agenttic-ui": "^0.1.89",
+		"@automattic/agenttic-ui": "workspace:^",
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-config": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/packages/zendesk-client/tsconfig.json
+++ b/packages/zendesk-client/tsconfig.json
@@ -7,5 +7,9 @@
 	},
 	"include": [ "src", "types.d.ts" ],
 	"exclude": [ "**/test/*" ],
-	"references": [ { "path": "../data-stores" }, { "path": "../calypso-config" } ]
+	"references": [
+		{ "path": "../agenttic-ui" },
+		{ "path": "../data-stores" },
+		{ "path": "../calypso-config" }
+	]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -294,8 +294,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/agents-manager@workspace:packages/agents-manager"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.89"
-    "@automattic/agenttic-ui": "npm:^0.1.89"
+    "@automattic/agenttic-client": "workspace:^"
+    "@automattic/agenttic-ui": "workspace:^"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -342,25 +342,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-client@npm:^0.1.89":
-  version: 0.1.89
-  resolution: "@automattic/agenttic-client@npm:0.1.89"
-  dependencies:
-    "@types/react": "npm:^18.0.0 || ^19.0.0"
-    marked: "npm:^16.2.1"
-  peerDependencies:
-    "@wordpress/api-fetch": ^6.0.0 || ^7.0.0
-    react: ^18.0.0 || ^19.0.0
-  dependenciesMeta:
-    marked:
-      optional: true
-  peerDependenciesMeta:
-    "@wordpress/api-fetch":
-      optional: true
-  checksum: 4cac4119dd28f042e1e71f14ae3f16fdc61583f804fc260c4bc1b54f41e3987233ab3ef04d72666e38b0f203e6c8c25d68aba652dc72219154dbdb615e37fde3
-  languageName: node
-  linkType: hard
-
 "@automattic/agenttic-client@workspace:^, @automattic/agenttic-client@workspace:packages/agenttic-client":
   version: 0.0.0-use.local
   resolution: "@automattic/agenttic-client@workspace:packages/agenttic-client"
@@ -406,35 +387,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@automattic/agenttic-ui@npm:^0.1.89":
-  version: 0.1.89
-  resolution: "@automattic/agenttic-ui@npm:0.1.89"
-  dependencies:
-    "@automattic/charts": "npm:^1.10.0"
-    "@radix-ui/react-popover": "npm:^1.1.15"
-    "@radix-ui/react-scroll-area": "npm:^1.2.9"
-    "@radix-ui/react-slot": "npm:^1.2.3"
-    "@wordpress/i18n": "npm:^6.1.0"
-    class-variance-authority: "npm:^0.7.1"
-    clsx: "npm:^2.1.1"
-    framer-motion: "npm:^12.23.0"
-    lucide-react: "npm:^0.525.0"
-    marked: "npm:^16.2.1"
-    react-markdown: "npm:^10.1.0"
-    react-textarea-autosize: "npm:^8.5.9"
-    remark-gfm: "npm:^4.0.1"
-    unified: "npm:^11.0.5"
-    use-debounce: "npm:^10.0.6"
-  peerDependencies:
-    react: ^18.0.0 || ^19.0.0
-    react-dom: ^18.0.0 || ^19.0.0
-  dependenciesMeta:
-    marked:
-      optional: true
-  checksum: 68eee5766e2ef691ab8efa5c5e99503a6ce1bab52585a5c7a9bd351b1483da4e9a0916b38df21dd7d0b7a8d63ae054df874142a6ff347e551a95a8114cfb5c3d
-  languageName: node
-  linkType: hard
-
 "@automattic/agenttic-ui@workspace:^, @automattic/agenttic-ui@workspace:packages/agenttic-ui":
   version: 0.0.0-use.local
   resolution: "@automattic/agenttic-ui@workspace:packages/agenttic-ui"
@@ -458,7 +410,6 @@ __metadata:
     "@types/react-dom": "npm:^18.0.0 || ^19.0.0"
     "@vitejs/plugin-react": "npm:^4.0.0"
     "@wordpress/i18n": "npm:^6.1.0"
-    "@wordpress/prettier-config": "npm:^4.2.0"
     autoprefixer: "npm:^10.4.0"
     class-variance-authority: "npm:^0.7.1"
     clsx: "npm:^2.1.1"
@@ -1735,8 +1686,8 @@ __metadata:
   resolution: "@automattic/image-studio@workspace:packages/image-studio"
   dependencies:
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-client": "npm:^0.1.89"
-    "@automattic/agenttic-ui": "npm:^0.1.89"
+    "@automattic/agenttic-client": "workspace:^"
+    "@automattic/agenttic-ui": "workspace:^"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/oauth-token": "workspace:^"
@@ -1824,7 +1775,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/jetpack-ai-sidebar@workspace:packages/jetpack-ai-sidebar"
   dependencies:
-    "@automattic/agenttic-client": "npm:^0.1.89"
+    "@automattic/agenttic-client": "workspace:^"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/calypso-url": "workspace:^"
@@ -2091,7 +2042,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/odie-client@workspace:packages/odie-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.89"
+    "@automattic/agenttic-ui": "workspace:^"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
@@ -2934,7 +2885,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@automattic/zendesk-client@workspace:packages/zendesk-client"
   dependencies:
-    "@automattic/agenttic-ui": "npm:^0.1.89"
+    "@automattic/agenttic-ui": "workspace:^"
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-config": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
@@ -15215,7 +15166,7 @@ __metadata:
   dependencies:
     "@automattic/accessible-focus": "workspace:^"
     "@automattic/agents-manager": "workspace:^"
-    "@automattic/agenttic-ui": "npm:^0.1.89"
+    "@automattic/agenttic-ui": "workspace:^"
     "@automattic/api-core": "workspace:^"
     "@automattic/api-queries": "workspace:^"
     "@automattic/block-renderer": "workspace:^"


### PR DESCRIPTION
Part of the agenttic → Calypso migration stack (#113566 → #113567 → #113568 → #113569 → #113593).

## Proposed Changes

Switches every agenttic consumer from the npm releases (`^0.1.87`) to the in-repo workspace packages. After this lands, changes to `packages/agenttic-client` / `packages/agenttic-ui` actually reach their consumers — until now the workspace copies were registered but unconsumed, and npm publishes from the archived source repo are retired.

* Flip 8 dependency declarations across 6 consumers to `workspace:^`: client (`agenttic-ui`), agents-manager (both packages), image-studio (both), jetpack-ai-sidebar (`agenttic-client`), odie-client and zendesk-client (`agenttic-ui`). Lockfile regenerated.
* Add `"prepare": "yarn run build"` to both agenttic packages so installs produce `dist/`. Note: the ui build downloads translation files from translate.wordpress.com during every install.
* Pre-build both packages in `bin/build-packages-web.sh`. Docker image builds skip the full package build and resolve workspaces via `calypso:src`, which the agenttic packages cannot offer yet (their source uses vite-only features like `import.meta.glob`); they fall through the export map to `dist/index.js`, which otherwise never exists in the image.
* Add the agenttic projects to the tsconfig `references` of agents-manager, odie-client, and zendesk-client — postinstall runs `tsc --build packages/tsconfig.json` before prepare scripts, so fresh checkouts need the references to type-check consumers before the agenttic declaration files exist.
* Keep the agenttic `tsconfig.tsbuildinfo` inside `dist/` and exclude it from the published files. With the flat `outDir`, TypeScript's default places the buildinfo at the package root, where it survives `rm -rf dist` — a wiped `dist/` (interrupted build, the package's own `clean`, a stray vite watch) then makes `tsc --build` report "up to date" and skip re-emitting the deleted declarations, wedging `yarn install`'s postinstall typecheck with misleading errors until someone rebuilds manually. Other packages get the in-dist location for free from their nested `dist/esm` layout; this setting becomes obsolete if the agenttic packages ever converge on that layout. Also drop the `"README.md"` entry from `files` — yarn treats it as a glob (shipping `src/react/README.md`) and auto-includes the root README anyway. Verified via `yarn pack`: the tarball file lists and all consumer-facing manifest fields are identical to the published npm 0.1.89 artifacts.
* Remove agenttic-ui's `@wordpress/prettier-config` devDependency — orphaned since #113593 deleted the package `.prettierrc`, and its unmet `prettier` peer dependency produces install warnings that TeamCity promotes to errors once the package is consumed via the workspace protocol.

Expected on CI: an ICFY bundle-size comment from dependency-version duplication (react-markdown `^10` in agenttic vs `^8`/`^9` elsewhere, use-debounce `^10` vs `^3`). Known and accepted for now — aligning those versions is follow-up work.

Follow-up (deliberately not in this PR): `calypso:src` source consumption, which would remove the Docker prebuild and give consumers source-level webpack watching. It requires replacing the vite-only `import.meta.glob` in agenttic-ui's translations loading first.

## Why are these changes being made?

* This is the payoff step of the migration: the source repo is being archived and its npm publishes retired, so consumers must resolve the packages from the workspace. Keeping consumers on `^0.1.87` while the code lives in-repo would freeze them on a dead artifact.

## Testing Instructions

* `yarn install` → completes with zero peer-dependency warnings; `packages/agenttic-client/dist/index.js` and `packages/agenttic-ui/dist/index.js` exist afterwards (prepare ran).
* Sandbox smoke test: `cd apps/agents-manager && WPCOM_SANDBOX=<sandbox> yarn dev --sync` and exercise the Agents Manager UI — it now runs on the workspace agenttic build.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
