### PR TITLE
Omnibar: enable in non-production

### DIFF
--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -33,7 +33,7 @@
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": true,
-		"dashboard/omnibar-radical": false,
+		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,
 		"dashboard/simulate-full-rollout": false,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -28,6 +28,7 @@
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": true,
+		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,
 		"dashboard/simulate-full-rollout": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -33,6 +33,7 @@
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": true,
+		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/simulate-full-rollout": true,
 		"dashboard/wp-beta-program": true,

--- a/config/development.json
+++ b/config/development.json
@@ -74,7 +74,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": true,
-		"dashboard/omnibar-radical": false,
+		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,
 		"dashboard/rollout-advance-notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -44,6 +44,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
+		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": true,

--- a/config/test.json
+++ b/config/test.json
@@ -40,6 +40,7 @@
 		"current-site/notice": true,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
+		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": false,
 		"dashboard/simulate-full-rollout": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -43,6 +43,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
+		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,
 		"dashboard/rollout-advance-notice": true,


### PR DESCRIPTION
Part of DOTCOM-17657

## Proposed Changes

Show the omnibar from the new `@automattic/omnibar` package in dev and staging environments.

## Why are these changes being made?

Roll out to proxied Automatticians first.

## Testing Instructions

Smoke-test the admin bar in Calypso screens.