### PR TITLE
Update inline edit confirmation styling

### DIFF
--- a/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
+++ b/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
@@ -59,6 +59,7 @@ describe( 'Resolved edit action CSS contract', () => {
 		const action = getDeclarations( '.agents-manager-resolved-edit-action__undo' );
 
 		expect( status.get( 'color' ) ).toBe( 'var(--color-foreground)' );
+		expect( status.get( 'padding-inline-start' ) ).toBe( '0' );
 		expect( confirmedIcon.get( 'border-radius' ) ).toBe( '50%' );
 		expect( confirmedIcon.get( 'background-color' ) ).toBe( '#3858e8' );
 		expect( confirmedIcon.get( 'color' ) ).toBe( 'var(--color-white, #fff)' );

--- a/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
+++ b/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
@@ -51,19 +51,28 @@ describe( 'Resolved edit action CSS contract', () => {
 		expect( declarations.get( 'fill' ) ).toBe( 'currentColor' );
 	} );
 
-	it( 'uses a blue confirmation circle and muted Undo or Redo action', () => {
+	it( 'uses circular status icons and a muted Undo or Redo action', () => {
 		const status = getDeclarations( '.agents-manager-resolved-edit-action__status' );
+		const statusIcon = getDeclarations(
+			'.agents-manager-resolved-edit-action__status .agents-manager-resolved-edit-action__icon'
+		);
 		const confirmedIcon = getDeclarations(
 			'.agents-manager-resolved-edit-action__status:not(.agents-manager-resolved-edit-action__status--reverted) .agents-manager-resolved-edit-action__icon'
 		);
+		const revertedIcon = getDeclarations(
+			'.agents-manager-resolved-edit-action__status--reverted .agents-manager-resolved-edit-action__icon'
+		);
 		const action = getDeclarations( '.agents-manager-resolved-edit-action__undo' );
+		const disabledAction = getDeclarations( '.agents-manager-resolved-edit-action__undo:disabled' );
 
 		expect( status.get( 'color' ) ).toBe( 'var(--color-foreground)' );
 		expect( status.get( 'gap' ) ).toBe( '0.5rem' );
 		expect( status.get( 'padding-inline-start' ) ).toBe( '0' );
-		expect( confirmedIcon.get( 'border-radius' ) ).toBe( '50%' );
+		expect( statusIcon.get( 'border-radius' ) ).toBe( '50%' );
+		expect( statusIcon.get( 'color' ) ).toBe( 'var(--color-white, #fff)' );
 		expect( confirmedIcon.get( 'background-color' ) ).toBe( '#3858e8' );
-		expect( confirmedIcon.get( 'color' ) ).toBe( 'var(--color-white, #fff)' );
+		expect( revertedIcon.get( 'background-color' ) ).toBe( '#5e5e5e' );
 		expect( action.get( 'color' ) ).toBe( 'var(--color-muted-foreground)' );
+		expect( disabledAction.get( 'opacity' ) ).toBe( '0.66' );
 	} );
 } );

--- a/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
+++ b/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
@@ -68,10 +68,13 @@ describe( 'Resolved edit action CSS contract', () => {
 		expect( status.get( 'color' ) ).toBe( 'var(--color-foreground)' );
 		expect( status.get( 'gap' ) ).toBe( '0.5rem' );
 		expect( status.get( 'padding-inline-start' ) ).toBe( '0' );
+		expect( statusIcon.get( 'width' ) ).toBe( '22px' );
+		expect( statusIcon.get( 'height' ) ).toBe( '22px' );
 		expect( statusIcon.get( 'border-radius' ) ).toBe( '50%' );
 		expect( statusIcon.get( 'color' ) ).toBe( 'var(--color-white, #fff)' );
 		expect( confirmedIcon.get( 'background-color' ) ).toBe( '#3858e8' );
 		expect( revertedIcon.get( 'background-color' ) ).toBe( '#5e5e5e' );
+		expect( revertedIcon.get( 'padding' ) ).toBe( '3.5px' );
 		expect( action.get( 'color' ) ).toBe(
 			'color-mix(in srgb, var(--color-foreground) 75%, var(--color-background))'
 		);

--- a/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
+++ b/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
@@ -75,9 +75,7 @@ describe( 'Resolved edit action CSS contract', () => {
 		expect( confirmedIcon.get( 'background-color' ) ).toBe( '#3858e8' );
 		expect( revertedIcon.get( 'background-color' ) ).toBe( '#5e5e5e' );
 		expect( revertedIcon.get( 'padding' ) ).toBe( '3.5px' );
-		expect( action.get( 'color' ) ).toBe(
-			'color-mix(in srgb, var(--color-foreground) 75%, var(--color-background))'
-		);
+		expect( action.get( 'color' ) ).toBe( 'var(--color-foreground)' );
 		expect( disabledAction.get( 'color' ) ).toBe( 'var(--color-muted-foreground)' );
 		expect( disabledAction.get( 'opacity' ) ).toBe( '0.66' );
 	} );

--- a/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
+++ b/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
@@ -7,26 +7,61 @@ const postcss = require( 'postcss' );
 const sass = require( 'sass' );
 
 describe( 'Resolved edit action CSS contract', () => {
-	it( 'keeps icon paths on the surrounding action color', () => {
+	let css;
+
+	beforeAll( () => {
 		const stylesheet = path.resolve(
 			__dirname,
 			'../../../packages/agents-manager/src/components/agent-dock/style.scss'
 		);
-		const css = postcss.parse(
+		css = postcss.parse(
 			sass.compile( stylesheet, {
 				loadPaths: [ path.resolve( __dirname, '../../../node_modules' ) ],
 			} ).css
 		);
-		const selector = /\.agents-manager-resolved-edit-action__icon path$/;
-		const declarations = new Map();
+	} );
 
-		css.walkRules( selector, ( rule ) => {
-			rule.walkDecls( ( declaration ) => {
-				declarations.set( declaration.prop, declaration.value );
-			} );
+	const getDeclarations = ( selector ) => {
+		const matchingRules = [];
+
+		css.walkRules( ( rule ) => {
+			if ( rule.selectors.length === 1 && rule.selectors[ 0 ].endsWith( selector ) ) {
+				matchingRules.push( rule );
+			}
 		} );
+
+		if ( matchingRules.length !== 1 ) {
+			throw new Error(
+				`Expected exactly one CSS rule ending with ${ selector }, found ${ matchingRules.length }`
+			);
+		}
+
+		const declarations = new Map();
+		matchingRules[ 0 ].walkDecls( ( declaration ) => {
+			declarations.set( declaration.prop, declaration.value );
+		} );
+
+		return declarations;
+	};
+
+	it( 'keeps icon paths on the surrounding action color', () => {
+		const declarations = getDeclarations( '.agents-manager-resolved-edit-action__icon path' );
 
 		expect( declarations.get( 'color' ) ).toBe( 'inherit' );
 		expect( declarations.get( 'fill' ) ).toBe( 'currentColor' );
+	} );
+
+	it( 'uses a blue confirmation circle and muted Undo or Redo action', () => {
+		const status = getDeclarations( '.agents-manager-resolved-edit-action__status' );
+		const confirmedIcon = getDeclarations(
+			'.agents-manager-resolved-edit-action__status:not(.agents-manager-resolved-edit-action__status--reverted) .agents-manager-resolved-edit-action__icon'
+		);
+		const action = getDeclarations( '.agents-manager-resolved-edit-action__undo' );
+
+		expect( status.get( 'color' ) ).toBe( 'var(--color-foreground)' );
+		expect( confirmedIcon.get( 'border-radius' ) ).toBe( '50%' );
+		expect( confirmedIcon.get( 'background-color' ) ).toBe( '#3858e8' );
+		expect( confirmedIcon.get( 'color' ) ).toBe( 'var(--color-white, #fff)' );
+		expect( action.get( 'color' ) ).toBe( 'var(--color-muted-foreground)' );
 	} );
 } );

--- a/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
+++ b/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
@@ -51,7 +51,7 @@ describe( 'Resolved edit action CSS contract', () => {
 		expect( declarations.get( 'fill' ) ).toBe( 'currentColor' );
 	} );
 
-	it( 'uses circular status icons and a muted Undo or Redo action', () => {
+	it( 'uses circular status icons and distinct active and disabled actions', () => {
 		const status = getDeclarations( '.agents-manager-resolved-edit-action__status' );
 		const statusIcon = getDeclarations(
 			'.agents-manager-resolved-edit-action__status .agents-manager-resolved-edit-action__icon'
@@ -72,7 +72,10 @@ describe( 'Resolved edit action CSS contract', () => {
 		expect( statusIcon.get( 'color' ) ).toBe( 'var(--color-white, #fff)' );
 		expect( confirmedIcon.get( 'background-color' ) ).toBe( '#3858e8' );
 		expect( revertedIcon.get( 'background-color' ) ).toBe( '#5e5e5e' );
-		expect( action.get( 'color' ) ).toBe( 'var(--color-muted-foreground)' );
+		expect( action.get( 'color' ) ).toBe(
+			'color-mix(in srgb, var(--color-foreground) 75%, var(--color-background))'
+		);
+		expect( disabledAction.get( 'color' ) ).toBe( 'var(--color-muted-foreground)' );
 		expect( disabledAction.get( 'opacity' ) ).toBe( '0.66' );
 	} );
 } );

--- a/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
+++ b/apps/agents-manager/__tests__/resolved-edit-action-style.test.js
@@ -59,6 +59,7 @@ describe( 'Resolved edit action CSS contract', () => {
 		const action = getDeclarations( '.agents-manager-resolved-edit-action__undo' );
 
 		expect( status.get( 'color' ) ).toBe( 'var(--color-foreground)' );
+		expect( status.get( 'gap' ) ).toBe( '0.5rem' );
 		expect( status.get( 'padding-inline-start' ) ).toBe( '0' );
 		expect( confirmedIcon.get( 'border-radius' ) ).toBe( '50%' );
 		expect( confirmedIcon.get( 'background-color' ) ).toBe( '#3858e8' );

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -95,30 +95,37 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 
 			&__status {
 				background: transparent;
-				color: #4ab866;
-				font-weight: 600;
+				color: var( --color-foreground );
+				font-weight: 500;
 
-				&--reverted {
-					background: transparent;
-					color: var( --color-foreground );
-					font-weight: 500;
+				&:not( .agents-manager-resolved-edit-action__status--reverted ) {
+					.agents-manager-resolved-edit-action__icon {
+						width: 22px;
+						height: 22px;
+						padding: 1px;
+						border-radius: 50%;
+						background-color: #3858e8;
+						color: var( --color-white, #fff );
+					}
 				}
 			}
 
 			&__undo {
 				border: 0;
 				background: transparent;
-				color: var( --color-foreground );
+				color: var( --color-muted-foreground );
 				font-family: inherit;
 				font-weight: 500;
 				cursor: pointer;
 
 				&:hover:not( :disabled ) {
 					background: var( --color-muted );
+					color: var( --color-foreground );
 				}
 
 				&:focus-visible:not( :disabled ) {
 					background: var( --color-muted );
+					color: var( --color-foreground );
 					outline: 2px solid var( --wp-admin-theme-color, #3858e9 );
 					outline-offset: 1px;
 				}

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -100,15 +100,21 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 				gap: 0.5rem;
 				padding-inline-start: 0;
 
-				&:not( .agents-manager-resolved-edit-action__status--reverted ) {
+				.agents-manager-resolved-edit-action__icon {
+					width: 22px;
+					height: 22px;
+					padding: 1px;
+					border-radius: 50%;
+					color: var( --color-white, #fff );
+				}
+
+				&:not( .agents-manager-resolved-edit-action__status--reverted )
 					.agents-manager-resolved-edit-action__icon {
-						width: 22px;
-						height: 22px;
-						padding: 1px;
-						border-radius: 50%;
-						background-color: #3858e8;
-						color: var( --color-white, #fff );
-					}
+					background-color: #3858e8;
+				}
+
+				&--reverted .agents-manager-resolved-edit-action__icon {
+					background-color: #5e5e5e;
 				}
 			}
 
@@ -134,12 +140,8 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 
 				&:disabled {
 					cursor: default;
+					opacity: 0.66;
 				}
-			}
-
-			&__status--reverted,
-			&__undo:disabled {
-				opacity: 0.66;
 			}
 
 			&__icon {

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -121,7 +121,8 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 			&__undo {
 				border: 0;
 				background: transparent;
-				color: var( --color-muted-foreground );
+				color: var( --color-foreground );
+				color: color-mix( in srgb, var( --color-foreground ) 75%, var( --color-background ) );
 				font-family: inherit;
 				font-weight: 500;
 				cursor: pointer;
@@ -139,6 +140,7 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 				}
 
 				&:disabled {
+					color: var( --color-muted-foreground );
 					cursor: default;
 					opacity: 0.66;
 				}

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -114,6 +114,7 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 				}
 
 				&--reverted .agents-manager-resolved-edit-action__icon {
+					padding: 3.5px;
 					background-color: #5e5e5e;
 				}
 			}

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -97,6 +97,7 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 				background: transparent;
 				color: var( --color-foreground );
 				font-weight: 500;
+				gap: 0.5rem;
 				padding-inline-start: 0;
 
 				&:not( .agents-manager-resolved-edit-action__status--reverted ) {

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -123,7 +123,6 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 				border: 0;
 				background: transparent;
 				color: var( --color-foreground );
-				color: color-mix( in srgb, var( --color-foreground ) 75%, var( --color-background ) );
 				font-family: inherit;
 				font-weight: 500;
 				cursor: pointer;

--- a/packages/agents-manager/src/components/agent-dock/chat-ui.scss
+++ b/packages/agents-manager/src/components/agent-dock/chat-ui.scss
@@ -97,6 +97,7 @@ body.wp-admin.modal-open .agents-manager-chat--docked {
 				background: transparent;
 				color: var( --color-foreground );
 				font-weight: 500;
+				padding-inline-start: 0;
 
 				&:not( .agents-manager-resolved-edit-action__status--reverted ) {
 					.agents-manager-resolved-edit-action__icon {

--- a/packages/agents-manager/src/components/resolved-edit-action.tsx
+++ b/packages/agents-manager/src/components/resolved-edit-action.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { check, closeSmall, Icon, redo, undo } from '@wordpress/icons';
+import { check, Icon, redo, undo } from '@wordpress/icons';
 
 type ResolvedEditActionProps = {
 	disabled?: boolean;
@@ -46,7 +46,7 @@ export default function ResolvedEditAction( {
 			>
 				<Icon
 					className="agents-manager-resolved-edit-action__icon"
-					icon={ isReverted ? closeSmall : check }
+					icon={ isReverted ? undo : check }
 					size={ 20 }
 				/>
 				{ isReverted

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -27,7 +27,6 @@ jest.mock( '@wordpress/icons', () => {
 
 	return {
 		check: 'check',
-		closeSmall: 'closeSmall',
 		redo: 'redo',
 		undo: 'undo',
 		Icon: ( { className, icon }: { className?: string; icon: unknown } ) => {
@@ -171,7 +170,7 @@ describe( 'useCheckpointAction', () => {
 		} );
 		expect( screen.queryByRole( 'button', { name: 'Undo' } ) ).not.toBeInTheDocument();
 		expect( status ).toHaveTextContent( 'Reverted' );
-		expect( within( status ).getByTestId( 'icon-closeSmall' ) ).toBeInTheDocument();
+		expect( within( status ).getByTestId( 'icon-undo' ) ).toBeInTheDocument();
 		expect( status ).toHaveClass( 'agents-manager-resolved-edit-action__status--reverted' );
 		expect( getActions( registration, message )[ 0 ] ).toMatchObject( {
 			label: 'Reverted',
@@ -230,7 +229,7 @@ describe( 'useCheckpointAction', () => {
 
 		const status = screen.getByRole( 'status' );
 		expect( status ).toHaveTextContent( 'Reverted' );
-		expect( within( status ).getByTestId( 'icon-closeSmall' ) ).toBeInTheDocument();
+		expect( within( status ).getByTestId( 'icon-undo' ) ).toBeInTheDocument();
 		expect( status ).toHaveClass( 'agents-manager-resolved-edit-action__status--reverted' );
 		expect( screen.queryByRole( 'button', { name: 'Undo' } ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: 'Redo' } ) ).not.toBeInTheDocument();
@@ -335,7 +334,10 @@ describe( 'useCheckpointAction', () => {
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Undo' } ) );
 		await waitFor( () => expect( screen.getByRole( 'button', { name: 'Redo' } ) ).toBeEnabled() );
-		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Reverted' );
+		const status = screen.getByRole( 'status' );
+		const redoButton = screen.getByRole( 'button', { name: 'Redo' } );
+		expect( status ).toHaveTextContent( 'Reverted' );
+		expect( within( redoButton ).getByTestId( 'icon-redo' ) ).toBeInTheDocument();
 		expect( recordBigSkyTracksEvent ).toHaveBeenNthCalledWith( 1, 'restore_checkpoint_action', {
 			action: 'undo',
 			id: 'swappable-tool-call',


### PR DESCRIPTION
Part of Automattic/big-sky-plugin#6233

<img width="335" height="181" alt="Screenshot 2026-08-18 at 12 46 42" src="https://github.com/user-attachments/assets/2e6f3077-3772-44e2-8171-b83a7e6ef6e9" />
<img width="328" height="178" alt="Screenshot 2026-08-18 at 12 46 50" src="https://github.com/user-attachments/assets/09ab720b-9c12-4999-9c5e-8ac2cf67b5ea" />


## Proposed Changes

* Show the successful inline-edit checkmark on the circular `#3858e8` background from the design reference.
* Show `Reverted` with a white undo arrow on the circular `#5e5e5e` background from the follow-up reference.
* Keep both status circles at 22px and inset the larger Reverted arrow so it matches the checkmark's visual weight.
* Align both status badges with the message content and use the design’s 8px icon-to-label gap.
* Use normal foreground text for both statuses and enabled Undo and Redo.
* Reserve muted color and reduced opacity for disabled actions, with full foreground hover and focus states.
* Add compiled CSS and component coverage for both badges, alignment, spacing, action states, and Undo/Redo icon separation.

## Why are these changes being made?

* Match the [inline Undo/Redo design feedback](https://github.com/Automattic/big-sky-plugin/pull/6233#issuecomment-5320745419) and keep the status states from looking like buttons.
* Keep enabled Undo and Redo from reading as disabled by matching the full foreground strength of the status text.
* Keep this follow-up scoped to the inline edit row. Existing Content Writing ability badges are unchanged.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Open the editor with WordPress Agent enabled.
3. Trigger a successful text-only edit.
4. Confirm `Updated` has a white check in a blue circle, normal foreground text, aligns with the message’s start edge, and has 8px between the circle and label.
5. Confirm enabled Undo matches `Updated` at full foreground strength. Confirm a disabled action stays muted at 0.66 opacity.
6. Select Undo and confirm `Reverted` has a smaller white undo arrow, visually matched to the checkmark, in a 22px gray circle at full opacity while enabled Redo matches the full foreground strength of `Reverted`.
7. Select Redo and confirm the blue `Updated` badge returns.
8. While Undo or Redo is pending, confirm only the disabled action uses muted color and 0.66 opacity.

### Simple and Atomic sandbox

1. Run `cd apps/agents-manager && yarn dev --sync`.
2. Repeat the successful edit, Undo, and Redo checks on Simple and Atomic test sites.
3. Repeat the checks in dark mode.

### Automated checks

* `yarn jest -c test/apps/jest.config.js apps/agents-manager --runInBand` (7 suites, 79 tests)
* `yarn jest -c test/packages/jest.config.js --testPathPattern=agents-manager --runInBand` (67 suites, 827 tests)
* `yarn typecheck-packages`
* Scoped ESLint, Stylelint, Prettier, and `git diff --check`
* Claude review loop: no blockers

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://react-redux.js.org/api/hooks/using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
