### PR TITLE
Remove dead signup site-creation helpers

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -1,6 +1,6 @@
 import { Page, Locator, Frame } from 'playwright';
 import { getCalypsoURL } from '../../../data-helper';
-import type { NewSiteResponse, NewUserResponse } from '../../../types/rest-api-client.types';
+import type { NewUserResponse } from '../../../types/rest-api-client.types';
 
 /**
  * Signals a transient upstream failure during signup (a 502/503/504 server-error
@@ -403,49 +403,6 @@ export class UserSignupPage {
 				return transient.test( haystack ) || /Internal Server Error/i.test( haystack );
 			}, transientUpstreamServerErrorOnly )
 			.catch( () => false );
-	}
-
-	/**
-	 * Signup with email and wait for site creation.
-	 *
-	 * This happens in the domain-only flow, where site creation happens after user login.
-	 *
-	 * @param email {string} Email address of the new user.
-	 * @returns {NewUserResponse, NewSiteResponse} Details of the new user and the newly created site.
-	 */
-	async signupWithEmailAndWaitForSiteCreation(
-		email: string
-	): Promise< [ NewUserResponse, NewSiteResponse ] > {
-		const newUserDetails = await this.signupWithEmail( email );
-		const newSiteDetails = await this.waitForSiteCreation();
-		return [ newUserDetails, newSiteDetails ];
-	}
-
-	/**
-	 * Waits for the site creation response and returns the details of the newly created site.
-	 *
-	 * Site creation happens with the `/sites/new` endpoint call
-	 *
-	 * @returns {NewSiteResponse} Details of the newly created site.
-	 */
-	private async waitForSiteCreation(): Promise< NewSiteResponse > {
-		const response = await this.page.waitForResponse( /.*sites\/new\?.*/, { timeout: 30 * 1000 } );
-
-		if ( ! response ) {
-			throw new Error( 'Failed to intercept response for new site creation.' );
-		}
-
-		const responseJSON = await response.json();
-		const body = responseJSON.body;
-
-		if ( ! body.blog_details.blogid ) {
-			console.error( body );
-			throw new Error( 'Failed to locate blog ID for the created site.' );
-		}
-
-		// Cast the blogID value to a number, in case it comes in as a string.
-		body.blog_details.blogid = Number( body.blog_details.blogid );
-		return body;
 	}
 
 	/**


### PR DESCRIPTION
## Proposed Changes

* Delete `UserSignupPage.signupWithEmailAndWaitForSiteCreation` and the private `waitForSiteCreation` it wraps.

## Why are these changes being made?

* Neither has a caller. The domain flow specs they were written for take the new site from `SignupPickPlanPage.selectPlan` or `apiCreateFreeSiteForUser`.

## Testing Instructions

* `git grep waitForSiteCreation` returns nothing.
* `yarn typecheck-packages` and ESLint on `packages/calypso-e2e` pass.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?
