### PR TITLE
Site Spec: enable the next site brief for the build-wow flow

### DIFF
--- a/client/lib/site-spec/test/utils.ts
+++ b/client/lib/site-spec/test/utils.ts
@@ -226,5 +226,13 @@ describe( 'SiteSpec Utils', () => {
 
 			expect( result.features?.siteBrief ).toBe( 'next' );
 		} );
+
+		it( 'should leave the other flows on the default spec preview', () => {
+			// The widget gates the brief on a truthy features.siteBrief, so any
+			// flow that grows one starts rendering the brief. Pin that this one
+			// is the only flow asking for it.
+			expect( getDefaultSiteSpecConfig().features ).toBeUndefined();
+			expect( getEarlyProvisionSiteSpecConfig().features ).toBeUndefined();
+		} );
 	} );
 } );

--- a/client/lib/site-spec/test/utils.ts
+++ b/client/lib/site-spec/test/utils.ts
@@ -220,5 +220,11 @@ describe( 'SiteSpec Utils', () => {
 			expect( buildSiteUrl.searchParams.get( 'source' ) ).toBe( 'vega' );
 			expect( result.buildSiteUrl ).toContain( 'spec_id=' );
 		} );
+
+		it( 'should enable the next site brief', () => {
+			const result = getBuildWowSiteSpecConfig( { siteSlug: 'example.wordpress.com' } );
+
+			expect( result.features?.siteBrief ).toBe( 'next' );
+		} );
 	} );
 } );

--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -390,10 +390,13 @@ export function getBuildWowSiteSpecConfig( {
 		...( source ? { source } : {} ),
 	} );
 
+	const defaultConfig = getDefaultSiteSpecConfig();
+
 	return {
-		...getDefaultSiteSpecConfig(),
+		...defaultConfig,
 		buildSiteUrl: `${ buildSiteUrl }${ buildSiteUrl.includes( '?' ) ? '&' : '?' }spec_id=`,
 		features: {
+			...defaultConfig.features,
 			siteBrief: 'next',
 		},
 	};

--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -116,6 +116,11 @@ export interface SiteSpecConfig {
 		className?: string; // Custom class on root container
 		cssVariables?: Record< string, string >; // Arbitrary CSS custom props
 	};
+	features?: {
+		// `true` shows the site brief dialog in place of the basic spec preview;
+		// `'next'` also shows its socials/attachments sections.
+		siteBrief?: boolean | 'next';
+	};
 	tosConfig?: ToSConfig;
 	placeholder?: string | string[];
 	tracking?: {
@@ -388,5 +393,8 @@ export function getBuildWowSiteSpecConfig( {
 	return {
 		...getDefaultSiteSpecConfig(),
 		buildSiteUrl: `${ buildSiteUrl }${ buildSiteUrl.includes( '?' ) ? '&' : '?' }spec_id=`,
+		features: {
+			siteBrief: 'next',
+		},
 	};
 }


### PR DESCRIPTION
## Proposed Changes

* `getBuildWowSiteSpecConfig()` sets `features: { siteBrief: 'next' }`.
* `SiteSpecConfig` gains the `features` field so that compiles.
* No other config builder is touched.

## Why are these changes being made?

* The widget renders the Site Brief when `config.features.siteBrief` is set; `'next'` also enables the socials and attachments sections. Calypso never passed it, so build-wow got the basic spec preview by default.
* Calypso hand-mirrors the widget's config interface, and `features` was missing from the mirror. That is the type change, and the only reason this is two hunks instead of one.
* No `script_url` bump. Trunk pins `v1.15.0` in `config/_shared.json`, and that bundle already contains the code.

## Testing Instructions

1. Load `/setup/ai-site-builder-spec/site-spec?build_wow=1&siteSlug=<site>&siteId=<id>`.
2. This path needs an Automattician account. Without one, `shouldBuildWow` is false and you are testing the default config instead.
3. The brief renders at `spec_confirm`, not on the landing screen. Talk to the agent until it confirms.
4. Expect the Site Brief dialog with a socials section, not the basic spec preview.
5. Load the same step without `build_wow=1` and confirm it is unchanged.

Attachments have a second gate inside the widget (`VITE_SITESPEC_ENABLE_UPLOADS`, compile-time), so they depend on how the published bundle was built. Socials show regardless.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Unchecked items do not apply: no new strings, no new UI in this repo, no selectors, no Jetpack data collection. The dialog is drawn by the widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
