### PR TITLE
Launchpad: link Site Setup tasks to course video lessons

### DIFF
--- a/packages/launchpad/src/checklist-item/index.tsx
+++ b/packages/launchpad/src/checklist-item/index.tsx
@@ -1,10 +1,10 @@
 import { Button, Icon } from '@wordpress/components';
 import { __, isRTL, sprintf } from '@wordpress/i18n';
-import { check, chevronLeft, chevronRight } from '@wordpress/icons';
+import { check, chevronLeft, chevronRight, video } from '@wordpress/icons';
 import { Badge } from '@wordpress/ui';
 import clsx from 'clsx';
 import type { Task, Expandable } from '../types';
-import type { FC, Key } from 'react';
+import type { FC, Key, MouseEvent } from 'react';
 
 import './style.scss';
 
@@ -15,6 +15,8 @@ interface Props {
 	isHighlighted?: boolean;
 	expandable?: Expandable;
 	onClick?: () => void;
+	courseLessonUrl?: string | null;
+	onCourseLessonClick?: ( lessonUrl: string ) => void;
 }
 
 const ChecklistItem: FC< Props > = ( {
@@ -23,6 +25,8 @@ const ChecklistItem: FC< Props > = ( {
 	isHighlighted,
 	expandable,
 	onClick,
+	courseLessonUrl,
+	onCourseLessonClick,
 } ) => {
 	const { id, completed, disabled = false, title, subtitle, actionDispatch } = task;
 
@@ -40,6 +44,18 @@ const ChecklistItem: FC< Props > = ( {
 
 	const onClickHandler = onClick || actionDispatch;
 	const isClickable = !! ( buttonProps.href || onClickHandler );
+
+	// The task row itself is a button, so the course video lesson link has to be
+	// rendered as a sibling rather than nested inside it.
+	const shouldDisplayCourseLesson =
+		!! courseLessonUrl && ! completed && ! disabled && ! isPrimaryAction;
+
+	const handleCourseLessonClick = ( event: MouseEvent ) => {
+		if ( onCourseLessonClick && courseLessonUrl ) {
+			event.preventDefault();
+			onCourseLessonClick( courseLessonUrl );
+		}
+	};
 
 	// Display chevron if task is incomplete.
 	// Don't display chevron and badge at the same time.
@@ -103,6 +119,7 @@ const ChecklistItem: FC< Props > = ( {
 				disabled: disabled,
 				expanded: expandable && expandable.isOpen,
 				highlighted: isHighlighted,
+				'has-course-lesson': shouldDisplayCourseLesson,
 			} ) }
 			aria-current={ isHighlighted ? 'step' : undefined }
 		>
@@ -157,6 +174,21 @@ const ChecklistItem: FC< Props > = ( {
 					) }
 					{ subtitle && <p className="checklist-item__subtext">{ subtitle }</p> }
 				</ButtonElement>
+			) }
+			{ shouldDisplayCourseLesson && courseLessonUrl && (
+				<Button
+					className="checklist-item__course-lesson"
+					href={ courseLessonUrl }
+					onClick={ handleCourseLessonClick }
+					icon={ video }
+					iconSize={ 24 }
+					label={ sprintf(
+						/* translators: %s: Task title */
+						__( 'Watch video lesson: %s', 'launchpad' ),
+						typeof title === 'string' ? title : String( title )
+					) }
+					showTooltip
+				/>
 			) }
 			{ expandable && expandable.isOpen && (
 				<div className="checklist-item__expanded-content">{ expandable.content }</div>

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -109,6 +109,46 @@
 	cursor: default;
 }
 
+// Course video lesson link, rendered as a sibling of the task row button.
+.checklist-item__task.has-course-lesson {
+	display: flex;
+	align-items: stretch;
+
+	> .checklist-item__task-content.components-button {
+		flex: 1 1 auto;
+		min-width: 0;
+	}
+
+	.checklist-item__course-lesson.components-button {
+		align-items: center;
+		border-bottom: 1px solid var(--studio-gray-5);
+		border-radius: 0;
+		color: var(--color-neutral-60);
+		height: auto;
+		padding-inline: 4px;
+
+		&:hover,
+		&:focus {
+			color: var(--studio-blue-50);
+		}
+
+		&:focus-visible {
+			outline: var(--color-primary);
+			box-shadow: 0 0 0 2px var(--color-primary-light);
+		}
+	}
+
+	&:last-child .checklist-item__course-lesson.components-button {
+		border-bottom: none;
+	}
+}
+
+.checklist__has-primary-action
+.checklist-item__task.has-course-lesson:nth-last-child(2)
+.checklist-item__course-lesson.components-button {
+	border-bottom: none;
+}
+
 .checklist-item__checkmark-container {
 	margin-right: 7px;
 	display: flex;

--- a/packages/launchpad/src/checklist-item/test/index.tsx
+++ b/packages/launchpad/src/checklist-item/test/index.tsx
@@ -210,4 +210,60 @@ describe( 'ChecklistItem', () => {
 			} );
 		} );
 	} );
+
+	describe( 'when the task has a course video lesson', () => {
+		const courseLessonUrl =
+			'https://wordpress.com/support/courses/create-your-website/choose-a-theme/';
+
+		it( 'displays the video lesson link', () => {
+			renderComponent( {
+				task: buildTask( { title: 'Choose a theme', completed: false, disabled: false } ),
+				courseLessonUrl,
+			} );
+
+			const lessonLink = screen.getByRole( 'link', {
+				name: 'Watch video lesson: Choose a theme',
+			} );
+
+			expect( lessonLink ).toBeVisible();
+			expect( lessonLink ).toHaveAttribute( 'href', courseLessonUrl );
+		} );
+
+		it( 'calls onCourseLessonClick with the lesson url when clicked', async () => {
+			const onCourseLessonClick = jest.fn();
+			renderComponent( {
+				task: buildTask( { title: 'Choose a theme', completed: false, disabled: false } ),
+				courseLessonUrl,
+				onCourseLessonClick,
+			} );
+
+			await userEvent.click(
+				screen.getByRole( 'link', { name: 'Watch video lesson: Choose a theme' } )
+			);
+
+			expect( onCourseLessonClick ).toHaveBeenCalledWith( courseLessonUrl );
+		} );
+
+		it( 'hides the video lesson link when the task is completed', () => {
+			renderComponent( {
+				task: buildTask( { title: 'Choose a theme', completed: true, disabled: false } ),
+				courseLessonUrl,
+			} );
+
+			expect(
+				screen.queryByRole( 'link', { name: 'Watch video lesson: Choose a theme' } )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'hides the video lesson link when the task is disabled', () => {
+			renderComponent( {
+				task: buildTask( { title: 'Choose a theme', completed: false, disabled: true } ),
+				courseLessonUrl,
+			} );
+
+			expect(
+				screen.queryByRole( 'link', { name: 'Watch video lesson: Choose a theme' } )
+			).not.toBeInTheDocument();
+		} );
+	} );
 } );

--- a/packages/launchpad/src/course-lessons.ts
+++ b/packages/launchpad/src/course-lessons.ts
@@ -1,0 +1,137 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { dispatch } from '@wordpress/data';
+import type { HelpCenterDispatch } from '@automattic/data-stores';
+
+const HELP_CENTER_STORE = 'automattic/help-center';
+
+const WEBSITE_COURSE = 'create-your-website';
+const BLOG_COURSE = 'create-your-blog';
+const AUDIENCE_COURSE = 'grow-your-audience';
+const MONETIZE_COURSE = 'monetize-your-website';
+const STORE_COURSE = 'build-your-store-with-woocommerce';
+
+/**
+ * Task ids mapped to the course video lesson that walks through that task.
+ * Lessons live on the support site under /support/courses/<course>/<lesson>/,
+ * which the Help Center renders with lesson navigation and an embedded video.
+ */
+const COURSE_LESSONS_BY_TASK: Record< string, string > = {
+	design_selected: `${ WEBSITE_COURSE }/choose-a-theme/`,
+	design_completed: `${ WEBSITE_COURSE }/choose-a-theme/`,
+	design_edited: `${ WEBSITE_COURSE }/choose-a-theme/`,
+	site_theme_selected: `${ WEBSITE_COURSE }/choose-a-theme/`,
+	front_page_updated: `${ WEBSITE_COURSE }/edit-your-homepage/`,
+	add_new_page: `${ WEBSITE_COURSE }/add-new-pages/`,
+	edit_page: `${ WEBSITE_COURSE }/add-new-pages/`,
+	update_about_page: `${ WEBSITE_COURSE }/add-new-pages/`,
+	add_about_page: `${ WEBSITE_COURSE }/add-new-pages/`,
+	setup_free: `${ WEBSITE_COURSE }/fonts-and-colors/`,
+	site_launched: `${ WEBSITE_COURSE }/launch-your-site/`,
+	link_in_bio_launched: `${ WEBSITE_COURSE }/launch-your-site/`,
+	videopress_launched: `${ WEBSITE_COURSE }/launch-your-site/`,
+	blog_launched: `${ BLOG_COURSE }/launch-and-grow-your-blog/`,
+	first_post_published: `${ BLOG_COURSE }/create-blog-posts/`,
+	first_post_published_newsletter: `${ BLOG_COURSE }/create-blog-posts/`,
+	write_3_posts: `${ BLOG_COURSE }/create-blog-posts/`,
+	post_sharing_enabled: `${ BLOG_COURSE }/comments-and-social-sharing/`,
+	subscribers_added: `${ BLOG_COURSE }/grow-your-subscribers/`,
+	import_subscribers: `${ BLOG_COURSE }/grow-your-subscribers/`,
+	manage_subscribers: `${ BLOG_COURSE }/grow-your-subscribers/`,
+	add_10_email_subscribers: `${ BLOG_COURSE }/grow-your-subscribers/`,
+	add_first_subscribers: `${ BLOG_COURSE }/grow-your-subscribers/`,
+	start_building_your_audience: `${ BLOG_COURSE }/grow-your-subscribers/`,
+	add_subscribe_block: `${ AUDIENCE_COURSE }/convert-visitors-into-email-subscribers/`,
+	drive_traffic: `${ AUDIENCE_COURSE }/leverage-social-media-for-growth/`,
+	connect_social_media: `${ AUDIENCE_COURSE }/leverage-social-media-for-growth/`,
+	set_up_payments: `${ MONETIZE_COURSE }/how-to-accept-payments/`,
+	stripe_connected: `${ MONETIZE_COURSE }/how-to-accept-payments/`,
+	newsletter_plan_created: `${ MONETIZE_COURSE }/turn-your-newsletter-into-a-paid-subscription/`,
+	manage_paid_newsletter_plan: `${ MONETIZE_COURSE }/turn-your-newsletter-into-a-paid-subscription/`,
+	earn_money: `${ MONETIZE_COURSE }/turn-your-newsletter-into-a-paid-subscription/`,
+	paid_offer_created: `${ MONETIZE_COURSE }/create-paid-content/`,
+	woocommerce_setup: `${ STORE_COURSE }/get-started-with-woo/`,
+	woo_products: `${ STORE_COURSE }/add-products/`,
+	woo_woocommerce_payments: `${ STORE_COURSE }/set-up-payments/`,
+	woo_tax: `${ STORE_COURSE }/collect-sales-tax/`,
+	woo_customize_store: `${ STORE_COURSE }/set-up-store-pages/`,
+	woo_launch_site: `${ STORE_COURSE }/launch-extend/`,
+};
+
+/**
+ * Checklists shown to blog-intent users, where theme/homepage/launch tasks
+ * should point at the "Create your blog" course instead of the website one.
+ */
+const BLOG_CHECKLIST_SLUGS = [
+	'write',
+	'intent-write',
+	'design-first',
+	'start-writing',
+	'newsletter',
+	'intent-newsletter-goal',
+	'intent-free-newsletter',
+	'intent-paid-newsletter',
+];
+
+const BLOG_COURSE_LESSON_OVERRIDES: Record< string, string > = {
+	design_selected: `${ BLOG_COURSE }/blog-theme/`,
+	design_completed: `${ BLOG_COURSE }/blog-theme/`,
+	design_edited: `${ BLOG_COURSE }/blog-theme/`,
+	site_theme_selected: `${ BLOG_COURSE }/blog-theme/`,
+	front_page_updated: `${ BLOG_COURSE }/blog-homepage/`,
+	site_launched: `${ BLOG_COURSE }/launch-and-grow-your-blog/`,
+};
+
+export const getCourseLessonUrl = (
+	taskId: string,
+	checklistSlug?: string | null
+): string | null => {
+	const lessonPath =
+		( checklistSlug &&
+			BLOG_CHECKLIST_SLUGS.includes( checklistSlug ) &&
+			BLOG_COURSE_LESSON_OVERRIDES[ taskId ] ) ||
+		COURSE_LESSONS_BY_TASK[ taskId ];
+
+	return lessonPath ? localizeUrl( `https://wordpress.com/support/courses/${ lessonPath }` ) : null;
+};
+
+type WpWithData = {
+	data?: {
+		dispatch?: ( store: string ) => unknown;
+	};
+};
+
+const loadHelpCenterDispatch = async () => {
+	// In wp-admin the Help Center registers its store on the global `wp.data`
+	// registry, which is separate from this bundle's `@wordpress/data` registry.
+	const wp = typeof window !== 'undefined' ? ( window.wp as WpWithData | undefined ) : undefined;
+	if ( wp?.data?.dispatch?.( HELP_CENTER_STORE ) ) {
+		return wp.data.dispatch( HELP_CENTER_STORE ) as HelpCenterDispatch[ 'dispatch' ];
+	}
+
+	if ( ! dispatch( HELP_CENTER_STORE ) ) {
+		const { HelpCenter: HelpCenterStore } = await import(
+			/* webpackChunkName: "async-load-automattic-data-stores" */ '@automattic/data-stores'
+		);
+		HelpCenterStore.register();
+	}
+
+	return dispatch( HELP_CENTER_STORE ) as HelpCenterDispatch[ 'dispatch' ];
+};
+
+/**
+ * Opens a course video lesson in the Help Center, falling back to a new tab
+ * when the Help Center is not available.
+ */
+export const openCourseLesson = async ( lessonUrl: string ) => {
+	try {
+		const helpCenterDispatch = await loadHelpCenterDispatch();
+		if ( helpCenterDispatch?.setShowSupportDoc ) {
+			helpCenterDispatch.setShowSupportDoc( lessonUrl );
+			return;
+		}
+	} catch {
+		// Fall through to opening in a new tab.
+	}
+
+	window.open( lessonUrl, '_blank', 'noopener,noreferrer' );
+};

--- a/packages/launchpad/src/launchpad-internal.tsx
+++ b/packages/launchpad/src/launchpad-internal.tsx
@@ -2,9 +2,13 @@ import { useLaunchpad } from '@automattic/data-stores';
 import { type FC, useMemo } from 'react';
 import Checklist, { Placeholder as ChecklistPlaceHolder } from './checklist';
 import ChecklistItem from './checklist-item';
+import { getCourseLessonUrl, openCourseLesson } from './course-lessons';
 import { useTracking } from './use-tracking';
 import type { Task } from './types';
 import type { SiteDetails, UseLaunchpadOptions } from '@automattic/data-stores';
+
+// Site Setup surfaces where tasks link to their matching course video lesson.
+const COURSE_LESSON_CONTEXTS = [ 'customer-home', 'wpadmin-dashboard-widget' ];
 
 interface Props {
 	site?: SiteDetails | null;
@@ -52,7 +56,7 @@ const LaunchpadInternal: FC< Props > = ( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ JSON.stringify( checklist ), taskFilter ] );
 
-	const { trackTaskClick } = useTracking( {
+	const { trackTaskClick, trackCourseLessonClick } = useTracking( {
 		tasks,
 		checklistSlug,
 		site,
@@ -63,6 +67,13 @@ const LaunchpadInternal: FC< Props > = ( {
 	const itemClickHandler = ( task: Task ) => {
 		trackTaskClick( task );
 		task?.actionDispatch?.();
+	};
+
+	const showCourseLessons = COURSE_LESSON_CONTEXTS.includes( launchpadContext );
+
+	const courseLessonClickHandler = ( task: Task, lessonUrl: string ) => {
+		trackCourseLessonClick( task, lessonUrl );
+		openCourseLesson( lessonUrl );
 	};
 
 	return (
@@ -77,6 +88,10 @@ const LaunchpadInternal: FC< Props > = ( {
 							task={ task }
 							key={ task.id }
 							onClick={ () => itemClickHandler( task ) }
+							courseLessonUrl={
+								showCourseLessons ? getCourseLessonUrl( task.id, checklistSlug ) : undefined
+							}
+							onCourseLessonClick={ ( lessonUrl ) => courseLessonClickHandler( task, lessonUrl ) }
 						/>
 					) ) }
 				</Checklist>

--- a/packages/launchpad/src/test/course-lessons.ts
+++ b/packages/launchpad/src/test/course-lessons.ts
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getCourseLessonUrl } from '../course-lessons';
+
+describe( 'getCourseLessonUrl', () => {
+	it( 'returns the matching lesson for a mapped task', () => {
+		expect( getCourseLessonUrl( 'design_completed', 'free' ) ).toBe(
+			'https://wordpress.com/support/courses/create-your-website/choose-a-theme/'
+		);
+	} );
+
+	it( 'returns null for an unmapped task', () => {
+		expect( getCourseLessonUrl( 'verify_email', 'free' ) ).toBeNull();
+	} );
+
+	it( 'uses the blog course for blog-intent checklists', () => {
+		expect( getCourseLessonUrl( 'design_completed', 'write' ) ).toBe(
+			'https://wordpress.com/support/courses/create-your-blog/blog-theme/'
+		);
+		expect( getCourseLessonUrl( 'site_launched', 'intent-write' ) ).toBe(
+			'https://wordpress.com/support/courses/create-your-blog/launch-and-grow-your-blog/'
+		);
+	} );
+
+	it( 'falls back to the default lesson for blog-intent checklists without an override', () => {
+		expect( getCourseLessonUrl( 'first_post_published', 'write' ) ).toBe(
+			'https://wordpress.com/support/courses/create-your-blog/create-blog-posts/'
+		);
+	} );
+
+	it( 'handles a missing checklist slug', () => {
+		expect( getCourseLessonUrl( 'site_launched', null ) ).toBe(
+			'https://wordpress.com/support/courses/create-your-website/launch-your-site/'
+		);
+	} );
+} );

--- a/packages/launchpad/src/use-tracking/index.tsx
+++ b/packages/launchpad/src/use-tracking/index.tsx
@@ -85,7 +85,19 @@ export const useTracking = ( params: Params ) => {
 		} );
 	};
 
+	const trackCourseLessonClick = ( task: Task, lessonUrl: string ) => {
+		recordTracksEvent( 'calypso_launchpad_task_course_lesson_clicked', {
+			checklist_slug: checklistSlug,
+			context: context,
+			task_id: task.id,
+			lesson_url: lessonUrl,
+			flow,
+			goals,
+		} );
+	};
+
 	return {
 		trackTaskClick,
+		trackCourseLessonClick,
 	};
 };


### PR DESCRIPTION
<!-- Linear issue reference intentionally omitted for now (exploration). -->

## Proposed Changes

Add contextual course video lesson links to the Site Setup checklist (Launchpad) tasks, opening the matching lesson in the Help Center.

* New `course-lessons` module in `@automattic/launchpad` that maps Launchpad task ids (e.g. `design_completed`, `post_sharing_enabled`, `site_launched`) to the matching lesson of the [WordPress.com courses](https://wordpress.com/support/courses/) (`Create your website`, `Create your blog`, `Grow your audience`, `Monetize your website`, `Build your store with WooCommerce`). Blog-intent checklists (`write`, `intent-write`, `design-first`, newsletter checklists, …) get "Create your blog" lessons for theme/homepage/launch tasks.
* `ChecklistItem` renders a subtle video icon button for incomplete, enabled tasks that have a matching lesson. Since the whole task row is already a button, the lesson link is rendered as a sibling element inside the same `<li>`.
* Clicking the icon opens the lesson in the **Help Center** via `setShowSupportDoc()`. Lesson URLs under `/support/courses/<course>/<lesson>/` automatically get the Help Center's course chrome (embedded video, previous/next lesson navigation, "Open full course" header link). When the Help Center store is unavailable, the lesson opens in a new tab.
* The links are gated to the two "Site Setup" surfaces from the issue: the My Home card (`launchpadContext: 'customer-home'`) and the wp-admin dashboard widget (`launchpadContext: 'wpadmin-dashboard-widget'`). The full-screen onboarding launchpad is intentionally not affected.
* New tracks event: `calypso_launchpad_task_course_lesson_clicked` (with `checklist_slug`, `task_id`, `lesson_url`, `context`).

Note: the wp-admin "Site Setup" dashboard widget bundles this same `@automattic/launchpad` package via jetpack-mu-wpcom, so it picks this up once the package is published and jetpack-mu-wpcom updates its dependency — no separate implementation needed, but it does need that follow-up release.

## Why are these changes being made?

The Site Setup checklist is one of the highest-intent moments in the customer journey, but course video lessons are only discoverable via docs, the Help Center and Odie — not at the moment the user is working through a setup task. Course-takers churn at 3.51% and refund at 5.24%, vs. 8% / 13.8% for the general customer base, so surfacing the matching lesson contextually is a cheap, high-leverage nudge.

The approach follows the design discussion on the AI Launchpad heads-up P2: a subtle support link on the task (not a primary action, not a modal) that opens the lesson in the Help Center, so users aren't pulled away from the task and learn to use the Help Center for guidance.

## Testing Instructions

1. On a site with an incomplete Site Setup checklist (e.g. a new free site), go to My Home (`/home/<site>`).
2. In the "Site Setup" / "Next steps for your site" card, incomplete tasks with a matching course lesson (e.g. "Choose a theme", "Write your first post", "Launch your site") show a small video icon at the end of the row.
3. Click the icon: the Help Center opens on the matching course lesson, with the embedded video and previous/next lesson navigation.
4. Hover the icon: a tooltip reads "Watch video lesson: <task title>".
5. Complete a task and confirm its video icon disappears.
6. Confirm the full-screen onboarding launchpad (`/setup/.../launchpad`) is unchanged.
7. Unit tests: `yarn test-packages packages/launchpad`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
