### PR TITLE
Use proper Big Sky icon for site generation UI

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/style.scss
@@ -346,17 +346,17 @@
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	height: 32px;
-	margin-block-end: 20px;
+	margin-block-end: 12px;
 	padding: 0;
 
 	@include break-medium {
-		height: 38px;
 		padding-inline: 8px;
 	}
 }
 
 .site-generation__assistant-icon {
+	display: flex;
+	margin-inline-start: -8px;
 	color: var( --studio-blue-50 );
 	fill: currentColor;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/view.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/view.tsx
@@ -1,5 +1,4 @@
-import { WordPressWordmark } from '@automattic/components';
-import { sparkles } from '@automattic/components/src/icons';
+import { BigSkyLogo, WordPressWordmark } from '@automattic/components';
 import { Button, Icon, Notice } from '@wordpress/components';
 import { check, wordpress } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -249,12 +248,9 @@ export function SiteGenerationView( {
 				className="site-generation__sidebar"
 			>
 				<div className="site-generation__sidebar-header">
-					<Icon
-						aria-hidden="true"
-						className="site-generation__assistant-icon"
-						icon={ sparkles }
-						size={ 32 }
-					/>
+					<span aria-hidden="true" className="site-generation__assistant-icon">
+						<BigSkyLogo.CentralLogo fill="currentColor" heartless size={ 48 } />
+					</span>
 				</div>
 				<div className="site-generation__conversation">
 					<p className="site-generation__conversation-message">


### PR DESCRIPTION
## Proposed Changes

- Use Big Sky logo instead of generic Sparkles icon
- Improve spacing around logo and paragraph


| Before | After |
| - | - |
| <img width="1376" height="894" alt="Capture d’écran 2026-08-18 à 14 58 31" src="https://github.com/user-attachments/assets/34a3aa3e-3fcf-40d3-8157-836d28b0f718" /> | <img width="1376" height="894" alt="Capture d’écran 2026-08-18 à 14 57 58" src="https://github.com/user-attachments/assets/222610de-2070-4df7-92ce-26cc7e6f6c99" /> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
