### PR TITLE
Jetpack AI sidebar: disable writing suggestions on an empty post

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -332,21 +332,6 @@ describe( 'AgentChat', () => {
 		);
 	} );
 
-	it( 'explains the empty view when a suggestion is disabled', () => {
-		renderAgentChat( {
-			isOpen: true,
-			emptyViewSuggestions: [
-				{ id: 'optimize-title', label: 'Optimize title', prompt: 'Optimize.', disabled: true },
-			],
-		} );
-
-		expect(
-			screen.getByText(
-				'Some options are unavailable until the post has content. Got a different request? Ask away.'
-			)
-		).toBeInTheDocument();
-	} );
-
 	it( 'keeps the plain help line when every suggestion is usable', () => {
 		renderAgentChat( {
 			isOpen: true,

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -332,6 +332,21 @@ describe( 'AgentChat', () => {
 		);
 	} );
 
+	it( 'explains the empty view when a suggestion is disabled', () => {
+		renderAgentChat( {
+			isOpen: true,
+			emptyViewSuggestions: [
+				{ id: 'optimize-title', label: 'Optimize title', prompt: 'Optimize.', disabled: true },
+			],
+		} );
+
+		expect(
+			screen.getByText(
+				'Some options are unavailable until the post has content. Got a different request? Ask away.'
+			)
+		).toBeInTheDocument();
+	} );
+
 	it( 'keeps the plain help line when every suggestion is usable', () => {
 		renderAgentChat( {
 			isOpen: true,

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -108,16 +108,23 @@ jest.mock(
 		}
 
 		function MockEmptyView( {
+			help,
 			suggestions = [],
 			onSuggestionClick,
 		}: {
+			help?: string;
 			suggestions?: Suggestion[];
 			onSuggestionClick?: (
 				selectedSuggestion: Suggestion,
 				availableSuggestions: Suggestion[]
 			) => void;
 		} ) {
-			return <MockSuggestionButtons suggestions={ suggestions } onSubmit={ onSuggestionClick } />;
+			return (
+				<>
+					{ help && <p>{ help }</p> }
+					<MockSuggestionButtons suggestions={ suggestions } onSubmit={ onSuggestionClick } />
+				</>
+			);
 		}
 
 		function MockSuggestions( {
@@ -323,6 +330,30 @@ describe( 'AgentChat', () => {
 		expect( mockInputProps ).toHaveBeenCalledWith(
 			expect.objectContaining( { readOnly: true, disabled: true } )
 		);
+	} );
+
+	it( 'explains the empty view when a suggestion is disabled', () => {
+		renderAgentChat( {
+			isOpen: true,
+			emptyViewSuggestions: [
+				{ id: 'optimize-title', label: 'Optimize title', prompt: 'Optimize.', disabled: true },
+			],
+		} );
+
+		expect(
+			screen.getByText(
+				'Some options need content in the post. Got a different request? Ask away.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	it( 'keeps the plain help line when every suggestion is usable', () => {
+		renderAgentChat( {
+			isOpen: true,
+			emptyViewSuggestions: [ { id: 'optimize-title', label: 'Optimize title', prompt: 'Go.' } ],
+		} );
+
+		expect( screen.getByText( 'Got a different request? Ask away.' ) ).toBeInTheDocument();
 	} );
 
 	it( 'forwards empty view suggestion clicks to the shared suggestion handler', async () => {

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -179,7 +179,10 @@ jest.mock( '@wordpress/data', () => ( {
 		} ) ),
 } ) );
 
-jest.mock( '@wordpress/i18n', () => ( { __: ( text: string ) => text, isRTL: () => false } ) );
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+	isRTL: () => false,
+} ) );
 jest.mock( '../../utils/tracks', () => ( {
 	recordBigSkyTracksEvent: jest.fn(),
 	recordAgentsManagerTracksEvent: jest.fn(),
@@ -332,28 +335,26 @@ describe( 'AgentChat', () => {
 		);
 	} );
 
-	it( 'explains the empty view when a suggestion is disabled', () => {
+	// The chip carries its own reason, so the help line stays the same whether or
+	// not anything is disabled.
+	it( 'keeps the plain help line when a suggestion is disabled', () => {
 		renderAgentChat( {
 			isOpen: true,
 			emptyViewSuggestions: [
-				{ id: 'optimize-title', label: 'Optimize title', prompt: 'Optimize.', disabled: true },
+				{
+					id: 'optimize-title',
+					label: 'Optimize title',
+					prompt: 'Optimize.',
+					disabled: true,
+					disabledReason: 'This feature will be available once content is added to the page.',
+				},
 			],
 		} );
 
-		expect(
-			screen.getByText(
-				'Some options are unavailable until the post has content. Got a different request? Ask away.'
-			)
-		).toBeInTheDocument();
-	} );
-
-	it( 'keeps the plain help line when every suggestion is usable', () => {
-		renderAgentChat( {
-			isOpen: true,
-			emptyViewSuggestions: [ { id: 'optimize-title', label: 'Optimize title', prompt: 'Go.' } ],
-		} );
-
 		expect( screen.getByText( 'Got a different request? Ask away.' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByText( /This feature will be available once content is added/ )
+		).toBeNull();
 	} );
 
 	it( 'forwards empty view suggestion clicks to the shared suggestion handler', async () => {

--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -342,7 +342,7 @@ describe( 'AgentChat', () => {
 
 		expect(
 			screen.getByText(
-				'Some options need content in the post. Got a different request? Ask away.'
+				'Some options are unavailable until the post has content. Got a different request? Ask away.'
 			)
 		).toBeInTheDocument();
 	} );

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -142,19 +142,13 @@ function getEmptyViewHeading(): string {
 	return __( 'Howdy! How can I help you today?', __i18n_text_domain__ );
 }
 
-function getEmptyViewHelp( hasDisabledSuggestion = false ): string {
+function getEmptyViewHelp(): string {
 	const override = getAgentsManagerInlineData()?.emptyViewHelp;
 	if ( override ) {
 		return override;
 	}
 	if ( isReaderChatHost() ) {
 		return __( 'Or type your own question below.', __i18n_text_domain__ );
-	}
-	if ( hasDisabledSuggestion ) {
-		return __(
-			'Some options are unavailable until the post has content. Got a different request? Ask away.',
-			__i18n_text_domain__
-		);
 	}
 	return __( 'Got a different request? Ask away.', __i18n_text_domain__ );
 }
@@ -325,13 +319,7 @@ export default function AgentChat( {
 				) : (
 					<GroupedEmptyView
 						heading={ getEmptyViewHeading() }
-						help={
-							emptyViewSuggestions.length > 0
-								? getEmptyViewHelp(
-										emptyViewSuggestions.some( ( suggestion ) => suggestion.disabled )
-								  )
-								: undefined
-						}
+						help={ emptyViewSuggestions.length > 0 ? getEmptyViewHelp() : undefined }
 						suggestions={ emptyViewSuggestions }
 						groupWritingSuggestions={ groupWritingSuggestions }
 						onSuggestionClick={ onSuggestionClick }

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -142,13 +142,19 @@ function getEmptyViewHeading(): string {
 	return __( 'Howdy! How can I help you today?', __i18n_text_domain__ );
 }
 
-function getEmptyViewHelp(): string {
+function getEmptyViewHelp( hasDisabledSuggestion = false ): string {
 	const override = getAgentsManagerInlineData()?.emptyViewHelp;
 	if ( override ) {
 		return override;
 	}
 	if ( isReaderChatHost() ) {
 		return __( 'Or type your own question below.', __i18n_text_domain__ );
+	}
+	if ( hasDisabledSuggestion ) {
+		return __(
+			'Some options need content in the post. Got a different request? Ask away.',
+			__i18n_text_domain__
+		);
 	}
 	return __( 'Got a different request? Ask away.', __i18n_text_domain__ );
 }
@@ -319,7 +325,13 @@ export default function AgentChat( {
 				) : (
 					<GroupedEmptyView
 						heading={ getEmptyViewHeading() }
-						help={ emptyViewSuggestions.length > 0 ? getEmptyViewHelp() : undefined }
+						help={
+							emptyViewSuggestions.length > 0
+								? getEmptyViewHelp(
+										emptyViewSuggestions.some( ( suggestion ) => suggestion.disabled )
+								  )
+								: undefined
+						}
 						suggestions={ emptyViewSuggestions }
 						groupWritingSuggestions={ groupWritingSuggestions }
 						onSuggestionClick={ onSuggestionClick }

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -152,7 +152,7 @@ function getEmptyViewHelp( hasDisabledSuggestion = false ): string {
 	}
 	if ( hasDisabledSuggestion ) {
 		return __(
-			'Some options need content in the post. Got a different request? Ask away.',
+			'Some options are unavailable until the post has content. Got a different request? Ask away.',
 			__i18n_text_domain__
 		);
 	}

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -142,13 +142,19 @@ function getEmptyViewHeading(): string {
 	return __( 'Howdy! How can I help you today?', __i18n_text_domain__ );
 }
 
-function getEmptyViewHelp(): string {
+function getEmptyViewHelp( hasDisabledSuggestion = false ): string {
 	const override = getAgentsManagerInlineData()?.emptyViewHelp;
 	if ( override ) {
 		return override;
 	}
 	if ( isReaderChatHost() ) {
 		return __( 'Or type your own question below.', __i18n_text_domain__ );
+	}
+	if ( hasDisabledSuggestion ) {
+		return __(
+			'Some options are unavailable until the post has content. Got a different request? Ask away.',
+			__i18n_text_domain__
+		);
 	}
 	return __( 'Got a different request? Ask away.', __i18n_text_domain__ );
 }
@@ -319,7 +325,13 @@ export default function AgentChat( {
 				) : (
 					<GroupedEmptyView
 						heading={ getEmptyViewHeading() }
-						help={ emptyViewSuggestions.length > 0 ? getEmptyViewHelp() : undefined }
+						help={
+							emptyViewSuggestions.length > 0
+								? getEmptyViewHelp(
+										emptyViewSuggestions.some( ( suggestion ) => suggestion.disabled )
+								  )
+								: undefined
+						}
 						suggestions={ emptyViewSuggestions }
 						groupWritingSuggestions={ groupWritingSuggestions }
 						onSuggestionClick={ onSuggestionClick }

--- a/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
@@ -8,6 +8,7 @@ let mockContext = {
 	currentRoute: undefined as string | undefined,
 };
 let mockCurrentPostType: string | undefined;
+let mockIsEditedPostEmpty = false;
 
 jest.mock( '@wordpress/data', () => ( {
 	useSelect: (
@@ -72,6 +73,7 @@ function mockCoreStoreReady( isReady: boolean ) {
 			if ( storeName === 'core/editor' ) {
 				return {
 					getCurrentPostType: () => mockCurrentPostType,
+					isEditedPostEmpty: () => mockIsEditedPostEmpty,
 				};
 			}
 
@@ -98,6 +100,7 @@ describe( 'useEmptyViewSuggestions', () => {
 			currentRoute: undefined,
 		};
 		mockCurrentPostType = undefined;
+		mockIsEditedPostEmpty = false;
 		mockCoreStoreReady( true );
 	} );
 
@@ -361,5 +364,38 @@ describe( 'hideTopLevelDescriptions', () => {
 		expect( hideTopLevelDescriptions( [ siteEditorSuggestion ] ) ).toEqual( [
 			siteEditorSuggestion,
 		] );
+	} );
+} );
+
+describe( 'useEmptyViewSuggestions post content changes', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockContext = { sectionName: 'gutenberg', currentRoute: undefined };
+		mockCurrentPostType = 'post';
+		mockIsEditedPostEmpty = true;
+		mockCoreStoreReady( true );
+	} );
+
+	afterEach( () => {
+		delete ( window as unknown as { agentsManagerData?: unknown } ).agentsManagerData;
+		mockIsEditedPostEmpty = false;
+	} );
+
+	// The list is cached in state, so it has to be rebuilt when emptiness flips.
+	it( 'refreshes the suggestions when the post gains content', async () => {
+		const getEmptyViewSuggestions = jest.fn( () => [
+			{ ...jetpackSuggestion, disabled: mockIsEditedPostEmpty },
+		] );
+		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
+
+		const { result, rerender } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
+
+		await waitFor( () => expect( result.current?.[ 0 ]?.disabled ).toBe( true ) );
+
+		mockIsEditedPostEmpty = false;
+		mockCoreStoreReady( true );
+		rerender();
+
+		await waitFor( () => expect( result.current?.[ 0 ]?.disabled ).toBe( false ) );
 	} );
 } );

--- a/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
@@ -381,21 +381,25 @@ describe( 'useEmptyViewSuggestions post content changes', () => {
 		mockIsEditedPostEmpty = false;
 	} );
 
-	// The list is cached in state, so it has to be rebuilt when emptiness flips.
+	// The provider drops content-derived suggestions on an empty post, and the list is
+	// cached in state, so it has to be rebuilt when emptiness flips.
 	it( 'refreshes the suggestions when the post gains content', async () => {
-		const getEmptyViewSuggestions = jest.fn( () => [
-			{ ...jetpackSuggestion, disabled: mockIsEditedPostEmpty },
-		] );
+		// Generate featured image survives an empty post, so the provider keeps
+		// returning a list rather than nothing.
+		const featuredImage = { id: 'generate-featured-image', label: 'Generate', prompt: '' };
+		const getEmptyViewSuggestions = jest.fn( () =>
+			mockIsEditedPostEmpty ? [ featuredImage ] : [ featuredImage, jetpackSuggestion ]
+		);
 		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
 
 		const { result, rerender } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
 
-		await waitFor( () => expect( result.current?.[ 0 ]?.disabled ).toBe( true ) );
+		await waitFor( () => expect( result.current ).toEqual( [ featuredImage ] ) );
 
 		mockIsEditedPostEmpty = false;
 		mockCoreStoreReady( true );
 		rerender();
 
-		await waitFor( () => expect( result.current?.[ 0 ]?.disabled ).toBe( false ) );
+		await waitFor( () => expect( result.current ).toEqual( [ featuredImage, jetpackSuggestion ] ) );
 	} );
 } );

--- a/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-empty-view-suggestions.test.ts
@@ -381,25 +381,21 @@ describe( 'useEmptyViewSuggestions post content changes', () => {
 		mockIsEditedPostEmpty = false;
 	} );
 
-	// The provider drops content-derived suggestions on an empty post, and the list is
-	// cached in state, so it has to be rebuilt when emptiness flips.
+	// The list is cached in state, so it has to be rebuilt when emptiness flips.
 	it( 'refreshes the suggestions when the post gains content', async () => {
-		// Generate featured image survives an empty post, so the provider keeps
-		// returning a list rather than nothing.
-		const featuredImage = { id: 'generate-featured-image', label: 'Generate', prompt: '' };
-		const getEmptyViewSuggestions = jest.fn( () =>
-			mockIsEditedPostEmpty ? [ featuredImage ] : [ featuredImage, jetpackSuggestion ]
-		);
+		const getEmptyViewSuggestions = jest.fn( () => [
+			{ ...jetpackSuggestion, disabled: mockIsEditedPostEmpty },
+		] );
 		const loadedProviders = { getEmptyViewSuggestions } as unknown as LoadedProviders;
 
 		const { result, rerender } = renderHook( () => useEmptyViewSuggestions( { loadedProviders } ) );
 
-		await waitFor( () => expect( result.current ).toEqual( [ featuredImage ] ) );
+		await waitFor( () => expect( result.current?.[ 0 ]?.disabled ).toBe( true ) );
 
 		mockIsEditedPostEmpty = false;
 		mockCoreStoreReady( true );
 		rerender();
 
-		await waitFor( () => expect( result.current ).toEqual( [ featuredImage, jetpackSuggestion ] ) );
+		await waitFor( () => expect( result.current?.[ 0 ]?.disabled ).toBe( false ) );
 	} );
 } );

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -144,7 +144,7 @@ function readOverrideSuggestions(): Suggestion[] | null {
 
 function getSuggestionsKey( suggestions: Suggestion[] | null ): string | null {
 	return suggestions
-		? JSON.stringify( suggestions.map( ( s ) => [ s.id, s.label, s.prompt, s.disabled ] ) )
+		? JSON.stringify( suggestions.map( ( s ) => [ s.id, s.label, s.prompt ] ) )
 		: null;
 }
 

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -188,37 +188,30 @@ export function isPageOrSiteEditorSurface(
 }
 
 /**
- * Providers key suggestions on this, so the effect below has to re-run when it
- * flips. Hosts with no editor store (Reader chat, Plugin Compass) report false.
+ * Providers key suggestions on `isEditedPostEmpty`, so the effect below has to
+ * re-run when it flips. Hosts with no editor store (Reader chat, Plugin
+ * Compass) report false.
  */
-function useIsEditedPostEmpty(): boolean {
-	return useSelect( ( select ) => {
-		try {
-			const editorStore = select( 'core/editor' ) as {
-				isEditedPostEmpty?: () => boolean;
-			};
-			return editorStore?.isEditedPostEmpty?.() === true;
-		} catch {
-			return false;
-		}
-	}, [] );
-}
-
 export function usePageOrSiteEditorSurface() {
 	const { sectionName, currentRoute } = useAgentsManagerContext();
-	const currentPostType = useSelect( ( select ) => {
+	const { currentPostType, isEditedPostEmpty } = useSelect( ( select ) => {
 		try {
 			const editorStore = select( 'core/editor' ) as {
 				getCurrentPostType?: () => string | undefined;
+				isEditedPostEmpty?: () => boolean;
 			};
-			return editorStore?.getCurrentPostType?.();
+			return {
+				currentPostType: editorStore?.getCurrentPostType?.(),
+				isEditedPostEmpty: editorStore?.isEditedPostEmpty?.() === true,
+			};
 		} catch {
-			return undefined;
+			return { currentPostType: undefined, isEditedPostEmpty: false };
 		}
 	}, [] );
 
 	return {
 		currentPostType,
+		isEditedPostEmpty,
 		isPageOrSiteEditorSurface: isPageOrSiteEditorSurface(
 			sectionName,
 			currentRoute,
@@ -243,9 +236,11 @@ export function useEmptyViewSuggestions( {
 	loadedProviders,
 }: UseEmptyViewSuggestionsOptions ): Suggestion[] | null {
 	const isReaderChat = isReaderChatHost();
-	const { currentPostType, isPageOrSiteEditorSurface: shouldShowSiteEditorSuggestions } =
-		usePageOrSiteEditorSurface();
-	const isEditedPostEmpty = useIsEditedPostEmpty();
+	const {
+		currentPostType,
+		isPageOrSiteEditorSurface: shouldShowSiteEditorSuggestions,
+		isEditedPostEmpty,
+	} = usePageOrSiteEditorSurface();
 
 	// Default suggestions - used when Big Sky doesn't provide custom ones
 	const defaultSuggestions = useMemo(

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -144,7 +144,7 @@ function readOverrideSuggestions(): Suggestion[] | null {
 
 function getSuggestionsKey( suggestions: Suggestion[] | null ): string | null {
 	return suggestions
-		? JSON.stringify( suggestions.map( ( s ) => [ s.id, s.label, s.prompt ] ) )
+		? JSON.stringify( suggestions.map( ( s ) => [ s.id, s.label, s.prompt, s.disabled ] ) )
 		: null;
 }
 

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -144,7 +144,7 @@ function readOverrideSuggestions(): Suggestion[] | null {
 
 function getSuggestionsKey( suggestions: Suggestion[] | null ): string | null {
 	return suggestions
-		? JSON.stringify( suggestions.map( ( s ) => [ s.id, s.label, s.prompt ] ) )
+		? JSON.stringify( suggestions.map( ( s ) => [ s.id, s.label, s.prompt, s.disabled ] ) )
 		: null;
 }
 
@@ -185,6 +185,23 @@ export function isPageOrSiteEditorSurface(
 	}
 
 	return sectionName === 'site-editor';
+}
+
+/**
+ * Providers key suggestions on this, so the effect below has to re-run when it
+ * flips. Hosts with no editor store (Reader chat, Plugin Compass) report false.
+ */
+function useIsEditedPostEmpty(): boolean {
+	return useSelect( ( select ) => {
+		try {
+			const editorStore = select( 'core/editor' ) as {
+				isEditedPostEmpty?: () => boolean;
+			};
+			return editorStore?.isEditedPostEmpty?.() === true;
+		} catch {
+			return false;
+		}
+	}, [] );
 }
 
 export function usePageOrSiteEditorSurface() {
@@ -228,6 +245,7 @@ export function useEmptyViewSuggestions( {
 	const isReaderChat = isReaderChatHost();
 	const { currentPostType, isPageOrSiteEditorSurface: shouldShowSiteEditorSuggestions } =
 		usePageOrSiteEditorSurface();
+	const isEditedPostEmpty = useIsEditedPostEmpty();
 
 	// Default suggestions - used when Big Sky doesn't provide custom ones
 	const defaultSuggestions = useMemo(
@@ -362,6 +380,7 @@ export function useEmptyViewSuggestions( {
 		overrideVersion,
 		shouldShowSiteEditorSuggestions,
 		currentPostType,
+		isEditedPostEmpty,
 	] );
 
 	return emptyViewSuggestions;

--- a/packages/agenttic-ui/package.json
+++ b/packages/agenttic-ui/package.json
@@ -89,6 +89,7 @@
 		"@radix-ui/react-popover": "^1.1.15",
 		"@radix-ui/react-scroll-area": "^1.2.9",
 		"@radix-ui/react-slot": "^1.2.3",
+		"@radix-ui/react-tooltip": "1.2.9",
 		"@wordpress/i18n": "^6.1.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",

--- a/packages/agenttic-ui/src/components/chat/SuggestionDropdown.tsx
+++ b/packages/agenttic-ui/src/components/chat/SuggestionDropdown.tsx
@@ -33,6 +33,8 @@ export interface SuggestionDropdownProps {
 	onOpenChange?: ( open: boolean ) => void;
 	/** Render the suggestion's description under the label (vertical layout). */
 	showDescription?: boolean;
+	/** Id of the element explaining why the suggestion is inert, when it is. */
+	describedById?: string;
 }
 
 export const SuggestionDropdown: React.FC< SuggestionDropdownProps > = ( {
@@ -41,6 +43,7 @@ export const SuggestionDropdown: React.FC< SuggestionDropdownProps > = ( {
 	availableSuggestions,
 	onOpenChange,
 	showDescription,
+	describedById,
 } ) => {
 	const [ open, setOpen ] = React.useState( false );
 	const containerRef = React.useRef< HTMLDivElement | null >( null );
@@ -69,6 +72,11 @@ export const SuggestionDropdown: React.FC< SuggestionDropdownProps > = ( {
 
 	const updateOpen = React.useCallback(
 		( nextOpen: boolean ) => {
+			// `aria-disabled` leaves the trigger clickable, so the list has to be
+			// held shut here.
+			if ( nextOpen && suggestion.disabled ) {
+				return;
+			}
 			if ( nextOpen ) {
 				const suggestionsEl = containerRef.current?.closest< HTMLElement >(
 					'[data-slot="suggestions"]'
@@ -80,8 +88,15 @@ export const SuggestionDropdown: React.FC< SuggestionDropdownProps > = ( {
 			setOpen( nextOpen );
 			onOpenChange?.( nextOpen );
 		},
-		[ onOpenChange ]
+		[ onOpenChange, suggestion.disabled ]
 	);
+
+	// Close a list left open by a suggestion that became disabled behind it.
+	React.useEffect( () => {
+		if ( suggestion.disabled && open ) {
+			setOpen( false );
+		}
+	}, [ suggestion.disabled, open ] );
 
 	const handleOptionSelect = ( option: SuggestionOption ) => {
 		const { options: _options, ...rest } = suggestion;
@@ -98,7 +113,12 @@ export const SuggestionDropdown: React.FC< SuggestionDropdownProps > = ( {
 		<div ref={ setContainerNode } className={ styles.container }>
 			<Popover.Root open={ open } onOpenChange={ updateOpen }>
 				<Popover.Trigger asChild>
-					<Button variant="outline" className={ suggestionStyles.button }>
+					<Button
+						aria-disabled={ suggestion.disabled }
+						aria-describedby={ describedById }
+						variant="outline"
+						className={ suggestionStyles.button }
+					>
 						<div
 							className={ cn(
 								suggestionStyles[ 'suggestion-content' ],

--- a/packages/agenttic-ui/src/components/chat/SuggestionTooltip.module.css
+++ b/packages/agenttic-ui/src/components/chat/SuggestionTooltip.module.css
@@ -1,0 +1,44 @@
+/* The trigger has to leave the chip the width it would have had unwrapped.
+   `inline-flex` shrinks to the label, so a chip with a tooltip comes out
+   narrower than its neighbours in the stacked vertical layout. Block-level flex
+   fills the row, and growing the chip covers both a bare button and the
+   dropdown's wrapper div. */
+.trigger {
+	display: flex;
+}
+
+.trigger > * {
+	flex-grow: 1;
+}
+
+.content {
+	max-width: 240px;
+	padding: var( --spacing-1\.5 ) var( --spacing-2 );
+	background-color: var( --color-background );
+	color: var( --color-foreground );
+	border-radius: var( --radius-sm );
+	box-shadow: var( --shadow-lg );
+	font-size: var( --font-size-sm );
+	line-height: 1.4;
+	/* 1000 matches the floating-layer convention used by the suggestion dropdown. */
+	z-index: 1000;
+}
+
+/* stylelint-disable-next-line selector-pseudo-class-no-unknown -- CSS Modules :global */
+:global( .agenttic.dark ) .content {
+	border: 1px solid var( --color-muted );
+}
+
+/* The tooltip itself only describes the chip while it is open, and it never
+   opens on touch, so the reason also lives here for assistive technology. */
+.description {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip-path: inset( 50% );
+	white-space: nowrap;
+	border: 0;
+}

--- a/packages/agenttic-ui/src/components/chat/SuggestionTooltip.tsx
+++ b/packages/agenttic-ui/src/components/chat/SuggestionTooltip.tsx
@@ -1,0 +1,56 @@
+import * as Tooltip from '@radix-ui/react-tooltip';
+import * as React from 'react';
+import styles from './SuggestionTooltip.module.css';
+
+export interface SuggestionTooltipProps {
+	label: string;
+	/**
+	 * Id of the hidden copy of `label`. The chip inside must point its
+	 * `aria-describedby` at it, since Radix describes the trigger element rather
+	 * than the button within, and only while the tooltip is open.
+	 */
+	descriptionId: string;
+	children: React.ReactNode;
+}
+
+/**
+ * Wraps a suggestion chip so hovering or focusing it explains why it is inert.
+ * The chip must carry `aria-disabled` rather than `disabled`: a disabled button
+ * emits no pointer events and leaves the tab order, so neither trigger fires.
+ */
+export const SuggestionTooltip: React.FC< SuggestionTooltipProps > = ( {
+	label,
+	descriptionId,
+	children,
+} ) => {
+	const [ portalTarget, setPortalTarget ] = React.useState< HTMLElement | null >( null );
+
+	// Nearest `.agenttic` ancestor inherits the theme CSS vars while escaping the
+	// chat's overflow clipping. Falls back to the local node when a consumer uses
+	// `Suggestions` without that wrapper.
+	const setContainerNode = React.useCallback( ( node: HTMLElement | null ) => {
+		setPortalTarget( node ? node.closest< HTMLElement >( '.agenttic' ) ?? node : null );
+	}, [] );
+
+	return (
+		<Tooltip.Provider delayDuration={ 200 }>
+			<Tooltip.Root>
+				<Tooltip.Trigger asChild>
+					<span ref={ setContainerNode } className={ styles.trigger }>
+						{ children }
+					</span>
+				</Tooltip.Trigger>
+				<span id={ descriptionId } className={ styles.description }>
+					{ label }
+				</span>
+				{ portalTarget && (
+					<Tooltip.Portal container={ portalTarget }>
+						<Tooltip.Content className={ styles.content } side="top" sideOffset={ 6 }>
+							{ label }
+						</Tooltip.Content>
+					</Tooltip.Portal>
+				) }
+			</Tooltip.Root>
+		</Tooltip.Provider>
+	);
+};

--- a/packages/agenttic-ui/src/components/chat/Suggestions.test.tsx
+++ b/packages/agenttic-ui/src/components/chat/Suggestions.test.tsx
@@ -42,6 +42,18 @@ const makeContext = (
 let container: HTMLDivElement;
 let root: Root;
 
+// Throws rather than returning undefined: a missing chip would otherwise turn
+// every click into a no-op and let a negative assertion pass vacuously.
+const getButton = ( label: string ): HTMLButtonElement => {
+	const button = Array.from( container.querySelectorAll( 'button' ) ).find(
+		( candidate ) => candidate.textContent?.includes( label )
+	);
+	if ( ! button ) {
+		throw new Error( `No button found containing "${ label }".` );
+	}
+	return button;
+};
+
 beforeEach( () => {
 	container = document.createElement( 'div' );
 	document.body.appendChild( container );
@@ -157,5 +169,136 @@ describe( 'Suggestions dropdown description wiring', () => {
 		} );
 
 		expect( container.textContent ).not.toContain( 'Adjust the tone of your post.' );
+	} );
+} );
+
+describe( 'Suggestions disabled', () => {
+	const dropdownSuggestion: Suggestion = {
+		id: 'seo',
+		label: 'SEO Enhancer',
+		prompt: '',
+		options: [ { id: 'title', label: 'Title', value: 'Write a title' } ],
+	};
+
+	it( 'renders a plain suggestion as a disabled button', () => {
+		render( 'embedded', vi.fn(), {
+			suggestions: [ { id: 'a', label: 'A', prompt: 'A', disabled: true } ],
+		} );
+
+		expect( getButton( 'A' ).getAttribute( 'aria-disabled' ) ).toBe( 'true' );
+	} );
+
+	it( 'renders a dropdown suggestion as a disabled trigger', () => {
+		render( 'embedded', vi.fn(), {
+			suggestions: [ { ...dropdownSuggestion, disabled: true } ],
+		} );
+
+		expect( getButton( 'SEO Enhancer' ).getAttribute( 'aria-disabled' ) ).toBe( 'true' );
+	} );
+
+	it( 'runs neither the action nor the submit for a disabled suggestion', async () => {
+		const action = vi.fn( () => true );
+		const onSubmit = vi.fn();
+		render( 'embedded', vi.fn(), {
+			suggestions: [ { id: 'a', label: 'A', prompt: 'A', action, disabled: true } ],
+			onSubmit,
+		} );
+
+		await act( async () => {
+			getButton( 'A' ).click();
+		} );
+
+		expect( action ).not.toHaveBeenCalled();
+		expect( onSubmit ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not open the option list of a disabled dropdown', async () => {
+		const onDropdownOpenChange = vi.fn();
+		render( 'embedded', vi.fn(), {
+			suggestions: [ { ...dropdownSuggestion, disabled: true } ],
+			onDropdownOpenChange,
+		} );
+
+		await act( async () => {
+			getButton( 'SEO Enhancer' ).click();
+		} );
+
+		expect( onDropdownOpenChange ).not.toHaveBeenCalledWith( true );
+		expect( container.textContent ).not.toContain( 'Title' );
+	} );
+} );
+
+describe( 'Suggestions disabled tooltip', () => {
+	const disabledWithReason: Suggestion = {
+		id: 'a',
+		label: 'A',
+		prompt: 'A',
+		disabled: true,
+		disabledReason: 'Add content first.',
+	};
+
+	it( 'keeps a disabled chip focusable so the tooltip is reachable', () => {
+		render( 'embedded', vi.fn(), { suggestions: [ disabledWithReason ] } );
+
+		// A real `disabled` button leaves the tab order, so a tooltip could never
+		// reach a keyboard user.
+		expect( getButton( 'A' ).disabled ).toBe( false );
+		expect( getButton( 'A' ).tabIndex ).not.toBe( -1 );
+		expect( getButton( 'A' ).getAttribute( 'aria-disabled' ) ).toBe( 'true' );
+	} );
+
+	// SEO Enhancer is this shape in production: a dropdown, gated on empty
+	// content, carrying a reason. It also nests a Radix popover trigger inside a
+	// Radix tooltip trigger, which fails quietly when it breaks.
+	it( 'describes a disabled dropdown trigger and keeps its list shut', async () => {
+		const onDropdownOpenChange = vi.fn();
+		render( 'embedded', vi.fn(), {
+			suggestions: [
+				{
+					id: 'seo',
+					label: 'SEO Enhancer',
+					prompt: '',
+					options: [ { id: 'title', label: 'Title', value: 'Write a title' } ],
+					disabled: true,
+					disabledReason: 'Add content first.',
+				},
+			],
+			onDropdownOpenChange,
+		} );
+
+		const describedBy = getButton( 'SEO Enhancer' ).getAttribute( 'aria-describedby' );
+		expect( describedBy ).toBeTruthy();
+		expect( document.getElementById( describedBy as string )?.textContent ).toBe(
+			'Add content first.'
+		);
+
+		await act( async () => {
+			getButton( 'SEO Enhancer' ).click();
+		} );
+
+		expect( onDropdownOpenChange ).not.toHaveBeenCalledWith( true );
+		expect( container.textContent ).not.toContain( 'Title' );
+	} );
+
+	it( 'describes the disabled chip itself, not its wrapper', () => {
+		render( 'embedded', vi.fn(), { suggestions: [ disabledWithReason ] } );
+
+		// Radix describes its trigger, and only while the tooltip is open, so the
+		// reason has to hang off the button for assistive technology and touch.
+		const describedBy = getButton( 'A' ).getAttribute( 'aria-describedby' );
+		expect( describedBy ).toBeTruthy();
+		expect( document.getElementById( describedBy as string )?.textContent ).toBe(
+			'Add content first.'
+		);
+	} );
+
+	it( 'leaves an enabled chip undescribed even when it carries a stale reason', () => {
+		render( 'embedded', vi.fn(), {
+			suggestions: [ { id: 'a', label: 'A', prompt: 'A', disabledReason: 'Unused.' } ],
+		} );
+
+		expect( getButton( 'A' ).getAttribute( 'aria-disabled' ) ).toBeNull();
+		expect( getButton( 'A' ).getAttribute( 'aria-describedby' ) ).toBeNull();
+		expect( document.body.textContent ).not.toContain( 'Unused.' );
 	} );
 } );

--- a/packages/agenttic-ui/src/components/chat/Suggestions.tsx
+++ b/packages/agenttic-ui/src/components/chat/Suggestions.tsx
@@ -5,6 +5,7 @@ import { cn } from '../../utils/classNames';
 import { fastSpringWithDelay } from '../animations';
 import { Button } from '../ui/button';
 import { SuggestionDropdown } from './SuggestionDropdown';
+import { SuggestionTooltip } from './SuggestionTooltip';
 import styles from './Suggestions.module.css';
 import type { Suggestion } from '../../types';
 
@@ -51,6 +52,10 @@ export const Suggestions: React.FC< SuggestionsProps > = ( {
 		selectedSuggestion: Suggestion,
 		availableSuggestions: Suggestion[]
 	) => {
+		if ( selectedSuggestion.disabled ) {
+			return;
+		}
+
 		let shouldSubmit = true;
 		if ( selectedSuggestion.action ) {
 			shouldSubmit = await selectedSuggestion.action();
@@ -85,6 +90,47 @@ export const Suggestions: React.FC< SuggestionsProps > = ( {
 				>
 					{ internalSuggestions.map( ( suggestion: Suggestion, index: number ) => {
 						const isEligibleForDescription = !! suggestion.description && layout !== 'horizontal';
+						const hasDisabledReason = !! suggestion.disabled && !! suggestion.disabledReason;
+						const reasonId = hasDisabledReason
+							? `agenttic-suggestion-reason-${ suggestion.id }`
+							: undefined;
+
+						const chip =
+							suggestion.options && suggestion.options.length > 0 ? (
+								<SuggestionDropdown
+									suggestion={ suggestion }
+									onSelect={ handleSuggestionClick }
+									availableSuggestions={ internalSuggestions }
+									onOpenChange={ onDropdownOpenChange }
+									showDescription={ isEligibleForDescription }
+									describedById={ reasonId }
+								/>
+							) : (
+								<Button
+									onClick={ ( e ) => {
+										e.stopPropagation();
+										handleSuggestionClick( suggestion, internalSuggestions );
+									} }
+									aria-disabled={ suggestion.disabled }
+									aria-describedby={ reasonId }
+									variant="outline"
+									className={ styles.button }
+								>
+									<div
+										className={ cn(
+											styles[ 'suggestion-content' ],
+											isEligibleForDescription
+												? styles[ 'suggestion-content--with-description' ]
+												: ''
+										) }
+									>
+										<span className={ styles.label }>{ suggestion.label }</span>
+										{ isEligibleForDescription && (
+											<span className={ styles.description }>{ suggestion.description }</span>
+										) }
+									</div>
+								</Button>
+							);
 
 						return (
 							<motion.div
@@ -97,37 +143,15 @@ export const Suggestions: React.FC< SuggestionsProps > = ( {
 									delay: index * 0.05,
 								} }
 							>
-								{ suggestion.options && suggestion.options.length > 0 ? (
-									<SuggestionDropdown
-										suggestion={ suggestion }
-										onSelect={ handleSuggestionClick }
-										availableSuggestions={ internalSuggestions }
-										onOpenChange={ onDropdownOpenChange }
-										showDescription={ isEligibleForDescription }
-									/>
-								) : (
-									<Button
-										onClick={ ( e ) => {
-											e.stopPropagation();
-											handleSuggestionClick( suggestion, internalSuggestions );
-										} }
-										variant="outline"
-										className={ styles.button }
+								{ reasonId ? (
+									<SuggestionTooltip
+										label={ suggestion.disabledReason as string }
+										descriptionId={ reasonId }
 									>
-										<div
-											className={ cn(
-												styles[ 'suggestion-content' ],
-												isEligibleForDescription
-													? styles[ 'suggestion-content--with-description' ]
-													: ''
-											) }
-										>
-											<span className={ styles.label }>{ suggestion.label }</span>
-											{ isEligibleForDescription && (
-												<span className={ styles.description }>{ suggestion.description }</span>
-											) }
-										</div>
-									</Button>
+										{ chip }
+									</SuggestionTooltip>
+								) : (
+									chip
 								) }
 							</motion.div>
 						);

--- a/packages/agenttic-ui/src/components/ui/button.module.css
+++ b/packages/agenttic-ui/src/components/ui/button.module.css
@@ -24,6 +24,14 @@
 	color: var( --color-muted-foreground );
 }
 
+/* Matches the disabled look but keeps pointer events, so a tooltip explaining
+   the state can still open on hover. */
+.button[aria-disabled='true'] {
+	background-color: var( --color-muted );
+	color: var( --color-muted-foreground );
+	cursor: default;
+}
+
 .button:focus-visible {
 	outline: 2px solid var( --color-ring );
 	outline-offset: 1.5px;
@@ -88,7 +96,7 @@
 	background-color: var( --color-background );
 }
 
-.outline:hover:not( :disabled ) {
+.outline:hover:not( :disabled ):not( [aria-disabled='true'] ) {
 	box-shadow: var( --shadow-outline-strong );
 }
 
@@ -96,7 +104,8 @@
 	outline-offset: 0;
 }
 
-.outline:disabled {
+.outline:disabled,
+.outline[aria-disabled='true'] {
 	background-color: var( --color-background );
 }
 

--- a/packages/agenttic-ui/src/types/index.ts
+++ b/packages/agenttic-ui/src/types/index.ts
@@ -44,6 +44,8 @@ export interface Suggestion {
 	action?: () => boolean | Promise< boolean >;
 	autoSubmit?: boolean; // When true, clicking the suggestion automatically submits it to the LLM
 	options?: SuggestionOption[]; // When present, renders as a dropdown picker
+	disabled?: boolean; // Greyed out and inert. For a feature with nothing to act on yet; drop one the user can never use
+	disabledReason?: string; // Tooltip on a disabled suggestion, explaining what would make it usable
 }
 
 export interface QuestionChoice {

--- a/packages/agenttic-ui/vite.config.ts
+++ b/packages/agenttic-ui/vite.config.ts
@@ -27,6 +27,7 @@ export default defineConfig( {
 				'@radix-ui/react-popover',
 				'@radix-ui/react-scroll-area',
 				'@radix-ui/react-slot',
+				'@radix-ui/react-tooltip',
 				'@wordpress/i18n',
 				'class-variance-authority',
 				'clsx',

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -1884,12 +1884,12 @@ describe( 'Proofread', () => {
 } );
 
 describe( 'empty post gating', () => {
+	// The three reviews sit inside the Get feedback dropdown, so that chip gates
+	// as a whole rather than each review separately.
 	const CONTENT_DEPENDENT_IDS = [
 		'optimize-title',
 		'generate-excerpt',
-		'generate-feedback',
-		'proofread-content',
-		'ai-editorial-review',
+		'get-feedback',
 		'seo-enhancer',
 	];
 
@@ -1924,6 +1924,32 @@ describe( 'empty post gating', () => {
 
 		expect( suggestion ).toBeDefined();
 		expect( suggestion?.disabled ).toBeFalsy();
+	} );
+
+	it.each( CONTENT_DEPENDENT_IDS )( 'gives %s a reason for being disabled', ( id ) => {
+		const suggestion = suggestionsFor( { isPostEmpty: true } ).find( ( s ) => s.id === id );
+
+		expect( suggestion?.disabledReason ).toBe(
+			'This feature will be available once content is added to the post.'
+		);
+	} );
+
+	it( 'names the page rather than the post when editing a page', () => {
+		installAiEditorialReviewData( ALL_FEATURES );
+		installPostTypeMock( 'page', 123, { supportsExcerpt: true, isPostEmpty: true } );
+		const suggestion = getEmptyViewSuggestions().find( ( s ) => s.id === 'optimize-title' );
+
+		expect( suggestion?.disabledReason ).toBe(
+			'This feature will be available once content is added to the page.'
+		);
+	} );
+
+	it( 'gives no reason once the suggestion is usable', () => {
+		const suggestion = suggestionsFor( { isPostEmpty: false } ).find(
+			( s ) => s.id === 'optimize-title'
+		);
+
+		expect( suggestion?.disabledReason ).toBeUndefined();
 	} );
 
 	it( 'keeps the disabled suggestions in the list so a blank post still shows them', () => {

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -1906,60 +1906,30 @@ describe( 'empty post gating', () => {
 		mockImageStudioActions = null;
 	} );
 
-	function suggestionsFor( options: { isPostEmpty?: boolean; omitIsEditedPostEmpty?: boolean } ) {
+	function idsFor( options: { isPostEmpty?: boolean; omitIsEditedPostEmpty?: boolean } ) {
 		installAiEditorialReviewData( ALL_FEATURES );
 		installPostTypeMock( 'post', 123, { supportsExcerpt: true, ...options } );
-		return getEmptyViewSuggestions();
+		return getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
 	}
 
-	it.each( CONTENT_DEPENDENT_IDS )( 'disables %s on an empty post', ( id ) => {
-		const suggestion = suggestionsFor( { isPostEmpty: true } ).find( ( s ) => s.id === id );
-
-		expect( suggestion ).toBeDefined();
-		expect( suggestion?.disabled ).toBe( true );
+	it.each( CONTENT_DEPENDENT_IDS )( 'hides %s on an empty post', ( id ) => {
+		expect( idsFor( { isPostEmpty: true } ) ).not.toContain( id );
 	} );
 
-	it.each( CONTENT_DEPENDENT_IDS )( 'enables %s once the post has content', ( id ) => {
-		const suggestion = suggestionsFor( { isPostEmpty: false } ).find( ( s ) => s.id === id );
-
-		expect( suggestion ).toBeDefined();
-		expect( suggestion?.disabled ).toBeFalsy();
+	it.each( CONTENT_DEPENDENT_IDS )( 'shows %s once the post has content', ( id ) => {
+		expect( idsFor( { isPostEmpty: false } ) ).toContain( id );
 	} );
 
-	it( 'keeps the disabled suggestions in the list so a blank post still shows them', () => {
-		const ids = suggestionsFor( { isPostEmpty: true } ).map( ( suggestion ) => suggestion.id );
-
-		CONTENT_DEPENDENT_IDS.forEach( ( id ) => expect( ids ).toContain( id ) );
-	} );
-
-	it( 'leaves generate-featured-image enabled, since the user types their own prompt', () => {
+	it( 'keeps generate-featured-image, since the user types their own prompt', () => {
 		// The chip only appears when Image Studio is available.
 		mockImageStudioActions = { openImageStudio: jest.fn() };
-		const suggestion = suggestionsFor( { isPostEmpty: true } ).find(
-			( s ) => s.id === 'generate-featured-image'
-		);
 
-		expect( suggestion ).toBeDefined();
-		expect( suggestion?.disabled ).toBeFalsy();
+		expect( idsFor( { isPostEmpty: true } ) ).toContain( 'generate-featured-image' );
 	} );
 
-	it( 'does not mutate the shared suggestion definitions', () => {
-		// They are module constants, so marking one disabled in place would leak into
-		// every later render.
-		suggestionsFor( { isPostEmpty: true } );
-		const suggestion = suggestionsFor( { isPostEmpty: false } ).find(
-			( s ) => s.id === 'optimize-title'
-		);
-
-		expect( suggestion?.disabled ).toBeFalsy();
-	} );
-
-	it( 'enables the suggestions when the editor cannot say whether the post is empty', () => {
-		const suggestion = suggestionsFor( { omitIsEditedPostEmpty: true } ).find(
-			( s ) => s.id === 'optimize-title'
-		);
-
-		expect( suggestion?.disabled ).toBeFalsy();
+	it( 'shows the suggestions when the editor cannot say whether the post is empty', () => {
+		// Failing open: an unreadable editor must not empty the panel.
+		expect( idsFor( { omitIsEditedPostEmpty: true } ) ).toContain( 'optimize-title' );
 	} );
 } );
 

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -273,6 +273,9 @@ interface PostTypeMockOptions {
 	themeSupportsResolved?: boolean;
 	/** Whole getThemeSupports return value, for a store that returns something else. */
 	themeSupportsReturnValue?: unknown;
+	isPostEmpty?: boolean;
+	/** Drops the selector, as an editor predating it would. */
+	omitIsEditedPostEmpty?: boolean;
 }
 
 function installPostTypeMock(
@@ -285,6 +288,8 @@ function installPostTypeMock(
 		postTypeRecordResolved = true,
 		themeSupportsThumbnails = true,
 		themeSupportsResolved = true,
+		isPostEmpty = false,
+		omitIsEditedPostEmpty = false,
 	} = options;
 
 	// remove_post_type_support unsets the key, so an explicit undefined omits it.
@@ -311,6 +316,7 @@ function installPostTypeMock(
 					return {
 						getCurrentPostId: () => postId,
 						getCurrentPostType: () => postType,
+						...( omitIsEditedPostEmpty ? {} : { isEditedPostEmpty: () => isPostEmpty } ),
 					};
 				}
 				if ( store === 'core/block-editor' ) {
@@ -1874,6 +1880,86 @@ describe( 'Proofread', () => {
 			jest.advanceTimersByTime( 1000 );
 		} );
 		jest.useRealTimers();
+	} );
+} );
+
+describe( 'empty post gating', () => {
+	const CONTENT_DEPENDENT_IDS = [
+		'optimize-title',
+		'generate-excerpt',
+		'generate-feedback',
+		'proofread-content',
+		'ai-editorial-review',
+		'seo-enhancer',
+	];
+
+	const ALL_FEATURES = {
+		optimizeTitleSuggestion: true,
+		excerptSuggestion: true,
+		proofreadContent: true,
+		seoSuggestions: true,
+	};
+
+	afterEach( () => {
+		delete ( globalThis as any ).agentsManagerData;
+		delete ( window as any ).wp;
+		mockImageStudioActions = null;
+	} );
+
+	function suggestionsFor( options: { isPostEmpty?: boolean; omitIsEditedPostEmpty?: boolean } ) {
+		installAiEditorialReviewData( ALL_FEATURES );
+		installPostTypeMock( 'post', 123, { supportsExcerpt: true, ...options } );
+		return getEmptyViewSuggestions();
+	}
+
+	it.each( CONTENT_DEPENDENT_IDS )( 'disables %s on an empty post', ( id ) => {
+		const suggestion = suggestionsFor( { isPostEmpty: true } ).find( ( s ) => s.id === id );
+
+		expect( suggestion ).toBeDefined();
+		expect( suggestion?.disabled ).toBe( true );
+	} );
+
+	it.each( CONTENT_DEPENDENT_IDS )( 'enables %s once the post has content', ( id ) => {
+		const suggestion = suggestionsFor( { isPostEmpty: false } ).find( ( s ) => s.id === id );
+
+		expect( suggestion ).toBeDefined();
+		expect( suggestion?.disabled ).toBeFalsy();
+	} );
+
+	it( 'keeps the disabled suggestions in the list so a blank post still shows them', () => {
+		const ids = suggestionsFor( { isPostEmpty: true } ).map( ( suggestion ) => suggestion.id );
+
+		CONTENT_DEPENDENT_IDS.forEach( ( id ) => expect( ids ).toContain( id ) );
+	} );
+
+	it( 'leaves generate-featured-image enabled, since the user types their own prompt', () => {
+		// The chip only appears when Image Studio is available.
+		mockImageStudioActions = { openImageStudio: jest.fn() };
+		const suggestion = suggestionsFor( { isPostEmpty: true } ).find(
+			( s ) => s.id === 'generate-featured-image'
+		);
+
+		expect( suggestion ).toBeDefined();
+		expect( suggestion?.disabled ).toBeFalsy();
+	} );
+
+	it( 'does not mutate the shared suggestion definitions', () => {
+		// They are module constants, so marking one disabled in place would leak into
+		// every later render.
+		suggestionsFor( { isPostEmpty: true } );
+		const suggestion = suggestionsFor( { isPostEmpty: false } ).find(
+			( s ) => s.id === 'optimize-title'
+		);
+
+		expect( suggestion?.disabled ).toBeFalsy();
+	} );
+
+	it( 'enables the suggestions when the editor cannot say whether the post is empty', () => {
+		const suggestion = suggestionsFor( { omitIsEditedPostEmpty: true } ).find(
+			( s ) => s.id === 'optimize-title'
+		);
+
+		expect( suggestion?.disabled ).toBeFalsy();
 	} );
 } );
 

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -1906,30 +1906,60 @@ describe( 'empty post gating', () => {
 		mockImageStudioActions = null;
 	} );
 
-	function idsFor( options: { isPostEmpty?: boolean; omitIsEditedPostEmpty?: boolean } ) {
+	function suggestionsFor( options: { isPostEmpty?: boolean; omitIsEditedPostEmpty?: boolean } ) {
 		installAiEditorialReviewData( ALL_FEATURES );
 		installPostTypeMock( 'post', 123, { supportsExcerpt: true, ...options } );
-		return getEmptyViewSuggestions().map( ( suggestion ) => suggestion.id );
+		return getEmptyViewSuggestions();
 	}
 
-	it.each( CONTENT_DEPENDENT_IDS )( 'hides %s on an empty post', ( id ) => {
-		expect( idsFor( { isPostEmpty: true } ) ).not.toContain( id );
+	it.each( CONTENT_DEPENDENT_IDS )( 'disables %s on an empty post', ( id ) => {
+		const suggestion = suggestionsFor( { isPostEmpty: true } ).find( ( s ) => s.id === id );
+
+		expect( suggestion ).toBeDefined();
+		expect( suggestion?.disabled ).toBe( true );
 	} );
 
-	it.each( CONTENT_DEPENDENT_IDS )( 'shows %s once the post has content', ( id ) => {
-		expect( idsFor( { isPostEmpty: false } ) ).toContain( id );
+	it.each( CONTENT_DEPENDENT_IDS )( 'enables %s once the post has content', ( id ) => {
+		const suggestion = suggestionsFor( { isPostEmpty: false } ).find( ( s ) => s.id === id );
+
+		expect( suggestion ).toBeDefined();
+		expect( suggestion?.disabled ).toBeFalsy();
 	} );
 
-	it( 'keeps generate-featured-image, since the user types their own prompt', () => {
+	it( 'keeps the disabled suggestions in the list so a blank post still shows them', () => {
+		const ids = suggestionsFor( { isPostEmpty: true } ).map( ( suggestion ) => suggestion.id );
+
+		CONTENT_DEPENDENT_IDS.forEach( ( id ) => expect( ids ).toContain( id ) );
+	} );
+
+	it( 'leaves generate-featured-image enabled, since the user types their own prompt', () => {
 		// The chip only appears when Image Studio is available.
 		mockImageStudioActions = { openImageStudio: jest.fn() };
+		const suggestion = suggestionsFor( { isPostEmpty: true } ).find(
+			( s ) => s.id === 'generate-featured-image'
+		);
 
-		expect( idsFor( { isPostEmpty: true } ) ).toContain( 'generate-featured-image' );
+		expect( suggestion ).toBeDefined();
+		expect( suggestion?.disabled ).toBeFalsy();
 	} );
 
-	it( 'shows the suggestions when the editor cannot say whether the post is empty', () => {
-		// Failing open: an unreadable editor must not empty the panel.
-		expect( idsFor( { omitIsEditedPostEmpty: true } ) ).toContain( 'optimize-title' );
+	it( 'does not mutate the shared suggestion definitions', () => {
+		// They are module constants, so marking one disabled in place would leak into
+		// every later render.
+		suggestionsFor( { isPostEmpty: true } );
+		const suggestion = suggestionsFor( { isPostEmpty: false } ).find(
+			( s ) => s.id === 'optimize-title'
+		);
+
+		expect( suggestion?.disabled ).toBeFalsy();
+	} );
+
+	it( 'enables the suggestions when the editor cannot say whether the post is empty', () => {
+		const suggestion = suggestionsFor( { omitIsEditedPostEmpty: true } ).find(
+			( s ) => s.id === 'optimize-title'
+		);
+
+		expect( suggestion?.disabled ).toBeFalsy();
 	} );
 } );
 

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -1929,19 +1929,7 @@ describe( 'empty post gating', () => {
 	it.each( CONTENT_DEPENDENT_IDS )( 'gives %s a reason for being disabled', ( id ) => {
 		const suggestion = suggestionsFor( { isPostEmpty: true } ).find( ( s ) => s.id === id );
 
-		expect( suggestion?.disabledReason ).toBe(
-			'This feature will be available once content is added to the post.'
-		);
-	} );
-
-	it( 'names the page rather than the post when editing a page', () => {
-		installAiEditorialReviewData( ALL_FEATURES );
-		installPostTypeMock( 'page', 123, { supportsExcerpt: true, isPostEmpty: true } );
-		const suggestion = getEmptyViewSuggestions().find( ( s ) => s.id === 'optimize-title' );
-
-		expect( suggestion?.disabledReason ).toBe(
-			'This feature will be available once content is added to the page.'
-		);
+		expect( suggestion?.disabledReason ).toBe( 'This feature requires content to work.' );
 	} );
 
 	it( 'gives no reason once the suggestion is usable', () => {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -518,11 +518,8 @@ function getPostLevelSuggestions(
 		return suggestions;
 	}
 
-	// Greyed out rather than dropped, so a blank post still shows what is on offer.
-	return suggestions.map( ( suggestion ) =>
-		CONTENT_DEPENDENT_SUGGESTION_IDS.has( suggestion.id )
-			? { ...suggestion, disabled: true }
-			: suggestion
+	return suggestions.filter(
+		( suggestion ) => ! CONTENT_DEPENDENT_SUGGESTION_IDS.has( suggestion.id )
 	);
 }
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -491,21 +491,8 @@ const CONTENT_DEPENDENT_SUGGESTION_IDS: Set< string > = new Set( [
 	SEO_ENHANCER_SUGGESTION.id,
 ] );
 
-/**
- * Written out per post type rather than built from a noun, because a noun
- * dropped into a sentence cannot agree with the rest of it in every language.
- * Only posts and pages reach these suggestions.
- */
-function getContentRequiredReason( currentPostType?: string ): string {
-	return currentPostType === 'page'
-		? __(
-				'This feature will be available once content is added to the page.',
-				__i18n_text_domain__
-		  )
-		: __(
-				'This feature will be available once content is added to the post.',
-				__i18n_text_domain__
-		  );
+function getContentRequiredReason(): string {
+	return __( 'This feature requires content to work.', __i18n_text_domain__ );
 }
 
 function getPostLevelSuggestions(
@@ -535,7 +522,7 @@ function getPostLevelSuggestions(
 	}
 
 	// Greyed out rather than dropped, so a blank post still shows what is on offer.
-	const disabledReason = getContentRequiredReason( currentPostType );
+	const disabledReason = getContentRequiredReason();
 
 	return suggestions.map( ( suggestion ) =>
 		CONTENT_DEPENDENT_SUGGESTION_IDS.has( suggestion.id )

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -518,8 +518,11 @@ function getPostLevelSuggestions(
 		return suggestions;
 	}
 
-	return suggestions.filter(
-		( suggestion ) => ! CONTENT_DEPENDENT_SUGGESTION_IDS.has( suggestion.id )
+	// Greyed out rather than dropped, so a blank post still shows what is on offer.
+	return suggestions.map( ( suggestion ) =>
+		CONTENT_DEPENDENT_SUGGESTION_IDS.has( suggestion.id )
+			? { ...suggestion, disabled: true }
+			: suggestion
 	);
 }
 

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -145,6 +145,18 @@ function canSwapBlockEditSnapshot( snapshot: BlockEditSnapshot ): boolean {
 	);
 }
 
+/**
+ * Uses the selector the legacy "Improve with AI" panel gates on. It is blocks-only
+ * and never reads the title, so a titled post with no body counts as empty. An
+ * editor that cannot answer reports "not empty", so nothing greys out on a store
+ * we cannot read.
+ */
+function isPostContentEmpty(): boolean {
+	const isEditedPostEmpty = ( window as any ).wp?.data?.select?.( 'core/editor' )
+		?.isEditedPostEmpty;
+	return typeof isEditedPostEmpty === 'function' && isEditedPostEmpty() === true;
+}
+
 /** Default suggestion shown when no block is selected. */
 const OPTIMIZE_TITLE_SUGGESTION = {
 	id: 'optimize-title',
@@ -467,6 +479,19 @@ function getFeedbackSuggestions( currentPostType?: string, currentPostId?: Edito
 	];
 }
 
+/**
+ * `generate-featured-image` is absent on purpose: it opens Image Studio, where the
+ * user writes their own prompt.
+ */
+const CONTENT_DEPENDENT_SUGGESTION_IDS: Set< string > = new Set( [
+	OPTIMIZE_TITLE_SUGGESTION.id,
+	GENERATE_EXCERPT_SUGGESTION.id,
+	POST_FEEDBACK_SUGGESTION.id,
+	PROOFREAD_SUGGESTION.id,
+	AI_EDITORIAL_REVIEW_SUGGESTION.id,
+	SEO_ENHANCER_SUGGESTION.id,
+] );
+
 function getPostLevelSuggestions(
 	currentPostType?: string,
 	currentPostId?: EditorPostId | null,
@@ -476,7 +501,7 @@ function getPostLevelSuggestions(
 		return [];
 	}
 
-	return [
+	const suggestions = [
 		...( isFeaturedImageSuggestionAvailable( currentPostType )
 			? [ GENERATE_FEATURED_IMAGE_SUGGESTION ]
 			: [] ),
@@ -488,6 +513,17 @@ function getPostLevelSuggestions(
 		// Surface the SEO Enhancer dropdown last.
 		...( isSeoSuggestionsEnabled() ? [ SEO_ENHANCER_SUGGESTION ] : [] ),
 	];
+
+	if ( ! isPostContentEmpty() ) {
+		return suggestions;
+	}
+
+	// Greyed out rather than dropped, so a blank post still shows what is on offer.
+	return suggestions.map( ( suggestion ) =>
+		CONTENT_DEPENDENT_SUGGESTION_IDS.has( suggestion.id )
+			? { ...suggestion, disabled: true }
+			: suggestion
+	);
 }
 
 function getReservedSuggestions< T extends { id: string } >( suggestions: T[] ): T[] {

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -486,11 +486,27 @@ function getFeedbackSuggestions( currentPostType?: string, currentPostId?: Edito
 const CONTENT_DEPENDENT_SUGGESTION_IDS: Set< string > = new Set( [
 	OPTIMIZE_TITLE_SUGGESTION.id,
 	GENERATE_EXCERPT_SUGGESTION.id,
-	POST_FEEDBACK_SUGGESTION.id,
-	PROOFREAD_SUGGESTION.id,
-	AI_EDITORIAL_REVIEW_SUGGESTION.id,
+	// Every review behind this chip needs content, so the chip gates as a whole.
+	GET_FEEDBACK_SUGGESTION_ID,
 	SEO_ENHANCER_SUGGESTION.id,
 ] );
+
+/**
+ * Written out per post type rather than built from a noun, because a noun
+ * dropped into a sentence cannot agree with the rest of it in every language.
+ * Only posts and pages reach these suggestions.
+ */
+function getContentRequiredReason( currentPostType?: string ): string {
+	return currentPostType === 'page'
+		? __(
+				'This feature will be available once content is added to the page.',
+				__i18n_text_domain__
+		  )
+		: __(
+				'This feature will be available once content is added to the post.',
+				__i18n_text_domain__
+		  );
+}
 
 function getPostLevelSuggestions(
 	currentPostType?: string,
@@ -519,9 +535,11 @@ function getPostLevelSuggestions(
 	}
 
 	// Greyed out rather than dropped, so a blank post still shows what is on offer.
+	const disabledReason = getContentRequiredReason( currentPostType );
+
 	return suggestions.map( ( suggestion ) =>
 		CONTENT_DEPENDENT_SUGGESTION_IDS.has( suggestion.id )
-			? { ...suggestion, disabled: true }
+			? { ...suggestion, disabled: true, disabledReason }
 			: suggestion
 	);
 }
@@ -1239,6 +1257,8 @@ export function getEmptyViewSuggestions(): Array< {
 	description?: string;
 	prompt?: string;
 	options?: SuggestionOption[];
+	disabled?: boolean;
+	disabledReason?: string;
 	action?: () => boolean | Promise< boolean >;
 } > {
 	return getPostLevelSuggestions( getCurrentEditorPostType() );

--- a/yarn.lock
+++ b/yarn.lock
@@ -396,6 +396,7 @@ __metadata:
     "@radix-ui/react-popover": "npm:^1.1.15"
     "@radix-ui/react-scroll-area": "npm:^1.2.9"
     "@radix-ui/react-slot": "npm:^1.2.3"
+    "@radix-ui/react-tooltip": "npm:1.2.9"
     "@storybook/addon-a11y": "npm:^9.0.18"
     "@storybook/addon-docs": "npm:^9.0.18"
     "@storybook/addon-essentials": "npm:9.0.0-alpha.12"
@@ -7813,6 +7814,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-tooltip@npm:1.2.9":
+  version: 1.2.9
+  resolution: "@radix-ui/react-tooltip@npm:1.2.9"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.4"
+    "@radix-ui/react-compose-refs": "npm:1.1.3"
+    "@radix-ui/react-context": "npm:1.1.4"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.12"
+    "@radix-ui/react-id": "npm:1.1.2"
+    "@radix-ui/react-popper": "npm:1.3.0"
+    "@radix-ui/react-portal": "npm:1.1.11"
+    "@radix-ui/react-presence": "npm:1.1.6"
+    "@radix-ui/react-primitive": "npm:2.1.5"
+    "@radix-ui/react-slot": "npm:1.2.5"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.3"
+    "@radix-ui/react-visually-hidden": "npm:1.2.5"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: fc109d0967485b21d8360a3d5a193102bd8281e45eda3dd4db7735ac3d4ad18269cac5c320641950be413575f6d466c02e8f10e3fd8a9bfca33dd4816bb260fd
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-use-callback-ref@npm:1.0.1":
   version: 1.0.1
   resolution: "@radix-ui/react-use-callback-ref@npm:1.0.1"
@@ -8000,6 +8031,25 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 0a088412bb831fd1d59f9058352aca384c2d0a07b894b35707b3486eea4a1d8a37a04fb117379f9a8a46a921b0092f97b29b517689c8f97029ec73eb68973521
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-visually-hidden@npm:1.2.5":
+  version: 1.2.5
+  resolution: "@radix-ui/react-visually-hidden@npm:1.2.5"
+  dependencies:
+    "@radix-ui/react-primitive": "npm:2.1.5"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 9d0169a1950cbc4a9c47893e7101fc1286bfec85489665692f818c4322a8614dcccab873ce06099220c20dc454d978153e29fc6fb23d37bc89c10b8ed4f037db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Part of FORNO-475

## Proposed Changes

### Jetpack AI

* Disables the writing suggestions on an empty post. Generate featured image stays enabled.

### Agenttic

- Add support for disabled suggestions
- Introduce tooltip component for rendering disabled reason on suggestions

<img width="345" height="772" alt="Screenshot 2026-08-27 at 13 38 57" src="https://github.com/user-attachments/assets/48d8ae58-e392-4cd9-8c58-0b4d3fcc1726" />



## Why are these changes being made?

* They have nothing to work with until the post has a body. The legacy "Improve with AI" panel disabled the same controls rather than hiding them.

## Testing Instructions

* checkout PR
* This PR depends on https://github.com/Automattic/wp-calypso/pull/113627. For testing before this is merged, apply this patch

```DIFF
-- a/packages/agents-manager/package.json
+++ b/packages/agents-manager/package.json
@@ -42,7 +42,7 @@
        },
        "dependencies": {
                "@automattic/agenttic-client": "^0.1.89",
-               "@automattic/agenttic-ui": "^0.1.89",
+               "@automattic/agenttic-ui": "workspace:^",
```

* `yarn install`
* `cd apps/agents-manager && yarn dev --sync`
* sandbox widgets.wp.com
* open a new post. The writing suggestions should be greyed out, including the SEO Enhancer dropdown
* type something. They should become usable
* delete it again. They should grey out again

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
