### PR TITLE
Agenttic: expose session hydration state

### DIFF
--- a/packages/agenttic-client/src/agents-api/types.ts
+++ b/packages/agenttic-client/src/agents-api/types.ts
@@ -140,6 +140,9 @@ export interface AgentsApiChatState {
 	messages: AgentsApiMessage[];
 	sessions: AgentsApiSession[];
 	sessionId: string | null;
+	hasLoadedSessions: boolean;
+	isLoadingSessions: boolean;
+	isLoadingSession: boolean;
 	isProcessing: boolean;
 	error: string | null;
 	sendMessage: ( message: string, files?: File[] ) => Promise< void >;

--- a/packages/agenttic-client/src/agents-api/types.ts
+++ b/packages/agenttic-client/src/agents-api/types.ts
@@ -140,9 +140,12 @@ export interface AgentsApiChatState {
 	messages: AgentsApiMessage[];
 	sessions: AgentsApiSession[];
 	sessionId: string | null;
-	hasLoadedSessions: boolean;
+	/** Whether the initial session-list request has settled, successfully or with an error. */
+	hasResolvedSessions: boolean;
+	/** Whether initial session discovery is in progress. Background refreshes do not set this. */
 	isLoadingSessions: boolean;
-	isLoadingSession: boolean;
+	/** Whether a stored conversation transcript is being loaded. */
+	isLoadingTranscript: boolean;
 	isProcessing: boolean;
 	error: string | null;
 	sendMessage: ( message: string, files?: File[] ) => Promise< void >;
@@ -153,6 +156,8 @@ export interface AgentsApiChatState {
 
 export interface AgentsApiChatOptions {
 	adapter: AgentsApiChatAdapter;
+	/** Stable conversation scope. Changing it intentionally clears chat and session state. */
+	scopeKey?: string;
 	mediaUploadFn?: AgentsApiMediaUpload;
 	runAdapter?: AgentsApiRunAdapter;
 	getRunId?: ( metadata: Record< string, unknown > ) => string | null | undefined;

--- a/packages/agenttic-client/src/agents-api/useAgentsApiChat.test.tsx
+++ b/packages/agenttic-client/src/agents-api/useAgentsApiChat.test.tsx
@@ -17,10 +17,11 @@ function deferred< T >() {
 }
 
 let adapter: AgentsApiChatAdapter;
+let scopeKey: string;
 let latestHookValue: AgentsApiChatState | null = null;
 
 function HookHarness(): null {
-	latestHookValue = useAgentsApiChat( { adapter } );
+	latestHookValue = useAgentsApiChat( { adapter, scopeKey } );
 	return null;
 }
 
@@ -36,6 +37,7 @@ describe( 'useAgentsApiChat session hydration', () => {
 			markSessionRead: vi.fn().mockResolvedValue( {} ),
 			deleteSession: vi.fn(),
 		};
+		scopeKey = 'agent-1';
 		latestHookValue = null;
 		container = document.createElement( 'div' );
 		document.body.appendChild( container );
@@ -55,18 +57,18 @@ describe( 'useAgentsApiChat session hydration', () => {
 
 		await act( async () => root.render( <HookHarness /> ) );
 		expect( latestHookValue?.isLoadingSessions ).toBe( true );
-		expect( latestHookValue?.hasLoadedSessions ).toBe( false );
+		expect( latestHookValue?.hasResolvedSessions ).toBe( false );
 		expect( latestHookValue?.isProcessing ).toBe( false );
 
 		await act( async () => sessions.resolve( [ { id: 'session-1' } ] ) );
 		expect( latestHookValue?.isLoadingSessions ).toBe( false );
-		expect( latestHookValue?.hasLoadedSessions ).toBe( true );
+		expect( latestHookValue?.hasResolvedSessions ).toBe( true );
 
 		let loadPromise!: Promise< void >;
 		await act( async () => {
 			loadPromise = latestHookValue!.loadSession( 'session-1' );
 		} );
-		expect( latestHookValue?.isLoadingSession ).toBe( true );
+		expect( latestHookValue?.isLoadingTranscript ).toBe( true );
 		expect( latestHookValue?.isProcessing ).toBe( true );
 		expect( latestHookValue?.messages ).toEqual( [] );
 
@@ -77,7 +79,7 @@ describe( 'useAgentsApiChat session hydration', () => {
 			} );
 			await loadPromise;
 		} );
-		expect( latestHookValue?.isLoadingSession ).toBe( false );
+		expect( latestHookValue?.isLoadingTranscript ).toBe( false );
 		expect( latestHookValue?.sessionId ).toBe( 'session-1' );
 		expect( latestHookValue?.messages[ 0 ]?.id ).toBe( 'old-user' );
 	} );
@@ -92,7 +94,7 @@ describe( 'useAgentsApiChat session hydration', () => {
 			loadPromise = latestHookValue!.loadSession( 'session-1' );
 		} );
 		await act( async () => latestHookValue!.newSession() );
-		expect( latestHookValue?.isLoadingSession ).toBe( false );
+		expect( latestHookValue?.isLoadingTranscript ).toBe( false );
 
 		await act( async () => {
 			transcript.resolve( {
@@ -137,5 +139,111 @@ describe( 'useAgentsApiChat session hydration', () => {
 
 		expect( latestHookValue?.sessionId ).toBe( 'session-2' );
 		expect( latestHookValue?.messages[ 0 ]?.id ).toBe( 'second' );
+		expect( latestHookValue?.isLoadingTranscript ).toBe( false );
+		expect( latestHookValue?.isProcessing ).toBe( false );
+	} );
+
+	it( 'resolves initial session discovery after an error', async () => {
+		vi.mocked( adapter.listSessions ).mockRejectedValueOnce( new Error( 'Unavailable' ) );
+
+		await act( async () => root.render( <HookHarness /> ) );
+
+		expect( latestHookValue?.hasResolvedSessions ).toBe( true );
+		expect( latestHookValue?.isLoadingSessions ).toBe( false );
+		expect( latestHookValue?.error ).toBe( 'Unavailable' );
+	} );
+
+	it( 'preserves conversation state when only the adapter reference changes', async () => {
+		vi.mocked( adapter.loadSession ).mockResolvedValueOnce( {
+			session_id: 'session-1',
+			messages: [ { id: 'existing', role: 'user', content: 'Existing' } ],
+		} );
+		await act( async () => root.render( <HookHarness /> ) );
+		await act( async () => latestHookValue!.loadSession( 'session-1' ) );
+
+		adapter = {
+			...adapter,
+			listSessions: vi.fn().mockResolvedValue( [] ),
+		};
+		await act( async () => root.render( <HookHarness /> ) );
+
+		expect( latestHookValue?.sessionId ).toBe( 'session-1' );
+		expect( latestHookValue?.messages[ 0 ]?.id ).toBe( 'existing' );
+	} );
+
+	it( 'clears the old conversation and rejects its late load when scope changes', async () => {
+		const transcript = deferred< unknown >();
+		vi.mocked( adapter.loadSession )
+			.mockResolvedValueOnce( {
+				session_id: 'session-1',
+				messages: [ { id: 'existing', role: 'user', content: 'Existing' } ],
+			} )
+			.mockReturnValueOnce( transcript.promise );
+		await act( async () => root.render( <HookHarness /> ) );
+		await act( async () => latestHookValue!.loadSession( 'session-1' ) );
+
+		let loadPromise!: Promise< void >;
+		await act( async () => {
+			loadPromise = latestHookValue!.loadSession( 'session-2' );
+		} );
+		scopeKey = 'agent-2';
+		await act( async () => root.render( <HookHarness /> ) );
+		expect( latestHookValue?.sessionId ).toBeNull();
+		expect( latestHookValue?.messages ).toEqual( [] );
+
+		await act( async () => {
+			transcript.resolve( {
+				session_id: 'session-2',
+				messages: [ { id: 'late', role: 'user', content: 'Late' } ],
+			} );
+			await loadPromise;
+		} );
+		expect( latestHookValue?.sessionId ).toBeNull();
+		expect( latestHookValue?.messages ).toEqual( [] );
+		expect( latestHookValue?.isProcessing ).toBe( false );
+	} );
+
+	it( 'keeps New blank when an older send resolves late', async () => {
+		const send = deferred< unknown >();
+		vi.mocked( adapter.sendMessage ).mockReturnValueOnce( send.promise );
+		await act( async () => root.render( <HookHarness /> ) );
+
+		let sendPromise!: Promise< void >;
+		await act( async () => {
+			sendPromise = latestHookValue!.sendMessage( 'Hello' );
+		} );
+		await act( async () => latestHookValue!.newSession() );
+
+		await act( async () => {
+			send.resolve( { session_id: 'sent-session', response: 'Late reply' } );
+			await sendPromise;
+		} );
+		expect( latestHookValue?.sessionId ).toBeNull();
+		expect( latestHookValue?.messages ).toEqual( [] );
+		expect( latestHookValue?.isProcessing ).toBe( false );
+	} );
+
+	it( 'keeps a selected transcript when an older send resolves late', async () => {
+		const send = deferred< unknown >();
+		vi.mocked( adapter.sendMessage ).mockReturnValueOnce( send.promise );
+		vi.mocked( adapter.loadSession ).mockResolvedValueOnce( {
+			session_id: 'selected-session',
+			messages: [ { id: 'selected', role: 'user', content: 'Selected' } ],
+		} );
+		await act( async () => root.render( <HookHarness /> ) );
+
+		let sendPromise!: Promise< void >;
+		await act( async () => {
+			sendPromise = latestHookValue!.sendMessage( 'Hello' );
+		} );
+		await act( async () => latestHookValue!.loadSession( 'selected-session' ) );
+		await act( async () => {
+			send.resolve( { session_id: 'sent-session', response: 'Late reply' } );
+			await sendPromise;
+		} );
+
+		expect( latestHookValue?.sessionId ).toBe( 'selected-session' );
+		expect( latestHookValue?.messages[ 0 ]?.id ).toBe( 'selected' );
+		expect( latestHookValue?.isProcessing ).toBe( false );
 	} );
 } );

--- a/packages/agenttic-client/src/agents-api/useAgentsApiChat.test.tsx
+++ b/packages/agenttic-client/src/agents-api/useAgentsApiChat.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { act } from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAgentsApiChat } from './useAgentsApiChat';
+import type { AgentsApiChatAdapter, AgentsApiChatState } from './types';
+
+( globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean } ).IS_REACT_ACT_ENVIRONMENT = true;
+
+function deferred< T >() {
+	let resolve!: ( value: T ) => void;
+	const promise = new Promise< T >( ( nextResolve ) => {
+		resolve = nextResolve;
+	} );
+	return { promise, resolve };
+}
+
+let adapter: AgentsApiChatAdapter;
+let latestHookValue: AgentsApiChatState | null = null;
+
+function HookHarness(): null {
+	latestHookValue = useAgentsApiChat( { adapter } );
+	return null;
+}
+
+describe( 'useAgentsApiChat session hydration', () => {
+	let container: HTMLDivElement;
+	let root: Root;
+
+	beforeEach( () => {
+		adapter = {
+			sendMessage: vi.fn(),
+			listSessions: vi.fn().mockResolvedValue( [] ),
+			loadSession: vi.fn(),
+			markSessionRead: vi.fn().mockResolvedValue( {} ),
+			deleteSession: vi.fn(),
+		};
+		latestHookValue = null;
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		root = createRoot( container );
+	} );
+
+	afterEach( async () => {
+		await act( async () => root.unmount() );
+		container.remove();
+	} );
+
+	it( 'exposes session discovery and transcript hydration independently', async () => {
+		const sessions = deferred< unknown >();
+		const transcript = deferred< unknown >();
+		vi.mocked( adapter.listSessions ).mockReturnValueOnce( sessions.promise );
+		vi.mocked( adapter.loadSession ).mockReturnValue( transcript.promise );
+
+		await act( async () => root.render( <HookHarness /> ) );
+		expect( latestHookValue?.isLoadingSessions ).toBe( true );
+		expect( latestHookValue?.hasLoadedSessions ).toBe( false );
+		expect( latestHookValue?.isProcessing ).toBe( false );
+
+		await act( async () => sessions.resolve( [ { id: 'session-1' } ] ) );
+		expect( latestHookValue?.isLoadingSessions ).toBe( false );
+		expect( latestHookValue?.hasLoadedSessions ).toBe( true );
+
+		let loadPromise!: Promise< void >;
+		await act( async () => {
+			loadPromise = latestHookValue!.loadSession( 'session-1' );
+		} );
+		expect( latestHookValue?.isLoadingSession ).toBe( true );
+		expect( latestHookValue?.isProcessing ).toBe( true );
+		expect( latestHookValue?.messages ).toEqual( [] );
+
+		await act( async () => {
+			transcript.resolve( {
+				session_id: 'session-1',
+				messages: [ { id: 'old-user', role: 'user', content: 'Old' } ],
+			} );
+			await loadPromise;
+		} );
+		expect( latestHookValue?.isLoadingSession ).toBe( false );
+		expect( latestHookValue?.sessionId ).toBe( 'session-1' );
+		expect( latestHookValue?.messages[ 0 ]?.id ).toBe( 'old-user' );
+	} );
+
+	it( 'keeps New blank when an older transcript resolves late', async () => {
+		const transcript = deferred< unknown >();
+		vi.mocked( adapter.loadSession ).mockReturnValue( transcript.promise );
+		await act( async () => root.render( <HookHarness /> ) );
+
+		let loadPromise!: Promise< void >;
+		await act( async () => {
+			loadPromise = latestHookValue!.loadSession( 'session-1' );
+		} );
+		await act( async () => latestHookValue!.newSession() );
+		expect( latestHookValue?.isLoadingSession ).toBe( false );
+
+		await act( async () => {
+			transcript.resolve( {
+				session_id: 'session-1',
+				messages: [ { id: 'old-user', role: 'user', content: 'Old' } ],
+			} );
+			await loadPromise;
+		} );
+		expect( latestHookValue?.sessionId ).toBeNull();
+		expect( latestHookValue?.messages ).toEqual( [] );
+		expect( adapter.markSessionRead ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps the newest selection when session loads resolve out of order', async () => {
+		const firstTranscript = deferred< unknown >();
+		const secondTranscript = deferred< unknown >();
+		vi.mocked( adapter.loadSession )
+			.mockReturnValueOnce( firstTranscript.promise )
+			.mockReturnValueOnce( secondTranscript.promise );
+		await act( async () => root.render( <HookHarness /> ) );
+
+		let firstLoad!: Promise< void >;
+		let secondLoad!: Promise< void >;
+		await act( async () => {
+			firstLoad = latestHookValue!.loadSession( 'session-1' );
+			secondLoad = latestHookValue!.loadSession( 'session-2' );
+		} );
+		await act( async () => {
+			secondTranscript.resolve( {
+				session_id: 'session-2',
+				messages: [ { id: 'second', role: 'user', content: 'Second' } ],
+			} );
+			await secondLoad;
+		} );
+		await act( async () => {
+			firstTranscript.resolve( {
+				session_id: 'session-1',
+				messages: [ { id: 'first', role: 'user', content: 'First' } ],
+			} );
+			await firstLoad;
+		} );
+
+		expect( latestHookValue?.sessionId ).toBe( 'session-2' );
+		expect( latestHookValue?.messages[ 0 ]?.id ).toBe( 'second' );
+	} );
+} );

--- a/packages/agenttic-client/src/agents-api/useAgentsApiChat.ts
+++ b/packages/agenttic-client/src/agents-api/useAgentsApiChat.ts
@@ -61,7 +61,10 @@ export function useAgentsApiChat( {
 	const [ sessions, setSessions ] = useState< AgentsApiSession[] >( [] );
 	const [ sessionId, setSessionId ] = useState< string | null >( null );
 	const [ runId, setRunId ] = useState< string | null >( null );
-	const [ isProcessing, setIsProcessing ] = useState( false );
+	const [ hasLoadedSessions, setHasLoadedSessions ] = useState( false );
+	const [ isLoadingSessions, setIsLoadingSessions ] = useState( false );
+	const [ isLoadingSession, setIsLoadingSession ] = useState( false );
+	const [ isSending, setIsSending ] = useState( false );
 	const [ error, setError ] = useState< string | null >( null );
 	const messageIdsRef = useRef< Set< string > >( new Set() );
 	const onErrorRef = useRef( onError );
@@ -70,6 +73,8 @@ export function useAgentsApiChat( {
 	const onUnreadChangeRef = useRef( onUnreadChange );
 	const mountedRef = useRef( true );
 	const refreshRequestRef = useRef( 0 );
+	const loadRequestRef = useRef( 0 );
+	const isProcessing = isSending || isLoadingSession;
 
 	useEffect( () => {
 		onErrorRef.current = onError;
@@ -97,14 +102,32 @@ export function useAgentsApiChat( {
 	const refreshSessions = useCallback( async () => {
 		/* eslint-disable @wordpress/no-unused-vars-before-return -- the request must complete before the staleness guard */
 		const requestId = ++refreshRequestRef.current;
-		const response = await adapter.listSessions();
-		const nextSessions = normalizeSessions( response );
-		/* eslint-enable @wordpress/no-unused-vars-before-return */
-		if ( ! mountedRef.current || requestId !== refreshRequestRef.current ) {
-			return;
+		setIsLoadingSessions( true );
+		try {
+			const response = await adapter.listSessions();
+			const nextSessions = normalizeSessions( response );
+			/* eslint-enable @wordpress/no-unused-vars-before-return */
+			if ( ! mountedRef.current || requestId !== refreshRequestRef.current ) {
+				return;
+			}
+			setSessions( nextSessions );
+			setHasLoadedSessions( true );
+			onUnreadChangeRef.current?.( unreadTotal( nextSessions ) );
+		} finally {
+			if ( mountedRef.current && requestId === refreshRequestRef.current ) {
+				setIsLoadingSessions( false );
+			}
 		}
-		setSessions( nextSessions );
-		onUnreadChangeRef.current?.( unreadTotal( nextSessions ) );
+	}, [ adapter ] );
+
+	useEffect( () => {
+		refreshRequestRef.current += 1;
+		loadRequestRef.current += 1;
+		setSessions( [] );
+		setSessionId( null );
+		setHasLoadedSessions( false );
+		setIsLoadingSessions( false );
+		setIsLoadingSession( false );
 	}, [ adapter ] );
 
 	useEffect( () => {
@@ -128,7 +151,7 @@ export function useAgentsApiChat( {
 				},
 				'user'
 			);
-			setIsProcessing( true );
+			setIsSending( true );
 			setError( null );
 			setMessages( ( currentMessages ) => [ ...currentMessages, submittedMessage ] );
 			messageIdsRef.current = new Set( [ ...messageIdsRef.current, submittedMessage.id ] );
@@ -163,7 +186,7 @@ export function useAgentsApiChat( {
 				setNormalizedError( err );
 			} finally {
 				if ( mountedRef.current ) {
-					setIsProcessing( false );
+					setIsSending( false );
 				}
 			}
 		},
@@ -172,11 +195,13 @@ export function useAgentsApiChat( {
 
 	const loadSession = useCallback(
 		async ( nextSessionId: string ) => {
-			setIsProcessing( true );
+			const requestId = ++loadRequestRef.current;
+			setIsLoadingSession( true );
+			setError( null );
 			try {
 				const response = await adapter.loadSession( nextSessionId );
 				const loaded = normalizeLoadedSession( response );
-				if ( ! mountedRef.current ) {
+				if ( ! mountedRef.current || requestId !== loadRequestRef.current ) {
 					return;
 				}
 				messageIdsRef.current = new Set( loaded.messages.map( ( item ) => item.id ) );
@@ -184,12 +209,17 @@ export function useAgentsApiChat( {
 				setMessages( loaded.messages );
 				onResponseMetadataRef.current?.( loaded.metadata );
 				await adapter.markSessionRead( nextSessionId );
+				if ( requestId !== loadRequestRef.current ) {
+					return;
+				}
 				await refreshSessions();
 			} catch ( err ) {
-				setNormalizedError( err );
+				if ( requestId === loadRequestRef.current ) {
+					setNormalizedError( err );
+				}
 			} finally {
-				if ( mountedRef.current ) {
-					setIsProcessing( false );
+				if ( mountedRef.current && requestId === loadRequestRef.current ) {
+					setIsLoadingSession( false );
 				}
 			}
 		},
@@ -197,8 +227,10 @@ export function useAgentsApiChat( {
 	);
 
 	const newSession = useCallback( () => {
+		loadRequestRef.current += 1;
 		setSessionId( null );
 		setRunId( null );
+		setIsLoadingSession( false );
 		messageIdsRef.current = new Set();
 		setMessages( [] );
 		setError( null );
@@ -209,13 +241,16 @@ export function useAgentsApiChat( {
 			return;
 		}
 		await runAdapter.cancel( { runId, sessionId } );
-		setIsProcessing( false );
+		setIsSending( false );
 	}, [ runAdapter, runId, sessionId ] );
 
 	return {
 		messages,
 		sessions,
 		sessionId,
+		hasLoadedSessions,
+		isLoadingSessions,
+		isLoadingSession,
 		isProcessing,
 		error,
 		sendMessage,

--- a/packages/agenttic-client/src/agents-api/useAgentsApiChat.ts
+++ b/packages/agenttic-client/src/agents-api/useAgentsApiChat.ts
@@ -48,6 +48,7 @@ function containsUserMessage( messages: AgentsApiMessage[], message: AgentsApiMe
 
 export function useAgentsApiChat( {
 	adapter,
+	scopeKey,
 	mediaUploadFn,
 	runAdapter,
 	getRunId,
@@ -61,20 +62,21 @@ export function useAgentsApiChat( {
 	const [ sessions, setSessions ] = useState< AgentsApiSession[] >( [] );
 	const [ sessionId, setSessionId ] = useState< string | null >( null );
 	const [ runId, setRunId ] = useState< string | null >( null );
-	const [ hasLoadedSessions, setHasLoadedSessions ] = useState( false );
+	const [ hasResolvedSessions, setHasResolvedSessions ] = useState( false );
 	const [ isLoadingSessions, setIsLoadingSessions ] = useState( false );
-	const [ isLoadingSession, setIsLoadingSession ] = useState( false );
-	const [ isSending, setIsSending ] = useState( false );
+	const [ activeOperation, setActiveOperation ] = useState< 'send' | 'transcript' | null >( null );
 	const [ error, setError ] = useState< string | null >( null );
 	const messageIdsRef = useRef< Set< string > >( new Set() );
+	const hasResolvedSessionsRef = useRef( false );
 	const onErrorRef = useRef( onError );
 	const onMessageRef = useRef( onMessage );
 	const onResponseMetadataRef = useRef( onResponseMetadata );
 	const onUnreadChangeRef = useRef( onUnreadChange );
 	const mountedRef = useRef( true );
 	const refreshRequestRef = useRef( 0 );
-	const loadRequestRef = useRef( 0 );
-	const isProcessing = isSending || isLoadingSession;
+	const operationRequestRef = useRef( 0 );
+	const isLoadingTranscript = activeOperation === 'transcript';
+	const isProcessing = activeOperation !== null;
 
 	useEffect( () => {
 		onErrorRef.current = onError;
@@ -102,7 +104,10 @@ export function useAgentsApiChat( {
 	const refreshSessions = useCallback( async () => {
 		/* eslint-disable @wordpress/no-unused-vars-before-return -- the request must complete before the staleness guard */
 		const requestId = ++refreshRequestRef.current;
-		setIsLoadingSessions( true );
+		const isInitialLoad = ! hasResolvedSessionsRef.current;
+		if ( isInitialLoad ) {
+			setIsLoadingSessions( true );
+		}
 		try {
 			const response = await adapter.listSessions();
 			const nextSessions = normalizeSessions( response );
@@ -111,31 +116,46 @@ export function useAgentsApiChat( {
 				return;
 			}
 			setSessions( nextSessions );
-			setHasLoadedSessions( true );
 			onUnreadChangeRef.current?.( unreadTotal( nextSessions ) );
 		} finally {
 			if ( mountedRef.current && requestId === refreshRequestRef.current ) {
-				setIsLoadingSessions( false );
+				hasResolvedSessionsRef.current = true;
+				setHasResolvedSessions( true );
+				if ( isInitialLoad ) {
+					setIsLoadingSessions( false );
+				}
 			}
 		}
 	}, [ adapter ] );
 
-	useEffect( () => {
-		refreshRequestRef.current += 1;
-		loadRequestRef.current += 1;
-		setSessions( [] );
+	const newSession = useCallback( () => {
+		operationRequestRef.current += 1;
 		setSessionId( null );
-		setHasLoadedSessions( false );
+		setRunId( null );
+		setActiveOperation( null );
+		messageIdsRef.current = new Set();
+		setMessages( [] );
+		setError( null );
+	}, [] );
+
+	useEffect( () => {
+		if ( scopeKey === undefined ) {
+			return;
+		}
+		refreshRequestRef.current += 1;
+		hasResolvedSessionsRef.current = false;
+		setSessions( [] );
+		setHasResolvedSessions( false );
 		setIsLoadingSessions( false );
-		setIsLoadingSession( false );
-	}, [ adapter ] );
+		newSession();
+	}, [ newSession, scopeKey ] );
 
 	useEffect( () => {
 		if ( ! isVisible ) {
 			return;
 		}
 		refreshSessions().catch( setNormalizedError );
-	}, [ isVisible, refreshSessions, setNormalizedError ] );
+	}, [ isVisible, refreshSessions, scopeKey, setNormalizedError ] );
 
 	const sendMessage = useCallback(
 		async ( message: string, files?: File[] ) => {
@@ -151,13 +171,17 @@ export function useAgentsApiChat( {
 				},
 				'user'
 			);
-			setIsSending( true );
+			const requestId = ++operationRequestRef.current;
+			setActiveOperation( 'send' );
 			setError( null );
 			setMessages( ( currentMessages ) => [ ...currentMessages, submittedMessage ] );
 			messageIdsRef.current = new Set( [ ...messageIdsRef.current, submittedMessage.id ] );
 			onMessageRef.current?.( submittedMessage );
 			try {
 				const attachments = await uploadFiles( files, mediaUploadFn );
+				if ( requestId !== operationRequestRef.current ) {
+					return;
+				}
 				const existingMessageIds = new Set( messageIdsRef.current );
 				const response = await adapter.sendMessage( {
 					message: content,
@@ -165,7 +189,7 @@ export function useAgentsApiChat( {
 					attachments,
 				} );
 				const normalized = normalizeSendResponse( response, content, attachments );
-				if ( ! mountedRef.current ) {
+				if ( ! mountedRef.current || requestId !== operationRequestRef.current ) {
 					return;
 				}
 				const nextMessages = containsUserMessage( normalized.messages, submittedMessage )
@@ -183,10 +207,12 @@ export function useAgentsApiChat( {
 				onResponseMetadataRef.current?.( normalized.metadata );
 				await refreshSessions();
 			} catch ( err ) {
-				setNormalizedError( err );
+				if ( requestId === operationRequestRef.current ) {
+					setNormalizedError( err );
+				}
 			} finally {
-				if ( mountedRef.current ) {
-					setIsSending( false );
+				if ( mountedRef.current && requestId === operationRequestRef.current ) {
+					setActiveOperation( null );
 				}
 			}
 		},
@@ -195,13 +221,13 @@ export function useAgentsApiChat( {
 
 	const loadSession = useCallback(
 		async ( nextSessionId: string ) => {
-			const requestId = ++loadRequestRef.current;
-			setIsLoadingSession( true );
+			const requestId = ++operationRequestRef.current;
+			setActiveOperation( 'transcript' );
 			setError( null );
 			try {
 				const response = await adapter.loadSession( nextSessionId );
 				const loaded = normalizeLoadedSession( response );
-				if ( ! mountedRef.current || requestId !== loadRequestRef.current ) {
+				if ( ! mountedRef.current || requestId !== operationRequestRef.current ) {
 					return;
 				}
 				messageIdsRef.current = new Set( loaded.messages.map( ( item ) => item.id ) );
@@ -209,48 +235,41 @@ export function useAgentsApiChat( {
 				setMessages( loaded.messages );
 				onResponseMetadataRef.current?.( loaded.metadata );
 				await adapter.markSessionRead( nextSessionId );
-				if ( requestId !== loadRequestRef.current ) {
+				if ( requestId !== operationRequestRef.current ) {
 					return;
 				}
 				await refreshSessions();
 			} catch ( err ) {
-				if ( requestId === loadRequestRef.current ) {
+				if ( requestId === operationRequestRef.current ) {
 					setNormalizedError( err );
 				}
 			} finally {
-				if ( mountedRef.current && requestId === loadRequestRef.current ) {
-					setIsLoadingSession( false );
+				if ( mountedRef.current && requestId === operationRequestRef.current ) {
+					setActiveOperation( null );
 				}
 			}
 		},
 		[ adapter, refreshSessions, setNormalizedError ]
 	);
 
-	const newSession = useCallback( () => {
-		loadRequestRef.current += 1;
-		setSessionId( null );
-		setRunId( null );
-		setIsLoadingSession( false );
-		messageIdsRef.current = new Set();
-		setMessages( [] );
-		setError( null );
-	}, [] );
-
 	const cancelRun = useCallback( async () => {
 		if ( ! runId || ! sessionId || ! runAdapter?.cancel ) {
 			return;
 		}
 		await runAdapter.cancel( { runId, sessionId } );
-		setIsSending( false );
-	}, [ runAdapter, runId, sessionId ] );
+		if ( activeOperation === 'send' ) {
+			operationRequestRef.current += 1;
+		}
+		setActiveOperation( ( current ) => ( current === 'send' ? null : current ) );
+	}, [ activeOperation, runAdapter, runId, sessionId ] );
 
 	return {
 		messages,
 		sessions,
 		sessionId,
-		hasLoadedSessions,
+		hasResolvedSessions,
 		isLoadingSessions,
-		isLoadingSession,
+		isLoadingTranscript,
 		isProcessing,
 		error,
 		sendMessage,


### PR DESCRIPTION
## Proposed changes

- expose explicit initial session-discovery and transcript-loading state from `useAgentsApiChat`
- reset chat and session state only when a consumer-provided stable conversation scope changes
- use one operation generation so New, scope changes, transcript loads, and sends cannot overwrite newer state
- preserve conversation state across adapter reference churn and avoid loading flashes during background session refreshes
- add hook coverage for discovery failure and competing adapter, scope, load, New, and send operations

This is the Agenttic dependency for Automattic/frontend-agent-chat#131 and its reported restoration bug in Automattic/frontend-agent-chat#129. The behavior remains isolated to the Agents API hook; Agents Manager and `useAgentChat` are unchanged.

## Testing instructions

- `yarn workspace @automattic/agenttic-client test`
- `yarn workspace @automattic/agenttic-client type-check`
- `yarn workspace @automattic/agenttic-client build`
- `yarn workspace @automattic/agents-manager build`
- `yarn eslint packages/agenttic-client/src/agents-api/types.ts packages/agenttic-client/src/agents-api/useAgentsApiChat.ts packages/agenttic-client/src/agents-api/useAgentsApiChat.test.tsx`
- `yarn prettier --check packages/agenttic-client/src/agents-api/types.ts packages/agenttic-client/src/agents-api/useAgentsApiChat.ts packages/agenttic-client/src/agents-api/useAgentsApiChat.test.tsx`

The Agenttic suite passes 226 tests. Eight focused hook tests cover initial loading, failed discovery, New versus transcript, out-of-order transcripts, adapter churn, explicit scope changes, New versus send, and transcript versus send, including final processing-state convergence.

The downstream runtime-backed campaign in Automattic/frontend-agent-chat#131 additionally executes delayed REST responses for restore, New versus transcript, New versus a real send POST, and transcript versus a real send POST.

## AI assistance

GPT-5.6 Sol was used through OpenCode to investigate the races, implement the state-machine fix and tests, and run compatibility verification. Chris Huber reviewed and is responsible for the changes.