### PR TITLE
Logged in LOHP: E2E - expect the new dashboard after authentication

### DIFF
--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -55,6 +55,17 @@ export class TestAccount {
 		const browserContext = page.context();
 		await browserContext.clearCookies();
 
+		// Re-add after the clear above: `/` serves the marketing homepage to
+		// logged-in visitors without it, and the app shell never renders.
+		await browserContext.addCookies( [
+			{
+				name: 'wpcom_skip_lohp',
+				value: '1',
+				domain: '.wordpress.com',
+				path: '/',
+			},
+		] );
+
 		if ( await this.hasFreshAuthCookies() ) {
 			this.log( 'Found fresh cookies, skipping log in' );
 			await browserContext.addCookies( await this.getAuthCookies() );

--- a/test/e2e/lib/pw-base.ts
+++ b/test/e2e/lib/pw-base.ts
@@ -533,6 +533,14 @@ export const test = base.extend<
 				domain: '.wordpress.com',
 				path: '/',
 			},
+			{
+				// Opt out of the logged-in marketing homepage, so `/` keeps taking
+				// logged-in test accounts to the app.
+				name: 'wpcom_skip_lohp',
+				value: '1',
+				domain: '.wordpress.com',
+				path: '/',
+			},
 		] );
 
 		if ( testInfo.project.name === 'authentication' ) {

--- a/test/e2e/specs/authentication/authentication__google.spec.ts
+++ b/test/e2e/specs/authentication/authentication__google.spec.ts
@@ -9,7 +9,7 @@ test.describe( 'Authentication: Google', { tag: [ tags.AUTHENTICATION ] }, () =>
 	);
 
 	test( 'As a WordPress.com user, I can use my Google account to authenticate ', async ( {
-		page,
+		pageDashboard,
 		pageLogin,
 		secrets,
 	}, workerInfo ) => {
@@ -60,9 +60,8 @@ test.describe( 'Authentication: Google', { tag: [ tags.AUTHENTICATION ] }, () =>
 			await googlePopupPageClosePromise;
 		} );
 
-		await test.step( 'Then I can see My Home on WordPress.com', async function () {
-			await page.waitForURL( /.*\/home\/.*/ );
-			await expect( page.getByRole( 'heading', { name: 'My Home' } ) ).toBeVisible();
+		await test.step( 'Then I land on the WordPress.com dashboard', async function () {
+			await expect.poll( () => pageDashboard.isLoaded(), { timeout: 20_000 } ).toBe( true );
 		} );
 	} );
 } );

--- a/test/e2e/specs/authentication/authentication__magic-link.spec.ts
+++ b/test/e2e/specs/authentication/authentication__magic-link.spec.ts
@@ -15,6 +15,7 @@ test.describe(
 		test( 'As a WordPress.com user, I can use a magic link to login to WordPress.com', async ( {
 			clientEmail,
 			page,
+			pageDashboard,
 			pageLogin,
 			secrets,
 		}, workerInfo ) => {
@@ -51,12 +52,8 @@ test.describe(
 				await page.goto( magicLinkURL.href );
 			} );
 
-			await test.step( 'Then I am redirected to the WordPress.com homepage', async function () {
-				await page.waitForURL( /home/, { timeout: 15 * 1000 } );
-			} );
-
-			await test.step( 'And I can see My Home on WordPress.com', async function () {
-				await expect( page.getByRole( 'heading', { name: 'My Home' } ) ).toBeVisible();
+			await test.step( 'Then I land on the WordPress.com dashboard', async function () {
+				await expect.poll( () => pageDashboard.isLoaded(), { timeout: 20_000 } ).toBe( true );
 			} );
 
 			await test.step( 'And I can delete the magic link email', async function () {

--- a/test/e2e/specs/authentication/authentication__sms.spec.ts
+++ b/test/e2e/specs/authentication/authentication__sms.spec.ts
@@ -15,7 +15,10 @@ test.describe(
 			'Skipping unless running on WordPress.com'
 		);
 
-		test( 'As a WordPress.com user, I can require 2fa via SMS', async ( { page }, workerInfo ) => {
+		test( 'As a WordPress.com user, I can require 2fa via SMS', async ( {
+			page,
+			pageDashboard,
+		}, workerInfo ) => {
 			test.skip(
 				workerInfo.project.name !== 'authentication',
 				'The authentication project is the only one that has the right browser settings for authentication tests'
@@ -28,9 +31,8 @@ test.describe(
 				await testAccount.logInViaLoginPage( page );
 			} );
 
-			await test.step( 'Then I am on the home page', async function () {
-				await page.waitForURL( /home/ );
-				await expect( page.getByRole( 'heading', { name: 'My Home' } ) ).toBeVisible();
+			await test.step( 'Then I land on the WordPress.com dashboard', async function () {
+				await expect.poll( () => pageDashboard.isLoaded(), { timeout: 20_000 } ).toBe( true );
 			} );
 		} );
 	}


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to 235705-ghe-Automattic/wpcom.

## Proposed Changes

* Mark test sessions so logged-in homepage requests skip the marketing homepage.
* Update the Google, magic-link, and SMS login tests to expect the new WordPress.com dashboard instead of My Home.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* All dashboard fallbacks now go to `my.wordpress.com`. Authentication tests use a normal browser user agent, so they need the test marker as well as assertions for the new destination.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Prettier completed for the three changed authentication specs.
* ESLint completed with no errors; seven existing test-policy warnings remain.
* The full login flows were not run locally because they require the CI authentication accounts and email, SMS, and OAuth credentials.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
