### PR TITLE
Cookie banner: suppress in the mobile app login webview

### DIFF
--- a/client/lib/analytics/utils/should-see-cookie-banner.ts
+++ b/client/lib/analytics/utils/should-see-cookie-banner.ts
@@ -1,6 +1,7 @@
 import { type TrackingPrefs, isCountryInGdprZone } from '@automattic/calypso-analytics';
 import { isE2ETest } from 'calypso/lib/e2e';
 import { isWpMobileApp, isWcMobileApp } from 'calypso/lib/mobile-app';
+import { isMobileAppRedirectUri } from 'calypso/lib/oauth2-clients';
 
 const isServer = typeof document === 'undefined';
 
@@ -10,15 +11,23 @@ const isServer = typeof document === 'undefined';
  * Defaults to `false` if the country code is unknown.
  * @param countryCode Country code determined either from cookie or from a special header
  * @param trackingPrefs Parsed object based on `sensitive_pixel_options` (v2) cookie structure
+ * @param redirectUri OAuth2 redirect_uri from the login query. Lets the SSR path detect the mobile
+ * app webview, where `isWpMobileApp()` can't read the URL (there is no `window` on the server).
  * @returns Whether the current user could be in the GDPR zone. When the `countryCode` are
  * `undefined`, we return `null` which has a meaning of "result unknown".
  */
 export default function shouldSeeCookieBanner(
 	countryCode?: string,
-	trackingPrefs?: TrackingPrefs
+	trackingPrefs?: TrackingPrefs,
+	redirectUri?: string | null
 ): boolean {
 	// the banner is not shown for pages embedded as web view inside the mobile app or during e2e tests
-	if ( isWpMobileApp() || isWcMobileApp() || ( ! isServer && isE2ETest() ) ) {
+	if (
+		isWpMobileApp() ||
+		isWcMobileApp() ||
+		isMobileAppRedirectUri( redirectUri ) ||
+		( ! isServer && isE2ETest() )
+	) {
 		return false;
 	}
 

--- a/client/lib/mobile-app/index.js
+++ b/client/lib/mobile-app/index.js
@@ -1,12 +1,24 @@
+import { getQueryArgs } from '@wordpress/url';
+import { getOAuth2RedirectUri, isMobileAppRedirectUri } from 'calypso/lib/oauth2-clients';
+
 /**
- * Returns whether user is using a WordPress mobile app.
- * @returns {boolean} Whether the user agent matches the ones used on the WordPress mobile apps.
+ * Returns whether the user is in a first-party mobile app (WordPress or Jetpack) — either the
+ * user agent carries the app token, or the page is the app's OAuth login webview, identified by
+ * a `jetpack://` / `wordpress://` redirect_uri. The login webview runs in a system auth session
+ * whose user agent carries no `wp-iphone`/`wp-android` token, so the scheme is the only signal.
+ * @returns {boolean}
  */
 export function isWpMobileApp() {
 	if ( typeof navigator === 'undefined' ) {
 		return false;
 	}
-	return navigator.userAgent && /wp-(android|iphone)/.test( navigator.userAgent );
+	if ( navigator.userAgent && /wp-(android|iphone)/.test( navigator.userAgent ) ) {
+		return true;
+	}
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+	return isMobileAppRedirectUri( getOAuth2RedirectUri( getQueryArgs( window.location.href ) ) );
 }
 
 /**

--- a/client/lib/mobile-app/test/index.js
+++ b/client/lib/mobile-app/test/index.js
@@ -27,6 +27,21 @@ describe( 'isWpMobileApp', () => {
 
 		expect( isWpMobileApp() ).toBeFalsy();
 	} );
+
+	test( 'should identify the app login webview by its OAuth redirect_uri without an app user agent', () => {
+		global.navigator = {
+			userAgent:
+				'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+		};
+		const redirectTo = encodeURIComponent(
+			'https://example.com/authorize?redirect_uri=jetpack%3A%2F%2Foauth2-callback'
+		);
+		global.window = { location: { href: `/log-in?client_id=11&redirect_to=${ redirectTo }` } };
+
+		expect( isWpMobileApp() ).toBe( true );
+
+		delete global.window;
+	} );
 } );
 
 describe( 'isWcMobileApp', () => {

--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -94,6 +94,7 @@ export const isCiabOAuth2Client = ( oauth2Client ) => {
 };
 
 const JETPACK_APP_URI_SCHEME = 'jetpack://';
+const WORDPRESS_APP_URI_SCHEME = 'wordpress://';
 
 // The redirect_uri reaches the login page nested inside redirect_to, where it is
 // often multiply percent-encoded (e.g. `jetpack%253A%252F%252F...`). Decode until
@@ -135,5 +136,19 @@ export const isJetpackAppRedirectUri = ( redirectUri ) => {
 	return (
 		typeof redirectUri === 'string' &&
 		fullyDecode( redirectUri ).toLowerCase().startsWith( JETPACK_APP_URI_SCHEME )
+	);
+};
+
+// True when the redirect_uri targets either WordPress.com mobile app (WordPress or Jetpack).
+// Both drive login/signup through a system auth session whose user agent lacks the
+// `wp-iphone`/`wp-android` token, so the redirect_uri scheme is the only reliable app signal
+// on that surface.
+export const isMobileAppRedirectUri = ( redirectUri ) => {
+	if ( typeof redirectUri !== 'string' ) {
+		return false;
+	}
+	const decoded = fullyDecode( redirectUri ).toLowerCase();
+	return (
+		decoded.startsWith( JETPACK_APP_URI_SCHEME ) || decoded.startsWith( WORDPRESS_APP_URI_SCHEME )
 	);
 };

--- a/client/lib/test/oauth2-clients.js
+++ b/client/lib/test/oauth2-clients.js
@@ -4,6 +4,7 @@ import {
 	isSharedMobileAppOAuth2Client,
 	getOAuth2RedirectUri,
 	isJetpackAppRedirectUri,
+	isMobileAppRedirectUri,
 } from 'calypso/lib/oauth2-clients';
 
 describe( 'oauth2-clients mobile app helpers', () => {
@@ -88,6 +89,26 @@ describe( 'oauth2-clients mobile app helpers', () => {
 			expect( isJetpackAppRedirectUri( '' ) ).toBe( false );
 			expect( isJetpackAppRedirectUri( null ) ).toBe( false );
 			expect( isJetpackAppRedirectUri( undefined ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isMobileAppRedirectUri', () => {
+		test( 'is true for both the jetpack:// and wordpress:// app schemes', () => {
+			expect( isMobileAppRedirectUri( 'jetpack://oauth2-callback' ) ).toBe( true );
+			expect( isMobileAppRedirectUri( 'wordpress://oauth2-callback' ) ).toBe( true );
+			expect( isMobileAppRedirectUri( 'WORDPRESS://oauth2-callback' ) ).toBe( true );
+		} );
+
+		test( 'is true even when singly or multiply percent-encoded', () => {
+			expect( isMobileAppRedirectUri( 'wordpress%3A%2F%2Foauth2-callback' ) ).toBe( true );
+			expect( isMobileAppRedirectUri( 'jetpack%253A%252F%252Foauth2-callback' ) ).toBe( true );
+		} );
+
+		test( 'is false for non-app schemes and empty values', () => {
+			expect( isMobileAppRedirectUri( 'https://wordpress.com/oauth2-callback' ) ).toBe( false );
+			expect( isMobileAppRedirectUri( '' ) ).toBe( false );
+			expect( isMobileAppRedirectUri( null ) ).toBe( false );
+			expect( isMobileAppRedirectUri( undefined ) ).toBe( false );
 		} );
 	} );
 } );

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -42,6 +42,7 @@ import { isInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { shouldSeeCookieBanner } from 'calypso/lib/analytics/utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { getOAuth2RedirectUri } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import loginRouter, { LOGIN_SECTION_DEFINITION } from 'calypso/login';
 import sections from 'calypso/sections';
@@ -220,7 +221,8 @@ function getDefaultContext( request, response, entrypoint = 'entry-main' ) {
 
 	const showGdprBanner = shouldSeeCookieBanner(
 		validCountryCodeCookie || geoIPCountryCode,
-		trackingPrefs
+		trackingPrefs,
+		getOAuth2RedirectUri( request.query )
 	);
 
 	if ( ! validCountryCodeCookie && geoIPCountryCode ) {


### PR DESCRIPTION
Fixes CMM-2137

On a fresh Jetpack app install in a GDPR region, tapping "Continue with WordPress.com" opens a login webview where the cookie-consent banner sits on top of the login form. Dismissing the password-manager pre-fill focuses the field and raises the keyboard, but the banner still covers it — you're typing into a field you can't see.

## Proposed Changes

- Add `isMobileAppRedirectUri()` to `client/lib/oauth2-clients.js` — true when the OAuth2 `redirect_uri` uses a WordPress.com app scheme (`jetpack://` or `wordpress://`), reusing the existing `fullyDecode()` that unwinds the multiply-percent-encoded value.
- Teach `isWpMobileApp()` (`client/lib/mobile-app`) to also return `true` when the page carries that `redirect_uri`, on top of the existing `wp-iphone` / `wp-android` user-agent match. This handles the client render.
- Thread the `redirect_uri` into the server render: `shouldSeeCookieBanner()` takes it as an argument, and `pages/index.js` passes `getOAuth2RedirectUri( request.query )`. This handles the SSR render, which `isWpMobileApp()` can't reach.

## Why are these changes being made?

Calypso already tries to hide the banner inside the mobile apps — `shouldSeeCookieBanner()` returns `false` when `isWpMobileApp()` / `isWcMobileApp()` match — but those only test the `wp-iphone` / `wp-android` user-agent token, and the OAuth login webview doesn't send it. Nothing else on that page identifies the app, so the banner renders over the form and blocks account creation in GDPR regions.

The OAuth2 `redirect_uri` scheme *is* present on the login URL, and `getIsJetpackApp` already trusts it for login-page branding. The fix keys off that signal on **both** render paths:

- **Client** — through `isWpMobileApp()`, which reads `window.location`. Because that function is shared, its other callers (masterbar suppression, the "get the app" banner) also treat the auth webview as the app. The broadened condition only fires on app-OAuth pages — a web user never has a `jetpack://` redirect_uri — so nothing else is affected.
- **Server** — `isWpMobileApp()` can't run during SSR (no `window`), so the `redirect_uri` is passed into `shouldSeeCookieBanner()` from `request.query`. Without this the banner is server-rendered into the HTML and only removed on hydration — a flash. Suppressing on both paths keeps it out of the SSR HTML entirely.

**No change to what we track.** This extends the existing in-app suppression to a context it already meant to cover; it doesn't alter tracking or consent for web users.

## Testing Instructions

Automated (run locally):

- [x] `client/lib/mobile-app/test/index.js` — `isWpMobileApp()` returns `true` for a non-app (Safari) user agent when the URL carries a `jetpack://` `redirect_uri`.
- [x] `client/lib/test/oauth2-clients.js` — `isMobileAppRedirectUri` cases (both app schemes, single/double percent-encoding, non-app schemes → `false`).
- [x] `should-display-app-banner` selector suite still green (23/23) — confirms broadening `isWpMobileApp()` didn't disturb its other callers.
- [x] `yarn typecheck-client` clean; `yarn eslint` clean on the touched files.

Reviewer — exercise the change without the native app. The banner is behind the `cookie-banner` feature flag (on in `wpcalypso`/calypso.live, off in local dev), and geo comes from cookies, so:

- [ ] Log out (incognito). In the console: `document.cookie = 'flags=cookie-banner; path=/'` (local dev only), `document.cookie = 'country_code=FR; path=/'`, `document.cookie = 'region=IDF; path=/'`, and clear `sensitive_pixel_options` / `sensitive_pixel_option`. Setting both geo cookies pins France and stops the client re-fetching over them.
- [ ] Open `/log-in` → the cookie banner **shows** (control).
- [ ] Open `/log-in?redirect_uri=jetpack%3A%2F%2Ftest` → the banner is **absent** — no flash, since SSR is suppressed too. The masterbar is also dropped, another sign `isWpMobileApp()` flipped. (Realistic form: a `client_id` plus a `redirect_to` whose nested `redirect_uri` is `jetpack://…`.)
- [ ] End-to-end (needs the app): fresh Jetpack install from a GDPR region → "Continue with WordPress.com" → the banner no longer covers the form. I can't run the native app; this is the real target and the one check that needs it.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
