### PR TITLE
Onboarding: show the post-checkout AI setup choice on Commerce plans

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -64,7 +64,10 @@ const PostCheckoutOnboarding: StepType< {
 	const showBigSkyChoice =
 		isEnabled( 'onboarding/post-checkout-ai-step' ) &&
 		!! site?.plan &&
-		( isPersonal( site.plan ) || isPremium( site.plan ) || isBusiness( site.plan ) ) &&
+		( isPersonal( site.plan ) ||
+			isPremium( site.plan ) ||
+			isBusiness( site.plan ) ||
+			isEcommerce( site.plan ) ) &&
 		site.plan.features?.active?.includes( FEATURE_BIG_SKY );
 
 	const intent = useSelect(


### PR DESCRIPTION
## Proposed Changes

Buying a Commerce plan through the build-wow flow ([Generated themes replace Assembler in Big Sky](https://linear.app/a8c/project/generated-themes-replace-assembler-in-big-sky-ea75fac8fa1f/overview)) skips the post-checkout AI setup chooser (`setup-your-site-ai`: Build with AI / the Automattician-only generate-theme (build-wow) entry / start simple) and lands straight on `/home/:site`.

The gate is `showBigSkyChoice` in `post-checkout-onboarding.tsx`: it allowlists `isPersonal || isPremium || isBusiness` before the `FEATURE_BIG_SKY` check, so an eCommerce plan fails the plan-type test and `postCheckoutBigSky` is never submitted — `onboarding.ts`'s processing case then falls through to `window.location.replace( destination )`, the default My Home destination from `getOnboardingPostCheckoutDestination`.

Commerce plans do carry the feature: wpcom grants `big-sky` to `WPCOM_PERSONAL_AND_HIGHER_PLANS`, which includes the eCommerce bundles (`wp-content/mu-plugins/wpcom-features/class-wpcom-features.php`).

**One-line fix**: add `isEcommerce( site.plan )` (already imported in this file for `isCommercePlan`) to the plan-type list. The trailing `site.plan.features?.active?.includes( FEATURE_BIG_SKY )` check is unchanged and still gates the chooser on the plan actually carrying Big Sky.

## Why the backend copes with this

A Commerce purchase fires wpcom's `activate_ecommerce_product()` webhook (`wp-content/admin-plugins/atomic.php`), which auto-starts an Atomic transfer (context `ecommerce_plan_purchase`) before the user returns from checkout. That is compatible with showing the chooser:

- This step's pending action already handles it: `siteTransferStatusData?.isTransferring` → `waitForAtomic()`, so the chooser renders once the transfer settles. (Commerce buyers wait on the loading screen for the transfer — same as the marketplace-theme path today.)
- The build-wow endpoint (`wpcom/v2/…/big-sky/build-wow`) treats an already-running or completed transfer as success (`big_sky_build_wow_ensure_atomic_transfer()` returns the current transfer / the atomic state), and its marker blog options (`big_sky_build_wow_enabled`, pending spec/user) are in the `woa_get_transfer_options()` allowlist, so they survive a transfer that's already in flight when they're written.
- The webhook's tsubaki + Headstart pre-transfer theme setup is superseded by whichever AI build the user picks; "start simple" keeps the standard Commerce store setup.

## Testing Instructions

- `yarn test client/landing/stepper/declarative-flow/test/onboarding-setup-your-site-ai.ts` — existing chooser routing coverage.
- Live (Automattician, `onboarding/post-checkout-ai-step` enabled): run `/setup/onboarding`, pick a **Commerce** plan at the plans step, complete checkout. Before: brief processing screen, then `/home/:site`. After: the pending action waits for the webhook-initiated Atomic transfer, then the `setup-your-site-ai` chooser renders; `generate-theme` proceeds into the build-wow site-spec flow against the already-Atomic site.
- Regression: Personal/Premium/Business purchases still show the chooser; Free plan still goes to My Home.

Related wpcom references: `activate_ecommerce_product()` webhook auto-transfer (`wp-content/admin-plugins/atomic.php:123`), build-wow transfer tolerance (`wp-content/mu-plugins/big-sky.php` `big_sky_build_wow_ensure_atomic_transfer()`), transfer-options allowlist (`wp-content/lib/atomic/woa.php:3245`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
