### PR TITLE
Purchases: offer an add-payment-method CTA when auto-renew can't be re-enabled

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -880,7 +880,11 @@ function getFields( {
 					) : (
 						helpText
 					);
-				if ( purchase.is_auto_renew_enabled && ! purchase.is_rechargeable ) {
+				if (
+					! purchase.is_rechargeable &&
+					! purchase.is_iap_purchase &&
+					( purchase.is_auto_renew_enabled || isAutoRenewToggleDisabled( purchase, user ) )
+				) {
 					if ( String( user.ID ) !== String( purchase.user_id ) ) {
 						return null;
 					}

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/auto-renew-payment-method-cta.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/auto-renew-payment-method-cta.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import { render } from '../../../../test-utils';
+import { ManageSubscriptionCard } from '../index';
+import type { Purchase } from '@automattic/api-core';
+
+// The rendering wrapper's default user has ID 1, so a purchase owned by user 1
+// belongs to the current user.
+function makePurchase( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 1,
+		user_id: 1,
+		product_name: 'WordPress.com Personal',
+		product_slug: 'personal-bundle',
+		site_slug: 'example.com',
+		is_plan: true,
+		is_auto_renew_enabled: false,
+		is_rechargeable: false,
+		can_disable_auto_renew: false,
+		can_reenable_auto_renewal: false,
+		subscription_status: 'active',
+		expiry_status: 'manual-renew',
+		expiry_date: '2027-01-01',
+		...overrides,
+	} as Purchase;
+}
+
+describe( 'auto-renew without a payment method', () => {
+	test( 'auto-renew off and un-reenableable offers an add payment method CTA instead of a dead toggle', () => {
+		render( <ManageSubscriptionCard purchase={ makePurchase() } /> );
+
+		expect( screen.getByText( 'Auto-renew needs a payment method.' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Add payment method' } ) ).toBeVisible();
+		expect(
+			screen.queryByRole( 'checkbox', { name: 'Enable auto-renew' } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'auto-renew on without a rechargeable payment method keeps its existing CTA', () => {
+		render(
+			<ManageSubscriptionCard
+				purchase={ makePurchase( {
+					is_auto_renew_enabled: true,
+					expiry_status: 'auto-renewing',
+				} ) }
+			/>
+		);
+
+		expect( screen.getByText( 'Auto-renew needs a payment method.' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Add payment method' } ) ).toBeVisible();
+	} );
+
+	test( 'an in-app purchase gets no CTA, since its payment method lives in the app store', () => {
+		render(
+			<ManageSubscriptionCard
+				purchase={ makePurchase( { is_auto_renew_enabled: true, is_iap_purchase: true } ) }
+			/>
+		);
+
+		expect( screen.queryByText( 'Auto-renew needs a payment method.' ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Add payment method' } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'a re-enableable purchase keeps the toggle, so the CTA does not take over', () => {
+		render(
+			<ManageSubscriptionCard
+				purchase={ makePurchase( { can_reenable_auto_renewal: true, is_rechargeable: true } ) }
+			/>
+		);
+
+		expect( screen.getByRole( 'checkbox', { name: 'Enable auto-renew' } ) ).toBeVisible();
+		expect( screen.queryByText( 'Auto-renew needs a payment method.' ) ).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Part of DOTMSD-1483

## Proposed Changes

* When a subscription's auto-renew toggle would be dead because there is no payment method on file, show the existing "Auto-renew needs a payment method" row with an **Add payment method** button instead of a greyed-out toggle.
* Skip that treatment for in-app purchases, whose payment method is managed in the App/Play Store and can't be added from here.

| Before | After |
| - | - |
|<img width="683" height="135" alt="image" src="https://github.com/user-attachments/assets/efd93204-52b5-4244-83d3-e908351b6e8f" />|<img width="676" height="128" alt="image" src="https://github.com/user-attachments/assets/6e078ea2-9217-4fab-a862-28a41ae338b9" />|

## Why are these changes being made?

A subscription with no payment method on file can't have auto-renew re-enabled, so we render a disabled toggle with nothing to explain it. A top-of-page notice already offers **Add payment method** in most cases, but it reads as an expiry warning further up the page and leaves the control the customer just tried to flip dead and unlabelled. For trial plans, domain transfers, hundred-year domains, and a few other purchase types that notice doesn't render at all, so the bare toggle is all there is.

The card already handled the mirror case — auto-renew **on** with no chargeable method swapped the toggle for this same row — but it was gated on auto-renew being on, so the more common dead end never reached it. This reuses it for both, minus in-app purchases, whose payment method lives in the App/Play Store.

## Testing Instructions

1. Open a subscription under Billing → Active subscriptions and turn auto-renew off.
2. Remove the stored payment method for it, so nothing is on file.
3. Back in **Manage subscription**, confirm you see the **Add payment method** button instead of a disabled toggle, and that it opens the change-payment-method screen.
4. Add a card, return, and confirm the toggle is back and interactive.
5. Regression: a subscription with a valid card still shows a normal toggle, and an in-app purchase shows the toggle rather than the button.

Unit tests cover the four states: `yarn test-client client/dashboard/me/billing-purchases/purchase-settings/`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?




