### PR TITLE
Build with AI: forward ?graph= into the build request

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import { getBuildWowGraph } from 'calypso/landing/stepper/utils/build-wow';
 import { getSafeEditorUrl } from './editor-url';
 import { useSiteGeneration } from './use-site-generation';
 import { SiteGenerationView } from './view';
@@ -13,6 +14,7 @@ const SiteGeneration: StepType = function SiteGeneration() {
 	const siteIdentifier = query.get( 'siteId' ) || query.get( 'siteSlug' );
 	const editorUrl = getSafeEditorUrl( query.get( 'editorUrl' ) );
 	const specId = query.get( 'specId' );
+	const graph = getBuildWowGraph( query );
 	// Fallback checklist only: the server-computed ui.steps from the status
 	// endpoint is authoritative (labels included, already localized). This
 	// list covers the moments before the first response arrives, and backends
@@ -28,7 +30,7 @@ const SiteGeneration: StepType = function SiteGeneration() {
 		],
 		[ translate ]
 	);
-	const state = useSiteGeneration( { siteIdentifier, editorUrl, specId, steps } );
+	const state = useSiteGeneration( { siteIdentifier, editorUrl, specId, graph, steps } );
 
 	const reload = () => {
 		window.location.reload();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
@@ -341,7 +341,7 @@ describe( 'useSiteGeneration', () => {
 			result.current.retryBuild?.();
 		} );
 
-		expect( requestBuildWowSiteMock ).toHaveBeenCalledWith( '123', 'spec-1' );
+		expect( requestBuildWowSiteMock ).toHaveBeenCalledWith( '123', 'spec-1', undefined );
 		expect( logMock ).toHaveBeenCalledWith( 'site_generation_retry_requested', {
 			site_identifier: '123',
 			spec_id: 'spec-1',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/use-site-generation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/use-site-generation.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { logBuildWowEvent, requestBuildWowSite } from 'calypso/landing/stepper/utils/build-wow';
 import { pollForBuildWowStatus } from './build-status-poller';
 import type { BuildWowUi } from './build-status-poller';
+import type { BuildWowGraph } from 'calypso/landing/stepper/utils/build-wow';
 
 export type SiteGenerationStep = {
 	id: string;
@@ -59,11 +60,14 @@ export function useSiteGeneration( {
 	siteIdentifier,
 	editorUrl,
 	specId,
+	graph,
 	steps,
 }: {
 	siteIdentifier: string | null;
 	editorUrl: string | null;
 	specId?: string | null;
+	/** Graph the build was queued with, so a retry rebuilds on the same one. */
+	graph?: BuildWowGraph;
 	steps: Array< Pick< SiteGenerationStep, 'id' | 'label' > >;
 } ): SiteGenerationState {
 	const [ serverSteps, setServerSteps ] = useState< SiteGenerationStep[] | null >( null );
@@ -123,7 +127,7 @@ export function useSiteGeneration( {
 			spec_id: specId,
 		} );
 		try {
-			await requestBuildWowSite( siteIdentifier, specId );
+			await requestBuildWowSite( siteIdentifier, specId, graph );
 			setFallbackStartedAt( Date.now() );
 			setServerSteps( null );
 			setFailure( null );
@@ -138,7 +142,7 @@ export function useSiteGeneration( {
 			isRetryingRef.current = false;
 			setIsRetryingBuild( false );
 		}
-	}, [ siteIdentifier, specId ] );
+	}, [ siteIdentifier, specId, graph ] );
 
 	let failureReason: SiteGenerationFailureReason | undefined;
 	if ( ! hasRequiredParameters ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -17,6 +17,7 @@ import {
 	waitForBlueprintImportComplete,
 } from 'calypso/landing/stepper/utils/blueprint-archive-import';
 import {
+	getBuildWowGraph,
 	getBuildWowSiteIdentifier,
 	isBuildWowEnabled,
 	logBuildWowEvent,
@@ -278,7 +279,11 @@ const SiteSpec: StepType = function SiteSpec() {
 					site_identifier: buildWowSiteIdentifier,
 				} );
 
-				const response = await requestBuildWowSite( buildWowSiteIdentifier, specId );
+				const response = await requestBuildWowSite(
+					buildWowSiteIdentifier,
+					specId,
+					getBuildWowGraph( queryParams )
+				);
 				responseBlogId = response.blog_id;
 
 				logBuildWowEvent(

--- a/client/landing/stepper/utils/build-wow.ts
+++ b/client/landing/stepper/utils/build-wow.ts
@@ -6,6 +6,21 @@ import { pollUntil, PollTimeoutError } from './poll-until';
 export const BUILD_WOW_QUERY_VALUE = '1';
 const BUILD_WOW_SITE_SPEC_PATH = '/setup/ai-site-builder-spec/site-spec';
 
+/**
+ * Generation graphs a build may ask for. The server takes this as an enum and
+ * rejects anything else with a 400, so an unrecognized value is dropped here
+ * instead: a typo in the URL then means "whatever the deploy runs" rather than
+ * a build request that fails outright.
+ */
+const BUILD_WOW_GRAPHS = [ 'html-first', 'legacy' ] as const;
+export type BuildWowGraph = ( typeof BUILD_WOW_GRAPHS )[ number ];
+
+export function getBuildWowGraph( queryParams: URLSearchParams ): BuildWowGraph | undefined {
+	const requested = queryParams.get( 'graph' );
+
+	return BUILD_WOW_GRAPHS.find( ( graph ) => graph === requested );
+}
+
 type BuildWowAtomicState = {
 	is_atomic?: boolean;
 	is_transfer_active?: boolean;
@@ -88,14 +103,21 @@ export function isBuildWowSiteEditorReady( response: BuildWowResponse ): boolean
 
 export async function requestBuildWowSite(
 	siteIdentifier: string,
-	specId?: string
+	specId?: string,
+	graph?: BuildWowGraph
 ): Promise< BuildWowResponse > {
 	return wpcom.req.post(
 		{
 			path: `/sites/${ siteIdentifier }/big-sky/build-wow`,
 			apiNamespace: 'wpcom/v2',
 		},
-		specId ? { spec_id: specId } : {}
+		{
+			...( specId ? { spec_id: specId } : {} ),
+			// Only sent on the call that carries a spec, which is the one that
+			// queues a build: the server records the graph with that build, and a
+			// call without a spec queues nothing to record it against.
+			...( specId && graph ? { graph } : {} ),
+		}
 	);
 }
 

--- a/client/landing/stepper/utils/test/build-wow.ts
+++ b/client/landing/stepper/utils/test/build-wow.ts
@@ -1,8 +1,11 @@
+import wpcom from 'calypso/lib/wp';
 import {
+	getBuildWowGraph,
 	getBuildWowSiteIdentifier,
 	getBuildWowSiteSpecUrl,
 	isBuildWowEnabled,
 	isBuildWowSiteEditorReady,
+	requestBuildWowSite,
 } from '../build-wow';
 
 jest.mock( 'calypso/lib/logstash', () => ( {
@@ -85,5 +88,33 @@ describe( 'build-wow utilities', () => {
 				remote_option_ready: true,
 			} )
 		).toBe( false );
+	} );
+
+	it( 'reads the requested graph and ignores anything it does not know', () => {
+		expect( getBuildWowGraph( new URLSearchParams( 'graph=html-first' ) ) ).toBe( 'html-first' );
+		expect( getBuildWowGraph( new URLSearchParams( 'graph=legacy' ) ) ).toBe( 'legacy' );
+
+		// The server takes this as an enum and 400s on anything else, so a typo
+		// has to read as "no graph" rather than break the build request.
+		expect( getBuildWowGraph( new URLSearchParams( 'graph=htmlfirst' ) ) ).toBeUndefined();
+		expect( getBuildWowGraph( new URLSearchParams( 'graph=' ) ) ).toBeUndefined();
+		expect( getBuildWowGraph( new URLSearchParams( '' ) ) ).toBeUndefined();
+	} );
+
+	it( 'sends the graph only on the call that queues a build', async () => {
+		const post = wpcom.req.post as jest.Mock;
+		post.mockReset();
+		post.mockResolvedValue( {} );
+
+		await requestBuildWowSite( '123', 'spec-1', 'html-first' );
+		expect( post.mock.calls[ 0 ][ 1 ] ).toEqual( { spec_id: 'spec-1', graph: 'html-first' } );
+
+		// No spec means nothing is queued, so there is no build to record a
+		// graph against.
+		await requestBuildWowSite( '123', undefined, 'html-first' );
+		expect( post.mock.calls[ 1 ][ 1 ] ).toEqual( {} );
+
+		await requestBuildWowSite( '123', 'spec-1' );
+		expect( post.mock.calls[ 2 ][ 1 ] ).toEqual( { spec_id: 'spec-1' } );
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

* `getBuildWowGraph()` reads an optional `graph` query arg (`html-first` or `legacy`) and `requestBuildWowSite()` forwards it to the build-wow endpoint.
* Wired at both call sites: the spec confirm in `site-spec`, and the retry in `site-generation`.
* Unrecognized values are dropped here, so a typo in the URL means "whatever the backend default is" instead of a request that 400s on the enum.
* The param only rides along with the call that carries a `spec_id`, since that is the call that queues a build for it to be recorded against.

## Why are these changes being made?

The API side now accepts an optional `graph` on the build-wow request and records it for that single build, so a build can be pointed at one generation graph without a deploy or a code change. Today switching graphs means flipping a server-side filter for everyone, which is a bad fit for comparing the two on one site while both paths are live.

This is the client half: it lets us open the flow with `&graph=html-first` (or `legacy`) and have that one build run that graph.

## Testing Instructions

Needs an Automattician account and the `site-spec` flag, e.g. on wpcalypso:

1. `/setup?build_wow=1&flags=site-spec&graph=html-first`
2. Go through the spec chat and confirm.
3. Check the `POST .../big-sky/build-wow` request in the network tab: the body carries `spec_id` and `graph: "html-first"`.
4. Repeat with `&graph=legacy`, and with no `graph` at all (body should have no `graph` key), and with `&graph=nonsense` (also no `graph` key, build still starts).

Unit tests: `TZ=UTC yarn jest client/landing/stepper/utils/test/build-wow.ts client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
