### PR TITLE
E2E: skip the "Bring it over" specs on a domain-availability ban

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -180,7 +180,15 @@ export class DomainSearchComponent {
 	 * Clicks on the button to bring over an external domain to WordPress.com
 	 */
 	async clickBringItOver(): Promise< void > {
-		await this.page.getByRole( 'button', { name: 'Bring it over' } ).click();
+		try {
+			await this.page.getByRole( 'button', { name: 'Bring it over' } ).click();
+		} catch ( error ) {
+			// The button is rendered off the availability query, so a `domain-availability`
+			// ban leaves it absent and the click times out. Checking here rather than before
+			// the click keeps a button that did render clickable.
+			handleActiveThrottles( [ 'domain-availability' ] );
+			throw error;
+		}
 	}
 
 	/**

--- a/packages/calypso-e2e/src/test/lib/pages/domain-throttle-actions.test.ts
+++ b/packages/calypso-e2e/src/test/lib/pages/domain-throttle-actions.test.ts
@@ -46,6 +46,16 @@ function response( url: string, body: string, status = 200 ) {
 	};
 }
 
+/** A page whose "Bring it over" button never appears. */
+function bringItOverPage(): Page {
+	const button = {
+		click: jest.fn( async () => {
+			throw new Error( 'locator timeout' );
+		} ),
+	};
+	return { getByRole: jest.fn( () => button ) } as unknown as Page;
+}
+
 /** A page whose first suggestion row never appears. */
 function suggestionRowPage(): Page {
 	const row = {
@@ -188,6 +198,30 @@ describe( 'domain throttle actions', () => {
 			'policy applied'
 		);
 		expect( actionHandler ).toHaveBeenCalledWith( 'skip', [ 'domain-availability' ] );
+	} );
+
+	test( 'the "Bring it over" button acts on an availability ban when it never renders', async () => {
+		// The button is rendered off the availability query, so a ban leaves it
+		// absent and the click times out on a test that should have skipped.
+		const page = bringItOverPage();
+		process.env.THROTTLE_DOMAIN_AVAILABILITY_EXPIRATION = String( Date.now() + 60_000 );
+		actionHandler.mockImplementation( () => {
+			throw new Error( 'policy applied' );
+		} );
+
+		await expect( new DomainSearchComponent( page ).clickBringItOver() ).rejects.toThrow(
+			'policy applied'
+		);
+		expect( actionHandler ).toHaveBeenCalledWith( 'skip', [ 'domain-availability' ] );
+	} );
+
+	test( 'a "Bring it over" button that never appears keeps its own error when no ban is in force', async () => {
+		const page = bringItOverPage();
+
+		await expect( new DomainSearchComponent( page ).clickBringItOver() ).rejects.toThrow(
+			'locator timeout'
+		);
+		expect( actionHandler ).not.toHaveBeenCalled();
 	} );
 
 	test( 'a suggestion row that never appears keeps its own error when no ban is in force', async () => {


### PR DESCRIPTION
Fixes TESTOPS-232

## Proposed Changes

* Gate `DomainSearchComponent.clickBringItOver` on the `domain-availability` throttle, on the failure path.

## Why are these changes being made?

The first pre-release build on trunk after #113594 failed two `setup-domain__flows.spec.ts` tests where the rest of the file skipped: `:26` (connect an external domain) and `:647` (transfer an external domain). Both died at `clickBringItOver` with a 10s locator timeout, and the build had imported a peer's ban:

```
Another build hit the domain-availability throttle; treating it as in force until 2026-08-20T08:42:11.469Z.
```

`UnavailableSearchResult` renders the CTA only when the availability query returns data, so under a ban the button is absent and the click times out. The gate for that throttle sits one step later, in `UseADomainIOwnPage.fillUseDomainIOwnInput`, which these two never reach.

Build: https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Pre_Release/19061903

## Testing Instructions

Unit: `yarn jest --config packages/calypso-e2e/jest.config.js src/test/lib/pages/domain-throttle-actions.test.ts` — two new cases cover a ban in force and a click that failed for its own reason.

E2E: run `setup-domain__flows.spec.ts` with `THROTTLE_DOMAIN_AVAILABILITY_EXPIRATION` set to a future timestamp and `E2E_THROTTLE_DOMAIN_AVAILABILITY_ACTION=skip`. Both specs skip instead of timing out.

**Invariant to check:** the check must stay after the click, not before it. A pre-check would skip a test whose button did render, which is the regression #113594 already had to remove once.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?
