### PR TITLE
Stats: name My Jetpack as a second source of the plan-chosen arg

### DIFF
--- a/client/my-sites/stats/pricing-grid/gate.tsx
+++ b/client/my-sites/stats/pricing-grid/gate.tsx
@@ -14,30 +14,35 @@ import useIsPricingGridEligible from './hooks/use-eligibility';
 import type { Callback } from '@automattic/calypso-router';
 import type { ReactNode } from 'react';
 
-const PRE_CONNECTION_RETURN_ARGS = [ PLAN_CHOSEN_QUERY_ARG, 'force_refresh' ];
+const PLAN_CHOICE_RETURN_ARGS = [ PLAN_CHOSEN_QUERY_ARG, 'force_refresh' ];
 
 const loadPricingGrid = () =>
 	import(
 		/* webpackChunkName: "async-load-calypso-my-sites-stats-pricing-grid" */ './pricing-grid'
 	);
 
-/** `unknown` is what a bundle that predates the marker naming the plan sends back. */
-type PlanChosenBeforeConnecting = 'free' | 'paid' | 'unknown';
+/** `unknown` is what a producer that predates the marker naming the plan sends back. */
+type PlanChosenElsewhere = 'free' | 'paid' | 'unknown';
 
 /**
- * Which plan the visitor picked on Odyssey's pre-connection screen, which asks exactly what this
- * gate asks — but before the site had a blog id to record the answer against, so the answer travels
- * back as a query arg on the page the connection flow lands on. `null` when the site was connected
- * by any other route.
+ * Which plan the visitor picked on another surface that asks exactly what this gate asks, or `null`
+ * when the site arrived by any other route. Two surfaces send it, both as a query arg on the page
+ * they redirect to:
+ *
+ * - Odyssey’s pre-connection screen, which asks before the site has a blog id to record an answer
+ *   against, so the answer has to travel back through the connection flow in the URL.
+ * - My Jetpack’s Add Stats interstitial, whose “Start for Free” is the same Free-vs-Paid choice.
+ *   It could record the dismissal itself, but saying so in the URL keeps the decision to dismiss
+ *   with the dashboard that owns the notice.
  *
  * Remembered after the first read: those args are then stripped from the address bar so they do
  * not sit in the Referer of every dashboard REST request, and the gate remounts on route changes.
  *
  * Exported for tests: too eager and a site never sees the grid, too shy and it is asked twice.
  */
-let rememberedChoiceBeforeConnecting: PlanChosenBeforeConnecting | null = null;
+let rememberedPlanChoice: PlanChosenElsewhere | null = null;
 
-function readChoiceBeforeConnecting(): PlanChosenBeforeConnecting | null {
+function readPlanChoice(): PlanChosenElsewhere | null {
 	const marker = new URLSearchParams( window.location.search ).get( PLAN_CHOSEN_QUERY_ARG );
 
 	if ( marker === 'free' || marker === 'paid' ) {
@@ -47,39 +52,39 @@ function readChoiceBeforeConnecting(): PlanChosenBeforeConnecting | null {
 	return marker === '1' ? 'unknown' : null;
 }
 
-export function getChoiceBeforeConnecting(): PlanChosenBeforeConnecting | null {
-	if ( ! rememberedChoiceBeforeConnecting ) {
-		rememberedChoiceBeforeConnecting = readChoiceBeforeConnecting();
+export function getPlanChosenElsewhere(): PlanChosenElsewhere | null {
+	if ( ! rememberedPlanChoice ) {
+		rememberedPlanChoice = readPlanChoice();
 	}
 
-	return rememberedChoiceBeforeConnecting;
+	return rememberedPlanChoice;
 }
 
-export function hasChosenBeforeConnecting(): boolean {
-	return getChoiceBeforeConnecting() !== null;
+export function hasChosenPlanElsewhere(): boolean {
+	return getPlanChosenElsewhere() !== null;
 }
 
 /** Clears the in-memory plan-chosen flag so tests can set a fresh query string. */
-export function resetHasChosenBeforeConnecting() {
-	rememberedChoiceBeforeConnecting = null;
+export function resetHasChosenPlanElsewhere() {
+	rememberedPlanChoice = null;
 }
 
 /**
- * Drops the pre-connection return args from a URL. `force_refresh` in particular is read from the
+ * Drops the plan-choice return args from a URL. `force_refresh` in particular is read from the
  * Referer on every Odyssey REST request and bypasses both server caches while it stays in the bar.
  */
-export function getUrlWithPreConnectionReturnArgsRemoved( url: string ): URL {
+export function getUrlWithPlanChoiceReturnArgsRemoved( url: string ): URL {
 	const next = new URL( url );
 
-	PRE_CONNECTION_RETURN_ARGS.forEach( ( arg ) => next.searchParams.delete( arg ) );
+	PLAN_CHOICE_RETURN_ARGS.forEach( ( arg ) => next.searchParams.delete( arg ) );
 
 	return next;
 }
 
-function stripPreConnectionReturnArgsFromCurrentUrl() {
+function stripPlanChoiceReturnArgsFromCurrentUrl() {
 	const current = new URL( window.location.href );
 
-	if ( ! PRE_CONNECTION_RETURN_ARGS.some( ( arg ) => current.searchParams.has( arg ) ) ) {
+	if ( ! PLAN_CHOICE_RETURN_ARGS.some( ( arg ) => current.searchParams.has( arg ) ) ) {
 		return;
 	}
 
@@ -89,7 +94,7 @@ function stripPreConnectionReturnArgsFromCurrentUrl() {
 	// URL is read inside the timeout so a rewrite by another stripper in the same load (the
 	// `statsPurchaseSuccess` one) is kept rather than overwritten with a stale copy.
 	setTimeout( () => {
-		const next = getUrlWithPreConnectionReturnArgsRemoved( window.location.href );
+		const next = getUrlWithPlanChoiceReturnArgsRemoved( window.location.href );
 
 		window.history.replaceState( null, '', next.toString() );
 		if ( isOdysseyStats ) {
@@ -99,9 +104,9 @@ function stripPreConnectionReturnArgsFromCurrentUrl() {
 }
 
 // The query arg is gone on the next visit, so the choice has to be recorded server-side once the
-// site finally has an id. Module-scoped rather than a ref: the gate remounts on every route change
-// away from and back to the traffic page, and one POST per page load is enough.
-let hasRecordedChoiceBeforeConnecting = false;
+// site has an id. Module-scoped rather than a ref: the gate remounts on every route change away
+// from and back to the traffic page, and one POST per page load is enough.
+let hasRecordedPlanChoice = false;
 
 /**
  * Replaces the Stats dashboard with the pricing grid for newly connected sites
@@ -114,7 +119,7 @@ function PricingGridGate( { children }: { children: ReactNode } ) {
 	const siteId = useSelector( getSelectedSiteId );
 	// Choosing a plan swaps the dashboard in immediately; the server-side dismissal
 	// catches up in the background and keeps the grid away on later visits.
-	const [ hasChosen, setHasChosen ] = useState( hasChosenBeforeConnecting );
+	const [ hasChosen, setHasChosen ] = useState( hasChosenPlanElsewhere );
 	const dismissPricingGrid = useDismissPricingGrid( siteId );
 
 	const { isEligible, isApplicable, isLoading } = useIsPricingGridEligible( siteId );
@@ -125,24 +130,26 @@ function PricingGridGate( { children }: { children: ReactNode } ) {
 	);
 
 	useEffect( () => {
-		stripPreConnectionReturnArgsFromCurrentUrl();
+		stripPlanChoiceReturnArgsFromCurrentUrl();
 	}, [] );
 
 	useEffect( () => {
-		if ( ! siteId || hasRecordedChoiceBeforeConnecting || ! hasChosenBeforeConnecting() ) {
+		if ( ! siteId || hasRecordedPlanChoice || ! hasChosenPlanElsewhere() ) {
 			return;
 		}
 
-		hasRecordedChoiceBeforeConnecting = true;
+		hasRecordedPlanChoice = true;
 		dismissPricingGrid();
-		// Where the pre-connection flow ends: the site is connected, and this is the first moment
-		// the choice made minutes ago can be recorded against a blog id. The property is named for
-		// what the marker carries — the plan picked on the grid, not necessarily the one the
-		// visitor left with, since taking free from the purchase page returns under the marker the
-		// paid choice set. That exit is counted by the purchase page's own button event.
+		// Where the flow that asked elsewhere ends: the site is connected, and this is the first
+		// moment the choice made minutes ago can be recorded against a blog id. The event is named
+		// for the pre-connection screen it was added for; My Jetpack's interstitial now reports
+		// through it too. The property is named for what the marker carries — the plan picked on
+		// the grid, not necessarily the one the visitor left with, since taking free from the
+		// purchase page returns under the marker the paid choice set. That exit is counted by the
+		// purchase page's own button event.
 		trackStatsAnalyticsEvent( 'stats_pre_connection_plan_completed', {
 			blog_id: siteId,
-			plan_chosen: getChoiceBeforeConnecting(),
+			plan_chosen: getPlanChosenElsewhere(),
 		} );
 	}, [ siteId, dismissPricingGrid ] );
 

--- a/client/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid.ts
+++ b/client/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid.ts
@@ -7,9 +7,10 @@ import type { Notices } from 'calypso/my-sites/stats/hooks/use-notice-visibility
 export const PRICING_GRID_REFERRER = 'jetpack-stats-pricing-grid';
 
 /**
- * Query arg that Odyssey's pre-connection screen carries back through the connection flow to name
- * the plan the visitor picked. It has to travel in the URL because the choice is made before the
- * site has a blog id to record it against.
+ * Query arg naming the plan the visitor picked on a surface that asked the Free-vs-Paid question
+ * before this grid could, so the grid must not ask again. Sent by Odyssey's pre-connection screen —
+ * which has no blog id to record an answer against, so the choice can only travel in the URL — and
+ * by My Jetpack's Add Stats interstitial.
  */
 export const PLAN_CHOSEN_QUERY_ARG = 'stats_plan_chosen';
 

--- a/client/my-sites/stats/pricing-grid/test/gate.test.ts
+++ b/client/my-sites/stats/pricing-grid/test/gate.test.ts
@@ -71,6 +71,16 @@ describe( 'getUrlWithPlanChoiceReturnArgsRemoved', () => {
 		).toBe( 'https://example.com/wp-admin/admin.php?page=stats' );
 	} );
 
+	it( 'drops the marker when it arrives alone, as My Jetpack sends it', () => {
+		// My Jetpack redirects straight to the product's post-activation URL, so the marker
+		// arrives without the force_refresh its pre-connection sibling pairs it with.
+		expect(
+			getUrlWithPlanChoiceReturnArgsRemoved(
+				'https://example.com/wp-admin/admin.php?page=stats&stats_plan_chosen=1'
+			).toString()
+		).toBe( 'https://example.com/wp-admin/admin.php?page=stats' );
+	} );
+
 	it( 'leaves unrelated query args in place', () => {
 		expect(
 			getUrlWithPlanChoiceReturnArgsRemoved(

--- a/client/my-sites/stats/pricing-grid/test/gate.test.ts
+++ b/client/my-sites/stats/pricing-grid/test/gate.test.ts
@@ -2,18 +2,18 @@
  * @jest-environment jsdom
  */
 import {
-	getChoiceBeforeConnecting,
-	getUrlWithPreConnectionReturnArgsRemoved,
-	hasChosenBeforeConnecting,
-	resetHasChosenBeforeConnecting,
+	getPlanChosenElsewhere,
+	getUrlWithPlanChoiceReturnArgsRemoved,
+	hasChosenPlanElsewhere,
+	resetHasChosenPlanElsewhere,
 } from '../gate';
 
 const setSearch = ( search: string ) =>
 	window.history.replaceState( {}, '', `/wp-admin/admin.php${ search }` );
 
-describe( 'hasChosenBeforeConnecting', () => {
+describe( 'hasChosenPlanElsewhere', () => {
 	afterEach( () => {
-		resetHasChosenBeforeConnecting();
+		resetHasChosenPlanElsewhere();
 		setSearch( '' );
 	} );
 
@@ -22,50 +22,50 @@ describe( 'hasChosenBeforeConnecting', () => {
 		( plan ) => {
 			setSearch( `?page=stats&stats_plan_chosen=${ plan }` );
 
-			expect( hasChosenBeforeConnecting() ).toBe( true );
-			expect( getChoiceBeforeConnecting() ).toBe( plan );
+			expect( hasChosenPlanElsewhere() ).toBe( true );
+			expect( getPlanChosenElsewhere() ).toBe( plan );
 		}
 	);
 
-	it( 'suppresses the grid for a marker from before it named the plan', () => {
-		// A bundle still cached from an earlier release sends `1` back, which says a plan was
-		// picked without saying which.
+	it( 'suppresses the grid for a marker that does not name the plan', () => {
+		// `1` says a plan was picked without saying which: what a bundle still cached from an
+		// earlier release sends back, and what My Jetpack's interstitial sends.
 		setSearch( '?page=stats&stats_plan_chosen=1' );
 
-		expect( hasChosenBeforeConnecting() ).toBe( true );
-		expect( getChoiceBeforeConnecting() ).toBe( 'unknown' );
+		expect( hasChosenPlanElsewhere() ).toBe( true );
+		expect( getPlanChosenElsewhere() ).toBe( 'unknown' );
 	} );
 
 	it( 'shows the grid to a site connected by any other route', () => {
 		setSearch( '?page=stats' );
 
-		expect( hasChosenBeforeConnecting() ).toBe( false );
-		expect( getChoiceBeforeConnecting() ).toBeNull();
+		expect( hasChosenPlanElsewhere() ).toBe( false );
+		expect( getPlanChosenElsewhere() ).toBeNull();
 	} );
 
 	it( 'ignores a marker that does not say a plan was picked', () => {
 		setSearch( '?page=stats&stats_plan_chosen=0' );
 
-		expect( hasChosenBeforeConnecting() ).toBe( false );
+		expect( hasChosenPlanElsewhere() ).toBe( false );
 	} );
 
 	it( 'shows the grid in Calypso, where no such arg exists', () => {
-		expect( hasChosenBeforeConnecting() ).toBe( false );
+		expect( hasChosenPlanElsewhere() ).toBe( false );
 	} );
 
 	it( 'still reports the choice after the return args have been stripped', () => {
 		setSearch( '?page=stats&stats_plan_chosen=free&force_refresh=1' );
-		expect( getChoiceBeforeConnecting() ).toBe( 'free' );
+		expect( getPlanChosenElsewhere() ).toBe( 'free' );
 
 		setSearch( '?page=stats' );
-		expect( getChoiceBeforeConnecting() ).toBe( 'free' );
+		expect( getPlanChosenElsewhere() ).toBe( 'free' );
 	} );
 } );
 
-describe( 'getUrlWithPreConnectionReturnArgsRemoved', () => {
+describe( 'getUrlWithPlanChoiceReturnArgsRemoved', () => {
 	it( 'drops the plan-chosen marker and force_refresh from the wp-admin query', () => {
 		expect(
-			getUrlWithPreConnectionReturnArgsRemoved(
+			getUrlWithPlanChoiceReturnArgsRemoved(
 				'https://example.com/wp-admin/admin.php?page=stats&stats_plan_chosen=free&force_refresh=1'
 			).toString()
 		).toBe( 'https://example.com/wp-admin/admin.php?page=stats' );
@@ -73,7 +73,7 @@ describe( 'getUrlWithPreConnectionReturnArgsRemoved', () => {
 
 	it( 'leaves unrelated query args in place', () => {
 		expect(
-			getUrlWithPreConnectionReturnArgsRemoved(
+			getUrlWithPlanChoiceReturnArgsRemoved(
 				'https://example.com/wp-admin/admin.php?page=stats&force_refresh=1&foo=bar'
 			).toString()
 		).toBe( 'https://example.com/wp-admin/admin.php?page=stats&foo=bar' );


### PR DESCRIPTION
Part of STATS-448

## Proposed Changes

* Rename the pricing grid's plan-choice symbols to say what the flag *means* rather than where it came from: `hasChosenBeforeConnecting` → `hasChosenPlanElsewhere`, `PRE_CONNECTION_RETURN_ARGS` → `PLAN_CHOICE_RETURN_ARGS`, `getUrlWithPreConnectionReturnArgsRemoved` → `getUrlWithPlanChoiceReturnArgsRemoved`, and the two module-scoped flags to match.
* Document both producers of `stats_plan_chosen=1` on `PLAN_CHOSEN_QUERY_ARG` and on the reader.
* Add a stripping case for the arg arriving on its own, without the `force_refresh` its pre-connection sibling pairs it with.

No behaviour change: the same arg is read from `window.location.search`, the same two args are stripped, and the dismissal is still recorded once per page load.

## Why are these changes being made?

The grid's suppression path was written for a single producer — Odyssey's pre-connection screen — and is named for it throughout. The naming made sense when only that screen could send the arg: it asks before the site has a blog id, so the answer can only travel back in the URL.

Automattic/jetpack#51413 makes My Jetpack's **Add Stats** interstitial a second producer. Its "Start for Free" is the same Free-vs-Paid choice, and without it the dashboard asks the question a second time. That surface is not pre-connection, so every `BeforeConnecting` name is now actively misleading — nothing in the file hints that a second caller exists, and the next person to touch this would have no reason to look for one.

The Jetpack side needs nothing else from Odyssey: the gate already renders the dashboard on first paint when the arg is present, and records the `pricing_grid` dismissal itself. Keeping that decision here, with the dashboard that owns the notice, is why the Jetpack side sends a query arg instead of POSTing the dismissal itself.

## Testing Instructions

This is a rename plus docs, so the check is that nothing moved:

1. `yarn test-client client/my-sites/stats/pricing-grid/test/gate.test.ts` — 8 passing.
2. Confirm no references to the old names remain: `git grep -n 'BeforeConnecting\|PRE_CONNECTION_RETURN_ARGS'` returns nothing.

To see the behaviour it documents, on a Jetpack site running Automattic/jetpack#51413:

3. Open `admin.php?page=my-jetpack#/add-stats` and click **Start for Free**.
4. You land on the Stats dashboard with `stats_plan_chosen=1`; the dashboard renders immediately with no grid, and a `POST` to `…/jetpack-stats-dashboard/notices` records the dismissal.
5. Loading `admin.php?page=stats` without the arg fires no such POST.

Verified end to end against a local Jetpack docker site.

### Known, pre-existing

Odyssey rewrites the URL into its hashbang form after load, which moves the return args out of `window.location.search` and into the hash — so the stripper no longer matches them and `stats_plan_chosen=1` lingers in the address bar. Cosmetic only, and it predates this change: the read happens at first render, before the rewrite, which is why suppression works either way. Not fixed here to keep this a no-behaviour-change PR.
