### PR TITLE
Omnibar: various UI fixes 5

### DIFF
--- a/client/dashboard/app/omnibar/plugin-launch-site.scss
+++ b/client/dashboard/app/omnibar/plugin-launch-site.scss
@@ -18,16 +18,11 @@
 	}
 
 	svg {
-		width: 28px;
-		height: 28px;
-
-		@media ( min-width: 782px ) {
-			width: 15px;
-			height: 15px;
-		}
+		width: 15px;
+		height: 15px;
 	}
 
-	@media ( max-width: 480px ) {
+	@media ( max-width: 781px ) {
 		display: none;
 	}
 }

--- a/client/dashboard/app/omnibar/plugin-shopping-cart.scss
+++ b/client/dashboard/app/omnibar/plugin-shopping-cart.scss
@@ -1,4 +1,8 @@
 .omnibar .omnibar__secondary .omnibar__menu.omnibar__cart {
+	@media ( max-width: 480px ) {
+		min-width: 52px;
+	}
+
 	@media ( min-width: 782px ) {
 		padding-inline: 6px;
 	}

--- a/client/dashboard/app/omnibar/plugin-site-badges.scss
+++ b/client/dashboard/app/omnibar/plugin-site-badges.scss
@@ -4,6 +4,10 @@
 		min-width: 260px;
 	}
 
+	.omnibar__menu-group:has( .omnibar__site-badge ) {
+		padding-block: 10px;
+	}
+
 	.omnibar__site-badge {
 		display: flex;
 		flex-direction: row;
@@ -21,6 +25,6 @@
 		background-color: rgba( 255, 255, 255, 0.15 );
 		color: var( --omnibar-submenu-text-color );
 		font-size: 12px;
-		line-height: 20px;
+		line-height: 24px;
 	}
 }

--- a/packages/omnibar/src/components/omnibar-node.tsx
+++ b/packages/omnibar/src/components/omnibar-node.tsx
@@ -7,22 +7,9 @@ export function OmnibarNodeContent( { node }: { node: OmnibarNode } ) {
 	}
 	if ( node.icon && node.title ) {
 		return (
-			<Stack
-				direction="row"
-				align="center"
-				className="omnibar__node-content"
-				style={ { minWidth: 0 } }
-			>
+			<Stack direction="row" align="center" className="omnibar__node-content">
 				<span style={ { display: 'flex', flexShrink: 0 } }>{ node.icon }</span>
-				<span
-					className="omnibar__label"
-					style={ {
-						overflow: 'hidden',
-						textOverflow: 'ellipsis',
-						whiteSpace: 'nowrap',
-						minWidth: 0,
-					} }
-				>
+				<span className="omnibar__label" style={ { whiteSpace: 'nowrap' } }>
 					{ node.title }
 				</span>
 			</Stack>

--- a/packages/omnibar/src/components/omnibar-responsive-menu.scss
+++ b/packages/omnibar/src/components/omnibar-responsive-menu.scss
@@ -1,5 +1,14 @@
 .omnibar {
 	.omnibar__menu.omnibar__responsive-menu {
+		@media ( max-width: 480px ) {
+			min-width: 48px;
+
+			.dashicons-before::before {
+				width: 48px;
+				inset-inline-start: 1px;
+			}
+		}
+
 		@media ( min-width: 782px ) {
 			display: none;
 		}

--- a/packages/omnibar/src/components/omnibar-user.scss
+++ b/packages/omnibar/src/components/omnibar-user.scss
@@ -54,6 +54,10 @@
 	justify-content: flex-end;
 	padding-inline-end: 10px;
 
+	@media ( max-width: 480px ) {
+		padding-inline-end: 7px;
+	}
+
 	@media ( min-width: 782px ) {
 		justify-content: center;
 		padding-inline-end: 8px;

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -19,6 +19,26 @@ body:has( .omnibar ) {
 	}
 }
 
+.omnibar,
+.omnibar__popover {
+	.dashicons-before {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 20px;
+
+		&::before {
+			position: relative;
+			width: 20px;
+			height: 20px;
+			font-size: 20px;
+			line-height: 1;
+			-webkit-font-smoothing: antialiased;
+			-moz-osx-font-smoothing: grayscale;
+		}
+	}
+}
+
 .omnibar {
 	background-color: var( --omnibar-background );
 	min-height: var( --omnibar-height );
@@ -33,14 +53,10 @@ body:has( .omnibar ) {
 	.omnibar__secondary {
 		display: flex;
 		align-items: center;
-		margin-inline-start: auto;
-
-		@media ( max-width: 480px ) {
-			position: absolute;
-			top: 0;
-			inset-inline-end: 0;
-			background: var( --omnibar-background );
-		}
+		position: absolute;
+		top: 0;
+		inset-inline-end: 0;
+		background: var( --omnibar-background );
 
 		.omnibar__menu {
 			@media ( min-width: 782px ) {
@@ -104,27 +120,48 @@ body:has( .omnibar ) {
 			}
 		}
 
+		@media ( max-width: 480px ) {
+			min-width: 46px;
+		}
+
 		@media ( min-width: 782px ) {
 			min-width: auto;
 			padding-inline: 7px 8px;
 		}
 	}
 
-	.omnibar__responsive-menu {
-		.dashicons-before::before {
-			padding-inline: 1px;
+	.omnibar__menu:has( .omnibar__site-action ) {
+		@media ( max-width: 480px ) {
+			min-width: 52px;
 		}
 	}
 
 	.omnibar__home {
+		@media ( max-width: 480px ) {
+			min-width: 44px;
+
+			svg {
+				position: relative;
+				inset-inline-start: -1px;
+			}
+		}
+
 		@media ( min-width: 782px ) {
 			padding-inline-start: 8px;
 		}
 	}
 
 	.omnibar__site {
-		@media ( min-width: 782px ) {
-			min-width: 0;
+		@media ( max-width: 480px ) {
+			.dashicons-before::before {
+				width: 46px;
+				inset-inline-start: 3px;
+			}
+
+			.omnibar__site-icon {
+				position: relative;
+				inset-inline-start: 3px;
+			}
 		}
 
 		.omnibar__site-icon {
@@ -166,24 +203,42 @@ body:has( .omnibar ) {
 	.omnibar__node-content {
 		gap: 6px;
 	}
-}
 
-.omnibar,
-.omnibar__popover {
 	.dashicons-before {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		height: 20px;
+		height: 40px;
 
 		&::before {
-			position: relative;
-			width: 20px;
+			width: 52px;
+			height: 40px;
+			font-size: 40px;
+			text-align: center;
+		}
+
+		@media ( min-width: 782px ) {
+			height: 20px;
+
+			&::before {
+				width: 20px;
+				height: 20px;
+				font-size: 20px;
+				text-align: initial;
+			}
+		}
+	}
+
+	.dashicons-menu-alt::before {
+		top: 0.5px;
+		inset-inline-start: -1px;
+		margin-inline-end: 1px;
+	}
+
+	.dashicons-admin-home::before {
+		height: 32px;
+		font-size: 32px;
+
+		@media ( min-width: 782px ) {
 			height: 20px;
 			font-size: 20px;
-			line-height: 1;
-			-webkit-font-smoothing: antialiased;
-			-moz-osx-font-smoothing: grayscale;
 		}
 	}
 
@@ -193,51 +248,14 @@ body:has( .omnibar ) {
 
 	.dashicons-admin-comments::before,
 	.dashicons-search::before {
-		top: 1px;
-	}
-}
+		height: 34px;
+		font-size: 34px;
+		top: 0.5px;
 
-.omnibar .dashicons-before {
-	height: 40px;
-
-	&::before {
-		width: 52px;
-		height: 40px;
-		font-size: 40px;
-		text-align: center;
-	}
-
-	@media ( min-width: 782px ) {
-		height: 20px;
-
-		&::before {
-			width: 20px;
+		@media ( min-width: 782px ) {
 			height: 20px;
 			font-size: 20px;
-			text-align: initial;
+			top: 1px;
 		}
-	}
-}
-
-.omnibar .dashicons-admin-home::before {
-	height: 32px;
-	font-size: 32px;
-
-	@media ( min-width: 782px ) {
-		height: 20px;
-		font-size: 20px;
-	}
-}
-
-.omnibar .dashicons-admin-comments::before,
-.omnibar .dashicons-search::before {
-	height: 34px;
-	font-size: 34px;
-	top: 0.5px;
-
-	@media ( min-width: 782px ) {
-		height: 20px;
-		font-size: 20px;
-		top: 1px;
 	}
 }


### PR DESCRIPTION
This fixes various layout issues in the new `dashboard/omnibar-radical`:

- Removes the launch site button on mobile resolution
- Make the nodes pixel-perfect with wp-admin on < 480px width
- Add padding around the site status badge to match wp-admin