### PR TITLE
Jetpack AI: align review tool resolution badges with inline edit style

### DIFF
--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.scss
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.scss
@@ -285,11 +285,6 @@
 			opacity: 0.85;
 		}
 
-		&.is-accepted {
-			opacity: 0.55;
-			border-color: rgba(74, 184, 102, 0.7);
-		}
-
 		&.is-dismissed {
 			opacity: 0.4;
 		}
@@ -417,30 +412,46 @@
 
 	// ---------- Resolved (accepted / dismissed) row ----------
 	// On accept/dismiss the card keeps its header and swaps the body for a
-	// resolution chip + Undo — the same shape the shared review-card uses in
-	// Generate Feedback / Proofreader, tuned for the dark chat surface.
+	// circled status icon + Undo — the same shape the shared review-card uses
+	// in Generate Feedback / Proofreader, matching the inline-edit
+	// confirmation badge in agents-manager (agent-dock/chat-ui.scss).
 	&__resolution {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.25rem;
+		gap: 0.5rem;
 		min-height: 32px;
-		padding: 0.4rem 0.75rem;
-		border-radius: 4px;
+		padding: 0.4rem 0.75rem 0.4rem 0;
 		font-size: 13px;
-		font-weight: 600;
+		font-weight: 500;
 
-		&.is-accepted {
-			background: rgba(74, 184, 102, 0.2);
-			color: #4ab866;
+		&.is-accepted .jetpack-ai-editorial-review__resolution-icon {
+			background-color: #3858e8;
 		}
 
-		&.is-dismissed {
-			background: rgba(255, 255, 255, 0.08);
-			opacity: 0.75;
+		&.is-dismissed .jetpack-ai-editorial-review__resolution-icon {
+			padding: 3.5px;
+			background-color: #5e5e5e;
 		}
 	}
 
-	&__resolution-check,
+	// Scoped to the badge (two classes) so the white glyph outranks agenttic's
+	// same-specificity `color` rule on message descendants.
+	&__resolution &__resolution-icon {
+		flex: 0 0 auto;
+		width: 22px;
+		height: 22px;
+		padding: 1px;
+		border-radius: 50%;
+		color: var(--color-white, #fff);
+		fill: currentColor;
+
+		// Agenttic sets `color` directly on every message descendant.
+		path {
+			color: inherit;
+			fill: currentColor;
+		}
+	}
+
 	&__undo-icon {
 		flex: 0 0 auto;
 		fill: currentColor;
@@ -666,23 +677,13 @@
 			opacity: 0.85;
 		}
 
-		&.is-accepted {
-			opacity: 0.6;
-			border-color: rgba(74, 184, 102, 0.7);
-		}
-
-		&.is-dismissed {
-			opacity: 0.4;
-		}
-
 		&.is-failed {
 			border-color: rgba(214, 54, 56, 0.7);
 		}
 
-		// Resolved cards keep full opacity + a neutral surface — the state is
-		// carried by the chip, matching the shared review-card silhouette.
+		// Resolved cards keep a neutral surface — the state is carried by the
+		// status badge, matching the shared review-card silhouette.
 		&.is-resolved {
-			opacity: 1;
 			border-color: rgba(255, 255, 255, 0.12);
 			background: rgba(255, 255, 255, 0.02);
 		}

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.test.tsx
@@ -1429,7 +1429,7 @@ describe( 'AiEditorialReview — conflict resolutions', () => {
 			contentAfter: 'The council voted on Tuesday on the procedural matter.',
 		} );
 
-		render( <AiEditorialReview { ...conflictPayload } /> );
+		const { container } = render( <AiEditorialReview { ...conflictPayload } /> );
 
 		await act( async () => {
 			fireEvent.click( screen.getByRole( 'button', { name: 'Apply AI change' } ) );
@@ -1438,6 +1438,9 @@ describe( 'AiEditorialReview — conflict resolutions', () => {
 		await waitFor( () => {
 			expect( screen.getByText( 'Applied' ) ).toBeInTheDocument();
 		} );
+		expect(
+			container.querySelector( '.jetpack-ai-editorial-review__resolution-icon' )
+		).toBeInTheDocument();
 		// Not collapsed to a one-liner: the subject header stays, and the row
 		// offers Undo — the shared resolved shape from GF / Proofreader.
 		expect( screen.getByText( 'Procedural framing' ) ).toBeInTheDocument();

--- a/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/ai-editorial-review.tsx
@@ -11,7 +11,7 @@ import { Panel, PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useState, useCallback, useEffect, useMemo, useRef } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Icon, check, undo } from '@wordpress/icons';
+import { Icon, undo } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
@@ -35,7 +35,11 @@ import { getBulkResponseActionOutcome, type OnResponseAction } from '../utils/re
 import { useCopyToClipboard } from '../utils/use-copy-to-clipboard';
 import useLatestResponseAction from '../utils/use-latest-response-action';
 import BlockRef, { getBlockTypeName, type BlockSnapshot } from './block-ref';
-import ReviewCard, { ReviewCardActions, type ReviewCardRow } from './review-card';
+import ReviewCard, {
+	ReviewCardActions,
+	ReviewCardResolution,
+	type ReviewCardRow,
+} from './review-card';
 import ReviewerChip, { type ReviewerMetadata } from './reviewer-chip';
 import SplitScreenGuide from './split-screen-guide';
 
@@ -1179,20 +1183,10 @@ export default function AiEditorialReview( {
 														) }
 													</header>
 													<div className="jetpack-ai-editorial-review__actions">
-														<span
-															className={ `jetpack-ai-editorial-review__resolution is-${ status }` }
-														>
-															{ status === 'accepted' && (
-																<Icon
-																	className="jetpack-ai-editorial-review__resolution-check"
-																	icon={ check }
-																	size={ 20 }
-																/>
-															) }
-															{ status === 'accepted'
-																? __( 'Applied', __i18n_text_domain__ )
-																: __( 'Dismissed', __i18n_text_domain__ ) }
-														</span>
+														<ReviewCardResolution
+															classPrefix="jetpack-ai-editorial-review"
+															status={ status }
+														/>
 														<button
 															type="button"
 															className="jetpack-ai-editorial-review__resolution-undo"

--- a/packages/jetpack-ai-sidebar/src/components/feedback-list.scss
+++ b/packages/jetpack-ai-sidebar/src/components/feedback-list.scss
@@ -13,7 +13,6 @@
 		var( --jetpack-ai-feedback-list-primary ) 12%,
 		transparent
 	);
-	--jetpack-ai-feedback-list-applied: #079d2c;
 
 	// Agenttic's message row has a spacing-4 inline gutter. Let the review
 	// content fill that gutter, then restore it only for non-card content.
@@ -154,7 +153,6 @@
 			var( --jetpack-ai-feedback-list-primary ) 12%,
 			transparent
 		);
-		--jetpack-ai-feedback-list-applied: #079d2c;
 
 		border: 1px solid var( --jetpack-ai-feedback-list-border );
 		border-radius: 8px;
@@ -405,31 +403,44 @@
 		fill: currentColor;
 	}
 
-	// Applied / Dismissed resolution chip that replaces the card body.
+	// Applied / Dismissed status that replaces the card body: a circled icon
+	// plus a plain label, matching the inline-edit confirmation badge in
+	// agents-manager (agent-dock/chat-ui.scss).
 	&__resolution {
 		display: inline-flex;
 		align-items: center;
-		gap: 0.25rem;
+		gap: 0.5rem;
 		min-height: 32px;
-		padding: 0.4rem 0.75rem;
-		border-radius: 4px;
+		padding: 0.4rem 0.75rem 0.4rem 0;
 		font-size: 13px;
-		font-weight: 600;
+		font-weight: 500;
 
-		&.is-accepted {
-			background: color-mix( in srgb, var( --jetpack-ai-feedback-list-applied ) 20%, transparent );
-			color: var( --jetpack-ai-feedback-list-applied );
+		&.is-accepted .jetpack-ai-feedback-list__resolution-icon {
+			background-color: #3858e8;
 		}
 
-		&.is-dismissed {
-			background: color-mix( in srgb, currentColor 8%, transparent );
-			opacity: 0.75;
+		&.is-dismissed .jetpack-ai-feedback-list__resolution-icon {
+			padding: 3.5px;
+			background-color: #5e5e5e;
 		}
 	}
 
-	&__resolution-check {
+	// Scoped to the badge (two classes) so the white glyph outranks agenttic's
+	// same-specificity `color` rule on message descendants.
+	&__resolution &__resolution-icon {
 		flex: 0 0 auto;
+		width: 22px;
+		height: 22px;
+		padding: 1px;
+		border-radius: 50%;
+		color: var( --color-white, #fff );
 		fill: currentColor;
+
+		// Agenttic sets `color` directly on every message descendant.
+		path {
+			color: inherit;
+			fill: currentColor;
+		}
 	}
 
 	&__status {

--- a/packages/jetpack-ai-sidebar/src/components/review-card.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-card.test.tsx
@@ -29,7 +29,7 @@ jest.mock( '@wordpress/block-editor', () => {
 	};
 } );
 
-function renderCard( bodyRows: ReviewCardRow[] ) {
+function renderCard( bodyRows: ReviewCardRow[], overrides: Partial< ReviewCardProps > = {} ) {
 	const props: ReviewCardProps = {
 		model: {
 			badge: 'Clarity (1/1)',
@@ -50,8 +50,15 @@ function renderCard( bodyRows: ReviewCardRow[] ) {
 		onCopy: jest.fn(),
 		onDismiss: jest.fn(),
 		onUndo: jest.fn(),
+		...overrides,
 	};
 	return render( <ReviewCard { ...props } /> );
+}
+
+function getResolutionIconPath( container: HTMLElement ): string | null | undefined {
+	return container
+		.querySelector( '.jetpack-ai-feedback-list__resolution-icon path' )
+		?.getAttribute( 'd' );
 }
 
 describe( 'ReviewCard rich-text rows', () => {
@@ -178,5 +185,31 @@ describe( 'ReviewCard rich-text rows', () => {
 		expect( ins?.querySelector( 'strong' ) ).toHaveTextContent( 'safe preview' );
 		expect( ins ).not.toHaveTextContent( 'raw' );
 		expect( ( window as unknown as { pwned?: boolean } ).pwned ).toBeUndefined();
+	} );
+} );
+
+describe( 'ReviewCard resolved states', () => {
+	it( 'shows Applied with a status icon and an Undo action', () => {
+		const { container } = renderCard( [], { status: 'accepted' } );
+
+		expect( screen.getByText( 'Applied' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /Undo/ } ) ).toBeInTheDocument();
+		const resolution = container.querySelector( '.jetpack-ai-feedback-list__resolution' );
+		expect( resolution ).toHaveClass( 'is-accepted' );
+		expect( getResolutionIconPath( container ) ).toBeTruthy();
+	} );
+
+	it( 'shows Dismissed with a status icon distinct from the Applied check', () => {
+		const accepted = renderCard( [], { status: 'accepted' } );
+		const acceptedIconPath = getResolutionIconPath( accepted.container );
+		accepted.unmount();
+
+		const { container } = renderCard( [], { status: 'dismissed' } );
+
+		expect( screen.getByText( 'Dismissed' ) ).toBeInTheDocument();
+		const resolution = container.querySelector( '.jetpack-ai-feedback-list__resolution' );
+		expect( resolution ).toHaveClass( 'is-dismissed' );
+		expect( getResolutionIconPath( container ) ).toBeTruthy();
+		expect( getResolutionIconPath( container ) ).not.toEqual( acceptedIconPath );
 	} );
 } );

--- a/packages/jetpack-ai-sidebar/src/components/review-card.test.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-card.test.tsx
@@ -12,6 +12,26 @@ import ReviewCard, { type ReviewCardProps, type ReviewCardRow } from './review-c
 jest.mock( '@wordpress/blocks', () => ( {
 	getBlockType: jest.fn(),
 } ) );
+jest.mock( '@wordpress/icons', () => {
+	const { createElement: mockCreateElement } =
+		jest.requireActual< typeof import('@wordpress/element') >( '@wordpress/element' );
+
+	return {
+		check: 'check',
+		close: 'close',
+		undo: 'undo',
+		Icon: ( { className, icon }: { className?: string; icon: unknown } ) => {
+			if ( typeof icon !== 'string' ) {
+				throw new Error( 'Unexpected unmocked icon' );
+			}
+
+			return mockCreateElement( 'span', {
+				className,
+				'data-testid': `icon-${ icon }`,
+			} );
+		},
+	};
+} );
 jest.mock( '@wordpress/block-editor', () => {
 	const react = jest.requireActual< typeof import('react') >( 'react' );
 	const { RawHTML } =
@@ -53,12 +73,6 @@ function renderCard( bodyRows: ReviewCardRow[], overrides: Partial< ReviewCardPr
 		...overrides,
 	};
 	return render( <ReviewCard { ...props } /> );
-}
-
-function getResolutionIconPath( container: HTMLElement ): string | null | undefined {
-	return container
-		.querySelector( '.jetpack-ai-feedback-list__resolution-icon path' )
-		?.getAttribute( 'd' );
 }
 
 describe( 'ReviewCard rich-text rows', () => {
@@ -189,27 +203,30 @@ describe( 'ReviewCard rich-text rows', () => {
 } );
 
 describe( 'ReviewCard resolved states', () => {
-	it( 'shows Applied with a status icon and an Undo action', () => {
+	it( 'shows Applied with the check status icon and an Undo action', () => {
 		const { container } = renderCard( [], { status: 'accepted' } );
 
 		expect( screen.getByText( 'Applied' ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: /Undo/ } ) ).toBeInTheDocument();
-		const resolution = container.querySelector( '.jetpack-ai-feedback-list__resolution' );
-		expect( resolution ).toHaveClass( 'is-accepted' );
-		expect( getResolutionIconPath( container ) ).toBeTruthy();
+		expect( container.querySelector( '.jetpack-ai-feedback-list__resolution' ) ).toHaveClass(
+			'is-accepted'
+		);
+		expect( screen.getByTestId( 'icon-check' ) ).toHaveClass(
+			'jetpack-ai-feedback-list__resolution-icon'
+		);
+		expect( screen.queryByTestId( 'icon-close' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'shows Dismissed with a status icon distinct from the Applied check', () => {
-		const accepted = renderCard( [], { status: 'accepted' } );
-		const acceptedIconPath = getResolutionIconPath( accepted.container );
-		accepted.unmount();
-
+	it( 'shows Dismissed with the close status icon', () => {
 		const { container } = renderCard( [], { status: 'dismissed' } );
 
 		expect( screen.getByText( 'Dismissed' ) ).toBeInTheDocument();
-		const resolution = container.querySelector( '.jetpack-ai-feedback-list__resolution' );
-		expect( resolution ).toHaveClass( 'is-dismissed' );
-		expect( getResolutionIconPath( container ) ).toBeTruthy();
-		expect( getResolutionIconPath( container ) ).not.toEqual( acceptedIconPath );
+		expect( container.querySelector( '.jetpack-ai-feedback-list__resolution' ) ).toHaveClass(
+			'is-dismissed'
+		);
+		expect( screen.getByTestId( 'icon-close' ) ).toHaveClass(
+			'jetpack-ai-feedback-list__resolution-icon'
+		);
+		expect( screen.queryByTestId( 'icon-check' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/jetpack-ai-sidebar/src/components/review-card.tsx
+++ b/packages/jetpack-ai-sidebar/src/components/review-card.tsx
@@ -10,7 +10,7 @@
  */
 import { RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { Icon, check, undo } from '@wordpress/icons';
+import { Icon, check, close, undo } from '@wordpress/icons';
 import { type ReactNode } from 'react';
 /**
  * Internal dependencies
@@ -97,6 +97,30 @@ function getApplyLabel( status: ReviewCardStatus ): string {
 	}
 }
 
+interface ReviewCardResolutionProps {
+	classPrefix?: string;
+	status: 'accepted' | 'dismissed';
+}
+
+/** Resolved-state badge: a circled status icon plus the Applied/Dismissed label. */
+export function ReviewCardResolution( {
+	classPrefix = DEFAULT_PREFIX,
+	status,
+}: ReviewCardResolutionProps ) {
+	return (
+		<span className={ `${ classPrefix }__resolution is-${ status }` }>
+			<Icon
+				className={ `${ classPrefix }__resolution-icon` }
+				icon={ status === 'accepted' ? check : close }
+				size={ 20 }
+			/>
+			{ status === 'accepted'
+				? __( 'Applied', __i18n_text_domain__ )
+				: __( 'Dismissed', __i18n_text_domain__ ) }
+		</span>
+	);
+}
+
 /** Shared action row for applicable review cards and conflict resolutions. */
 export function ReviewCardActions( {
 	applyAction,
@@ -172,14 +196,7 @@ export default function ReviewCard( {
 			<div className={ `${ classPrefix }__item is-resolved is-${ status }` }>
 				{ header }
 				<div className={ `${ classPrefix }__actions` }>
-					<span className={ `${ classPrefix }__resolution is-${ status }` }>
-						{ status === 'accepted' && (
-							<Icon className={ `${ classPrefix }__resolution-check` } icon={ check } size={ 20 } />
-						) }
-						{ status === 'accepted'
-							? __( 'Applied', __i18n_text_domain__ )
-							: __( 'Dismissed', __i18n_text_domain__ ) }
-					</span>
+					<ReviewCardResolution classPrefix={ classPrefix } status={ status } />
 					<button
 						type="button"
 						className={ `${ classPrefix }__action-button is-undo` }


### PR DESCRIPTION
Follow-up to #113649.

## Proposed Changes

* Restyle the Applied/Dismissed resolution badges in the review tools (Editorial Review, Proofread, Simple Review) so they no longer look like buttons: a white check in a `#3858e8` circle for Applied, a white cross in a `#5e5e5e` circle for Dismissed. Labels are unchanged.
* Extract a shared `ReviewCardResolution` component, used by `ReviewCard` and the AER conflict row, and rename `__resolution-check` to `__resolution-icon`.
* Remove dead resolution CSS (never-rendering accepted/dismissed card rules) and the unused applied colour variable.
* Add resolved-state test coverage for both badges.

## Screenshots
<img width="342" height="151" alt="image" src="https://github.com/user-attachments/assets/b2a50f41-77d8-4280-bde2-6fa5ab27caaf" />

<img width="378" height="152" alt="image" src="https://github.com/user-attachments/assets/56f3b5f2-4c53-4763-92a0-9db345365816" />

<img width="337" height="135" alt="image" src="https://github.com/user-attachments/assets/0fbcf8da-196b-43ac-b094-49a54fbfed52" />

<img width="341" height="177" alt="image" src="https://github.com/user-attachments/assets/eafb7e1f-8271-4bac-8fde-20b458728814" />


## Why are these changes being made?

* Match the resolved states of the review tools to the inline-edit confirmation badge shipped in #113649, so both use one consistent, non-button style.

## Testing Instructions

1. Sandbox `widgets.wp.com`.
2. From `apps/agents-manager`, sync this branch to the sandbox with `yarn dev --sync`.
3. Open a draft post and run Editorial Review on a reasonably sized post with multiple mistakes and room for improvement.
4. On a suggested edit that offers "Apply change", apply it and validate the styling of the "Applied" text with its icon.
5. Undo it, then hit Dismiss, and validate the styling of the dismissed icon as per the screenshots above.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
