### PR TITLE
Refer a friend: Route upgrade CTA to yearly plans

### DIFF
--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -408,7 +408,7 @@ const Home = () => {
 							return;
 						}
 						const url = plansLink( '/plans', site.slug, 'yearly', true );
-						if ( isSimple && isJetpackCloud() ) {
+						if ( isJetpackCloud() ) {
 							page( getCalypsoUrl( url ) );
 							return;
 						}

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -7,9 +7,9 @@ import {
 	PLAN_JETPACK_SECURITY_DAILY,
 	PLAN_PREMIUM,
 	getPlan,
-	getYearlyPlanByMonthly,
 	isMonthly,
 	planMatches,
+	plansLink,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { getCalypsoUrl } from '@automattic/calypso-url';
@@ -404,15 +404,15 @@ const Home = () => {
 					isPrimary: true,
 					action: () => {
 						trackUpgrade( 'plans', 'peer-referral' );
-						if ( isMonthlyPlan && site?.slug && sitePlanSlug ) {
-							const annualPlanSlug = getYearlyPlanByMonthly( sitePlanSlug );
-							const planPath = annualPlanSlug || undefined;
-							if ( planPath ) {
-								page( `/checkout/${ site.slug }/${ planPath }` );
-								return;
-							}
+						if ( ! site?.slug ) {
+							return;
 						}
-						page( `/plans/${ site?.slug }` );
+						const url = plansLink( '/plans', site.slug, 'yearly', true );
+						if ( isSimple && isJetpackCloud() ) {
+							page( getCalypsoUrl( url ) );
+							return;
+						}
+						page( url );
 					},
 			  };
 


### PR DESCRIPTION
Fixes MARTECH-2494
Fixes MARTECH-2495

## Proposed Changes

* Route the ineligible Refer a Friend CTA to the yearly Plans page instead of direct checkout.
* Preserve the WordPress.com handoff for Simple sites viewed in Jetpack Cloud.

## Why are these changes being made?

* Free sites can currently be sent to checkout with `free_plan`, resulting in an empty cart.
* Monthly-plan customers should be able to compare the available annual plans and features before checkout.

## Testing Instructions

* On a Free WordPress.com site, visit `/earn/<site>` and click **Unlock this feature** in the Refer a Friend card.
* Confirm the yearly Plans page loads for the site and displays the available plans and features.
* Repeat with a paid monthly plan and confirm yearly billing is selected initially.
* On an eligible annual plan, confirm the **Earn free credits** flow remains unchanged.
* For a Simple site viewed in Jetpack Cloud, confirm the upgrade CTA opens the WordPress.com Plans page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
