### PR TITLE
Marketplace: Harden install recovery after refresh

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-install-deadline.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-install-deadline.tsx
@@ -3,7 +3,7 @@
  */
 import { siteLatestAtomicTransferQuery } from '@automattic/api-queries';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import React, { useState } from 'react';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
 import { INSTALL_DEADLINE_MS, useInstallDeadline } from '../use-install-deadline';
@@ -88,6 +88,14 @@ describe( 'useInstallDeadline', () => {
 		await advance( INSTALL_DEADLINE_MS + 10000 );
 
 		expect( result.current.hasTimedOut ).toBe( true );
+	} );
+
+	it( 'reports a 404 lookup as an authoritative no-transfer result', async () => {
+		const { result } = renderDeadline();
+
+		await waitFor( () => expect( result.current.isTransferLookupComplete ).toBe( true ) );
+
+		expect( result.current.isTransferLookupNotFound ).toBe( true );
 	} );
 
 	it( 'stays disarmed when the wait is not running', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -138,6 +138,10 @@ const marketplaceHandoff = {
 	},
 };
 
+const directInstallAuthorization = {
+	route: { query: { current: { directInstall: '1' } } },
+};
+
 const jetpackSite = {
 	ui: { selectedSiteId: SITE_ID },
 	sites: { items: { [ SITE_ID ]: { ID: SITE_ID, URL: `https://${ SITE_SLUG }`, jetpack: true } } },
@@ -336,6 +340,37 @@ describe( 'useProductInstall progression', () => {
 		expect( installPlugin ).not.toHaveBeenCalled();
 	} );
 
+	it( 'does not initiate another transfer after a timed-out refresh sees one still running', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'active' ) );
+
+		const firstRender = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...directInstallAuthorization,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		await waitFor( () => expect( firstRender.result.current.currentStep ).toBe( 1 ) );
+		firstRender.unmount();
+
+		initiatePluginTransfer.mockClear();
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...directInstallAuthorization,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+
+		await advance( INSTALL_DEADLINE_MS + 10000 );
+
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+		expect( result.current.error ).toEqual( { type: 'timeout' } );
+	} );
+
 	it.each( [
 		'pending',
 		'active',
@@ -384,6 +419,50 @@ describe( 'useProductInstall progression', () => {
 		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
 	} );
 
+	it( 'keeps a completed recovery latched after its marker expires', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'completed' ) );
+
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...directInstallAuthorization,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		await waitFor( () => expect( result.current.currentStep ).toBe( 2 ) );
+
+		await advance( INSTALL_DEADLINE_MS + 10000 );
+
+		expect( result.current.currentStep ).toBe( 2 );
+		expect( result.current.error ).toBeNull();
+	} );
+
+	it( 'does not carry a completed transfer latch across products', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'completed' ) );
+
+		const { result, rerender } = renderHookWithProvider(
+			( { pluginSlug }: { pluginSlug: string } ) => useProductInstall( { pluginSlug } ),
+			{
+				reducers,
+				initialState: {
+					...directInstallAuthorization,
+					...simpleAtomicEligibleSite,
+					plugins: { wporg: { items: wporgItems } },
+				},
+				initialProps: { pluginSlug: 'give' },
+			}
+		);
+		await waitFor( () => expect( result.current.currentStep ).toBe( 2 ) );
+
+		rerender( { pluginSlug: 'akismet' } );
+		await advance( INSTALL_DEADLINE_MS + 10000 );
+
+		expect( result.current.error ).toEqual( { type: 'timeout' } );
+	} );
+
 	it( 'adopts a recently completed transfer after refresh', async () => {
 		await beginAtomicPluginTransfer();
 		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'completed', 1000 ) );
@@ -417,6 +496,40 @@ describe( 'useProductInstall progression', () => {
 
 		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
 		expect( installPlugin ).not.toHaveBeenCalled();
+	} );
+
+	it( 'adopts its own transfer dated before the attempt by clock skew', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'completed', 5000 ) );
+
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...directInstallAuthorization,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+
+		await waitFor( () => expect( result.current.currentStep ).toBe( 2 ) );
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+	} );
+
+	it( 'recovers through direct-install authorization after refresh', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'active' ) );
+
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...directInstallAuthorization,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		await waitFor( () => expect( result.current.currentStep ).toBe( 1 ) );
+
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
 	} );
 
 	it( 'starts a fresh authorized transfer instead of adopting a stale completion', async () => {
@@ -455,10 +568,10 @@ describe( 'useProductInstall progression', () => {
 		expect( result.current.currentStep ).toBe( 1 );
 	} );
 
-	it( 'does not adopt a product-blind active transfer', async () => {
+	it( 'does not start beside a product-blind active transfer', async () => {
 		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'active' ) );
 
-		renderProgress(
+		const { result } = renderProgress(
 			{ pluginSlug: 'give' },
 			{
 				...marketplaceHandoff,
@@ -466,7 +579,9 @@ describe( 'useProductInstall progression', () => {
 				plugins: { wporg: { items: wporgItems } },
 			}
 		);
-		await waitFor( () => expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 ) );
+		await waitFor( () => expect( mockFetchLatestAtomicTransfer ).toHaveBeenCalled() );
+		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
+		expect( result.current.error ).toBeNull();
 	} );
 
 	it( 'adopts its persisted transfer when the handoff survives', async () => {
@@ -529,6 +644,35 @@ describe( 'useProductInstall progression', () => {
 		expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'does not adopt a previous failed transfer when lookup finishes after initiation', async () => {
+		let resolveLookup: ( transfer: unknown ) => void = () => {};
+		mockFetchLatestAtomicTransfer.mockReturnValue(
+			new Promise( ( resolve ) => {
+				resolveLookup = resolve;
+			} )
+		);
+
+		const { result } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...directInstallAuthorization,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+
+		await advance( 2000 );
+		await waitFor( () => expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 ) );
+
+		await act( async () => {
+			resolveLookup( latestTransfer( 'error', 40000 ) );
+		} );
+		await waitFor( () => expect( mockFetchLatestAtomicTransfer ).toHaveBeenCalled() );
+
+		expect( result.current.error ).toBeNull();
+		expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'does not re-initiate a persisted attempt when the transfer lookup never settles', async () => {
 		await beginAtomicPluginTransfer();
 		mockFetchLatestAtomicTransfer.mockReturnValue( new Promise( () => undefined ) );
@@ -550,6 +694,7 @@ describe( 'useProductInstall progression', () => {
 
 	it( 'does not re-initiate a persisted attempt when the transfer lookup errors', async () => {
 		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockRejectedValue( new Error( 'network failure' ) );
 
 		const { result } = renderProgress(
 			{ pluginSlug: 'give' },
@@ -565,6 +710,24 @@ describe( 'useProductInstall progression', () => {
 
 		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
 		expect( result.current.error ).toEqual( { type: 'timeout' } );
+	} );
+
+	it( 're-initiates a persisted attempt when lookup returns 404', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockRejectedValue(
+			Object.assign( new Error( '404' ), { status: 404 } )
+		);
+
+		renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...directInstallAuthorization,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+
+		await waitFor( () => expect( initiatePluginTransfer ).toHaveBeenCalledTimes( 1 ) );
 	} );
 
 	it( 're-initiates a persisted attempt after a successful lookup proves no match', async () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-install-deadline.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-install-deadline.ts
@@ -70,6 +70,7 @@ export function useInstallDeadline( {
 	transfer: AtomicTransfer | undefined;
 	isTransferFresh: boolean;
 	isTransferLookupComplete: boolean;
+	isTransferLookupNotFound: boolean;
 } {
 	const [ now, setNow ] = useState( () => Date.now() );
 	// Null while the wait is not running. The clock is stamped when it starts, never while it is
@@ -109,7 +110,9 @@ export function useInstallDeadline( {
 	// deadline the moment this mounts — latching a timeout on an install that has since completed.
 	const {
 		data: transfer,
+		error: transferError,
 		isFetchedAfterMount,
+		isError: isTransferError,
 		isSuccess,
 	} = useQuery( {
 		...siteLatestAtomicTransferQuery( siteId ),
@@ -209,5 +212,9 @@ export function useInstallDeadline( {
 		transfer,
 		isTransferFresh: isFetchedAfterMount && isSuccess,
 		isTransferLookupComplete: isFetchedAfterMount,
+		isTransferLookupNotFound:
+			isFetchedAfterMount &&
+			isTransferError &&
+			( transferError as { status?: number } )?.status === 404,
 	};
 }

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -4,7 +4,10 @@ import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState, useMemo, useRef } from 'react';
 import { useQueryTheme } from 'calypso/components/data/query-theme';
-import { isRevertedTransferStatus } from 'calypso/landing/stepper/utils/atomic-transfer-outcome';
+import {
+	isRevertedTransferStatus,
+	transferStates as atomicTransferStates,
+} from 'calypso/landing/stepper/utils/atomic-transfer-outcome';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useWaitHeartbeat } from 'calypso/lib/analytics/wait-heartbeat';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -64,6 +67,9 @@ const TRANSFER_ATTEMPT_KEY_PREFIX = 'marketplace-product-install-transfer';
 type TransferAttempt = {
 	initiatedAt: number;
 	previousTransferId: number | null;
+	// Whether the transfer lookup had answered by the time this attempt started. Without it, a null
+	// `previousTransferId` cannot tell "the site had no transfer" from "we never found out".
+	lookupSettled: boolean;
 };
 
 const getTransferAttemptKey = ( siteId: number, pluginSlug: string ) =>
@@ -76,10 +82,14 @@ const readTransferAttempt = ( key: string ): TransferAttempt | null => {
 
 	try {
 		const value = JSON.parse( window.sessionStorage.getItem( key ) ?? 'null' );
-		return Number.isFinite( value?.initiatedAt ) &&
-			( Number.isFinite( value.previousTransferId ) || value.previousTransferId === null )
-			? value
-			: null;
+		if (
+			! Number.isFinite( value?.initiatedAt ) ||
+			! ( Number.isFinite( value.previousTransferId ) || value.previousTransferId === null )
+		) {
+			return null;
+		}
+		// A marker from before this field existed is read as an unresolved lookup, the stricter rule.
+		return { ...value, lookupSettled: value.lookupSettled === true };
 	} catch {
 		return null;
 	}
@@ -198,11 +208,18 @@ export function useProductInstall( {
 		key: '',
 		attempt: null,
 	} );
+	// A transfer outcome outlives the poll that reported it, so it is latched rather than derived.
+	// Both belong to the attempt below and are cleared with it — a different product must not
+	// inherit the previous one's completion.
+	const durableTransferCompletedRef = useRef( false );
+	const durableTransferFailedRef = useRef( false );
 	if ( transferAttemptRef.current.key !== transferAttemptKey ) {
 		transferAttemptRef.current = {
 			key: transferAttemptKey,
 			attempt: readTransferAttempt( transferAttemptKey ),
 		};
+		durableTransferCompletedRef.current = false;
+		durableTransferFailedRef.current = false;
 	}
 	const persistedTransferAttempt = transferAttemptRef.current.attempt;
 	const transferAttemptAge = persistedTransferAttempt
@@ -220,12 +237,22 @@ export function useProductInstall( {
 
 			const createdAt = Date.parse( candidate.created_at );
 			const age = Date.now() - createdAt;
+			// Our own transfer is created after we ask for it, so clock skew is the only thing that can
+			// date it before this attempt. The grace for that is safe to give except when the lookup
+			// had not answered yet: a null `previousTransferId` then hides a transfer that already
+			// existed, and the grace would adopt it as ours.
+			const isPriorTransferUnknown =
+				persistedTransferAttempt.previousTransferId === null &&
+				! persistedTransferAttempt.lookupSettled;
+			const minimumCreatedAt = isPriorTransferUnknown
+				? persistedTransferAttempt.initiatedAt
+				: persistedTransferAttempt.initiatedAt - TRANSFER_ATTEMPT_CLOCK_SKEW_MS;
 			return (
 				! Number.isNaN( createdAt ) &&
 				age >= -TRANSFER_ATTEMPT_CLOCK_SKEW_MS &&
 				age <= ADOPTABLE_TRANSFER_AGE_MS &&
 				candidate.atomic_transfer_id !== persistedTransferAttempt.previousTransferId &&
-				createdAt >= persistedTransferAttempt.initiatedAt - TRANSFER_ATTEMPT_CLOCK_SKEW_MS
+				createdAt >= minimumCreatedAt
 			);
 		},
 		[ hasCurrentTransferAttempt, persistedTransferAttempt ]
@@ -341,6 +368,7 @@ export function useProductInstall( {
 		transfer,
 		isTransferFresh,
 		isTransferLookupComplete,
+		isTransferLookupNotFound,
 	} = useInstallDeadline( {
 		siteId,
 		enabled: !! siteId && ! preflightError && ! isUploadStillSending,
@@ -349,12 +377,20 @@ export function useProductInstall( {
 	const latestTransfer = isTransferFresh ? transfer : undefined;
 	const transferBelongsToAttempt = !! latestTransfer && isTransferFromAttempt( latestTransfer );
 	const transferInFlight = transferBelongsToAttempt && ! isSettled( latestTransfer.status );
-	const durableTransferCompleted =
-		transferBelongsToAttempt && latestTransfer.status === 'completed';
-	const durableTransferFailed =
+	if ( transferBelongsToAttempt && latestTransfer.status === atomicTransferStates.COMPLETED ) {
+		durableTransferCompletedRef.current = true;
+	}
+	if (
 		transferBelongsToAttempt &&
-		( latestTransfer.status === 'error' || isRevertedTransferStatus( latestTransfer.status ) );
+		( latestTransfer.status === atomicTransferStates.ERROR ||
+			isRevertedTransferStatus( latestTransfer.status ) )
+	) {
+		durableTransferFailedRef.current = true;
+	}
+	const durableTransferCompleted = durableTransferCompletedRef.current;
+	const durableTransferFailed = durableTransferFailedRef.current;
 	const transferHasFailed = hasTransferFailed || durableTransferFailed;
+	const transferTimedOut = ! durableTransferCompleted && ( hasTimedOut || hasTransferTimedOut );
 	const transferLookupGraceElapsed = useDelayedCondition(
 		installStrategy === 'atomic-transfer' &&
 			!! pluginSlug &&
@@ -401,7 +437,7 @@ export function useProductInstall( {
 			return;
 		}
 
-		if ( transferHasFailed || hasTimedOut || hasTransferTimedOut ) {
+		if ( transferHasFailed || transferTimedOut ) {
 			return;
 		}
 
@@ -410,7 +446,24 @@ export function useProductInstall( {
 		}
 
 		// A persisted attempt must be resolved by a successful lookup before any install path starts.
-		if ( pluginSlug && hasCurrentTransferAttempt && ! isTransferFresh ) {
+		if (
+			pluginSlug &&
+			hasCurrentTransferAttempt &&
+			! isTransferFresh &&
+			! isTransferLookupNotFound
+		) {
+			return;
+		}
+
+		// A latest non-settled transfer means the site is already moving toward Atomic. Its identity
+		// cannot be safely attributed after a marker expires, so never start another one on this site.
+		if (
+			installStrategy === 'atomic-transfer' &&
+			pluginSlug &&
+			isTransferFresh &&
+			!! latestTransfer &&
+			! isSettled( latestTransfer.status )
+		) {
 			return;
 		}
 
@@ -438,6 +491,7 @@ export function useProductInstall( {
 			const attempt = {
 				initiatedAt: Date.now(),
 				previousTransferId: latestTransfer?.atomic_transfer_id ?? null,
+				lookupSettled: isTransferFresh || isTransferLookupNotFound,
 			};
 			transferAttemptRef.current = { key: transferAttemptKey, attempt };
 			writeTransferAttempt( transferAttemptKey, attempt );
@@ -463,8 +517,10 @@ export function useProductInstall( {
 		transferHasFailed,
 		hasTimedOut,
 		hasTransferTimedOut,
+		transferTimedOut,
 		hasCurrentTransferAttempt,
 		isTransferFresh,
+		isTransferLookupNotFound,
 		isTransferLookupComplete,
 		transferLookupGraceElapsed,
 		transferAttemptKey,
@@ -515,7 +571,7 @@ export function useProductInstall( {
 	if ( ! error && transferHasFailed ) {
 		error = { type: 'transfer-failed' };
 	}
-	if ( ! error && ( hasTimedOut || hasTransferTimedOut ) ) {
+	if ( ! error && transferTimedOut ) {
 		error = { type: 'timeout' };
 	}
 
@@ -566,7 +622,7 @@ export function useProductInstall( {
 		let outcome = null;
 		if ( transferHasFailed ) {
 			outcome = 'transfer_failed';
-		} else if ( hasTimedOut || hasTransferTimedOut ) {
+		} else if ( transferTimedOut ) {
 			outcome = 'timeout';
 		}
 		if ( ! outcome || reportedOutcomeRef.current === outcome ) {
@@ -588,6 +644,7 @@ export function useProductInstall( {
 	}, [
 		hasTimedOut,
 		hasTransferTimedOut,
+		transferTimedOut,
 		transferHasFailed,
 		themeSlug,
 		installStrategy,


### PR DESCRIPTION
## Proposed Changes

**Hardens the refresh-recovery flow shipped in #113596 so a recovered install can’t drift into a false timeout, a duplicate transfer, or the adoption of someone else’s transfer.**

- A transfer’s completed/failed outcome is now latched for the lifetime of the attempt, so a recovery that already reached the install step stays there when its attempt marker later expires. The latch resets when the site/plugin changes.
- The page never initiates a new Atomic transfer while the site’s latest transfer is still in flight — even when the attempt marker is gone and the transfer can no longer be attributed.
- A `404` from the latest-transfer lookup is treated as an authoritative “no transfer”, so a persisted attempt can be re-initiated right away instead of waiting out the 2s grace.
- The attempt marker records whether the lookup had settled when the attempt started (`lookupSettled`); clock-skew grace when matching a transfer to the attempt is only granted when the prior transfer was actually known. Markers written before this field is present are read as unsettled.

## Why are these changes being made?

Follow-up to [DOTCOM-18174](https://linear.app/a8c/issue/DOTCOM-18174/marketplace-install-recover-flow-after-page-refresh). The first pass made the install page survive a refresh, but a few edges could still bite a customer sitting on that page for a while:

- After the transfer had completed and the page had moved on, the attempt marker aging out could flip the screen back to a “timed out” error on an install that had actually finished.
- If a customer refreshed late enough that the marker had expired while the transfer was still running, the page could start a second transfer for a site that was already being transferred — the exact thing the original fix was meant to prevent.
- On a site that had never had a transfer, the lookup comes back as `404`, which was treated like a network failure and made the page wait out a grace period for nothing.
- Because of clock-skew tolerance, a transfer that already existed before the attempt started (but that the page never got to see) could be mistaken for the one the page had just requested.

## Testing Instructions

1. Run `yarn start`.
2. On a Simple site with a Business/Commerce plan (not yet Atomic), start a marketplace plugin install so you land on the install page and the transfer begins.
3. Refresh while the “transferring” step is running: progress should resume, no second transfer request appears in the network tab.
4. Let the transfer complete, then leave the tab open on the install/thank-you step for well over the install deadline (or clear the `marketplace-product-install-transfer:*` key from `sessionStorage`): the page must not show a timeout error.
5. With the transfer still running, remove the `marketplace-product-install-transfer:*` key from `sessionStorage` and refresh: the page should not start a new transfer, and should end in a timeout once the deadline passes rather than a duplicate transfer.
6. Regression: open the install page directly (no purchase/authorization) on a site with no recent transfer — the no-direct-access error should still appear.
