### PR TITLE
Omnibar: update E2E tests to work with old masterbar and new omnibar

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -260,6 +260,7 @@ class MasterbarLoggedIn extends Component {
 				isActive={ this.isSidebarOpen() }
 				className="masterbar__item-sidebar-menu"
 				tooltip={ translate( 'Menu' ) }
+				ariaLabel={ translate( 'Menu' ) }
 			/>
 		);
 	}
@@ -927,6 +928,7 @@ class MasterbarLoggedIn extends Component {
 				isActive={ this.isActive( 'notifications' ) }
 				className="masterbar__item-notifications"
 				tooltip={ translate( 'Manage your notifications' ) }
+				ariaLabel={ translate( 'Notifications' ) }
 			>
 				<span className="masterbar__item-notifications-label">
 					{ translate( 'Notifications', {

--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -19,6 +19,7 @@ class MasterbarItemNotifications extends Component {
 		isActive: PropTypes.bool,
 		className: PropTypes.string,
 		tooltip: TranslatableString,
+		ariaLabel: TranslatableString,
 		//connected
 		isNotificationsOpen: PropTypes.bool,
 		hasUnseenNotifications: PropTypes.bool,
@@ -100,6 +101,7 @@ class MasterbarItemNotifications extends Component {
 					onClick={ this.toggleNotesFrame }
 					isActive={ this.props.isActive }
 					tooltip={ this.props.tooltip }
+					ariaLabel={ this.props.ariaLabel }
 					className={ classes }
 					key={ this.state.animationState }
 				/>

--- a/packages/calypso-e2e/src/lib/components/me/dashboard-me-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/me/dashboard-me-sidebar-component.ts
@@ -28,10 +28,7 @@ export class DashboardMeSidebarComponent {
 			return;
 		}
 
-		// The toggle is an icon-only button whose accessible name is empty (the
-		// icon is a CSS pseudo-element and it carries no aria-label), so matching
-		// by role and name never resolves it. Match its `title` instead.
-		const menuToggle = this.page.getByTitle( 'Menu' ).first();
+		const menuToggle = this.page.getByRole( 'button', { name: 'Menu', exact: true } ).first();
 		// The overlay is portalled into place only while the sidebar is open, so
 		// its presence is a reliable "sidebar is open" signal.
 		const openSidebar = this.page.getByTestId( 'dashboard-responsive-sidebar-overlay' );

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -3,9 +3,7 @@ import { Page } from 'playwright';
 const selectors = {
 	// Buttons on navbar
 	mySiteButton: '[data-tip-target="my-sites"]',
-	mobileMenuButton: '[data-tip-target="mobile-menu"]',
 	editorBackButton: '[data-tip-target="back-home"]',
-	notificationsButton: 'a.masterbar-notifications',
 	meButton: 'a[data-tip-target="me"]',
 };
 /**
@@ -38,7 +36,7 @@ export class NavbarComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickMobileMenu(): Promise< void > {
-		await this.page.click( selectors.mobileMenuButton );
+		await this.page.getByRole( 'button', { name: 'Menu', exact: true } ).first().click();
 	}
 
 	/**
@@ -73,7 +71,9 @@ export class NavbarComponent {
 			return await this.page.keyboard.type( 'n' );
 		}
 
-		const notificationsButtonLocator = this.page.locator( selectors.notificationsButton );
+		const notificationsButtonLocator = this.page
+			.getByLabel( 'Notifications', { exact: true } )
+			.first();
 
 		return await notificationsButtonLocator.click();
 	}

--- a/test/e2e/specs/dashboard/dashboard__rum-tracking.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__rum-tracking.spec.ts
@@ -136,7 +136,7 @@ test.describe( 'Dashboard: RUM Performance Tracking', { tag: [ tags.DASHBOARD_PR
 				// With omnibar: click Domains in the responsive sidebar.
 				// On mobile, open the sidebar first via the masterbar menu button.
 				if ( viewportName === 'mobile' ) {
-					await page.getByTitle( 'Menu', { exact: true } ).click();
+					await page.getByRole( 'button', { name: 'Menu', exact: true } ).first().click();
 				}
 				await page.locator( '#wpcom' ).getByRole( 'link', { name: 'Domains' } ).click();
 			} else if ( viewportName === 'mobile' ) {


### PR DESCRIPTION
This is exactly the same changes as https://github.com/Automattic/wp-calypso/pull/113687 which was reverted due to flaky tests.

## Proposed Changes

Added `aria-label` to the hamburger (responsive) menu and notification bell nodes to our masterbar, so that the E2E tests can target the nodes via accessible names instead of HTML attributes.

## Why are these changes being made?

We want to replace the masterbar with the new omnibar which already has the accessible selectors.

## Testing Instructions

Verify the E2E tests pass.

