### PR TITLE
Logs: wrap long User agent values in the server logs table

### DIFF
--- a/client/dashboard/sites/logs/dataviews/fields.tsx
+++ b/client/dashboard/sites/logs/dataviews/fields.tsx
@@ -246,6 +246,9 @@ export function useFields( {
 				label: __( 'User agent' ),
 				enableSorting: false,
 				getValue: ( { item }: { item: ServerLog } ) => item.http_user_agent,
+				render: ( { item }: DataViewRenderFieldProps< ServerLog > ) => (
+					<span className="site-logs-wrap">{ String( item.http_user_agent ) }</span>
+				),
 				filterBy: { operators: [] as Operator[] },
 			},
 			{


### PR DESCRIPTION
Fixes DOTMSD-1381

## Proposed Changes

* Wrap long values in the "User agent" column of the Web Server Logs table, matching how "Request URL" and "HTTP referrer" already behave.

## Why are these changes being made?

* User agent strings are long, and the column rendered them without any wrapping. The column stretched to fit the longest entry and the text spilled over the neighbouring columns, making the table unreadable once the column was enabled.
* The other long-text columns in this table were already given a wrapping treatment when they were added; the User agent column was added later and missed it.

## Testing Instructions

* Open a site's Web Server Logs.
* Via the view options, add the "User agent" column to the table.
* Confirm long user agent strings now wrap onto multiple lines inside their own column, and no longer overlap adjacent columns.
* Confirm "Request URL" and "HTTP referrer" are unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
