### PR TITLE
Sites: surface deleted sites to users with no live sites

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -48,6 +48,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { createLazyRoute, createRoute, lazyRouteComponent, notFound } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
+import { deletedSitesCheckFetchOptions, hasNoLiveSites } from '../../sites/deleted-sites';
 import {
 	canManageSite,
 	canOptOutOfWordPressBeta,
@@ -56,7 +57,6 @@ import {
 	canViewHundredYearPlanSettings,
 } from '../../sites/features';
 import { VALUES_SEVERITY } from '../../sites/logs/dataviews/constants';
-import { deletedSitesCheckFetchOptions } from '../../sites/restore-deleted-sites-notice';
 import { reauthRequiredLink } from '../../utils/link';
 import {
 	getActivityLogHiddenGroups,
@@ -92,7 +92,7 @@ export const sitesRoute = createRoute( {
 			queryClient.ensureQueryData( isAutomatticianQuery() ),
 			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
 			// Settle the restore-deleted-sites notice eligibility before first paint.
-			user?.site_count === 0 &&
+			hasNoLiveSites( user ) &&
 				queryClient.ensureQueryData(
 					context.config.queries.paginatedSitesQuery( deletedSitesCheckFetchOptions )
 				),

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -56,6 +56,7 @@ import {
 	canViewHundredYearPlanSettings,
 } from '../../sites/features';
 import { VALUES_SEVERITY } from '../../sites/logs/dataviews/constants';
+import { deletedSitesCheckFetchOptions } from '../../sites/restore-deleted-sites-notice';
 import { reauthRequiredLink } from '../../utils/link';
 import {
 	getActivityLogHiddenGroups,
@@ -85,10 +86,16 @@ export const sitesRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'sites',
-	loader: async () => {
+	loader: async ( { context } ) => {
+		const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
 		await Promise.all( [
 			queryClient.ensureQueryData( isAutomatticianQuery() ),
 			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
+			// Settle the restore-deleted-sites notice eligibility before first paint.
+			user?.site_count === 0 &&
+				queryClient.ensureQueryData(
+					context.config.queries.paginatedSitesQuery( deletedSitesCheckFetchOptions )
+				),
 		] );
 	},
 } );

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -48,7 +48,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { createLazyRoute, createRoute, lazyRouteComponent, notFound } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { deletedSitesCheckFetchOptions, hasNoLiveSites } from '../../sites/deleted-sites';
 import {
 	canManageSite,
 	canOptOutOfWordPressBeta,
@@ -86,15 +85,10 @@ export const sitesRoute = createRoute( {
 	} ),
 	getParentRoute: () => rootRoute,
 	path: 'sites',
-	loader: async ( { context } ) => {
-		const user = queryClient.getQueryData< User >( AUTH_QUERY_KEY );
+	loader: async () => {
 		await Promise.all( [
 			queryClient.ensureQueryData( isAutomatticianQuery() ),
 			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
-			hasNoLiveSites( user ) &&
-				queryClient.ensureQueryData(
-					context.config.queries.paginatedSitesQuery( deletedSitesCheckFetchOptions )
-				),
 		] );
 	},
 } );

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -91,7 +91,6 @@ export const sitesRoute = createRoute( {
 		await Promise.all( [
 			queryClient.ensureQueryData( isAutomatticianQuery() ),
 			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
-			// Settle the restore-deleted-sites notice eligibility before first paint.
 			hasNoLiveSites( user ) &&
 				queryClient.ensureQueryData(
 					context.config.queries.paginatedSitesQuery( deletedSitesCheckFetchOptions )

--- a/client/dashboard/sites/deleted-sites.ts
+++ b/client/dashboard/sites/deleted-sites.ts
@@ -1,0 +1,11 @@
+import type { FetchPaginatedSitesOptions, User } from '@automattic/api-core';
+
+export const deletedSitesCheckFetchOptions: FetchPaginatedSitesOptions = {
+	site_visibility: 'deleted',
+	include_a8c_owned: false,
+	per_page: 1,
+};
+
+export function hasNoLiveSites( user: User | undefined ): boolean {
+	return user?.site_count === 0;
+}

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -38,6 +38,10 @@ import {
 import { EmptySitesStateContent, EmptySitesSearchStateContent } from './empty-sites-state';
 import { InviteAcceptedFlashMessage } from './invite-accepted-flash-message';
 import { SitesNoticeArbiter } from './notice-arbiter';
+import {
+	RestoreDeletedSitesNotice,
+	useShouldShowRestoreDeletedSitesNotice,
+} from './restore-deleted-sites-notice';
 import { RestoringSitesNotices } from './restoring-sites-notice';
 import type { FetchPaginatedSitesOptions, Site, DashboardFilters } from '@automattic/api-core';
 import type { View, Filter } from '@wordpress/dataviews';
@@ -167,6 +171,7 @@ export default function Sites() {
 
 	const isSecurityKeyReregisterRequired = useShouldShowSecurityKeyReregisterNotice();
 	const showSecurityKeyReregisterNotice = supports.me && isSecurityKeyReregisterRequired;
+	const shouldShowRestoreDeletedSitesNotice = useShouldShowRestoreDeletedSitesNotice();
 
 	const defaultView = getDefaultView( {
 		siteCount: user.site_count,
@@ -252,6 +257,9 @@ export default function Sites() {
 					<SitesNoticeArbiter>
 						{ showSecurityKeyReregisterNotice && <SecurityKeyReregisterNotice /> }
 						{ ! isDashboardBackport() && isRestoringAccount && <RestoringSitesNotices /> }
+						{ ! isRestoringAccount &&
+							! isDeletedFilterActive( filters ) &&
+							shouldShowRestoreDeletedSitesNotice && <RestoreDeletedSitesNotice /> }
 					</SitesNoticeArbiter>
 				}
 			>

--- a/client/dashboard/sites/restore-deleted-sites-notice.tsx
+++ b/client/dashboard/sites/restore-deleted-sites-notice.tsx
@@ -1,0 +1,65 @@
+import { useQuery } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { useAuth } from '../app/auth';
+import { useAppContext } from '../app/context';
+import ComponentViewTracker from '../components/component-view-tracker';
+import Notice from '../components/notice';
+import RouterLinkButton from '../components/router-link-button';
+import type { FetchPaginatedSitesOptions } from '@automattic/api-core';
+
+export const deletedSitesCheckFetchOptions: FetchPaginatedSitesOptions = {
+	site_visibility: 'deleted',
+	include_a8c_owned: false,
+	per_page: 1,
+};
+
+/**
+ * Whether the restore-deleted-sites notice is eligible to show. Read at the
+ * call site so the notice never decides its own visibility inside the arbiter.
+ * See client/dashboard/sites/AGENTS.md.
+ */
+export function useShouldShowRestoreDeletedSitesNotice() {
+	const { user } = useAuth();
+	const { queries } = useAppContext();
+	const hasNoLiveSites = user.site_count === 0;
+
+	// Prefetched by the sitesRoute loader for zero-site users, so eligibility
+	// is settled before first paint.
+	const { data } = useQuery( {
+		...queries.paginatedSitesQuery( deletedSitesCheckFetchOptions ),
+		enabled: hasNoLiveSites,
+	} );
+
+	return hasNoLiveSites && ( data?.total ?? 0 ) > 0;
+}
+
+export function RestoreDeletedSitesNotice() {
+	const [ isDismissed, setIsDismissed ] = useState( false );
+
+	if ( isDismissed ) {
+		return null;
+	}
+
+	return (
+		<>
+			<ComponentViewTracker eventName="calypso_dashboard_sites_restore_deleted_sites_notice_impression" />
+			<Notice
+				title={ __( 'You have deleted sites' ) }
+				onClose={ () => setIsDismissed( true ) }
+				actions={
+					<RouterLinkButton
+						to="/sites"
+						search={ { is_deleted: true } }
+						variant="primary"
+						__next40pxDefaultSize
+					>
+						{ __( 'View deleted sites' ) }
+					</RouterLinkButton>
+				}
+			>
+				{ __( 'Deleted sites can be restored within 30 days of deletion.' ) }
+			</Notice>
+		</>
+	);
+}

--- a/client/dashboard/sites/restore-deleted-sites-notice.tsx
+++ b/client/dashboard/sites/restore-deleted-sites-notice.tsx
@@ -6,13 +6,7 @@ import { useAppContext } from '../app/context';
 import ComponentViewTracker from '../components/component-view-tracker';
 import Notice from '../components/notice';
 import RouterLinkButton from '../components/router-link-button';
-import type { FetchPaginatedSitesOptions } from '@automattic/api-core';
-
-export const deletedSitesCheckFetchOptions: FetchPaginatedSitesOptions = {
-	site_visibility: 'deleted',
-	include_a8c_owned: false,
-	per_page: 1,
-};
+import { deletedSitesCheckFetchOptions, hasNoLiveSites } from './deleted-sites';
 
 /**
  * Whether the restore-deleted-sites notice is eligible to show. Read at the
@@ -22,16 +16,16 @@ export const deletedSitesCheckFetchOptions: FetchPaginatedSitesOptions = {
 export function useShouldShowRestoreDeletedSitesNotice() {
 	const { user } = useAuth();
 	const { queries } = useAppContext();
-	const hasNoLiveSites = user.site_count === 0;
+	const noLiveSites = hasNoLiveSites( user );
 
 	// Prefetched by the sitesRoute loader for zero-site users, so eligibility
 	// is settled before first paint.
 	const { data } = useQuery( {
 		...queries.paginatedSitesQuery( deletedSitesCheckFetchOptions ),
-		enabled: hasNoLiveSites,
+		enabled: noLiveSites,
 	} );
 
-	return hasNoLiveSites && ( data?.total ?? 0 ) > 0;
+	return noLiveSites && ( data?.total ?? 0 ) > 0;
 }
 
 export function RestoreDeletedSitesNotice() {

--- a/client/dashboard/sites/restore-deleted-sites-notice.tsx
+++ b/client/dashboard/sites/restore-deleted-sites-notice.tsx
@@ -18,11 +18,11 @@ export function useShouldShowRestoreDeletedSitesNotice() {
 	const { queries } = useAppContext();
 	const noLiveSites = hasNoLiveSites( user );
 
-	// Prefetched by the sitesRoute loader for zero-site users, so eligibility
-	// is settled before first paint.
+	// Holds the full-page loader so eligibility is settled before first paint.
 	const { data } = useQuery( {
 		...queries.paginatedSitesQuery( deletedSitesCheckFetchOptions ),
 		enabled: noLiveSites,
+		meta: { fullPageLoader: true },
 	} );
 
 	return noLiveSites && ( data?.total ?? 0 ) > 0;

--- a/client/dashboard/sites/restoring-sites-notice.tsx
+++ b/client/dashboard/sites/restoring-sites-notice.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { sitesRoute } from '../app/router/sites';
@@ -22,10 +22,12 @@ export const RestoringSitesNotices = () => {
 		<Notice title={ __( 'Choose which sites you’d like to restore' ) } onClose={ handleClose }>
 			{ createInterpolateElement(
 				__(
-					'<restoreSiteLink>Restore sites</restoreSiteLink> from the action menu. You’ll also need to <invitePeopleLink>invite any users</invitePeopleLink> that previously had access to your sites.'
+					'<deletedSitesLink>View your deleted sites</deletedSitesLink> and restore the ones you’d like to keep. You’ll also need to <invitePeopleLink>invite any users</invitePeopleLink> that previously had access to your sites.'
 				),
 				{
-					restoreSiteLink: <InlineSupportLink supportContext="restore-site" />,
+					deletedSitesLink: (
+						<Link to="/sites" search={ { ...currentSearchParams, is_deleted: true } } />
+					),
 					invitePeopleLink: <InlineSupportLink supportContext="invite-people" />,
 				}
 			) }

--- a/client/dashboard/sites/test/index.test.tsx
+++ b/client/dashboard/sites/test/index.test.tsx
@@ -39,6 +39,15 @@ function mockSitesEndpoint( sites: Site[] ) {
 		.reply( 200, { sites, total: sites.length } );
 }
 
+// Register before mockSitesEndpoint so the catch-all interceptor doesn't
+// consume the deleted-sites check request.
+function mockDeletedSitesCheckEndpoint( total: number ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.3/me/sites' )
+		.query( ( query ) => query.site_visibility === 'deleted' )
+		.reply( 200, { sites: [], total } );
+}
+
 describe( '<Sites>', () => {
 	beforeEach( () => {
 		nock( 'https://public-api.wordpress.com' )
@@ -65,6 +74,7 @@ describe( '<Sites>', () => {
 	} );
 
 	test( 'renders empty state when the user has no sites', async () => {
+		mockDeletedSitesCheckEndpoint( 0 );
 		mockSitesEndpoint( mockSites );
 		render( <Sites />, {
 			user: {
@@ -77,6 +87,37 @@ describe( '<Sites>', () => {
 		).toBeVisible();
 		expect( screen.getByRole( 'link', { name: 'Create a site' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'table' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'shows the restore deleted sites notice when a zero-site user has deleted sites', async () => {
+		mockDeletedSitesCheckEndpoint( 1 );
+		mockSitesEndpoint( [] );
+		render( <Sites />, {
+			user: {
+				site_count: 0,
+			} as User,
+		} );
+
+		expect( await screen.findByText( 'You have deleted sites' ) ).toBeVisible();
+		const link = screen.getByRole( 'link', { name: 'View deleted sites' } );
+		expect( link ).toBeVisible();
+		expect( link ).toHaveAttribute( 'href', expect.stringContaining( 'is_deleted=true' ) );
+	} );
+
+	test( 'does not show the restore deleted sites notice when a zero-site user has no deleted sites', async () => {
+		const deletedCheckScope = mockDeletedSitesCheckEndpoint( 0 );
+		mockSitesEndpoint( [] );
+		render( <Sites />, {
+			user: {
+				site_count: 0,
+			} as User,
+		} );
+
+		expect(
+			await screen.findByRole( 'heading', { name: /You don.t have any sites yet/ } )
+		).toBeVisible();
+		await waitFor( () => expect( deletedCheckScope.isDone() ).toBe( true ) );
+		expect( screen.queryByText( 'You have deleted sites' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'collision listener rewrites wpcom site slug when it collides with a Jetpack site', async () => {

--- a/client/sites/components/sites-dashboard-banners/use-restore-sites-reminder-banner.tsx
+++ b/client/sites/components/sites-dashboard-banners/use-restore-sites-reminder-banner.tsx
@@ -37,12 +37,10 @@ export function useRestoreSitesBanner() {
 					>
 						{ createInterpolateElement(
 							__(
-								'<restoreSiteLink>Restore sites</restoreSiteLink> from the action menu. You’ll also need to <invitePeopleLink>invite any users</invitePeopleLink> that previously had access to your sites.'
+								'<deletedSitesLink>View your deleted sites</deletedSitesLink> and restore the ones you’d like to keep. You’ll also need to <invitePeopleLink>invite any users</invitePeopleLink> that previously had access to your sites.'
 							),
 							{
-								restoreSiteLink: (
-									<InlineSupportLink showIcon={ false } supportContext="restore-site" />
-								),
+								deletedSitesLink: <a href="/sites?is_deleted=true" />,
 								invitePeopleLink: (
 									<InlineSupportLink showIcon={ false } supportContext="invite-people" />
 								),


### PR DESCRIPTION
Part of DOTMSD-1213. Alternative: #113643.

## Proposed Changes

* Show a "You have deleted sites" notice on `/sites` when the user has no live sites but has restorable deleted ones, linking to the deleted-sites view.
* The account-restore (`?restored=true`) banners link to the deleted-sites view instead of referencing an action menu that doesn't render for zero-site users.
* The deleted-sites check runs only when `site_count === 0` and holds the full-page loader, so users with sites pay no extra request and there is no banner pop-in.

## Screenshot

<img width="2844" height="2002" alt="my localhost_3000_sites (8)" src="https://github.com/user-attachments/assets/b7fb4b2b-abac-472f-b6ee-849a46f53b8d" />



## Why are these changes being made?

* Users whose only sites were deleted (commonly after closing and reopening their account) land on onboarding with no path to self-serve restore; support keeps escalating these. The only workaround was knowing to type `?is_deleted=true`.

## Testing Instructions

Use a test account with exactly one site, then delete that site.

1. `yarn start-dashboard`, visit `/sites`.
   * "You have deleted sites" notice shows above the empty state.
   * "View deleted sites" lands on the deleted view with the site listed and "Restore site" in the row menu; the notice doesn't show there.
   * Dismissing the notice hides it for the session.
2. Visit `/sites?restored=true`: the account-restore banner shows instead (only one), and its "View your deleted sites" link works.
3. Repeat on `calypso.localhost:3000/sites` (`yarn start`, backport).
4. With an account that has live sites: no new banner, and no `/me/sites` request with `site_visibility=deleted` in the Network tab.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XNecbLqLbmQvQEx3Tsy7RY
