### PR TITLE
Import: modernize destination picker

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-step-navigation.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-step-navigation.ts
@@ -25,6 +25,7 @@ const EXCLUDED_DEPENDENCIES = [
 	'domainCart',
 	'domainForm',
 	'suggestion',
+	'site',
 ];
 
 export function recordStepNavigation( {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -86,6 +86,11 @@ const SitePickerStep: Step< {
 	};
 
 	const onSelectSite = ( site: SiteExcerptData ) => {
+		if ( ! sourceSiteSlug ) {
+			selectSite( site );
+			return;
+		}
+
 		setDestinationSite( site );
 		setShowConfirmModal( true );
 	};
@@ -127,6 +132,7 @@ const SitePickerStep: Step< {
 						page={ page }
 						search={ search }
 						status={ status }
+						hasSourceSite={ !! sourceSiteSlug }
 						onCreateSite={ createNewSite }
 						onSelectSite={ onSelectSite }
 						onQueryParamChange={ onQueryParamChange }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/index.tsx
@@ -123,7 +123,7 @@ const SitePickerStep: Step< {
 
 	return (
 		<>
-			<DocumentHead title={ __( 'Pick your destination' ) } />
+			<DocumentHead title={ __( 'Choose a destination site' ) } />
 			<StepContainer
 				stepName="site-picker"
 				goBack={ () => history.back() }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -115,11 +115,15 @@ const SitePicker = function SitePicker( props: Props ) {
 							{ paginatedSites.length > 0 || isLoading ? (
 								<>
 									{ isLoading ? (
-										<div className="site-picker--loading" aria-label={ __( 'Loading sites' ) } />
+										<div
+											className="site-picker--loading"
+											role="status"
+											aria-label={ __( 'Loading sites' ) }
+										/>
 									) : (
-										<div className="site-picker--list">
+										<ul className="site-picker--list">
 											{ paginatedSites.map( ( site ) => (
-												<div className="site-picker--site" key={ site.ID }>
+												<li className="site-picker--site" key={ site.ID }>
 													<div className="site-picker--site-icon" aria-hidden="true">
 														{ site.icon?.img ? (
 															<img src={ site.icon.img } alt="" />
@@ -128,7 +132,9 @@ const SitePicker = function SitePicker( props: Props ) {
 														) }
 													</div>
 													<div className="site-picker--site-details">
-														<strong>{ site.title || site.name }</strong>
+														<strong id={ `site-picker--site-name-${ site.ID }` }>
+															{ site.title || site.name }
+														</strong>
 														<span>{ formatSiteDomain( site.URL ) }</span>
 														{ ( site.is_coming_soon || site.is_private ) && (
 															<small>
@@ -136,12 +142,17 @@ const SitePicker = function SitePicker( props: Props ) {
 															</small>
 														) }
 													</div>
-													<Button variant="primary" onClick={ () => onSelectSite( site ) }>
+													<Button
+														id={ `site-picker--choose-${ site.ID }` }
+														aria-labelledby={ `site-picker--choose-${ site.ID } site-picker--site-name-${ site.ID }` }
+														variant="primary"
+														onClick={ () => onSelectSite( site ) }
+													>
 														{ __( 'Choose' ) }
 													</Button>
-												</div>
+												</li>
 											) ) }
-										</div>
+										</ul>
 									) }
 									{ ( selectedStatus.hiddenCount > 0 || sites.length > perPage ) && (
 										<PageBodyBottomContainer>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -1,5 +1,10 @@
+import { WordPressLogo } from '@automattic/components';
 import { SubTitle, Title } from '@automattic/onboarding';
-import { createSitesListComponent, GroupableSiteLaunchStatuses } from '@automattic/sites';
+import {
+	createSitesListComponent,
+	DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE,
+	GroupableSiteLaunchStatuses,
+} from '@automattic/sites';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
@@ -49,17 +54,15 @@ const SitePicker = function SitePicker( props: Props ) {
 	return (
 		<div className="site-picker--container">
 			<div className="site-picker--title">
-				<Title>
-					{ hasSourceSite ? __( 'Pick your destination' ) : __( 'Choose where to import' ) }
-				</Title>
+				<Title>{ __( 'Choose a destination site' ) }</Title>
 				<SubTitle>
 					{ createInterpolateElement(
 						hasSourceSite
 							? __(
-									'Select the WordPress.com site where you’ll move your old site or <button>create a new one</button>'
+									'Choose the WordPress.com site where you want to move your old site, or <button>create a new site</button>'
 							  )
 							: __(
-									'Select a WordPress.com site to import into or <button>create a new site</button>'
+									'This is where we’ll add the content you import. Choose an existing site or <button>create a new site</button>'
 							  ),
 						{
 							button: <Button onClick={ onCreateSite } />,
@@ -76,20 +79,24 @@ const SitePicker = function SitePicker( props: Props ) {
 				{ ( { sites, statuses } ) => {
 					const paginatedSites = sites.slice( ( page - 1 ) * perPage, page * perPage );
 					const selectedStatus = statuses.find( ( { name } ) => name === status ) || statuses[ 0 ];
+					const showControls =
+						allSites.length > 8 || !! search || status !== DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE;
 
 					return (
 						<>
-							<div className="site-picker--controls">
-								<SitesContentControls
-									initialSearch={ search }
-									onQueryParamChange={ onQueryParamChange }
-									sitesSorting={ sitesSorting }
-									onSitesSortingChange={ onSitesSortingChange }
-									statuses={ statuses }
-									selectedStatus={ selectedStatus }
-									hasSitesSortingPreferenceLoaded
-								/>
-							</div>
+							{ showControls && (
+								<div className="site-picker--controls">
+									<SitesContentControls
+										initialSearch={ search }
+										onQueryParamChange={ onQueryParamChange }
+										sitesSorting={ sitesSorting }
+										onSitesSortingChange={ onSitesSortingChange }
+										statuses={ statuses }
+										selectedStatus={ selectedStatus }
+										hasSitesSortingPreferenceLoaded
+									/>
+								</div>
+							) }
 							{ paginatedSites.length > 0 || isLoading ? (
 								<>
 									{ isLoading ? (
@@ -102,7 +109,7 @@ const SitePicker = function SitePicker( props: Props ) {
 														{ site.icon?.img ? (
 															<img src={ site.icon.img } alt="" />
 														) : (
-															( site.title || site.name || '?' ).trim().charAt( 0 ).toUpperCase()
+															<WordPressLogo size={ 24 } />
 														) }
 													</div>
 													<div className="site-picker--site-details">
@@ -115,7 +122,7 @@ const SitePicker = function SitePicker( props: Props ) {
 														) }
 													</div>
 													<Button variant="primary" onClick={ () => onSelectSite( site ) }>
-														{ __( 'Select' ) }
+														{ __( 'Choose' ) }
 													</Button>
 												</div>
 											) ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -1,4 +1,3 @@
-import { WordPressLogo } from '@automattic/components';
 import { SubTitle, Title } from '@automattic/onboarding';
 import {
 	createSitesListComponent,
@@ -109,7 +108,7 @@ const SitePicker = function SitePicker( props: Props ) {
 														{ site.icon?.img ? (
 															<img src={ site.icon.img } alt="" />
 														) : (
-															<WordPressLogo size={ 24 } />
+															( site.title || site.name || '?' ).trim().charAt( 0 ).toUpperCase()
 														) }
 													</div>
 													<div className="site-picker--site-details">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -24,6 +24,7 @@ interface Props {
 	perPage?: number;
 	search: string;
 	status: GroupableSiteLaunchStatuses;
+	hasSourceSite: boolean;
 	onCreateSite: () => void;
 	onSelectSite: ( site: SiteExcerptData ) => void;
 	onQueryParamChange: ( params: Partial< SitesDashboardQueryParams > ) => void;
@@ -35,6 +36,7 @@ const SitePicker = function SitePicker( props: Props ) {
 		perPage = 96,
 		search,
 		status,
+		hasSourceSite,
 		onSelectSite,
 		onCreateSite,
 		onQueryParamChange,
@@ -48,12 +50,18 @@ const SitePicker = function SitePicker( props: Props ) {
 	return (
 		<div className="site-picker--container">
 			<div className="site-picker--title">
-				<Title>{ __( 'Pick your destination' ) }</Title>
+				<Title>
+					{ hasSourceSite ? __( 'Pick your destination' ) : __( 'Choose where to import' ) }
+				</Title>
 				<SubTitle>
 					{ createInterpolateElement(
-						__(
-							'Select the WordPress.com site where you’ll move your old site or <button>create a new one</button>'
-						),
+						hasSourceSite
+							? __(
+									'Select the WordPress.com site where you’ll move your old site or <button>create a new one</button>'
+							  )
+							: __(
+									'Select a WordPress.com site to import into or <button>create a new site</button>'
+							  ),
 						{
 							button: <Button onClick={ onCreateSite } />,
 						}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -45,7 +45,12 @@ const SitePicker = function SitePicker( props: Props ) {
 		onQueryParamChange,
 	} = props;
 	const { sitesSorting, onSitesSortingChange } = useSitesSorting();
-	const { data: allSites = [], isLoading } = useSiteExcerptsQuery(
+	const {
+		data: allSites = [],
+		isLoading,
+		isError,
+		refetch,
+	} = useSiteExcerptsQuery(
 		SITE_PICKER_FILTER_CONFIG,
 		( site ) => ! site.is_wpcom_staging_site && ! site.is_deleted
 	);
@@ -80,6 +85,17 @@ const SitePicker = function SitePicker( props: Props ) {
 					const selectedStatus = statuses.find( ( { name } ) => name === status ) || statuses[ 0 ];
 					const showControls =
 						allSites.length > 8 || !! search || status !== DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE;
+
+					if ( isError ) {
+						return (
+							<div className="site-picker--error" role="alert">
+								<p>{ __( 'We couldn’t load your sites. Please try again.' ) }</p>
+								<Button variant="secondary" onClick={ () => refetch() }>
+									{ __( 'Try again' ) }
+								</Button>
+							</div>
+						);
+					}
 
 					return (
 						<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/site-picker.tsx
@@ -13,7 +13,6 @@ import {
 	SitesDashboardQueryParams,
 } from 'calypso/sites-dashboard/components/sites-content-controls';
 import { PageBodyBottomContainer } from 'calypso/sites-dashboard/components/sites-dashboard';
-import { SitesGrid } from 'calypso/sites-dashboard/components/sites-grid';
 import { useSitesSorting } from 'calypso/state/sites/hooks/use-sites-sorting';
 import type { SiteExcerptData } from '@automattic/sites';
 
@@ -80,22 +79,48 @@ const SitePicker = function SitePicker( props: Props ) {
 
 					return (
 						<>
-							<SitesContentControls
-								initialSearch={ search }
-								onQueryParamChange={ onQueryParamChange }
-								sitesSorting={ sitesSorting }
-								onSitesSortingChange={ onSitesSortingChange }
-								statuses={ statuses }
-								selectedStatus={ selectedStatus }
-								hasSitesSortingPreferenceLoaded
-							/>
+							<div className="site-picker--controls">
+								<SitesContentControls
+									initialSearch={ search }
+									onQueryParamChange={ onQueryParamChange }
+									sitesSorting={ sitesSorting }
+									onSitesSortingChange={ onSitesSortingChange }
+									statuses={ statuses }
+									selectedStatus={ selectedStatus }
+									hasSitesSortingPreferenceLoaded
+								/>
+							</div>
 							{ paginatedSites.length > 0 || isLoading ? (
 								<>
-									<SitesGrid
-										isLoading={ isLoading }
-										sites={ paginatedSites }
-										onSiteSelectBtnClick={ onSelectSite }
-									/>
+									{ isLoading ? (
+										<div className="site-picker--loading" aria-label={ __( 'Loading sites' ) } />
+									) : (
+										<div className="site-picker--list">
+											{ paginatedSites.map( ( site ) => (
+												<div className="site-picker--site" key={ site.ID }>
+													<div className="site-picker--site-icon" aria-hidden="true">
+														{ site.icon?.img ? (
+															<img src={ site.icon.img } alt="" />
+														) : (
+															( site.title || site.name || '?' ).trim().charAt( 0 ).toUpperCase()
+														) }
+													</div>
+													<div className="site-picker--site-details">
+														<strong>{ site.title || site.name }</strong>
+														<span>{ formatSiteDomain( site.URL ) }</span>
+														{ ( site.is_coming_soon || site.is_private ) && (
+															<small>
+																{ site.is_coming_soon ? __( 'Coming soon' ) : __( 'Private' ) }
+															</small>
+														) }
+													</div>
+													<Button variant="primary" onClick={ () => onSelectSite( site ) }>
+														{ __( 'Select' ) }
+													</Button>
+												</div>
+											) ) }
+										</div>
+									) }
 									{ ( selectedStatus.hiddenCount > 0 || sites.length > perPage ) && (
 										<PageBodyBottomContainer>
 											<Pagination
@@ -124,3 +149,11 @@ const SitePicker = function SitePicker( props: Props ) {
 };
 
 export default SitePicker;
+
+function formatSiteDomain( siteUrl: string ) {
+	try {
+		return new URL( siteUrl ).hostname;
+	} catch {
+		return siteUrl;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/styles.scss
@@ -1,7 +1,12 @@
-@import "@automattic/typography/styles/variables";
+@import '@automattic/typography/styles/variables';
 
 .site-picker--container {
-	padding-bottom: rem(28px);
+	box-sizing: border-box;
+	padding: 0 rem( 16px ) rem( 28px );
+
+	@media ( min-width: 660px ) {
+		padding-inline: rem( 32px );
+	}
 
 	.onboarding-subtitle button {
 		display: inline-block;
@@ -9,9 +14,92 @@
 		font-size: 1rem;
 		padding: 0;
 	}
+
+	@media ( max-width: 659px ) {
+		.site-picker--controls > div {
+			margin-bottom: rem( 24px );
+			padding-block: 0;
+		}
+	}
+
+	.site-picker--loading {
+		height: rem( 180px );
+		border-radius: rem( 4px );
+		background: #f0f0f0;
+	}
+
+	.site-picker--list {
+		display: grid;
+		grid-template-columns: minmax( 0, 1fr );
+		gap: rem( 12px );
+
+		@media ( min-width: 780px ) {
+			grid-template-columns: repeat( 2, minmax( 0, 1fr ) );
+		}
+	}
+
+	.site-picker--site {
+		display: flex;
+		align-items: center;
+		gap: rem( 12px );
+		min-width: 0;
+		padding: rem( 16px );
+		border: 1px solid #dcdcde;
+		border-radius: rem( 4px );
+		background: #fff;
+	}
+
+	.site-picker--site-icon {
+		display: flex;
+		flex: 0 0 rem( 40px );
+		align-items: center;
+		justify-content: center;
+		height: rem( 40px );
+		overflow: hidden;
+		border-radius: rem( 4px );
+		background: #f0f0f0;
+		color: #50575e;
+		font-size: rem( 18px );
+
+		img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+	}
+
+	.site-picker--site-details {
+		display: flex;
+		flex: 1;
+		flex-direction: column;
+		min-width: 0;
+		line-height: 1.35;
+
+		strong,
+		span {
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+
+		span {
+			color: #646970;
+			font-size: rem( 13px );
+		}
+
+		small {
+			width: fit-content;
+			margin-top: rem( 4px );
+			padding: rem( 1px ) rem( 6px );
+			border: 1px solid #a7aaad;
+			border-radius: rem( 8px );
+			color: #50575e;
+			font-size: rem( 11px );
+		}
+	}
 }
 
 .site-picker--title {
 	text-align: center;
-	margin-bottom: rem(68px);
+	margin-bottom: rem( 32px );
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/styles.scss
@@ -59,7 +59,10 @@
 		border-radius: rem( 4px );
 		background: #f0f0f0;
 		color: #50575e;
-		font-size: rem( 18px );
+
+		svg {
+			fill: currentColor;
+		}
 
 		img {
 			width: 100%;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/styles.scss
@@ -44,6 +44,9 @@
 		display: grid;
 		grid-template-columns: minmax( 0, 1fr );
 		gap: rem( 12px );
+		margin: 0;
+		padding: 0;
+		list-style: none;
 
 		@media ( min-width: 780px ) {
 			grid-template-columns: repeat( 2, minmax( 0, 1fr ) );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/styles.scss
@@ -59,10 +59,7 @@
 		border-radius: rem( 4px );
 		background: #f0f0f0;
 		color: #50575e;
-
-		svg {
-			fill: currentColor;
-		}
+		font-size: rem( 18px );
 
 		img {
 			width: 100%;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/styles.scss
@@ -28,6 +28,18 @@
 		background: #f0f0f0;
 	}
 
+	.site-picker--error {
+		padding: rem( 24px );
+		border: 1px solid #dcdcde;
+		border-radius: rem( 4px );
+		background: #fff;
+		text-align: center;
+
+		p {
+			margin: 0 0 rem( 16px );
+		}
+	}
+
 	.site-picker--list {
 		display: grid;
 		grid-template-columns: minmax( 0, 1fr );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
@@ -6,7 +6,7 @@ import {
 	GroupableSiteLaunchStatuses,
 } from '@automattic/sites';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import nock from 'nock';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
@@ -16,7 +16,7 @@ import type { JSX } from 'react';
 const renderComponent = ( component: JSX.Element, initialState = {} ) => {
 	const mockStore = configureStore();
 	const store = mockStore( initialState );
-	const queryClient = new QueryClient();
+	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
 
 	return render(
 		<Provider store={ store }>
@@ -180,5 +180,27 @@ describe( 'SitePicker', () => {
 		renderComponent( <SitePicker { ...props } />, initialState );
 
 		expect( screen.getByText( 'You have no private sites' ) ).toBeVisible();
+	} );
+
+	test( 'recovers when loading sites fails', async () => {
+		nock.cleanAll();
+		let requestCount = 0;
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( ( uri ) => uri.startsWith( '/rest/v1.2/me/sites' ) )
+			.reply( () =>
+				requestCount++ === 0
+					? [ 500, { error: 'fixture_site_fetch_failed' } ]
+					: [ 200, { sites: Object.values( initialState.sites.items ) } ]
+			);
+
+		renderComponent( <SitePicker { ...defaultProps } />, initialState );
+
+		expect( await screen.findByRole( 'alert' ) ).toHaveTextContent(
+			'We couldn’t load your sites. Please try again.'
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Try again' } ) );
+
+		expect( await screen.findByText( 'A Test Site' ) ).toBeVisible();
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
@@ -117,9 +117,11 @@ describe( 'SitePicker', () => {
 			initialState
 		);
 
-		expect( getByText( 'Pick your destination' ) ).toBeInTheDocument();
+		expect( getByText( 'Choose a destination site' ) ).toBeInTheDocument();
 
-		expect( screen.getAllByRole( 'button', { name: 'Select' } ) ).toHaveLength( 2 );
+		expect( screen.getAllByRole( 'button', { name: 'Choose' } ) ).toHaveLength( 2 );
+		expect( container.querySelectorAll( '.site-picker--site-icon svg' ) ).toHaveLength( 2 );
+		expect( container.querySelector( '.site-picker--controls' ) ).not.toBeInTheDocument();
 		expect(
 			[ ...container.querySelectorAll( '.site-picker--site-details strong' ) ].map(
 				( element ) => element.textContent
@@ -130,7 +132,8 @@ describe( 'SitePicker', () => {
 	test( 'renders import-specific copy when there is no source site', () => {
 		renderComponent( <SitePicker { ...defaultProps } hasSourceSite={ false } />, initialState );
 
-		expect( screen.getByText( 'Choose where to import' ) ).toBeVisible();
+		expect( screen.getByText( 'Choose a destination site' ) ).toBeVisible();
+		expect( screen.getByText( /This is where we’ll add the content you import/ ) ).toBeVisible();
 		expect( screen.getByText( 'create a new site' ) ).toBeVisible();
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
@@ -34,6 +34,7 @@ describe( 'SitePicker', () => {
 		perPage: 96,
 		search: '',
 		status: DEFAULT_SITE_LAUNCH_STATUS_GROUP_VALUE as GroupableSiteLaunchStatuses,
+		hasSourceSite: true,
 		onCreateSite: noop,
 		onSelectSite: noop,
 		onQueryParamChange: noop,
@@ -121,6 +122,13 @@ describe( 'SitePicker', () => {
 		const allLinks = container.getElementsByClassName( 'components-external-link' );
 		expect( allLinks.length ).toBeGreaterThan( 0 );
 		expect( allLinks[ 0 ] ).toHaveAttribute( 'href', initialState.sites.items[ 1 ].URL );
+	} );
+
+	test( 'renders import-specific copy when there is no source site', () => {
+		renderComponent( <SitePicker { ...defaultProps } hasSourceSite={ false } />, initialState );
+
+		expect( screen.getByText( 'Choose where to import' ) ).toBeVisible();
+		expect( screen.getByText( 'create a new site' ) ).toBeVisible();
 	} );
 
 	test( 'renders with correctly sorted list of sites', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
@@ -120,7 +120,11 @@ describe( 'SitePicker', () => {
 		expect( getByText( 'Choose a destination site' ) ).toBeInTheDocument();
 
 		expect( screen.getAllByRole( 'button', { name: 'Choose' } ) ).toHaveLength( 2 );
-		expect( container.querySelectorAll( '.site-picker--site-icon svg' ) ).toHaveLength( 2 );
+		expect(
+			[ ...container.querySelectorAll( '.site-picker--site-icon' ) ].map(
+				( element ) => element.textContent
+			)
+		).toEqual( [ 'A', 'A' ] );
 		expect( container.querySelector( '.site-picker--controls' ) ).not.toBeInTheDocument();
 		expect(
 			[ ...container.querySelectorAll( '.site-picker--site-details strong' ) ].map(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
@@ -119,9 +119,12 @@ describe( 'SitePicker', () => {
 
 		expect( getByText( 'Pick your destination' ) ).toBeInTheDocument();
 
-		const allLinks = container.getElementsByClassName( 'components-external-link' );
-		expect( allLinks.length ).toBeGreaterThan( 0 );
-		expect( allLinks[ 0 ] ).toHaveAttribute( 'href', initialState.sites.items[ 1 ].URL );
+		expect( screen.getAllByRole( 'button', { name: 'Select' } ) ).toHaveLength( 2 );
+		expect(
+			[ ...container.querySelectorAll( '.site-picker--site-details strong' ) ].map(
+				( element ) => element.textContent
+			)
+		).toEqual( [ 'A Test Site', 'Another test Site' ] );
 	} );
 
 	test( 'renders import-specific copy when there is no source site', () => {
@@ -143,9 +146,11 @@ describe( 'SitePicker', () => {
 
 		const { container } = renderComponent( <SitePicker { ...defaultProps } />, state );
 
-		const allLinks = container.getElementsByClassName( 'components-external-link' );
-		expect( allLinks.length ).toBeGreaterThan( 0 );
-		expect( allLinks[ 0 ] ).toHaveAttribute( 'href', initialState.sites.items[ 1 ].URL );
+		expect(
+			[ ...container.querySelectorAll( '.site-picker--site-details strong' ) ].map(
+				( element ) => element.textContent
+			)
+		).toEqual( [ 'A Test Site', 'Another test Site' ] );
 	} );
 
 	test( 'renders without sites when not valid search term', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-picker/test/site-picker.tsx
@@ -119,7 +119,10 @@ describe( 'SitePicker', () => {
 
 		expect( getByText( 'Choose a destination site' ) ).toBeInTheDocument();
 
-		expect( screen.getAllByRole( 'button', { name: 'Choose' } ) ).toHaveLength( 2 );
+		expect( screen.getByRole( 'list' ) ).toBeVisible();
+		expect( screen.getAllByRole( 'listitem' ) ).toHaveLength( 2 );
+		expect( screen.getByRole( 'button', { name: 'Choose A Test Site' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Choose Another test Site' } ) ).toBeVisible();
 		expect(
 			[ ...container.querySelectorAll( '.site-picker--site-icon' ) ].map(
 				( element ) => element.textContent

--- a/client/my-sites/importer/index.js
+++ b/client/my-sites/importer/index.js
@@ -1,11 +1,13 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { navigation, redirectWithoutSite, sites, siteSelection } from 'calypso/my-sites/controller';
+import { navigation, redirectWithoutSite, siteSelection } from 'calypso/my-sites/controller';
 import { importSite, importSubstackSite } from 'calypso/my-sites/importer/controller';
 import addTracker from './tracker';
 
 export default function () {
-	page( '/import', siteSelection, navigation, sites, makeLayout, clientRender );
+	page( '/import', () => {
+		page.redirect( '/setup/site-migration/sitePicker?platform=unknown&ref=calypso-importer' );
+	} );
 
 	page(
 		'/import/:site_id',

--- a/client/my-sites/importer/index.js
+++ b/client/my-sites/importer/index.js
@@ -6,7 +6,7 @@ import addTracker from './tracker';
 
 export default function () {
 	page( '/import', () => {
-		window.location.assign(
+		window.location.replace(
 			'/setup/site-migration/sitePicker?platform=unknown&ref=calypso-importer'
 		);
 	} );

--- a/client/my-sites/importer/index.js
+++ b/client/my-sites/importer/index.js
@@ -6,7 +6,9 @@ import addTracker from './tracker';
 
 export default function () {
 	page( '/import', () => {
-		page.redirect( '/setup/site-migration/sitePicker?platform=unknown&ref=calypso-importer' );
+		window.location.assign(
+			'/setup/site-migration/sitePicker?platform=unknown&ref=calypso-importer'
+		);
 	} );
 
 	page(

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -32,6 +32,7 @@ const EXCLUDED_DEPENDENCIES = [
 	'password',
 	'password_confirm',
 	'domainCart',
+	'site',
 ];
 
 function recordSubmitStep( flow, stepName, providedDependencies, optionalProps ) {


### PR DESCRIPTION
## Proposed Changes

* Route bare `/import` to the modern site-migration destination picker instead of the legacy generic site selector.
* Present destinations as a responsive list with site initials/icons, domains, statuses, and explicit actions.
* Preserve existing-site, create-site, `/import/:site_id`, Back, reload, and login-return behavior.
* Show an accessible, retryable error when destination sites cannot be loaded.
* Keep nested site objects out of generic Stepper Tracks payloads while retaining the dedicated picker events.

## Why are these changes being made?

The logged-in `/import` entry currently renders a decade-old selector with no clear create-site continuation. This draft reuses the existing destination and site-creation flow as the smallest repair while broader source-first `/import` work remains separate. It stays draft until the bounded production compatibility gates are accepted.

## Testing Instructions

1. Visit `/import` while logged out and confirm login returns to `/import`, then opens the destination picker.
2. Verify zero-site users create a destination automatically, while one-site and many-site users can select an existing destination.
3. Choose an existing site and confirm the importer list renders.
4. Choose “create a new site” and confirm creation returns to the importer list.
5. Reload the picker and importer list; verify the route and content persist.
6. Use keyboard activation for a destination, verify mobile layout, and verify Back does not loop through `/import`.
7. Open `/import/:site_id` and confirm the legacy importer survives reload.
8. Simulate site-list and site-creation failures; verify retry and explicit error outcomes.

## Verification

* Site picker component: 6 tests passed, including failed-fetch recovery, list semantics, and contextual destination action names.
* Site migration flow: 48 tests passed.
* ESLint, Prettier, stylelint, and `git diff --check` passed.
* Revision-bound fixture browser matrix passed 9/9 at `b49b3778fe` and again at `a9aeb57b36`; the latest replay includes semantic list/status markup and contextual destination action names: entry query/reload, logged-out return, zero-site auto-create, one-site keyboard selection, many-site mobile creation, Back-history exit, legacy-route reload, site-fetch recovery, and site-creation failure.
* Browser evidence used synthetic user/site/API state with no production cookies, bearer tokens, private account data, production writes, or production API access. Calypso owned route redirects, return routing, Stepper navigation, and rendering; credential exchange and WPCOM API responses were adapted.

## Remaining Draft Gates

* Real WordPress.com credential exchange and representative account/site testing.
* Localization and manual accessibility review beyond the tested keyboard, list, status, and alert semantics.

## Out-of-scope Follow-ups

* Actual importer upload and durable job execution.
* `/move` source analysis and migration routing.
* Browser execution beyond the fixture harness Chromium runtime.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [x] Have you written new tests for your changes?
- [x] Have you checked for TypeScript, React, or other console errors in the bounded route matrix?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you tested accessibility beyond keyboard activation and alert semantics?
- [ ] Has the string-freeze label been added if required?

## AI Assistance

OpenAI `gpt-5.6-sol` via OpenCode was used to inspect routing and tracking contracts, implement the draft and fixture matrix, diagnose failures, and run verification. Chris Huber directed the scope and remains responsible for the submitted changes.