### PR TITLE
Notifications: track how deep users page the note list

### DIFF
--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -38,6 +38,8 @@ export function Client() {
 	this.filterName = 'all';
 	// Per-tab load-more exhaustion, keyed by tab name.
 	this.filteredHasMore = {};
+	// Per-tab last page ordinal fetched; the initial window is page 1.
+	this.loadMorePage = {};
 	this.gettingFilteredNotes = false;
 	this.retries = 0;
 	this.subscribeTry = 0;
@@ -246,6 +248,8 @@ function getNotes( before ) {
 			);
 			debug( 'getNotes error, using backoff_ms=%d', backoff_ms );
 			this.noteList = [];
+			// The window restarts from the head, so paging depth restarts with it.
+			delete this.loadMorePage.all;
 			this.reschedule( backoff_ms );
 			return;
 		}
@@ -723,7 +727,7 @@ function loadMore() {
 		if ( ! oldest ) {
 			return;
 		}
-		trackLoadMore( key, filteredIds.length );
+		trackLoadMore.call( this, key, filteredIds.length );
 		this.getFilteredNotes( Math.floor( Date.parse( oldest.timestamp ) / 1000 ) );
 		return;
 	}
@@ -744,7 +748,7 @@ function loadMore() {
 		return;
 	}
 
-	trackLoadMore( 'all', this.noteList.length || allNotes.length );
+	trackLoadMore.call( this, 'all', this.noteList.length || allNotes.length );
 
 	// The endpoint's `before` cursor is UNIX epoch seconds, not the note's ISO
 	// timestamp; a raw string is ignored and load-more would refetch page one.
@@ -753,11 +757,15 @@ function loadMore() {
 
 // Depth telemetry: which page ordinal this fetch begins (the initial window is
 // page 1). Fires only after loadMore's guards, so a no-op scroll records nothing.
+// The ordinal is an explicit counter: it can't be derived from the loaded count,
+// since the inclusive `before` echoes the anchor back and pages grow the list
+// by increment_limit - 1.
 function trackLoadMore( filter, loaded ) {
+	this.loadMorePage[ filter ] = ( this.loadMorePage[ filter ] ?? 1 ) + 1;
 	recordTracksEvent( 'calypso_notification_load_more', {
 		filter,
 		notes_loaded: loaded,
-		page: Math.floor( loaded / settings.increment_limit ) + 1,
+		page: this.loadMorePage[ filter ],
 	} );
 }
 

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -1,6 +1,7 @@
 import debugFactory from 'debug';
 import repliesCache from '../comment-replies-cache';
 import { logError } from '../helpers/log-error';
+import { recordTracksEvent } from '../helpers/stats';
 import { store } from '../state';
 import actions from '../state/actions';
 import getAllNotes from '../state/selectors/get-all-notes';
@@ -722,6 +723,7 @@ function loadMore() {
 		if ( ! oldest ) {
 			return;
 		}
+		trackLoadMore( key, filteredIds.length );
 		this.getFilteredNotes( Math.floor( Date.parse( oldest.timestamp ) / 1000 ) );
 		return;
 	}
@@ -742,9 +744,21 @@ function loadMore() {
 		return;
 	}
 
+	trackLoadMore( 'all', this.noteList.length || allNotes.length );
+
 	// The endpoint's `before` cursor is UNIX epoch seconds, not the note's ISO
 	// timestamp; a raw string is ignored and load-more would refetch page one.
 	this.getNotes( Math.floor( Date.parse( oldest.timestamp ) / 1000 ) );
+}
+
+// Depth telemetry: which page ordinal this fetch begins (the initial window is
+// page 1). Fires only after loadMore's guards, so a no-op scroll records nothing.
+function trackLoadMore( filter, loaded ) {
+	recordTracksEvent( 'calypso_notification_load_more', {
+		filter,
+		notes_loaded: loaded,
+		page: Math.floor( loaded / settings.increment_limit ) + 1,
+	} );
 }
 
 // Whether the server may still have notes older than those already loaded.

--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -38,8 +38,6 @@ export function Client() {
 	this.filterName = 'all';
 	// Per-tab load-more exhaustion, keyed by tab name.
 	this.filteredHasMore = {};
-	// Per-tab last page ordinal fetched; the initial window is page 1.
-	this.loadMorePage = {};
 	this.gettingFilteredNotes = false;
 	this.retries = 0;
 	this.subscribeTry = 0;
@@ -248,8 +246,6 @@ function getNotes( before ) {
 			);
 			debug( 'getNotes error, using backoff_ms=%d', backoff_ms );
 			this.noteList = [];
-			// The window restarts from the head, so paging depth restarts with it.
-			delete this.loadMorePage.all;
 			this.reschedule( backoff_ms );
 			return;
 		}
@@ -298,6 +294,7 @@ function getNotes( before ) {
 			// `before` echoes back isn't double-counted.
 			const known = new Set( this.noteList.map( ( n ) => n.id ) );
 			this.noteList = this.noteList.concat( pageList.filter( ( n ) => ! known.has( n.id ) ) );
+			trackLoadMore( 'all', this.noteList.length, ! this.hasMoreNotes( 'all' ) );
 		} else {
 			// Merge the head over the window, keeping the older paged-in tail.
 			const headIds = new Set( pageList.map( ( n ) => n.id ) );
@@ -524,6 +521,8 @@ function getFilteredNotes( before ) {
 				fresh.length > 0 &&
 				data.notes.length >= parameters.number &&
 				appended.length < settings.max_limit;
+
+			trackLoadMore( key, appended.length, ! this.filteredHasMore[ key ] );
 		} else {
 			// Merge the head over the list, keeping the older paged-in tail. Drop
 			// within-head ids the server no longer returns (read/deleted elsewhere).
@@ -727,7 +726,6 @@ function loadMore() {
 		if ( ! oldest ) {
 			return;
 		}
-		trackLoadMore.call( this, key, filteredIds.length );
 		this.getFilteredNotes( Math.floor( Date.parse( oldest.timestamp ) / 1000 ) );
 		return;
 	}
@@ -748,24 +746,18 @@ function loadMore() {
 		return;
 	}
 
-	trackLoadMore.call( this, 'all', this.noteList.length || allNotes.length );
-
 	// The endpoint's `before` cursor is UNIX epoch seconds, not the note's ISO
 	// timestamp; a raw string is ignored and load-more would refetch page one.
 	this.getNotes( Math.floor( Date.parse( oldest.timestamp ) / 1000 ) );
 }
 
-// Depth telemetry: which page ordinal this fetch begins (the initial window is
-// page 1). Fires only after loadMore's guards, so a no-op scroll records nothing.
-// The ordinal is an explicit counter: it can't be derived from the loaded count,
-// since the inclusive `before` echoes the anchor back and pages grow the list
-// by increment_limit - 1.
-function trackLoadMore( filter, loaded ) {
-	this.loadMorePage[ filter ] = ( this.loadMorePage[ filter ] ?? 1 ) + 1;
+// Depth telemetry, recorded once an older page has merged: how far down the tab
+// the reader got, and whether that exhausted the list.
+function trackLoadMore( filter, total, reachedEnd ) {
 	recordTracksEvent( 'calypso_notification_load_more', {
 		filter,
-		notes_loaded: loaded,
-		page: this.loadMorePage[ filter ],
+		total,
+		reached_end: reachedEnd,
 	} );
 }
 

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -274,65 +274,75 @@ describe( 'RestClient', () => {
 			window._tkq = [];
 		} );
 
-		it( 'records a Tracks event with the page ordinal when paging the all tab', () => {
+		it( 'records the total after a load-more response lands on the all tab', () => {
 			seedFirstWindow(); // ids 100..91, 10 loaded
 
 			client.loadMore();
-
-			expect( trackedEvents() ).toEqual( [ { filter: 'all', notes_loaded: 10, page: 2 } ] );
-		} );
-
-		it( 'advances the page ordinal on each successive load-more', () => {
-			seedFirstWindow();
-
-			client.loadMore();
-			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 90 ), last_seen_time: 0 } ); // 90..81
-			getCalls.length = 0;
-			client.loadMore();
-
-			expect( trackedEvents() ).toEqual( [
-				{ filter: 'all', notes_loaded: 10, page: 2 },
-				{ filter: 'all', notes_loaded: 20, page: 3 },
-			] );
-		} );
-
-		it( 'keeps advancing the page when the echoed anchor shrinks page growth to nine', () => {
-			seedFirstWindow(); // ids 100..91
-
-			client.loadMore();
+			expect( trackedEvents() ).toEqual( [] );
 			// The inclusive `before` echoes the anchor (91) back with nine older
-			// notes, so the loaded count grows to 19, not 20.
+			// notes, so the total grows to 19, not 20.
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 91 ), last_seen_time: 0 } );
-			getCalls.length = 0;
-			client.loadMore();
 
-			expect( trackedEvents() ).toEqual( [
-				{ filter: 'all', notes_loaded: 10, page: 2 },
-				{ filter: 'all', notes_loaded: 19, page: 3 },
-			] );
+			expect( trackedEvents() ).toEqual( [ { filter: 'all', total: 19, reached_end: false } ] );
 		} );
 
-		it( 'records nothing when load-more is a no-op', () => {
+		it( 'flags reached_end when a short page exhausts the server', () => {
 			seedFirstWindow();
 
 			client.loadMore();
-			// A short page exhausts the server; the next load-more sends no request.
-			getCalls[ 0 ].callback( null, { notes: fullPage( 5, 90 ), last_seen_time: 0 } );
-			window._tkq = [];
+			getCalls[ 0 ].callback( null, { notes: fullPage( 5, 90 ), last_seen_time: 0 } ); // 90..86
+
+			expect( trackedEvents() ).toEqual( [ { filter: 'all', total: 15, reached_end: true } ] );
+		} );
+
+		it( 'flags reached_end when a full page adds nothing new', () => {
+			seedFirstWindow();
 
 			client.loadMore();
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 100 ), last_seen_time: 0 } ); // all known
+
+			expect( trackedEvents() ).toEqual( [ { filter: 'all', total: 10, reached_end: true } ] );
+		} );
+
+		it( 'records nothing for the initial window or a poll refresh', () => {
+			seedFirstWindow();
+
+			client.getNotesList();
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 100 ), last_seen_time: 0 } );
+
+			expect( trackedEvents() ).toEqual( [] );
+		} );
+
+		it( 'records nothing when a load-more fails', () => {
+			seedFirstWindow();
+
+			client.loadMore();
+			getCalls[ 0 ].callback( { status: 500 }, null );
 
 			expect( trackedEvents() ).toEqual( [] );
 		} );
 
 		it( 'records the active tab when paging a filtered tab', () => {
 			client.setFilter( 'unread' );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } ); // 209..200
+			getCalls.length = 0;
+
+			client.loadMore();
+			// Echoed anchor (200) plus nine older notes.
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 200 ), last_seen_time: 0 } );
+
+			expect( trackedEvents() ).toEqual( [ { filter: 'unread', total: 19, reached_end: false } ] );
+		} );
+
+		it( 'flags reached_end when a filtered tab gets a short page', () => {
+			client.setFilter( 'unread' );
 			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
 			getCalls.length = 0;
 
 			client.loadMore();
+			getCalls[ 0 ].callback( null, { notes: fullPage( 3, 200 ), last_seen_time: 0 } ); // 200..198
 
-			expect( trackedEvents() ).toEqual( [ { filter: 'unread', notes_loaded: 10, page: 2 } ] );
+			expect( trackedEvents() ).toEqual( [ { filter: 'unread', total: 12, reached_end: true } ] );
 		} );
 	} );
 

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -264,6 +264,62 @@ describe( 'RestClient', () => {
 		} );
 	} );
 
+	describe( 'load-more tracking', () => {
+		const trackedEvents = () =>
+			( window._tkq || [] )
+				.filter( ( [ , event ] ) => event === 'calypso_notification_load_more' )
+				.map( ( [ , , properties ] ) => properties );
+
+		beforeEach( () => {
+			window._tkq = [];
+		} );
+
+		it( 'records a Tracks event with the page ordinal when paging the all tab', () => {
+			seedFirstWindow(); // ids 100..91, 10 loaded
+
+			client.loadMore();
+
+			expect( trackedEvents() ).toEqual( [ { filter: 'all', notes_loaded: 10, page: 2 } ] );
+		} );
+
+		it( 'advances the page ordinal on each successive load-more', () => {
+			seedFirstWindow();
+
+			client.loadMore();
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 90 ), last_seen_time: 0 } ); // 90..81
+			getCalls.length = 0;
+			client.loadMore();
+
+			expect( trackedEvents() ).toEqual( [
+				{ filter: 'all', notes_loaded: 10, page: 2 },
+				{ filter: 'all', notes_loaded: 20, page: 3 },
+			] );
+		} );
+
+		it( 'records nothing when load-more is a no-op', () => {
+			seedFirstWindow();
+
+			client.loadMore();
+			// A short page exhausts the server; the next load-more sends no request.
+			getCalls[ 0 ].callback( null, { notes: fullPage( 5, 90 ), last_seen_time: 0 } );
+			window._tkq = [];
+
+			client.loadMore();
+
+			expect( trackedEvents() ).toEqual( [] );
+		} );
+
+		it( 'records the active tab when paging a filtered tab', () => {
+			client.setFilter( 'unread' );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
+			getCalls.length = 0;
+
+			client.loadMore();
+
+			expect( trackedEvents() ).toEqual( [ { filter: 'unread', notes_loaded: 10, page: 2 } ] );
+		} );
+	} );
+
 	describe( 'polling window', () => {
 		// Load-more pages with `before`; the poll/refresh must keep requesting a small
 		// fixed head window instead of growing to cover everything paged in (which

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -296,6 +296,22 @@ describe( 'RestClient', () => {
 			] );
 		} );
 
+		it( 'keeps advancing the page when the echoed anchor shrinks page growth to nine', () => {
+			seedFirstWindow(); // ids 100..91
+
+			client.loadMore();
+			// The inclusive `before` echoes the anchor (91) back with nine older
+			// notes, so the loaded count grows to 19, not 20.
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 91 ), last_seen_time: 0 } );
+			getCalls.length = 0;
+			client.loadMore();
+
+			expect( trackedEvents() ).toEqual( [
+				{ filter: 'all', notes_loaded: 10, page: 2 },
+				{ filter: 'all', notes_loaded: 19, page: 3 },
+			] );
+		} );
+
 		it( 'records nothing when load-more is a no-op', () => {
 			seedFirstWindow();
 


### PR DESCRIPTION
## Proposed Changes

* Record a `calypso_notification_load_more` Tracks event each time the notifications panel loads more notes, with the total loaded, whether the list ran out, and the active tab.

## Why are these changes being made?

* We don't know how far down their notifications users get, or whether anyone reaches the end.

## Testing Instructions

* Run `yarn test-apps apps/notifications`.
* Open the notifications panel and scroll. Each load of older notes should push the event to `window._tkq` with a growing total.
* Test the different tabs, expect `filter`, `total`, `reached_end` to be set in the `http://pixel.wp.com/t.gif?`
* Scroll to the bottom of a short list, expect `reached_end` true.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011r5wtEj7u4rThb5qDCQinG