### PR TITLE
E2E: make masterbar locators work with both omnibars

### DIFF
--- a/packages/calypso-e2e/src/lib/components/me/dashboard-me-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/me/dashboard-me-sidebar-component.ts
@@ -28,10 +28,12 @@ export class DashboardMeSidebarComponent {
 			return;
 		}
 
-		// The toggle is an icon-only button whose accessible name is empty (the
-		// icon is a CSS pseudo-element and it carries no aria-label), so matching
-		// by role and name never resolves it. Match its `title` instead.
-		const menuToggle = this.page.getByTitle( 'Menu' ).first();
+		// Old masterbar labels the toggle with `title`, omnibar with `aria-label`;
+		// a flag decides which one renders, so match either.
+		const menuToggle = this.page
+			.locator( 'button[title="Menu"], button[aria-label="Menu"]' )
+			.filter( { visible: true } )
+			.first();
 		// The overlay is portalled into place only while the sidebar is open, so
 		// its presence is a reliable "sidebar is open" signal.
 		const openSidebar = this.page.getByTestId( 'dashboard-responsive-sidebar-overlay' );

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -3,9 +3,10 @@ import { Page } from 'playwright';
 const selectors = {
 	// Buttons on navbar
 	mySiteButton: '[data-tip-target="my-sites"]',
-	mobileMenuButton: '[data-tip-target="mobile-menu"]',
-	editorBackButton: '[data-tip-target="back-home"]',
-	notificationsButton: 'a.masterbar-notifications',
+	// Old masterbar and omnibar identify these differently; a flag decides which
+	// one renders, so match either.
+	mobileMenuButton: '[data-tip-target="mobile-menu"], button[aria-label="Menu"]',
+	notificationsButton: 'a.masterbar-notifications, .omnibar__notifications',
 	meButton: 'a[data-tip-target="me"]',
 };
 /**
@@ -38,16 +39,11 @@ export class NavbarComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickMobileMenu(): Promise< void > {
-		await this.page.click( selectors.mobileMenuButton );
-	}
-
-	/**
-	 * Clicks on `<` back button on the top left of the masterbar shown only to mobile users of the editor.
-	 *
-	 * @returns {Promise<void>} No return value.
-	 */
-	async clickEditorBackButton(): Promise< void > {
-		await this.page.click( selectors.editorBackButton );
+		await this.page
+			.locator( selectors.mobileMenuButton )
+			.filter( { visible: true } )
+			.first()
+			.click();
 	}
 
 	/**
@@ -73,7 +69,10 @@ export class NavbarComponent {
 			return await this.page.keyboard.type( 'n' );
 		}
 
-		const notificationsButtonLocator = this.page.locator( selectors.notificationsButton );
+		const notificationsButtonLocator = this.page
+			.locator( selectors.notificationsButton )
+			.filter( { visible: true } )
+			.first();
 
 		return await notificationsButtonLocator.click();
 	}

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -1419,11 +1419,9 @@ export class EditorPage {
 		const actions: Promise< unknown >[] = [ navigationPromise ];
 
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			// Mobile viewports do not use an EditorNavSidebar.
-			// Instead, the regular NavBar is used, and the
-			// `<` button exits the editor.
+			// Mobile has no EditorNavSidebar; My Sites doubles as the back button.
 			const navbarComponent = new NavbarComponent( this.page );
-			actions.push( navbarComponent.clickEditorBackButton() );
+			actions.push( navbarComponent.clickMySites() );
 		} else {
 			actions.push( this.editorToolbarComponent.closeEditor() );
 		}


### PR DESCRIPTION
## Proposed Changes

* Match the mobile menu toggle and the notifications button in either omnibar, instead of only the old masterbar.
* Filter to visible elements before taking the first match, so a hidden node from the other omnibar can't win.
* Remove `clickEditorBackButton`, and exit the editor on mobile via My Sites instead.

## Why are these changes being made?

Two different components render the masterbar depending on the `dashboard/omnibar-radical` feature flag, and they identify these controls differently — the old masterbar uses `data-tip-target` and its own class names, the new omnibar uses `aria-label` and `omnibar__*` classes. Locators written against just one of them break when the flag moves.

That is what happened with #113687: it switched the dashboard `/me` sidebar toggle to a role+name locator that only the new omnibar satisfies, the flag is off everywhere, and the flow tests failed. It was reverted in #113698. Matching both shapes means these locators survive the flag being switched on, and no follow-up is needed at that point.

Separately, the editor's back button selector had been dead for a while. The dedicated `<` masterbar item was removed in #103331, and My Sites has doubled as the editor's back button on mobile since. The mobile branch of `exitEditor` already documented that behaviour in its own docblock while doing something else; the two now agree.

## Testing Instructions

E2E only — no product code is touched.

The affected specs are the ones that open the dashboard `/me` sidebar, the Calypso mobile sidebar, the notifications panel, and mobile editor exit. Running the mobile project against a local Calypso instance covers all four:

* `flows/setup-domain__flows.spec.ts` — mobile sidebar on dashboard `/me`
* `infrastructure/notifications__general-interaction.spec.ts` — notifications panel
* any editor spec calling `exitEditor` on the mobile viewport

Worth flagging for review: only the old-masterbar half of each locator can actually be exercised right now, since `dashboard/omnibar-radical` is off in every config. The omnibar half is verified by reading the components, not by a run. The mobile editor-exit change is the one I would most like a second opinion on — My Sites carries submenu items, so if a click there expands rather than navigates, the alternative is to drop the viewport branch and use the editor's own close control for both.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
