### PR TITLE
Dashboard: stop persisting query-param filters into the saved view

### DIFF
--- a/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
+++ b/client/dashboard/app/hooks/test/use-persistent-view.test.tsx
@@ -7,7 +7,7 @@ import { createRouter, RouterProvider, createRootRoute, createRoute } from '@tan
 import { act, renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { Suspense } from 'react';
-import { usePersistentView } from '../use-persistent-view';
+import { useBasePersistentView, usePersistentView } from '../use-persistent-view';
 import type { View } from '@wordpress/dataviews';
 
 const defaultView: View = {
@@ -315,7 +315,156 @@ describe( 'usePersistentView', () => {
 		} );
 	} );
 
+	// These exercise query param changes across re-renders, which the router-based wrapper
+	// cannot do (it rebuilds the router, and so remounts the hook, on every render).
+	describe( 'transient filters', () => {
+		const renderTransientView = ( getQueryParams: () => any ) => {
+			const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+			const navigate = jest.fn();
+			const utils = renderHook(
+				() =>
+					useBasePersistentView( {
+						slug,
+						defaultView,
+						queryParams: getQueryParams(),
+						queryParamFilterFields: [ 'domainName' ],
+						navigate,
+					} ),
+				{
+					wrapper: ( { children } ) => (
+						<QueryClientProvider client={ queryClient }>
+							<Suspense fallback={ null }>{ children }</Suspense>
+						</QueryClientProvider>
+					),
+				}
+			);
+
+			return { ...utils, navigate };
+		};
+
+		it( 'should not persist a transient filter whose value was edited', async () => {
+			mockGetCalypsoPreferences( {} );
+			const unexpectedUpdatePreferences = mockUpdateCalypsoPreferences();
+
+			const queryParams = { 'current-param': 'current-value', domainName: 'a.com' };
+			const { result, navigate } = renderTransientView( () => queryParams );
+
+			await waitFor( () => {
+				expect( result.current.updateView ).toBeTruthy();
+			} );
+
+			act( () => {
+				result.current.updateView( {
+					...defaultView,
+					filters: [ { field: 'domainName', operator: 'isAny', value: [ 'b.com' ] } ],
+				} );
+			} );
+
+			// The query param no longer describes the filter, so it is dropped from the URL.
+			expect( navigate ).toHaveBeenCalledWith( {
+				search: { 'current-param': 'current-value' },
+				replace: true,
+			} );
+
+			// The edited filter stays on the view, but only for this session.
+			expect( result.current.view.filters ).toEqual( [
+				{ field: 'domainName', operator: 'isAny', value: [ 'b.com' ] },
+			] );
+			expect( unexpectedUpdatePreferences.isDone() ).toBe( false );
+		} );
+
+		it( 'should keep a transient filter transient after its query param is dropped', async () => {
+			mockGetCalypsoPreferences( {} );
+			const unexpectedUpdatePreferences = mockUpdateCalypsoPreferences();
+
+			let queryParams: any = { domainName: 'a.com' };
+			const { result, rerender } = renderTransientView( () => queryParams );
+
+			await waitFor( () => {
+				expect( result.current.updateView ).toBeTruthy();
+			} );
+
+			act( () => {
+				result.current.updateView( {
+					...defaultView,
+					filters: [ { field: 'domainName', operator: 'isAny', value: [ 'b.com' ] } ],
+				} );
+			} );
+
+			// Mirror the navigation that dropped the query param.
+			queryParams = {};
+			rerender();
+
+			expect( result.current.view.filters ).toEqual( [
+				{ field: 'domainName', operator: 'isAny', value: [ 'b.com' ] },
+			] );
+
+			act( () => {
+				result.current.updateView( {
+					...result.current.view,
+					filters: [ { field: 'domainName', operator: 'isAny', value: [ 'c.com' ] } ],
+				} );
+			} );
+
+			expect( result.current.view.filters ).toEqual( [
+				{ field: 'domainName', operator: 'isAny', value: [ 'c.com' ] },
+			] );
+			expect( unexpectedUpdatePreferences.isDone() ).toBe( false );
+		} );
+
+		it( 'should re-seed the transient filter when the query param value changes', async () => {
+			mockGetCalypsoPreferences( {} );
+
+			let queryParams: any = { domainName: 'a.com' };
+			const { result, rerender } = renderTransientView( () => queryParams );
+
+			await waitFor( () => {
+				expect( result.current.view.filters ).toEqual( [
+					{ field: 'domainName', operator: 'isAny', value: [ 'a.com' ] },
+				] );
+			} );
+
+			queryParams = { domainName: 'b.com' };
+			rerender();
+
+			await waitFor( () => {
+				expect( result.current.view.filters ).toEqual( [
+					{ field: 'domainName', operator: 'isAny', value: [ 'b.com' ] },
+				] );
+			} );
+		} );
+	} );
+
 	describe( 'resetView', () => {
+		it( 'should be available while only a transient filter is active, and clear it', async () => {
+			mockGetCalypsoPreferences( {} );
+			mockUpdateCalypsoPreferences();
+
+			const { Wrapper, getRouter } = createTestWrapper();
+
+			const queryParams = { 'current-param': 'current-value', domainName: 'a.com' };
+			const queryParamFilterFields = [ 'domainName' ];
+			const { result } = renderHook(
+				() => usePersistentView( { slug, defaultView, queryParams, queryParamFilterFields } ),
+				{ wrapper: Wrapper }
+			);
+
+			await waitFor( () => {
+				expect( result.current.resetView ).toBeTruthy();
+			} );
+
+			act( () => {
+				result.current.resetView?.();
+			} );
+
+			await waitFor( () => {
+				expect( getRouter()?.state.location.search ).toEqual( {
+					'current-param': 'current-value',
+				} );
+			} );
+			expect( result.current.view.filters ).toBeUndefined();
+		} );
+
 		it( 'should clear the persisted view', async () => {
 			const persistedView = {
 				type: 'grid',

--- a/client/dashboard/app/hooks/use-persistent-view.ts
+++ b/client/dashboard/app/hooks/use-persistent-view.ts
@@ -88,23 +88,36 @@ export function useBasePersistentView( {
 
 	const transientProperties = useMemo( () => ( { page, search } ), [ page, search ] );
 
-	const transientFilterFields = queryParamFilterFields.filter(
-		( field ) => queryParams && queryParams[ field ] !== undefined
+	const filterFieldsKey = JSON.stringify( queryParamFilterFields );
+	const filterFields = useMemo(
+		() => queryParamFilterFields,
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[ filterFieldsKey ]
 	);
 
-	const [ transientFilters, setTransientFilters ] = useState< Filter[] >( () =>
-		queryParamFilterFields
-			.filter( ( field ) => queryParams && queryParams[ field ] !== undefined )
-			.map( ( field ) => getTransientFilter( field, queryParams[ field ] ) )
+	const [ transientFilterState, setTransientFilterState ] = useState< TransientFilterState >( () =>
+		getTransientFilterState( filterFields, queryParams )
+	);
+	const { filters: transientFilters, seeds: transientFilterSeeds } = transientFilterState;
+	const transientFilterFields = useMemo(
+		() => transientFilters.map( ( { field } ) => field ),
+		[ transientFilters ]
 	);
 
+	// Re-seed whenever the query params themselves change, so that navigating from
+	// `?domainName=a.com` to `?domainName=b.com` without unmounting picks up the new value.
+	const seedKey = JSON.stringify(
+		filterFields.map( ( field ) => [ field, queryParams?.[ field ] ?? null ] )
+	);
 	useEffect( () => {
-		setTransientFilters(
-			transientFilterFields.map( ( field ) => getTransientFilter( field, queryParams[ field ] ) )
+		setTransientFilterState( ( current ) =>
+			filterFields.some( ( field ) => queryParams?.[ field ] !== current.seeds[ field ] )
+				? getTransientFilterState( filterFields, queryParams )
+				: current
 		);
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ JSON.stringify( transientFilterFields ) ] );
+	}, [ seedKey ] );
 
 	useEffect( () => {
 		if ( ! matches || matches.length === 0 ) {
@@ -113,7 +126,9 @@ export function useBasePersistentView( {
 
 		let transientQueryParams: Record< string, unknown > = {};
 		transientFilters.forEach( ( { field } ) => {
-			transientQueryParams[ field ] = queryParams[ field ];
+			if ( queryParams?.[ field ] !== undefined ) {
+				transientQueryParams[ field ] = queryParams[ field ];
+			}
 		} );
 		transientQueryParams = mergeQueryParamsWithTransientProperties(
 			transientQueryParams,
@@ -149,14 +164,33 @@ export function useBasePersistentView( {
 
 	const updateView = useCallback(
 		( newView: View ) => {
-			const newTransientFilterFields = transientFilterFields.filter(
-				( field ) =>
-					newView.filters?.some(
+			const newTransientFilters = transientFilterFields
+				.map( ( field ) => newView.filters?.find( ( filter ) => filter.field === field ) )
+				.filter( ( filter ): filter is Filter => filter !== undefined );
+
+			// A query param only describes the view for as long as its filter is untouched.
+			// Once the value is edited or the filter is removed, the param is dropped, but the
+			// filter itself stays transient so that it is never written to the preference.
+			const staleQueryParamFields = filterFields.filter( ( field ) => {
+				const seed = transientFilterSeeds[ field ];
+				return (
+					seed !== undefined &&
+					! newTransientFilters.some(
 						( filter ) =>
-							filter.field === field &&
-							fastDeepEqual( filter.value, getTransientFilter( field, queryParams[ field ] ).value )
+							filter.field === field && fastDeepEqual( filter, getTransientFilter( field, seed ) )
 					)
-			);
+				);
+			} );
+
+			if (
+				staleQueryParamFields.length > 0 ||
+				! fastDeepEqual( newTransientFilters, transientFilters )
+			) {
+				setTransientFilterState( ( current ) => ( {
+					filters: newTransientFilters,
+					seeds: { ...current.seeds, ...clearSeeds( staleQueryParamFields ) },
+				} ) );
+			}
 
 			if ( queryParams ) {
 				const newTransientProperties = {
@@ -164,10 +198,12 @@ export function useBasePersistentView( {
 					search: newView.search,
 				};
 
-				if ( ! fastDeepEqual( newTransientFilterFields, transientFilterFields ) ) {
-					setTransientFilters( [] );
+				if ( staleQueryParamFields.length > 0 ) {
 					navigate( {
-						search: clearQueryParamsFromTransientFilters( queryParams, transientFilterFields ),
+						search: mergeQueryParamsWithTransientProperties(
+							clearQueryParamsFromTransientFilters( queryParams, staleQueryParamFields ),
+							newTransientProperties
+						),
 						replace: true,
 					} );
 				} else if ( ! fastDeepEqual( newTransientProperties, transientProperties ) ) {
@@ -180,7 +216,7 @@ export function useBasePersistentView( {
 
 			let viewToPersist = newView;
 			viewToPersist = removeTransientPropertiesFromView( viewToPersist );
-			viewToPersist = removeTransientFiltersFromView( viewToPersist, newTransientFilterFields );
+			viewToPersist = removeTransientFiltersFromView( viewToPersist, transientFilterFields );
 			viewToPersist = removeEmptyFiltersFromView( viewToPersist );
 
 			// Persist view if different from baseView.
@@ -195,7 +231,10 @@ export function useBasePersistentView( {
 		[
 			queryParams,
 			transientProperties,
+			transientFilters,
 			transientFilterFields,
+			transientFilterSeeds,
+			filterFields,
 			navigate,
 			baseView,
 			defaultView,
@@ -203,17 +242,53 @@ export function useBasePersistentView( {
 		]
 	);
 
-	const isViewModified = !! persistedView;
+	const isViewModified = !! persistedView || transientFilters.length > 0;
 
 	const resetView = useCallback( () => {
 		persistView( undefined );
+		setTransientFilterState( ( current ) => ( {
+			filters: [],
+			seeds: clearSeeds( Object.keys( current.seeds ) ),
+		} ) );
 		navigate( {
-			search: mergeQueryParamsWithTransientProperties( queryParams, { page: 1, search: '' } ),
+			search: mergeQueryParamsWithTransientProperties(
+				clearQueryParamsFromTransientFilters( queryParams, filterFields ),
+				{ page: 1, search: '' }
+			),
 			replace: true,
 		} );
-	}, [ persistView, navigate, queryParams ] );
+	}, [ persistView, navigate, queryParams, filterFields ] );
 
 	return { view, updateView, resetView: isViewModified ? resetView : undefined };
+}
+
+/**
+ * Filters seeded from the URL query params, alongside the raw param values they were
+ * seeded from. Comparing the seeds against the current params tells us whether the
+ * params changed underneath us, and keeps a filter transient once its param is dropped.
+ */
+interface TransientFilterState {
+	filters: Filter[];
+	seeds: Record< string, unknown >;
+}
+
+function getTransientFilterState( fields: string[], queryParams: any ): TransientFilterState {
+	const seeds: Record< string, unknown > = {};
+	const filters: Filter[] = [];
+
+	fields.forEach( ( field ) => {
+		const rawValue = queryParams?.[ field ];
+		seeds[ field ] = rawValue;
+		if ( rawValue !== undefined ) {
+			filters.push( getTransientFilter( field, rawValue ) );
+		}
+	} );
+
+	return { filters, seeds };
+}
+
+function clearSeeds( fields: string[] ): Record< string, unknown > {
+	return Object.fromEntries( fields.map( ( field ) => [ field, undefined ] ) );
 }
 
 function getTransientFilter( field: string, rawValue: unknown ): Filter {


### PR DESCRIPTION
Fixes DOTMSD-1499

## Proposed Changes

* Stop writing filters that came from a URL query param into the saved-view preference, including after their value is edited.
* Re-apply a query-param filter when the param's *value* changes, not only when the set of params changes.
* Make Reset clear the query-param filter as well as the saved view, and offer Reset when such a filter is the only thing active.

## Why are these changes being made?

* Opening `/emails?domainName=a.com` seeds a temporary domain filter. Changing that filter to another domain in the dropdown saved it to the user's preferences, so every later visit to a bare `/emails` was silently filtered to that domain — with nothing in the URL to explain it and only the small dot on the filter button as a hint. Mailboxes and forwarders on every other domain simply appeared to be missing, which is an easy way for someone to conclude their email forwards are gone.
* The filter was only ever meant to last for the visit. The old code decided what to strip before saving by checking which filters still matched the query param they came from — so the moment a value was edited, the filter stopped being recognised as temporary and was saved instead.
* The same code path had two smaller rough edges, fixed here: Reset left the temporary filter in place, and moving between two links that differ only in the param value kept filtering by the old one.

Found during a UX audit of the email list, prompted by a user having trouble with the email forwards UI.

## Testing Instructions

* Open a site's domain overview and follow the Emails link, so you land on `/emails` with a `domainName` param.
* In the filter dropdown, change the domain to a different one — don't clear it.
* Confirm the list now shows the newly chosen domain and the param drops out of the URL.
* Open `/emails` fresh (top nav or command palette) and confirm the list is unfiltered.
* Repeat step 2 but clear the filter instead, and confirm the list is unfiltered and the param is gone.
* With a param-seeded filter active, use Reset and confirm the filter clears.
* Worth a pass on the other lists that use the same mechanism: Sites, Deployments, Purchases, Billing history.

## Considerations

* An alternative was to keep the URL authoritative and rewrite the param to the new value on every edit. Each of these routes validates its param as a single string, so a multi-select filter can't round-trip through it — that option would have meant changing five route schemas and still failing for multi-value selections. Dropping the param on edit is the existing behaviour and is left as-is; the change is only that the filter no longer leaks into storage on its way out.
* The edited filter deliberately stays applied for the rest of the visit rather than disappearing, so that editing it doesn't look like it silently reverted.
* Unrelated, so left alone: the router in this hook's test wrapper is rebuilt inside the component body, so `rerender()` remounts the hook and resets its state. That makes query-param-change tests impossible to write against it, so the new tests drive the router-free `useBasePersistentView` export with a mock navigate. Worth fixing separately before someone writes a rerender-based test that passes for the wrong reason.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
