### PR TITLE
Blueprint onboarding: hand the editor a site to personalize

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -406,7 +406,9 @@ const SiteSpec: StepType = function SiteSpec() {
 				} );
 
 				const adminUrl = await getSiteAdminUrl( blueprintArchiveSiteIdentifier );
-				const siteEditorUrl = getSiteEditorUrl( adminUrl );
+				const siteEditorUrl = getSiteEditorUrl( adminUrl, {
+					startWalkthrough: applied,
+				} );
 
 				logBlueprintArchiveEvent( 'redirect_site_editor', {
 					site_identifier: blueprintArchiveSiteIdentifier,

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -282,9 +282,21 @@ export async function getSiteAdminUrl( siteIdentifier: string ): Promise< string
 /**
  * Build the Site Editor URL from a site's wp-admin URL.
  */
-export function getSiteEditorUrl( adminUrl: string ): string {
+export function getSiteEditorUrl(
+	adminUrl: string,
+	{ startWalkthrough = false }: { startWalkthrough?: boolean } = {}
+): string {
 	const base = adminUrl.endsWith( '/' ) ? adminUrl : `${ adminUrl }/`;
-	return `${ base }site-editor.php`;
+	const url = `${ base }site-editor.php`;
+
+	// The editor agent is ready to offer a copy walkthrough on a blueprint site,
+	// but it only speaks when spoken to — without this the customer lands on
+	// their new site and has to work out that saying "hi" is the way in. Big Sky
+	// reads the flag on arrival and opens the conversation for them.
+	//
+	// Only worth setting when the spec actually applied: the walkthrough has
+	// nothing to personalize from otherwise.
+	return startWalkthrough ? addQueryArgs( url, { 'blueprint-walkthrough': '1' } ) : url;
 }
 
 export function logBlueprintArchiveEvent(

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -289,22 +289,16 @@ export function getSiteEditorUrl(
 	const base = adminUrl.endsWith( '/' ) ? adminUrl : `${ adminUrl }/`;
 	const url = `${ base }site-editor.php`;
 
-	// The editor agent is ready to offer a copy walkthrough on a blueprint site,
-	// but it only speaks when spoken to — without this the customer lands on
-	// their new site and has to work out that saying "hi" is the way in. Big Sky
-	// reads the flag on arrival and opens the conversation for them.
+	// `go` tells Big Sky this arrival came from onboarding, so it personalizes the
+	// copy instead of waiting to be spoken to. It never re-runs: the flag stays in
+	// the editor URL, so a site that has already been personalized has to see it
+	// and do nothing. `reset` is the way to run it again.
 	//
-	// `go` says this arrival came from onboarding. It is deliberately not a value
-	// that re-runs anything: it rides in the editor URL and comes back on every
-	// load of it, so a site whose copy has already been rewritten must be able to
-	// see it again and do nothing. `reset` is the way to run it a second time.
+	// `canvas=edit` is required — Big Sky only mounts on the editing canvas, and
+	// the Site Editor opens in view mode.
 	//
-	// `canvas=edit` is not optional here: the Site Editor opens in view mode by
-	// default, and Big Sky only mounts on the editing canvas. Without it the flag
-	// arrives on a page where nothing is listening for it.
-	//
-	// Only worth setting when the spec actually applied: the walkthrough has
-	// nothing to personalize from otherwise.
+	// Only set when the spec applied; there is nothing to personalize from
+	// otherwise.
 	return startWalkthrough
 		? addQueryArgs( url, { canvas: 'edit', 'blueprint-walkthrough': 'go' } )
 		: url;

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -294,6 +294,11 @@ export function getSiteEditorUrl(
 	// their new site and has to work out that saying "hi" is the way in. Big Sky
 	// reads the flag on arrival and opens the conversation for them.
 	//
+	// `go` says this arrival came from onboarding. It is deliberately not a value
+	// that re-runs anything: it rides in the editor URL and comes back on every
+	// load of it, so a site whose copy has already been rewritten must be able to
+	// see it again and do nothing. `reset` is the way to run it a second time.
+	//
 	// `canvas=edit` is not optional here: the Site Editor opens in view mode by
 	// default, and Big Sky only mounts on the editing canvas. Without it the flag
 	// arrives on a page where nothing is listening for it.
@@ -301,7 +306,7 @@ export function getSiteEditorUrl(
 	// Only worth setting when the spec actually applied: the walkthrough has
 	// nothing to personalize from otherwise.
 	return startWalkthrough
-		? addQueryArgs( url, { canvas: 'edit', 'blueprint-walkthrough': '1' } )
+		? addQueryArgs( url, { canvas: 'edit', 'blueprint-walkthrough': 'go' } )
 		: url;
 }
 

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -294,9 +294,15 @@ export function getSiteEditorUrl(
 	// their new site and has to work out that saying "hi" is the way in. Big Sky
 	// reads the flag on arrival and opens the conversation for them.
 	//
+	// `canvas=edit` is not optional here: the Site Editor opens in view mode by
+	// default, and Big Sky only mounts on the editing canvas. Without it the flag
+	// arrives on a page where nothing is listening for it.
+	//
 	// Only worth setting when the spec actually applied: the walkthrough has
 	// nothing to personalize from otherwise.
-	return startWalkthrough ? addQueryArgs( url, { 'blueprint-walkthrough': '1' } ) : url;
+	return startWalkthrough
+		? addQueryArgs( url, { canvas: 'edit', 'blueprint-walkthrough': '1' } )
+		: url;
 }
 
 export function logBlueprintArchiveEvent(

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -2,7 +2,11 @@
  * @jest-environment jsdom
  */
 import wpcom from 'calypso/lib/wp';
-import { applyBlueprintSpec, getStandaloneBlueprintArchiveSlug } from '../blueprint-archive-import';
+import {
+	applyBlueprintSpec,
+	getSiteEditorUrl,
+	getStandaloneBlueprintArchiveSlug,
+} from '../blueprint-archive-import';
 
 jest.mock( 'calypso/lib/wp', () => ( {
 	__esModule: true,
@@ -73,5 +77,35 @@ describe( 'applyBlueprintSpec', () => {
 		mockPost.mockRejectedValue( new Error( 'nope' ) );
 
 		await expect( applyBlueprintSpec( '12345', 'spec-123', 'coachava' ) ).resolves.toBe( false );
+	} );
+} );
+
+describe( 'getSiteEditorUrl', () => {
+	it( 'returns a plain site editor URL by default', () => {
+		expect( getSiteEditorUrl( 'https://example.com/wp-admin/' ) ).toBe(
+			'https://example.com/wp-admin/site-editor.php'
+		);
+	} );
+
+	it( 'tolerates an admin URL without a trailing slash', () => {
+		expect( getSiteEditorUrl( 'https://example.com/wp-admin' ) ).toBe(
+			'https://example.com/wp-admin/site-editor.php'
+		);
+	} );
+
+	/**
+	 * The flag is how Big Sky knows to open the copy walkthrough instead of
+	 * waiting for the customer to speak first.
+	 */
+	it( 'flags the walkthrough when the spec was applied', () => {
+		expect( getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } ) ).toBe(
+			'https://example.com/wp-admin/site-editor.php?blueprint-walkthrough=1'
+		);
+	} );
+
+	it( 'leaves the flag off when the spec did not apply', () => {
+		expect(
+			getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: false } )
+		).not.toContain( 'blueprint-walkthrough' );
 	} );
 } );

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -99,8 +99,19 @@ describe( 'getSiteEditorUrl', () => {
 	 */
 	it( 'flags the walkthrough when the spec was applied', () => {
 		expect( getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } ) ).toBe(
-			'https://example.com/wp-admin/site-editor.php?blueprint-walkthrough=1'
+			'https://example.com/wp-admin/site-editor.php?canvas=edit&blueprint-walkthrough=1'
 		);
+	} );
+
+	/**
+	 * Big Sky only mounts on the editing canvas, so a walkthrough hand-off that
+	 * lands in the Site Editor's default view mode is inert — the flag arrives
+	 * but nothing is listening for it.
+	 */
+	it( 'opens the editing canvas alongside the walkthrough flag', () => {
+		expect(
+			getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } )
+		).toContain( 'canvas=edit' );
 	} );
 
 	it( 'leaves the flag off when the spec did not apply', () => {

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -99,7 +99,7 @@ describe( 'getSiteEditorUrl', () => {
 	 */
 	it( 'flags the walkthrough when the spec was applied', () => {
 		expect( getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } ) ).toBe(
-			'https://example.com/wp-admin/site-editor.php?canvas=edit&blueprint-walkthrough=1'
+			'https://example.com/wp-admin/site-editor.php?canvas=edit&blueprint-walkthrough=go'
 		);
 	} );
 


### PR DESCRIPTION
Hands the freshly built blueprint site to the editor with everything it needs to start personalizing it.

## What it adds to the editor URL

`canvas=edit` and `blueprint-walkthrough=1`.

The flag tells the editor this arrival came from onboarding. On the other side, Big Sky shows the page with its copy as placeholders and the agent rewrites it straight away — no offer, no confirmation — then accounts for what it changed and invites adjustments. See Automattic/wpcom#235778 and Automattic/big-sky-plugin#6295.

`canvas=edit` is not optional. The Site Editor opens in view mode by default and Big Sky only mounts on the editing canvas, so without it the flag arrives on a page where nothing is listening for it.

The flag is only set when the spec actually applied — there is nothing to personalize from otherwise.

## Testing

12 unit tests, covering the URL with and without the flag, the trailing-slash case, and that `canvas=edit` accompanies the hand-off.

## Note

`check-channel-status` failed on the previous run because the Calypso Slack channel was red at the time — a deploy gate, unrelated to this change. Re-evaluated on this push.