### PR TITLE
Revert test changes from 'Omnibar: update E2E tests to work with old masterbar and new omnibar'

### DIFF
--- a/packages/calypso-e2e/src/lib/components/me/dashboard-me-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/me/dashboard-me-sidebar-component.ts
@@ -28,7 +28,10 @@ export class DashboardMeSidebarComponent {
 			return;
 		}
 
-		const menuToggle = this.page.getByRole( 'button', { name: 'Menu', exact: true } ).first();
+		// The toggle is an icon-only button whose accessible name is empty (the
+		// icon is a CSS pseudo-element and it carries no aria-label), so matching
+		// by role and name never resolves it. Match its `title` instead.
+		const menuToggle = this.page.getByTitle( 'Menu' ).first();
 		// The overlay is portalled into place only while the sidebar is open, so
 		// its presence is a reliable "sidebar is open" signal.
 		const openSidebar = this.page.getByTestId( 'dashboard-responsive-sidebar-overlay' );

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -3,7 +3,9 @@ import { Page } from 'playwright';
 const selectors = {
 	// Buttons on navbar
 	mySiteButton: '[data-tip-target="my-sites"]',
+	mobileMenuButton: '[data-tip-target="mobile-menu"]',
 	editorBackButton: '[data-tip-target="back-home"]',
+	notificationsButton: 'a.masterbar-notifications',
 	meButton: 'a[data-tip-target="me"]',
 };
 /**
@@ -36,7 +38,7 @@ export class NavbarComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickMobileMenu(): Promise< void > {
-		await this.page.getByRole( 'button', { name: 'Menu', exact: true } ).first().click();
+		await this.page.click( selectors.mobileMenuButton );
 	}
 
 	/**
@@ -71,9 +73,7 @@ export class NavbarComponent {
 			return await this.page.keyboard.type( 'n' );
 		}
 
-		const notificationsButtonLocator = this.page
-			.getByLabel( 'Notifications', { exact: true } )
-			.first();
+		const notificationsButtonLocator = this.page.locator( selectors.notificationsButton );
 
 		return await notificationsButtonLocator.click();
 	}

--- a/test/e2e/specs/dashboard/dashboard__rum-tracking.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__rum-tracking.spec.ts
@@ -136,7 +136,7 @@ test.describe( 'Dashboard: RUM Performance Tracking', { tag: [ tags.DASHBOARD_PR
 				// With omnibar: click Domains in the responsive sidebar.
 				// On mobile, open the sidebar first via the masterbar menu button.
 				if ( viewportName === 'mobile' ) {
-					await page.getByRole( 'button', { name: 'Menu', exact: true } ).first().click();
+					await page.getByTitle( 'Menu', { exact: true } ).click();
 				}
 				await page.locator( '#wpcom' ).getByRole( 'link', { name: 'Domains' } ).click();
 			} else if ( viewportName === 'mobile' ) {


### PR DESCRIPTION
Reverts test changes from https://github.com/Automattic/wp-calypso/pull/113700 since it's causing failing prerelease tests.