### PR TITLE
A4A-3186: Add Pressable to managed WordPress hosts option

### DIFF
--- a/client/a8c-for-agencies/sections/partner-directory/components/hooks/use-form-selectors.ts
+++ b/client/a8c-for-agencies/sections/partner-directory/components/hooks/use-form-selectors.ts
@@ -119,7 +119,7 @@ export function useFormSelectors() {
 		shared_managed: translate(
 			'Common shared / managed hosting (SiteGround, Bluehost, GoDaddy, etc.)'
 		),
-		managed_wp_hosts: translate( 'Managed WordPress hosts (WP Engine, Kinsta, etc.)' ),
+		managed_wp_hosts: translate( 'Managed WordPress hosts (Pressable, WP Engine, Kinsta, etc.)' ),
 		self_hosted: translate( 'Self-hosted / custom hosting' ),
 	};
 


### PR DESCRIPTION
Resolves A4A-3186

## Proposed Changes

- Add Pressable first in the managed WordPress hosts example shown in the A4A lead-matching form.

<img width="740" height="469" alt="image" src="https://github.com/user-attachments/assets/19a93fe9-6372-4fff-a5be-f6314bdcc332" />

## Why are these changes being made?

The hosting example should explicitly include Pressable among the managed WordPress hosts agencies can select.

## Testing Instructions

- Open Partner Directory → Lead matching.
- Go to Hosting and platforms.
- Verify the managed WordPress hosts option reads `Managed WordPress hosts (Pressable, WP Engine, Kinsta, etc.)`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md), [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors), and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md).
- [x] Have we added the “[Status] String Freeze” label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have you tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the “[Status] Needs Privacy Updates” label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

*— ClemenAgent (Powered by Codex)*
