### PR TITLE
Atomic transfer: bound the post-transfer wait loops

### DIFF
--- a/client/landing/stepper/hooks/test/use-wait-for-atomic.tsx
+++ b/client/landing/stepper/hooks/test/use-wait-for-atomic.tsx
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
+import { useWaitForAtomic, type FailureInfo } from '../use-wait-for-atomic';
+
+const mockReduxDispatch = jest.fn();
+
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockReduxDispatch,
+} ) );
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( { requestLatestAtomicTransfer: jest.fn() } ),
+	useSelect: () => ( {
+		getSiteLatestAtomicTransfer: jest.fn(),
+		getSiteLatestAtomicTransferError: jest.fn(),
+	} ),
+} ) );
+jest.mock( 'react-router-dom', () => ( {
+	useSearchParams: () => [ new URLSearchParams( 'feature=sftp' ) ],
+} ) );
+jest.mock( 'calypso/landing/stepper/stores', () => ( { SITE_STORE: 'site-store' } ) );
+jest.mock( '../use-site-data', () => ( { useSiteData: () => ( { siteId: 123 } ) } ) );
+jest.mock( 'calypso/state/sites/actions', () => ( {
+	requestSite: ( siteId: number ) => ( { type: 'REQUEST_SITE', siteId } ),
+} ) );
+jest.mock( 'calypso/state/sites/features/actions', () => ( {
+	fetchSiteFeatures: jest.fn( ( siteId: number ) => ( { type: 'FETCH_FEATURES', siteId } ) ),
+} ) );
+jest.mock( 'calypso/state/themes/actions', () => ( {
+	initiateThemeTransfer: jest.fn(),
+} ) );
+
+const SITE_ID = 123;
+
+const renderWaitForAtomic = () => {
+	const failures: FailureInfo[] = [];
+	const { result } = renderHook( () =>
+		useWaitForAtomic( {
+			siteId: SITE_ID,
+			handleTransferFailure: ( failureInfo ) => failures.push( failureInfo ),
+		} )
+	);
+	return { result, failures };
+};
+
+describe( 'useWaitForAtomic', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		mockReduxDispatch.mockReset();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	describe( 'waitForFeature', () => {
+		it( 'resolves once the feature is active', async () => {
+			mockReduxDispatch
+				.mockResolvedValueOnce( { active: [] } )
+				.mockResolvedValue( { active: [ 'sftp' ] } );
+
+			const { result } = renderWaitForAtomic();
+			const promise = result.current.waitForFeature();
+			await jest.advanceTimersByTimeAsync( 2000 );
+
+			await expect( promise ).resolves.toBeUndefined();
+			expect( fetchSiteFeatures ).toHaveBeenCalledWith( SITE_ID );
+		} );
+
+		it( 'fails after repeated swallowed fetch errors instead of looping forever', async () => {
+			mockReduxDispatch.mockResolvedValue( undefined );
+
+			const { result, failures } = renderWaitForAtomic();
+			const promise = result.current.waitForFeature();
+			promise.catch( () => {} );
+			await jest.advanceTimersByTimeAsync( 10_000 );
+
+			await expect( promise ).rejects.toThrow();
+			expect( failures ).toEqual( [
+				expect.objectContaining( { type: 'feature_fetch', code: 'feature_fetch_failed' } ),
+			] );
+			expect( mockReduxDispatch ).toHaveBeenCalledTimes( 5 );
+		} );
+
+		it( 'fails with a timeout when the feature never activates', async () => {
+			mockReduxDispatch.mockResolvedValue( { active: [ 'some-other-feature' ] } );
+
+			const { result, failures } = renderWaitForAtomic();
+			const promise = result.current.waitForFeature();
+			promise.catch( () => {} );
+			await jest.advanceTimersByTimeAsync( 181_000 );
+
+			await expect( promise ).rejects.toThrow();
+			expect( failures ).toEqual( [
+				expect.objectContaining( { type: 'feature_timeout', code: 'feature_timeout' } ),
+			] );
+		} );
+	} );
+
+	describe( 'waitForLatestSiteData', () => {
+		it( 'resolves once the site is atomic and manageable', async () => {
+			mockReduxDispatch
+				.mockResolvedValueOnce( { options: { is_wpcom_atomic: true }, capabilities: {} } )
+				.mockResolvedValue( {
+					options: { is_wpcom_atomic: true },
+					capabilities: { manage_options: true },
+				} );
+
+			const { result } = renderWaitForAtomic();
+			const promise = result.current.waitForLatestSiteData();
+			await jest.advanceTimersByTimeAsync( 2000 );
+
+			await expect( promise ).resolves.toBeUndefined();
+		} );
+
+		it( 'fails with a timeout when the site data never reflects the transfer', async () => {
+			mockReduxDispatch.mockResolvedValue( {
+				options: { is_wpcom_atomic: false },
+				capabilities: { manage_options: true },
+			} );
+
+			const { result, failures } = renderWaitForAtomic();
+			const promise = result.current.waitForLatestSiteData();
+			promise.catch( () => {} );
+			await jest.advanceTimersByTimeAsync( 181_000 );
+
+			await expect( promise ).rejects.toThrow();
+			expect( failures ).toEqual( [
+				expect.objectContaining( { type: 'site_data_timeout', code: 'site_data_timeout' } ),
+			] );
+		} );
+	} );
+} );

--- a/client/landing/stepper/hooks/use-wait-for-atomic.ts
+++ b/client/landing/stepper/hooks/use-wait-for-atomic.ts
@@ -15,6 +15,10 @@ import type { SiteSelect, SiteDetails } from '@automattic/data-stores';
 
 const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
 
+// The transfer itself is bounded below (300s); these bound the shorter phases that run after it.
+const POST_TRANSFER_TIMEOUT_MS = 1000 * 180;
+const MAX_FEATURE_FETCH_FAILURES = 5;
+
 export interface FailureInfo {
 	type: string;
 	code: number | string;
@@ -113,6 +117,9 @@ export const useWaitForAtomic = ( {
 			return;
 		}
 
+		const maxFinishTime = new Date().getTime() + POST_TRANSFER_TIMEOUT_MS;
+		let consecutiveFetchFailures = 0;
+
 		while ( true ) {
 			const siteFeatures = await reduxDispatch< Promise< { active: string[] } > >(
 				fetchSiteFeatures( siteId )
@@ -121,11 +128,34 @@ export const useWaitForAtomic = ( {
 				break;
 			}
 
+			// fetchSiteFeatures swallows request errors and resolves undefined, so a run of them
+			// means the endpoint is failing, not that the feature is still activating.
+			consecutiveFetchFailures = siteFeatures ? 0 : consecutiveFetchFailures + 1;
+			if ( consecutiveFetchFailures >= MAX_FEATURE_FETCH_FAILURES ) {
+				handleTransferFailure?.( {
+					type: 'feature_fetch',
+					error: `fetching site features kept failing while waiting for ${ feature }`,
+					code: 'feature_fetch_failed',
+				} );
+				throw new Error( getTransferFailureMessage( 'error' ) );
+			}
+
+			if ( maxFinishTime < new Date().getTime() ) {
+				handleTransferFailure?.( {
+					type: 'feature_timeout',
+					error: `feature ${ feature } did not activate in time`,
+					code: 'feature_timeout',
+				} );
+				throw new Error( getTransferFailureMessage( 'timeout' ) );
+			}
+
 			await wait( 1000 );
 		}
 	};
 
 	const waitForLatestSiteData = async () => {
+		const maxFinishTime = new Date().getTime() + POST_TRANSFER_TIMEOUT_MS;
+
 		while ( true ) {
 			const requestedSite = await reduxDispatch< SiteDetails >( requestSite( siteId ) );
 			if (
@@ -133,6 +163,15 @@ export const useWaitForAtomic = ( {
 				requestedSite?.capabilities?.manage_options
 			) {
 				break;
+			}
+
+			if ( maxFinishTime < new Date().getTime() ) {
+				handleTransferFailure?.( {
+					type: 'site_data_timeout',
+					error: 'site data did not reflect the transfer in time',
+					code: 'site_data_timeout',
+				} );
+				throw new Error( getTransferFailureMessage( 'timeout' ) );
 			}
 
 			await wait( 1000 );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18247/the-two-post-transfer-wait-loops-in-usewaitforatomic-can-spin-forever

## Proposed Changes

**The two post-transfer wait loops in `useWaitForAtomic` now have deadlines, so they end in a visible failure instead of spinning forever.**

- `waitForFeature` and `waitForLatestSiteData` get the same deadline treatment `waitForTransfer` already has (180 seconds each): on expiry they report the failure and throw, which lands the user on the error screen instead of an eternal processing screen.
- `waitForFeature` now treats five consecutive failed feature fetches as a failure of its own. `fetchSiteFeatures` swallows request errors and resolves `undefined`, which the loop used to read as “feature not active yet” — a persistently failing endpoint kept it polling every second, forever.
- Adds the hook’s first test coverage: resolve paths, the fetch-failure cap, and both timeouts.

## Why are these changes being made?

After an Atomic transfer finishes, the stepper still waits for two things before letting the user through: the purchased feature showing up on the site, and the site record reflecting its new Atomic state. Both waits were infinite loops with no exit on failure. If the features endpoint kept erroring, or the site’s capabilities never propagated, the user watched the processing screen forever — no error, no way out. This is a sibling of the stuck-forever traps already fixed in this project ([DOTCOM-17962](https://linear.app/a8c/issue/DOTCOM-17962), [DOTCOM-17964](https://linear.app/a8c/issue/DOTCOM-17964)), found by the [DOTCOM-17959](https://linear.app/a8c/issue/DOTCOM-17959) audit.

## Testing Instructions

1. Run `yarn start` and start a hosting activation on a Simple site with a Business plan (Hosting Features → Activate now), which lands on `/setup/transferring-hosted-site`.
2. Let it run: the transfer should complete and redirect as before (happy path unchanged).
3. To see the new failure path, block `*/sites/*/features*` requests in DevTools during the “almost ready” phase: after five failed fetches the flow should surface the error screen instead of spinning forever.
