### PR TITLE
TESTOPS-232: stop the unit tests raising real throttle bans

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -1,4 +1,5 @@
 import { Locator, Page } from 'playwright';
+import { handleActiveThrottles, recordResponseThrottle } from '../../throttle-flags';
 import { PlansPage, Plans } from '../plans-page';
 import type { NewSiteResponse } from '../../../types/rest-api-client.types';
 
@@ -49,6 +50,14 @@ export class SignupPickPlanPage {
 						const body = await response.body();
 						await route.fulfill( { response } );
 
+						// `/sites/new` is where the signup ban is answered, and this is the
+						// only place the suite reads what it answers with. A refusal parses
+						// as nothing and would otherwise leave a syntax error behind.
+						const throttle = await recordResponseThrottle( response );
+						if ( throttle ) {
+							handleActiveThrottles( [ throttle ] );
+						}
+
 						const parsed = JSON.parse( body.toString() );
 						const siteDetails: NewSiteResponse = parsed.body;
 
@@ -85,14 +94,18 @@ export class SignupPickPlanPage {
 			redirectUrl ??= new RegExp( '.*(setup/site-setup|home/.+ref=onboarding).*' );
 		}
 
+		// Awaited alongside the redirect rather than after it: a refused creation
+		// never redirects, and a skip left to be read afterwards would spend the
+		// ninety seconds first and then be lost to the timeout that ends the wait.
 		const responsePromise = this.captureNewSiteResponse();
 
-		await Promise.all( [
+		const [ , , siteDetails ] = await Promise.all( [
 			this.page.waitForURL( redirectUrl, { timeout: 90 * 1000 } ),
 			this.plansPage.selectPlan( name ),
+			responsePromise,
 		] );
 
-		return responsePromise;
+		return siteDetails;
 	}
 
 	/**

--- a/packages/calypso-e2e/src/test/lib/pages/domain-throttle-actions.test.ts
+++ b/packages/calypso-e2e/src/test/lib/pages/domain-throttle-actions.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { DomainSearchComponent } from '../../../lib/components/domain-search-component';
 import { UseADomainIOwnPage } from '../../../lib/pages/use-a-domain-i-own-page';
+import * as teamcity from '../../../lib/teamcity';
 import {
 	flushThrottleWrites,
 	registerThrottleActionHandler,
@@ -21,6 +22,11 @@ let actionHandler: jest.Mock;
 let unregister: () => void;
 
 beforeEach( () => {
+	// These tests raise flags through the real helpers. Left alone, the helpers
+	// tag the build running the unit tests and write the ban to its log, and
+	// every E2E build in the project reads that for the next six hours.
+	jest.spyOn( teamcity, 'tagOwnBuild' ).mockResolvedValue( 200 );
+	jest.spyOn( teamcity, 'appendOwnBuildLog' ).mockResolvedValue( 200 );
 	actionHandler = jest.fn();
 	unregister = registerThrottleActionHandler( actionHandler );
 	[ ...ACTION_VARIABLES, ...EXPIRATION_VARIABLES ].forEach( ( name ) => {
@@ -35,6 +41,7 @@ afterEach( async () => {
 	[ ...ACTION_VARIABLES, ...EXPIRATION_VARIABLES ].forEach( ( name ) => {
 		delete process.env[ name ];
 	} );
+	jest.restoreAllMocks();
 } );
 
 /** Builds the response shape used by the domain helpers. */

--- a/packages/calypso-e2e/src/test/lib/pages/signup-throttle-actions.test.ts
+++ b/packages/calypso-e2e/src/test/lib/pages/signup-throttle-actions.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { SignupPickPlanPage } from '../../../lib/pages/signup/signup-pick-plan-page';
+import * as teamcity from '../../../lib/teamcity';
+import {
+	flushThrottleWrites,
+	registerThrottleActionHandler,
+	resetThrottleState,
+} from '../../../lib/throttle-flags';
+import type { Page } from 'playwright';
+
+const VARIABLES = [ 'E2E_THROTTLE_SIGNUP_ACTION', 'THROTTLE_SIGNUP_EXPIRATION' ] as const;
+
+let actionHandler: jest.Mock;
+let unregister: () => void;
+
+beforeEach( () => {
+	// A flag raised here is raised through the real helpers, which would tag the
+	// build running the unit tests and write the ban to its log for every E2E
+	// build in the project to read.
+	jest.spyOn( teamcity, 'tagOwnBuild' ).mockResolvedValue( 200 );
+	jest.spyOn( teamcity, 'appendOwnBuildLog' ).mockResolvedValue( 200 );
+	actionHandler = jest.fn();
+	unregister = registerThrottleActionHandler( actionHandler );
+	VARIABLES.forEach( ( name ) => delete process.env[ name ] );
+} );
+
+afterEach( async () => {
+	unregister();
+	await flushThrottleWrites();
+	resetThrottleState();
+	VARIABLES.forEach( ( name ) => delete process.env[ name ] );
+	jest.restoreAllMocks();
+} );
+
+/**
+ * A page whose `/sites/new` route answers with the given body and status.
+ */
+function siteCreationPage( body: string, status = 200 ): Page {
+	return {
+		getByRole: jest.fn( () => undefined ),
+		route: jest.fn( async ( _pattern: unknown, handler: ( route: unknown ) => Promise< void > ) => {
+			await handler( {
+				fetch: async () => ( {
+					url: () => 'https://public-api.wordpress.com/rest/v1.1/sites/new?locale=en',
+					status: () => status,
+					text: async () => body,
+					body: async () => Buffer.from( body ),
+				} ),
+				fulfill: async () => undefined,
+			} );
+		} ),
+	} as unknown as Page;
+}
+
+/**
+ * The site creation response the page captures, however it ends.
+ */
+function capture( page: Page ): Promise< unknown > {
+	return (
+		new SignupPickPlanPage( page ) as unknown as {
+			captureNewSiteResponse(): Promise< unknown >;
+		}
+	 ).captureNewSiteResponse();
+}
+
+describe( 'signup throttle actions', () => {
+	test( 'site creation acts on a signup ban answered on the response', async () => {
+		actionHandler.mockImplementation( () => {
+			throw new Error( 'policy applied' );
+		} );
+
+		await expect( capture( siteCreationPage( '{"error":"throttled"}', 429 ) ) ).rejects.toThrow(
+			'policy applied'
+		);
+		expect( actionHandler ).toHaveBeenCalledWith( 'skip', [ 'signup' ] );
+	} );
+
+	test( 'a body that is no ban keeps its own error', async () => {
+		await expect( capture( siteCreationPage( '<!DOCTYPE html><html></html>' ) ) ).rejects.toThrow(
+			SyntaxError
+		);
+		expect( actionHandler ).not.toHaveBeenCalled();
+	} );
+
+	test( 'a created site is returned with its blog id as a number', async () => {
+		const body = JSON.stringify( { body: { blog_details: { blogid: '12345' } } } );
+
+		await expect( capture( siteCreationPage( body ) ) ).resolves.toEqual( {
+			blog_details: { blogid: 12345 },
+		} );
+		expect( actionHandler ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Part of TESTOPS-232

## Proposed Changes

* Mock the TeamCity module in the domain throttle action tests, so a flag raised there tags nothing.
* Record and act on a signup ban answered by `/sites/new`, where the site creation response is captured.

## Why are these changes being made?

Every `Run_All_Unit_Tests` build on trunk since the throttle work merged carries `throttle-domain-availability` and `throttle-domain-suggestions`, and states a ban in its own log. `fetchBuildsByTag` locates on the whole `calypso` project, so the E2E pre-release suite reads them.

Build 19064331 acted on one:

```
[10:48:13] [e2e-throttle-debug] domain-availability is throttled:
           unknown duration, ~3 minutes left, until 2026-08-20T10:50:54.976Z.
```

`end=1787223054976` is the number unit build 19064237 wrote at 10:44:55. All 19 tests that batch skipped were domain specs — `setup-domain__flows` (7), `start-launch-site__flows` (3), `start-domain__purchase-flows`, `setup-hundred-year-domain`, `domains__add`, `domain-upsell__sidebar`, both `new-hosted-site__domain-selection` specs. The next build, 19065326, skipped 21 of the same kind on a ban written at 11:52:21. Domain coverage has been off on every pre-release build, on a ban nobody hit.

The signup gap is separate and older: `/sites/new` is the endpoint the signup throttle answers on, and the route interception that captures the created site is the only place the suite reads that answer. Build 19064331 failed there with `SyntaxError: Unexpected token '<'`.

## Testing Instructions

* `yarn jest --config packages/calypso-e2e/jest.config.js --rootDir packages/calypso-e2e`
* After merge, check that new `Run_All_Unit_Tests` builds carry no `throttle-*` tag, and that a pre-release batch runs the domain specs instead of skipping them.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
