### PR TITLE
Omnibar: add aria-label to masterbar to prepare for E2E tests to for new omnibar

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -260,6 +260,7 @@ class MasterbarLoggedIn extends Component {
 				isActive={ this.isSidebarOpen() }
 				className="masterbar__item-sidebar-menu"
 				tooltip={ translate( 'Menu' ) }
+				ariaLabel={ translate( 'Menu' ) }
 			/>
 		);
 	}
@@ -927,6 +928,7 @@ class MasterbarLoggedIn extends Component {
 				isActive={ this.isActive( 'notifications' ) }
 				className="masterbar__item-notifications"
 				tooltip={ translate( 'Manage your notifications' ) }
+				ariaLabel={ translate( 'Notifications' ) }
 			>
 				<span className="masterbar__item-notifications-label">
 					{ translate( 'Notifications', {

--- a/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
+++ b/client/layout/masterbar/masterbar-notifications/notifications-button.jsx
@@ -19,6 +19,7 @@ class MasterbarItemNotifications extends Component {
 		isActive: PropTypes.bool,
 		className: PropTypes.string,
 		tooltip: TranslatableString,
+		ariaLabel: TranslatableString,
 		//connected
 		isNotificationsOpen: PropTypes.bool,
 		hasUnseenNotifications: PropTypes.bool,
@@ -100,6 +101,7 @@ class MasterbarItemNotifications extends Component {
 					onClick={ this.toggleNotesFrame }
 					isActive={ this.props.isActive }
 					tooltip={ this.props.tooltip }
+					ariaLabel={ this.props.ariaLabel }
 					className={ classes }
 					key={ this.state.animationState }
 				/>


### PR DESCRIPTION
## Proposed Changes

Added `aria-label` to the hamburger (responsive) menu and notification bell nodes to our masterbar, so that the E2E tests (will be updated later) can target the nodes via accessible names instead of HTML attributes.

## Why are these changes being made?

We want to replace the masterbar with the new omnibar which already has the accessible selectors.

## Testing Instructions

Verify the old E2E tests pass.