### PR TITLE
Blueprint onboarding: apply the confirmed site spec before handing off to the editor

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import {
+	applyBlueprintSpec,
 	getBlueprintArchiveSiteIdentifier,
 	getSiteAdminUrl,
 	getSiteEditorUrl,
@@ -367,43 +368,62 @@ const SiteSpec: StepType = function SiteSpec() {
 	// the background (kicked off on mount below). On spec confirm we poll the
 	// canonical Atomic transfer endpoint, then the import status, and finally hand
 	// the user off to the Atomic Site Editor.
-	const handleBlueprintArchiveSpecConfirm = useCallback( async () => {
-		if ( isSubmittingRef.current ) {
-			return;
-		}
+	const handleBlueprintArchiveSpecConfirm = useCallback(
+		async ( specData: unknown ) => {
+			if ( isSubmittingRef.current ) {
+				return;
+			}
 
-		if ( ! blueprintArchiveSiteIdentifier ) {
-			// eslint-disable-next-line no-console
-			console.error( 'Failed to finish blueprint import: missing target site.' );
-			return;
-		}
+			if ( ! blueprintArchiveSiteIdentifier ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to finish blueprint import: missing target site.' );
+				return;
+			}
 
-		isSubmittingRef.current = true;
+			isSubmittingRef.current = true;
 
-		try {
-			logBlueprintArchiveEvent( 'spec_confirm_poll_start', {
-				site_identifier: blueprintArchiveSiteIdentifier,
-			} );
+			try {
+				logBlueprintArchiveEvent( 'spec_confirm_poll_start', {
+					site_identifier: blueprintArchiveSiteIdentifier,
+				} );
 
-			await waitForAtomicTransferComplete( blueprintArchiveSiteIdentifier );
-			await waitForBlueprintImportComplete( blueprintArchiveSiteIdentifier );
-			const adminUrl = await getSiteAdminUrl( blueprintArchiveSiteIdentifier );
-			const siteEditorUrl = getSiteEditorUrl( adminUrl );
+				await waitForAtomicTransferComplete( blueprintArchiveSiteIdentifier );
+				await waitForBlueprintImportComplete( blueprintArchiveSiteIdentifier );
 
-			logBlueprintArchiveEvent( 'redirect_site_editor', {
-				site_identifier: blueprintArchiveSiteIdentifier,
-			} );
-			window.location.href = siteEditorUrl;
-		} catch ( error ) {
-			logBlueprintArchiveEvent( 'spec_confirm_error', {
-				site_identifier: blueprintArchiveSiteIdentifier,
-				error: error instanceof Error ? error.message : String( error ),
-			} );
-			// eslint-disable-next-line no-console
-			console.error( 'Failed to finish blueprint import:', error );
-			isSubmittingRef.current = false;
-		}
-	}, [ blueprintArchiveSiteIdentifier ] );
+				// Only once the restore is done: it replaces the site's options
+				// wholesale, so a spec applied earlier would be overwritten.
+				// Never blocks the hand-off — applyBlueprintSpec() resolves either way.
+				const specId = getSpecId( specData );
+				const applied = await applyBlueprintSpec(
+					blueprintArchiveSiteIdentifier,
+					specId,
+					blueprintArchiveSlug
+				);
+				logBlueprintArchiveEvent( 'apply_spec_done', {
+					site_identifier: blueprintArchiveSiteIdentifier,
+					applied,
+					has_spec_id: Boolean( specId ),
+				} );
+
+				const adminUrl = await getSiteAdminUrl( blueprintArchiveSiteIdentifier );
+				const siteEditorUrl = getSiteEditorUrl( adminUrl );
+
+				logBlueprintArchiveEvent( 'redirect_site_editor', {
+					site_identifier: blueprintArchiveSiteIdentifier,
+				} );
+				window.location.href = siteEditorUrl;
+			} catch ( error ) {
+				logBlueprintArchiveEvent( 'spec_confirm_error', {
+					site_identifier: blueprintArchiveSiteIdentifier,
+					error: error instanceof Error ? error.message : String( error ),
+				} );
+				// eslint-disable-next-line no-console
+				console.error( 'Failed to finish blueprint import:', error );
+				isSubmittingRef.current = false;
+			}
+		},
+		[ blueprintArchiveSiteIdentifier, blueprintArchiveSlug ]
+	);
 
 	// Kick off the background transfer + blueprint-archive import as soon as the
 	// spec page mounts, so it runs while the user reviews the spec.

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -222,6 +222,48 @@ export async function waitForAtomicTransferComplete(
 	);
 }
 
+/**
+ * Reconcile the confirmed site spec with the freshly imported blueprint site:
+ * writes the owner's site title/tagline, records which blueprint the site was
+ * built from, and stores the collected details as agent context so the editor
+ * can offer to personalize the blueprint's demo copy.
+ *
+ * Must run AFTER waitForBlueprintImportComplete(): the archive restore replaces
+ * the site's options wholesale, so anything written before it is overwritten.
+ *
+ * Resolves either way — a failure here costs the user personalization, not
+ * their site, so it must never block the hand-off to the editor.
+ */
+export async function applyBlueprintSpec(
+	siteIdentifier: string,
+	specId: string,
+	blueprintSlug?: string | null
+): Promise< boolean > {
+	if ( ! specId ) {
+		return false;
+	}
+
+	try {
+		await wpcom.req.post(
+			{
+				path: `/sites/${ siteIdentifier }/big-sky/apply-blueprint-spec`,
+				apiNamespace: 'wpcom/v2',
+			},
+			{
+				spec_id: specId,
+				...( blueprintSlug ? { blueprint_id: blueprintSlug } : {} ),
+			}
+		);
+		return true;
+	} catch ( error ) {
+		logBlueprintArchiveEvent( 'apply_spec_error', {
+			site_identifier: siteIdentifier,
+			error: error instanceof Error ? error.message : String( error ),
+		} );
+		return false;
+	}
+}
+
 export async function getSiteAdminUrl( siteIdentifier: string ): Promise< string > {
 	const site = ( await wpcom.req.get(
 		{

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -1,4 +1,19 @@
-import { getStandaloneBlueprintArchiveSlug } from '../blueprint-archive-import';
+/**
+ * @jest-environment jsdom
+ */
+import wpcom from 'calypso/lib/wp';
+import { applyBlueprintSpec, getStandaloneBlueprintArchiveSlug } from '../blueprint-archive-import';
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	__esModule: true,
+	default: { req: { post: jest.fn() } },
+} ) );
+
+jest.mock( 'calypso/lib/logstash', () => ( {
+	logToLogstash: jest.fn( () => Promise.resolve() ),
+} ) );
+
+const mockPost = wpcom.req.post as jest.Mock;
 
 describe( 'getStandaloneBlueprintArchiveSlug', () => {
 	it( 'returns the Blueprint archive slug for a standalone build_dest=wow flow', () => {
@@ -12,5 +27,51 @@ describe( 'getStandaloneBlueprintArchiveSlug', () => {
 	it( 'ignores retained Blueprint values after a Playground ID exists', () => {
 		expect( getStandaloneBlueprintArchiveSlug( '945', 'playground-uuid', null ) ).toBeNull();
 		expect( getStandaloneBlueprintArchiveSlug( '945', 'playground-uuid', 'wow' ) ).toBeNull();
+	} );
+} );
+
+describe( 'applyBlueprintSpec', () => {
+	beforeEach( () => {
+		mockPost.mockReset();
+	} );
+
+	it( 'posts the spec and blueprint to the apply endpoint', async () => {
+		mockPost.mockResolvedValue( { success: true } );
+
+		await expect( applyBlueprintSpec( 'example.wordpress.com', 'spec-123', 'coachava' ) ).resolves.toBe(
+			true
+		);
+
+		expect( mockPost ).toHaveBeenCalledWith(
+			{
+				path: '/sites/example.wordpress.com/big-sky/apply-blueprint-spec',
+				apiNamespace: 'wpcom/v2',
+			},
+			{ spec_id: 'spec-123', blueprint_id: 'coachava' }
+		);
+	} );
+
+	it( 'omits the blueprint when one is not known', async () => {
+		mockPost.mockResolvedValue( { success: true } );
+
+		await applyBlueprintSpec( '12345', 'spec-123' );
+
+		expect( mockPost ).toHaveBeenCalledWith( expect.anything(), { spec_id: 'spec-123' } );
+	} );
+
+	it( 'skips the request without a spec id', async () => {
+		await expect( applyBlueprintSpec( '12345', '' ) ).resolves.toBe( false );
+
+		expect( mockPost ).not.toHaveBeenCalled();
+	} );
+
+	/**
+	 * Personalization is a bonus on top of a site the user already paid for, so a
+	 * failure here must never propagate and block the hand-off to the editor.
+	 */
+	it( 'resolves false instead of throwing when the request fails', async () => {
+		mockPost.mockRejectedValue( new Error( 'nope' ) );
+
+		await expect( applyBlueprintSpec( '12345', 'spec-123', 'coachava' ) ).resolves.toBe( false );
 	} );
 } );

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -38,9 +38,9 @@ describe( 'applyBlueprintSpec', () => {
 	it( 'posts the spec and blueprint to the apply endpoint', async () => {
 		mockPost.mockResolvedValue( { success: true } );
 
-		await expect( applyBlueprintSpec( 'example.wordpress.com', 'spec-123', 'coachava' ) ).resolves.toBe(
-			true
-		);
+		await expect(
+			applyBlueprintSpec( 'example.wordpress.com', 'spec-123', 'coachava' )
+		).resolves.toBe( true );
 
 		expect( mockPost ).toHaveBeenCalledWith(
 			{


### PR DESCRIPTION
### Problem

The blueprint funnel collects a site spec during onboarding and then drops it. The customer lands in the editor on a site still carrying the blueprint's demo title, tagline and copy, and the editor agent knows nothing about the business they just described.

### Change

Call `POST /sites/{id}/big-sky/apply-blueprint-spec` on spec confirm. That writes the owner's site title and tagline, records which blueprint the site came from, and stores the collected details as agent context so the editor can offer to personalize the demo copy.

`handleBlueprintArchiveSpecConfirm` now takes the `specData` the widget already passes and pulls the id with the file's existing `getSpecId()` helper:

```
waitForAtomicTransferComplete()
waitForBlueprintImportComplete()
applyBlueprintSpec()             ← new
getSiteAdminUrl() → redirect to the site editor
```

**Placement is load-bearing.** The call sits after `waitForBlueprintImportComplete()` because the archive restore replaces the site's options wholesale — a spec applied earlier would be overwritten.

### Failure handling

`applyBlueprintSpec()` resolves rather than throws, and the handler logs the outcome and continues. Personalization is a bonus on top of a site the customer already paid for; losing it must never block the hand-off to the editor. Outcomes are visible as the `blueprint_archive_import_apply_spec_done` / `_apply_spec_error` logstash events.

### Ordering with the backend

Requires the wpcom endpoint in `234940-ghe-Automattic/wpcom`. Until that ships the call 404s, is swallowed, and the flow behaves exactly as it does today — so these two can land in either order.

### Testing

`yarn test-client client/landing/stepper/utils/test/blueprint-archive-import.ts` — 7/7 pass, including 4 new cases: correct payload, blueprint omitted when unknown, request skipped without a spec id, and resolves `false` instead of throwing on failure. ESLint clean; no type errors in either changed file.

Also exercised by hand against a real funnel-built Atomic site: the spec applied, the title and tagline updated on the site, and the collected details were readable back as agent context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
