### PR TITLE
Atomic transfer: don't let one wait's client timeout end the next wait

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/transfer-pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/transfer-pending/index.tsx
@@ -6,6 +6,7 @@ import Loading from 'calypso/components/loading';
 import { useWaitHeartbeat } from 'calypso/lib/analytics/wait-heartbeat';
 import { useInterval } from 'calypso/lib/interval';
 import { useDispatch, useSelector } from 'calypso/state';
+import { fetchAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
 import { transferStates } from 'calypso/state/atomic-transfer/constants';
 import { errorNotice } from 'calypso/state/notices/actions';
 import getAtomicTransfer from 'calypso/state/selectors/get-atomic-transfer';
@@ -81,6 +82,21 @@ const TransferPending: React.FunctionComponent< Props > = ( props ) => {
 		};
 	}, [ dispatch ] );
 
+	const latestTransfer = React.useRef( transfer );
+	latestTransfer.current = transfer;
+
+	// A client_timeout already in the store when this screen asks for the transfer is an earlier
+	// wait's verdict: the request drops it, and only a timeout stored afterwards ends this wait.
+	const preRequestTransfer = React.useRef( transfer );
+	React.useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		preRequestTransfer.current = latestTransfer.current;
+		dispatch( fetchAtomicTransfer( siteId ) );
+	}, [ siteId, dispatch ] );
+
 	// Redirect based on transfer status
 	const didRedirect = React.useRef( false );
 	React.useEffect( () => {
@@ -121,11 +137,13 @@ const TransferPending: React.FunctionComponent< Props > = ( props ) => {
 			}
 
 			if ( transferStates.CLIENT_TIMEOUT === transfer.status ) {
-				redirectWithNotice(
-					__(
-						'Your transfer is taking longer than expected. It may still finish — reload the page to check.'
-					)
-				);
+				if ( transfer !== preRequestTransfer.current ) {
+					redirectWithNotice(
+						__(
+							'Your transfer is taking longer than expected. It may still finish — reload the page to check.'
+						)
+					);
+				}
 
 				return;
 			}

--- a/client/my-sites/checkout/checkout-thank-you/transfer-pending/test/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/transfer-pending/test/index.tsx
@@ -3,6 +3,7 @@
  */
 
 import { render } from '@testing-library/react';
+import { fetchAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
 import { transferStates } from 'calypso/state/atomic-transfer/constants';
 import TransferPending from '..';
 
@@ -70,10 +71,48 @@ describe( 'TransferPending', () => {
 		}
 	);
 
-	test( 'redirects timed out transfers to stats with a timeout notice', () => {
+	test( 'requests the latest transfer for its site', () => {
+		render( <TransferPending siteId={ 123 } orderId={ 456 } /> );
+
+		expect( mockDispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( 123 ) );
+	} );
+
+	test( 'does not request a transfer until it has a site id', () => {
+		render( <TransferPending siteId={ 0 } orderId={ 456 } /> );
+
+		expect( mockDispatch ).not.toHaveBeenCalledWith( fetchAtomicTransfer( 0 ) );
+	} );
+
+	test( 'does not redirect on a stale client_timeout when the site id arrives late', () => {
+		const { rerender } = render( <TransferPending siteId={ 0 } orderId={ 456 } /> );
+
+		mockTransfer = { status: transferStates.CLIENT_TIMEOUT };
+		rerender( <TransferPending siteId={ 123 } orderId={ 456 } /> );
+
+		expect( mockPage ).not.toHaveBeenCalled();
+		expect( mockDispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( 123 ) );
+	} );
+
+	test( 'does not redirect when a client_timeout is already in the store at mount', () => {
 		mockTransfer = { status: transferStates.CLIENT_TIMEOUT };
 
 		render( <TransferPending siteId={ 123 } orderId={ 456 } /> );
+
+		expect( mockPage ).not.toHaveBeenCalled();
+		expect( mockDispatch ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { notice: expect.anything() } )
+		);
+	} );
+
+	test( 'redirects to stats with a timeout notice when the store transitions to client_timeout after mount', () => {
+		mockTransfer = { status: transferStates.ACTIVE };
+
+		const { rerender } = render( <TransferPending siteId={ 123 } orderId={ 456 } /> );
+
+		expect( mockPage ).not.toHaveBeenCalled();
+
+		mockTransfer = { status: transferStates.CLIENT_TIMEOUT };
+		rerender( <TransferPending siteId={ 123 } orderId={ 456 } /> );
 
 		expect( mockDispatch ).toHaveBeenCalledWith(
 			expect.objectContaining( {

--- a/client/state/atomic-transfer/reducer.js
+++ b/client/state/atomic-transfer/reducer.js
@@ -1,11 +1,20 @@
 import { withStorageKey } from '@automattic/state-utils';
-import { ATOMIC_TRANSFER_SET } from 'calypso/state/action-types';
+import { ATOMIC_TRANSFER_REQUEST, ATOMIC_TRANSFER_SET } from 'calypso/state/action-types';
+import { transferStates } from 'calypso/state/atomic-transfer/constants';
 import { keyedReducer } from 'calypso/state/utils';
 
 export const atomicTransfer = ( state = {}, action ) => {
 	switch ( action.type ) {
 		case ATOMIC_TRANSFER_SET:
 			return { ...state, ...action.transfer };
+		case ATOMIC_TRANSFER_REQUEST: {
+			if ( state.status !== transferStates.CLIENT_TIMEOUT ) {
+				return state;
+			}
+
+			const { status, ...rest } = state;
+			return rest;
+		}
 	}
 
 	return state;

--- a/client/state/atomic-transfer/test/reducer.js
+++ b/client/state/atomic-transfer/test/reducer.js
@@ -1,0 +1,50 @@
+import {
+	ATOMIC_TRANSFER_REQUEST as TRANSFER_REQUEST,
+	ATOMIC_TRANSFER_SET as SET_TRANSFER,
+} from 'calypso/state/action-types';
+import { transferStates } from '../constants';
+import { atomicTransfer } from '../reducer';
+
+describe( 'reducer', () => {
+	describe( 'atomicTransfer', () => {
+		describe( 'ATOMIC_TRANSFER_REQUEST', () => {
+			test( 'should drop a client timeout status, keeping the rest of the transfer', () => {
+				const state = {
+					atomic_transfer_id: 1,
+					blog_id: 1916284,
+					status: transferStates.CLIENT_TIMEOUT,
+				};
+
+				expect( atomicTransfer( state, { type: TRANSFER_REQUEST } ) ).toEqual( {
+					atomic_transfer_id: 1,
+					blog_id: 1916284,
+				} );
+			} );
+
+			test.each( [ transferStates.ACTIVE, transferStates.COMPLETED ] )(
+				'should leave a %s status untouched',
+				( status ) => {
+					const state = { status };
+
+					expect( atomicTransfer( state, { type: TRANSFER_REQUEST } ) ).toBe( state );
+				}
+			);
+
+			test( 'should leave an empty state untouched', () => {
+				expect( atomicTransfer( {}, { type: TRANSFER_REQUEST } ) ).toEqual( {} );
+			} );
+		} );
+
+		describe( 'ATOMIC_TRANSFER_SET', () => {
+			test( 'should merge the transfer into the state', () => {
+				const state = { status: transferStates.PENDING };
+				const transfer = { status: transferStates.ACTIVE, atomic_transfer_id: 1 };
+
+				expect( atomicTransfer( state, { type: SET_TRANSFER, transfer } ) ).toEqual( {
+					status: transferStates.ACTIVE,
+					atomic_transfer_id: 1,
+				} );
+			} );
+		} );
+	} );
+} );

--- a/client/state/data-layer/wpcom/sites/transfers/latest.js
+++ b/client/state/data-layer/wpcom/sites/transfers/latest.js
@@ -46,9 +46,10 @@ const giveUp = ( siteId, dispatch, transfer = {} ) => {
 	dispatch( setAtomicTransfer( siteId, { ...transfer, status: transferStates.CLIENT_TIMEOUT } ) );
 };
 
-// Two consumers poll the same site, and a response can arrive after we stopped waiting, so every
-// entry point asks the store first: a wait that already ended in a timeout must not revive the
-// progress bar. A response carrying a different transfer means a new wait, which may proceed.
+// Two consumers poll the same site, and a response can arrive after we stopped waiting, so
+// responses and errors ask the store first: a late answer for a wait that already timed out
+// must not revive the progress bar. A response carrying a different transfer, or a new request,
+// means a new wait — the reducer drops the client-only verdict on request, so requests skip this.
 const gaveUp = ( getState, siteId, transferId ) => {
 	const stored = getAtomicTransfer( getState(), siteId );
 
@@ -74,8 +75,8 @@ export const requestTransfer = ( action ) => [
 	// Responses are the only other thing that ends a wait, so a request that never answers — a
 	// stalled connection, a frozen tab — would wait forever without this. One timer per wait: a
 	// second request joins the deadline already running instead of opening a new one.
-	( dispatch, getState ) => {
-		if ( waits.get( action.siteId )?.deadlineTimerId || gaveUp( getState, action.siteId ) ) {
+	( dispatch ) => {
+		if ( waits.get( action.siteId )?.deadlineTimerId ) {
 			return;
 		}
 
@@ -133,7 +134,7 @@ export const onTransferError =
 			// never started, and waiting on it is what traps the user.
 			if ( isMissingRecord && attempts < MISSING_RECORD_ATTEMPTS ) {
 				waits.set( siteId, { ...waits.get( siteId ), missingRecordAttempts: attempts } );
-				schedulePoll( siteId, dispatch );
+				keepWaiting( siteId, dispatch, getState );
 				return;
 			}
 

--- a/client/state/data-layer/wpcom/sites/transfers/test/latest.js
+++ b/client/state/data-layer/wpcom/sites/transfers/test/latest.js
@@ -1,5 +1,6 @@
 import { fetchAtomicTransfer, setAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
 import { transferStates } from 'calypso/state/atomic-transfer/constants';
+import { atomicTransfer } from 'calypso/state/atomic-transfer/reducer';
 import { http } from 'calypso/state/data-layer/wpcom-http/actions';
 import { requestSite } from 'calypso/state/sites/actions';
 import {
@@ -30,18 +31,15 @@ const transfer = ( status, atomicTransferId = 1 ) => ( {
 const timedOut = ( transferData = {} ) =>
 	setAtomicTransfer( siteId, { ...transferData, status: transferStates.CLIENT_TIMEOUT } );
 
-// The handlers read the transfer back out of the store, so the fake one applies what they dispatch
-// the same way the reducer does.
+// The handlers read the transfer back out of the store, so the fake one runs the real reducer.
 const createStore = () => {
 	const state = { atomicTransfer: {} };
 	const getState = () => state;
 	const dispatch = jest.fn( ( action ) => {
-		if ( action?.type === setAtomicTransfer( siteId, {} ).type ) {
-			state.atomicTransfer[ action.siteId ] = {
-				...state.atomicTransfer[ action.siteId ],
-				...action.transfer,
-			};
-		}
+		state.atomicTransfer[ action.siteId ] = atomicTransfer(
+			state.atomicTransfer[ action.siteId ],
+			action
+		);
 
 		return action;
 	} );
@@ -49,9 +47,12 @@ const createStore = () => {
 	return { dispatch, getState };
 };
 
-// Every response follows a request, so tests arm the deadline the way production arms it.
-const startWait = ( { dispatch, getState } ) =>
+// Every response follows a request, so tests arm the deadline the way production arms it, and
+// dispatch the request action so the reducer clears a stale timeout the same way it does live.
+const startWait = ( { dispatch, getState } ) => {
+	dispatch( fetchAtomicTransfer( siteId ) );
 	requestTransfer( { siteId } )[ 1 ]( dispatch, getState );
+};
 
 const receive = ( store, transferData ) =>
 	receiveTransfer( { siteId }, transferData )( store.dispatch, store.getState );
@@ -105,16 +106,29 @@ describe( 'requestTransfer', () => {
 		expect( store.dispatch ).toHaveBeenCalledWith( timedOut() );
 	} );
 
-	test( 'should not start a new deadline once the wait has timed out', () => {
+	test( 'should arm a fresh deadline for a new request after a timeout', () => {
 		const store = createStore();
 
-		startWait( store );
-		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS );
+		store.dispatch( timedOut() );
 		store.dispatch.mockClear();
 		startWait( store );
 		jest.advanceTimersByTime( TRANSFER_POLL_DEADLINE_MS );
 
-		expect( store.dispatch ).not.toHaveBeenCalled();
+		expect( store.dispatch ).toHaveBeenCalledWith( timedOut() );
+	} );
+
+	test( 'should accept a response for the same transfer after a new request', () => {
+		const store = createStore();
+		const response = transfer( transferStates.ACTIVE );
+
+		store.dispatch( timedOut( response ) );
+		store.dispatch.mockClear();
+		startWait( store );
+		receive( store, response );
+
+		expect( store.dispatch ).toHaveBeenCalledWith( setAtomicTransfer( siteId, response ) );
+		jest.advanceTimersByTime( POLL_INTERVAL_MS );
+		expect( store.dispatch ).toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
 	} );
 } );
 
@@ -254,6 +268,7 @@ describe( 'onTransferError', () => {
 			const store = createStore();
 
 			startWait( store );
+			store.dispatch.mockClear();
 			fail( store, error );
 			jest.advanceTimersByTime( POLL_INTERVAL_MS );
 
@@ -278,6 +293,22 @@ describe( 'onTransferError', () => {
 		fail( store, missingRecord );
 
 		expect( store.dispatch ).toHaveBeenCalledWith( timedOut() );
+	} );
+
+	test( 'should not revive a timed-out wait when a missing-record error arrives late', () => {
+		const store = createStore();
+		const missingRecord = { status: 400, error: 'no_transfer_record' };
+
+		store.dispatch( timedOut() );
+		store.dispatch.mockClear();
+
+		fail( store, missingRecord );
+		jest.advanceTimersByTime( POLL_INTERVAL_MS );
+
+		expect( store.dispatch ).not.toHaveBeenCalledWith( fetchAtomicTransfer( siteId ) );
+		expect( store.getState().atomicTransfer[ siteId ].status ).toBe(
+			transferStates.CLIENT_TIMEOUT
+		);
 	} );
 
 	test( 'should poll again after a server error', () => {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18203/a-client-timeout-sticks-in-the-store-and-short-circuits-the-next-wait

## Proposed Changes

**A client-side transfer timeout no longer outlives the wait that produced it — starting a new wait clears the old verdict and gets its own five-minute deadline.**

- The atomic-transfer reducer drops a stored `client_timeout` when a new transfer request starts; server statuses (`completed`/`error`/`reverted`) are untouched.
- The transfer poll always arms a deadline for a new request, and the missing-record retry path now checks the store first so a late error response can’t revive a wait that already timed out.
- `TransferPending` (the eCommerce checkout wait screen) requests the transfer itself once it knows its site, and only treats a timeout stored after its own request as this wait’s verdict — a leftover from an earlier wait no longer redirects on sight.

## Why are these changes being made?

[DOTCOM-18203](https://linear.app/a8c/issue/DOTCOM-18203): `client_timeout` is a status the browser invents when a transfer wait gives up after five minutes — the server never says it. It was written into Redux and never cleared, so it haunted the rest of the session: returning to the checkout thank-you screen for the same site bounced the user straight to Stats with a “taking longer than expected” notice before asking the server anything, even while a fresh transfer was progressing normally underneath. The stale verdict also stopped the next wait from getting its own timeout, so that wait could hang forever on a stalled connection.

## Testing Instructions

1. Run `yarn start`.
2. Buy an eCommerce/Business plan upgrade for a Simple site and land on the checkout thank-you screen while the Atomic transfer runs.
3. Simulate a timeout (block or stub `/sites/:id/transfers/latest`, or temporarily lower `TRANSFER_POLL_DEADLINE_MS`): after the deadline you’re redirected to Stats with the “taking longer than expected” notice.
4. Navigate back to the thank-you screen client-side (browser back or re-enter the receipt URL without reloading): the wait screen shows again and polls the server — no instant redirect with the stale notice.
5. Let the second wait run: with the endpoint healthy it completes to the thank-you page; with the endpoint still blocked it times out again after five minutes and redirects with the notice.
