### PR TITLE
E2E: read the domain-suggestions ban where Skip purchase goes missing

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -465,7 +465,19 @@ export class DomainSearchComponent {
 	async skipPurchase(): Promise< string > {
 		const button = this.page.getByRole( 'button', { name: 'Skip purchase' } );
 
-		await button.waitFor();
+		try {
+			await button.waitFor();
+		} catch ( error ) {
+			// The button carries the free subdomain a second `/domains/suggestions`
+			// call answered with. `search` records a ban it meets mid-search but
+			// leaves acting to whichever caller needed the list, and this is one of
+			// them: without this the ban leaves the button absent and the wait spends
+			// its timeout. Never `domain-availability`: nothing on this button comes
+			// from `is-available`, and reading that ban here would skip a test it had
+			// no part in.
+			handleActiveThrottles( [ 'domain-suggestions' ] );
+			throw error;
+		}
 
 		let domain = await button.getAttribute( 'aria-label' );
 		domain = domain?.replace( 'Skip purchase and continue with ', '' ) ?? null;

--- a/packages/calypso-e2e/src/test/lib/pages/domain-throttle-actions.test.ts
+++ b/packages/calypso-e2e/src/test/lib/pages/domain-throttle-actions.test.ts
@@ -63,6 +63,16 @@ function bringItOverPage(): Page {
 	return { getByRole: jest.fn( () => button ) } as unknown as Page;
 }
 
+/** A page whose "Skip purchase" button never appears. */
+function skipPurchasePage(): Page {
+	const button = {
+		waitFor: jest.fn( async () => {
+			throw new Error( 'locator timeout' );
+		} ),
+	};
+	return { getByRole: jest.fn( () => button ) } as unknown as Page;
+}
+
 /** A page whose first suggestion row never appears. */
 function suggestionRowPage(): Page {
 	const row = {
@@ -226,6 +236,43 @@ describe( 'domain throttle actions', () => {
 		const page = bringItOverPage();
 
 		await expect( new DomainSearchComponent( page ).clickBringItOver() ).rejects.toThrow(
+			'locator timeout'
+		);
+		expect( actionHandler ).not.toHaveBeenCalled();
+	} );
+
+	test( 'the "Skip purchase" button acts on a suggestions ban when it never renders', async () => {
+		// `search` records a ban it meets mid-search and leaves acting to whichever
+		// caller needed the list. This is one of them: the button carries the free
+		// subdomain a second `/domains/suggestions` call answered with.
+		const page = skipPurchasePage();
+		process.env.THROTTLE_DOMAIN_SUGGESTIONS_EXPIRATION = String( Date.now() + 60_000 );
+		actionHandler.mockImplementation( () => {
+			throw new Error( 'policy applied' );
+		} );
+
+		await expect( new DomainSearchComponent( page ).skipPurchase() ).rejects.toThrow(
+			'policy applied'
+		);
+		expect( actionHandler ).toHaveBeenCalledWith( 'skip', [ 'domain-suggestions' ] );
+	} );
+
+	test( 'an availability ban leaves a missing "Skip purchase" button its own error', async () => {
+		// Nothing on this button comes from `is-available`. Reading that ban here
+		// would skip a test it had no part in, which is how a real failure hides.
+		const page = skipPurchasePage();
+		process.env.THROTTLE_DOMAIN_AVAILABILITY_EXPIRATION = String( Date.now() + 60_000 );
+
+		await expect( new DomainSearchComponent( page ).skipPurchase() ).rejects.toThrow(
+			'locator timeout'
+		);
+		expect( actionHandler ).not.toHaveBeenCalled();
+	} );
+
+	test( 'a "Skip purchase" button that never appears keeps its own error when no ban is in force', async () => {
+		const page = skipPurchasePage();
+
+		await expect( new DomainSearchComponent( page ).skipPurchase() ).rejects.toThrow(
 			'locator timeout'
 		);
 		expect( actionHandler ).not.toHaveBeenCalled();


### PR DESCRIPTION
Part of TESTOPS-232

## Proposed Changes

* `DomainSearchComponent.skipPurchase` now reads an active `domain-suggestions` ban when the button never renders.

## Why are these changes being made?

The "Skip purchase" button is rendered by `SkipSuggestion` off a second `/domains/suggestions` call — the free-subdomain query — so a ban on that endpoint leaves it absent and the wait spends its full 10s reporting a missing button on a test that should have skipped. `search()` reads the same ban immediately before, so this closes the gap between the two calls.

It is deliberately not `domain-availability`. Nothing on this button comes from `is-available`, and reading that ban here would skip tests it had no part in — Pre-Release #38148 and #38149 both failed on this button while a `domain-availability` ban happened to be in force, with six other `skipPurchase` specs passing in the same batch. A test covers that case.

## Testing Instructions

```
yarn jest --config=packages/calypso-e2e/jest.config.js src/test/lib/pages/domain-throttle-actions.test.ts
```

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
