### PR TITLE
MSD Plugins: Match list counts to the sites the dashboard can display

### DIFF
--- a/client/dashboard/plugins/manage/components/plugin-switcher.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.tsx
@@ -22,7 +22,7 @@ export const PluginSwitcher = ( {
 	onChangeView,
 	paginationInfo,
 }: {
-	pluginsWithIcon: PluginListRow[];
+	pluginsWithIcon?: PluginListRow[];
 	searchableFields: Field< PluginListRow >[];
 	selectedPluginSlug?: string;
 	view: View;
@@ -153,8 +153,9 @@ export const PluginSwitcher = ( {
 					filter={
 						<PluginUpdatesFilter
 							siteCount={
-								pluginsWithIcon.filter( ( plugin ) => plugin.sitesWithPluginUpdate.length > 0 )
-									.length
+								( pluginsWithIcon ?? [] ).filter(
+									( plugin ) => plugin.sitesWithPluginUpdate.length > 0
+								).length
 							}
 							updatesField={ updatesField }
 							view={ view }

--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -44,8 +44,9 @@ const searchableFields = [
 export default function PluginsList() {
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const isSmallViewport = useViewportMatch( 'xlarge', '<' );
-	const { data: sitesPlugins, isLoading: sitesPluginsLoading } = useQuery( pluginsQuery() );
-	const { sitesById } = useSitesById();
+	const { data: sitesPlugins, isLoading: pluginsQueryLoading } = useQuery( pluginsQuery() );
+	const { sitesById, isLoadingSites } = useSitesById();
+	const sitesPluginsLoading = pluginsQueryLoading || isLoadingSites;
 	const { pluginId: pluginSlug } = useParams( { strict: false } );
 	const fields = useMemo( () => {
 		return searchableFields.map( ( searchableField ) => ( {

--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -151,7 +151,7 @@ export default function PluginsList() {
 					<PluginSites selectedPluginSlug={ selectedPluginSlug } />
 				) : (
 					<PluginSwitcher
-						pluginsWithIcon={ pluginsWithIcon }
+						pluginsWithIcon={ sitesPluginsLoading ? undefined : pluginsWithIcon }
 						searchableFields={ searchableFields }
 						view={ view }
 						onChangeView={ setView }
@@ -175,7 +175,7 @@ export default function PluginsList() {
 		>
 			<Grid columns={ 2 } gap={ 3 } templateColumns="392px 1fr">
 				<PluginSwitcher
-					pluginsWithIcon={ pluginsWithIcon }
+					pluginsWithIcon={ sitesPluginsLoading ? undefined : pluginsWithIcon }
 					searchableFields={ searchableFields }
 					selectedPluginSlug={ selectedPluginSlug }
 					view={ view }

--- a/client/dashboard/plugins/manage/utils/map-api-plugins-to-dataview.ts
+++ b/client/dashboard/plugins/manage/utils/map-api-plugins-to-dataview.ts
@@ -39,6 +39,13 @@ export function mapApiPluginsToDataViewPlugins(
 
 	Object.entries( pluginsBySite ).forEach( ( [ siteIdStr, plugins ] ) => {
 		const siteId = Number( siteIdStr );
+		// The API can report sites that are not part of the dashboard's site
+		// list (hidden, filtered out, or without the update_plugins capability).
+		// Skip them so counts match what the site-level views can display.
+		const site = sitesById.get( siteId );
+		if ( ! site ) {
+			return;
+		}
 		( plugins as PluginItem[] ).forEach( ( p ) => {
 			if ( ! p.id ) {
 				return;
@@ -71,25 +78,22 @@ export function mapApiPluginsToDataViewPlugins(
 				entry.isManaged = true;
 			}
 
-			const site = sitesById.get( siteId );
-			if ( site ) {
-				const { autoupdate } = getAllowedPluginActions(
-					{ isPluginActive: p.active, ...site, isPluginManaged: entry.isManaged },
-					p.slug
-				);
+			const { autoupdate } = getAllowedPluginActions(
+				{ isPluginActive: p.active, ...site, isPluginManaged: entry.isManaged },
+				p.slug
+			);
 
-				entry.autoupdateAllowedCount += autoupdate ? 1 : 0;
+			entry.autoupdateAllowedCount += autoupdate ? 1 : 0;
 
-				if ( autoupdate ) {
-					if ( p.update ) {
-						entry.updatableSites.push( siteId );
-					}
+			if ( autoupdate ) {
+				if ( p.update ) {
+					entry.updatableSites.push( siteId );
+				}
 
-					if ( p.autoupdate ) {
-						entry.autoupdatedSites.push( siteId );
-					} else {
-						entry.notAutoupdatedSites.push( siteId );
-					}
+				if ( p.autoupdate ) {
+					entry.autoupdatedSites.push( siteId );
+				} else {
+					entry.notAutoupdatedSites.push( siteId );
 				}
 			}
 


### PR DESCRIPTION
Fixes DOTMSD-1526

## Proposed Changes

* Make the plugin list's site counts match the "Installed on N sites" number in the plugin detail view.
* The list previously counted every site returned by the plugins API, including sites the dashboard doesn't display (hidden sites, or Automattic-owned sites on Automattician accounts). The detail view only counts displayable sites, so the two numbers could disagree. The list now counts the same set as the detail view.
* Show the plugin list's "Loading…" state until both the plugins and the site list have loaded, instead of briefly rendering "No plugins found." while either is still loading.

## Why are these changes being made?

* Seeing "50 sites" in the list and "Installed on 48 sites" in the detail panel for the same plugin is confusing and looks broken. Both numbers should describe the same thing: the sites the dashboard can actually show you.

## Testing Instructions

* Use an account that has a hidden site (or, for Automatticians, an a8c-owned site) with plugins installed, plus several normal sites.
* Open the Dashboard (dotcom) live link and go to Plugins → Manage plugins.
* Pick a plugin that is installed on the hidden site: the count under it in the list should now equal the "Installed on N sites" number in the detail panel.
* Confirm the rest of the screen still behaves: filtering by "Updates available", bulk actions, and the plugin detail tabs ("Installed on" / "Available on").
* With an account that has no hidden or a8c-owned sites, confirm the counts are unchanged from production.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

