### PR TITLE
Stats: instrument the pre-connection plan choice

### DIFF
--- a/apps/odyssey-stats/src/lib/jetpack-connection.ts
+++ b/apps/odyssey-stats/src/lib/jetpack-connection.ts
@@ -61,20 +61,45 @@ interface Registration {
 }
 
 /**
+ * Why registration failed. The message cannot answer that: the REST API returns it already
+ * translated, it can name the site, and the failures that do not come from the API carry none at
+ * all — so only a code is worth recording.
+ */
+export type RegistrationErrorCode =
+	| 'no_connection_state'
+	| 'request_failed'
+	| 'http_error'
+	| 'no_authorize_url';
+
+interface RegistrationError extends Error {
+	code: RegistrationErrorCode;
+}
+
+function registrationError( code: RegistrationErrorCode, message = '' ): RegistrationError {
+	return Object.assign( new Error( message ), { code } );
+}
+
+/** Reads the code off a {@link registerSite} rejection; anything else is a request that never completed. */
+export function getRegistrationErrorCode( error: unknown ): RegistrationErrorCode {
+	return ( error as Partial< RegistrationError > | null )?.code ?? 'request_failed';
+}
+
+/**
  * Registers the site with WordPress.com. Registration alone leaves the site connected but nobody
  * signed in, so every caller is expected to send the visitor on to `authorizeUrl`, sooner (the
  * free plan) or later (after checkout, via `connect_after_checkout`).
  *
  * Rejects with the REST API's own (already localized) message where there is one; callers are
- * expected to supply a translated fallback for the rest.
+ * expected to supply a translated fallback for the rest, and to report the rejection's
+ * {@link getRegistrationErrorCode} rather than its message.
  * @param redirectUri Admin path to return to once the user has authorized, relative to `admin_url()`.
- * @throws {Error} When the site prints no connection state, or the request fails.
+ * @throws {RegistrationError} When the site prints no connection state, or the request fails.
  */
 export async function registerSite( redirectUri: string ): Promise< Registration > {
 	const state = getInitialState();
 
 	if ( ! state?.apiRoot ) {
-		throw new Error();
+		throw registrationError( 'no_connection_state' );
 	}
 
 	const response = await globalThis.fetch( `${ state.apiRoot }jetpack/v4/connection/register`, {
@@ -98,8 +123,12 @@ export async function registerSite( redirectUri: string ): Promise< Registration
 
 	const body = await response.json().catch( () => null );
 
-	if ( ! response.ok || ! body?.authorizeUrl ) {
-		throw new Error( body?.message ?? '' );
+	if ( ! response.ok ) {
+		throw registrationError( 'http_error', body?.message ?? '' );
+	}
+
+	if ( ! body?.authorizeUrl ) {
+		throw registrationError( 'no_authorize_url', body?.message ?? '' );
 	}
 
 	return { authorizeUrl: body.authorizeUrl, blogId: readBlogId( body.authorizeUrl ) };

--- a/apps/odyssey-stats/src/lib/jetpack-connection.ts
+++ b/apps/odyssey-stats/src/lib/jetpack-connection.ts
@@ -48,19 +48,29 @@ export function getSiteSuffix(): string {
 	return getInitialState()?.siteSuffix ?? '';
 }
 
+interface Registration {
+	/** Links the current user to a WordPress.com account. */
+	authorizeUrl: string;
+	/**
+	 * The blog id WordPress.com just assigned, read off the authorization URL's `client_id`. It is
+	 * the first identifier this site has ever had, and the only key that ties what happened before
+	 * registration — where events can be keyed by nothing but the site suffix — to everything
+	 * after. `null` if the URL carries no usable one; the site's own Jetpack builds it.
+	 */
+	blogId: number | null;
+}
+
 /**
- * Registers the site with WordPress.com and returns the URL that links the current user to a
- * WordPress.com account. Registration alone leaves the site connected but nobody signed in, so
- * every caller is expected to send the visitor on to this URL, sooner (the free plan) or later
- * (after checkout, via `connect_after_checkout`).
+ * Registers the site with WordPress.com. Registration alone leaves the site connected but nobody
+ * signed in, so every caller is expected to send the visitor on to `authorizeUrl`, sooner (the
+ * free plan) or later (after checkout, via `connect_after_checkout`).
  *
  * Rejects with the REST API's own (already localized) message where there is one; callers are
  * expected to supply a translated fallback for the rest.
- *
  * @param redirectUri Admin path to return to once the user has authorized, relative to `admin_url()`.
  * @throws {Error} When the site prints no connection state, or the request fails.
  */
-export async function registerSite( redirectUri: string ): Promise< string > {
+export async function registerSite( redirectUri: string ): Promise< Registration > {
 	const state = getInitialState();
 
 	if ( ! state?.apiRoot ) {
@@ -92,5 +102,15 @@ export async function registerSite( redirectUri: string ): Promise< string > {
 		throw new Error( body?.message ?? '' );
 	}
 
-	return body.authorizeUrl;
+	return { authorizeUrl: body.authorizeUrl, blogId: readBlogId( body.authorizeUrl ) };
+}
+
+function readBlogId( authorizeUrl: string ): number | null {
+	try {
+		const clientId = Number( new URL( authorizeUrl ).searchParams.get( 'client_id' ) );
+
+		return Number.isInteger( clientId ) && clientId > 0 ? clientId : null;
+	} catch {
+		return null;
+	}
 }

--- a/apps/odyssey-stats/src/lib/test/jetpack-connection.test.js
+++ b/apps/odyssey-stats/src/lib/test/jetpack-connection.test.js
@@ -1,7 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-import { getSiteSuffix, isOfflineMode, registerSite } from '../jetpack-connection';
+import {
+	getRegistrationErrorCode,
+	getSiteSuffix,
+	isOfflineMode,
+	registerSite,
+} from '../jetpack-connection';
 
 const REDIRECT_URI = 'admin.php?page=stats';
 
@@ -134,5 +139,37 @@ describe( 'registerSite', () => {
 
 		await expect( registerSite( REDIRECT_URI ) ).rejects.toThrow( Error );
 		expect( globalThis.fetch ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'getRegistrationErrorCode', () => {
+	// The message cannot stand in for these: it is translated, and empty for all but the first.
+	const codeOfRejection = ( registration ) =>
+		registration.then( () => null, getRegistrationErrorCode );
+
+	it( 'tells the API refusing apart from the API answering with nothing usable', async () => {
+		globalThis.fetch = mockResponse( { ok: false, body: { message: 'Nope.' } } );
+		await expect( codeOfRejection( registerSite( REDIRECT_URI ) ) ).resolves.toBe( 'http_error' );
+
+		globalThis.fetch = mockResponse( { body: {} } );
+		await expect( codeOfRejection( registerSite( REDIRECT_URI ) ) ).resolves.toBe(
+			'no_authorize_url'
+		);
+	} );
+
+	it( 'reports a site that printed no connection state', async () => {
+		delete window.JP_CONNECTION_INITIAL_STATE;
+
+		await expect( codeOfRejection( registerSite( REDIRECT_URI ) ) ).resolves.toBe(
+			'no_connection_state'
+		);
+	} );
+
+	it( 'reads a request that never completed off a bare browser error', async () => {
+		globalThis.fetch = jest.fn().mockRejectedValue( new TypeError( 'Failed to fetch' ) );
+
+		await expect( codeOfRejection( registerSite( REDIRECT_URI ) ) ).resolves.toBe(
+			'request_failed'
+		);
 	} );
 } );

--- a/apps/odyssey-stats/src/lib/test/jetpack-connection.test.js
+++ b/apps/odyssey-stats/src/lib/test/jetpack-connection.test.js
@@ -60,19 +60,30 @@ describe( 'connection state readers', () => {
 	} );
 } );
 
-describe( 'registerSite', () => {
-	it( 'returns the authorization URL the site was given', async () => {
-		globalThis.fetch = mockResponse( {
-			body: { authorizeUrl: 'https://wordpress.com/authorize' },
-		} );
+const AUTHORIZE_URL = 'https://wordpress.com/jetpack/connect/authorize?client_id=123456789';
 
-		await expect( registerSite( REDIRECT_URI ) ).resolves.toBe( 'https://wordpress.com/authorize' );
+describe( 'registerSite', () => {
+	it( 'returns the authorization URL the site was given, and the blog id it names', async () => {
+		globalThis.fetch = mockResponse( { body: { authorizeUrl: AUTHORIZE_URL } } );
+
+		await expect( registerSite( REDIRECT_URI ) ).resolves.toEqual( {
+			authorizeUrl: AUTHORIZE_URL,
+			blogId: 123456789,
+		} );
+	} );
+
+	it.each( [
+		[ 'carries no client id', 'https://wordpress.com/jetpack/connect/authorize' ],
+		[ 'carries one that is not a number', 'https://wordpress.com/authorize?client_id=nonsense' ],
+		[ 'is not a URL at all', 'not-a-url' ],
+	] )( 'reports no blog id when the authorization URL %s', async ( _label, authorizeUrl ) => {
+		globalThis.fetch = mockResponse( { body: { authorizeUrl } } );
+
+		await expect( registerSite( REDIRECT_URI ) ).resolves.toEqual( { authorizeUrl, blogId: null } );
 	} );
 
 	it( 'posts to the site itself, authenticated by the wp-admin session', async () => {
-		globalThis.fetch = mockResponse( {
-			body: { authorizeUrl: 'https://wordpress.com/authorize' },
-		} );
+		globalThis.fetch = mockResponse( { body: { authorizeUrl: AUTHORIZE_URL } } );
 
 		await registerSite( REDIRECT_URI );
 

--- a/apps/odyssey-stats/src/pre-connection/index.tsx
+++ b/apps/odyssey-stats/src/pre-connection/index.tsx
@@ -1,7 +1,7 @@
 import { PRODUCT_JETPACK_STATS_YEARLY } from '@automattic/calypso-products';
 import { Notice } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import StatsMain from 'calypso/my-sites/stats/components/stats-main';
 import PageLoading from 'calypso/my-sites/stats/pages/shared/page-loading';
@@ -10,8 +10,10 @@ import {
 	PRICING_GRID_REFERRER,
 } from 'calypso/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid';
 import PricingGrid from 'calypso/my-sites/stats/pricing-grid/pricing-grid';
+import PageViewTracker from 'calypso/my-sites/stats/stats-page-view-tracker';
 import { StatsSingleItemPagePurchaseFrame } from 'calypso/my-sites/stats/stats-purchase/stats-purchase-shared';
 import { StatsCommercialPurchase } from 'calypso/my-sites/stats/stats-purchase/stats-purchase-single-item';
+import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getSiteSuffix, isOfflineMode, registerSite } from '../lib/jetpack-connection';
@@ -41,22 +43,61 @@ const AUTHORIZE_REDIRECT_URI = `${ STATS_ADMIN_PATH }&${ PLAN_CHOSEN_QUERY_ARG }
 export default function PreConnection() {
 	const translate = useTranslate();
 	const [ authorizeUrl, setAuthorizeUrl ] = useState< string | null >( null );
+	const [ blogId, setBlogId ] = useState< number | null >( null );
 	const [ isRegistering, setIsRegistering ] = useState( false );
 	const [ error, setError ] = useState< string | null >( null );
+
+	const isOffline = isOfflineMode();
+
+	/**
+	 * Nothing here has a blog id to be recorded against, so every event carries the site suffix
+	 * instead — the only identifier the site has until it registers, and what ties this screen to
+	 * the checkout it hands over to. `is_pre_connection` tells these apart from the same grid
+	 * shown on a connected site's dashboard.
+	 */
+	const eventProps = useMemo(
+		() => ( { site_suffix: getSiteSuffix(), is_pre_connection: 1 } ),
+		[]
+	);
 
 	const product = useSelector( ( state ) =>
 		getProductBySlug( state, PRODUCT_JETPACK_STATS_YEARLY )
 	);
 
-	const connect = async () => {
+	useEffect( () => {
+		if ( isOffline ) {
+			trackStatsAnalyticsEvent( 'stats_pre_connection_offline_notice_view', eventProps );
+		}
+	}, [ isOffline, eventProps ] );
+
+	const connect = async ( plan: 'free' | 'paid' ) => {
 		setError( null );
 		setIsRegistering( true );
+		trackStatsAnalyticsEvent( 'stats_pre_connection_register_start', { ...eventProps, plan } );
 
 		try {
-			return await registerSite( AUTHORIZE_REDIRECT_URI );
+			const registration = await registerSite( AUTHORIZE_REDIRECT_URI );
+
+			// The one event carrying both keys, and so the join between everything above and
+			// everything the site does once it has an id.
+			trackStatsAnalyticsEvent( 'stats_pre_connection_register_success', {
+				...eventProps,
+				plan,
+				blog_id: registration.blogId,
+			} );
+			setBlogId( registration.blogId );
+
+			return registration.authorizeUrl;
 		} catch ( e ) {
+			const message = ( e as Error ).message;
+
+			trackStatsAnalyticsEvent( 'stats_pre_connection_register_failed', {
+				...eventProps,
+				plan,
+				error: message,
+			} );
 			setError(
-				( e as Error ).message ||
+				message ||
 					String(
 						translate( 'Jetpack could not connect this site to WordPress.com. Please try again.' )
 					)
@@ -67,7 +108,7 @@ export default function PreConnection() {
 	};
 
 	const startForFree = async () => {
-		const url = await connect();
+		const url = await connect( 'free' );
 
 		// Deliberately leaves the spinner up: the browser is on its way to WordPress.com.
 		if ( url ) {
@@ -76,7 +117,7 @@ export default function PreConnection() {
 	};
 
 	const goToPurchase = async () => {
-		const url = await connect();
+		const url = await connect( 'paid' );
 
 		if ( url ) {
 			setAuthorizeUrl( url );
@@ -85,7 +126,7 @@ export default function PreConnection() {
 	};
 
 	const renderStep = () => {
-		if ( isOfflineMode() ) {
+		if ( isOffline ) {
 			return (
 				<StatsMain fullWidthLayout>
 					<Notice status="warning" isDismissible={ false }>
@@ -112,10 +153,14 @@ export default function PreConnection() {
 								adminUrl={ getWpAdminUrl() }
 								redirectUri={ STATS_ADMIN_PATH }
 								from={ PRICING_GRID_REFERRER }
+								// Registration is behind us, so the blog id is known here even though the
+								// screen still runs without one.
+								eventProps={ blogId ? { ...eventProps, blog_id: blogId } : eventProps }
 								// Nobody is putting anything off here: this is the free plan, and taking it
 								// still needs an account attached. Reaching this screen already registered
 								// the site, so the URL to attach one is in hand.
 								postponeLabel={ String( translate( 'Start for free' ) ) }
+								postponeEventName="stats_purchase_commercial_start_for_free_button_clicked"
 								onPostpone={ () => {
 									window.location.href = authorizeUrl;
 								} }
@@ -130,11 +175,23 @@ export default function PreConnection() {
 			return PageLoading;
 		}
 
-		return <PricingGrid onSelectFree={ startForFree } onSelectPaid={ goToPurchase } />;
+		return (
+			<PricingGrid
+				onSelectFree={ startForFree }
+				onSelectPaid={ goToPurchase }
+				eventProps={ eventProps }
+			/>
+		);
 	};
 
 	return (
 		<>
+			<PageViewTracker
+				path="/stats/pricing"
+				title="Stats > Pricing"
+				site_suffix={ eventProps.site_suffix }
+				is_pre_connection={ eventProps.is_pre_connection }
+			/>
 			{ /* Mounted across every step: the tier slider reads the same product the grid prices,
 			     and unmounting mid-flight would lose the response that populates it. */ }
 			<QueryProductsList type="jetpack" />

--- a/apps/odyssey-stats/src/pre-connection/index.tsx
+++ b/apps/odyssey-stats/src/pre-connection/index.tsx
@@ -41,16 +41,17 @@ const navigateOnceRecorded = ( url: string ) => {
 };
 
 /**
- * Where authorizing returns the visitor to. The marker tells the dashboard's pricing grid that the
- * plan question was already answered here — it cannot be recorded against the site at the time it
- * is asked, since the site has no blog id yet. It names the plan rather than merely reporting that
- * one was picked: registration happens for both, so the marker alone says nothing about which.
+ * Where the connection flow returns the visitor to — after authorizing on the free path, and after
+ * checkout on the paid one. The marker tells the dashboard's pricing grid which plan was picked
+ * here; it cannot be recorded against the site at the time it is asked, since the site has no blog
+ * id yet. It names the plan rather than merely reporting that one was picked: registration happens
+ * for both, so the marker alone says nothing about which.
  *
  * `force_refresh` drops what the site cached while it had no connection. The pricing grid gate
  * strips it (and the plan-chosen marker) from the address bar once the dashboard has read them,
  * so later REST requests do not keep bypassing the server caches via the Referer.
  */
-const authorizeRedirectUri = ( plan: Plan ) =>
+const preConnectionReturnUri = ( plan: Plan ) =>
 	`${ STATS_ADMIN_PATH }&${ PLAN_CHOSEN_QUERY_ARG }=${ plan }&force_refresh=1`;
 
 /**
@@ -97,7 +98,7 @@ export default function PreConnection() {
 		trackStatsAnalyticsEvent( 'stats_pre_connection_register_start', { ...eventProps, plan } );
 
 		try {
-			const registration = await registerSite( authorizeRedirectUri( plan ) );
+			const registration = await registerSite( preConnectionReturnUri( plan ) );
 
 			// The one event carrying both keys, and so the join between everything above and
 			// everything the site does once it has an id.
@@ -174,7 +175,10 @@ export default function PreConnection() {
 								planValue={ 0 }
 								currencyCode={ product?.currency_code ?? 'USD' }
 								adminUrl={ getWpAdminUrl() }
-								redirectUri={ STATS_ADMIN_PATH }
+								// Checkout returns here rather than through the URL registration stored, so
+								// the marker has to travel this path too — otherwise a purchase that
+								// completes never reports the end of the pre-connection flow.
+								redirectUri={ preConnectionReturnUri( 'paid' ) }
 								from={ PRICING_GRID_REFERRER }
 								// Registration is behind us, so the blog id is known here even though the
 								// screen still runs without one.

--- a/apps/odyssey-stats/src/pre-connection/index.tsx
+++ b/apps/odyssey-stats/src/pre-connection/index.tsx
@@ -16,21 +16,42 @@ import { StatsCommercialPurchase } from 'calypso/my-sites/stats/stats-purchase/s
 import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
-import { getSiteSuffix, isOfflineMode, registerSite } from '../lib/jetpack-connection';
+import {
+	getRegistrationErrorCode,
+	getSiteSuffix,
+	isOfflineMode,
+	registerSite,
+} from '../lib/jetpack-connection';
 import getWpAdminUrl from '../lib/selectors/get-wp-admin-url';
 
 const STATS_ADMIN_PATH = 'admin.php?page=stats';
 
+type Plan = 'free' | 'paid';
+
+/**
+ * Tracks only queues an event; navigating in the same tick cancels the request that would have
+ * sent it. The purchase flow waits the same beat everywhere else it leaves the page.
+ */
+const TRACKS_FLUSH_DELAY = 250;
+
+const navigateOnceRecorded = ( url: string ) => {
+	setTimeout( () => {
+		window.location.href = url;
+	}, TRACKS_FLUSH_DELAY );
+};
+
 /**
  * Where authorizing returns the visitor to. The marker tells the dashboard's pricing grid that the
  * plan question was already answered here — it cannot be recorded against the site at the time it
- * is asked, since the site has no blog id yet.
+ * is asked, since the site has no blog id yet. It names the plan rather than merely reporting that
+ * one was picked: registration happens for both, so the marker alone says nothing about which.
  *
  * `force_refresh` drops what the site cached while it had no connection. The pricing grid gate
  * strips it (and the plan-chosen marker) from the address bar once the dashboard has read them,
  * so later REST requests do not keep bypassing the server caches via the Referer.
  */
-const AUTHORIZE_REDIRECT_URI = `${ STATS_ADMIN_PATH }&${ PLAN_CHOSEN_QUERY_ARG }=1&force_refresh=1`;
+const authorizeRedirectUri = ( plan: Plan ) =>
+	`${ STATS_ADMIN_PATH }&${ PLAN_CHOSEN_QUERY_ARG }=${ plan }&force_refresh=1`;
 
 /**
  * The plan choice a site sees before it is connected to WordPress.com.
@@ -70,13 +91,13 @@ export default function PreConnection() {
 		}
 	}, [ isOffline, eventProps ] );
 
-	const connect = async ( plan: 'free' | 'paid' ) => {
+	const connect = async ( plan: Plan ) => {
 		setError( null );
 		setIsRegistering( true );
 		trackStatsAnalyticsEvent( 'stats_pre_connection_register_start', { ...eventProps, plan } );
 
 		try {
-			const registration = await registerSite( AUTHORIZE_REDIRECT_URI );
+			const registration = await registerSite( authorizeRedirectUri( plan ) );
 
 			// The one event carrying both keys, and so the join between everything above and
 			// everything the site does once it has an id.
@@ -94,7 +115,9 @@ export default function PreConnection() {
 			trackStatsAnalyticsEvent( 'stats_pre_connection_register_failed', {
 				...eventProps,
 				plan,
-				error: message,
+				// Not the message: it arrives already translated, can name the site, and is empty
+				// for every failure that did not come from the API.
+				error_code: getRegistrationErrorCode( e ),
 			} );
 			setError(
 				message ||
@@ -112,7 +135,7 @@ export default function PreConnection() {
 
 		// Deliberately leaves the spinner up: the browser is on its way to WordPress.com.
 		if ( url ) {
-			window.location.href = url;
+			navigateOnceRecorded( url );
 		}
 	};
 
@@ -162,7 +185,7 @@ export default function PreConnection() {
 								postponeLabel={ String( translate( 'Start for free' ) ) }
 								postponeEventName="stats_purchase_commercial_start_for_free_button_clicked"
 								onPostpone={ () => {
-									window.location.href = authorizeUrl;
+									navigateOnceRecorded( authorizeUrl );
 								} }
 							/>
 						</StatsSingleItemPagePurchaseFrame>
@@ -176,22 +199,27 @@ export default function PreConnection() {
 		}
 
 		return (
-			<PricingGrid
-				onSelectFree={ startForFree }
-				onSelectPaid={ goToPurchase }
-				eventProps={ eventProps }
-			/>
+			<>
+				{ /* Recorded with the grid rather than above every step: an offline site never sees
+				     the grid and can never convert, so counting it here would inflate the top of
+				     the funnel against the view the grid records. */ }
+				<PageViewTracker
+					path="/stats/pricing"
+					title="Stats > Pricing"
+					site_suffix={ eventProps.site_suffix }
+					is_pre_connection={ eventProps.is_pre_connection }
+				/>
+				<PricingGrid
+					onSelectFree={ startForFree }
+					onSelectPaid={ goToPurchase }
+					eventProps={ eventProps }
+				/>
+			</>
 		);
 	};
 
 	return (
 		<>
-			<PageViewTracker
-				path="/stats/pricing"
-				title="Stats > Pricing"
-				site_suffix={ eventProps.site_suffix }
-				is_pre_connection={ eventProps.is_pre_connection }
-			/>
 			{ /* Mounted across every step: the tier slider reads the same product the grid prices,
 			     and unmounting mid-flight would lose the response that populates it. */ }
 			<QueryProductsList type="jetpack" />

--- a/client/my-sites/stats/pricing-grid/gate.tsx
+++ b/client/my-sites/stats/pricing-grid/gate.tsx
@@ -21,32 +21,47 @@ const loadPricingGrid = () =>
 		/* webpackChunkName: "async-load-calypso-my-sites-stats-pricing-grid" */ './pricing-grid'
 	);
 
+/** `unknown` is what a bundle that predates the marker naming the plan sends back. */
+type PlanChosenBeforeConnecting = 'free' | 'paid' | 'unknown';
+
 /**
- * Whether the visitor already answered the plan question on Odyssey's pre-connection screen, which
- * asks exactly what this gate asks — but before the site had a blog id to record the answer
- * against, so the answer travels back as a query arg on the page the connection flow lands on.
+ * Which plan the visitor picked on Odyssey's pre-connection screen, which asks exactly what this
+ * gate asks — but before the site had a blog id to record the answer against, so the answer travels
+ * back as a query arg on the page the connection flow lands on. `null` when the site was connected
+ * by any other route.
  *
  * Remembered after the first read: those args are then stripped from the address bar so they do
  * not sit in the Referer of every dashboard REST request, and the gate remounts on route changes.
  *
  * Exported for tests: too eager and a site never sees the grid, too shy and it is asked twice.
  */
-let rememberedChoiceBeforeConnecting = false;
+let rememberedChoiceBeforeConnecting: PlanChosenBeforeConnecting | null = null;
 
-export function hasChosenBeforeConnecting(): boolean {
-	if ( rememberedChoiceBeforeConnecting ) {
-		return true;
+function readChoiceBeforeConnecting(): PlanChosenBeforeConnecting | null {
+	const marker = new URLSearchParams( window.location.search ).get( PLAN_CHOSEN_QUERY_ARG );
+
+	if ( marker === 'free' || marker === 'paid' ) {
+		return marker;
 	}
 
-	rememberedChoiceBeforeConnecting =
-		new URLSearchParams( window.location.search ).get( PLAN_CHOSEN_QUERY_ARG ) === '1';
+	return marker === '1' ? 'unknown' : null;
+}
+
+export function getChoiceBeforeConnecting(): PlanChosenBeforeConnecting | null {
+	if ( ! rememberedChoiceBeforeConnecting ) {
+		rememberedChoiceBeforeConnecting = readChoiceBeforeConnecting();
+	}
 
 	return rememberedChoiceBeforeConnecting;
 }
 
+export function hasChosenBeforeConnecting(): boolean {
+	return getChoiceBeforeConnecting() !== null;
+}
+
 /** Clears the in-memory plan-chosen flag so tests can set a fresh query string. */
 export function resetHasChosenBeforeConnecting() {
-	rememberedChoiceBeforeConnecting = false;
+	rememberedChoiceBeforeConnecting = null;
 }
 
 /**
@@ -120,9 +135,15 @@ function PricingGridGate( { children }: { children: ReactNode } ) {
 
 		hasRecordedChoiceBeforeConnecting = true;
 		dismissPricingGrid();
-		// Where the free path ends: the site is connected, the plan it chose minutes ago is in
-		// effect, and this is the first moment that choice can be recorded against a blog id.
-		trackStatsAnalyticsEvent( 'stats_pre_connection_free_plan_completed', { blog_id: siteId } );
+		// Where the pre-connection flow ends: the site is connected, and this is the first moment
+		// the choice made minutes ago can be recorded against a blog id. `plan` is what was picked
+		// on the grid, which is all the marker can carry — a visitor who picked paid and then took
+		// free from the purchase page returns under the registration the paid choice made, and is
+		// counted as free by that page's own button event.
+		trackStatsAnalyticsEvent( 'stats_pre_connection_plan_completed', {
+			blog_id: siteId,
+			plan: getChoiceBeforeConnecting(),
+		} );
 	}, [ siteId, dismissPricingGrid ] );
 
 	if ( ! isApplicable || hasChosen ) {

--- a/client/my-sites/stats/pricing-grid/gate.tsx
+++ b/client/my-sites/stats/pricing-grid/gate.tsx
@@ -5,6 +5,7 @@ import AsyncLoad from 'calypso/components/async-load';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import { trackStatsAnalyticsEvent } from 'calypso/my-sites/stats/utils';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PageLoading from '../pages/shared/page-loading';
@@ -119,6 +120,9 @@ function PricingGridGate( { children }: { children: ReactNode } ) {
 
 		hasRecordedChoiceBeforeConnecting = true;
 		dismissPricingGrid();
+		// Where the free path ends: the site is connected, the plan it chose minutes ago is in
+		// effect, and this is the first moment that choice can be recorded against a blog id.
+		trackStatsAnalyticsEvent( 'stats_pre_connection_free_plan_completed', { blog_id: siteId } );
 	}, [ siteId, dismissPricingGrid ] );
 
 	if ( ! isApplicable || hasChosen ) {

--- a/client/my-sites/stats/pricing-grid/gate.tsx
+++ b/client/my-sites/stats/pricing-grid/gate.tsx
@@ -136,13 +136,13 @@ function PricingGridGate( { children }: { children: ReactNode } ) {
 		hasRecordedChoiceBeforeConnecting = true;
 		dismissPricingGrid();
 		// Where the pre-connection flow ends: the site is connected, and this is the first moment
-		// the choice made minutes ago can be recorded against a blog id. `plan` is what was picked
-		// on the grid, which is all the marker can carry — a visitor who picked paid and then took
-		// free from the purchase page returns under the registration the paid choice made, and is
-		// counted as free by that page's own button event.
+		// the choice made minutes ago can be recorded against a blog id. The property is named for
+		// what the marker carries — the plan picked on the grid, not necessarily the one the
+		// visitor left with, since taking free from the purchase page returns under the marker the
+		// paid choice set. That exit is counted by the purchase page's own button event.
 		trackStatsAnalyticsEvent( 'stats_pre_connection_plan_completed', {
 			blog_id: siteId,
-			plan: getChoiceBeforeConnecting(),
+			plan_chosen: getChoiceBeforeConnecting(),
 		} );
 	}, [ siteId, dismissPricingGrid ] );
 

--- a/client/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid.ts
+++ b/client/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid.ts
@@ -7,9 +7,9 @@ import type { Notices } from 'calypso/my-sites/stats/hooks/use-notice-visibility
 export const PRICING_GRID_REFERRER = 'jetpack-stats-pricing-grid';
 
 /**
- * Query arg that Odyssey's pre-connection screen carries back through the connection flow to say
- * the plan question was already answered. It has to travel in the URL because the choice is made
- * before the site has a blog id to record it against.
+ * Query arg that Odyssey's pre-connection screen carries back through the connection flow to name
+ * the plan the visitor picked. It has to travel in the URL because the choice is made before the
+ * site has a blog id to record it against.
  */
 export const PLAN_CHOSEN_QUERY_ARG = 'stats_plan_chosen';
 

--- a/client/my-sites/stats/pricing-grid/pricing-grid.tsx
+++ b/client/my-sites/stats/pricing-grid/pricing-grid.tsx
@@ -49,8 +49,7 @@ interface PricingGridProps {
 	/**
 	 * Added to every event this grid records. A host with no blog id to be identified by has to
 	 * supply whatever key it does have, since `blog_id` is null there and nothing else on the
-	 * event would tie it to what the site does next. The view event depends on it, so pass a
-	 * stable reference.
+	 * event would tie it to what the site does next.
 	 */
 	eventProps?: Record< string, string | number >;
 }
@@ -77,7 +76,10 @@ export default function PricingGrid( {
 
 	useEffect( () => {
 		trackStatsAnalyticsEvent( 'stats_pricing_grid_view', { blog_id: siteId, ...eventProps } );
-	}, [ siteId, eventProps ] );
+		// One view per grid: `eventProps` only labels it, and depending on it would re-record the
+		// view on every render of a host that builds the object inline.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ siteId ] );
 
 	const product = useSelector( ( state ) =>
 		getProductBySlug( state, PRODUCT_JETPACK_STATS_YEARLY )

--- a/client/my-sites/stats/pricing-grid/pricing-grid.tsx
+++ b/client/my-sites/stats/pricing-grid/pricing-grid.tsx
@@ -46,6 +46,13 @@ interface PricingGridProps {
 	 * connection cannot form: it has no site slug yet.
 	 */
 	onSelectPaid?: () => void;
+	/**
+	 * Added to every event this grid records. A host with no blog id to be identified by has to
+	 * supply whatever key it does have, since `blog_id` is null there and nothing else on the
+	 * event would tie it to what the site does next. The view event depends on it, so pass a
+	 * stable reference.
+	 */
+	eventProps?: Record< string, string | number >;
 }
 
 /**
@@ -55,7 +62,12 @@ interface PricingGridProps {
  * to the Search one. Gating lives in `gate.tsx`; by the time this renders the site
  * is known to be eligible and undismissed.
  */
-export default function PricingGrid( { onDismiss, onSelectFree, onSelectPaid }: PricingGridProps ) {
+export default function PricingGrid( {
+	onDismiss,
+	onSelectFree,
+	onSelectPaid,
+	eventProps,
+}: PricingGridProps ) {
 	const translate = useTranslate();
 	// Same breakpoint the jetpack-components PricingTable uses via useViewportMatch.
 	const isLg = useViewportMatch( 'large' );
@@ -64,8 +76,8 @@ export default function PricingGrid( { onDismiss, onSelectFree, onSelectPaid }: 
 	const dismissPricingGrid = useDismissPricingGrid( siteId );
 
 	useEffect( () => {
-		trackStatsAnalyticsEvent( 'stats_pricing_grid_view', { blog_id: siteId } );
-	}, [ siteId ] );
+		trackStatsAnalyticsEvent( 'stats_pricing_grid_view', { blog_id: siteId, ...eventProps } );
+	}, [ siteId, eventProps ] );
 
 	const product = useSelector( ( state ) =>
 		getProductBySlug( state, PRODUCT_JETPACK_STATS_YEARLY )
@@ -150,6 +162,7 @@ export default function PricingGrid( { onDismiss, onSelectFree, onSelectPaid }: 
 		trackStatsAnalyticsEvent( 'stats_pricing_grid_free_cta_clicked', {
 			blog_id: siteId,
 			cta: 'free',
+			...eventProps,
 		} );
 
 		if ( onSelectFree ) {
@@ -170,6 +183,7 @@ export default function PricingGrid( { onDismiss, onSelectFree, onSelectPaid }: 
 		trackStatsAnalyticsEvent( 'stats_pricing_grid_paid_cta_clicked', {
 			blog_id: siteId,
 			cta: 'paid',
+			...eventProps,
 		} );
 
 		if ( onSelectPaid ) {

--- a/client/my-sites/stats/pricing-grid/test/gate.test.ts
+++ b/client/my-sites/stats/pricing-grid/test/gate.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import {
+	getChoiceBeforeConnecting,
 	getUrlWithPreConnectionReturnArgsRemoved,
 	hasChosenBeforeConnecting,
 	resetHasChosenBeforeConnecting,
@@ -16,16 +17,30 @@ describe( 'hasChosenBeforeConnecting', () => {
 		setSearch( '' );
 	} );
 
-	it( 'suppresses the grid when the connection flow reports a plan was already picked', () => {
+	it.each( [ 'free', 'paid' ] )(
+		'suppresses the grid when the connection flow reports the %s plan was picked',
+		( plan ) => {
+			setSearch( `?page=stats&stats_plan_chosen=${ plan }` );
+
+			expect( hasChosenBeforeConnecting() ).toBe( true );
+			expect( getChoiceBeforeConnecting() ).toBe( plan );
+		}
+	);
+
+	it( 'suppresses the grid for a marker from before it named the plan', () => {
+		// A bundle still cached from an earlier release sends `1` back, which says a plan was
+		// picked without saying which.
 		setSearch( '?page=stats&stats_plan_chosen=1' );
 
 		expect( hasChosenBeforeConnecting() ).toBe( true );
+		expect( getChoiceBeforeConnecting() ).toBe( 'unknown' );
 	} );
 
 	it( 'shows the grid to a site connected by any other route', () => {
 		setSearch( '?page=stats' );
 
 		expect( hasChosenBeforeConnecting() ).toBe( false );
+		expect( getChoiceBeforeConnecting() ).toBeNull();
 	} );
 
 	it( 'ignores a marker that does not say a plan was picked', () => {
@@ -39,11 +54,11 @@ describe( 'hasChosenBeforeConnecting', () => {
 	} );
 
 	it( 'still reports the choice after the return args have been stripped', () => {
-		setSearch( '?page=stats&stats_plan_chosen=1&force_refresh=1' );
-		expect( hasChosenBeforeConnecting() ).toBe( true );
+		setSearch( '?page=stats&stats_plan_chosen=free&force_refresh=1' );
+		expect( getChoiceBeforeConnecting() ).toBe( 'free' );
 
 		setSearch( '?page=stats' );
-		expect( hasChosenBeforeConnecting() ).toBe( true );
+		expect( getChoiceBeforeConnecting() ).toBe( 'free' );
 	} );
 } );
 
@@ -51,7 +66,7 @@ describe( 'getUrlWithPreConnectionReturnArgsRemoved', () => {
 	it( 'drops the plan-chosen marker and force_refresh from the wp-admin query', () => {
 		expect(
 			getUrlWithPreConnectionReturnArgsRemoved(
-				'https://example.com/wp-admin/admin.php?page=stats&stats_plan_chosen=1&force_refresh=1'
+				'https://example.com/wp-admin/admin.php?page=stats&stats_plan_chosen=free&force_refresh=1'
 			).toString()
 		).toBe( 'https://example.com/wp-admin/admin.php?page=stats' );
 	} );

--- a/client/my-sites/stats/stats-page-view-tracker/index.tsx
+++ b/client/my-sites/stats/stats-page-view-tracker/index.tsx
@@ -13,6 +13,8 @@ export interface StatsPageViewTrackerProps {
 	variant?: string;
 	is_upgrade?: string | number;
 	is_site_commercial?: string | number;
+	site_suffix?: string;
+	is_pre_connection?: number;
 }
 
 // This component will pass through all properties to PageViewTracker from the analytics library.

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -63,6 +63,11 @@ type StatsCommercialUpgradeSliderProps = {
 	analyticsEventName?: string;
 	onSliderChange: ( quantity: number ) => void;
 	tiers: StatsPlanTierUI[];
+	/**
+	 * Added to the slider's own event. A host with no blog id to be identified by has to supply
+	 * whatever key it does have, since `blog_id` is null there.
+	 */
+	eventProps?: Record< string, string | number >;
 };
 
 const getTierQuantity = ( tiers: StatsPlanTierUI ) => {
@@ -78,6 +83,7 @@ function StatsCommercialUpgradeSlider( {
 	analyticsEventName,
 	onSliderChange,
 	tiers,
+	eventProps,
 }: StatsCommercialUpgradeSliderProps ) {
 	const translate = useTranslate();
 	const uiStrings = useTranslatedStrings();
@@ -131,6 +137,7 @@ function StatsCommercialUpgradeSlider( {
 				tier_views: quantity,
 				default_changed: index !== 0, // 0 is the default initialVlaue value for <TierUpgradeSlider />
 				blog_id: siteId,
+				...eventProps,
 			} );
 		}
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -234,7 +234,6 @@ const gotoCheckoutPage = ( {
 		type,
 		quantity,
 		blog_id: siteId,
-		site_slug: siteSlug,
 		...eventProps,
 	} );
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -182,6 +182,7 @@ const gotoCheckoutPage = ( {
 	isUpgrade = false,
 	isSiteFullyConnected = true,
 	redirect = true,
+	eventProps,
 }: {
 	from: string;
 	type: 'pwyw' | 'free' | 'commercial';
@@ -194,6 +195,12 @@ const gotoCheckoutPage = ( {
 	isUpgrade?: boolean;
 	isSiteFullyConnected?: boolean;
 	redirect?: boolean;
+	/**
+	 * Added to the purchase click. A caller with no blog id in `siteId` — the pre-connection
+	 * screens, which register the site only once the visitor picks a plan — supplies whatever keys
+	 * it does have here, so this click still joins the screens it came from.
+	 */
+	eventProps?: Record< string, string | number >;
 } ) => {
 	let eventName = '';
 	let product: string;
@@ -227,9 +234,8 @@ const gotoCheckoutPage = ( {
 		type,
 		quantity,
 		blog_id: siteId,
-		// The only identifier a site that is not connected yet has, and so the only thing tying
-		// this click to the screens it came from.
 		site_slug: siteSlug,
+		...eventProps,
 	} );
 
 	const redirectUrl = getRedirectUrl( { type, adminUrl, redirectUri, siteSlug } );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-checkout-redirect.tsx
@@ -227,6 +227,9 @@ const gotoCheckoutPage = ( {
 		type,
 		quantity,
 		blog_id: siteId,
+		// The only identifier a site that is not connected yet has, and so the only thing tying
+		// this click to the screens it came from.
+		site_slug: siteSlug,
 	} );
 
 	const redirectUrl = getRedirectUrl( { type, adminUrl, redirectUri, siteSlug } );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -345,6 +345,7 @@ const StatsCommercialPurchase = ( {
 					isOdysseyStats ? 'jetpack_odyssey' : 'calypso'
 				}_stats_purchase_commercial_slider_clicked` }
 				onSliderChange={ handleSliderChanged }
+				eventProps={ eventProps }
 			/>
 		</>
 	) : (

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -58,8 +58,9 @@ interface StatsCommercialPurchaseProps {
 	 */
 	postponeEventName?: string;
 	/**
-	 * Added to the events this component records itself. A host with no blog id to be identified
-	 * by has to supply whatever key it does have, since `blog_id` is null there.
+	 * Added to the events this screen records, including the purchase click it hands to checkout.
+	 * A host with no blog id to be identified by has to supply whatever key it does have, since
+	 * `blog_id` is null there.
 	 */
 	eventProps?: Record< string, string | number >;
 }
@@ -406,6 +407,7 @@ const StatsCommercialPurchase = ( {
 							quantity: purchaseTierQuantity,
 							isUpgrade: hasAnyStatsPlan, // All cross grades are not possible for the site-only flow.
 							isSiteFullyConnected: !! connectionStatus?.isSiteFullyConnected,
+							eventProps,
 						} )
 					}
 				>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -52,6 +52,16 @@ interface StatsCommercialPurchaseProps {
 	 * something to do before it can come back to this, so it is not simply putting it off.
 	 */
 	postponeLabel?: string;
+	/**
+	 * Replaces the event name that goes with `onPostpone`, so a button that no longer skips
+	 * anything stops counting towards the skip metric. Prefixed like every other event here.
+	 */
+	postponeEventName?: string;
+	/**
+	 * Added to the events this component records itself. A host with no blog id to be identified
+	 * by has to supply whatever key it does have, since `blog_id` is null there.
+	 */
+	eventProps?: Record< string, string | number >;
 }
 
 interface StatsSingleItemPagePurchaseProps {
@@ -223,6 +233,8 @@ const StatsCommercialPurchase = ( {
 	redirectUri,
 	onPostpone,
 	postponeLabel,
+	postponeEventName = 'stats_purchase_commercial_skip_button_clicked',
+	eventProps,
 }: StatsCommercialPurchaseProps ) => {
 	const translate = useTranslate();
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
@@ -289,9 +301,10 @@ const StatsCommercialPurchase = ( {
 
 	const handleCheckoutPostponed = () => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-		recordTracksEvent( `${ event_from }_stats_purchase_commercial_skip_button_clicked`, {
+		recordTracksEvent( `${ event_from }_${ postponeEventName }`, {
 			blog_id: siteId,
 			from,
+			...eventProps,
 		} );
 
 		if ( onPostpone ) {

--- a/client/my-sites/stats/stats-purchase/test/stats-purchase-checkout-redirect.test.ts
+++ b/client/my-sites/stats/stats-purchase/test/stats-purchase-checkout-redirect.test.ts
@@ -65,6 +65,19 @@ describe( 'gotoCheckoutPage — site with no WordPress.com connection', () => {
 		);
 	} );
 
+	it( 'keeps what the caller put on the return path', () => {
+		// The pre-connection screen marks it with the plan picked, which is what tells the
+		// dashboard the flow completed once the site finally has an id.
+		const redirectTo = checkoutUrl( {
+			siteId: null,
+			redirectUri: 'admin.php?page=stats&stats_plan_chosen=paid&force_refresh=1',
+		} ).searchParams.get( 'redirect_to' );
+
+		expect( redirectTo ).toBe(
+			`${ ADMIN_URL }admin.php?page=stats&stats_plan_chosen=paid&force_refresh=1&statsPurchaseSuccess=paid`
+		);
+	} );
+
 	it( 'carries the chosen views tier', () => {
 		const url = checkoutUrl( { siteId: null, quantity: 50000 } );
 


### PR DESCRIPTION
Part of STATS-444, following up the Tracks review on #113497.

## Proposed Changes

* Return the newly assigned blog id from `registerSite()` alongside the authorization URL, read off the URL's `client_id`.
* Instrument the pre-connection screen: a `/stats/pricing` page view recorded with the pricing grid, `stats_pre_connection_register_{start,success,failed}` around the register call, and an event for the offline notice. Every one carries the site suffix and `is_pre_connection: 1`. The failure carries an error code rather than the REST API's message, which arrives translated and can name the site.
* Let a host add properties to the pricing grid's, the commercial purchase screen's and the tier slider's own events (`eventProps`), so the pre-connection copies of those screens carry a key their `blog_id: null` cannot supply. The purchase screen passes them on to the checkout click as well.
* Let a host replace the postpone button's event name (`postponeEventName`), and use it for the "Start for free" button so it stops counting as a skip.
* Name the plan in the marker the connection flow carries back (`stats_plan_chosen=free|paid`), on the authorization return and on the paid checkout return alike, and record `stats_pre_connection_plan_completed` where the gate recognises it — the pre-connection flow's end point, and the first place the choice can be recorded against a `blog_id`. `plan_chosen` is the plan picked on the grid: a visitor who picks paid and then takes “Start for free” from the purchase screen returns under the marker the paid choice set, and that exit is counted by the purchase screen's own button event.
* Add the host's `eventProps` to `stats_purchase_button_clicked`, which is otherwise `blog_id: null` and nothing else on this screen — on the pre-connection path that restores the blog id registration has already assigned.
* Defer the two navigations that follow a Tracks event on this screen by the 250 ms the rest of the purchase flow waits: `recordTracksEvent` only queues, and unloading in the same tick cancels the request that would have sent it.

## Why are these changes being made?

The plan choice #113497 added is the only Stats screen that runs before the site has a blog id, and it shipped without instrumentation of its own. Everything that did fire there carried `blog_id: null` and no other key, and the server-side `jpc_register_*` events are anonymous — so *grid view → registered → connected / purchased* could not be computed for this surface at all.

The join was already sitting in a response nobody read. `jetpack/v4/connection/register` answers with an authorization URL whose `client_id` **is** the blog id WordPress.com just assigned, so `stats_pre_connection_register_success` can carry both the site suffix — the only identifier the screen has — and the blog id every later event carries. One event bridges the two halves of the funnel.

That also settles the last review item, about `from=jetpack-connector` having taken the Stats marker off the authorize page's events: no change is needed in `client/jetpack-connect`. `calypso_jpc_authorize_form_view` already records `site: clientId`, which is the same blog id, so those events can be attributed to Stats by joining on it rather than by a `from` value of our own.

`skip_button_clicked` was the one straightforwardly wrong event: the button reads "Start for free" and starts authorization, so counting it as a skip understates nothing and overstates skips. It now has its own name, and the connected purchase page is untouched.

## Testing Instructions

Nothing here is visual — the change is which events fire and what they carry. Needs the Jetpack companion (Automattic/jetpack#51200), and this has to deploy before a site sees it, since the plugin loads the bundle from the CDN.

Build Odyssey into a local Jetpack checkout ("Option 1" in the Field Guide's Odyssey Stats page):

```
cd apps/odyssey-stats
STATS_PACKAGE_PATH=/path/to/jetpack/projects/packages/stats-admin \
NODE_ENV=production BROWSERSLIST_ENV=wpcom \
yarn workspace @automattic/odyssey-stats run build:stats
```

Then, on a tunnelled self-hosted site with **no** Jetpack connection, with `localStorage.debug = 'calypso:analytics*'` set:

1. Open **Stats**. Expect `jetpack_odyssey_stats_page_view` for `/stats/pricing` and `jetpack_odyssey_stats_pricing_grid_view`, both carrying `site_suffix` and `is_pre_connection: 1`.
2. **Start for free** → `..._free_cta_clicked`, then `..._register_start` and `..._register_success` with `plan: 'free'`. Check its `blog_id` against `client_id` on the authorization URL you land on. The URL's `redirect_uri` should carry `stats_plan_chosen=free`. Approve; back on the dashboard, expect `jetpack_odyssey_stats_pre_connection_plan_completed` with `plan: 'free'` and that same `blog_id`.
3. Disconnect and reload. **Get Paid Stats** → `..._paid_cta_clicked`, `..._register_start` / `_success` with `plan: 'paid'`. The `redirect_uri` should carry `stats_plan_chosen=paid` this time. On the purchase screen the slider and both buttons carry `site_suffix` and the registered `blog_id`: the secondary fires `jetpack_odyssey_stats_purchase_commercial_start_for_free_button_clicked` — never the skip name — and the primary fires `..._stats_purchase_button_clicked`, whose `redirect_to` carries the marker so completing the purchase reports the end of the flow.
4. Put the site in offline mode (`JETPACK_DEV_DEBUG`) and open Stats: expect `..._stats_pre_connection_offline_notice_view`, and no page view or register events — an offline site never sees the grid and can never convert.
5. Regression on a fully connected site: `/stats/purchase/:site`'s secondary button still fires `..._stats_purchase_commercial_skip_button_clicked`, and the traffic page's pricing grid events are unchanged apart from carrying no extra properties.

### New events to register

These need adding to the Tracks events registry before the data is usable:

| Event | Fires |
| --- | --- |
| `jetpack_odyssey_stats_pre_connection_register_start` | Either CTA, before the register call |
| `jetpack_odyssey_stats_pre_connection_register_success` | Registered — carries `site_suffix` **and** `blog_id` |
| `jetpack_odyssey_stats_pre_connection_register_failed` | The register call was rejected — carries `error_code`, not the message |
| `jetpack_odyssey_stats_pre_connection_offline_notice_view` | Site is in offline mode and can never register |
| `jetpack_odyssey_stats_pre_connection_plan_completed` | Pre-connection flow complete, back on the dashboard with a `blog_id` — carries the `plan_chosen` on the grid |
| `jetpack_odyssey_stats_purchase_commercial_start_for_free_button_clicked` | Replaces the mislabelled skip event on the pre-connection purchase screen |

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

<!--
No UI, no new strings: this pull request only changes which Tracks events fire and what they carry.
Self-hosted Jetpack is the only environment the pre-connection screen exists in; Simple and Atomic
are always connected and never reach it, and the connected regression in step 5 is what covers them.
-->


