### PR TITLE
Purchases: read product-plan-overlap-notices from api-core

### DIFF
--- a/client/blocks/product-plan-overlap-notices/index.tsx
+++ b/client/blocks/product-plan-overlap-notices/index.tsx
@@ -1,22 +1,22 @@
+import { sitePurchasesQuery } from '@automattic/api-queries';
 import {
 	isJetpackProduct,
 	planHasFeature,
 	planHasSuperiorFeature,
 	JETPACK_SEARCH_PRODUCTS,
 } from '@automattic/calypso-products';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Notice from 'calypso/dashboard/components/notice';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getAvailableProductsList } from 'calypso/state/products-list/selectors';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import type { Purchase } from 'calypso/lib/purchases/types';
+import type { Purchase } from '@automattic/api-core';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
 import './style.scss';
@@ -49,13 +49,16 @@ export default function ProductPlanOverlapNotices( {
 	const currentPlanSlug = useSelector( ( state ) =>
 		selectedSiteId ? getSitePlanSlug( state, selectedSiteId ) : null
 	);
-	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
+	const { data: purchases = [] } = useQuery( {
+		...sitePurchasesQuery( selectedSiteId as number ),
+		enabled: !! selectedSiteId,
+	} );
 
 	const getProductName = ( productSlug: string ) =>
 		availableProducts[ productSlug ]?.product_name ?? '';
 
 	const getProductItem = ( productSlug: string ) => {
-		const productPurchase = purchases.find( ( purchase ) => purchase.productSlug === productSlug );
+		const productPurchase = purchases.find( ( purchase ) => purchase.product_slug === productSlug );
 
 		if ( ! productPurchase ) {
 			return null;
@@ -64,7 +67,7 @@ export default function ProductPlanOverlapNotices( {
 		return (
 			<li key={ productSlug }>
 				<a
-					href={ getManagePurchaseUrlFor( productPurchase.domain, productPurchase.id ) }
+					href={ getManagePurchaseUrlFor( productPurchase.domain, productPurchase.ID ) }
 					onClick={ () =>
 						reduxDispatch(
 							recordTracksEvent( 'calypso_product_overlap_purchase_click', {
@@ -84,8 +87,8 @@ export default function ProductPlanOverlapNotices( {
 
 	// Which of the products we're interested in are currently purchased?
 	const currentProductSlugs = purchases
-		.filter( ( purchase ) => products.includes( purchase.productSlug ) )
-		.map( ( purchase ) => purchase.productSlug );
+		.filter( ( purchase ) => products.includes( purchase.product_slug ) )
+		.map( ( purchase ) => purchase.product_slug );
 
 	// Does the current plan include any of those products as a feature, or have a superior version of it?
 	const overlappingProductSlugs =
@@ -106,13 +109,12 @@ export default function ProductPlanOverlapNotices( {
 		! (
 			currentPurchase &&
 			isJetpackProduct( currentPurchase ) &&
-			! overlappingProductSlugs.includes( currentPurchase.productSlug )
+			! overlappingProductSlugs.includes( currentPurchase.product_slug )
 		);
 
 	return (
 		<>
 			<QuerySitePlans siteId={ selectedSiteId } />
-			<QuerySitePurchases siteId={ selectedSiteId } />
 			<QueryProductsList />
 
 			{ showOverlap && (

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1752,11 +1752,6 @@ function PlanOverlapNotice( {
 	siteId: number;
 	purchase: Purchase;
 } ) {
-	// Temporary bridge (SHILL-2256): ProductPlanOverlapNotices still expects the
-	// camelCase Purchase. Remove once it reads the raw shape.
-	const currentPurchase = createPurchaseObject(
-		purchase as unknown as Parameters< typeof createPurchaseObject >[ 0 ]
-	);
 	if ( isSiteLevel ) {
 		if ( ! selectedSiteId ) {
 			// Probably still loading
@@ -1769,7 +1764,7 @@ function PlanOverlapNotice( {
 				plans={ JETPACK_PLANS }
 				products={ JETPACK_PRODUCTS_LIST }
 				siteId={ selectedSiteId }
-				currentPurchase={ currentPurchase }
+				currentPurchase={ purchase }
 			/>
 		);
 	}
@@ -1784,7 +1779,7 @@ function PlanOverlapNotice( {
 			plans={ JETPACK_PLANS }
 			products={ JETPACK_PRODUCTS_LIST }
 			siteId={ siteId }
-			currentPurchase={ currentPurchase }
+			currentPurchase={ purchase }
 		/>
 	);
 }


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2256

## Proposed Changes

Converts the `ProductPlanOverlapNotices` block to read the raw snake_case `Purchase` from `@automattic/api-core` instead of the camelCase assembled type, fetching its purchases with `sitePurchasesQuery` (TanStack Query) rather than the `getSitePurchases` Redux selector. This removes the last remaining `createPurchaseObject` bridge in `client/me/purchases/manage-purchase`.

* Replace the `getSitePurchases` Redux selector + `<QuerySitePurchases />` in `client/blocks/product-plan-overlap-notices` with `useQuery( sitePurchasesQuery( siteId ) )`.
* Retype the block's `currentPurchase` prop as the api-core `Purchase`; rename the fields it reads (`productSlug` → `product_slug`, `id` → `ID`).
* Drop the temporary `createPurchaseObject` bridge from `PlanOverlapNotice` in `manage-purchase/index.tsx` — it now passes its already-raw `purchase` straight through.

## Why are these changes being made?

Part of the ongoing effort to delete the `@automattic/data-stores` purchases assembler (`createPurchaseObject`/`createPurchasesArray`) and the duplicate camelCase `Purchase` type, so that all consumers read the raw snake_case `Purchase` the API actually returns. The migration is being done page by page; each slice converts one consumer and deletes the temporary raw → camelCase bridges that were left behind at its boundary.

`manage-purchase` was migrated to the raw shape earlier, but it still had to re-assemble a camelCase object purely to satisfy `ProductPlanOverlapNotices`. Converting the block itself is cheap — it only reads `product_slug`, `domain`, and `ID` — and it removes that bridge instead of relocating it. Since the block's only purchase data came from Redux, it was also a good candidate to move onto `sitePurchasesQuery`, which lets it drop the `<QuerySitePurchases />` fetch-trigger component entirely. Every remaining caller (`manage-purchase`, `my-sites/purchases/subscriptions`) already renders its own `QuerySitePurchases`, so no other Redux consumer loses its data source.

After this, the only `createPurchaseObject` calls left in app code are the renew-click-handler bridges (already handled in #113319) and the root assembly point in `client/state/purchases/selectors/get-purchases.js`.

## Testing Instructions

TC:
```
yarn test-client client/me/purchases
```

Manual testing:
* Needs a Jetpack site with both a plan and a standalone Jetpack product whose feature the plan already includes (for example a Jetpack Complete/Security plan plus a standalone Jetpack Backup or VideoPress subscription).
* Visit `/me/purchases` — the overlap notice ("Your %(planName)s Plan includes: …") should appear above that site's purchases, listing the redundant products, and each product link should navigate to its manage-purchase page.
* Open the manage-purchase page for the redundant product (`/purchases/subscriptions/:site/:purchaseId`) — the same notice should render there.
* Open the manage-purchase page for the plan itself, or for an unrelated non-Jetpack purchase — the notice should be hidden (this is the `currentPurchase` check).
* Confirm no console errors and that the notice does not flash/disappear on reload.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
