### PR TITLE
Jetpack AI sidebar: group the review tools under one Get feedback chip

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -429,19 +429,10 @@ describe( 'AgentChat', () => {
 				prompt: 'Optimize this content for search engines',
 			},
 			{
-				id: 'generate-feedback',
-				label: 'Simple Review',
-				prompt: 'Review this saved content',
-			},
-			{
-				id: 'proofread-content',
-				label: 'Proofread',
-				prompt: 'Proofread this saved content',
-			},
-			{
-				id: 'ai-editorial-review',
-				label: 'Editorial Review',
-				prompt: 'Run an AI Editorial Review',
+				id: 'get-feedback',
+				label: 'Get feedback',
+				prompt: '',
+				options: [ { id: 'proofread-content', label: 'Proofread', value: 'Proofread this.' } ],
 			},
 		];
 		const suggestions = [ designSuggestion, whatElseSuggestion, ...writingSuggestions ];
@@ -471,14 +462,13 @@ describe( 'AgentChat', () => {
 		expect( screen.getByRole( 'button', { name: 'Optimize title' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Generate excerpt' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Optimize SEO' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'Simple review' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'Editorial review' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Get feedback: Proofread' } ) ).toBeInTheDocument();
 
 		await user.click( screen.getByRole( 'button', { name: 'Optimize title' } ) );
 		expect( onSuggestionClick ).toHaveBeenCalledWith( writingSuggestions[ 0 ], suggestions );
 
 		await user.click( writingToggle );
-		expect( screen.queryByRole( 'button', { name: 'Proofread' } ) ).toBeNull();
+		expect( screen.queryByRole( 'button', { name: 'Get feedback: Proofread' } ) ).toBeNull();
 	} );
 
 	it( 'keeps the featured image suggestion out of the writing group', () => {

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -239,6 +239,17 @@ const mockAgentChat = jest.fn(
 			>
 				Click post dropdown suggestion
 			</button>
+			<button
+				onClick={ () =>
+					onSuggestionClick( {
+						id: 'get-feedback',
+						label: 'Get feedback Proofread',
+						prompt: 'Proofread this saved post',
+					} )
+				}
+			>
+				Click feedback dropdown without context
+			</button>
 			<button onClick={ () => onSuggestionClick( 'Check the grammar and spelling of this text' ) }>
 				Click string suggestion
 			</button>
@@ -881,6 +892,31 @@ describe( 'OrchestratorChat', () => {
 			suggestion_id: 'seo-enhancer',
 			available_suggestions: '|seo-enhancer|',
 			option_id: 'seo-title',
+		} );
+	} );
+
+	it( 'records the option when the click carries no available suggestions', () => {
+		// Agenttic's own container reports the footer list, which is empty while the
+		// chips live in the empty view.
+		const feedback = {
+			id: 'get-feedback',
+			label: 'Get feedback',
+			prompt: '',
+			options: [
+				{ id: 'proofread-content', label: 'Proofread', value: 'Proofread this saved post' },
+			],
+		};
+
+		render( chat( { emptyViewSuggestions: [ feedback ] } ) );
+		jest.mocked( recordBigSkyTracksEvent ).mockClear();
+
+		fireEvent.click( screen.getByText( 'Click feedback dropdown without context' ) );
+
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestion_click', {
+			suggestion_text: 'Proofread this saved post',
+			suggestion_id: 'get-feedback',
+			available_suggestions: '|get-feedback|',
+			option_id: 'proofread-content',
 		} );
 	} );
 

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -171,11 +171,8 @@ function formatSuggestionIds( suggestions: Suggestion[] ): string {
  */
 function getSelectedOptionId(
 	selectedSuggestion: Suggestion,
-	availableSuggestions: Suggestion[]
+	originalSuggestion: Suggestion | undefined
 ): string | undefined {
-	const originalSuggestion = availableSuggestions.find(
-		( suggestion ) => suggestion.id === selectedSuggestion.id
-	);
 	return originalSuggestion?.options?.find(
 		( option ) => option.value === selectedSuggestion.prompt
 	)?.id;
@@ -1424,6 +1421,8 @@ export default function OrchestratorChat( {
 		};
 	}, [] );
 
+	const renderedSuggestionsRef = useRef< Suggestion[] >( [] );
+
 	const handleSuggestionClick = useCallback(
 		( suggestion: Suggestion | string, availableSuggestions?: Suggestion[] ) => {
 			const value =
@@ -1431,9 +1430,18 @@ export default function OrchestratorChat( {
 
 			const autoSubmit = typeof suggestion !== 'string' && !! suggestion.autoSubmit;
 			const suggestionId = typeof suggestion !== 'string' ? suggestion.id : undefined;
+			// A click routed through Agenttic's own container reports the footer list,
+			// which is empty while the chips live in the empty view.
+			const knownSuggestions = availableSuggestions?.length
+				? availableSuggestions
+				: renderedSuggestionsRef.current;
+			const originalSuggestion =
+				typeof suggestion !== 'string'
+					? knownSuggestions.find( ( available ) => available.id === suggestion.id )
+					: undefined;
 			const optionId =
 				typeof suggestion !== 'string'
-					? getSelectedOptionId( suggestion, availableSuggestions ?? [] )
+					? getSelectedOptionId( suggestion, originalSuggestion )
 					: undefined;
 			const blockType =
 				typeof suggestion !== 'string' && contextualSuggestionIds.has( suggestion.id )
@@ -1444,7 +1452,7 @@ export default function OrchestratorChat( {
 				recordBigSkyTracksEvent( 'chat_suggestion_click', {
 					suggestion_text: suggestion.prompt || '',
 					suggestion_id: suggestion.id || '',
-					available_suggestions: formatSuggestionIds( availableSuggestions ?? [] ),
+					available_suggestions: formatSuggestionIds( knownSuggestions ),
 					...( optionId ? { option_id: optionId } : {} ),
 					...( blockType ? { block_type: blockType } : {} ),
 				} );
@@ -1738,6 +1746,7 @@ export default function OrchestratorChat( {
 	} else if ( suggestions.length > 0 ) {
 		displayedEmptyViewSuggestions = suggestions;
 	}
+	renderedSuggestionsRef.current = displayedEmptyViewSuggestions;
 
 	// Track when a set of suggestions is rendered — the dynamic block-context
 	// suggestions or, on an empty chat, the empty-view starter chips. Mirrors

--- a/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
+++ b/packages/agents-manager/src/hooks/use-empty-view-suggestions.ts
@@ -32,9 +32,7 @@ const WRITING_SUGGESTION_LABELS: Record< string, () => string > = {
 	'optimize-title': () => __( 'Optimize title', __i18n_text_domain__ ),
 	'generate-excerpt': () => __( 'Generate excerpt', __i18n_text_domain__ ),
 	'seo-enhancer': () => __( 'Optimize SEO', __i18n_text_domain__ ),
-	'generate-feedback': () => __( 'Simple review', __i18n_text_domain__ ),
-	'proofread-content': () => __( 'Proofread', __i18n_text_domain__ ),
-	'ai-editorial-review': () => __( 'Editorial review', __i18n_text_domain__ ),
+	'get-feedback': () => __( 'Get feedback', __i18n_text_domain__ ),
 };
 
 export const WRITING_SUGGESTION_IDS = new Set( Object.keys( WRITING_SUGGESTION_LABELS ) );

--- a/packages/jetpack-ai-sidebar/src/index.test.ts
+++ b/packages/jetpack-ai-sidebar/src/index.test.ts
@@ -395,6 +395,19 @@ function SuggestionsProbe( {
 	return null;
 }
 
+function feedbackOptionIds(): string[] {
+	const options =
+		getEmptyViewSuggestions().find( ( suggestion ) => suggestion.id === 'get-feedback' )?.options ??
+		[];
+	return options.map( ( option: { id: string } ) => option.id );
+}
+
+function feedbackOptionPrompt( optionId: string ): string | undefined {
+	return getEmptyViewSuggestions()
+		.find( ( suggestion ) => suggestion.id === 'get-feedback' )
+		?.options?.find( ( option: { id: string } ) => option.id === optionId )?.value;
+}
+
 function getTracksCalls( eventName: string ) {
 	return mockedRecordTracksEvent.mock.calls.filter( ( [ name ] ) => name === eventName );
 }
@@ -1878,21 +1891,24 @@ describe( 'getEmptyViewSuggestions', () => {
 	it( 'hides post suggestions without a sidebar config', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).not.toContain( 'Editorial Review' );
+		expect( feedbackOptionIds() ).not.toContain( 'ai-editorial-review' );
 	} );
 
 	it( 'returns one AI Editorial Review suggestion with the existing UX label', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock( 'post' );
 
-		const suggestions = getEmptyViewSuggestions();
-		const aiEditorialReviewSuggestions = suggestions.filter(
-			( suggestion ) => suggestion.id === 'ai-editorial-review'
+		const feedback = getEmptyViewSuggestions().filter(
+			( suggestion ) => suggestion.id === 'get-feedback'
 		);
 
-		expect( aiEditorialReviewSuggestions ).toEqual( [
-			expect.objectContaining( { label: 'Editorial Review' } ),
-		] );
+		expect( feedback ).toEqual( [ expect.objectContaining( { label: 'Get feedback' } ) ] );
+		expect( feedback[ 0 ].options ).toContainEqual(
+			expect.objectContaining( {
+				id: 'ai-editorial-review',
+				label: 'In-depth review against guidelines',
+			} )
+		);
 	} );
 
 	it( 'shows AI Editorial Review when enabled by agentsManagerData', () => {
@@ -1900,8 +1916,8 @@ describe( 'getEmptyViewSuggestions', () => {
 		installPostTypeMock( 'post' );
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).toContain( 'Editorial Review' );
-		expect( labels ).toContain( 'Simple Review' );
+		expect( feedbackOptionIds() ).toContain( 'ai-editorial-review' );
+		expect( feedbackOptionIds() ).toContain( 'generate-feedback' );
 	} );
 
 	it( 'shows AI Editorial Review on page editors', () => {
@@ -1911,8 +1927,8 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).toContain( 'Editorial Review' );
-		expect( labels ).toContain( 'Simple Review' );
+		expect( feedbackOptionIds() ).toContain( 'ai-editorial-review' );
+		expect( feedbackOptionIds() ).toContain( 'generate-feedback' );
 	} );
 
 	it( 'shows all enabled editor-level suggestions on page editors', () => {
@@ -1925,12 +1941,11 @@ describe( 'getEmptyViewSuggestions', () => {
 
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
-		expect( labels ).toEqual( [
-			'Optimize Title',
-			'Generate Excerpt',
-			'Simple Review',
-			'Proofread',
-			'Editorial Review',
+		expect( labels ).toEqual( [ 'Optimize Title', 'Generate Excerpt', 'Get feedback' ] );
+		expect( feedbackOptionIds() ).toEqual( [
+			'generate-feedback',
+			'proofread-content',
+			'ai-editorial-review',
 		] );
 	} );
 
@@ -1958,50 +1973,40 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).not.toContain( 'Editorial Review' );
+		expect( feedbackOptionIds() ).not.toContain( 'ai-editorial-review' );
 	} );
 
 	it( 'hides Simple Review until the editor entity has a saved ID', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock( 'post', null );
 
-		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
-
-		expect( labels ).not.toContain( 'Simple Review' );
-		expect( labels ).toContain( 'Editorial Review' );
+		expect( feedbackOptionIds() ).not.toContain( 'generate-feedback' );
+		expect( feedbackOptionIds() ).toContain( 'ai-editorial-review' );
 	} );
 
 	it( 'hides Simple Review when the preview feature disables it', () => {
 		installAiEditorialReviewData( { generateFeedback: false } );
 		installPostTypeMock( 'post' );
 
-		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
-
-		expect( labels ).not.toContain( 'Simple Review' );
-		expect( labels ).toContain( 'Editorial Review' );
+		expect( feedbackOptionIds() ).not.toContain( 'generate-feedback' );
+		expect( feedbackOptionIds() ).toContain( 'ai-editorial-review' );
 	} );
 
 	it( 'hides Proofread by default and shows it when the preview feature enables it', () => {
 		installAiEditorialReviewData();
 		installPostTypeMock( 'post' );
-		expect( getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label ) ).not.toContain(
-			'Proofread'
-		);
+		expect( feedbackOptionIds() ).not.toContain( 'proofread-content' );
 
 		installAiEditorialReviewData( { proofreadContent: true } );
 		installPostTypeMock( 'post' );
-		expect( getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label ) ).toContain(
-			'Proofread'
-		);
+		expect( feedbackOptionIds() ).toContain( 'proofread-content' );
 	} );
 
 	it( 'hides Proofread until the editor entity has a saved ID', () => {
 		installAiEditorialReviewData( { proofreadContent: true } );
 		installPostTypeMock( 'post', null );
 
-		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
-
-		expect( labels ).not.toContain( 'Proofread' );
+		expect( feedbackOptionIds() ).not.toContain( 'proofread-content' );
 	} );
 
 	it( 'hides Optimize Title when the feature disables it', () => {
@@ -2011,7 +2016,7 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).not.toContain( 'Editorial Review' );
+		expect( feedbackOptionIds() ).not.toContain( 'ai-editorial-review' );
 	} );
 
 	it( 'treats missing features as disabled', () => {
@@ -2026,11 +2031,11 @@ describe( 'getEmptyViewSuggestions', () => {
 		const labels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 
 		expect( labels ).not.toContain( 'Optimize Title' );
-		expect( labels ).toContain( 'Editorial Review' );
-		expect( labels ).not.toContain( 'Simple Review' );
+		expect( feedbackOptionIds() ).toContain( 'ai-editorial-review' );
+		expect( feedbackOptionIds() ).not.toContain( 'generate-feedback' );
 	} );
 
-	it( 'attaches a one-line description to every starting-screen suggestion', () => {
+	it( 'carries no descriptions, since the labels say what each one does', () => {
 		installAiEditorialReviewData( {
 			optimizeTitleSuggestion: true,
 			proofreadContent: true,
@@ -2039,23 +2044,8 @@ describe( 'getEmptyViewSuggestions', () => {
 		} );
 		installPostTypeMock( 'post' );
 
-		const suggestions = getEmptyViewSuggestions();
-		const byLabel = ( label: string ) =>
-			suggestions.find( ( suggestion ) => suggestion.label === label );
-
-		[
-			'Optimize Title',
-			'Proofread',
-			'Simple Review',
-			'Editorial Review',
-			'SEO Enhancer',
-			'Generate Excerpt',
-		].forEach( ( label ) => {
-			const suggestion = byLabel( label );
-			expect( suggestion ).toBeDefined();
-			expect( typeof suggestion?.description ).toBe( 'string' );
-			expect( suggestion?.description ).toBeTruthy();
-			expect( suggestion?.description ).not.toContain( '\n' );
+		getEmptyViewSuggestions().forEach( ( suggestion ) => {
+			expect( suggestion.description ).toBeUndefined();
 		} );
 	} );
 
@@ -2475,7 +2465,7 @@ describe( 'useSuggestions', () => {
 
 		const emptyViewLabels = getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label );
 		expect( emptyViewLabels ).toContain( 'Optimize Title' );
-		expect( emptyViewLabels ).toContain( 'Editorial Review' );
+		expect( emptyViewLabels ).toContain( 'Get feedback' );
 
 		// Chip exposure is tracked by Agents Manager's jetpack_big_sky_chat_suggestions_rendered.
 		expect( getTracksCalls( 'jetpack_ai_editorial_review_suggestion_rendered' ) ).toEqual( [] );
@@ -2591,8 +2581,9 @@ describe( 'useSuggestions', () => {
 			onSuggestions.mock.calls[ onSuggestions.mock.calls.length - 1 ]?.[ 0 ] ?? [];
 		expect( latestSuggestions ).toEqual( [] );
 		expect( getEmptyViewSuggestions().map( ( suggestion ) => suggestion.label ) ).toEqual( [
-			'Editorial Review',
+			'Get feedback',
 		] );
+		expect( feedbackOptionIds() ).toEqual( [ 'ai-editorial-review' ] );
 	} );
 
 	it( 'keeps Simple Review on the backend path without opening split-screen when clicked', () => {
@@ -2600,9 +2591,7 @@ describe( 'useSuggestions', () => {
 		installPostTypeMock( 'post' );
 		const addMessage = jest.fn();
 		const clearSuggestions = jest.fn();
-		const feedbackPrompt = getEmptyViewSuggestions().find(
-			( suggestion ) => suggestion.id === 'generate-feedback'
-		)?.prompt;
+		const feedbackPrompt = feedbackOptionPrompt( 'generate-feedback' );
 
 		expect( feedbackPrompt ).toContain( 'saved title and saved block content' );
 		expect( feedbackPrompt ).toContain( 'one-click suggestions when safe' );
@@ -2629,16 +2618,14 @@ describe( 'useSuggestions', () => {
 	it( 'does not open split-screen when the Proofread suggestion is clicked', () => {
 		installAiEditorialReviewData( { proofreadContent: true } );
 		installPostTypeMock( 'post' );
-		const proofreadPrompt = getEmptyViewSuggestions().find(
-			( suggestion ) => suggestion.id === 'proofread-content'
-		)?.prompt;
+		const proofreadPrompt = feedbackOptionPrompt( 'proofread-content' );
 
 		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
 
 		act( () => {
 			window.dispatchEvent(
 				new CustomEvent( 'big-sky-inline-suggestion-click', {
-					detail: { value: proofreadPrompt, suggestionId: 'proofread-content' },
+					detail: { value: proofreadPrompt, suggestionId: 'get-feedback' },
 				} )
 			);
 		} );
@@ -2654,7 +2641,7 @@ describe( 'useSuggestions', () => {
 		act( () => {
 			window.dispatchEvent(
 				new CustomEvent( 'big-sky-inline-suggestion-click', {
-					detail: { suggestionId: 'ai-editorial-review' },
+					detail: { suggestionId: 'get-feedback' },
 				} )
 			);
 		} );
@@ -2731,7 +2718,7 @@ describe( 'useSuggestions', () => {
 		act( () => {
 			window.dispatchEvent(
 				new CustomEvent( 'big-sky-inline-suggestion-click', {
-					detail: { suggestionId: 'ai-editorial-review' },
+					detail: { suggestionId: 'get-feedback' },
 				} )
 			);
 		} );
@@ -2803,9 +2790,7 @@ describe( 'useSuggestions', () => {
 		installAiEditorialReviewData( { proofreadContent: true } );
 		installPostTypeMock( 'post' );
 		mockSelectedBlock = { clientId: 'b-proofread', name: 'core/paragraph' };
-		const proofreadPrompt = getEmptyViewSuggestions().find(
-			( suggestion ) => suggestion.id === 'proofread-content'
-		)?.prompt;
+		const proofreadPrompt = feedbackOptionPrompt( 'proofread-content' );
 		const onSuggestions = jest.fn();
 
 		render( React.createElement( SuggestionsProbe, { onSuggestions } ) );
@@ -2813,7 +2798,7 @@ describe( 'useSuggestions', () => {
 		act( () => {
 			window.dispatchEvent(
 				new CustomEvent( 'big-sky-inline-suggestion-click', {
-					detail: { value: proofreadPrompt, suggestionId: 'proofread-content' },
+					detail: { value: proofreadPrompt, suggestionId: 'get-feedback' },
 				} )
 			);
 			useAbilitiesSetup( {
@@ -2927,16 +2912,14 @@ describe( 'contextProvider', () => {
 	it( 'suppresses full page content for the next Simple Review chip request', () => {
 		installAiEditorialReviewData();
 		installContextProviderMock();
-		const feedbackPrompt = getEmptyViewSuggestions().find(
-			( suggestion ) => suggestion.id === 'generate-feedback'
-		)?.prompt;
+		const feedbackPrompt = feedbackOptionPrompt( 'generate-feedback' );
 
 		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
 
 		act( () => {
 			window.dispatchEvent(
 				new CustomEvent( 'big-sky-inline-suggestion-click', {
-					detail: { value: feedbackPrompt, suggestionId: 'generate-feedback' },
+					detail: { value: feedbackPrompt, suggestionId: 'get-feedback' },
 				} )
 			);
 		} );
@@ -2951,16 +2934,14 @@ describe( 'contextProvider', () => {
 	it( 'suppresses full page content for the next Proofread chip request', () => {
 		installAiEditorialReviewData( { proofreadContent: true } );
 		installContextProviderMock();
-		const proofreadPrompt = getEmptyViewSuggestions().find(
-			( suggestion ) => suggestion.id === 'proofread-content'
-		)?.prompt;
+		const proofreadPrompt = feedbackOptionPrompt( 'proofread-content' );
 
 		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
 
 		act( () => {
 			window.dispatchEvent(
 				new CustomEvent( 'big-sky-inline-suggestion-click', {
-					detail: { value: proofreadPrompt, suggestionId: 'proofread-content' },
+					detail: { value: proofreadPrompt, suggestionId: 'get-feedback' },
 				} )
 			);
 		} );
@@ -3003,27 +2984,22 @@ describe( 'contextProvider', () => {
 	it( 'clears pending Simple Review content suppression when another suggestion is clicked', () => {
 		installAiEditorialReviewData();
 		installContextProviderMock();
-		const suggestions = getEmptyViewSuggestions();
-		const feedbackPrompt = suggestions.find(
-			( suggestion ) => suggestion.id === 'generate-feedback'
-		)?.prompt;
-		const aiEditorialReviewPrompt = suggestions.find(
-			( suggestion ) => suggestion.id === 'ai-editorial-review'
-		)?.prompt;
+		const feedbackPrompt = feedbackOptionPrompt( 'generate-feedback' );
+		const aiEditorialReviewPrompt = feedbackOptionPrompt( 'ai-editorial-review' );
 
 		render( React.createElement( SuggestionsProbe, { onSuggestions: jest.fn() } ) );
 
 		act( () => {
 			window.dispatchEvent(
 				new CustomEvent( 'big-sky-inline-suggestion-click', {
-					detail: { value: feedbackPrompt, suggestionId: 'generate-feedback' },
+					detail: { value: feedbackPrompt, suggestionId: 'get-feedback' },
 				} )
 			);
 			window.dispatchEvent(
 				new CustomEvent( 'big-sky-inline-suggestion-click', {
 					detail: {
 						value: aiEditorialReviewPrompt,
-						suggestionId: 'ai-editorial-review',
+						suggestionId: 'get-feedback',
 					},
 				} )
 			);

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -149,10 +149,6 @@ function canSwapBlockEditSnapshot( snapshot: BlockEditSnapshot ): boolean {
 const OPTIMIZE_TITLE_SUGGESTION = {
 	id: 'optimize-title',
 	label: __( 'Optimize Title', __i18n_text_domain__ ),
-	description: __(
-		'Refine the title based on your post’s content and SEO best practices.',
-		__i18n_text_domain__
-	),
 	prompt: __( 'Optimize the title of this post', __i18n_text_domain__ ),
 };
 
@@ -166,10 +162,6 @@ const OPTIMIZE_TITLE_SUGGESTION = {
 const GENERATE_FEATURED_IMAGE_SUGGESTION = {
 	id: 'generate-featured-image',
 	label: __( 'Generate featured image', __i18n_text_domain__ ),
-	description: __(
-		'Create a new image with AI and set it as the featured image.',
-		__i18n_text_domain__
-	),
 	prompt: '',
 	action: () => ! openImageStudioForFeaturedImage(),
 };
@@ -183,7 +175,6 @@ const GENERATE_FEATURED_IMAGE_SUGGESTION = {
 const GENERATE_EXCERPT_SUGGESTION = {
 	id: 'generate-excerpt',
 	label: __( 'Generate Excerpt', __i18n_text_domain__ ),
-	description: __( 'Generate an excerpt for your post.', __i18n_text_domain__ ),
 	prompt: __( 'Generate an excerpt for this post', __i18n_text_domain__ ),
 };
 
@@ -206,10 +197,6 @@ const GENERATE_EXCERPT_SUGGESTION = {
 const SEO_ENHANCER_SUGGESTION = {
 	id: 'seo-enhancer',
 	label: __( 'SEO Enhancer', __i18n_text_domain__ ),
-	description: __(
-		'Generate metadata for the contents of the post to optimize SEO.',
-		__i18n_text_domain__
-	),
 	prompt: '',
 	options: [
 		{
@@ -233,36 +220,48 @@ const SEO_ENHANCER_SUGGESTION = {
 	],
 };
 
-/** Editor-level suggestion to run AI Editorial Review on saved content. */
-const AI_EDITORIAL_REVIEW_SUGGESTION = {
+/**
+ * The three review tools share one dropdown. Each option's `value` is the whole
+ * prompt, which the dropdown submits verbatim because the parent `prompt` is empty
+ * — the same arrangement SEO Enhancer uses.
+ */
+const GET_FEEDBACK_SUGGESTION_ID = 'get-feedback';
+
+const AI_EDITORIAL_REVIEW_OPTION = {
 	id: 'ai-editorial-review',
-	label: __( 'Editorial Review', __i18n_text_domain__ ),
-	description: __( 'In-depth review against your content guidelines.', __i18n_text_domain__ ),
-	prompt: __(
+	label: __( 'In-depth review against guidelines', __i18n_text_domain__ ),
+	value: __(
 		'Run an AI Editorial Review for this post. Check the content, reviewer notes, and site guidelines, then surface conflicts, implications, guideline issues, and suggested edits.',
 		__i18n_text_domain__
 	),
 };
 
-const POST_FEEDBACK_SUGGESTION = {
+const POST_FEEDBACK_OPTION = {
 	id: 'generate-feedback',
-	label: __( 'Simple Review', __i18n_text_domain__ ),
-	description: __( 'Quick feedback on your content’s structure.', __i18n_text_domain__ ),
-	prompt: __(
+	label: __( 'Quick feedback on structure', __i18n_text_domain__ ),
+	value: __(
 		'Generate feedback for this saved post. Review the saved title and saved block content for content structure, reader clarity, completeness, media/caption/link issues, and obvious publishability concerns. Return practical feedback with one-click suggestions when safe.',
 		__i18n_text_domain__
 	),
 };
 
-const PROOFREAD_SUGGESTION = {
+const PROOFREAD_OPTION = {
 	id: 'proofread-content',
-	label: __( 'Proofread', __i18n_text_domain__ ),
-	description: __( 'Correct spelling, grammar, and punctuation.', __i18n_text_domain__ ),
-	prompt: __(
+	label: __( 'Spelling and grammar check', __i18n_text_domain__ ),
+	value: __(
 		'Proofread this saved post for spelling, grammar, and punctuation. Review the saved title and saved block content, and return practical fixes with one-click suggestions when safe.',
 		__i18n_text_domain__
 	),
 };
+
+/**
+ * Both abilities read the saved post, so the edited page content would mislead
+ * them. Matched by prompt rather than id: a dropdown submits its parent's id.
+ */
+const SAVED_POST_PROMPTS: Set< string > = new Set( [
+	POST_FEEDBACK_OPTION.value,
+	PROOFREAD_OPTION.value,
+] );
 
 const LIMITED_BLOCK_SUGGESTION_PRIORITY = [
 	'translate',
@@ -440,11 +439,32 @@ function isProofreadAvailable(
 	);
 }
 
-function getAiEditorialReviewSuggestions( currentPostType?: string ) {
-	if ( ! isAiEditorialReviewAvailable( currentPostType ) ) {
+/**
+ * The review tools as one dropdown, carrying only the options this post qualifies
+ * for. With none available the dropdown is dropped entirely.
+ */
+function getFeedbackSuggestions( currentPostType?: string, currentPostId?: EditorPostId | null ) {
+	const options = [
+		...( isGenerateFeedbackAvailable( currentPostType, currentPostId )
+			? [ POST_FEEDBACK_OPTION ]
+			: [] ),
+		...( isProofreadAvailable( currentPostType, currentPostId ) ? [ PROOFREAD_OPTION ] : [] ),
+		...( isAiEditorialReviewAvailable( currentPostType ) ? [ AI_EDITORIAL_REVIEW_OPTION ] : [] ),
+	];
+
+	if ( options.length === 0 ) {
 		return [];
 	}
-	return [ AI_EDITORIAL_REVIEW_SUGGESTION ];
+
+	return [
+		{
+			id: GET_FEEDBACK_SUGGESTION_ID,
+			label: __( 'Get feedback', __i18n_text_domain__ ),
+			// Empty, so the dropdown submits the picked option's value verbatim.
+			prompt: '',
+			options,
+		},
+	];
 }
 
 function getPostLevelSuggestions(
@@ -464,18 +484,14 @@ function getPostLevelSuggestions(
 		...( isExcerptSuggestionAvailable( currentPostType, supportsExcerpt )
 			? [ GENERATE_EXCERPT_SUGGESTION ]
 			: [] ),
-		...( isGenerateFeedbackAvailable( currentPostType, currentPostId )
-			? [ POST_FEEDBACK_SUGGESTION ]
-			: [] ),
-		...( isProofreadAvailable( currentPostType, currentPostId ) ? [ PROOFREAD_SUGGESTION ] : [] ),
-		...getAiEditorialReviewSuggestions( currentPostType ),
+		...getFeedbackSuggestions( currentPostType, currentPostId ),
 		// Surface the SEO Enhancer dropdown last.
 		...( isSeoSuggestionsEnabled() ? [ SEO_ENHANCER_SUGGESTION ] : [] ),
 	];
 }
 
 function getReservedSuggestions< T extends { id: string } >( suggestions: T[] ): T[] {
-	return [ POST_FEEDBACK_SUGGESTION.id, PROOFREAD_SUGGESTION.id, AI_EDITORIAL_REVIEW_SUGGESTION.id ]
+	return [ GET_FEEDBACK_SUGGESTION_ID ]
 		.map( ( id ) => suggestions.find( ( suggestion ) => suggestion.id === id ) )
 		.filter( Boolean ) as T[];
 }
@@ -1434,10 +1450,7 @@ export function useSuggestions( maxSuggestions?: number ): {
 				? getSelectedOrRememberedBlock()?.clientId ?? null
 				: null;
 
-			if ( matchesSuggestion( POST_FEEDBACK_SUGGESTION ) ) {
-				suppressCurrentPageContentForNextContext = true;
-			}
-			if ( matchesSuggestion( PROOFREAD_SUGGESTION ) ) {
+			if ( typeof value === 'string' && SAVED_POST_PROMPTS.has( value ) ) {
 				suppressCurrentPageContentForNextContext = true;
 			}
 		};


### PR DESCRIPTION
Part of FORNO-481

## Proposed Changes

* Drop the suggestion descriptions, which repeated their labels.
* Group Simple Review, Proofread and Editorial Review under one Get feedback dropdown. Their old descriptions become the option labels.
* By grouping the review suggestions, Tracks events for suggestion clicks will now be tracked under the `get-feedback` suggestion ID (consistent with how SEO suggestions are currently tracked)

| Before | After | 
| :--- | :---: | 
| <img width="338" height="654" alt="Screenshot 2026-08-19 at 12 05 16" src="https://github.com/user-attachments/assets/8c7215a6-6214-4fe2-abda-9c68d60ce66f" /> | <img width="339" height="382" alt="Screenshot 2026-08-19 at 12 04 29" src="https://github.com/user-attachments/assets/70fbb894-4143-4fe2-8c16-44d3a808587e" /> | 

## Why are these changes being made?

* The descriptions add a lot of text and cause the suggestion list to take up a lot of space while often duplicating the suggestion title.

## Testing Instructions

* Checkout this branch
* `cd apps/agents-manager && yarn dev --sync`
* Sandbox widgets.wp.com
* Open a post. The writing suggestions should show Get feedback in place of the three review chips, and no descriptions.
* Pick each option. Each should behave as its chip did.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
