### PR TITLE
Bind agent canvas writes to the page the editor has open

### DIFF
--- a/packages/agents-manager/src/abilities/ability-name.ts
+++ b/packages/agents-manager/src/abilities/ability-name.ts
@@ -1,7 +1,13 @@
 import type { Ability } from './types';
 
-// The agent routes tool calls with `/` → `__` and `-` → `_`.
-const normalizeAbilityName = ( name: string ) => name.replace( /\//g, '__' ).replace( /-/g, '_' );
+/**
+ * The agent routes tool calls with `/` → `__` and `-` → `_`, so an ability
+ * registered as `big-sky/apply-block-edits` is invoked as
+ * `big_sky__apply_block_edits`. Anything matching an ability by name — execution,
+ * ownership checks, the canvas guard — has to normalize both sides.
+ */
+export const normalizeAbilityName = ( name: string ) =>
+	name.replace( /\//g, '__' ).replace( /-/g, '_' );
 
 /**
  * Finds an ability by its raw or agent-normalized name — the one matching

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -51,13 +51,24 @@ const mockSetCheckpointActionReverted = jest.fn(
 );
 let mockSelectedBlockType: string | undefined;
 let mockBlockEditorStoreThrows = false;
+let mockOpenPost: { id?: number | string; type?: string; title?: string } | null = null;
+
 let mockHasEditorRedo = false;
 let mockEditorBlocks: unknown[] = [];
 const mockDataStoreSubscribers = new Set< () => void >();
 
 const mockSelectDataStore = ( storeName: string ) => {
 	if ( storeName === 'core/editor' ) {
-		return { hasEditorRedo: () => mockHasEditorRedo };
+		return {
+			hasEditorRedo: () => mockHasEditorRedo,
+			// The open canvas, read by the component's own `useSelect` and by
+			// `canvas-binding` through `select` — the same object, so the two can
+			// never disagree about what is open.
+			getCurrentPostId: () => mockOpenPost?.id,
+			getCurrentPostType: () => mockOpenPost?.type,
+			getEditedPostAttribute: ( attribute: string ) =>
+				attribute === 'title' ? mockOpenPost?.title : undefined,
+		};
 	}
 	if ( storeName === 'core/block-editor' ) {
 		if ( mockBlockEditorStoreThrows ) {
@@ -396,6 +407,12 @@ jest.mock( '../agent-chat', () => ( {
 } ) );
 
 import { getSessionId } from '../../utils/agent-session';
+import {
+	bindToOpenCanvas,
+	blockCurrentRequest,
+	getBlockingMove,
+	startNewUserRequest,
+} from '../../utils/canvas-binding';
 import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import OrchestratorChat from '../orchestrator-chat';
 
@@ -620,6 +637,7 @@ describe( 'OrchestratorChat', () => {
 		sessionStorage.clear();
 		mockManagerHasAgent = true;
 		mockHasEditorRedo = false;
+		mockOpenPost = null;
 		mockEditorBlocks = [];
 		mockDataStoreSubscribers.clear();
 		mockInvalidatedCheckpointIds.clear();
@@ -3303,5 +3321,164 @@ describe( 'OrchestratorChat', () => {
 		rerender( chat() );
 
 		expect( countShowComponentMessages() ).toBe( 1 );
+	} );
+
+	describe( 'editor canvas binding', () => {
+		const ABOUT_PAGE = { id: 4, type: 'page', title: 'About' };
+		const CONTACT_PAGE = { id: 9, type: 'page', title: 'Contact' };
+
+		// The canvas moving, as the editor store does it: change what the store
+		// reports, then notify its subscribers. That is the whole signal — there is
+		// no host event to dispatch.
+		const openPage = ( post: typeof ABOUT_PAGE | null ) => {
+			act( () => {
+				mockOpenPost = post;
+				mockDataStoreSubscribers.forEach( ( notify ) => notify() );
+			} );
+		};
+
+		beforeEach( () => {
+			// The binding is module-level state, so each test has to start from the
+			// unbound, unblocked position a fresh page load would give it.
+			startNewUserRequest();
+			mockOpenPost = ABOUT_PAGE;
+		} );
+
+		it( 'aborts and blocks the request when the canvas moves mid-request', () => {
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { abortCurrentRequest } = mockUseAgentChat();
+
+			render( chat() );
+			// The canvas the model was looking at when it decided what to do.
+			bindToOpenCanvas();
+
+			openPage( CONTACT_PAGE );
+
+			expect( abortCurrentRequest ).toHaveBeenCalledTimes( 1 );
+			// Blocked as well as aborted, and carrying the pages it was blocked for:
+			// a tool call already in flight when the abort loses the race must still
+			// be refused, naming the page it was meant for.
+			expect( getBlockingMove() ).toEqual( { from: 'About', to: 'Contact' } );
+		} );
+
+		it( 'explains the cancellation in the thread, without sending it to the server', () => {
+			// An aborted turn otherwise stops mid-sentence and reads as a failure.
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { addMessage } = mockUseAgentChat();
+
+			render( chat() );
+			bindToOpenCanvas();
+
+			openPage( CONTACT_PAGE );
+
+			expect( addMessage ).toHaveBeenCalledTimes( 1 );
+
+			const message = addMessage.mock.calls[ 0 ][ 0 ];
+			expect( message.id ).toContain( 'canvas-move-abort-' );
+			expect( message.role ).toBe( 'agent' );
+			expect( message.content[ 0 ].text ).toContain( 'switched pages' );
+			// `addMessage` only touches the UI list. Anything that dispatched to the
+			// agent would restart the request the abort just stopped.
+			expect( mockUseAgentChat().onSubmit ).not.toHaveBeenCalled();
+		} );
+
+		it( 'leaves the request running while the canvas has not moved', () => {
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { abortCurrentRequest, addMessage } = mockUseAgentChat();
+
+			render( chat() );
+			bindToOpenCanvas();
+
+			// Editor churn that does not move the canvas — a block selection, a
+			// keystroke — must not read as a move.
+			mockSelectedBlockType = 'core/heading';
+			openPage( ABOUT_PAGE );
+
+			expect( abortCurrentRequest ).not.toHaveBeenCalled();
+			expect( addMessage ).not.toHaveBeenCalled();
+			expect( getBlockingMove() ).toBeNull();
+		} );
+
+		it( 'does not abort on a title edit', () => {
+			// The title is part of what a refusal names, but editing it does not move
+			// the canvas — keying off it would abort on every keystroke in the title.
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { abortCurrentRequest } = mockUseAgentChat();
+
+			render( chat() );
+			bindToOpenCanvas();
+
+			openPage( { ...ABOUT_PAGE, title: 'About us' } );
+
+			expect( abortCurrentRequest ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not abort when no request is running', () => {
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: false } ) );
+			const { abortCurrentRequest } = mockUseAgentChat();
+
+			render( chat() );
+			bindToOpenCanvas();
+
+			openPage( CONTACT_PAGE );
+
+			expect( abortCurrentRequest ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not abort when the editor store stops resolving a canvas', () => {
+			// A store that has not settled is not a wrong canvas. Aborting here would
+			// kill legitimate requests for the width of a mount.
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { abortCurrentRequest } = mockUseAgentChat();
+
+			render( chat() );
+			bindToOpenCanvas();
+
+			openPage( null );
+
+			expect( abortCurrentRequest ).not.toHaveBeenCalled();
+		} );
+
+		it( 'lifts the block when the composer submits the next message', async () => {
+			// The rebind has to sit on the callback the composer is wired to. One
+			// canvas-move abort would otherwise latch the block for the rest of the
+			// page session, refusing every canvas write until a reload.
+			const { onSubmit } = mockUseAgentChat();
+
+			render( chat() );
+			bindToOpenCanvas();
+			mockOpenPost = CONTACT_PAGE;
+			blockCurrentRequest();
+			expect( getBlockingMove() ).not.toBeNull();
+
+			await act( async () => {
+				fireEvent.click( screen.getByText( 'Submit message' ) );
+			} );
+
+			expect( onSubmit ).toHaveBeenCalledWith( 'Describe these images' );
+			expect( getBlockingMove() ).toBeNull();
+		} );
+
+		it( 'lifts the block when the turn is regenerated', async () => {
+			// A regeneration is a fresh dispatch that rebinds on its own outbound
+			// message, so it is a new request for the binding too. It goes through
+			// agenttic's own handler rather than the composer, so without this the
+			// block would survive into a request it has nothing to do with.
+			render( chat() );
+			bindToOpenCanvas();
+			mockOpenPost = CONTACT_PAGE;
+			blockCurrentRequest();
+			expect( getBlockingMove() ).not.toBeNull();
+
+			const config = mockUseRegenerateAction.mock.calls.at( -1 )![ 0 ] as {
+				getRegenerateHandler?: ( message: unknown ) => ( () => Promise< void > ) | null | undefined;
+			};
+			const wrappedHandler = config.getRegenerateHandler?.( showComponentMessage( 'agent-1' ) );
+			await act( async () => {
+				await wrappedHandler?.();
+			} );
+
+			expect( getBlockingMove() ).toBeNull();
+		} );
 	} );
 } );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -3439,6 +3439,31 @@ describe( 'OrchestratorChat', () => {
 			expect( abortCurrentRequest ).not.toHaveBeenCalled();
 		} );
 
+		it( 'does not abort a new message sent after navigating between turns', async () => {
+			// The main hazard `startNewUserRequest()` closes, and it has nothing to do
+			// with the block: turn one binds to About, the user then moves to Contact
+			// with nothing running (so no abort), and sends a new message. The new turn
+			// flips `isProcessing` before its own outbound message rebinds, so a
+			// binding left over from turn one reads as a move and aborts the request
+			// the user just made — every time they ask a question after navigating.
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: false } ) );
+			const { rerender } = render( chat() );
+			bindToOpenCanvas();
+
+			openPage( CONTACT_PAGE );
+
+			await act( async () => {
+				fireEvent.click( screen.getByText( 'Submit message' ) );
+			} );
+
+			const processingTurn = agentChatReturn( { isProcessing: true } );
+			mockUseAgentChat.mockReturnValue( processingTurn );
+			rerender( chat() );
+
+			expect( processingTurn.abortCurrentRequest ).not.toHaveBeenCalled();
+			expect( processingTurn.addMessage ).not.toHaveBeenCalled();
+		} );
+
 		it( 'lifts the block when the composer submits the next message', async () => {
 			// The rebind has to sit on the callback the composer is wired to. One
 			// canvas-move abort would otherwise latch the block for the rest of the

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -410,6 +410,7 @@ import { getSessionId } from '../../utils/agent-session';
 import {
 	bindToOpenCanvas,
 	blockCurrentRequest,
+	clearCanvasBinding,
 	getBlockingMove,
 	startNewUserRequest,
 } from '../../utils/canvas-binding';
@@ -3376,7 +3377,9 @@ describe( 'OrchestratorChat', () => {
 			const message = addMessage.mock.calls[ 0 ][ 0 ];
 			expect( message.id ).toContain( 'canvas-move-abort-' );
 			expect( message.role ).toBe( 'agent' );
-			expect( message.content[ 0 ].text ).toContain( 'switched pages' );
+			// Worded for both shapes of move — landing on another page and leaving the
+			// editor altogether both reach this message.
+			expect( message.content[ 0 ].text ).toContain( 'navigated away' );
 			// `addMessage` only touches the UI list. Anything that dispatched to the
 			// agent would restart the request the abort just stopped.
 			expect( mockUseAgentChat().onSubmit ).not.toHaveBeenCalled();
@@ -3425,9 +3428,10 @@ describe( 'OrchestratorChat', () => {
 			expect( abortCurrentRequest ).not.toHaveBeenCalled();
 		} );
 
-		it( 'does not abort when the editor store stops resolving a canvas', () => {
-			// A store that has not settled is not a wrong canvas. Aborting here would
-			// kill legitimate requests for the width of a mount.
+		it( 'aborts when the canvas goes away entirely', () => {
+			// Leaving the editor is as much a reason to stop as landing on another
+			// page — more so, because the write abilities poll for a canvas to appear,
+			// so a request left running against nothing retries until the turn dies.
 			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
 			const { abortCurrentRequest } = mockUseAgentChat();
 
@@ -3436,7 +3440,8 @@ describe( 'OrchestratorChat', () => {
 
 			openPage( null );
 
-			expect( abortCurrentRequest ).not.toHaveBeenCalled();
+			expect( abortCurrentRequest ).toHaveBeenCalledTimes( 1 );
+			expect( getBlockingMove() ).toEqual( { from: 'About', to: null } );
 		} );
 
 		it( 'never aborts on a surface with no editor', () => {
@@ -3456,17 +3461,19 @@ describe( 'OrchestratorChat', () => {
 			expect( abortCurrentRequest ).not.toHaveBeenCalled();
 		} );
 
-		it( 'does not abort when the editor is left for a screen with no canvas', () => {
-			// Leaving the editor entirely resolves no canvas, which is "not settled"
-			// rather than "a different page" — so a support turn that sends the user
-			// to a settings screen is not killed on the way.
+		it( 'does not abort while the agent is moving the canvas itself', () => {
+			// `editor-navigate` clears the binding before it runs, so the unmount and
+			// remount it causes are not read as the user walking away. Without this the
+			// agent's own navigation would abort the agent's own request.
 			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
 			const { abortCurrentRequest } = mockUseAgentChat();
 
 			render( chat() );
 			bindToOpenCanvas();
+			clearCanvasBinding();
 
 			openPage( null );
+			openPage( CONTACT_PAGE );
 
 			expect( abortCurrentRequest ).not.toHaveBeenCalled();
 		} );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -3439,6 +3439,38 @@ describe( 'OrchestratorChat', () => {
 			expect( abortCurrentRequest ).not.toHaveBeenCalled();
 		} );
 
+		it( 'never aborts on a surface with no editor', () => {
+			// The same dock serves support guides, Reader and the editor, so this
+			// effect runs everywhere AM runs. On a surface with no `core/editor` — a
+			// help or settings context — nothing ever binds, so route changes there
+			// cannot abort anything however far the user or the agent navigates.
+			mockOpenPost = null;
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { abortCurrentRequest } = mockUseAgentChat();
+
+			render( chat() );
+
+			openPage( CONTACT_PAGE );
+			openPage( null );
+
+			expect( abortCurrentRequest ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not abort when the editor is left for a screen with no canvas', () => {
+			// Leaving the editor entirely resolves no canvas, which is "not settled"
+			// rather than "a different page" — so a support turn that sends the user
+			// to a settings screen is not killed on the way.
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { abortCurrentRequest } = mockUseAgentChat();
+
+			render( chat() );
+			bindToOpenCanvas();
+
+			openPage( null );
+
+			expect( abortCurrentRequest ).not.toHaveBeenCalled();
+		} );
+
 		it( 'does not abort a new message sent after navigating between turns', async () => {
 			// The main hazard `startNewUserRequest()` closes, and it has nothing to do
 			// with the block: turn one binds to About, the user then moves to Contact

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -3444,6 +3444,40 @@ describe( 'OrchestratorChat', () => {
 			expect( getBlockingMove() ).toEqual( { from: 'About', to: null } );
 		} );
 
+		it( 'does not abort an agent whose turns cannot write to the canvas', () => {
+			// A support chat runs in this same dock, including inside the editor. Its
+			// turns never call a canvas ability, so stopping one because the user
+			// browsed to another page loses the answer for nothing — and tells them it
+			// was stopped "before it changed the wrong one", which it never would have.
+			mockAgentConfig = { agentId: 'wpcom-workflow-support_chat' };
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { abortCurrentRequest, addMessage } = mockUseAgentChat();
+
+			render( chat() );
+			bindToOpenCanvas();
+
+			openPage( CONTACT_PAGE );
+
+			expect( abortCurrentRequest ).not.toHaveBeenCalled();
+			expect( addMessage ).not.toHaveBeenCalled();
+		} );
+
+		it( 'aborts for unified chat as well as the orchestrator', () => {
+			// The canvas abilities are migrating into AM, which serves them on
+			// unified-chat surfaces. Gating on the orchestrator alone would leave this
+			// switched off exactly where those abilities are heading.
+			mockAgentConfig = { agentId: 'wpcom-workflow-unified_chat' };
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { abortCurrentRequest } = mockUseAgentChat();
+
+			render( chat() );
+			bindToOpenCanvas();
+
+			openPage( CONTACT_PAGE );
+
+			expect( abortCurrentRequest ).toHaveBeenCalledTimes( 1 );
+		} );
+
 		it( 'never aborts on a surface with no editor', () => {
 			// The same dock serves support guides, Reader and the editor, so this
 			// effect runs everywhere AM runs. On a surface with no `core/editor` — a

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -408,6 +408,7 @@ jest.mock( '../agent-chat', () => ( {
 
 import { getSessionId } from '../../utils/agent-session';
 import {
+	bindToNavigationTarget,
 	bindToOpenCanvas,
 	blockCurrentRequest,
 	clearCanvasBinding,
@@ -3510,6 +3511,49 @@ describe( 'OrchestratorChat', () => {
 			openPage( CONTACT_PAGE );
 
 			expect( abortCurrentRequest ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not abort when the agent opens a page it just had created', () => {
+			// The reported failure, end to end: `add-page` creates the page on the
+			// server and hands the client an `editor-navigate` call for it. That
+			// result is an outgoing message, so it rebinds — and a page created a
+			// moment ago on the server is not in the store, so the editor is still
+			// reporting the old one when it does. Binding ahead to the destination is
+			// what stops the arrival killing the turn that asked for it.
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { abortCurrentRequest, addMessage } = mockUseAgentChat();
+
+			render( chat() );
+			bindToOpenCanvas();
+
+			// The guard, seeing `editor-navigate` bound for `/page/9`.
+			bindToNavigationTarget( 'page:9' );
+			// The navigate tool result, sent while the editor still shows About.
+			bindToOpenCanvas();
+
+			openPage( CONTACT_PAGE );
+
+			expect( abortCurrentRequest ).not.toHaveBeenCalled();
+			expect( addMessage ).not.toHaveBeenCalled();
+		} );
+
+		it( 'still aborts when the user leaves a page the agent navigated to', () => {
+			// The destination binding must hand back to the ordinary rules on arrival,
+			// or one agent navigation would disarm the guard for the rest of the turn.
+			mockUseAgentChat.mockReturnValue( agentChatReturn( { isProcessing: true } ) );
+			const { abortCurrentRequest } = mockUseAgentChat();
+
+			render( chat() );
+			bindToOpenCanvas();
+
+			bindToNavigationTarget( 'page:9' );
+			openPage( CONTACT_PAGE );
+			bindToOpenCanvas();
+
+			openPage( ABOUT_PAGE );
+
+			expect( abortCurrentRequest ).toHaveBeenCalledTimes( 1 );
+			expect( getBlockingMove() ).toEqual( { from: 'Contact', to: 'About' } );
 		} );
 
 		it( 'does not abort a new message sent after navigating between turns', async () => {

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -38,6 +38,12 @@ import useFeedbackAction from '../../hooks/use-feedback-action';
 import { useImageUpload } from '../../hooks/use-image-upload';
 import useRegenerateAction from '../../hooks/use-regenerate-action';
 import useSourcesAction from '../../hooks/use-sources-action';
+import {
+	blockCurrentRequest,
+	buildCanvasKey,
+	getCanvasMove,
+	startNewUserRequest,
+} from '../../utils/canvas-binding';
 import convertToolMessagesToComponents, {
 	type AgentsManagerUIMessage,
 	isContextOnlyMessage,
@@ -49,6 +55,7 @@ import {
 	type ExternalContextCard,
 	type ExternalContextCardAction,
 } from '../../utils/external-context';
+import { generateUUID } from '../../utils/generate-uuid';
 import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
 import { mergeEmptyViewSuggestions } from '../../utils/merge-empty-view-suggestions';
 import { getOrchestratorErrorMessage } from '../../utils/orchestrator-error-message';
@@ -354,6 +361,17 @@ export default function OrchestratorChat( {
 		const editor = select( 'core/editor' ) as { getCurrentPostId?: () => number | string };
 		return editor?.getCurrentPostId?.();
 	}, [] );
+	// The canvas the editor has open, as the value the abort effect watches. A
+	// separate select from `currentPostId` above: that one feeds message rendering
+	// and stays a bare id, while this needs the post type too — a page and a
+	// template can share an id, and a move between them must not read as a stay.
+	const canvasKey = useSelect( ( select ) => {
+		const editor = select( 'core/editor' ) as {
+			getCurrentPostId?: () => number | string | undefined;
+			getCurrentPostType?: () => string | undefined;
+		};
+		return buildCanvasKey( editor?.getCurrentPostType?.(), editor?.getCurrentPostId?.() );
+	}, [] );
 	const selectedBlockType = useSelect( ( select ) => {
 		try {
 			const blockEditor = select( 'core/block-editor' ) as {
@@ -526,6 +544,49 @@ export default function OrchestratorChat( {
 	const wasProcessingRef = useRef( isProcessing );
 	messagesRef.current = messages;
 
+	// Stop a request the moment the canvas it was made for goes away. The guard in
+	// `load-external-providers` would refuse the eventual write anyway, but only
+	// once the model got there — the user would sit and watch a request run against
+	// a page they have already left.
+	//
+	// Driven by the editor store rather than a host event: AM runs in the same
+	// realm as the editor, so `useSelect` is the whole signal. It lands a tick
+	// later than a synchronous listener would, which is why `blockCurrentRequest()`
+	// below is not optional — the guard is what actually stops the write.
+	useEffect( () => {
+		// Keyed off the live move rather than `getBlockingMove()`: a request already
+		// blocked would otherwise abort again on every later canvas change.
+		if ( ! isProcessing || ! getCanvasMove() ) {
+			return;
+		}
+
+		// Blocked as well as aborted: an abort that loses the race to an in-flight
+		// tool call must not let that call land on the new page.
+		blockCurrentRequest();
+		abortCurrentRequest();
+
+		// Say why, or the reply just stops mid-sentence and reads as a failure.
+		// UI-only: the message carries an id the agent's client history does not
+		// have, so `filterUiOnlyMessages` keeps it on screen and it is never sent
+		// back to the server as conversation history.
+		addMessage( {
+			id: `canvas-move-abort-${ generateUUID() }`,
+			role: 'agent',
+			content: [
+				{
+					type: 'text',
+					text: __(
+						'You switched pages, so I stopped that request before it changed the wrong one. Ask again to apply it here.',
+						__i18n_text_domain__
+					),
+				},
+			],
+			timestamp: Date.now(),
+			archived: false,
+			showIcon: true,
+		} );
+	}, [ canvasKey, isProcessing, abortCurrentRequest, addMessage ] );
+
 	// Drop all retained placeholders, keeping the map reference stable when
 	// already empty so no re-render is triggered.
 	const clearRetainedShowComponentMessages = useCallback( () => {
@@ -563,6 +624,11 @@ export default function OrchestratorChat( {
 				// rewound, so a leftover picker would otherwise reappear once
 				// regeneration settles if the new response omits the component.
 				clearRetainedShowComponentMessages();
+				// A regeneration is a fresh dispatch that rebinds via
+				// `getClientContext()` on its own outbound message, so it starts a
+				// new request for the binding too — carrying a previous request's
+				// block into it would refuse writes the new canvas is bound to.
+				startNewUserRequest();
 				try {
 					await handler();
 				} finally {
@@ -1214,6 +1280,13 @@ export default function OrchestratorChat( {
 				// unrelated draft in it).
 				setInputValue( ( currentValue ) => ( currentValue === message ? '' : currentValue ) );
 			}
+
+			// A new user message is a new intent: rebind to whatever canvas is open
+			// now, and lift any block left by a previous request. This sits on the
+			// dispatch path rather than in `submitChatMessage` — the composer calls
+			// this callback directly, and the sends above that bail out early must
+			// not disturb a binding that still belongs to a running request.
+			startNewUserRequest();
 
 			submitDispatchedRef.current = true;
 			try {

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -64,7 +64,7 @@ import { setProviderCheckpoints } from '../../utils/provider-checkpoints';
 import { getReaderChatErrorMessage } from '../../utils/reader-chat-error-message';
 import { isShowComponentTool } from '../../utils/show-component-tools';
 import { isBlockEditToolId } from '../../utils/tool-message-utils';
-import { recordBigSkyTracksEvent } from '../../utils/tracks';
+import { recordAgentsManagerTracksEvent, recordBigSkyTracksEvent } from '../../utils/tracks';
 import AgentChat from '../agent-chat';
 import { type Options as ChatHeaderOptions } from '../chat-header';
 import type { BigSkyMessage } from '../../types';
@@ -565,6 +565,10 @@ export default function OrchestratorChat( {
 		// tool call must not let that call land on the new page.
 		blockCurrentRequest();
 		abortCurrentRequest();
+
+		recordAgentsManagerTracksEvent( 'editor_canvas_move_request_aborted', {
+			agent_id: agentConfig?.agentId,
+		} );
 
 		// Say why, or the reply just stops mid-sentence and reads as a failure.
 		// UI-only: the message carries an id the agent's client history does not

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -42,6 +42,7 @@ import {
 	blockCurrentRequest,
 	buildCanvasKey,
 	getCanvasMove,
+	isCanvasWritingAgent,
 	startNewUserRequest,
 } from '../../utils/canvas-binding';
 import convertToolMessagesToComponents, {
@@ -556,7 +557,7 @@ export default function OrchestratorChat( {
 	useEffect( () => {
 		// Keyed off the live move rather than `getBlockingMove()`: a request already
 		// blocked would otherwise abort again on every later canvas change.
-		if ( ! isProcessing || ! getCanvasMove() ) {
+		if ( ! isCanvasWritingAgent( agentConfig?.agentId ) || ! isProcessing || ! getCanvasMove() ) {
 			return;
 		}
 
@@ -585,7 +586,7 @@ export default function OrchestratorChat( {
 			archived: false,
 			showIcon: true,
 		} );
-	}, [ canvasKey, isProcessing, abortCurrentRequest, addMessage ] );
+	}, [ agentConfig?.agentId, canvasKey, isProcessing, abortCurrentRequest, addMessage ] );
 
 	// Drop all retained placeholders, keeping the map reference stable when
 	// already empty so no re-render is triggered.

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -576,7 +576,7 @@ export default function OrchestratorChat( {
 				{
 					type: 'text',
 					text: __(
-						'You switched pages, so I stopped that request before it changed the wrong one. Ask again to apply it here.',
+						'You navigated away from that page, so I stopped the request before it changed the wrong one. Open the page you want and ask again.',
 						__i18n_text_domain__
 					),
 				},

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -1281,11 +1281,14 @@ export default function OrchestratorChat( {
 				setInputValue( ( currentValue ) => ( currentValue === message ? '' : currentValue ) );
 			}
 
-			// A new user message is a new intent: rebind to whatever canvas is open
-			// now, and lift any block left by a previous request. This sits on the
-			// dispatch path rather than in `submitChatMessage` — the composer calls
-			// this callback directly, and the sends above that bail out early must
-			// not disturb a binding that still belongs to a running request.
+			// A new user message is a new intent, so it starts unbound and unblocked:
+			// the previous turn's canvas must not judge this one (the effect above
+			// would abort it on sight if the user has navigated since), and any block
+			// that turn left behind must not refuse this one's writes.
+			//
+			// This sits on the dispatch path rather than in `submitChatMessage` — the
+			// composer calls this callback directly, and the sends above that bail out
+			// early must not disturb a binding that still belongs to a running request.
 			startNewUserRequest();
 
 			submitDispatchedRef.current = true;

--- a/packages/agents-manager/src/utils/__tests__/canvas-binding.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/canvas-binding.test.ts
@@ -3,6 +3,7 @@
  */
 import { select } from '@wordpress/data';
 import {
+	bindToNavigationTarget,
 	bindToOpenCanvas,
 	blockCurrentRequest,
 	buildCanvasKey,
@@ -159,6 +160,51 @@ describe( 'canvas binding', () => {
 		setOpenPost( { id: 34, type: 'page' } );
 
 		expect( getCanvasMove() ).toBeNull();
+	} );
+
+	it( 'puts the previous binding back when a navigation never happens', () => {
+		// A destination is an assertion about a move that has not run yet. If it
+		// never runs, rolling back to the page that was bound — not to whatever is
+		// live — is what keeps a user navigation during the failed attempt visible.
+		setOpenPost( { id: 12, type: 'page', title: 'About' } );
+		bindToOpenCanvas();
+
+		const rollback = bindToNavigationTarget( 'page:34' );
+		rollback();
+
+		setOpenPost( { id: 56, type: 'page', title: 'Pricing' } );
+
+		expect( getCanvasMove() ).toEqual( { from: 'About', to: 'Pricing' } );
+	} );
+
+	it( 'keeps the destination when the editor arrived before the rollback', () => {
+		// An ability can report failure after it has already moved the editor. The
+		// page on screen is then the one the request belongs to, not the one it left.
+		setOpenPost( { id: 12, type: 'page', title: 'About' } );
+		bindToOpenCanvas();
+
+		const rollback = bindToNavigationTarget( 'page:34' );
+		setOpenPost( { id: 34, type: 'page', title: 'Contact' } );
+		rollback();
+
+		expect( getCanvasMove() ).toBeNull();
+	} );
+
+	it( 'leaves a binding taken since the navigation alone', () => {
+		// The rollback must not undo whatever replaced the binding after it. Object
+		// identity cannot tell that on its own: the unbound state reads as null
+		// however it was reached.
+		setOpenPost( { id: 12, type: 'page', title: 'About' } );
+		bindToOpenCanvas();
+
+		const rollback = clearCanvasBinding();
+		setOpenPost( { id: 34, type: 'page', title: 'Contact' } );
+		bindToOpenCanvas();
+		rollback();
+
+		setOpenPost( { id: 56, type: 'page', title: 'Pricing' } );
+
+		expect( getCanvasMove() ).toEqual( { from: 'Contact', to: 'Pricing' } );
 	} );
 
 	it( 'latches the move that blocked the request', () => {

--- a/packages/agents-manager/src/utils/__tests__/canvas-binding.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/canvas-binding.test.ts
@@ -9,6 +9,7 @@ import {
 	clearCanvasBinding,
 	getBlockingMove,
 	getCanvasMove,
+	isCanvasWritingAgent,
 	resolveCanvasKey,
 	startNewUserRequest,
 } from '../canvas-binding';
@@ -41,6 +42,20 @@ describe( 'canvas binding', () => {
 		mockSelect.mockReset();
 		startNewUserRequest();
 	} );
+
+	it.each( [ 'wp-orchestrator', 'wpcom-workflow-unified_chat' ] )(
+		'treats %s as an agent that can write to the canvas',
+		( agentId ) => {
+			expect( isCanvasWritingAgent( agentId ) ).toBe( true );
+		}
+	);
+
+	it.each( [ 'reader-chat', 'wpcom-workflow-support_chat', 'dolly', undefined, '' ] )(
+		'treats %s as an agent that cannot',
+		( agentId ) => {
+			expect( isCanvasWritingAgent( agentId ) ).toBe( false );
+		}
+	);
 
 	it( 'builds a key from post type and id', () => {
 		expect( buildCanvasKey( 'page', 12 ) ).toBe( 'page:12' );

--- a/packages/agents-manager/src/utils/__tests__/canvas-binding.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/canvas-binding.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @jest-environment jsdom
+ */
+import { select } from '@wordpress/data';
+import {
+	bindToOpenCanvas,
+	blockCurrentRequest,
+	buildCanvasKey,
+	clearCanvasBinding,
+	getBlockingMove,
+	getCanvasMove,
+	resolveCanvasKey,
+	startNewUserRequest,
+} from '../canvas-binding';
+
+jest.mock( '@wordpress/data', () => ( { select: jest.fn() } ) );
+
+const mockSelect = select as jest.MockedFunction< typeof select >;
+
+/**
+ * Point the mocked `core/editor` store at a given post.
+ *
+ * @param post The post the editor is treated as having open, or null for no store.
+ */
+function setOpenPost( post: { id?: number | string; type?: string; title?: string } | null ) {
+	mockSelect.mockImplementation( ( storeName ) => {
+		if ( storeName !== 'core/editor' || ! post ) {
+			return undefined as never;
+		}
+		return {
+			getCurrentPostId: () => post.id,
+			getCurrentPostType: () => post.type,
+			getEditedPostAttribute: ( attribute: string ) =>
+				attribute === 'title' ? post.title : undefined,
+		} as never;
+	} );
+}
+
+describe( 'canvas binding', () => {
+	beforeEach( () => {
+		mockSelect.mockReset();
+		startNewUserRequest();
+	} );
+
+	it( 'builds a key from post type and id', () => {
+		expect( buildCanvasKey( 'page', 12 ) ).toBe( 'page:12' );
+	} );
+
+	it( 'has no key when the post type or id is missing', () => {
+		expect( buildCanvasKey( 'page', undefined ) ).toBeNull();
+		expect( buildCanvasKey( undefined, 12 ) ).toBeNull();
+	} );
+
+	it( 'resolves the key from the editor store', () => {
+		setOpenPost( { id: 12, type: 'page' } );
+
+		expect( resolveCanvasKey() ).toBe( 'page:12' );
+	} );
+
+	it( 'resolves no key when the editor store is absent', () => {
+		setOpenPost( null );
+
+		expect( resolveCanvasKey() ).toBeNull();
+	} );
+
+	it( 'resolves no key when the editor store throws', () => {
+		mockSelect.mockImplementation( () => {
+			throw new Error( 'Editor store unavailable' );
+		} );
+
+		expect( resolveCanvasKey() ).toBeNull();
+	} );
+
+	it( 'reports no move while the canvas has not changed', () => {
+		setOpenPost( { id: 12, type: 'page', title: 'About' } );
+		bindToOpenCanvas();
+
+		expect( getCanvasMove() ).toBeNull();
+	} );
+
+	it( 'reports a move once the canvas changes, naming both pages', () => {
+		setOpenPost( { id: 12, type: 'page', title: 'About' } );
+		bindToOpenCanvas();
+
+		setOpenPost( { id: 34, type: 'page', title: 'Contact' } );
+
+		expect( getCanvasMove() ).toEqual( { from: 'About', to: 'Contact' } );
+	} );
+
+	it( 'falls back to the key when a page has no title', () => {
+		setOpenPost( { id: 12, type: 'page' } );
+		bindToOpenCanvas();
+
+		setOpenPost( { id: 34, type: 'page' } );
+
+		expect( getCanvasMove() ).toEqual( { from: 'page:12', to: 'page:34' } );
+	} );
+
+	it( 'treats a post and a template sharing an id as different canvases', () => {
+		// The reason the key carries the post type: ids are only unique within one.
+		setOpenPost( { id: 12, type: 'page' } );
+		bindToOpenCanvas();
+
+		setOpenPost( { id: 12, type: 'wp_template' } );
+
+		expect( getCanvasMove() ).toEqual( { from: 'page:12', to: 'wp_template:12' } );
+	} );
+
+	it( 'reports no move when nothing was bound', () => {
+		setOpenPost( { id: 34, type: 'page' } );
+
+		expect( getCanvasMove() ).toBeNull();
+	} );
+
+	it( 'reports no move when the live canvas is unreadable', () => {
+		// A store that has not settled is not a wrong canvas. Refusing here would
+		// block legitimate writes for the width of a mount.
+		setOpenPost( { id: 12, type: 'page' } );
+		bindToOpenCanvas();
+
+		setOpenPost( null );
+
+		expect( getCanvasMove() ).toBeNull();
+	} );
+
+	it( 'drops the binding when the agent moves the canvas itself', () => {
+		setOpenPost( { id: 12, type: 'page' } );
+		bindToOpenCanvas();
+		clearCanvasBinding();
+
+		setOpenPost( { id: 34, type: 'page' } );
+
+		expect( getCanvasMove() ).toBeNull();
+	} );
+
+	it( 'latches the move that blocked the request', () => {
+		setOpenPost( { id: 12, type: 'page', title: 'About' } );
+		bindToOpenCanvas();
+		setOpenPost( { id: 34, type: 'page', title: 'Contact' } );
+
+		expect( blockCurrentRequest() ).toBe( true );
+
+		// Rebinding to the page the user moved to must not clear the block, or the
+		// model could retry the refused write onto the new page.
+		bindToOpenCanvas();
+
+		expect( getCanvasMove() ).toBeNull();
+		expect( getBlockingMove() ).toEqual( { from: 'About', to: 'Contact' } );
+	} );
+
+	it( 'keeps the first move when blocked again', () => {
+		setOpenPost( { id: 12, type: 'page', title: 'About' } );
+		bindToOpenCanvas();
+		setOpenPost( { id: 34, type: 'page', title: 'Contact' } );
+		blockCurrentRequest();
+
+		bindToOpenCanvas();
+		setOpenPost( { id: 56, type: 'page', title: 'Pricing' } );
+
+		expect( blockCurrentRequest() ).toBe( true );
+		expect( getBlockingMove() ).toEqual( { from: 'About', to: 'Contact' } );
+	} );
+
+	it( 'cannot block without a real move', () => {
+		setOpenPost( { id: 12, type: 'page' } );
+		bindToOpenCanvas();
+
+		expect( blockCurrentRequest() ).toBe( false );
+		expect( getBlockingMove() ).toBeNull();
+	} );
+
+	it( 'lifts the block for a new user message', () => {
+		setOpenPost( { id: 12, type: 'page', title: 'About' } );
+		bindToOpenCanvas();
+		setOpenPost( { id: 34, type: 'page', title: 'Contact' } );
+		blockCurrentRequest();
+
+		startNewUserRequest();
+
+		expect( getBlockingMove() ).toBeNull();
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/canvas-binding.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/canvas-binding.test.ts
@@ -112,11 +112,24 @@ describe( 'canvas binding', () => {
 		expect( getCanvasMove() ).toBeNull();
 	} );
 
-	it( 'reports no move when the live canvas is unreadable', () => {
-		// A store that has not settled is not a wrong canvas. Refusing here would
-		// block legitimate writes for the width of a mount.
+	it( 'reports a move to nowhere when the canvas goes away', () => {
+		// Losing the canvas is a move, not a wait. A bound request was made while the
+		// editor was mounted, so an absent canvas means the user left — and the write
+		// abilities poll for a canvas, so letting this through loops forever.
+		setOpenPost( { id: 12, type: 'page', title: 'About' } );
+		bindToOpenCanvas();
+
+		setOpenPost( null );
+
+		expect( getCanvasMove() ).toEqual( { from: 'About', to: null } );
+	} );
+
+	it( 'reports no move for a mounting canvas when nothing is bound', () => {
+		// The agent navigating itself clears the binding first, so the mount that
+		// follows is unguarded and the write abilities do their own readiness retry.
 		setOpenPost( { id: 12, type: 'page' } );
 		bindToOpenCanvas();
+		clearCanvasBinding();
 
 		setOpenPost( null );
 

--- a/packages/agents-manager/src/utils/__tests__/canvas-guard.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/canvas-guard.test.ts
@@ -1,0 +1,217 @@
+/**
+ * @jest-environment jsdom
+ */
+import { select } from '@wordpress/data';
+import {
+	bindToOpenCanvas,
+	getBlockingMove,
+	getCanvasMove,
+	startNewUserRequest,
+} from '../canvas-binding';
+import { withCanvasBinding, withCanvasGuard } from '../canvas-guard';
+import type { ToolProvider } from '../../types';
+
+jest.mock( '@wordpress/data', () => ( { select: jest.fn() } ) );
+
+const mockSelect = select as jest.MockedFunction< typeof select >;
+
+/**
+ * Point the mocked `core/editor` store at a given post.
+ *
+ * @param post The post the editor is treated as having open, or null for no store.
+ */
+function setOpenPost( post: { id?: number | string; type?: string; title?: string } | null ) {
+	mockSelect.mockImplementation( ( storeName ) => {
+		if ( storeName !== 'core/editor' || ! post ) {
+			return undefined as never;
+		}
+		return {
+			getCurrentPostId: () => post.id,
+			getCurrentPostType: () => post.type,
+			getEditedPostAttribute: ( attribute: string ) =>
+				attribute === 'title' ? post.title : undefined,
+		} as never;
+	} );
+}
+
+function createToolProvider( executeAbility = jest.fn() ): ToolProvider {
+	return {
+		getAbilities: jest.fn( () => Promise.resolve( [] ) ),
+		executeAbility,
+	} as unknown as ToolProvider;
+}
+
+const ABOUT_PAGE = { id: 12, type: 'page', title: 'About' };
+const CONTACT_PAGE = { id: 34, type: 'page', title: 'Contact' };
+
+describe( 'withCanvasGuard', () => {
+	beforeEach( () => {
+		mockSelect.mockReset();
+		startNewUserRequest();
+	} );
+
+	it( 'refuses a canvas write once the canvas has moved', async () => {
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+		setOpenPost( CONTACT_PAGE );
+
+		const executeAbility = jest.fn();
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		const result = await guarded!.executeAbility( 'big_sky__apply_block_edits', {} );
+
+		expect( executeAbility ).not.toHaveBeenCalled();
+		expect( result ).toMatchObject( {
+			returnToAgent: true,
+			result: { success: false, error: 'editor_canvas_moved' },
+		} );
+		// Both pages named, so the model can tell the user what happened without
+		// another round trip.
+		expect( result.result.message ).toContain( 'About' );
+		expect( result.result.message ).toContain( 'Contact' );
+	} );
+
+	it( 'matches the registered ability name as well as the agent-normalized one', async () => {
+		// The agent invokes `big-sky/stream-page-design` as
+		// `big_sky__stream_page_design`; matching only one form leaves the guard
+		// inert for the other.
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+		setOpenPost( CONTACT_PAGE );
+
+		const executeAbility = jest.fn();
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		await guarded!.executeAbility( 'big-sky/stream-page-design', {} );
+
+		expect( executeAbility ).not.toHaveBeenCalled();
+	} );
+
+	it( 'guards restore-checkpoint too', async () => {
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+		setOpenPost( CONTACT_PAGE );
+
+		const executeAbility = jest.fn();
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		await guarded!.executeAbility( 'big_sky__restore_checkpoint', {} );
+
+		expect( executeAbility ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps refusing for the rest of the request once blocked', async () => {
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+		setOpenPost( CONTACT_PAGE );
+
+		const executeAbility = jest.fn();
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		await guarded!.executeAbility( 'big_sky__apply_block_edits', {} );
+		// The refused call's continuation rebinds to the page now open, so the live
+		// reading agrees again — but the request stays refused.
+		bindToOpenCanvas();
+		const result = await guarded!.executeAbility( 'big_sky__apply_block_edits', {} );
+
+		expect( executeAbility ).not.toHaveBeenCalled();
+		expect( result.result.message ).toContain( 'About' );
+	} );
+
+	it( 'lets a canvas write through while the canvas has not moved', async () => {
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+
+		const executeAbility = jest.fn().mockResolvedValue( { ok: true } );
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		await expect(
+			guarded!.executeAbility( 'big_sky__apply_block_edits', { edits: [] } )
+		).resolves.toEqual( { ok: true } );
+		expect( executeAbility ).toHaveBeenCalledWith( 'big_sky__apply_block_edits', { edits: [] } );
+	} );
+
+	it( 'lets an unguarded ability through even when the canvas has moved', async () => {
+		// `edit-entity-record` names its own target (`entityType`/`recordId`, often
+		// site-level like `root`/`site` or `wp_navigation`), so moving the canvas
+		// cannot redirect its write. Guarding it would refuse legitimate site-level
+		// edits.
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+		setOpenPost( CONTACT_PAGE );
+
+		const executeAbility = jest.fn().mockResolvedValue( { ok: true } );
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		await guarded!.executeAbility( 'big_sky__edit_entity_record', {} );
+
+		expect( executeAbility ).toHaveBeenCalled();
+	} );
+
+	it( 'drops the binding before an ability whose job is to move the canvas', async () => {
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+
+		const executeAbility = jest.fn().mockImplementation( async () => {
+			setOpenPost( CONTACT_PAGE );
+			return { ok: true };
+		} );
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		await guarded!.executeAbility( 'big_sky__editor_navigate', {} );
+
+		// The agent's own navigation must not read as a move on the next write.
+		expect( getCanvasMove() ).toBeNull();
+	} );
+
+	it( 'is a no-op without a tool provider', () => {
+		expect( withCanvasGuard( undefined ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'withCanvasBinding', () => {
+	beforeEach( () => {
+		mockSelect.mockReset();
+		startNewUserRequest();
+	} );
+
+	it( 'binds to the open canvas on every outgoing message', () => {
+		setOpenPost( ABOUT_PAGE );
+		const getClientContext = jest.fn().mockReturnValue( { url: 'https://example.com' } );
+
+		const wrapped = withCanvasBinding( { getClientContext } );
+		wrapped!.getClientContext();
+
+		expect( getCanvasMove() ).toBeNull();
+
+		setOpenPost( CONTACT_PAGE );
+
+		expect( getCanvasMove() ).toEqual( { from: 'About', to: 'Contact' } );
+	} );
+
+	it( 'passes the context through untouched', () => {
+		// Nothing is added to the wire: the binding is read from the editor store
+		// here, not carried in the client context.
+		setOpenPost( ABOUT_PAGE );
+		const context = { url: 'https://example.com', currentPageContent: [] };
+		const wrapped = withCanvasBinding( { getClientContext: () => context } );
+
+		expect( wrapped!.getClientContext() ).toBe( context );
+	} );
+
+	it( 'rebinds on each call, so a later message follows the user', () => {
+		setOpenPost( ABOUT_PAGE );
+		const wrapped = withCanvasBinding( { getClientContext: () => ( {} ) } );
+		wrapped!.getClientContext();
+
+		setOpenPost( CONTACT_PAGE );
+		wrapped!.getClientContext();
+
+		expect( getCanvasMove() ).toBeNull();
+		expect( getBlockingMove() ).toBeNull();
+	} );
+
+	it( 'is a no-op without a context provider', () => {
+		expect( withCanvasBinding( undefined ) ).toBeUndefined();
+	} );
+} );

--- a/packages/agents-manager/src/utils/__tests__/canvas-guard.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/canvas-guard.test.ts
@@ -210,6 +210,65 @@ describe( 'withCanvasGuard', () => {
 		expect( getCanvasMove() ).toBeNull();
 	} );
 
+	it( 'holds the destination while the navigation is still in flight', async () => {
+		// The gap a bare `clearCanvasBinding()` leaves. agenttic-client re-requests
+		// client context when it sends a tool result, so the navigate result rebinds
+		// before the editor has opened the page — and a page the server only just
+		// created is never in the store yet, so the editor still reports the old one.
+		// Binding to the destination up front is what stops that rebind latching the
+		// page the user is leaving and aborting the agent's own navigation.
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+
+		const executeAbility = jest.fn().mockResolvedValue( { ok: true } );
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		// `add-page` created page 34 server-side and asked the client to open it.
+		await guarded!.executeAbility( 'big_sky__editor_navigate', { path: '/page/34' } );
+
+		// The tool result goes out while the editor is still showing About.
+		bindToOpenCanvas();
+
+		// The editor arrives at the new page.
+		setOpenPost( CONTACT_PAGE );
+
+		expect( getCanvasMove() ).toBeNull();
+	} );
+
+	it( 'catches the user leaving once the navigation has landed', async () => {
+		// The binding must not stay pinned to the destination forever: once the
+		// editor arrives, an ordinary user navigation is a move again.
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+
+		const executeAbility = jest.fn().mockResolvedValue( { ok: true } );
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		await guarded!.executeAbility( 'big_sky__editor_navigate', { path: '/page/34' } );
+		setOpenPost( CONTACT_PAGE );
+		bindToOpenCanvas();
+
+		setOpenPost( ABOUT_PAGE );
+
+		expect( getCanvasMove() ).toEqual( { from: 'Contact', to: 'About' } );
+	} );
+
+	it( 'falls back to dropping the binding when the destination cannot be read', async () => {
+		// `wp-admin/navigate` takes a wp-admin path, not a canvas, and a malformed
+		// editor path names no page either. Unbound is the safe answer: it cannot
+		// pin the request to a page it guessed wrong.
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+
+		const executeAbility = jest.fn().mockResolvedValue( { ok: true } );
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		await guarded!.executeAbility( 'wp_admin__navigate', { path: '/wp-admin/plugins.php' } );
+		setOpenPost( CONTACT_PAGE );
+
+		expect( getCanvasMove() ).toBeNull();
+	} );
+
 	it( 'is a no-op without a tool provider', () => {
 		expect( withCanvasGuard( undefined ) ).toBeUndefined();
 	} );

--- a/packages/agents-manager/src/utils/__tests__/canvas-guard.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/canvas-guard.test.ts
@@ -252,6 +252,95 @@ describe( 'withCanvasGuard', () => {
 		expect( getCanvasMove() ).toEqual( { from: 'Contact', to: 'About' } );
 	} );
 
+	it( 'puts the binding back when a navigation reports failure', async () => {
+		// `editor-navigate` can answer `{ success: false }` without ever moving — a
+		// save conflict, a stale page id, a network error. A destination left bound
+		// for a trip that never started suppresses every move reading until the
+		// editor reaches a page it is not going to reach.
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+
+		const executeAbility = jest
+			.fn()
+			.mockResolvedValue( { result: { success: false, message: 'Could not open that page.' } } );
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		await guarded!.executeAbility( 'big_sky__editor_navigate', { path: '/page/34' } );
+
+		// The editor never left About, and then the user does.
+		setOpenPost( CONTACT_PAGE );
+
+		expect( getCanvasMove() ).toEqual( { from: 'About', to: 'Contact' } );
+	} );
+
+	it( 'puts the binding back when a navigation throws', async () => {
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+
+		const executeAbility = jest.fn().mockRejectedValue( new Error( 'Network error' ) );
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		// The failure still reaches the caller: the guard restores the binding, it
+		// does not swallow the error.
+		await expect(
+			guarded!.executeAbility( 'big_sky__editor_navigate', { path: '/page/34' } )
+		).rejects.toThrow( 'Network error' );
+
+		setOpenPost( CONTACT_PAGE );
+
+		expect( getCanvasMove() ).toEqual( { from: 'About', to: 'Contact' } );
+	} );
+
+	it( 'keeps guarding later writes in a turn whose navigation failed', async () => {
+		// What the stuck destination cost: the write that follows a failed
+		// navigation is the one that lands on the page the user moved to.
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+
+		const executeAbility = jest.fn().mockResolvedValue( { result: { success: false } } );
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		await guarded!.executeAbility( 'big_sky__editor_navigate', { path: '/page/34' } );
+		setOpenPost( CONTACT_PAGE );
+		const result = await guarded!.executeAbility( 'big_sky__apply_block_edits', {} );
+
+		expect( executeAbility ).toHaveBeenCalledTimes( 1 );
+		expect( result.result.error ).toBe( 'editor_canvas_moved' );
+	} );
+
+	it( 'keeps the destination when a navigation reports failure after landing', async () => {
+		// The editor got there. A failure reported on the way out does not make the
+		// page now on screen the wrong one to write to.
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+
+		const executeAbility = jest.fn().mockImplementation( async () => {
+			setOpenPost( CONTACT_PAGE );
+			return { result: { success: false } };
+		} );
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		await guarded!.executeAbility( 'big_sky__editor_navigate', { path: '/page/34' } );
+
+		expect( getCanvasMove() ).toBeNull();
+	} );
+
+	it( 'puts the binding back when a navigation with no readable destination fails', async () => {
+		// The other branch: `wp-admin/navigate` names no canvas, so the binding is
+		// dropped rather than moved — but a navigation that never happened has to
+		// leave the guard exactly where it found it either way.
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+
+		const executeAbility = jest.fn().mockResolvedValue( { result: { success: false } } );
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		await guarded!.executeAbility( 'wp_admin__navigate', { path: '/wp-admin/plugins.php' } );
+		setOpenPost( CONTACT_PAGE );
+
+		expect( getCanvasMove() ).toEqual( { from: 'About', to: 'Contact' } );
+	} );
+
 	it( 'falls back to dropping the binding when the destination cannot be read', async () => {
 		// `wp-admin/navigate` takes a wp-admin path, not a canvas, and a malformed
 		// editor path names no page either. Unbound is the safe answer: it cannot
@@ -350,6 +439,37 @@ describe( 'withCanvasGuard, dispatched through ability callbacks', () => {
 			returnToAgent: true,
 			result: { success: false, error: 'editor_canvas_moved' },
 		} );
+	} );
+
+	it( 'keeps guarding after a navigation callback reports failure', async () => {
+		// The same stuck destination on the dispatch that production uses. Big Sky
+		// registers `editor-navigate` with a callback, so this is the path a failed
+		// navigation actually takes.
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+
+		const failure = {
+			result: { success: false, message: 'Could not open that page.' },
+			returnToAgent: true,
+		};
+		const callback = jest.fn().mockResolvedValue( failure );
+		const guarded = withCanvasGuard( createCallbackProvider( callback ) );
+
+		const navigation = await callAbility( guarded!, 'big-sky/editor-navigate', {
+			path: '/page/34',
+		} );
+
+		// The tool result goes out while the editor is still on the page it never
+		// left, and the user moves off it.
+		bindToOpenCanvas();
+		setOpenPost( CONTACT_PAGE );
+
+		const design = await callAbility( guarded!, 'big-sky/stream-page-design', {} );
+
+		// The ability's own answer is handed back untouched.
+		expect( navigation ).toBe( failure );
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+		expect( design ).toMatchObject( { result: { success: false, error: 'editor_canvas_moved' } } );
 	} );
 
 	it( 'leaves an ability without a callback untouched', async () => {

--- a/packages/agents-manager/src/utils/__tests__/canvas-guard.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/canvas-guard.test.ts
@@ -97,6 +97,42 @@ describe( 'withCanvasGuard', () => {
 		expect( executeAbility ).not.toHaveBeenCalled();
 	} );
 
+	it( 'refuses a canvas write when the editor has no page open at all', async () => {
+		// The looping case: page-design polls for a canvas to appear, so letting this
+		// through leaves the agent retrying against a page that is never coming back.
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+		setOpenPost( null );
+
+		const executeAbility = jest.fn();
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		const result = await guarded!.executeAbility( 'big_sky__stream_page_design', {} );
+
+		expect( executeAbility ).not.toHaveBeenCalled();
+		expect( result.result.error ).toBe( 'editor_canvas_closed' );
+		expect( result.result.message ).toContain( 'About' );
+		// The model is told not to route around the refusal, which is what keeps a
+		// doomed request from being kept alive by a different tool.
+		expect( result.result.message ).toContain( 'another way' );
+	} );
+
+	it( 'still allows a write while the canvas mounts after the agent navigates', async () => {
+		// `editor-navigate` clears the binding, so the mount that follows is
+		// unguarded and the ability's own readiness retry does its job.
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+
+		const executeAbility = jest.fn().mockResolvedValue( { ok: true } );
+		const guarded = withCanvasGuard( createToolProvider( executeAbility ) );
+
+		await guarded!.executeAbility( 'big_sky__editor_navigate', {} );
+		setOpenPost( null );
+		await guarded!.executeAbility( 'big_sky__stream_page_design', {} );
+
+		expect( executeAbility ).toHaveBeenCalledWith( 'big_sky__stream_page_design', {} );
+	} );
+
 	it( 'guards restore-checkpoint too', async () => {
 		setOpenPost( ABOUT_PAGE );
 		bindToOpenCanvas();

--- a/packages/agents-manager/src/utils/__tests__/canvas-guard.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/canvas-guard.test.ts
@@ -17,7 +17,6 @@ const mockSelect = select as jest.MockedFunction< typeof select >;
 
 /**
  * Point the mocked `core/editor` store at a given post.
- *
  * @param post The post the editor is treated as having open, or null for no store.
  */
 function setOpenPost( post: { id?: number | string; type?: string; title?: string } | null ) {
@@ -271,6 +270,99 @@ describe( 'withCanvasGuard', () => {
 
 	it( 'is a no-op without a tool provider', () => {
 		expect( withCanvasGuard( undefined ) ).toBeUndefined();
+	} );
+} );
+
+// The path production actually takes. agenttic-client resolves an ability from
+// `getAbilities()` and calls `ability.callback` directly whenever it has one,
+// falling back to `executeAbility` only when it does not — and every Big Sky
+// ability is registered with a callback. A guard installed on `executeAbility`
+// alone never runs against them, which is invisible to any test that calls
+// `executeAbility` itself.
+describe( 'withCanvasGuard, dispatched through ability callbacks', () => {
+	/**
+	 * Fetch a guarded ability the way agenttic-client does, then invoke it.
+	 * @param provider The guarded provider.
+	 * @param name     The registered ability name.
+	 * @param input    The arguments, as agenttic-client passes them inline.
+	 * @returns Whatever the callback answers.
+	 */
+	async function callAbility( provider: ToolProvider, name: string, input: unknown ) {
+		const abilities = await provider.getAbilities();
+		const ability = abilities.find( ( candidate ) => candidate.name === name );
+
+		return ability!.callback!( input as never );
+	}
+
+	function createCallbackProvider( callback: jest.Mock ): ToolProvider {
+		return {
+			getAbilities: jest.fn( () =>
+				Promise.resolve( [
+					{ name: 'big-sky/editor-navigate', callback },
+					{ name: 'big-sky/stream-page-design', callback },
+				] )
+			),
+			executeAbility: jest.fn(),
+		} as unknown as ToolProvider;
+	}
+
+	beforeEach( () => {
+		mockSelect.mockReset();
+		startNewUserRequest();
+	} );
+
+	it( 'follows the agent to the page it navigates to', async () => {
+		// The reported failure. `add-page` creates the page server-side and hands
+		// the client an `editor-navigate` call, which arrives as a callback — so
+		// this is the dispatch that has to move the binding.
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+
+		const callback = jest.fn().mockResolvedValue( { result: { success: true }, ok: true } );
+		const guarded = withCanvasGuard( createCallbackProvider( callback ) );
+
+		await callAbility( guarded!, 'big-sky/editor-navigate', { path: '/page/34' } );
+
+		// The navigate result rebinds before the editor has opened the new page.
+		bindToOpenCanvas();
+		setOpenPost( CONTACT_PAGE );
+
+		expect( callback ).toHaveBeenCalled();
+		expect( getCanvasMove() ).toBeNull();
+	} );
+
+	it( 'refuses a canvas write whose page has moved', async () => {
+		// The other half the callback path was skipping: with the guard only on
+		// `executeAbility`, a stale write was never actually refused.
+		setOpenPost( ABOUT_PAGE );
+		bindToOpenCanvas();
+		setOpenPost( CONTACT_PAGE );
+
+		const callback = jest.fn();
+		const guarded = withCanvasGuard( createCallbackProvider( callback ) );
+
+		const result = await callAbility( guarded!, 'big-sky/stream-page-design', {} );
+
+		expect( callback ).not.toHaveBeenCalled();
+		// The same envelope the guarded abilities return from their own callbacks,
+		// so agenttic-client reads `returnToAgent` off it unchanged.
+		expect( result ).toMatchObject( {
+			returnToAgent: true,
+			result: { success: false, error: 'editor_canvas_moved' },
+		} );
+	} );
+
+	it( 'leaves an ability without a callback untouched', async () => {
+		// Nothing to wrap, and wrapping it would invent a callback that makes
+		// agenttic-client stop falling back to `executeAbility` for it.
+		const provider = {
+			getAbilities: jest.fn( () => Promise.resolve( [ { name: 'big-sky/editor-navigate' } ] ) ),
+			executeAbility: jest.fn(),
+		} as unknown as ToolProvider;
+
+		const abilities = await withCanvasGuard( provider )!.getAbilities();
+
+		expect( abilities[ 0 ].callback ).toBeUndefined();
 	} );
 } );
 

--- a/packages/agents-manager/src/utils/__tests__/canvas-guard.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/canvas-guard.test.ts
@@ -9,7 +9,7 @@ import {
 	startNewUserRequest,
 } from '../canvas-binding';
 import { withCanvasBinding, withCanvasGuard } from '../canvas-guard';
-import type { ToolProvider } from '../../types';
+import type { ClientContextType, ToolProvider } from '../../types';
 
 jest.mock( '@wordpress/data', () => ( { select: jest.fn() } ) );
 
@@ -39,6 +39,16 @@ function createToolProvider( executeAbility = jest.fn() ): ToolProvider {
 		getAbilities: jest.fn( () => Promise.resolve( [] ) ),
 		executeAbility,
 	} as unknown as ToolProvider;
+}
+
+function createClientContext( overrides: Partial< ClientContextType > = {} ): ClientContextType {
+	return {
+		url: 'https://example.com/wp-admin/site-editor.php',
+		pathname: '/wp-admin/site-editor.php',
+		search: '',
+		environment: 'wp-admin',
+		...overrides,
+	};
 }
 
 const ABOUT_PAGE = { id: 12, type: 'page', title: 'About' };
@@ -177,7 +187,7 @@ describe( 'withCanvasBinding', () => {
 
 	it( 'binds to the open canvas on every outgoing message', () => {
 		setOpenPost( ABOUT_PAGE );
-		const getClientContext = jest.fn().mockReturnValue( { url: 'https://example.com' } );
+		const getClientContext = jest.fn().mockReturnValue( createClientContext() );
 
 		const wrapped = withCanvasBinding( { getClientContext } );
 		wrapped!.getClientContext();
@@ -193,7 +203,7 @@ describe( 'withCanvasBinding', () => {
 		// Nothing is added to the wire: the binding is read from the editor store
 		// here, not carried in the client context.
 		setOpenPost( ABOUT_PAGE );
-		const context = { url: 'https://example.com', currentPageContent: [] };
+		const context = createClientContext( { currentPageContent: [] } );
 		const wrapped = withCanvasBinding( { getClientContext: () => context } );
 
 		expect( wrapped!.getClientContext() ).toBe( context );
@@ -201,7 +211,7 @@ describe( 'withCanvasBinding', () => {
 
 	it( 'rebinds on each call, so a later message follows the user', () => {
 		setOpenPost( ABOUT_PAGE );
-		const wrapped = withCanvasBinding( { getClientContext: () => ( {} ) } );
+		const wrapped = withCanvasBinding( { getClientContext: () => createClientContext() } );
 		wrapped!.getClientContext();
 
 		setOpenPost( CONTACT_PAGE );

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -972,15 +972,22 @@ describe( 'canvas guard wiring', () => {
 	} );
 
 	it( 'binds to the open canvas when the client context is built', async () => {
+		const providerContext = {
+			url: 'https://x',
+			pathname: '/x',
+			search: '',
+			environment: 'wp-admin',
+		};
 		setAgentsManagerData( {
-			agentProviders: [ { contextProvider: { getClientContext: () => ( { url: 'https://x' } ) } } ],
+			agentProviders: [ { contextProvider: { getClientContext: () => providerContext } } ],
 		} );
 
 		const providers = await loadExternalProviders();
 		const context = providers.contextProvider?.getClientContext();
 
 		expect( mockedBinding.bindToOpenCanvas ).toHaveBeenCalled();
-		// Nothing is added to the wire — the canvas is read from the editor store.
-		expect( context ).not.toHaveProperty( 'editorTarget' );
+		// The binding adds nothing to the wire: it reads the canvas from the editor
+		// store, so what the server receives is exactly what the provider built.
+		expect( context ).toEqual( providerContext );
 	} );
 } );

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -4,6 +4,7 @@
 import { amToolProvider } from '../../abilities';
 import { restoreCheckpointAbility } from '../../abilities/restore-checkpoint';
 import { showComponentAbility } from '../../abilities/show-component';
+import * as canvasBinding from '../canvas-binding';
 import { getAvailableCheckpoints } from '../checkpoints';
 import {
 	loadExternalProviders,
@@ -25,6 +26,11 @@ import type { UIMessage } from '@automattic/agenttic-client';
 jest.mock( '@automattic/agenttic-client', () => ( { getAgentManager: jest.fn() } ), {
 	virtual: true,
 } );
+jest.mock( '../canvas-binding', () => ( {
+	...jest.requireActual( '../canvas-binding' ),
+	bindToOpenCanvas: jest.fn(),
+	getBlockingMove: jest.fn( () => null ),
+} ) );
 jest.mock( '../provider-checkpoints', () => ( {
 	...jest.requireActual( '../provider-checkpoints' ),
 	getProviderCheckpointRecords: jest.fn( () => [] ),
@@ -922,5 +928,59 @@ describe( 'mergeUseSuggestionsHooks', () => {
 			suggestions: [ { id: 'second', label: 'Second', prompt: 'Second prompt.' } ],
 			replaceEmptyViewSuggestions: true,
 		} );
+	} );
+} );
+
+describe( 'canvas guard wiring', () => {
+	// Drives the binding directly rather than through a mocked editor store: what
+	// is under test here is that the wrappers are actually applied to the providers
+	// `loadExternalProviders` hands back, not the state machine itself (covered in
+	// `canvas-binding.test.ts`).
+	const mockedBinding = jest.mocked( canvasBinding );
+
+	beforeEach( () => {
+		mockedBinding.getBlockingMove.mockReturnValue( null );
+		mockedBinding.bindToOpenCanvas.mockClear();
+	} );
+
+	// Both provider counts, because the loader assigns the merged tool provider on
+	// two separate paths and only one of them runs for a given surface. A guard
+	// applied on the multi-provider path alone would be inert wherever a single
+	// provider is registered — which is most editor surfaces.
+	it.each( [ 1, 2 ] )( 'refuses a moved canvas write with %i tool provider(s)', async ( count ) => {
+		mockedBinding.getBlockingMove.mockReturnValue( { from: 'About', to: 'Contact' } );
+		const executeAbility = jest.fn();
+		setAgentsManagerData( {
+			agentProviders: Array.from( { length: count }, ( _unused, index ) => ( {
+				toolProvider: {
+					getAbilities: jest.fn( () =>
+						Promise.resolve( [ createAbility( `big-sky/apply-block-edits-${ index }` ) ] )
+					),
+					executeAbility,
+				},
+			} ) ),
+		} );
+
+		const providers = await loadExternalProviders();
+		const result = await providers.toolProvider?.executeAbility( 'big_sky__apply_block_edits', {} );
+
+		expect( executeAbility ).not.toHaveBeenCalled();
+		expect( result ).toMatchObject( {
+			returnToAgent: true,
+			result: { success: false, error: 'editor_canvas_moved' },
+		} );
+	} );
+
+	it( 'binds to the open canvas when the client context is built', async () => {
+		setAgentsManagerData( {
+			agentProviders: [ { contextProvider: { getClientContext: () => ( { url: 'https://x' } ) } } ],
+		} );
+
+		const providers = await loadExternalProviders();
+		const context = providers.contextProvider?.getClientContext();
+
+		expect( mockedBinding.bindToOpenCanvas ).toHaveBeenCalled();
+		// Nothing is added to the wire — the canvas is read from the editor store.
+		expect( context ).not.toHaveProperty( 'editorTarget' );
 	} );
 } );

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -68,6 +68,19 @@ function createAbility( name: string ): Ability {
 	};
 }
 
+/**
+ * An ability list compared without pinning callback identity.
+ *
+ * The canvas guard wraps the callback of every ability it polices, which is
+ * orthogonal to what these tests are about — merging, dedupe, ordering and
+ * resilience. Everything else still compares deeply.
+ * @param abilities The abilities to normalize.
+ * @returns The abilities without their callbacks.
+ */
+function abilityShapes( abilities: Ability[] = [] ) {
+	return abilities.map( ( { callback, ...rest } ) => rest );
+}
+
 function createCheckpointReturn(
 	overrides: Partial< UseCheckpointReturn > = {}
 ): UseCheckpointReturn {
@@ -199,12 +212,14 @@ describe( 'loadExternalProviders', () => {
 
 		const providers = await loadExternalProviders();
 
-		await expect( providers.toolProvider?.getAbilities() ).resolves.toEqual( [
-			restoreCheckpointAbility,
-			showComponentAbility,
-			createAbility( 'host/navigate' ),
-			createAbility( 'woocommerce/get-products' ),
-		] );
+		expect( abilityShapes( await providers.toolProvider?.getAbilities() ) ).toEqual(
+			abilityShapes( [
+				restoreCheckpointAbility,
+				showComponentAbility,
+				createAbility( 'host/navigate' ),
+				createAbility( 'woocommerce/get-products' ),
+			] )
+		);
 		await expect(
 			providers.toolProvider?.executeAbility( 'woocommerce__get_products', { limit: 5 } )
 		).resolves.toEqual( { handledBy: 'woo' } );
@@ -229,11 +244,13 @@ describe( 'loadExternalProviders', () => {
 
 		const providers = await loadExternalProviders();
 
-		await expect( providers.toolProvider?.getAbilities() ).resolves.toEqual( [
-			restoreCheckpointAbility,
-			showComponentAbility,
-			createAbility( 'shared/action' ),
-		] );
+		expect( abilityShapes( await providers.toolProvider?.getAbilities() ) ).toEqual(
+			abilityShapes( [
+				restoreCheckpointAbility,
+				showComponentAbility,
+				createAbility( 'shared/action' ),
+			] )
+		);
 		await expect( providers.toolProvider?.executeAbility( 'shared/action', {} ) ).resolves.toEqual(
 			{
 				handledBy: 'first',
@@ -313,11 +330,13 @@ describe( 'loadExternalProviders', () => {
 
 		const providers = await loadExternalProviders();
 
-		await expect( providers.toolProvider?.getAbilities() ).resolves.toEqual( [
-			restoreCheckpointAbility,
-			showComponentAbility,
-			createAbility( 'host/navigate' ),
-		] );
+		expect( abilityShapes( await providers.toolProvider?.getAbilities() ) ).toEqual(
+			abilityShapes( [
+				restoreCheckpointAbility,
+				showComponentAbility,
+				createAbility( 'host/navigate' ),
+			] )
+		);
 		expect( consoleWarn ).toHaveBeenCalledWith(
 			'[AgentsManager] Failed to load abilities from provider:',
 			expect.any( Error )
@@ -784,12 +803,14 @@ describe( 'loadExternalProviders', () => {
 		const providers = await loadExternalProviders();
 		editorAbilityRegistered = true;
 
-		await expect( providers.toolProvider?.getAbilities() ).resolves.toEqual( [
-			restoreCheckpointAbility,
-			showComponentAbility,
-			createAbility( 'big-sky/apply-block-edits' ),
-			createAbility( 'wpcom/manage-site' ),
-		] );
+		expect( abilityShapes( await providers.toolProvider?.getAbilities() ) ).toEqual(
+			abilityShapes( [
+				restoreCheckpointAbility,
+				showComponentAbility,
+				createAbility( 'big-sky/apply-block-edits' ),
+				createAbility( 'wpcom/manage-site' ),
+			] )
+		);
 		await expect(
 			providers.toolProvider?.executeAbility( 'big_sky__apply_block_edits', { updates: [] } )
 		).resolves.toEqual( { handledBy: 'big-sky' } );

--- a/packages/agents-manager/src/utils/canvas-binding.ts
+++ b/packages/agents-manager/src/utils/canvas-binding.ts
@@ -1,0 +1,193 @@
+/**
+ * Binds an agent request to the editor canvas it was made for.
+ *
+ * agenttic-client asks the context provider for client context on every outgoing
+ * message — including the tool-result continuations within a single request — so
+ * binding there means the bound canvas is, by construction, the one the model was
+ * looking at when it chose the tool that is now executing. If the live canvas
+ * differs, it moved in the gap and the pending write belongs to a page that is no
+ * longer on screen.
+ *
+ * The binding is deliberately not keyed by request id: nothing in the pipeline
+ * carries one to the ability layer, and the bind-then-execute ordering above makes
+ * one unnecessary.
+ *
+ * A canvas is a plain `postType:postId` string, and there is deliberately no
+ * "nothing is open here" state. The editor route only enables on screens that have
+ * a canvas (see wpcom's `route-settings/wp-orchestrator/wpcom-editor.php`), so an
+ * unreadable store means "not settled yet", never "no page open". Everything
+ * unreadable is therefore permissive — the write abilities do their own readiness
+ * handling.
+ *
+ * Module-level state, matching `provider-checkpoints.ts` — there is one chat per
+ * page load and the wrappers that read this are themselves module-level.
+ */
+
+import { select } from '@wordpress/data';
+
+/** A canvas the model was looking at, as key plus the label a refusal names it by. */
+type BoundCanvas = { key: string; label: string | null };
+
+/** A canvas change, described in the terms a refusal message uses. */
+export type CanvasMove = { from: string | null; to: string | null };
+
+type EditorSelectStore =
+	| {
+			getCurrentPostId?: () => number | string | undefined;
+			getCurrentPostType?: () => string | undefined;
+			getEditedPostAttribute?: ( attribute: string ) => unknown;
+	  }
+	| undefined;
+
+// `null` means nothing is bound — before the first message, or after an ability
+// deliberately moved the canvas. Nothing to enforce against either way.
+let bound: BoundCanvas | null = null;
+
+// The move that caused the current request to be blocked, if any. Set once a
+// request has been refused or aborted for leaving its canvas, so the model cannot
+// simply retry onto the page the user moved to.
+//
+// Storing the move rather than a bare flag makes "blocked without a move"
+// unrepresentable, and `blockCurrentRequest()` can only ever fill it from a live
+// reading — so a block can never name pages that did not actually move.
+let blockedMove: CanvasMove | null = null;
+
+function getEditorStore(): EditorSelectStore {
+	try {
+		return select( 'core/editor' ) as EditorSelectStore;
+	} catch {
+		// An unregistered store is not evidence of anything; stay permissive.
+		return undefined;
+	}
+}
+
+/**
+ * Compose a canvas key.
+ *
+ * Exported so a component's `useSelect` and this module cannot drift on the format
+ * — a mismatch would read as a permanent move and refuse every canvas write.
+ *
+ * Carries the post type as well as the id because ids are only unique within one:
+ * a page and a template can share an id, and treating them as the same canvas
+ * would let a write aimed at one land on the other.
+ *
+ * @param postType The editor's current post type.
+ * @param postId   The editor's current post id.
+ * @returns The key, or null when either half is missing.
+ */
+export function buildCanvasKey(
+	postType: string | undefined,
+	postId: number | string | undefined
+): string | null {
+	if ( ! postType || ! postId ) {
+		return null;
+	}
+
+	return `${ postType }:${ postId }`;
+}
+
+/**
+ * The canvas open right now.
+ *
+ * @returns The key, or null when the editor store cannot name one.
+ */
+export function resolveCanvasKey(): string | null {
+	const editor = getEditorStore();
+
+	return buildCanvasKey( editor?.getCurrentPostType?.(), editor?.getCurrentPostId?.() );
+}
+
+function readOpenCanvas(): BoundCanvas | null {
+	const key = resolveCanvasKey();
+
+	if ( null === key ) {
+		return null;
+	}
+
+	const title = getEditorStore()?.getEditedPostAttribute?.( 'title' );
+
+	return {
+		key,
+		label: typeof title === 'string' && title.trim() ? title.trim() : null,
+	};
+}
+
+/**
+ * Bind to whatever canvas is open now. Called on every outgoing message.
+ */
+export function bindToOpenCanvas(): void {
+	bound = readOpenCanvas();
+}
+
+/**
+ * Drop the binding because the agent itself is moving the canvas.
+ *
+ * Called before a navigation ability runs, not after: the navigation changes the
+ * canvas while it executes, and a binding still in place at that moment would read
+ * as a move and abort the agent's own request.
+ */
+export function clearCanvasBinding(): void {
+	bound = null;
+}
+
+/**
+ * Start a fresh binding for a new user message or a regenerate.
+ */
+export function startNewUserRequest(): void {
+	clearCanvasBinding();
+	blockedMove = null;
+}
+
+/**
+ * Whether the live canvas differs from the one the model last saw.
+ *
+ * The latch-free reading. Use it to decide whether something just moved; use
+ * `getBlockingMove()` to decide whether a write may proceed.
+ *
+ * @returns The move, or null when the live canvas still matches.
+ */
+export function getCanvasMove(): CanvasMove | null {
+	if ( ! bound ) {
+		return null;
+	}
+
+	const live = readOpenCanvas();
+
+	if ( ! live || live.key === bound.key ) {
+		return null;
+	}
+
+	return {
+		from: bound.label ?? bound.key,
+		to: live.label ?? live.key,
+	};
+}
+
+/**
+ * Refuse canvas writes for the remainder of the current request.
+ *
+ * Latches whatever move is live right now rather than accepting one, so a block can
+ * never outrun an actual move. Idempotent: an existing block is kept, never
+ * replaced, so every later refusal still names the pages the request was blocked
+ * for rather than a binding that has since moved on.
+ *
+ * @returns Whether a block is in place.
+ */
+export function blockCurrentRequest(): boolean {
+	if ( blockedMove ) {
+		return true;
+	}
+
+	blockedMove = getCanvasMove();
+
+	return null !== blockedMove;
+}
+
+/**
+ * Whether a pending canvas write would land somewhere it was not meant to.
+ *
+ * @returns The move, or null when the write may proceed.
+ */
+export function getBlockingMove(): CanvasMove | null {
+	return blockedMove ?? getCanvasMove();
+}

--- a/packages/agents-manager/src/utils/canvas-binding.ts
+++ b/packages/agents-manager/src/utils/canvas-binding.ts
@@ -24,7 +24,10 @@
  * the store yet, so that reading is reliably the stale one, and the arrival then
  * reads as the user walking away from a page the agent moved off deliberately.
  * `bindToNavigationTarget()` closes that by binding ahead to the destination and
- * holding it until the editor gets there.
+ * holding it until the editor gets there — for as long as the navigation is
+ * actually happening. A navigation that fails without moving hands the binding
+ * back, because a destination nothing is travelling to would suppress every move
+ * reading for the rest of the turn.
  *
  * That distinction matters because the write abilities *poll*: page-design's
  * `resolvePageDesignTargetRoot` returns null until a post resolves and the renderer
@@ -92,6 +95,11 @@ type EditorSelectStore =
 // deliberately moved the canvas. Nothing to enforce against either way.
 let bound: BoundCanvas | null = null;
 
+// Bumped by every write to `bound`, so a rollback can tell "nothing has touched
+// the binding since" from "it happens to look the same". Object identity cannot
+// answer that for the unbound state, which reads as null however it was reached.
+let bindingGeneration = 0;
+
 // The move that caused the current request to be blocked, if any. Set once a
 // request has been refused or aborted for leaving its canvas, so the model cannot
 // simply retry onto the page the user moved to.
@@ -100,6 +108,11 @@ let bound: BoundCanvas | null = null;
 // unrepresentable, and `blockCurrentRequest()` can only ever fill it from a live
 // reading — so a block can never name pages that did not actually move.
 let blockedMove: CanvasMove | null = null;
+
+function setBinding( next: BoundCanvas | null ): void {
+	bound = next;
+	bindingGeneration += 1;
+}
 
 function getEditorStore(): EditorSelectStore {
 	try {
@@ -170,8 +183,42 @@ function readOpenCanvas(): BoundCanvas | null {
  */
 function settleNavigationArrival(): void {
 	if ( bound?.pending && resolveCanvasKey() === bound.key ) {
-		bound = readOpenCanvas();
+		setBinding( readOpenCanvas() );
 	}
+}
+
+/**
+ * Hand the binding to a navigation that has not run yet, keeping a way back.
+ *
+ * Both ways of handing it over — forward to a destination, or off entirely when
+ * the ability names none — assert a move before it has happened. Abilities can
+ * answer `{ success: false }` or throw without ever navigating, and a destination
+ * left standing for a trip that never started is the worse half: `pending`
+ * suppresses every move reading until the editor reaches a page it is not going
+ * to reach, so the refusal and the abort both go quiet for the rest of the turn.
+ *
+ * The rollback restores the binding that was there rather than the live canvas:
+ * if the user left while the failed navigation ran, that is still a move to catch.
+ *
+ * @param next The binding the navigation takes.
+ * @returns The rollback, a no-op once anything else has taken the binding.
+ */
+function handBindingToNavigation( next: BoundCanvas | null ): () => void {
+	const previous = bound;
+
+	setBinding( next );
+
+	const generation = bindingGeneration;
+
+	return () => {
+		// An arrival counts even against a reported failure: the editor is on the
+		// destination, so that is the page the request belongs to now.
+		settleNavigationArrival();
+
+		if ( bindingGeneration === generation ) {
+			setBinding( previous );
+		}
+	};
 }
 
 /**
@@ -189,7 +236,7 @@ export function bindToOpenCanvas(): void {
 		return;
 	}
 
-	bound = readOpenCanvas();
+	setBinding( readOpenCanvas() );
 }
 
 /**
@@ -200,9 +247,10 @@ export function bindToOpenCanvas(): void {
  * unbound until something happens to rebind it.
  *
  * @param canvasKey The destination canvas key.
+ * @returns A rollback for a navigation that never happens; see `handBindingToNavigation`.
  */
-export function bindToNavigationTarget( canvasKey: string ): void {
-	bound = { key: canvasKey, label: null, pending: true };
+export function bindToNavigationTarget( canvasKey: string ): () => void {
+	return handBindingToNavigation( { key: canvasKey, label: null, pending: true } );
 }
 
 /**
@@ -211,9 +259,11 @@ export function bindToNavigationTarget( canvasKey: string ): void {
  * Called before a navigation ability runs, not after: the navigation changes the
  * canvas while it executes, and a binding still in place at that moment would read
  * as a move and abort the agent's own request.
+ *
+ * @returns A rollback for a navigation that never happens; see `handBindingToNavigation`.
  */
-export function clearCanvasBinding(): void {
-	bound = null;
+export function clearCanvasBinding(): () => void {
+	return handBindingToNavigation( null );
 }
 
 /**

--- a/packages/agents-manager/src/utils/canvas-binding.ts
+++ b/packages/agents-manager/src/utils/canvas-binding.ts
@@ -12,12 +12,17 @@
  * carries one to the ability layer, and the bind-then-execute ordering above makes
  * one unnecessary.
  *
- * A canvas is a plain `postType:postId` string, and there is deliberately no
- * "nothing is open here" state. The editor route only enables on screens that have
- * a canvas (see wpcom's `route-settings/wp-orchestrator/wpcom-editor.php`), so an
- * unreadable store means "not settled yet", never "no page open". Everything
- * unreadable is therefore permissive — the write abilities do their own readiness
- * handling.
+ * A canvas is a plain `postType:postId` string. Losing it counts as a move: once a
+ * request is bound, the editor reporting no canvas means the user left the page the
+ * request was for, not that the canvas is still coming up. Nothing can be bound
+ * before the editor has mounted — the binding is taken when the message goes out —
+ * and the one flow that legitimately runs against a mounting canvas, the agent
+ * navigating itself, drops the binding first via `clearCanvasBinding()`.
+ *
+ * That distinction matters because the write abilities *poll*: page-design's
+ * `resolvePageDesignTargetRoot` returns null until a post resolves and the renderer
+ * retries. Letting an absent canvas through turns that readiness retry into an
+ * unbounded loop against a page that is never coming back.
  *
  * Module-level state, matching `provider-checkpoints.ts` — there is one chat per
  * page load and the wrappers that read this are themselves module-level.
@@ -28,8 +33,13 @@ import { select } from '@wordpress/data';
 /** A canvas the model was looking at, as key plus the label a refusal names it by. */
 type BoundCanvas = { key: string; label: string | null };
 
-/** A canvas change, described in the terms a refusal message uses. */
-export type CanvasMove = { from: string | null; to: string | null };
+/**
+ * A canvas change, described in the terms a refusal message uses.
+ *
+ * `to: null` means the editor now has no canvas at all — the user left it — which
+ * needs different advice to the model than landing on a different page.
+ */
+export type CanvasMove = { from: string; to: string | null };
 
 type EditorSelectStore =
 	| {
@@ -167,13 +177,16 @@ export function getCanvasMove(): CanvasMove | null {
 
 	const live = readOpenCanvas();
 
-	if ( ! live || live.key === bound.key ) {
+	if ( live?.key === bound.key ) {
 		return null;
 	}
 
 	return {
 		from: bound.label ?? bound.key,
-		to: live.label ?? live.key,
+		// No live canvas is a move to nowhere, not a reason to wait: see the note
+		// at the top of this module on why a bound request can never be looking at
+		// a canvas that is merely still mounting.
+		to: live ? live.label ?? live.key : null,
 	};
 }
 

--- a/packages/agents-manager/src/utils/canvas-binding.ts
+++ b/packages/agents-manager/src/utils/canvas-binding.ts
@@ -14,10 +14,17 @@
  *
  * A canvas is a plain `postType:postId` string. Losing it counts as a move: once a
  * request is bound, the editor reporting no canvas means the user left the page the
- * request was for, not that the canvas is still coming up. Nothing can be bound
- * before the editor has mounted — the binding is taken when the message goes out —
- * and the one flow that legitimately runs against a mounting canvas, the agent
- * navigating itself, drops the binding first via `clearCanvasBinding()`.
+ * request was for, not that the canvas is still coming up.
+ *
+ * The one flow that legitimately runs against a canvas that is still arriving is the
+ * agent navigating itself, and dropping the binding for it is not enough. Binding is
+ * re-taken on every outgoing message, and a tool result is an outgoing message — so
+ * the navigate result rebinds within the same request, while the editor is still
+ * showing the page being left. Pages the server has only just created are never in
+ * the store yet, so that reading is reliably the stale one, and the arrival then
+ * reads as the user walking away from a page the agent moved off deliberately.
+ * `bindToNavigationTarget()` closes that by binding ahead to the destination and
+ * holding it until the editor gets there.
  *
  * That distinction matters because the write abilities *poll*: page-design's
  * `resolvePageDesignTargetRoot` returns null until a post resolves and the renderer
@@ -55,8 +62,15 @@ export function isCanvasWritingAgent( agentId: string | undefined | null ): bool
 	return !! agentId && CANVAS_WRITING_AGENT_IDS.has( agentId );
 }
 
-/** A canvas the model was looking at, as key plus the label a refusal names it by. */
-type BoundCanvas = { key: string; label: string | null };
+/**
+ * A canvas the model was looking at, as key plus the label a refusal names it by.
+ *
+ * `pending` marks a canvas bound ahead of the editor: the agent has been sent to
+ * this page but has not arrived. It is what separates "the navigation we asked
+ * for is still running" from "the user left", which read identically from a
+ * single live sample.
+ */
+type BoundCanvas = { key: string; label: string | null; pending: boolean };
 
 /**
  * A canvas change, described in the terms a refusal message uses.
@@ -144,14 +158,51 @@ function readOpenCanvas(): BoundCanvas | null {
 	return {
 		key,
 		label: typeof title === 'string' && title.trim() ? title.trim() : null,
+		pending: false,
 	};
+}
+
+/**
+ * Promote a destination binding to an ordinary one once the editor arrives.
+ *
+ * Re-reading rather than clearing the flag picks up the title, which a page bound
+ * before it loaded could not have.
+ */
+function settleNavigationArrival(): void {
+	if ( bound?.pending && resolveCanvasKey() === bound.key ) {
+		bound = readOpenCanvas();
+	}
 }
 
 /**
  * Bind to whatever canvas is open now. Called on every outgoing message.
  */
 export function bindToOpenCanvas(): void {
+	settleNavigationArrival();
+
+	// A destination outranks the live reading until the editor gets there. The
+	// tool result carrying the agent's own navigation goes out while the editor is
+	// still on the old page — rebinding then would pin the request to the page it
+	// is in the middle of leaving, and the arrival would read as the user walking
+	// away from it.
+	if ( bound?.pending ) {
+		return;
+	}
+
 	bound = readOpenCanvas();
+}
+
+/**
+ * Bind to the canvas an agent navigation is heading for, before it opens.
+ *
+ * Used in place of `clearCanvasBinding()` for a navigation whose destination is
+ * knowable, which keeps the request guarded across the move instead of leaving it
+ * unbound until something happens to rebind it.
+ *
+ * @param canvasKey The destination canvas key.
+ */
+export function bindToNavigationTarget( canvasKey: string ): void {
+	bound = { key: canvasKey, label: null, pending: true };
 }
 
 /**
@@ -196,6 +247,8 @@ export function startNewUserRequest(): void {
  * @returns The move, or null when the live canvas still matches.
  */
 export function getCanvasMove(): CanvasMove | null {
+	settleNavigationArrival();
+
 	if ( ! bound ) {
 		return null;
 	}
@@ -203,6 +256,12 @@ export function getCanvasMove(): CanvasMove | null {
 	const live = readOpenCanvas();
 
 	if ( live?.key === bound.key ) {
+		return null;
+	}
+
+	// Sent somewhere and not there yet: the mismatch is the navigation in flight,
+	// not the user leaving. Settling above means this only covers the trip.
+	if ( bound.pending ) {
 		return null;
 	}
 

--- a/packages/agents-manager/src/utils/canvas-binding.ts
+++ b/packages/agents-manager/src/utils/canvas-binding.ts
@@ -29,6 +29,31 @@
  */
 
 import { select } from '@wordpress/data';
+import { ORCHESTRATOR_AGENT_ID, UNIFIED_CHAT_AGENT_ID } from '../constants';
+
+// Agents whose turns can write to the editor canvas, and so are worth stopping
+// when it moves. The same dock serves support and Reader chats — including inside
+// the editor — and their turns never call a canvas ability, so aborting one for a
+// navigation is pure loss and the message would make no sense to the user.
+//
+// Both editor-capable agents are listed, not just the orchestrator: the canvas
+// abilities are migrating into AM, which serves them on unified-chat surfaces (see
+// the Big Sky plugin's AGENTS.md), so omitting unified chat would switch this off
+// exactly where the abilities are heading.
+const CANVAS_WRITING_AGENT_IDS = new Set< string >( [
+	ORCHESTRATOR_AGENT_ID,
+	UNIFIED_CHAT_AGENT_ID,
+] );
+
+/**
+ * Whether this agent's turns can write to the editor canvas.
+ *
+ * @param agentId The resolved agent id, from `useAgentConfig`.
+ * @returns Whether canvas binding applies to it.
+ */
+export function isCanvasWritingAgent( agentId: string | undefined | null ): boolean {
+	return !! agentId && CANVAS_WRITING_AGENT_IDS.has( agentId );
+}
 
 /** A canvas the model was looking at, as key plus the label a refusal names it by. */
 type BoundCanvas = { key: string; label: string | null };

--- a/packages/agents-manager/src/utils/canvas-binding.ts
+++ b/packages/agents-manager/src/utils/canvas-binding.ts
@@ -131,7 +131,21 @@ export function clearCanvasBinding(): void {
 }
 
 /**
- * Start a fresh binding for a new user message or a regenerate.
+ * Reset to the unbound, unblocked state for a new user message or a regenerate.
+ *
+ * Both halves matter, for different reasons.
+ *
+ * Dropping the binding is the load-bearing one, and it is not about the block at
+ * all. A new turn flips `isProcessing` before its own outbound message rebinds, so
+ * between those two moments the binding still names the *previous* turn's canvas.
+ * If the user navigated since that turn — the ordinary case of finishing on one
+ * page and asking about another — the abort effect reads the stale binding as a
+ * move and kills the request the user just made. Clearing here removes the window
+ * rather than racing it.
+ *
+ * Clearing the block is what keeps a refusal from outliving the request it was
+ * meant for. Nothing else ever clears `blockedMove`, so without this one canvas
+ * move would refuse every canvas write for the rest of the page load.
  */
 export function startNewUserRequest(): void {
 	clearCanvasBinding();

--- a/packages/agents-manager/src/utils/canvas-guard.ts
+++ b/packages/agents-manager/src/utils/canvas-guard.ts
@@ -5,6 +5,12 @@
  * abilities are bound to the open canvas, which ones legitimately move it, and what
  * a refusal says. The ability lists live next to the state machine they encode
  * against rather than in the provider loader, which only composes them.
+ *
+ * The policy is installed on both dispatch paths, because agenttic-client picks
+ * between them per ability: it calls an ability's own `callback` when it has one and
+ * only falls back to the provider's `executeAbility` when it does not. Every Big Sky
+ * ability is registered with a callback, so guarding `executeAbility` alone leaves
+ * the guard switched off for exactly the abilities it exists to police.
  */
 
 import { normalizeAbilityName } from '../abilities/ability-name';
@@ -17,7 +23,7 @@ import {
 	getBlockingMove,
 	type CanvasMove,
 } from './canvas-binding';
-import type { AbilityResult } from '../abilities/types';
+import type { Ability, AbilityResult } from '../abilities/types';
 import type { ContextProvider, ToolProvider } from '../types';
 
 // Abilities that write to the page open in the editor. Deliberately excludes
@@ -48,6 +54,10 @@ const CANVAS_MOVING_ABILITIES = new Set(
 	[ 'big-sky/editor-navigate', 'wp-admin/navigate' ].map( normalizeAbilityName )
 );
 
+// Every ability the policy acts on, and so the only ones whose callbacks are worth
+// wrapping.
+const POLICED_ABILITIES = new Set( [ ...CANVAS_BOUND_ABILITIES, ...CANVAS_MOVING_ABILITIES ] );
+
 const EDITOR_NAVIGATE_ABILITY = normalizeAbilityName( 'big-sky/editor-navigate' );
 
 // The editor path `editor-navigate` accepts, matching the shape Big Sky validates
@@ -60,7 +70,6 @@ const EDITOR_PAGE_PATH = /^\/?page\/(\d+)\/?$/;
  * Only `editor-navigate` names one. `wp-admin/navigate` takes a wp-admin path and
  * leaves the editor entirely, and a path that does not parse names no page — both
  * answer null, which leaves the caller to drop the binding instead of guessing.
- *
  * @param normalizedName The normalized ability name.
  * @param args           The ability arguments, untyped as they arrive off the wire.
  * @returns The destination canvas key, or null when the ability names no page.
@@ -129,6 +138,75 @@ export function withCanvasBinding(
 }
 
 /**
+ * Applies the canvas policy to one about-to-run ability.
+ *
+ * Shared by both dispatch paths, which is the whole point: agenttic-client calls an
+ * ability's own `callback` when it has one and only falls back to the provider's
+ * `executeAbility` when it does not, so a policy installed on one path alone is
+ * inert for every ability that takes the other.
+ * @param name The ability name, in either form.
+ * @param args The ability arguments.
+ * @returns A refusal to return instead of running it, or null to let it run.
+ */
+function applyCanvasPolicy( name: string, args: unknown ): AbilityResult | null {
+	// Normalize the incoming name too: it may arrive in either form
+	// (`findAbilityByName` accepts both), and normalizing an already
+	// normalized name is a no-op.
+	const normalizedName = normalizeAbilityName( name );
+
+	if ( CANVAS_BOUND_ABILITIES.has( normalizedName ) ) {
+		const move = getBlockingMove();
+		if ( move ) {
+			blockCurrentRequest();
+			return buildCanvasRefusal( move );
+		}
+	}
+
+	if ( CANVAS_MOVING_ABILITIES.has( normalizedName ) ) {
+		const target = resolveNavigationTarget( normalizedName, args );
+
+		if ( target ) {
+			bindToNavigationTarget( target );
+		} else {
+			clearCanvasBinding();
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Puts the policy on an ability's own callback.
+ *
+ * The refusal shape needs no translation: `AbilityResult` is what the abilities
+ * being guarded already return from their callbacks, and agenttic-client reads
+ * `returnToAgent` off that same object either way.
+ * @param ability The ability as its provider registered it.
+ * @returns The ability, with a guarded callback when it has one to guard.
+ */
+function guardAbilityCallback( ability: Ability ): Ability {
+	const { callback } = ability;
+
+	// Everything the policy has no opinion on is handed back as-is, identity and
+	// all: a wrapper there would buy nothing and put this module in the path of
+	// every ability on the site.
+	if ( ! callback || ! POLICED_ABILITIES.has( normalizeAbilityName( ability.name ) ) ) {
+		return ability;
+	}
+
+	return {
+		...ability,
+		callback: async ( input ) => {
+			// The callback path carries the arguments inline, alongside the ids
+			// agenttic-client adds — so `path` is read from the same object.
+			const refusal = applyCanvasPolicy( ability.name, input );
+
+			return refusal ?? callback( input );
+		},
+	};
+}
+
+/**
  * Refuses a canvas write whose canvas has moved since the model asked for it.
  *
  * Applied to the merged tool provider, so it is indifferent to which provider owns
@@ -144,32 +222,11 @@ export function withCanvasGuard(
 	}
 
 	return {
-		getAbilities: () => toolProvider.getAbilities(),
+		getAbilities: async () => ( await toolProvider.getAbilities() ).map( guardAbilityCallback ),
 		executeAbility: async ( name: string, args: unknown ) => {
-			// Normalize the incoming name too: it may arrive in either form
-			// (`findAbilityByName` accepts both), and normalizing an already
-			// normalized name is a no-op.
-			const normalizedName = normalizeAbilityName( name );
+			const refusal = applyCanvasPolicy( name, args );
 
-			if ( CANVAS_BOUND_ABILITIES.has( normalizedName ) ) {
-				const move = getBlockingMove();
-				if ( move ) {
-					blockCurrentRequest();
-					return buildCanvasRefusal( move );
-				}
-			}
-
-			if ( CANVAS_MOVING_ABILITIES.has( normalizedName ) ) {
-				const target = resolveNavigationTarget( normalizedName, args );
-
-				if ( target ) {
-					bindToNavigationTarget( target );
-				} else {
-					clearCanvasBinding();
-				}
-			}
-
-			return toolProvider.executeAbility( name, args );
+			return refusal ?? toolProvider.executeAbility( name, args );
 		},
 	};
 }

--- a/packages/agents-manager/src/utils/canvas-guard.ts
+++ b/packages/agents-manager/src/utils/canvas-guard.ts
@@ -46,18 +46,23 @@ const CANVAS_MOVING_ABILITIES = new Set(
 );
 
 function buildCanvasRefusal( move: CanvasMove ): AbilityResult {
+	// Untranslated on purpose: `returnToAgent: true` means these strings are read by
+	// the model, not shown to the user, unlike neighbouring abilities' messages.
+	//
+	// Both spell out "do not retry", and the no-canvas one says so hardest. The
+	// write abilities poll for a canvas to appear, so a model that responds to the
+	// refusal by trying another route into the same write can keep a doomed request
+	// alive indefinitely.
+	const message =
+		null === move.to
+			? `Nothing was changed: this was requested for ${ move.from }, but the editor is no longer open on it and there is no page on screen to change. Do not retry this or try another way to make the same change — nothing can be edited until a page is open. Tell the user the request stopped because they navigated away, and ask them to reopen the page if they still want it.`
+			: `Nothing was changed: this was requested for ${ move.from }, but the editor now has ${ move.to } open. Do not retry it here — tell the user what happened and ask whether they want the same change on the page they are now viewing.`;
+
 	return {
 		result: {
 			success: false,
-			// Untranslated on purpose: `returnToAgent: true` means this string is read
-			// by the model, not shown to the user, unlike neighbouring abilities'
-			// messages.
-			message: `Nothing was changed: this was requested for ${
-				move.from ?? 'a page that is no longer open'
-			}, but the editor now has ${
-				move.to ?? 'a different page'
-			} open. Do not retry it here — tell the user what happened and ask whether they want the same change on the page they are now viewing.`,
-			error: 'editor_canvas_moved',
+			message,
+			error: null === move.to ? 'editor_canvas_closed' : 'editor_canvas_moved',
 		},
 		returnToAgent: true,
 	};

--- a/packages/agents-manager/src/utils/canvas-guard.ts
+++ b/packages/agents-manager/src/utils/canvas-guard.ts
@@ -9,8 +9,10 @@
 
 import { normalizeAbilityName } from '../abilities/ability-name';
 import {
+	bindToNavigationTarget,
 	bindToOpenCanvas,
 	blockCurrentRequest,
+	buildCanvasKey,
 	clearCanvasBinding,
 	getBlockingMove,
 	type CanvasMove,
@@ -39,11 +41,44 @@ const CANVAS_BOUND_ABILITIES = new Set(
 	)
 );
 
-// Abilities whose whole job is to move the canvas. The binding is dropped before
-// they run, so the move they cause does not read as a violation.
+// Abilities whose whole job is to move the canvas, so the move they cause must not
+// read as a violation. Where the destination is knowable the binding follows them
+// to it; otherwise it is dropped. See `resolveNavigationTarget`.
 const CANVAS_MOVING_ABILITIES = new Set(
 	[ 'big-sky/editor-navigate', 'wp-admin/navigate' ].map( normalizeAbilityName )
 );
+
+const EDITOR_NAVIGATE_ABILITY = normalizeAbilityName( 'big-sky/editor-navigate' );
+
+// The editor path `editor-navigate` accepts, matching the shape Big Sky validates
+// before it will navigate: `/page/123`, with either slash optional.
+const EDITOR_PAGE_PATH = /^\/?page\/(\d+)\/?$/;
+
+/**
+ * The canvas a navigation ability is heading for.
+ *
+ * Only `editor-navigate` names one. `wp-admin/navigate` takes a wp-admin path and
+ * leaves the editor entirely, and a path that does not parse names no page — both
+ * answer null, which leaves the caller to drop the binding instead of guessing.
+ *
+ * @param normalizedName The normalized ability name.
+ * @param args           The ability arguments, untyped as they arrive off the wire.
+ * @returns The destination canvas key, or null when the ability names no page.
+ */
+function resolveNavigationTarget( normalizedName: string, args: unknown ): string | null {
+	if ( normalizedName !== EDITOR_NAVIGATE_ABILITY ) {
+		return null;
+	}
+
+	const path = ( args as { path?: unknown } | undefined )?.path;
+
+	if ( typeof path !== 'string' ) {
+		return null;
+	}
+
+	// Always a page: the path shape admits nothing else.
+	return buildCanvasKey( 'page', EDITOR_PAGE_PATH.exec( path )?.[ 1 ] );
+}
 
 function buildCanvasRefusal( move: CanvasMove ): AbilityResult {
 	// Untranslated on purpose: `returnToAgent: true` means these strings are read by
@@ -125,7 +160,13 @@ export function withCanvasGuard(
 			}
 
 			if ( CANVAS_MOVING_ABILITIES.has( normalizedName ) ) {
-				clearCanvasBinding();
+				const target = resolveNavigationTarget( normalizedName, args );
+
+				if ( target ) {
+					bindToNavigationTarget( target );
+				} else {
+					clearCanvasBinding();
+				}
 			}
 
 			return toolProvider.executeAbility( name, args );

--- a/packages/agents-manager/src/utils/canvas-guard.ts
+++ b/packages/agents-manager/src/utils/canvas-guard.ts
@@ -1,0 +1,129 @@
+/**
+ * Enforces the canvas binding on the merged providers.
+ *
+ * `canvas-binding` owns the state machine; this module owns the policy — which
+ * abilities are bound to the open canvas, which ones legitimately move it, and what
+ * a refusal says. The ability lists live next to the state machine they encode
+ * against rather than in the provider loader, which only composes them.
+ */
+
+import { normalizeAbilityName } from '../abilities/ability-name';
+import {
+	bindToOpenCanvas,
+	blockCurrentRequest,
+	clearCanvasBinding,
+	getBlockingMove,
+	type CanvasMove,
+} from './canvas-binding';
+import type { AbilityResult } from '../abilities/types';
+import type { ContextProvider, ToolProvider } from '../types';
+
+// Abilities that write to the page open in the editor. Deliberately excludes
+// `big-sky/apply-update-theme` and `big-sky/set-site-logo` (site-wide — moving
+// between pages does not make them wrong) and `big-sky/show-component` (not a
+// write). Ownership is irrelevant here: this list is checked on the merged
+// provider, so it covers abilities that have migrated into AM and abilities still
+// served by an external provider alike.
+//
+// `edit-entity-record` is deliberately absent: it names its target explicitly
+// (`entityType`/`entityName`/`recordId`, often site-level like `root`/`site` or
+// `wp_navigation`), so moving the canvas cannot redirect its write. Guarding it
+// would refuse legitimate site-level edits from any screen.
+//
+// Normalized, because the agent invokes `big-sky/apply-block-edits` as
+// `big_sky__apply_block_edits`. Matching the registered form against the name that
+// actually arrives would never hit, leaving the guard inert in production.
+const CANVAS_BOUND_ABILITIES = new Set(
+	[ 'big-sky/apply-block-edits', 'big-sky/stream-page-design', 'big-sky/restore-checkpoint' ].map(
+		normalizeAbilityName
+	)
+);
+
+// Abilities whose whole job is to move the canvas. The binding is dropped before
+// they run, so the move they cause does not read as a violation.
+const CANVAS_MOVING_ABILITIES = new Set(
+	[ 'big-sky/editor-navigate', 'wp-admin/navigate' ].map( normalizeAbilityName )
+);
+
+function buildCanvasRefusal( move: CanvasMove ): AbilityResult {
+	return {
+		result: {
+			success: false,
+			// Untranslated on purpose: `returnToAgent: true` means this string is read
+			// by the model, not shown to the user, unlike neighbouring abilities'
+			// messages.
+			message: `Nothing was changed: this was requested for ${
+				move.from ?? 'a page that is no longer open'
+			}, but the editor now has ${
+				move.to ?? 'a different page'
+			} open. Do not retry it here — tell the user what happened and ask whether they want the same change on the page they are now viewing.`,
+			error: 'editor_canvas_moved',
+		},
+		returnToAgent: true,
+	};
+}
+
+/**
+ * Binds to the open canvas on every outgoing message.
+ *
+ * Wraps the merged provider rather than each external one, so the binding happens
+ * once per message however many providers are registered. The context itself is
+ * passed through untouched — the canvas is read from the editor store here, not
+ * carried on the wire.
+ * @param contextProvider The merged context provider, if any.
+ * @returns The wrapped provider, or undefined when there is nothing to wrap.
+ */
+export function withCanvasBinding(
+	contextProvider: ContextProvider | undefined
+): ContextProvider | undefined {
+	if ( ! contextProvider ) {
+		return undefined;
+	}
+
+	return {
+		getClientContext: () => {
+			bindToOpenCanvas();
+			return contextProvider.getClientContext();
+		},
+	};
+}
+
+/**
+ * Refuses a canvas write whose canvas has moved since the model asked for it.
+ *
+ * Applied to the merged tool provider, so it is indifferent to which provider owns
+ * a given ability — including after an ability migrates into AM.
+ * @param toolProvider The merged tool provider, if any.
+ * @returns The wrapped provider, or undefined when there is nothing to wrap.
+ */
+export function withCanvasGuard(
+	toolProvider: ToolProvider | undefined
+): ToolProvider | undefined {
+	if ( ! toolProvider ) {
+		return undefined;
+	}
+
+	return {
+		getAbilities: () => toolProvider.getAbilities(),
+		executeAbility: async ( name: string, args: unknown ) => {
+			// Normalize the incoming name too: it may arrive in either form
+			// (`findAbilityByName` accepts both), and normalizing an already
+			// normalized name is a no-op.
+			const normalizedName = normalizeAbilityName( name );
+
+			if ( CANVAS_BOUND_ABILITIES.has( normalizedName ) ) {
+				const move = getBlockingMove();
+				if ( move ) {
+					blockCurrentRequest();
+					return buildCanvasRefusal( move );
+				}
+			}
+
+			if ( CANVAS_MOVING_ABILITIES.has( normalizedName ) ) {
+				clearCanvasBinding();
+			}
+
+			return toolProvider.executeAbility( name, args );
+		},
+	};
+}

--- a/packages/agents-manager/src/utils/canvas-guard.ts
+++ b/packages/agents-manager/src/utils/canvas-guard.ts
@@ -138,6 +138,18 @@ export function withCanvasBinding(
 }
 
 /**
+ * What the policy decided about one about-to-run ability.
+ *
+ * `rollbackBinding` is set only for an ability that moves the canvas: it has been
+ * handed the binding for a move that has not happened yet, and this puts it back
+ * if the move turns out not to happen at all.
+ */
+type CanvasPolicy = {
+	refusal: AbilityResult | null;
+	rollbackBinding: ( () => void ) | null;
+};
+
+/**
  * Applies the canvas policy to one about-to-run ability.
  *
  * Shared by both dispatch paths, which is the whole point: agenttic-client calls an
@@ -146,9 +158,9 @@ export function withCanvasBinding(
  * inert for every ability that takes the other.
  * @param name The ability name, in either form.
  * @param args The ability arguments.
- * @returns A refusal to return instead of running it, or null to let it run.
+ * @returns The refusal to return instead of running it, and how to undo the binding it took.
  */
-function applyCanvasPolicy( name: string, args: unknown ): AbilityResult | null {
+function applyCanvasPolicy( name: string, args: unknown ): CanvasPolicy {
 	// Normalize the incoming name too: it may arrive in either form
 	// (`findAbilityByName` accepts both), and normalizing an already
 	// normalized name is a no-op.
@@ -158,21 +170,80 @@ function applyCanvasPolicy( name: string, args: unknown ): AbilityResult | null 
 		const move = getBlockingMove();
 		if ( move ) {
 			blockCurrentRequest();
-			return buildCanvasRefusal( move );
+			return { refusal: buildCanvasRefusal( move ), rollbackBinding: null };
 		}
 	}
 
 	if ( CANVAS_MOVING_ABILITIES.has( normalizedName ) ) {
 		const target = resolveNavigationTarget( normalizedName, args );
 
-		if ( target ) {
-			bindToNavigationTarget( target );
-		} else {
-			clearCanvasBinding();
-		}
+		return {
+			refusal: null,
+			rollbackBinding: target ? bindToNavigationTarget( target ) : clearCanvasBinding(),
+		};
 	}
 
-	return null;
+	return { refusal: null, rollbackBinding: null };
+}
+
+/**
+ * Whether an ability answered that it did not do what it was asked.
+ *
+ * Abilities answer with the `AbilityResult` envelope, but the provider contract
+ * types both dispatch paths as `Promise< any >`, so this reads defensively and
+ * accepts the bare form too. Anything it cannot recognize counts as success: a
+ * navigation whose result shape drifts should leave the binding where a working
+ * navigation leaves it, not somewhere new.
+ * @param result Whatever the ability answered.
+ * @returns Whether it reported failure.
+ */
+function reportsFailure( result: unknown ): boolean {
+	const answer = result as { success?: unknown; result?: { success?: unknown } } | undefined;
+
+	return false === ( answer?.result?.success ?? answer?.success );
+}
+
+/**
+ * Dispatches one ability under the policy, undoing a move that never happened.
+ *
+ * The abilities that take the binding forward can fail without navigating —
+ * `editor-navigate` answers `{ success: false }` on a save conflict, a stale page
+ * id or a network error, and can throw outright. Without this, the destination it
+ * was handed stays bound to a page the editor is never going to open, and every
+ * later canvas write in the turn goes through unguarded.
+ * @param name     The ability name, in either form.
+ * @param args     The ability arguments.
+ * @param dispatch Runs the ability itself.
+ * @returns The refusal, or whatever the ability answered.
+ */
+async function dispatchUnderCanvasPolicy(
+	name: string,
+	args: unknown,
+	dispatch: () => Promise< unknown >
+): Promise< unknown > {
+	const { refusal, rollbackBinding } = applyCanvasPolicy( name, args );
+
+	if ( refusal ) {
+		return refusal;
+	}
+
+	if ( ! rollbackBinding ) {
+		return dispatch();
+	}
+
+	try {
+		const result = await dispatch();
+
+		if ( reportsFailure( result ) ) {
+			rollbackBinding();
+		}
+
+		return result;
+	} catch ( error ) {
+		// Restored, not swallowed: the caller still sees the failure.
+		rollbackBinding();
+		throw error;
+	}
 }
 
 /**
@@ -196,13 +267,10 @@ function guardAbilityCallback( ability: Ability ): Ability {
 
 	return {
 		...ability,
-		callback: async ( input ) => {
-			// The callback path carries the arguments inline, alongside the ids
-			// agenttic-client adds — so `path` is read from the same object.
-			const refusal = applyCanvasPolicy( ability.name, input );
-
-			return refusal ?? callback( input );
-		},
+		// The callback path carries the arguments inline, alongside the ids
+		// agenttic-client adds — so `path` is read from the same object.
+		callback: ( input ) =>
+			dispatchUnderCanvasPolicy( ability.name, input, async () => callback( input ) ),
 	};
 }
 
@@ -223,10 +291,9 @@ export function withCanvasGuard(
 
 	return {
 		getAbilities: async () => ( await toolProvider.getAbilities() ).map( guardAbilityCallback ),
-		executeAbility: async ( name: string, args: unknown ) => {
-			const refusal = applyCanvasPolicy( name, args );
-
-			return refusal ?? toolProvider.executeAbility( name, args );
-		},
+		executeAbility: ( name: string, args: unknown ) =>
+			dispatchUnderCanvasPolicy( name, args, async () =>
+				toolProvider.executeAbility( name, args )
+			),
 	};
 }

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -14,6 +14,7 @@
 import { getAgentManager, UIMessage } from '@automattic/agenttic-client';
 import { amToolProvider, getAmCheckpointContext } from '../abilities';
 import { findAbilityByName } from '../abilities/ability-name';
+import { withCanvasBinding, withCanvasGuard } from './canvas-guard';
 import { getAgentsManagerInlineData } from './get-agents-manager-inline-data';
 import { isReaderChatAgent } from './is-reader-chat-agent';
 import {
@@ -720,7 +721,9 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		}
 	}
 
-	const mergedContextProvider = withAmCheckpoints( mergeContextProviders( allContextProviders ) );
+	const mergedContextProvider = withCanvasBinding(
+		withAmCheckpoints( mergeContextProviders( allContextProviders ) )
+	);
 	const mergedMarkdownComponents = mergeMarkdownComponentsFromProviders( allMarkdownComponents );
 	const mergedMarkdownExtensions = mergeMarkdownExtensionsFromProviders( allMarkdownExtensions );
 
@@ -786,6 +789,11 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 			},
 		};
 	}
+
+	// After the branch, deliberately: the single-provider path above assigns
+	// `allToolProviders[ 0 ]` straight through, so a guard applied inside the
+	// multi-provider closure would silently not exist on those surfaces.
+	mergedToolProvider = withCanvasGuard( mergedToolProvider );
 
 	// Merge transformMessages: compose in registration order, so each provider
 	// rewrites what the previous one produced. Unlike the singleton exports this


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/AI-1129/prevent-agent-requests-from-writing-to-a-different-canvas

Agent requests could write to the wrong page. If you asked for a change in the site editor and navigated to another page before the tool ran, the edit landed on whatever canvas was mounted by then.

This binds each request to the canvas it was made for, and refuses — or aborts — when they stop matching.

## What this adds

**`utils/canvas-binding.ts`** — records the canvas the model last saw and reports when the live canvas differs. A canvas is a `postType:postId` string read straight from `core/editor`. The post type is part of the key because ids are only unique within one: a page and a template can share an id. When the agent moves the canvas itself, the binding follows it to the destination and holds there until the editor arrives — and is handed back if the navigation never happens.

**`utils/canvas-guard.ts`** — wraps the merged tool provider and refuses `apply-block-edits`, `stream-page-design` and `restore-checkpoint` when the canvas has moved. The refusal is a tool result, so the agent relays it and asks the user.  Wrapping the *merged* provider means the guard keeps working as abilities migrate from Big Sky into AM.

**Abort** — an in-flight request is stopped when the canvas moves, with a message saying why, and further canvas writes stay blocked until the next user message or regenerate.

`edit-entity-record` is deliberately not guarded: it names its own target (often site-level, like `root`/`site` or `wp_navigation`), so moving the canvas cannot redirect it.

## Testing

`yarn test-packages packages/agents-manager` — 878 tests, 65 suites.

Covered: key composition and post-type disambiguation, permissive handling of an unreadable/unsettled store, latching so a refused request cannot retry onto the new page, guard wiring on **both** the single- and multi-provider paths in `loadExternalProviders` (only one runs for a given surface), the abort driven through the real store-subscriber path, and navigations that fail or throw without moving — on both dispatch paths.

## Manual testing

- In `site-editor.php`, ask for a change on a page, then navigate to another page while it runs. The request stops and the chat explains why.
- After an aborted request, ask again on the new page. It works: a new user message lifts the block.
- Stay on the page after making a request and make sure it completes as expected.
- Ask for "add a new page for our services" — it navigates mid-request and completes, because the binding follows `editor-navigate` to the page it opens.

Should see the following when call is aborted for this reason:

<img width="387" height="309" alt="Screenshot 2026-08-19 at 1 14 57 PM" src="https://github.com/user-attachments/assets/2743b98d-000a-4d8a-bf47-fe688b1e5ffd" />

