### PR TITLE
E2E: drop the dashboard rollout flag override

### DIFF
--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -13,10 +13,6 @@ import { SidebarComponent } from './components/sidebar-component';
 import { LoginPage } from './pages/login-page';
 import type { TestAccountCredentials } from '../secrets';
 
-// Feature flags forced on for every E2E session, in the `flags` cookie format that
-// @automattic/calypso-config reads: a leading `-` disables.
-const FLAG_OVERRIDES = [ '-dashboard/enable-percentage-rollout' ];
-
 /**
  * Represents the WPCOM test account.
  */
@@ -58,7 +54,6 @@ export class TestAccount {
 	): Promise< void > {
 		const browserContext = page.context();
 		await browserContext.clearCookies();
-		await TestAccount.applyFlagOverrides( browserContext );
 
 		if ( await this.hasFreshAuthCookies() ) {
 			this.log( 'Found fresh cookies, skipping log in' );
@@ -75,27 +70,6 @@ export class TestAccount {
 		if ( waitUntilStable ) {
 			await TestAccount.waitForAppShell( page );
 		}
-	}
-
-	/**
-	 * Opts every E2E session out of the hosting dashboard rollout.
-	 *
-	 * These specs target classic Calypso, so they should not be moved onto the
-	 * dashboard by a percentage rollout they have no control over. Overrides are
-	 * honored in development, on the staging environments and on calypso.live, and
-	 * ignored on production, so release runs against production are unaffected.
-	 *
-	 * @param {BrowserContext} browserContext Browser context to set the cookie on.
-	 */
-	private static async applyFlagOverrides( browserContext: BrowserContext ): Promise< void > {
-		await browserContext.addCookies( [
-			{
-				name: 'flags',
-				value: FLAG_OVERRIDES.join( ',' ),
-				domain: new URL( getCalypsoURL( '/' ) ).hostname,
-				path: '/',
-			},
-		] );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed Changes

* Stop forcing every authenticated E2E session out of the hosting dashboard rollout, so tests run against whichever app shell a real user would get.

## Why are these changes being made?

* The override was added while the dashboard rollout was partial: specs written against classic Calypso would have been randomly moved onto the dashboard by an enrollment they had no control over.
* The rollout is now at 100%, so pinning the suite to classic Calypso means E2E is testing a surface users no longer see, and it hides dashboard regressions.
* This PR exists mainly to find out what actually breaks — the login path already tolerates either shell, so the interesting signal is which specs still assume the classic UI after login.

## Testing Instructions

* Let CI run the E2E suites on this branch and compare failures against trunk.
* Any new failure should be a spec asserting classic Calypso UI after login; those are the follow-up work, not a reason to restore the override.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
