### PR TITLE
A4A: move MCP page descriptions out of the header

### DIFF
--- a/client/a8c-for-agencies/sections/ai-mcp/primary/overview/index.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/overview/index.tsx
@@ -5,7 +5,6 @@ import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar
 import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
 	LayoutHeaderTitle as Title,
-	LayoutHeaderSubtitle as Subtitle,
 	LayoutHeaderActions as Actions,
 } from 'calypso/layout/hosting-dashboard/header';
 import AiMcpOverviewContent from './overview-content';
@@ -18,11 +17,6 @@ export default function AiMcpOverview() {
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title }</Title>
-					<Subtitle>
-						{ __(
-							'Control how AI assistants interact with your Automattic for Agencies account and sites.'
-						) }
-					</Subtitle>
 					<Actions>
 						<MobileSidebarNavigation />
 					</Actions>

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/overview/overview-content.tsx
@@ -1,3 +1,5 @@
+import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import {
 	A4A_AI_MCP_READ_TOOLS_LINK,
@@ -30,16 +32,23 @@ export default function AiMcpOverviewContent() {
 	);
 
 	return (
-		<McpOverview
-			settings={ settings }
-			isLoading={ isLoading }
-			isSaving={ saveSettings.isPending }
-			onSave={ onSave }
-			recordTracksEvent={ recordTracks }
-			readToolsPath={ A4A_AI_MCP_READ_TOOLS_LINK }
-			writeToolsPath={ A4A_AI_MCP_WRITE_TOOLS_LINK }
-			connectPath={ A4A_AI_MCP_CONNECT_LINK }
-			promptsPath={ A4A_AI_MCP_STARTER_PROMPTS_LINK }
-		/>
+		<VStack spacing={ 6 }>
+			<Text size={ 15 }>
+				{ __(
+					'Control how AI assistants interact with your Automattic for Agencies account and sites.'
+				) }
+			</Text>
+			<McpOverview
+				settings={ settings }
+				isLoading={ isLoading }
+				isSaving={ saveSettings.isPending }
+				onSave={ onSave }
+				recordTracksEvent={ recordTracks }
+				readToolsPath={ A4A_AI_MCP_READ_TOOLS_LINK }
+				writeToolsPath={ A4A_AI_MCP_WRITE_TOOLS_LINK }
+				connectPath={ A4A_AI_MCP_CONNECT_LINK }
+				promptsPath={ A4A_AI_MCP_STARTER_PROMPTS_LINK }
+			/>
+		</VStack>
 	);
 }

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/read-tools/index.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/read-tools/index.tsx
@@ -7,7 +7,6 @@ import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
 	LayoutHeaderActions as Actions,
 	LayoutHeaderBreadcrumb as Breadcrumb,
-	LayoutHeaderSubtitle as Subtitle,
 } from 'calypso/layout/hosting-dashboard/header';
 import AiMcpReadToolsContent from './read-tools-content';
 
@@ -30,9 +29,6 @@ export default function AiMcpReadTools() {
 							},
 						] }
 					/>
-					<Subtitle>
-						{ __( 'Control which AI tools are available to your external AI assistant.' ) }
-					</Subtitle>
 					<Actions useColumnAlignment>
 						<MobileSidebarNavigation />
 					</Actions>

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/read-tools/read-tools-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/read-tools/read-tools-content.tsx
@@ -1,3 +1,5 @@
+import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import useFetchMcpSettings from 'calypso/a8c-for-agencies/data/mcp-ai/use-fetch-mcp-settings';
 import useSaveMcpSettings from 'calypso/a8c-for-agencies/data/mcp-ai/use-save-mcp-settings';
@@ -25,12 +27,17 @@ export default function AiMcpReadToolsContent() {
 	);
 
 	return (
-		<McpTools
-			toolType="read"
-			settings={ settings }
-			isSaving={ isSaving }
-			onSave={ onSave }
-			recordTracksEvent={ recordTracks }
-		/>
+		<VStack spacing={ 6 }>
+			<Text size={ 15 }>
+				{ __( 'Control which AI tools are available to your external AI assistant.' ) }
+			</Text>
+			<McpTools
+				toolType="read"
+				settings={ settings }
+				isSaving={ isSaving }
+				onSave={ onSave }
+				recordTracksEvent={ recordTracks }
+			/>
+		</VStack>
 	);
 }

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/write-tools/index.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/write-tools/index.tsx
@@ -7,7 +7,6 @@ import LayoutBody from 'calypso/layout/hosting-dashboard/body';
 import LayoutHeader, {
 	LayoutHeaderActions as Actions,
 	LayoutHeaderBreadcrumb as Breadcrumb,
-	LayoutHeaderSubtitle as Subtitle,
 } from 'calypso/layout/hosting-dashboard/header';
 import AiMcpWriteToolsContent from './write-tools-content';
 
@@ -30,9 +29,6 @@ export default function AiMcpWriteTools() {
 							},
 						] }
 					/>
-					<Subtitle>
-						{ __( 'Control which actions your external AI assistant can take on your behalf.' ) }
-					</Subtitle>
 					<Actions useColumnAlignment>
 						<MobileSidebarNavigation />
 					</Actions>

--- a/client/a8c-for-agencies/sections/ai-mcp/primary/write-tools/write-tools-content.tsx
+++ b/client/a8c-for-agencies/sections/ai-mcp/primary/write-tools/write-tools-content.tsx
@@ -1,3 +1,5 @@
+import { __experimentalText as Text, __experimentalVStack as VStack } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import useFetchMcpSettings from 'calypso/a8c-for-agencies/data/mcp-ai/use-fetch-mcp-settings';
 import useSaveMcpSettings from 'calypso/a8c-for-agencies/data/mcp-ai/use-save-mcp-settings';
@@ -25,12 +27,17 @@ export default function AiMcpWriteToolsContent() {
 	);
 
 	return (
-		<McpTools
-			toolType="write"
-			settings={ settings }
-			isSaving={ isSaving }
-			onSave={ onSave }
-			recordTracksEvent={ recordTracks }
-		/>
+		<VStack spacing={ 6 }>
+			<Text size={ 15 }>
+				{ __( 'Control which actions your external AI assistant can take on your behalf.' ) }
+			</Text>
+			<McpTools
+				toolType="write"
+				settings={ settings }
+				isSaving={ isSaving }
+				onSave={ onSave }
+				recordTracksEvent={ recordTracks }
+			/>
+		</VStack>
 	);
 }


### PR DESCRIPTION
## Proposed Changes

* On the Classic dashboard AI and MCP screens (Overview, Read, Write), the page description no longer renders in the header. The header now shows only the title or breadcrumb, and the description moved to the top of the page body.

| Before | After |
|--------|--------|
| <img width="1731" height="960" alt="Screenshot 2026-08-19 at 8 09 14 PM" src="https://github.com/user-attachments/assets/a8b0ba0a-bb00-4106-a8de-f7b0e2986f39" /> | <img width="1729" height="960" alt="Screenshot 2026-08-19 at 8 09 21 PM" src="https://github.com/user-attachments/assets/e720a486-1bec-4c02-a1c2-bcd9ebbedf3b" /> |
| <img width="1729" height="960" alt="Screenshot 2026-08-19 at 8 09 43 PM" src="https://github.com/user-attachments/assets/be52fdba-5ddc-48af-b556-fe13110d085a" /> | <img width="1729" height="961" alt="Screenshot 2026-08-19 at 8 09 36 PM" src="https://github.com/user-attachments/assets/adb021c1-d22f-4f19-ace0-c31cd2e8e5f7" /> |
| <img width="1728" height="962" alt="Screenshot 2026-08-19 at 8 09 50 PM" src="https://github.com/user-attachments/assets/db7612ce-e881-4043-a933-e96e32c6d874" /> | <img width="1728" height="959" alt="Screenshot 2026-08-19 at 8 09 59 PM" src="https://github.com/user-attachments/assets/8815af88-1df7-4acb-a97e-98ea418af59b" /> | 

## Why are these changes being made?

* The header should carry the page title only. Moving the description into the body also makes these three screens consistent with Connect agent and Starter prompts, which already did this.

## Testing Instructions

* Go to AI and MCP in the Classic dashboard, then visit Overview, Read, and Write.
* Confirm each header shows only the title or breadcrumb, and the description appears above the page content.
* Confirm Connect agent and Starter prompts are unchanged, and that the new dashboard MCP screens are unaffected.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
