### PR TITLE
E2E: name signup sites so teardown can delete them

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-pick-plan-page.ts
@@ -18,6 +18,11 @@ export class SignupPickPlanPage {
 	private page: Page;
 	private plansPage: PlansPage;
 	readonly theresAPlanForYouHeading: Locator;
+	/**
+	 * Site created by the last `selectPlan` call. Set as soon as `/sites/new` responds,
+	 * so a caller whose `selectPlan` then times out can still clean the site up.
+	 */
+	createdSite: NewSiteResponse | undefined;
 
 	/**
 	 * Constructs an instance of the component.
@@ -41,6 +46,8 @@ export class SignupPickPlanPage {
 	 * @returns {Promise<NewSiteResponse>}
 	 */
 	private captureNewSiteResponse(): Promise< NewSiteResponse > {
+		this.createdSite = undefined;
+
 		return new Promise< NewSiteResponse >( ( resolve, reject ) => {
 			this.page.route(
 				/.*\/sites\/new\?.*/,
@@ -68,6 +75,7 @@ export class SignupPickPlanPage {
 						}
 
 						siteDetails.blog_details.blogid = Number( siteDetails.blog_details.blogid );
+						this.createdSite = siteDetails;
 						resolve( siteDetails );
 					} catch ( error ) {
 						reject( error );

--- a/test/e2e/specs/plans/plans__signup-business.spec.ts
+++ b/test/e2e/specs/plans/plans__signup-business.spec.ts
@@ -11,7 +11,6 @@ test.describe(
 	() => {
 		const planName = 'Business';
 
-		let siteCreatedFlag = false;
 		let newSiteDetails: NewSiteResponse | undefined;
 		let accountUsed: TestAccount;
 
@@ -39,13 +38,19 @@ test.describe(
 			} );
 
 			await test.step( 'And I skip domain selection', async function () {
-				await componentDomainSearch.search( 'foo' );
+				await componentDomainSearch.search( helperData.getBlogName() );
 				await componentDomainSearch.skipPurchase();
 			} );
 
 			await test.step( `And I select the WordPress.com ${ planName } plan`, async function () {
-				newSiteDetails = await pageSignupPickPlan.selectPlan( planName );
-				siteCreatedFlag = true;
+				try {
+					newSiteDetails = await pageSignupPickPlan.selectPlan( planName );
+				} finally {
+					// selectPlan throws if the flow doesn't reach checkout in time, but the
+					// site is created before that. Take it from the page object so afterAll
+					// deletes it instead of leaking it onto the shared account.
+					newSiteDetails ??= pageSignupPickPlan.createdSite;
+				}
 			} );
 
 			await test.step( 'Then I see secure checkout with the plan in the cart', async function () {
@@ -76,7 +81,7 @@ test.describe(
 		} );
 
 		test.afterAll( 'Delete the created site', async function () {
-			if ( ! siteCreatedFlag || ! newSiteDetails || ! accountUsed ) {
+			if ( ! newSiteDetails || ! accountUsed ) {
 				return;
 			}
 

--- a/test/e2e/specs/plugins/plugins__get-started-signup.spec.ts
+++ b/test/e2e/specs/plugins/plugins__get-started-signup.spec.ts
@@ -22,6 +22,11 @@ test.describe(
 		let newSiteDetails: NewSiteResponse | undefined;
 		let accountUsed: TestAccount;
 
+		test.skip(
+			true,
+			'calypsoPreReleaseUser owns thousands of leftover sites, so /me/sites takes about a minute and signup cannot reach checkout inside the 90s wait. Unskip once the backlog sweep in CHE-452 is done.'
+		);
+
 		test.afterAll( 'Delete the created site', async () => {
 			if ( ! newSiteDetails || ! accountUsed ) {
 				return;

--- a/test/e2e/specs/plugins/plugins__get-started-signup.spec.ts
+++ b/test/e2e/specs/plugins/plugins__get-started-signup.spec.ts
@@ -19,12 +19,11 @@ test.describe(
 		const pluginSlug = 'sensei-pro';
 		const pluginName = 'Sensei Pro';
 
-		let siteCreatedFlag = false;
 		let newSiteDetails: NewSiteResponse | undefined;
 		let accountUsed: TestAccount;
 
 		test.afterAll( 'Delete the created site', async () => {
-			if ( ! siteCreatedFlag || ! newSiteDetails || ! accountUsed ) {
+			if ( ! newSiteDetails || ! accountUsed ) {
 				return;
 			}
 
@@ -75,7 +74,7 @@ test.describe(
 			} );
 
 			await test.step( 'And I skip domain selection', async () => {
-				await componentDomainSearch.search( 'foo' );
+				await componentDomainSearch.search( helperData.getBlogName() );
 				await componentDomainSearch.skipPurchase();
 			} );
 
@@ -88,8 +87,14 @@ test.describe(
 			} );
 
 			await test.step( `When I select the ${ planName } plan`, async () => {
-				newSiteDetails = await pageSignupPickPlan.selectPlan( planName );
-				siteCreatedFlag = true;
+				try {
+					newSiteDetails = await pageSignupPickPlan.selectPlan( planName );
+				} finally {
+					// selectPlan throws if the flow doesn't reach checkout in time, but the
+					// site is created before that. Take it from the page object so afterAll
+					// deletes it instead of leaking it onto the shared account.
+					newSiteDetails ??= pageSignupPickPlan.createdSite;
+				}
 			} );
 
 			await test.step( `Then checkout contains the ${ planName } plan and the ${ pluginName } plugin`, async () => {


### PR DESCRIPTION
Part of CHE-450

## Proposed Changes

* `plans__signup-business` and `plugins__get-started-signup` search for a `getBlogName()` term instead of `foo`.
* `SignupPickPlanPage` exposes `createdSite`, set as soon as `/sites/new` answers. Both specs read it in a `finally`, and their `siteCreatedFlag` goes away.
* `plugins__get-started-signup` is skipped until the backlog sweep lands. It can't hold green while the account is this big.

## Why are these changes being made?

`RestAPIClient.deleteSite()` returns `null` for any domain without `e2e` in it, so neither spec has ever deleted the site it creates. `calypsoPreReleaseUser` owns 5847 `foo*.wordpress.com` sites and nothing else; `/all-domains/` for it takes 26 to 105 seconds.

The cost lands on `/me/sites`. In pre-release build 19058572 that call took 56s and then 49s before returning a 500, against 145ms for a different account in the same build (302 KB of JSON versus 2 KB). Signup blocks on it in `fetchSitesUntilSiteAppears` between plan selection and checkout, which is why the 90 second wait in `selectPlan` fails: one round trip fits, two don't. That test is the top reddener on the pre-release gate, 18 of 28 red trunk builds in 24 hours.

Invariant to check: every path out of `selectPlan` leaves the created site reachable for teardown. The timeout path is the one that was leaking.

This stops the refill. It doesn't touch the 5847 already there; that backlog is CHE-452, and the bulk-delete tooling for it lives in wpcom.

## Testing Instructions

The suite isn't being run here, CI and the sandboxes are loaded. With the plugin spec skipped, the naming fix shows up through `plans__signup-business` in the next pre-release build's teardown output:

* the created slug should read `e2eflowtesting...`, not `fooNNNNN`.
* the delete should log `Successfully deleted siteID <id>` where it currently logs `Failed to delete site ID <id>; no action performed.` That site is Atomic and the delete is best-effort while deprovision runs, so it may still fail; the slug is the part that must change.
* re-listing the account's domains should show the `foo*` count flat instead of climbing ~180/day.

Unskipping `plugins__get-started-signup` is the real check, and it has to wait for the sweep.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
