### PR TITLE
Receipts: show the tax identity a receipt was issued under

### DIFF
--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -43,7 +43,12 @@ import {
 	renderJetpackSearch10kTierBreakdown,
 	doesIntroductoryOfferHaveDifferentTermLengthThanProduct,
 } from './utils';
-import type { Receipt, ReceiptItem, ReceiptItemCostOverride } from '@automattic/api-core';
+import type {
+	Receipt,
+	ReceiptItem,
+	ReceiptItemCostOverride,
+	TaxCustomerInfo,
+} from '@automattic/api-core';
 import './styles.scss';
 
 export interface IntroductoryOfferTerms {
@@ -286,8 +291,30 @@ type ReceiptTaxDetail = {
 	value: ReactNode;
 };
 
-function UserVatDetails( { receipt }: { receipt: Receipt } ) {
-	const { data: vatDetails } = useSuspenseQuery( userTaxDetailsQuery() );
+/**
+ * The tax identity to print on a receipt.
+ *
+ * A receipt describes a supply that already happened, so it has to name the
+ * party it happened with. The API says who that was, taking account of any
+ * reissue that has since superseded the receipt. The user's current details are
+ * only a stand-in for receipts served by an API that predates the field, where
+ * they remain the best guess available.
+ */
+function useReceiptVatDetails( receipt: Receipt ): TaxCustomerInfo {
+	const { data: userTaxDetails } = useSuspenseQuery( userTaxDetailsQuery() );
+
+	return (
+		receipt.tax_customer_info ?? {
+			country: userTaxDetails.country ?? '',
+			id: userTaxDetails.id ?? null,
+			name: userTaxDetails.name ?? null,
+			address: userTaxDetails.address ?? null,
+		}
+	);
+}
+
+export function UserVatDetails( { receipt }: { receipt: Receipt } ) {
+	const vatDetails = useReceiptVatDetails( receipt );
 	const sendEmailMutation = useMutation(
 		withSnackbar( sendReceiptEmailMutation(), {
 			success: __( 'Your receipt was sent by email successfully.' ),

--- a/client/dashboard/me/billing-history/test/receipt.test.tsx
+++ b/client/dashboard/me/billing-history/test/receipt.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
@@ -73,10 +73,6 @@ describe( '<BillingDetailsField>', () => {
 } );
 
 describe( '<UserVatDetails>', () => {
-	afterEach( () => {
-		nock.cleanAll();
-	} );
-
 	test( 'shows the tax identity the receipt was issued under, not the current one', async () => {
 		mockCurrentTaxDetails();
 		render(
@@ -121,7 +117,8 @@ describe( '<UserVatDetails>', () => {
 			/>
 		);
 
-		await waitForElementToBeRemoved( () => screen.queryByTestId( 'loading' ) );
-		expect( screen.queryByText( 'VAT Details' ) ).not.toBeInTheDocument();
+		await waitFor( () => {
+			expect( screen.queryByText( 'VAT Details' ) ).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/client/dashboard/me/billing-history/test/receipt.test.tsx
+++ b/client/dashboard/me/billing-history/test/receipt.test.tsx
@@ -1,10 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-import { screen } from '@testing-library/react';
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 import { render } from '../../../test-utils';
-import { BillingDetailsField } from '../receipt';
+import { BillingDetailsField, UserVatDetails } from '../receipt';
 import type { Receipt } from '@automattic/api-core';
 
 const receipt = {
@@ -13,6 +14,29 @@ const receipt = {
 	cc_name: 'Jane Doe',
 	cc_email: 'jane@example.com',
 } as Receipt;
+
+const CURRENT_TAX_DETAILS = {
+	country: 'IE',
+	id: 'IE9999999',
+	name: 'Renamed Since The Purchase Ltd',
+	address: '2 New Street, Dublin',
+	can_user_edit: true,
+};
+
+function makeReceipt( overrides: Partial< Receipt > = {} ): Receipt {
+	return {
+		id: 1,
+		...overrides,
+	} as Receipt;
+}
+
+function mockCurrentTaxDetails() {
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( '/rest/v1.1/me/vat-info' )
+		.query( true )
+		.reply( 200, CURRENT_TAX_DETAILS );
+}
 
 describe( '<BillingDetailsField>', () => {
 	test( 'renders a multi-line field prefilled with the cardholder name and email', () => {
@@ -45,5 +69,59 @@ describe( '<BillingDetailsField>', () => {
 		const printable = container.querySelector( '.receipt-billing-details-printable' );
 		expect( printable ).toHaveTextContent( 'Line one Line two' );
 		expect( printable?.textContent ).toBe( 'Line one\nLine two' );
+	} );
+} );
+
+describe( '<UserVatDetails>', () => {
+	afterEach( () => {
+		nock.cleanAll();
+	} );
+
+	test( 'shows the tax identity the receipt was issued under, not the current one', async () => {
+		mockCurrentTaxDetails();
+		render(
+			<UserVatDetails
+				receipt={ makeReceipt( {
+					tax_customer_info: {
+						country: 'IE',
+						id: 'IE1234567',
+						name: 'Original Trading Name Ltd',
+						address: '1 Old Street, Dublin',
+					},
+				} ) }
+			/>
+		);
+
+		expect( await screen.findByText( 'Original Trading Name Ltd' ) ).toBeVisible();
+		expect( screen.getByText( '1 Old Street, Dublin' ) ).toBeVisible();
+		expect( screen.getByText( 'VAT #: IE IE1234567' ) ).toBeVisible();
+		expect( screen.queryByText( 'Renamed Since The Purchase Ltd' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'falls back to the current tax identity for a receipt served without one', async () => {
+		mockCurrentTaxDetails();
+		render( <UserVatDetails receipt={ makeReceipt() } /> );
+
+		expect( await screen.findByText( 'Renamed Since The Purchase Ltd' ) ).toBeVisible();
+		expect( screen.getByText( 'VAT #: IE IE9999999' ) ).toBeVisible();
+	} );
+
+	test( 'shows nothing for a receipt issued to a customer with no tax identity', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( '/rest/v1.1/me/vat-info' )
+			.query( true )
+			.reply( 200, { country: '', id: null, name: null, address: null, can_user_edit: true } );
+
+		render(
+			<UserVatDetails
+				receipt={ makeReceipt( {
+					tax_customer_info: { country: '', id: null, name: null, address: null },
+				} ) }
+			/>
+		);
+
+		await waitForElementToBeRemoved( () => screen.queryByTestId( 'loading' ) );
+		expect( screen.queryByText( 'VAT Details' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -274,9 +274,39 @@ function ReceiptPaymentMethod( { transaction }: { transaction: BillingTransactio
 	);
 }
 
+interface ReceiptVatDetails {
+	country?: string | null;
+	id?: string | null;
+	name?: string | null;
+	address?: string | null;
+}
+
+/**
+ * The tax identity to print on a receipt.
+ *
+ * A receipt describes a supply that already happened, so it has to name the
+ * party it happened with. The API says who that was, taking account of any
+ * reissue that has since superseded the receipt. The user's current details are
+ * only a stand-in for receipts served by an API that predates the field, where
+ * they remain the best guess available.
+ */
+function useReceiptVatDetails( transaction: BillingTransaction ): {
+	vatDetails: ReceiptVatDetails;
+	isLoading: boolean;
+	fetchError: unknown;
+} {
+	const { vatDetails, isLoading, fetchError } = useVatDetails();
+
+	if ( transaction.tax_customer_info ) {
+		return { vatDetails: transaction.tax_customer_info, isLoading: false, fetchError: null };
+	}
+
+	return { vatDetails, isLoading, fetchError };
+}
+
 function UserVatDetails( { transaction }: { transaction: BillingTransaction } ) {
 	const translate = useTranslate();
-	const { vatDetails, isLoading, fetchError } = useVatDetails();
+	const { vatDetails, isLoading, fetchError } = useReceiptVatDetails( transaction );
 	const reduxDispatch = useDispatch();
 
 	const getEmailReceiptLinkClickHandler = ( receiptId: string ) => {

--- a/client/state/billing-transactions/types.ts
+++ b/client/state/billing-transactions/types.ts
@@ -1,3 +1,4 @@
+import type { TaxCustomerInfo } from '@automattic/api-core';
 import type { IntroductoryOfferTerms } from '@automattic/shopping-cart';
 import type { TaxBreakdownEntry, TaxVendorInfo } from '@automattic/wpcom-checkout';
 
@@ -70,6 +71,16 @@ export interface BillingTransaction {
 	url: string;
 
 	tax_vendor_info?: TaxVendorInfo;
+
+	/**
+	 * The buyer's tax identity as the document currently standing for this
+	 * receipt states it, rather than the user's details today.
+	 *
+	 * Optional only because responses cached before this field shipped will not
+	 * carry it; the API always sends it.
+	 */
+	tax_customer_info?: TaxCustomerInfo;
+
 	tax_breakdown?: TaxBreakdownEntry[];
 }
 

--- a/packages/api-core/src/me-billing-history/types.ts
+++ b/packages/api-core/src/me-billing-history/types.ts
@@ -38,6 +38,28 @@ export interface TaxVendorInfo {
 	tax_name: string;
 }
 
+/**
+ * The buyer's tax identity as the document currently standing for a receipt
+ * states it: the reissue that supersedes it where there is one, and the receipt
+ * as issued where there is not.
+ *
+ * Not the same as the user's current details from `userTaxDetailsQuery`, which
+ * describe who they are today rather than who the receipt was issued to. Prefer
+ * this whenever rendering a receipt.
+ *
+ * Same shape as the `/me/vat-info` response minus `can_user_edit`, so either
+ * can be handed to the same renderer.
+ */
+export interface TaxCustomerInfo {
+	/**
+	 * Uppercase country code, or an empty string where none is on record.
+	 */
+	country: string;
+	id: string | null;
+	name: string | null;
+	address: string | null;
+}
+
 export interface ReceiptItemCostOverride {
 	id: number;
 	human_readable_reason: string;
@@ -119,6 +141,12 @@ export interface Receipt {
 	credit: string;
 	items: ReceiptItem[];
 	tax_vendor_info?: TaxVendorInfo;
+	/**
+	 * Optional only because responses cached before this field shipped will not
+	 * carry it; the API always sends it. Fall back to the user's current details
+	 * when it is absent.
+	 */
+	tax_customer_info?: TaxCustomerInfo;
 	tax_breakdown?: TaxBreakdownEntry[];
 	checkout_type?: string;
 	/**


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2429

## Proposed Changes

Depends on 234954-ghe-Automattic/wpcom

After this PR, both receipt views in calypso/dashboard now print the tax identity the receipt was actually issued to, taken from the API, instead of fetching the customer's current details and printing those onto a document written potentially months or years earlier.

> [!IMPORTANT]
> By merging this, users no longer can retroactively modify the VAT info displayed on their receipts. This is correct and by design, but it goes against our current guidance for how to correct mistaken VAT info and reissue a receipt. Therefore, before merging we need to make sure there's a replacement path for users who need to reissue an invoice with different VAT info.

## Why are these changes being made?

A receipt records a supply that happened on a date, and the party it happened with is part of that record. Both views have always rendered that party by fetching `/me/vat-info` — the customer's details *right now* — and printing them onto the receipt. So a customer who corrects their trading name sees every past receipt silently re-described under the new one, including documents they have already filed with their own accounts. Worse, once an invoice has been reissued, the receipt view ignored the correction that the reissue exists to record.

The server now answers this directly: `tax_customer_info` carries the identity of whichever document currently stands for the receipt — the latest reissue where one supersedes it, the receipt's own pinned identity where none does. The client's job shrinks to preferring that over the live lookup.

The live lookup is kept as a fallback for a response that predates the field. That is also why the API always sends the field rather than omitting it when the customer has no tax details: absent means "old cached response", empty means "no tax details", and the client needs to tell those apart.

The field is read on both endpoints for a reason. The classic view renders from the billing-history list before the individual receipt fetch lands, so a detail-only field would briefly show the current identity before correcting itself.

Depends on the corresponding wpcom change shipping first. Until it does, the field is absent and both views behave exactly as they do today.

## Testing Instructions

* Set some tax details, buy something, then change your tax details to a different name.
* Open the receipt for that purchase at `/me/purchases/billing/<receipt_id>` and again in the Dashboard receipt view.
* Confirm the VAT block shows the name the purchase was made under, not the name you just changed to. Before this change, both showed the new name.
* On an account with no tax details at all, confirm the VAT block is hidden rather than showing an empty one.
* Without the wpcom change deployed (or against production), confirm both views still show current details as before — the fallback path.