### PR TITLE
Email: surface cart errors in the my-sites add-mailbox flow

### DIFF
--- a/client/my-sites/email/add-mailboxes/get-add-to-cart-error-notice-options.ts
+++ b/client/my-sites/email/add-mailboxes/get-add-to-cart-error-notice-options.ts
@@ -1,0 +1,39 @@
+import type { CartActionError } from '@automattic/shopping-cart';
+import type { NoticeOptions } from 'calypso/state/notices/types';
+import type { translate as translateType } from 'i18n-calypso';
+
+/**
+ * Returned by the server's `remove_duplicate_email_products` cart validator when the
+ * cart already holds an email product for the domain.
+ */
+export const ERROR_ALREADY_CONTAINS_AN_EMAIL_PRODUCT = 'already-contains-an-email-product';
+
+/**
+ * Builds the notice shown when adding mailboxes to the cart is rejected.
+ *
+ * The notice id matches the cart message code so that this notice and any notice
+ * raised by CartMessages for the same error collapse into one rather than stacking.
+ */
+export const getAddToCartErrorNoticeOptions = ( {
+	checkoutPath,
+	error,
+	translate,
+}: {
+	checkoutPath: string;
+	error: CartActionError;
+	translate: typeof translateType;
+} ): NoticeOptions => {
+	const noticeOptions: NoticeOptions = {
+		id: error.code,
+		isPersistent: true,
+	};
+
+	// This error is only actionable if the user can reach the cart that holds the
+	// conflicting email product.
+	if ( error.code === ERROR_ALREADY_CONTAINS_AN_EMAIL_PRODUCT ) {
+		noticeOptions.button = translate( 'Shopping cart' );
+		noticeOptions.href = checkoutPath;
+	}
+
+	return noticeOptions;
+};

--- a/client/my-sites/email/add-mailboxes/get-tracks-event-name.ts
+++ b/client/my-sites/email/add-mailboxes/get-tracks-event-name.ts
@@ -2,8 +2,12 @@ import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 
 export const EVENT_CONTINUE_BUTTON_CLICK = 'continue_button_click';
 export const EVENT_CANCEL_BUTTON_CLICK = 'cancel_button_click';
+export const EVENT_ADD_TO_CART_FAILURE = 'add_to_cart_failure';
 
-export type EventName = typeof EVENT_CONTINUE_BUTTON_CLICK | typeof EVENT_CANCEL_BUTTON_CLICK;
+export type EventName =
+	| typeof EVENT_CONTINUE_BUTTON_CLICK
+	| typeof EVENT_CANCEL_BUTTON_CLICK
+	| typeof EVENT_ADD_TO_CART_FAILURE;
 
 export const getTracksEventName = ( provider: EmailProvider, genericName: EventName ): string => {
 	const eventNames = {
@@ -14,6 +18,10 @@ export const getTracksEventName = ( provider: EmailProvider, genericName: EventN
 		cancel_button_click: [
 			'calypso_email_management_titan_add_mailboxes_cancel_button_click',
 			'calypso_email_management_gsuite_add_users_cancel_button_click',
+		],
+		add_to_cart_failure: [
+			'calypso_email_management_titan_add_mailboxes_add_to_cart_failure',
+			'calypso_email_management_gsuite_add_users_add_to_cart_failure',
 		],
 	};
 

--- a/client/my-sites/email/add-mailboxes/index.tsx
+++ b/client/my-sites/email/add-mailboxes/index.tsx
@@ -20,7 +20,9 @@ import { TITAN_PROVIDER_NAME } from 'calypso/lib/titan/constants';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import AddEmailAddressesCardPlaceholder from 'calypso/my-sites/email/add-mailboxes/add-users-placeholder';
 import EmailProviderPricingNotice from 'calypso/my-sites/email/add-mailboxes/email-provider-pricing-notice';
+import { getAddToCartErrorNoticeOptions } from 'calypso/my-sites/email/add-mailboxes/get-add-to-cart-error-notice-options';
 import {
+	EVENT_ADD_TO_CART_FAILURE,
 	EVENT_CANCEL_BUTTON_CLICK,
 	EVENT_CONTINUE_BUTTON_CLICK,
 	getTracksEventName,
@@ -46,7 +48,8 @@ import {
 	getMailboxesPath,
 	getTitanSetUpMailboxPath,
 } from 'calypso/my-sites/email/paths';
-import { useSelector } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import {
@@ -56,6 +59,7 @@ import {
 } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { SiteDetails } from '@automattic/data-stores';
+import type { CartActionError } from '@automattic/shopping-cart';
 import type { HiddenFieldNames } from 'calypso/my-sites/email/form/mailboxes/components/new-mailbox-list';
 import type { translate } from 'i18n-calypso';
 
@@ -266,6 +270,7 @@ const MailboxesForm = ( {
 
 	const cartKey = useCartKey();
 	const cartManager = useShoppingCart( cartKey );
+	const reduxDispatch = useDispatch();
 
 	if ( isLoadingDomains || ! emailProduct ) {
 		return <AddEmailAddressesCardPlaceholder />;
@@ -333,8 +338,31 @@ const MailboxesForm = ( {
 				page( checkoutPath );
 			} )
 			.finally( () => setIsAddingToCart( false ) )
-			.catch( () => {
-				// Nothing needs to be done here. CartMessages will display the error to the user.
+			.catch( ( error: CartActionError ) => {
+				recordClickEvent( {
+					eventName: getTracksEventName( provider, EVENT_ADD_TO_CART_FAILURE ),
+					eventProps: {
+						error_code: error.code,
+						error_message: error.message,
+						mailbox_count: mailboxOperations.mailboxes.length,
+					},
+					provider,
+					selectedDomainName,
+					source,
+				} );
+
+				// CalypsoShoppingCartProvider also mounts CartMessages, whose effect runs
+				// after this handler and would replace the notice below with one that has
+				// no way to act on the error. Clear the cart messages so it stays quiet and
+				// the user sees a single notice.
+				cartManager.clearMessages().catch( () => undefined );
+
+				reduxDispatch(
+					errorNotice(
+						error.message,
+						getAddToCartErrorNoticeOptions( { checkoutPath, error, translate } )
+					)
+				);
 			} );
 	};
 

--- a/client/my-sites/email/add-mailboxes/test/get-add-to-cart-error-notice-options.ts
+++ b/client/my-sites/email/add-mailboxes/test/get-add-to-cart-error-notice-options.ts
@@ -1,0 +1,43 @@
+import { CartActionError } from '@automattic/shopping-cart';
+import {
+	ERROR_ALREADY_CONTAINS_AN_EMAIL_PRODUCT,
+	getAddToCartErrorNoticeOptions,
+} from 'calypso/my-sites/email/add-mailboxes/get-add-to-cart-error-notice-options';
+import type { translate as translateType } from 'i18n-calypso';
+
+const translate = ( ( text: string ) => text ) as unknown as typeof translateType;
+const checkoutPath = '/checkout/example.com';
+
+describe( 'getAddToCartErrorNoticeOptions', () => {
+	it( 'links to the cart when the cart already holds an email product', () => {
+		const error = new CartActionError(
+			'This domain already has an email subscription in your cart.',
+			ERROR_ALREADY_CONTAINS_AN_EMAIL_PRODUCT
+		);
+
+		expect( getAddToCartErrorNoticeOptions( { checkoutPath, error, translate } ) ).toEqual( {
+			id: ERROR_ALREADY_CONTAINS_AN_EMAIL_PRODUCT,
+			isPersistent: true,
+			button: 'Shopping cart',
+			href: checkoutPath,
+		} );
+	} );
+
+	it( 'omits the cart link for errors the cart cannot resolve', () => {
+		const error = new CartActionError( 'Purchases are currently disabled.', 'blocked' );
+
+		const noticeOptions = getAddToCartErrorNoticeOptions( { checkoutPath, error, translate } );
+
+		expect( noticeOptions ).toEqual( { id: 'blocked', isPersistent: true } );
+		expect( noticeOptions.button ).toBeUndefined();
+		expect( noticeOptions.href ).toBeUndefined();
+	} );
+
+	it( 'ids the notice by the cart message code so it does not stack with CartMessages', () => {
+		const error = new CartActionError( 'Something went wrong.', 'some-cart-error' );
+
+		expect( getAddToCartErrorNoticeOptions( { checkoutPath, error, translate } ).id ).toEqual(
+			'some-cart-error'
+		);
+	} );
+} );

--- a/client/my-sites/email/add-mailboxes/test/get-tracks-event-name.ts
+++ b/client/my-sites/email/add-mailboxes/test/get-tracks-event-name.ts
@@ -1,0 +1,25 @@
+import {
+	EVENT_ADD_TO_CART_FAILURE,
+	EVENT_CANCEL_BUTTON_CLICK,
+	EVENT_CONTINUE_BUTTON_CLICK,
+	getTracksEventName,
+} from 'calypso/my-sites/email/add-mailboxes/get-tracks-event-name';
+import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
+
+describe( 'getTracksEventName', () => {
+	it.each( [
+		[ EmailProvider.Titan, 'calypso_email_management_titan_add_mailboxes_add_to_cart_failure' ],
+		[ EmailProvider.Google, 'calypso_email_management_gsuite_add_users_add_to_cart_failure' ],
+	] )( 'returns the add-to-cart failure event for %s', ( provider, expected ) => {
+		expect( getTracksEventName( provider, EVENT_ADD_TO_CART_FAILURE ) ).toEqual( expected );
+	} );
+
+	it( 'still returns the existing button click events', () => {
+		expect( getTracksEventName( EmailProvider.Titan, EVENT_CONTINUE_BUTTON_CLICK ) ).toEqual(
+			'calypso_email_management_titan_add_mailboxes_continue_button_click'
+		);
+		expect( getTracksEventName( EmailProvider.Google, EVENT_CANCEL_BUTTON_CLICK ) ).toEqual(
+			'calypso_email_management_gsuite_add_users_cancel_button_click'
+		);
+	} );
+} );


### PR DESCRIPTION
Part of DOTEMP-163

## Proposed Changes

* Show a notice when adding mailboxes to the cart fails, instead of swallowing the rejection. Links to the cart when the cart already holds an email product for the domain.
* Record a Tracks event for the failure.

## Why are these changes being made?

The Continue button did nothing when the server rejected the cart. This has come up in several support reports: if a saved cart already holds an email product for the domain, every retry is rejected and the customer sees nothing at all.

`CartMessages` is mounted on this page, but it is not a reliable channel: it drops a repeat error when the cart timestamp doesn't advance and the error codes match, which is exactly the retry case here. Handling the rejection at the call site makes it deterministic. The `clearMessages()` call keeps `CartMessages` from raising a second notice for the same error.

Two things worth flagging:

* The my-sites flow is still what production serves. `client/dashboard/emails/add-mailbox/` is the other implementation of this screen, but its routes are not gated to it yet, so this file is live.
* The license-ceiling theory in the issue is a red herring: `used == max` is the normal steady state for every reseller Google Workspace subscription, and nothing in the purchase path reads the max.

## Testing Instructions

1. Add any email product for a domain to your cart.
2. Go to that domain's add-mailbox form (`/email/:domain/google-workspace/add-users/:site` or `/email/:domain/titan/new/:site`) and add a mailbox for the *same* domain.
3. Click Continue.

**Before:** nothing happens. **After:** an error notice with the server's message and a "Shopping cart" link.

Then confirm the happy path still works: add a mailbox for a domain with no email product in the cart, and check it navigates to checkout.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
