### PR TITLE
Block editor: Guard tracking against missing data stores

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/test/tracking.test.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/test/tracking.test.js
@@ -1,0 +1,18 @@
+describe( 'Redux tracking middleware', () => {
+	afterEach( () => {
+		delete window._currentSiteId;
+		delete window._currentSiteType;
+	} );
+
+	test( 'returns null when the requested data store is unavailable', () => {
+		window._currentSiteId = 1;
+		window._currentSiteType = 'simple';
+
+		jest.isolateModules( () => {
+			require( '../tracking' );
+			const { dispatch } = require( '@wordpress/data' );
+
+			expect( dispatch( 'core/edit-post' ) ).toBeNull();
+		} );
+	} );
+} );

--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -994,6 +994,9 @@ if (
 			const namespaceName = typeof namespace === 'object' ? namespace.name : namespace;
 			const actions = registry.dispatch( namespaceName );
 			const trackers = REDUX_TRACKING[ namespaceName ];
+			if ( ! actions ) {
+				return actions;
+			}
 
 			// Initialize namespace level objects if not yet done.
 			if ( ! rewrittenActions[ namespaceName ] ) {


### PR DESCRIPTION
Fixes TSCODE-661

## Proposed Changes

* Return the original empty result when the tracking middleware requests a WordPress data store that is not registered.
* Continue wrapping and tracking actions normally when the requested store is available.

## Why are these changes being made?

A customer using Kubio on a WP Cloud site could open and publish a page in the standard WordPress editor. When they opened the same page in Kubio, the header and footer appeared, but the main page content did not. Kubio displayed:

> This block has encountered an error and cannot be previewed.

The browser console showed this error from the WordPress.com block editor script:

```text
TypeError: Cannot read properties of null (reading 'setIsListViewOpened')
```

Removing the WordPress.com editor script allowed Kubio to display the content again.

The tracking middleware expects the `core/edit-post` data store used by the standard block editor. Kubio does not register that store. When the middleware requests it, the WordPress data registry returns `null`. The middleware then tries to read `setIsListViewOpened` from that result and crashes.

Adding a condition for one builder would fix only that builder. The same error could occur in another editor that does not provide the expected data store. This change checks the result from the data registry instead. If the store is unavailable, the middleware returns the original empty result. Registered stores and their existing tracking behavior are unchanged.

## Testing Instructions

### Reproduce the reported error

1. On a WP Cloud test site, install and activate Kubio.
2. Create a page and confirm that it opens in the standard WordPress editor.
3. Open the page with Kubio while using the current production `wpcom.editor` bundle.
4. Confirm that the page content fails to load and the browser console reports an error that reads `setIsListViewOpened` from `null`.

### Test this change

1. Build and load this branch's `wpcom.editor` bundle on the same site.
2. Open the page with Kubio.
3. Confirm that the page content loads and that the `setIsListViewOpened` error does not appear.
4. Open the same page in the standard WordPress editor.
5. Confirm that the standard editor still loads without new console errors.

### Tests completed locally

* Added an automated regression test that dispatches to an unavailable `core/edit-post` store and confirms that the data registry returns `null` without throwing.
* Reproduced the reported error with Kubio before the change.
* Confirmed that Kubio loads without the error after the change when `core/edit-post` is unavailable.
* Confirmed that the standard WordPress editor loads normally when `core/edit-post` is available.
* Loaded the fixed bundle in Elementor, Brizy, and Beaver Builder test environments where `core/edit-post` was unavailable. Each editor loaded without the reported error. These builders do not normally load the WordPress.com bundle in their visual editors; the bundle was added specifically to test the missing-store behavior.
* `yarn eslint apps/wpcom-block-editor/src/wpcom/features/tracking.js` passes.
* `yarn build:wpcom-block-editor-no-minify` passes from `apps/wpcom-block-editor`.
* `git diff --check` passes.
* `yarn typecheck-apps` currently fails in unrelated apps and generated package types. None of the reported errors point to the changed tracking file.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

