### PR TITLE
Help Center: pre-sales greeting and title on the pricing page

### DIFF
--- a/apps/help-center/async-help-center.jsx
+++ b/apps/help-center/async-help-center.jsx
@@ -1,11 +1,23 @@
 /* global helpCenterData */
+import { englishLocales } from '@automattic/i18n-utils';
+import {
+	ODIE_NEW_LOGGED_OUT_INTERACTIONS_BOT_SLUG,
+	PLANS_PRESALES_INTRO_MESSAGE,
+} from '@automattic/odie-client/src/constants';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { dispatch } from '@wordpress/data';
+import { hasTranslation } from '@wordpress/i18n';
 import { createRoot } from 'react-dom/client';
+
+// Memoize the in-flight load so concurrent calls during a cold chunk load share one mount.
+let helpCenterLoad = null;
 
 export default function loadHelpCenter() {
 	if ( document.getElementById( 'jetpack-help-center' ) ) {
 		return Promise.resolve();
+	}
+	if ( helpCenterLoad ) {
+		return helpCenterLoad;
 	}
 	const queryClient = new QueryClient();
 
@@ -23,18 +35,22 @@ export default function loadHelpCenter() {
 		customProps.launcherContext = helpCenterData.launcherContext;
 	}
 
-	return import( '@automattic/help-center' ).then( ( { default: HelpCenter } ) => {
+	helpCenterLoad = import( '@automattic/help-center' ).then( ( { default: HelpCenter } ) => {
 		// Only append once the chunk has loaded, so a failed import leaves no container behind and retries can mount.
 		const container = document.createElement( 'div' );
 		container.id = 'jetpack-help-center';
 		document.body.appendChild( container );
 
-		// Before the first render, so store resolvers (e.g. the logged-out
-		// auto-open route) already know which launcher surface this is.
-		if ( customProps.launcherContext ) {
+		// Before the first render, so store resolvers already know which launcher surface this is.
+		// Mirrors the UI's locale gate: an unlocalized visitor keeps the standard experience end to end.
+		const presalesLocaleReady =
+			englishLocales.includes( helpCenterData?.locale ) ||
+			hasTranslation( PLANS_PRESALES_INTRO_MESSAGE );
+		if ( customProps.launcherContext && presalesLocaleReady ) {
 			dispatch( 'automattic/help-center' ).setHelpCenterOptions( {
 				launcherContext: customProps.launcherContext,
-				loggedOutBotSlug: customProps.newLoggedOutInteractionsBotSlug,
+				loggedOutBotSlug:
+					customProps.newLoggedOutInteractionsBotSlug ?? ODIE_NEW_LOGGED_OUT_INTERACTIONS_BOT_SLUG,
 			} );
 		}
 		return createRoot( container ).render(
@@ -53,4 +69,9 @@ export default function loadHelpCenter() {
 			</QueryClientProvider>
 		);
 	} );
+	// Clear the memo on failure so a retry starts a fresh load.
+	helpCenterLoad.catch( () => {
+		helpCenterLoad = null;
+	} );
+	return helpCenterLoad;
 }

--- a/apps/help-center/async-help-center.jsx
+++ b/apps/help-center/async-help-center.jsx
@@ -32,6 +32,7 @@ export default function loadHelpCenter() {
 		if ( customProps.launcherContext ) {
 			dispatch( 'automattic/help-center' ).setHelpCenterOptions( {
 				launcherContext: customProps.launcherContext,
+				loggedOutBotSlug: customProps.newLoggedOutInteractionsBotSlug,
 			} );
 		}
 		return createRoot( container ).render(

--- a/apps/help-center/async-help-center.jsx
+++ b/apps/help-center/async-help-center.jsx
@@ -8,9 +8,6 @@ export default function loadHelpCenter() {
 		return Promise.resolve();
 	}
 	const queryClient = new QueryClient();
-	const container = document.createElement( 'div' );
-	container.id = 'jetpack-help-center';
-	document.body.appendChild( container );
 
 	const customProps = {};
 
@@ -27,6 +24,11 @@ export default function loadHelpCenter() {
 	}
 
 	return import( '@automattic/help-center' ).then( ( { default: HelpCenter } ) => {
+		// Only append once the chunk has loaded, so a failed import leaves no container behind and retries can mount.
+		const container = document.createElement( 'div' );
+		container.id = 'jetpack-help-center';
+		document.body.appendChild( container );
+
 		// Before the first render, so store resolvers (e.g. the logged-out
 		// auto-open route) already know which launcher surface this is.
 		if ( customProps.launcherContext ) {

--- a/apps/help-center/async-help-center.jsx
+++ b/apps/help-center/async-help-center.jsx
@@ -22,6 +22,10 @@ export default function loadHelpCenter() {
 		customProps.newLoggedOutInteractionsBotSlug = helpCenterData.newLoggedOutInteractionsBotSlug;
 	}
 
+	if ( helpCenterData?.launcherContext ) {
+		customProps.launcherContext = helpCenterData.launcherContext;
+	}
+
 	return import( '@automattic/help-center' ).then( ( { default: HelpCenter } ) =>
 		createRoot( container ).render(
 			<QueryClientProvider client={ queryClient }>

--- a/apps/help-center/async-help-center.jsx
+++ b/apps/help-center/async-help-center.jsx
@@ -26,8 +26,15 @@ export default function loadHelpCenter() {
 		customProps.launcherContext = helpCenterData.launcherContext;
 	}
 
-	return import( '@automattic/help-center' ).then( ( { default: HelpCenter } ) =>
-		createRoot( container ).render(
+	return import( '@automattic/help-center' ).then( ( { default: HelpCenter } ) => {
+		// Before the first render, so store resolvers (e.g. the logged-out
+		// auto-open route) already know which launcher surface this is.
+		if ( customProps.launcherContext ) {
+			dispatch( 'automattic/help-center' ).setHelpCenterOptions( {
+				launcherContext: customProps.launcherContext,
+			} );
+		}
+		return createRoot( container ).render(
 			<QueryClientProvider client={ queryClient }>
 				<HelpCenter
 					locale={ helpCenterData.locale }
@@ -41,6 +48,6 @@ export default function loadHelpCenter() {
 					{ ...customProps }
 				/>
 			</QueryClientProvider>
-		)
-	);
+		);
+	} );
 }

--- a/apps/help-center/async-help-center.jsx
+++ b/apps/help-center/async-help-center.jsx
@@ -1,9 +1,9 @@
 /* global helpCenterData */
-import { englishLocales } from '@automattic/i18n-utils';
+import { englishLocales } from '@automattic/i18n-utils/src/locales';
 import {
 	ODIE_NEW_LOGGED_OUT_INTERACTIONS_BOT_SLUG,
 	PLANS_PRESALES_INTRO_MESSAGE,
-} from '@automattic/odie-client/src/constants';
+} from '@automattic/odie-client/src/presales-constants';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { dispatch } from '@wordpress/data';
 import { hasTranslation } from '@wordpress/i18n';

--- a/packages/data-stores/src/help-center/constants.ts
+++ b/packages/data-stores/src/help-center/constants.ts
@@ -1,2 +1,4 @@
 export const STORE_KEY = 'automattic/help-center';
 export const PREFERENCES_KEY = 'logged_out_help_center_preferences_';
+// Set by the wpcom launcher on the pricing page so the assistant greets visitors as a pre-sales guide.
+export const PLANS_PRESALES_LAUNCHER_CONTEXT = 'plans-presales';

--- a/packages/data-stores/src/help-center/index.ts
+++ b/packages/data-stores/src/help-center/index.ts
@@ -42,4 +42,5 @@ export function register(): typeof STORE_KEY {
 }
 
 export { setHelpCenterAppId } from './utils';
+export { PLANS_PRESALES_LAUNCHER_CONTEXT } from './constants';
 export type { HelpCenterSite } from './types';

--- a/packages/data-stores/src/help-center/resolvers.ts
+++ b/packages/data-stores/src/help-center/resolvers.ts
@@ -4,9 +4,22 @@ import { getPersistedPreference } from './utils';
 export function isHelpCenterShown() {
 	return async ( { dispatch, select }: HelpCenterThunkProps ) => {
 		if ( select.hasLoggedOutOdieChat() ) {
+			// The plans-presales launcher reopens straight into the saved
+			// conversation; other surfaces keep landing on home.
+			// 'plans-presales' mirrors PLANS_PRESALES_LAUNCHER_CONTEXT in
+			// @automattic/odie-client (importing it would create a cycle).
+			const chat =
+				select.getHelpCenterOptions()?.launcherContext === 'plans-presales'
+					? select.getAnyLoggedOutOdieChat()
+					: undefined;
+			const route = chat
+				? `/odie?chatId=${ encodeURIComponent( chat.odieId ) }&sessionId=${ encodeURIComponent(
+						chat.sessionId
+				  ) }&botSlug=${ encodeURIComponent( chat.botSlug ) }`
+				: '/';
 			dispatch( {
 				type: 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE',
-				route: '/',
+				route,
 				coalesceParams: false,
 			} as const );
 			dispatch( {

--- a/packages/data-stores/src/help-center/resolvers.ts
+++ b/packages/data-stores/src/help-center/resolvers.ts
@@ -1,22 +1,28 @@
+import { addQueryArgs } from '@wordpress/url';
+import { PLANS_PRESALES_LAUNCHER_CONTEXT } from './constants';
 import { HelpCenterThunkProps } from './types';
 import { getPersistedPreference } from './utils';
 
 export function isHelpCenterShown() {
 	return async ( { dispatch, select }: HelpCenterThunkProps ) => {
 		if ( select.hasLoggedOutOdieChat() ) {
-			// The plans-presales launcher reopens straight into the saved
-			// conversation; other surfaces keep landing on home.
-			// 'plans-presales' mirrors PLANS_PRESALES_LAUNCHER_CONTEXT in
-			// @automattic/odie-client (importing it would create a cycle).
+			// Presales reopens the saved conversation; other surfaces land on home.
+			const options = select.getHelpCenterOptions();
+			const isPresales = options?.launcherContext === PLANS_PRESALES_LAUNCHER_CONTEXT;
 			const chat =
-				select.getHelpCenterOptions()?.launcherContext === 'plans-presales'
-					? select.getAnyLoggedOutOdieChat()
+				isPresales && options?.loggedOutBotSlug
+					? select.getLoggedOutOdieChat( options.loggedOutBotSlug )
 					: undefined;
-			const route = chat
-				? `/odie?chatId=${ encodeURIComponent( chat.odieId ) }&sessionId=${ encodeURIComponent(
-						chat.sessionId
-				  ) }&botSlug=${ encodeURIComponent( chat.botSlug ) }`
-				: '/';
+			let route = '/';
+			if ( isPresales ) {
+				route = chat
+					? addQueryArgs( '/odie', {
+							chatId: chat.odieId,
+							sessionId: chat.sessionId,
+							botSlug: chat.botSlug,
+					  } )
+					: '/odie';
+			}
 			dispatch( {
 				type: 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE',
 				route,

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -34,21 +34,6 @@ export const getLoggedOutOdieChat = ( state: State, botSlug: string ) => {
 	// Read the temporary keyed shape previously persisted under the singular field.
 	return legacySession?.[ botSlug ];
 };
-export const getAnyLoggedOutOdieChat = ( state: State ): LoggedOutOdieChat | undefined => {
-	const keyed = Object.values( state.loggedOutOdieChats ?? {} ).find( isLoggedOutOdieChat );
-
-	if ( keyed ) {
-		return keyed;
-	}
-
-	const legacySession = state.loggedOutOdieChat;
-
-	if ( isLoggedOutOdieChat( legacySession ) ) {
-		return legacySession;
-	}
-
-	return Object.values( legacySession ?? {} ).find( isLoggedOutOdieChat );
-};
 export const hasLoggedOutOdieChat = ( state: State ) => {
 	if ( state.loggedOutOdieChats && Object.keys( state.loggedOutOdieChats ).length ) {
 		return true;

--- a/packages/data-stores/src/help-center/selectors.ts
+++ b/packages/data-stores/src/help-center/selectors.ts
@@ -34,6 +34,21 @@ export const getLoggedOutOdieChat = ( state: State, botSlug: string ) => {
 	// Read the temporary keyed shape previously persisted under the singular field.
 	return legacySession?.[ botSlug ];
 };
+export const getAnyLoggedOutOdieChat = ( state: State ): LoggedOutOdieChat | undefined => {
+	const keyed = Object.values( state.loggedOutOdieChats ?? {} ).find( isLoggedOutOdieChat );
+
+	if ( keyed ) {
+		return keyed;
+	}
+
+	const legacySession = state.loggedOutOdieChat;
+
+	if ( isLoggedOutOdieChat( legacySession ) ) {
+		return legacySession;
+	}
+
+	return Object.values( legacySession ?? {} ).find( isLoggedOutOdieChat );
+};
 export const hasLoggedOutOdieChat = ( state: State ) => {
 	if ( state.loggedOutOdieChats && Object.keys( state.loggedOutOdieChats ).length ) {
 		return true;

--- a/packages/data-stores/src/help-center/test/resolvers.ts
+++ b/packages/data-stores/src/help-center/test/resolvers.ts
@@ -20,7 +20,7 @@ describe( 'Help Center resolvers', () => {
 		const select = {
 			hasLoggedOutOdieChat: jest.fn( () => true ),
 			getHelpCenterOptions: jest.fn( () => ( {} ) ),
-			getAnyLoggedOutOdieChat: jest.fn(),
+			getLoggedOutOdieChat: jest.fn(),
 		};
 
 		await isHelpCenterShown()( {
@@ -29,6 +29,7 @@ describe( 'Help Center resolvers', () => {
 		} as unknown as HelpCenterThunkProps );
 
 		expect( mockGetPersistedPreference ).not.toHaveBeenCalled();
+		expect( select.getLoggedOutOdieChat ).not.toHaveBeenCalled();
 		expect( dispatch ).toHaveBeenNthCalledWith( 1, {
 			type: 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE',
 			route: '/',
@@ -40,16 +41,47 @@ describe( 'Help Center resolvers', () => {
 		} );
 	} );
 
-	it( 'reopens the saved conversation for the plans-presales launcher', async () => {
+	it( 'reopens the saved conversation of the presales bot for the plans-presales launcher', async () => {
 		const dispatch = jest.fn();
 		const select = {
 			hasLoggedOutOdieChat: jest.fn( () => true ),
-			getHelpCenterOptions: jest.fn( () => ( { launcherContext: 'plans-presales' } ) ),
-			getAnyLoggedOutOdieChat: jest.fn( () => ( {
+			getHelpCenterOptions: jest.fn( () => ( {
+				launcherContext: 'plans-presales',
+				loggedOutBotSlug: 'wpcom-workflow-presales',
+			} ) ),
+			getLoggedOutOdieChat: jest.fn( () => ( {
 				odieId: 123,
 				sessionId: 'abc-def',
-				botSlug: 'wpcom-workflow-chat',
+				botSlug: 'wpcom-workflow-presales',
 			} ) ),
+		};
+
+		await isHelpCenterShown()( {
+			dispatch,
+			select,
+		} as unknown as HelpCenterThunkProps );
+
+		expect( select.getLoggedOutOdieChat ).toHaveBeenCalledWith( 'wpcom-workflow-presales' );
+		expect( dispatch ).toHaveBeenNthCalledWith( 1, {
+			type: 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE',
+			route: '/odie?chatId=123&sessionId=abc-def&botSlug=wpcom-workflow-presales',
+			coalesceParams: false,
+		} );
+		expect( dispatch ).toHaveBeenNthCalledWith( 2, {
+			type: 'HELP_CENTER_SET_SHOW',
+			show: true,
+		} );
+	} );
+
+	it( 'opens the presales launcher on a fresh chat when the saved conversation belongs to another bot', async () => {
+		const dispatch = jest.fn();
+		const select = {
+			hasLoggedOutOdieChat: jest.fn( () => true ),
+			getHelpCenterOptions: jest.fn( () => ( {
+				launcherContext: 'plans-presales',
+				loggedOutBotSlug: 'wpcom-workflow-presales',
+			} ) ),
+			getLoggedOutOdieChat: jest.fn( () => undefined ),
 		};
 
 		await isHelpCenterShown()( {
@@ -59,12 +91,29 @@ describe( 'Help Center resolvers', () => {
 
 		expect( dispatch ).toHaveBeenNthCalledWith( 1, {
 			type: 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE',
-			route: '/odie?chatId=123&sessionId=abc-def&botSlug=wpcom-workflow-chat',
+			route: '/odie',
 			coalesceParams: false,
 		} );
-		expect( dispatch ).toHaveBeenNthCalledWith( 2, {
-			type: 'HELP_CENTER_SET_SHOW',
-			show: true,
+	} );
+
+	it( 'opens the presales launcher on a fresh chat when no bot slug was provided', async () => {
+		const dispatch = jest.fn();
+		const select = {
+			hasLoggedOutOdieChat: jest.fn( () => true ),
+			getHelpCenterOptions: jest.fn( () => ( { launcherContext: 'plans-presales' } ) ),
+			getLoggedOutOdieChat: jest.fn(),
+		};
+
+		await isHelpCenterShown()( {
+			dispatch,
+			select,
+		} as unknown as HelpCenterThunkProps );
+
+		expect( select.getLoggedOutOdieChat ).not.toHaveBeenCalled();
+		expect( dispatch ).toHaveBeenNthCalledWith( 1, {
+			type: 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE',
+			route: '/odie',
+			coalesceParams: false,
 		} );
 	} );
 

--- a/packages/data-stores/src/help-center/test/resolvers.ts
+++ b/packages/data-stores/src/help-center/test/resolvers.ts
@@ -19,6 +19,8 @@ describe( 'Help Center resolvers', () => {
 		const dispatch = jest.fn();
 		const select = {
 			hasLoggedOutOdieChat: jest.fn( () => true ),
+			getHelpCenterOptions: jest.fn( () => ( {} ) ),
+			getAnyLoggedOutOdieChat: jest.fn(),
 		};
 
 		await isHelpCenterShown()( {
@@ -30,6 +32,34 @@ describe( 'Help Center resolvers', () => {
 		expect( dispatch ).toHaveBeenNthCalledWith( 1, {
 			type: 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE',
 			route: '/',
+			coalesceParams: false,
+		} );
+		expect( dispatch ).toHaveBeenNthCalledWith( 2, {
+			type: 'HELP_CENTER_SET_SHOW',
+			show: true,
+		} );
+	} );
+
+	it( 'reopens the saved conversation for the plans-presales launcher', async () => {
+		const dispatch = jest.fn();
+		const select = {
+			hasLoggedOutOdieChat: jest.fn( () => true ),
+			getHelpCenterOptions: jest.fn( () => ( { launcherContext: 'plans-presales' } ) ),
+			getAnyLoggedOutOdieChat: jest.fn( () => ( {
+				odieId: 123,
+				sessionId: 'abc-def',
+				botSlug: 'wpcom-workflow-chat',
+			} ) ),
+		};
+
+		await isHelpCenterShown()( {
+			dispatch,
+			select,
+		} as unknown as HelpCenterThunkProps );
+
+		expect( dispatch ).toHaveBeenNthCalledWith( 1, {
+			type: 'HELP_CENTER_SET_NAVIGATE_TO_ROUTE',
+			route: '/odie?chatId=123&sessionId=abc-def&botSlug=wpcom-workflow-chat',
 			coalesceParams: false,
 		} );
 		expect( dispatch ).toHaveBeenNthCalledWith( 2, {

--- a/packages/data-stores/src/help-center/types.ts
+++ b/packages/data-stores/src/help-center/types.ts
@@ -52,6 +52,7 @@ export type HelpCenterThunkProps = {
 
 export interface HelpCenterOptions {
 	hideBackButton?: boolean;
+	launcherContext?: string;
 }
 
 export type LoggedOutOdieChat = {

--- a/packages/data-stores/src/help-center/types.ts
+++ b/packages/data-stores/src/help-center/types.ts
@@ -53,6 +53,7 @@ export type HelpCenterThunkProps = {
 export interface HelpCenterOptions {
 	hideBackButton?: boolean;
 	launcherContext?: string;
+	loggedOutBotSlug?: string;
 }
 
 export type LoggedOutOdieChat = {

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -64,6 +64,7 @@ export type {
 	HelpCenterSite,
 	HelpCenterSelect,
 	Dispatch as HelpCenterDispatch,
+	LoggedOutOdieChat,
 } from './help-center/types';
 export type {
 	AgentsManagerSelect,

--- a/packages/help-center/src/components/get-presales-resume-route.ts
+++ b/packages/help-center/src/components/get-presales-resume-route.ts
@@ -1,0 +1,20 @@
+import { PLANS_PRESALES_LAUNCHER_CONTEXT } from '@automattic/odie-client/src/constants';
+import { addQueryArgs } from '@wordpress/url';
+import type { LoggedOutOdieChat } from '@automattic/data-stores';
+
+// A bare /odie open of the presales launcher resumes the saved logged-out
+// conversation; every other route or context passes through unchanged.
+export function getPresalesResumeRoute(
+	route: string,
+	launcherContext: string | undefined,
+	chat: LoggedOutOdieChat | undefined
+): string {
+	if ( route !== '/odie' || launcherContext !== PLANS_PRESALES_LAUNCHER_CONTEXT || ! chat ) {
+		return route;
+	}
+	return addQueryArgs( '/odie', {
+		chatId: chat.odieId,
+		sessionId: chat.sessionId,
+		botSlug: chat.botSlug,
+	} );
+}

--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -30,6 +30,7 @@ export function HelpCenterChat( {
 		newInteractionsBotSlug,
 		newLoggedOutInteractionsBotSlug,
 		newInteractionsBotVersion,
+		launcherContext,
 	} = useHelpCenterContext();
 	const featureConfig = useFeatureConfig();
 	const { search } = useLocation();
@@ -80,6 +81,7 @@ export function HelpCenterChat( {
 			isUserEligibleForPaidSupport={ isUserEligibleForPaidSupport }
 			forceEmailSupport={ Boolean( forceEmailSupport ) }
 			isChatRestricted={ Boolean( isChatRestricted ) }
+			launcherContext={ launcherContext }
 		>
 			<div className="help-center__container-chat">
 				<OdieAssistant />

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -17,6 +17,7 @@ import { useSupportStatus } from '../data/use-support-status';
 import { useChatStatus } from '../hooks';
 import { useHelpCenterTracksEvent } from '../hooks/use-help-center-tracks-event';
 import { HELP_CENTER_STORE } from '../stores';
+import { getPresalesResumeRoute } from './get-presales-resume-route';
 import { HelpCenterChat } from './help-center-chat';
 import { HelpCenterChatHistory } from './help-center-chat-history';
 import { HelpCenterContactForm } from './help-center-contact-form';
@@ -82,21 +83,26 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	const containerRef = useRef< HTMLDivElement >( null );
 	const navigate = useNavigate();
 	const { setNavigateToRoute } = useDispatch( HELP_CENTER_STORE );
-	const { sectionName, site } = useHelpCenterContext();
+	const { sectionName, site, launcherContext, newLoggedOutInteractionsBotSlug } =
+		useHelpCenterContext();
 	const recordTracksEvent = useHelpCenterTracksEvent();
 	const featureConfig = useFeatureConfig();
 	const { data, isLoading: isLoadingSupportStatus } = useSupportStatus();
 	const { forceEmailSupport } = useChatStatus();
 	const currentSiteDomain = site?.domain;
 
-	const { navigateToRoute, isMinimized, hasPremiumSupport } = useSelect( ( select ) => {
-		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
-		return {
-			navigateToRoute: store.getNavigateToRoute(),
-			isMinimized: store.getIsMinimized(),
-			hasPremiumSupport: store.getHasPremiumSupport(),
-		};
-	}, [] );
+	const { navigateToRoute, isMinimized, hasPremiumSupport, loggedOutOdieChat } = useSelect(
+		( select ) => {
+			const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
+			return {
+				navigateToRoute: store.getNavigateToRoute(),
+				isMinimized: store.getIsMinimized(),
+				hasPremiumSupport: store.getHasPremiumSupport(),
+				loggedOutOdieChat: store.getLoggedOutOdieChat( newLoggedOutInteractionsBotSlug ),
+			};
+		},
+		[ newLoggedOutInteractionsBotSlug ]
+	);
 	const isUserEligibleForPaidSupport =
 		Boolean( data?.eligibility?.is_user_eligible ) ||
 		hasPremiumSupport ||
@@ -121,7 +127,12 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 
 	useEffect( () => {
 		if ( navigateToRoute?.route ) {
-			const { route, coalesceParams } = navigateToRoute;
+			const { coalesceParams } = navigateToRoute;
+			const route = getPresalesResumeRoute(
+				navigateToRoute.route,
+				launcherContext,
+				loggedOutOdieChat
+			);
 			const fullLocation = [ location.pathname, location.search, location.hash ].join( '' );
 			// Only navigate once to keep the back button responsive.
 			if ( fullLocation !== route ) {
@@ -139,7 +150,14 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 			}
 			setNavigateToRoute( null );
 		}
-	}, [ navigate, navigateToRoute, setNavigateToRoute, location ] );
+	}, [
+		navigate,
+		navigateToRoute,
+		setNavigateToRoute,
+		location,
+		launcherContext,
+		loggedOutOdieChat,
+	] );
 
 	useEffect( () => {
 		function handler( event: Event ) {

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -1,10 +1,7 @@
 /* eslint-disable no-restricted-imports */
 import { useGetHistoryChats } from '@automattic/help-center/src/hooks/use-get-history-chats';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
-import {
-	PLANS_PRESALES_INTRO_MESSAGE,
-	PLANS_PRESALES_LAUNCHER_CONTEXT,
-} from '@automattic/odie-client/src/constants';
+import { isPlansPresalesExperience } from '@automattic/odie-client/src/constants';
 import { useCurrentSupportInteraction } from '@automattic/odie-client/src/data/use-current-support-interaction';
 import {
 	CardHeader,
@@ -163,10 +160,11 @@ const useHeaderText = () => {
 	const isConversationWithZendesk = currentSupportInteraction?.events.some(
 		( event ) => event.event_source === 'zendesk'
 	);
-	// Same gate as the greeting, so title and greeting switch together per locale.
+	// Same gate as the greeting, plus the title's own translation so a locale
+	// never shows an English title over a localized panel.
 	const isPlansPresales =
-		launcherContext === PLANS_PRESALES_LAUNCHER_CONTEXT &&
-		hasEnTranslation( PLANS_PRESALES_INTRO_MESSAGE, undefined, __i18n_text_domain__ );
+		isPlansPresalesExperience( launcherContext, hasEnTranslation ) &&
+		hasEnTranslation( 'Plans Assistant', undefined, __i18n_text_domain__ );
 
 	return useMemo( () => {
 		switch ( pathname ) {

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import { useGetHistoryChats } from '@automattic/help-center/src/hooks/use-get-history-chats';
+import { PLANS_PRESALES_LAUNCHER_CONTEXT } from '@automattic/odie-client/src/constants';
 import { useCurrentSupportInteraction } from '@automattic/odie-client/src/data/use-current-support-interaction';
 import {
 	CardHeader,
@@ -152,10 +153,12 @@ const useHeaderText = () => {
 	const { __ } = useI18n();
 	const { pathname } = useLocation();
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
+	const { launcherContext } = useHelpCenterContext();
 
 	const isConversationWithZendesk = currentSupportInteraction?.events.some(
 		( event ) => event.event_source === 'zendesk'
 	);
+	const isPlansPresales = launcherContext === PLANS_PRESALES_LAUNCHER_CONTEXT;
 
 	return useMemo( () => {
 		switch ( pathname ) {
@@ -171,8 +174,11 @@ const useHeaderText = () => {
 			case '/success':
 				return __( 'Message Submitted', __i18n_text_domain__ );
 			case '/odie':
-				return isConversationWithZendesk
-					? __( 'Support Team', __i18n_text_domain__ )
+				if ( isConversationWithZendesk ) {
+					return __( 'Support Team', __i18n_text_domain__ );
+				}
+				return isPlansPresales
+					? __( 'Plans Assistant', __i18n_text_domain__ )
 					: __( 'Support Assistant', __i18n_text_domain__ );
 			case '/chat-history':
 				return __( 'Support history', __i18n_text_domain__ );
@@ -181,7 +187,7 @@ const useHeaderText = () => {
 			default:
 				return __( 'Help Center', __i18n_text_domain__ );
 		}
-	}, [ __, isConversationWithZendesk, pathname ] );
+	}, [ __, isConversationWithZendesk, isPlansPresales, pathname ] );
 };
 
 const HeaderText = () => {

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -1,6 +1,10 @@
 /* eslint-disable no-restricted-imports */
 import { useGetHistoryChats } from '@automattic/help-center/src/hooks/use-get-history-chats';
-import { PLANS_PRESALES_LAUNCHER_CONTEXT } from '@automattic/odie-client/src/constants';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
+import {
+	PLANS_PRESALES_INTRO_MESSAGE,
+	PLANS_PRESALES_LAUNCHER_CONTEXT,
+} from '@automattic/odie-client/src/constants';
 import { useCurrentSupportInteraction } from '@automattic/odie-client/src/data/use-current-support-interaction';
 import {
 	CardHeader,
@@ -154,11 +158,15 @@ const useHeaderText = () => {
 	const { pathname } = useLocation();
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
 	const { launcherContext } = useHelpCenterContext();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const isConversationWithZendesk = currentSupportInteraction?.events.some(
 		( event ) => event.event_source === 'zendesk'
 	);
-	const isPlansPresales = launcherContext === PLANS_PRESALES_LAUNCHER_CONTEXT;
+	// Same gate as the greeting, so title and greeting switch together per locale.
+	const isPlansPresales =
+		launcherContext === PLANS_PRESALES_LAUNCHER_CONTEXT &&
+		hasEnTranslation( PLANS_PRESALES_INTRO_MESSAGE, undefined, __i18n_text_domain__ );
 
 	return useMemo( () => {
 		switch ( pathname ) {

--- a/packages/help-center/src/components/test/get-presales-resume-route.tsx
+++ b/packages/help-center/src/components/test/get-presales-resume-route.tsx
@@ -1,0 +1,29 @@
+import { getPresalesResumeRoute } from '../get-presales-resume-route';
+
+const chat = {
+	odieId: 123,
+	sessionId: 'abc-def',
+	botSlug: 'wpcom-workflow-chat_loggedout',
+};
+
+describe( 'getPresalesResumeRoute', () => {
+	it( 'rewrites a bare /odie open of the presales launcher to the saved conversation', () => {
+		expect( getPresalesResumeRoute( '/odie', 'plans-presales', chat ) ).toBe(
+			'/odie?chatId=123&sessionId=abc-def&botSlug=wpcom-workflow-chat_loggedout'
+		);
+	} );
+
+	it( 'leaves a bare /odie alone when there is no saved conversation', () => {
+		expect( getPresalesResumeRoute( '/odie', 'plans-presales', undefined ) ).toBe( '/odie' );
+	} );
+
+	it( 'leaves a bare /odie alone outside the presales launcher', () => {
+		expect( getPresalesResumeRoute( '/odie', undefined, chat ) ).toBe( '/odie' );
+	} );
+
+	it( 'never rewrites a route that already carries params', () => {
+		expect( getPresalesResumeRoute( '/odie?provider=zendesk', 'plans-presales', chat ) ).toBe(
+			'/odie?provider=zendesk'
+		);
+	} );
+} );

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -30,6 +30,10 @@ export type HelpCenterRequiredInformation = {
 	 * Product identifier. Defaults to 'wpcom' when omitted.
 	 */
 	product?: HelpCenterProduct;
+	/**
+	 * Page the launcher was opened from, when the host page sets one. Tailors the greeting and title.
+	 */
+	launcherContext?: string;
 };
 
 const defaultContext: HelpCenterRequiredInformation = {

--- a/packages/help-center/src/test/__mocks__/automattic-data-stores.js
+++ b/packages/help-center/src/test/__mocks__/automattic-data-stores.js
@@ -5,6 +5,7 @@
 
 const HelpCenter = {
 	register: () => 'help-center',
+	PLANS_PRESALES_LAUNCHER_CONTEXT: 'plans-presales',
 };
 
 module.exports = { HelpCenter };

--- a/packages/odie-client/src/components/chat-footer/index.tsx
+++ b/packages/odie-client/src/components/chat-footer/index.tsx
@@ -1,5 +1,6 @@
 import { Notice, animations, ChatInput, AgentUIProvider } from '@automattic/agenttic-ui';
 import { motion } from 'framer-motion';
+import { IntroSuggestions } from '../message/intro-suggestions';
 import './style.scss';
 import type { Transition } from 'framer-motion';
 import type { ComponentProps } from 'react';
@@ -13,6 +14,7 @@ type AgentUIFooterProps = ComponentProps< typeof ChatInput > & {
 export function AgentUIFooter( props: AgentUIFooterProps ) {
 	return (
 		<AgentUIProvider value={ {} as any }>
+			<IntroSuggestions />
 			<motion.div
 				data-slot="chat-footer"
 				className="agenttic--chat-footer-container"

--- a/packages/odie-client/src/components/message/intro-suggestions.scss
+++ b/packages/odie-client/src/components/message/intro-suggestions.scss
@@ -1,0 +1,36 @@
+/* Pin agenttic-ui Suggestions (vertical layout) in normal flow. The library's
+   base container class is position:absolute at the same specificity as the
+   vertical layout's position:static, so stylesheet order decides — this rule
+   out-specifies both deterministically. data-slot is the library's stable hook. */
+.odie-intro-suggestions[data-slot='suggestions'] {
+	position: static;
+	margin-bottom: 8px;
+	/* The component is a framer-motion div that floats itself up via an inline
+	   translateY transform even in vertical layout; !important is required to
+	   beat the inline style. Paired with translateY={0} on the component. */
+	transform: none !important;
+
+	/* Follow-up mode: compact horizontal pill row above the composer. The
+	   library's base container provides the row + horizontal scroll; drop its
+	   inset padding so pills align with the composer edges, size the pills
+	   down to reference proportions, and fade the right edge so a clipped
+	   pill reads as "scrolls" rather than "broken". */
+	&.odie-intro-suggestions--followups {
+		/* The library container is overflow-y: hidden — zero padding clips the
+		   pills' top borders. Keep a few px vertical, keep left flush with the
+		   composer, and leave right room so the last pill can scroll clear of
+		   the fade. */
+		padding: 3px 24px 3px 0;
+		mask-image: linear-gradient( to right, #000 calc( 100% - 24px ), transparent );
+
+		button {
+			height: auto;
+			padding: 8px 14px;
+			border-radius: 8px;
+			font-size: 13px;
+			line-height: 1.3;
+			white-space: nowrap;
+			flex-shrink: 0;
+		}
+	}
+}

--- a/packages/odie-client/src/components/message/intro-suggestions.scss
+++ b/packages/odie-client/src/components/message/intro-suggestions.scss
@@ -1,25 +1,12 @@
-/* Pin agenttic-ui Suggestions (vertical layout) in normal flow. The library's
-   base container class is position:absolute at the same specificity as the
-   vertical layout's position:static, so stylesheet order decides — this rule
-   out-specifies both deterministically. data-slot is the library's stable hook. */
+/* Pin the library's Suggestions in flow; it defaults to absolute + translateY. */
 .odie-intro-suggestions[data-slot='suggestions'] {
 	position: static;
 	margin-bottom: 8px;
-	/* The component is a framer-motion div that floats itself up via an inline
-	   translateY transform even in vertical layout; !important is required to
-	   beat the inline style. Paired with translateY={0} on the component. */
+	/* Override the library's inline translateY. */
 	transform: none !important;
 
-	/* Follow-up mode: compact horizontal pill row above the composer. The
-	   library's base container provides the row + horizontal scroll; drop its
-	   inset padding so pills align with the composer edges, size the pills
-	   down to reference proportions, and fade the right edge so a clipped
-	   pill reads as "scrolls" rather than "broken". */
+	/* Follow-up row; keep a few px vertical padding so the overflow-hidden container doesn't clip pill borders. */
 	&.odie-intro-suggestions--followups {
-		/* The library container is overflow-y: hidden — zero padding clips the
-		   pills' top borders. Keep a few px vertical, keep left flush with the
-		   composer, and leave right room so the last pill can scroll clear of
-		   the fade. */
 		padding: 3px 24px 3px 0;
 		mask-image: linear-gradient( to right, #000 calc( 100% - 24px ), transparent );
 

--- a/packages/odie-client/src/components/message/intro-suggestions.tsx
+++ b/packages/odie-client/src/components/message/intro-suggestions.tsx
@@ -1,0 +1,87 @@
+import { Suggestions } from '@automattic/agenttic-ui';
+import clsx from 'clsx';
+import { useState } from 'react';
+import { PLANS_PRESALES_LAUNCHER_CONTEXT } from '../../constants';
+import { useOdieAssistantContext } from '../../context';
+import { useSendChatMessage } from '../../hooks';
+import type { Message } from '../../types';
+import './intro-suggestions.scss';
+
+/**
+ * EXPERIMENT (Ilona, 2026-08-20): starter-prompt chips for the plans-presales
+ * assistant, rendered with agenttic-ui's Suggestions component.
+ *
+ * Two modes, one component:
+ * - Before the conversation starts: vertical stacked list under the greeting.
+ * - Once a prompt is chosen (or the visitor types): the not-yet-asked prompts
+ *   move into a compact horizontal follow-up row above the composer.
+ * Clicking marks the prompt as asked locally, so the swap is instant — the
+ * chat store round-trip is too slow to gate visibility on.
+ *
+ * Known library issues (report to Agenttic UI owners):
+ * - Base container is position:absolute at the same specificity as vertical's
+ *   position:static; the winner depends on stylesheet order, which Calypso's
+ *   build does not preserve. Companion .scss pins it in-flow via data-slot.
+ * - translateY defaults to "-100%" in every layout (floats over content).
+ * - onSubmit silently requires `prompt` on each suggestion; `label` alone
+ *   renders but never fires.
+ *
+ * Prototype gaps: untranslated copy, no analytics event on chip click.
+ */
+const PLANS_PRESALES_SUGGESTIONS = [
+	{ id: 'compare-plans', label: 'Compare the plans for me', prompt: 'Compare the plans for me' },
+	{ id: 'plan-payments', label: 'Which plan has payments?', prompt: 'Which plan has payments?' },
+	{
+		id: 'business-benefits',
+		label: 'What are the main benefits of the Business plan?',
+		prompt: 'What are the main benefits of the Business plan?',
+	},
+];
+
+export const IntroSuggestions = () => {
+	const { chat, launcherContext } = useOdieAssistantContext();
+	const { sendMessage } = useSendChatMessage();
+	const [ askedIds, setAskedIds ] = useState< string[] >( [] );
+
+	if ( launcherContext !== PLANS_PRESALES_LAUNCHER_CONTEXT ) {
+		return null;
+	}
+
+	const conversationStarted = ( chat?.messages?.length ?? 0 ) > 1 || askedIds.length > 0;
+	// A prompt counts as asked if clicked this session OR already present in the
+	// conversation history — history survives panel close/reopen, local state doesn't.
+	const askedInHistory = ( prompt: string ): boolean =>
+		!! chat?.messages?.some( ( m ) => m.role === 'user' && String( m.content ).trim() === prompt );
+	const remaining = PLANS_PRESALES_SUGGESTIONS.filter(
+		( s ) => ! askedIds.includes( s.id ) && ! askedInHistory( s.prompt )
+	);
+
+	if ( remaining.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<Suggestions
+			className={ clsx(
+				'odie-intro-suggestions',
+				conversationStarted && 'odie-intro-suggestions--followups'
+			) }
+			layout={ conversationStarted ? 'horizontal' : 'vertical' }
+			translateY={ 0 }
+			suggestions={ remaining }
+			onSubmit={ ( selected ) => {
+				// The composer disables itself while the bot is busy; mirror that.
+				if ( chat?.status && chat.status !== 'loaded' ) {
+					return;
+				}
+				setAskedIds( [ ...askedIds, selected.id ] );
+				const messageObj = {
+					content: selected.prompt ?? selected.label,
+					role: 'user',
+					type: 'message',
+				} as Message;
+				sendMessage( messageObj );
+			} }
+		/>
+	);
+};

--- a/packages/odie-client/src/components/message/intro-suggestions.tsx
+++ b/packages/odie-client/src/components/message/intro-suggestions.tsx
@@ -1,15 +1,20 @@
 import { Suggestions } from '@automattic/agenttic-ui';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
+import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { useState } from 'react';
-import { PLANS_PRESALES_LAUNCHER_CONTEXT } from '../../constants';
+import {
+	PLANS_PRESALES_INTRO_MESSAGE,
+	PLANS_PRESALES_LAUNCHER_CONTEXT,
+} from '../../constants';
 import { useOdieAssistantContext } from '../../context';
 import { useSendChatMessage } from '../../hooks';
 import type { Message } from '../../types';
 import './intro-suggestions.scss';
 
 /**
- * EXPERIMENT (Ilona, 2026-08-20): starter-prompt chips for the plans-presales
- * assistant, rendered with agenttic-ui's Suggestions component.
+ * Starter-prompt chips for the plans-presales assistant, rendered with
+ * agenttic-ui's Suggestions component.
  *
  * Two modes, one component:
  * - Before the conversation starts: vertical stacked list under the greeting.
@@ -25,25 +30,39 @@ import './intro-suggestions.scss';
  * - translateY defaults to "-100%" in every layout (floats over content).
  * - onSubmit silently requires `prompt` on each suggestion; `label` alone
  *   renders but never fires.
- *
- * Prototype gaps: untranslated copy, no analytics event on chip click.
  */
+// `original` is the untranslated source string hasEnTranslation checks against;
+// `copy` repeats it literally inside __() so string extraction picks it up.
 const PLANS_PRESALES_SUGGESTIONS = [
-	{ id: 'compare-plans', label: 'Compare the plans for me', prompt: 'Compare the plans for me' },
-	{ id: 'plan-payments', label: 'Which plan has payments?', prompt: 'Which plan has payments?' },
+	{
+		id: 'compare-plans',
+		original: 'Compare the plans for me',
+		copy: () => __( 'Compare the plans for me', __i18n_text_domain__ ),
+	},
+	{
+		id: 'plan-payments',
+		original: 'Which plan has payments?',
+		copy: () => __( 'Which plan has payments?', __i18n_text_domain__ ),
+	},
 	{
 		id: 'business-benefits',
-		label: 'What are the main benefits of the Business plan?',
-		prompt: 'What are the main benefits of the Business plan?',
+		original: 'What are the main benefits of the Business plan?',
+		copy: () => __( 'What are the main benefits of the Business plan?', __i18n_text_domain__ ),
 	},
 ];
 
 export const IntroSuggestions = () => {
-	const { chat, launcherContext } = useOdieAssistantContext();
+	const { chat, launcherContext, trackEvent } = useOdieAssistantContext();
 	const { sendMessage } = useSendChatMessage();
+	const hasEnTranslation = useHasEnTranslation();
 	const [ askedIds, setAskedIds ] = useState< string[] >( [] );
 
-	if ( launcherContext !== PLANS_PRESALES_LAUNCHER_CONTEXT ) {
+	// Same master gate as the greeting/title, so the whole presales surface
+	// switches together per locale.
+	if (
+		launcherContext !== PLANS_PRESALES_LAUNCHER_CONTEXT ||
+		! hasEnTranslation( PLANS_PRESALES_INTRO_MESSAGE, undefined, __i18n_text_domain__ )
+	) {
 		return null;
 	}
 
@@ -52,9 +71,11 @@ export const IntroSuggestions = () => {
 	// conversation history — history survives panel close/reopen, local state doesn't.
 	const askedInHistory = ( prompt: string ): boolean =>
 		!! chat?.messages?.some( ( m ) => m.role === 'user' && String( m.content ).trim() === prompt );
-	const remaining = PLANS_PRESALES_SUGGESTIONS.filter(
-		( s ) => ! askedIds.includes( s.id ) && ! askedInHistory( s.prompt )
-	);
+	const remaining = PLANS_PRESALES_SUGGESTIONS.filter( ( s ) =>
+		hasEnTranslation( s.original, undefined, __i18n_text_domain__ )
+	)
+		.map( ( s ) => ( { id: s.id, label: s.copy(), prompt: s.copy() } ) )
+		.filter( ( s ) => ! askedIds.includes( s.id ) && ! askedInHistory( s.prompt ) );
 
 	if ( remaining.length === 0 ) {
 		return null;
@@ -74,6 +95,10 @@ export const IntroSuggestions = () => {
 				if ( chat?.status && chat.status !== 'loaded' ) {
 					return;
 				}
+				trackEvent( 'plans_presales_suggestion_click', {
+					suggestion_id: selected.id,
+					suggestion_layout: conversationStarted ? 'followup_row' : 'intro_stack',
+				} );
 				setAskedIds( [ ...askedIds, selected.id ] );
 				const messageObj = {
 					content: selected.prompt ?? selected.label,

--- a/packages/odie-client/src/components/message/intro-suggestions.tsx
+++ b/packages/odie-client/src/components/message/intro-suggestions.tsx
@@ -2,35 +2,13 @@ import { Suggestions } from '@automattic/agenttic-ui';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
-import { useState } from 'react';
-import {
-	PLANS_PRESALES_INTRO_MESSAGE,
-	PLANS_PRESALES_LAUNCHER_CONTEXT,
-} from '../../constants';
+import { useMemo } from 'react';
+import { isPlansPresalesExperience, PLANS_PRESALES_LAUNCHER_CONTEXT } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
 import { useSendChatMessage } from '../../hooks';
 import type { Message } from '../../types';
 import './intro-suggestions.scss';
 
-/**
- * Starter-prompt chips for the plans-presales assistant, rendered with
- * agenttic-ui's Suggestions component.
- *
- * Two modes, one component:
- * - Before the conversation starts: vertical stacked list under the greeting.
- * - Once a prompt is chosen (or the visitor types): the not-yet-asked prompts
- *   move into a compact horizontal follow-up row above the composer.
- * Clicking marks the prompt as asked locally, so the swap is instant — the
- * chat store round-trip is too slow to gate visibility on.
- *
- * Known library issues (report to Agenttic UI owners):
- * - Base container is position:absolute at the same specificity as vertical's
- *   position:static; the winner depends on stylesheet order, which Calypso's
- *   build does not preserve. Companion .scss pins it in-flow via data-slot.
- * - translateY defaults to "-100%" in every layout (floats over content).
- * - onSubmit silently requires `prompt` on each suggestion; `label` alone
- *   renders but never fires.
- */
 // `original` is the untranslated source string hasEnTranslation checks against;
 // `copy` repeats it literally inside __() so string extraction picks it up.
 const PLANS_PRESALES_SUGGESTIONS = [
@@ -51,33 +29,38 @@ const PLANS_PRESALES_SUGGESTIONS = [
 	},
 ];
 
-export const IntroSuggestions = () => {
+const PlansPresalesSuggestions = () => {
 	const { chat, launcherContext, trackEvent } = useOdieAssistantContext();
 	const { sendMessage } = useSendChatMessage();
 	const hasEnTranslation = useHasEnTranslation();
-	const [ askedIds, setAskedIds ] = useState< string[] >( [] );
 
-	// Same master gate as the greeting/title, so the whole presales surface
-	// switches together per locale.
+	// A prompt counts as asked once it appears in the conversation history,
+	// which survives panel close/reopen.
+	const { conversationStarted, remaining } = useMemo( () => {
+		const askedPrompts = new Set(
+			( chat?.messages ?? [] )
+				.filter( ( message ) => message.role === 'user' )
+				.map( ( message ) => String( message.content ).trim() )
+		);
+		return {
+			conversationStarted: askedPrompts.size > 0,
+			remaining: PLANS_PRESALES_SUGGESTIONS.filter( ( suggestion ) =>
+				hasEnTranslation( suggestion.original, undefined, __i18n_text_domain__ )
+			)
+				.map( ( suggestion ) => {
+					const copy = suggestion.copy();
+					return { id: suggestion.id, label: copy, prompt: copy };
+				} )
+				.filter( ( suggestion ) => ! askedPrompts.has( suggestion.prompt ) ),
+		};
+	}, [ chat?.messages, hasEnTranslation ] );
+
 	if (
-		launcherContext !== PLANS_PRESALES_LAUNCHER_CONTEXT ||
-		! hasEnTranslation( PLANS_PRESALES_INTRO_MESSAGE, undefined, __i18n_text_domain__ )
+		! isPlansPresalesExperience( launcherContext, hasEnTranslation ) ||
+		// Never post a presales prompt into an escalated human conversation.
+		chat?.provider === 'zendesk' ||
+		remaining.length === 0
 	) {
-		return null;
-	}
-
-	const conversationStarted = ( chat?.messages?.length ?? 0 ) > 1 || askedIds.length > 0;
-	// A prompt counts as asked if clicked this session OR already present in the
-	// conversation history — history survives panel close/reopen, local state doesn't.
-	const askedInHistory = ( prompt: string ): boolean =>
-		!! chat?.messages?.some( ( m ) => m.role === 'user' && String( m.content ).trim() === prompt );
-	const remaining = PLANS_PRESALES_SUGGESTIONS.filter( ( s ) =>
-		hasEnTranslation( s.original, undefined, __i18n_text_domain__ )
-	)
-		.map( ( s ) => ( { id: s.id, label: s.copy(), prompt: s.copy() } ) )
-		.filter( ( s ) => ! askedIds.includes( s.id ) && ! askedInHistory( s.prompt ) );
-
-	if ( remaining.length === 0 ) {
 		return null;
 	}
 
@@ -95,18 +78,29 @@ export const IntroSuggestions = () => {
 				if ( chat?.status && chat.status !== 'loaded' ) {
 					return;
 				}
-				trackEvent( 'plans_presales_suggestion_click', {
+				trackEvent( 'chat_presales_suggestion_click', {
 					suggestion_id: selected.id,
 					suggestion_layout: conversationStarted ? 'followup_row' : 'intro_stack',
 				} );
-				setAskedIds( [ ...askedIds, selected.id ] );
 				const messageObj = {
 					content: selected.prompt ?? selected.label,
 					role: 'user',
 					type: 'message',
 				} as Message;
-				sendMessage( messageObj );
+				sendMessage( messageObj ).catch( () => {} );
 			} }
 		/>
 	);
+};
+
+// Starter-prompt chips for the plans-presales assistant: stacked under the
+// greeting at first, then a compact follow-up row of not-yet-asked prompts.
+export const IntroSuggestions = () => {
+	const { launcherContext } = useOdieAssistantContext();
+
+	if ( launcherContext !== PLANS_PRESALES_LAUNCHER_CONTEXT ) {
+		return null;
+	}
+
+	return <PlansPresalesSuggestions />;
 };

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -29,7 +29,7 @@ interface ChatMessagesProps {
 }
 
 export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
-	const { chat, isChatLoaded, isUserEligibleForPaidSupport, forceEmailSupport } =
+	const { chat, isChatLoaded, isUserEligibleForPaidSupport, forceEmailSupport, launcherContext } =
 		useOdieAssistantContext();
 	const isTestMode = isTestModeEnvironment();
 	const hasEnTranslation = useHasEnTranslation();
@@ -150,7 +150,8 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 						message={ getOdieInitialMessage(
 							supportInteraction?.bot_slug || ODIE_DEFAULT_BOT_SLUG_LEGACY,
 							currentUser?.display_name,
-							hasEnTranslation
+							hasEnTranslation,
+							launcherContext
 						) }
 						key={ 0 }
 					/>

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -1,6 +1,7 @@
 import { HelpCenter } from '@automattic/data-stores';
 import { isTestModeEnvironment } from '@automattic/zendesk-client';
 import { __, sprintf } from '@wordpress/i18n';
+import { PLANS_PRESALES_INTRO_MESSAGE } from './presales-constants';
 import type { Context, Message, OdieAllowedBots, OdieAllBotSlugs } from './types';
 declare const __i18n_text_domain__: string;
 
@@ -8,9 +9,7 @@ type HasEnTranslation = ( single: string, context?: string, domain?: string ) =>
 
 export const PLANS_PRESALES_LAUNCHER_CONTEXT = HelpCenter.PLANS_PRESALES_LAUNCHER_CONTEXT;
 
-// Shared with the panel title gate so greeting and title switch together per locale.
-export const PLANS_PRESALES_INTRO_MESSAGE =
-	"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.";
+export { PLANS_PRESALES_INTRO_MESSAGE } from './presales-constants';
 
 // Single gate for the presales surface, so greeting, title, and chips switch together per locale.
 export const isPlansPresalesExperience = (
@@ -429,7 +428,7 @@ export const ODIE_DEFAULT_BOT_SLUG_LEGACY = 'wpcom-support-chat';
  * New interactions will target this bot slug and store it in the interaction object. All future events of those interactions will use this bot slug.
  */
 export const ODIE_NEW_INTERACTIONS_BOT_SLUG = 'wpcom-workflow-support_chat';
-export const ODIE_NEW_LOGGED_OUT_INTERACTIONS_BOT_SLUG = 'wpcom-workflow-chat_loggedout';
+export { ODIE_NEW_LOGGED_OUT_INTERACTIONS_BOT_SLUG } from './presales-constants';
 
 export const ODIE_ALLOWED_BOTS = [
 	ODIE_DEFAULT_BOT_SLUG_LEGACY,

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -8,6 +8,10 @@ type HasEnTranslation = ( single: string, context?: string, domain?: string ) =>
 // Set by the wpcom launcher on the pricing page so the assistant greets visitors as a pre-sales guide.
 export const PLANS_PRESALES_LAUNCHER_CONTEXT = 'plans-presales';
 
+// Shared with the panel title gate so greeting and title switch together per locale.
+export const PLANS_PRESALES_INTRO_MESSAGE =
+	"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.";
+
 export const getOdieErrorMessage = (): string =>
 	__(
 		"Sorry, I'm offline right now. Leave our Support team a note and they'll get back to you as soon as possible.",
@@ -271,10 +275,7 @@ const getOdieIntroMessage = (
 	hasEnTranslation?: HasEnTranslation
 ): string => {
 	if ( launcherContext === PLANS_PRESALES_LAUNCHER_CONTEXT ) {
-		const presalesIntro =
-			"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.";
-
-		if ( hasEnTranslation?.( presalesIntro, undefined, __i18n_text_domain__ ) ) {
+		if ( hasEnTranslation?.( PLANS_PRESALES_INTRO_MESSAGE, undefined, __i18n_text_domain__ ) ) {
 			return __(
 				"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.",
 				__i18n_text_domain__

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -1,3 +1,4 @@
+import { HelpCenter } from '@automattic/data-stores';
 import { isTestModeEnvironment } from '@automattic/zendesk-client';
 import { __, sprintf } from '@wordpress/i18n';
 import type { Context, Message, OdieAllowedBots, OdieAllBotSlugs } from './types';
@@ -5,12 +6,19 @@ declare const __i18n_text_domain__: string;
 
 type HasEnTranslation = ( single: string, context?: string, domain?: string ) => boolean;
 
-// Set by the wpcom launcher on the pricing page so the assistant greets visitors as a pre-sales guide.
-export const PLANS_PRESALES_LAUNCHER_CONTEXT = 'plans-presales';
+export const PLANS_PRESALES_LAUNCHER_CONTEXT = HelpCenter.PLANS_PRESALES_LAUNCHER_CONTEXT;
 
 // Shared with the panel title gate so greeting and title switch together per locale.
 export const PLANS_PRESALES_INTRO_MESSAGE =
 	"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.";
+
+// Single gate for the presales surface, so greeting, title, and chips switch together per locale.
+export const isPlansPresalesExperience = (
+	launcherContext?: string,
+	hasEnTranslation?: HasEnTranslation
+): boolean =>
+	launcherContext === PLANS_PRESALES_LAUNCHER_CONTEXT &&
+	!! hasEnTranslation?.( PLANS_PRESALES_INTRO_MESSAGE, undefined, __i18n_text_domain__ );
 
 export const getOdieErrorMessage = (): string =>
 	__(
@@ -274,13 +282,11 @@ const getOdieIntroMessage = (
 	launcherContext?: string,
 	hasEnTranslation?: HasEnTranslation
 ): string => {
-	if ( launcherContext === PLANS_PRESALES_LAUNCHER_CONTEXT ) {
-		if ( hasEnTranslation?.( PLANS_PRESALES_INTRO_MESSAGE, undefined, __i18n_text_domain__ ) ) {
-			return __(
-				"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.",
-				__i18n_text_domain__
-			);
-		}
+	if ( isPlansPresalesExperience( launcherContext, hasEnTranslation ) ) {
+		return __(
+			"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.",
+			__i18n_text_domain__
+		);
 	}
 
 	return hasEnTranslation?.(

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -5,6 +5,9 @@ declare const __i18n_text_domain__: string;
 
 type HasEnTranslation = ( single: string, context?: string, domain?: string ) => boolean;
 
+// Set by the wpcom launcher on the pricing page so the assistant greets visitors as a pre-sales guide.
+export const PLANS_PRESALES_LAUNCHER_CONTEXT = 'plans-presales';
+
 export const getOdieErrorMessage = (): string =>
 	__(
 		"Sorry, I'm offline right now. Leave our Support team a note and they'll get back to you as soon as possible.",
@@ -263,12 +266,23 @@ const getOdieInitialPromptContext = ( botNameSlug: OdieAllowedBots ): Context | 
 	}
 };
 
-export const getOdieInitialMessage = (
-	botNameSlug: OdieAllowedBots,
-	displayName: string,
-	hasEnTranslation?: ( single: string, context?: string, domain?: string ) => boolean
-): Message => {
-	const introMessage = hasEnTranslation?.(
+const getOdieIntroMessage = (
+	launcherContext?: string,
+	hasEnTranslation?: HasEnTranslation
+): string => {
+	if ( launcherContext === PLANS_PRESALES_LAUNCHER_CONTEXT ) {
+		const presalesIntro =
+			"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.";
+
+		if ( hasEnTranslation?.( presalesIntro, undefined, __i18n_text_domain__ ) ) {
+			return __(
+				"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.",
+				__i18n_text_domain__
+			);
+		}
+	}
+
+	return hasEnTranslation?.(
 		"I'm your personal Support Assistant. I can help with any questions about your site or account.",
 		undefined,
 		__i18n_text_domain__
@@ -281,6 +295,15 @@ export const getOdieInitialMessage = (
 				"I'm your personal AI assistant. I can help with any questions about your site or account.",
 				__i18n_text_domain__
 		  );
+};
+
+export const getOdieInitialMessage = (
+	botNameSlug: OdieAllowedBots,
+	displayName: string,
+	hasEnTranslation?: ( single: string, context?: string, domain?: string ) => boolean,
+	launcherContext?: string
+): Message => {
+	const introMessage = getOdieIntroMessage( launcherContext, hasEnTranslation );
 
 	return {
 		content: `**${ sprintf(

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -83,6 +83,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 	currentUser,
 	forceEmailSupport = false,
 	isChatRestricted = false,
+	launcherContext,
 	children,
 } ) => {
 	const { dynamicNewInteractionsBotSlug, isMinimized, isChatLoaded } = useSelect(
@@ -209,6 +210,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 				version: overriddenVersion,
 				forceEmailSupport,
 				isChatRestricted,
+				launcherContext,
 			} }
 		>
 			{ children }

--- a/packages/odie-client/src/hooks/use-send-chat-message.ts
+++ b/packages/odie-client/src/hooks/use-send-chat-message.ts
@@ -11,7 +11,7 @@ export const useSendChatMessage = () => {
 	const { addMessage, odieBroadcastClientId, chat } = useOdieAssistantContext();
 
 	const [ abortController, setAbortController ] = useState< AbortController >(
-		new AbortController()
+		() => new AbortController()
 	);
 	const { mutateAsync: sendOdieMessage } = useSendOdieMessage( abortController.signal );
 	const { mutateAsync: sendZendeskMessage } = useSendZendeskMessage( abortController.signal );

--- a/packages/odie-client/src/presales-constants.ts
+++ b/packages/odie-client/src/presales-constants.ts
@@ -1,0 +1,8 @@
+// Imported by the always-loaded wpcom launcher entry — keep this module free of imports.
+
+// Shared with the panel title gate so greeting and title switch together per locale.
+export const PLANS_PRESALES_INTRO_MESSAGE =
+	"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.";
+
+// New logged-out interactions target this bot slug and store it in the interaction object.
+export const ODIE_NEW_LOGGED_OUT_INTERACTIONS_BOT_SLUG = 'wpcom-workflow-chat_loggedout';

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -27,6 +27,7 @@ export type OdieAssistantContextInterface = {
 	externalChatId?: string | null;
 	forceEmailSupport: boolean;
 	isChatRestricted: boolean;
+	launcherContext?: string;
 	setExperimentVariationName: ( variationName: string | null | undefined ) => void;
 	setChat: ( chat: Chat | SetStateAction< Chat > ) => void;
 	setChatStatus: ( status: ChatStatus ) => void;
@@ -53,6 +54,7 @@ export type OdieAssistantProviderProps = {
 	version?: string | null;
 	forceEmailSupport?: boolean;
 	isChatRestricted?: boolean;
+	launcherContext?: string;
 	children?: ReactNode;
 	setChatStatus?: ( status: ChatStatus ) => void;
 } & PropsWithChildren;


### PR DESCRIPTION
Related to [MARTECH-2892](https://linear.app/a8c/issue/MARTECH-2892/eng-v1-implementation-always-visible-labeled-fab-presales-greeting).
Companion wpcom PR (launcher side): 235108-ghe-Automattic/wpcom — that PR makes the /pricing button visible immediately and signals the plans context this PR consumes. Each is safe alone; the full experience needs both, plus the next help-center bundle release into widgets.wp.com after this deploys.

## Proposed Changes

* On the logged-out /pricing page, the Help Center opens as a "Plans Assistant" with a greeting written for plan shoppers.
* Three suggestion chips ask common plan questions in one click (adopted from @ilonagl's #113713); each click is tracked.
* Reopening the assistant returns to the existing conversation — after closing the panel, toggling the launcher, or reloading the page (it is the same assistant conversation as on other logged-out pages).
* All of it is gated to the pricing launcher context and to locales with translations — every other surface is unchanged.

## Why are these changes being made?

* The current greeting talks to existing customers; pricing visitors are prospects choosing a plan. Chips make starting a chat one click.

## Screenshots

<img width="480" alt="pr-2-panel-presales-greeting" src="https://github.com/user-attachments/assets/b5d5bd8e-4a28-484f-ba4b-8e84e3b08660" />

## Testing Instructions

* On a wpcom sandbox running the companion PR above, build `apps/help-center` and sync `dist/` to the sandboxed `widgets.wp.com/help-center`, then open wordpress.com/pricing logged out and click the "Questions about plans? Ask me." button: the panel opens as "Plans Assistant" with the plans greeting and three chips.
* Click a chip — it posts as your message and the remaining chips move into a row above the input; already-asked chips don't come back.
* Re-entry: close the panel with its X, or with the launcher button, or reload the page — reopening lands back in the same conversation each time.
* Any other Help Center surface (logged-in /help, the editor): default title, greeting, and no chips — unchanged.
* Unit: `yarn jest --config packages/odie-client/jest.config.js` and `yarn test-packages packages/data-stores/src/help-center/test/`.


