### PR TITLE
Dashboard receipts: restore multi-line billing details field

### DIFF
--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -12,7 +12,7 @@ import { Link } from '@tanstack/react-router';
 import {
 	Button,
 	Flex,
-	TextControl,
+	TextareaControl,
 	__experimentalDivider as Divider,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
@@ -20,6 +20,7 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { type ReactNode, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useLocale } from '../../app/locale';
@@ -150,10 +151,6 @@ export default function Receipt() {
 }
 
 function ReceiptDetails( { receipt }: { receipt: Receipt } ) {
-	const [ billingDetailsText, setBillingDetailsText ] = useState(
-		receipt.cc_num !== 'XXXX' ? `${ receipt.cc_name }\n${ receipt.cc_email }` : ''
-	);
-
 	const paymentMethodText = getPaymentMethodText( receipt );
 
 	return (
@@ -183,27 +180,49 @@ function ReceiptDetails( { receipt }: { receipt: Receipt } ) {
 				</VStack>
 			) }
 
-			{ receipt.cc_num !== 'XXXX' && ( receipt.cc_name || receipt.cc_email ) && (
-				<VStack spacing={ 1 } alignment="flex-start" className="receipt-billing-details">
-					<Text upperCase variant="muted" size={ 11 }>
-						{ __( 'Billing details' ) }
-					</Text>
-					<TextControl
-						value={ billingDetailsText }
-						onChange={ setBillingDetailsText }
-						className="receipt-text-control"
-						__nextHasNoMarginBottom
-					/>
-					<Text variant="muted" size={ 11 }>
-						{ __(
-							'Use this field to add your billing information (eg. business address) before printing.'
-						) }
-					</Text>
-				</VStack>
-			) }
+			<BillingDetailsField receipt={ receipt } />
 
 			<ReceiptTaxDetails receipt={ receipt } />
 			<VatDetails receipt={ receipt } />
+		</VStack>
+	);
+}
+
+export function BillingDetailsField( { receipt }: { receipt: Receipt } ) {
+	const [ billingDetailsText, setBillingDetailsText ] = useState(
+		receipt.cc_num !== 'XXXX' ? `${ receipt.cc_name }\n${ receipt.cc_email }` : ''
+	);
+
+	if ( receipt.cc_num === 'XXXX' || ( ! receipt.cc_name && ! receipt.cc_email ) ) {
+		return null;
+	}
+
+	return (
+		<VStack spacing={ 1 } alignment="flex-start" className="receipt-billing-details">
+			<Text upperCase variant="muted" size={ 11 }>
+				{ __( 'Billing details' ) }
+			</Text>
+			<TextareaControl
+				label={ __( 'Billing details' ) }
+				hideLabelFromVision
+				value={ billingDetailsText }
+				onChange={ setBillingDetailsText }
+				className="receipt-billing-details-input"
+				__nextHasNoMarginBottom
+			/>
+			{ /* A printed textarea clips its overflow, so mirror the text into a print-only element. */ }
+			<div
+				className={ clsx( 'receipt-billing-details-printable', {
+					'is-empty': billingDetailsText.trim().length === 0,
+				} ) }
+			>
+				{ billingDetailsText }
+			</div>
+			<Text variant="muted" size={ 11 } className="receipt-billing-details-description">
+				{ __(
+					'Use this field to add your billing information (eg. business address) before printing.'
+				) }
+			</Text>
 		</VStack>
 	);
 }

--- a/client/dashboard/me/billing-history/styles.scss
+++ b/client/dashboard/me/billing-history/styles.scss
@@ -43,8 +43,28 @@
 	width: 100%;
 }
 
-.receipt-text-control {
+.receipt-billing-details-input {
 	width: 100%;
+}
+
+.receipt-billing-details-printable {
+	display: none;
+}
+
+@media print {
+	.receipt-billing-details-input,
+	.receipt-billing-details-description {
+		display: none;
+	}
+
+	.receipt-billing-details-printable {
+		display: block;
+		white-space: pre-wrap;
+
+		&.is-empty {
+			display: none;
+		}
+	}
 }
 
 .receipt-table {

--- a/client/dashboard/me/billing-history/test/receipt.test.tsx
+++ b/client/dashboard/me/billing-history/test/receipt.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../test-utils';
+import { BillingDetailsField } from '../receipt';
+import type { Receipt } from '@automattic/api-core';
+
+const receipt = {
+	id: 1,
+	cc_num: '1234',
+	cc_name: 'Jane Doe',
+	cc_email: 'jane@example.com',
+} as Receipt;
+
+describe( '<BillingDetailsField>', () => {
+	test( 'renders a multi-line field prefilled with the cardholder name and email', () => {
+		render( <BillingDetailsField receipt={ receipt } /> );
+
+		const field = screen.getByRole( 'textbox', { name: 'Billing details' } );
+		expect( field.tagName ).toBe( 'TEXTAREA' );
+		expect( field ).toHaveValue( 'Jane Doe\njane@example.com' );
+	} );
+
+	test( 'accepts line breaks typed by the user', async () => {
+		const user = userEvent.setup();
+		render( <BillingDetailsField receipt={ receipt } /> );
+
+		const field = screen.getByRole( 'textbox', { name: 'Billing details' } );
+		await user.clear( field );
+		await user.type( field, 'Line one{Enter}Line two' );
+
+		expect( field ).toHaveValue( 'Line one\nLine two' );
+	} );
+
+	test( 'mirrors the text into a printable area that preserves line breaks', async () => {
+		const user = userEvent.setup();
+		const { container } = render( <BillingDetailsField receipt={ receipt } /> );
+
+		const field = screen.getByRole( 'textbox', { name: 'Billing details' } );
+		await user.clear( field );
+		await user.type( field, 'Line one{Enter}Line two' );
+
+		const printable = container.querySelector( '.receipt-billing-details-printable' );
+		expect( printable ).toHaveTextContent( 'Line one Line two' );
+		expect( printable?.textContent ).toBe( 'Line one\nLine two' );
+	} );
+} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-534/

## Proposed Changes

* Replace the single-line `TextControl` in the Dashboard receipt's "Billing details" field with a `TextareaControl`, so the field accepts line breaks again.
* Mirror the field's contents into a print-only element styled with `white-space: pre-wrap`, and hide the editable control and its description from print output.
* Extract the field into a `BillingDetailsField` component and add unit tests for it.
* Give the field an accessible name (it previously had none) via `label` + `hideLabelFromVision`, keeping the existing visual heading.

## Why are these changes being made?

The "Billing details" field on a receipt is free-form text customers use to add a business address before printing or saving a PDF. In classic Calypso (`client/me/purchases/billing-history/receipt.tsx`) it is a `TextareaAutosize` paired with a hidden, print-only `<div>` — that pairing exists because a printed `<textarea>` clips its overflow.

When the receipt page was ported to the Dashboard client, the field was implemented with `TextControl`, which renders an `<input type="text">`. Pressing Enter does nothing and only a single line can be entered, and the print-only mirror element was not ported either. So this is not a regression in the classic Calypso code — the behavior was never carried over to the Dashboard surface, which is what `my.wordpress.com/me/billing/history` now serves.

This affects customers in regions where detailed multi-line business addresses are standard for accounting compliance.

## Testing Instructions

1. Go to `/me/billing/history` on the Dashboard and click into a receipt that has a payment method on file (the field only renders when the receipt has a cardholder name or email).
2. Click into the "Billing details" field. It should be a multi-line textarea prefilled with the cardholder name and email on separate lines.
3. Press Enter mid-text — a new line should be inserted.
4. Enter a multi-line address, then click "Print Receipt". The print preview should show the full address across multiple lines, without the editable textarea box or the "Use this field to add your billing information…" hint.
5. Clear the field entirely and print again — the billing details block should not appear in the print output.

Unit tests: `yarn test-client client/dashboard/me/billing-history`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
