### PR TITLE
Help Center: starter-prompt chips for the plans-presales assistant (prototype)

### DIFF
--- a/apps/help-center/async-help-center.jsx
+++ b/apps/help-center/async-help-center.jsx
@@ -22,6 +22,10 @@ export default function loadHelpCenter() {
 		customProps.newLoggedOutInteractionsBotSlug = helpCenterData.newLoggedOutInteractionsBotSlug;
 	}
 
+	if ( helpCenterData?.launcherContext ) {
+		customProps.launcherContext = helpCenterData.launcherContext;
+	}
+
 	return import( '@automattic/help-center' ).then( ( { default: HelpCenter } ) =>
 		createRoot( container ).render(
 			<QueryClientProvider client={ queryClient }>

--- a/packages/help-center/src/components/help-center-chat.tsx
+++ b/packages/help-center/src/components/help-center-chat.tsx
@@ -30,6 +30,7 @@ export function HelpCenterChat( {
 		newInteractionsBotSlug,
 		newLoggedOutInteractionsBotSlug,
 		newInteractionsBotVersion,
+		launcherContext,
 	} = useHelpCenterContext();
 	const featureConfig = useFeatureConfig();
 	const { search } = useLocation();
@@ -80,6 +81,7 @@ export function HelpCenterChat( {
 			isUserEligibleForPaidSupport={ isUserEligibleForPaidSupport }
 			forceEmailSupport={ Boolean( forceEmailSupport ) }
 			isChatRestricted={ Boolean( isChatRestricted ) }
+			launcherContext={ launcherContext }
 		>
 			<div className="help-center__container-chat">
 				<OdieAssistant />

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import { useGetHistoryChats } from '@automattic/help-center/src/hooks/use-get-history-chats';
+import { PLANS_PRESALES_LAUNCHER_CONTEXT } from '@automattic/odie-client/src/constants';
 import { useCurrentSupportInteraction } from '@automattic/odie-client/src/data/use-current-support-interaction';
 import {
 	CardHeader,
@@ -152,10 +153,12 @@ const useHeaderText = () => {
 	const { __ } = useI18n();
 	const { pathname } = useLocation();
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
+	const { launcherContext } = useHelpCenterContext();
 
 	const isConversationWithZendesk = currentSupportInteraction?.events.some(
 		( event ) => event.event_source === 'zendesk'
 	);
+	const isPlansPresales = launcherContext === PLANS_PRESALES_LAUNCHER_CONTEXT;
 
 	return useMemo( () => {
 		switch ( pathname ) {
@@ -171,8 +174,11 @@ const useHeaderText = () => {
 			case '/success':
 				return __( 'Message Submitted', __i18n_text_domain__ );
 			case '/odie':
-				return isConversationWithZendesk
-					? __( 'Support Team', __i18n_text_domain__ )
+				if ( isConversationWithZendesk ) {
+					return __( 'Support Team', __i18n_text_domain__ );
+				}
+				return isPlansPresales
+					? __( 'Plans Assistant', __i18n_text_domain__ )
 					: __( 'Support Assistant', __i18n_text_domain__ );
 			case '/chat-history':
 				return __( 'Support history', __i18n_text_domain__ );
@@ -181,7 +187,7 @@ const useHeaderText = () => {
 			default:
 				return __( 'Help Center', __i18n_text_domain__ );
 		}
-	}, [ __, isConversationWithZendesk, pathname ] );
+	}, [ __, isConversationWithZendesk, isPlansPresales, pathname ] );
 };
 
 const HeaderText = () => {

--- a/packages/help-center/src/components/help-center-header.tsx
+++ b/packages/help-center/src/components/help-center-header.tsx
@@ -1,6 +1,10 @@
 /* eslint-disable no-restricted-imports */
 import { useGetHistoryChats } from '@automattic/help-center/src/hooks/use-get-history-chats';
-import { PLANS_PRESALES_LAUNCHER_CONTEXT } from '@automattic/odie-client/src/constants';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
+import {
+	PLANS_PRESALES_INTRO_MESSAGE,
+	PLANS_PRESALES_LAUNCHER_CONTEXT,
+} from '@automattic/odie-client/src/constants';
 import { useCurrentSupportInteraction } from '@automattic/odie-client/src/data/use-current-support-interaction';
 import {
 	CardHeader,
@@ -154,11 +158,15 @@ const useHeaderText = () => {
 	const { pathname } = useLocation();
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
 	const { launcherContext } = useHelpCenterContext();
+	const hasEnTranslation = useHasEnTranslation();
 
 	const isConversationWithZendesk = currentSupportInteraction?.events.some(
 		( event ) => event.event_source === 'zendesk'
 	);
-	const isPlansPresales = launcherContext === PLANS_PRESALES_LAUNCHER_CONTEXT;
+	// Same gate as the greeting, so title and greeting switch together per locale.
+	const isPlansPresales =
+		launcherContext === PLANS_PRESALES_LAUNCHER_CONTEXT &&
+		hasEnTranslation( PLANS_PRESALES_INTRO_MESSAGE, undefined, __i18n_text_domain__ );
 
 	return useMemo( () => {
 		switch ( pathname ) {

--- a/packages/help-center/src/contexts/HelpCenterContext.tsx
+++ b/packages/help-center/src/contexts/HelpCenterContext.tsx
@@ -30,6 +30,10 @@ export type HelpCenterRequiredInformation = {
 	 * Product identifier. Defaults to 'wpcom' when omitted.
 	 */
 	product?: HelpCenterProduct;
+	/**
+	 * Page the launcher was opened from, when the host page sets one. Tailors the greeting and title.
+	 */
+	launcherContext?: string;
 };
 
 const defaultContext: HelpCenterRequiredInformation = {

--- a/packages/odie-client/src/components/chat-footer/index.tsx
+++ b/packages/odie-client/src/components/chat-footer/index.tsx
@@ -1,5 +1,6 @@
 import { Notice, animations, ChatInput, AgentUIProvider } from '@automattic/agenttic-ui';
 import { motion } from 'framer-motion';
+import { IntroSuggestions } from '../message/intro-suggestions';
 import './style.scss';
 import type { Transition } from 'framer-motion';
 import type { ComponentProps } from 'react';
@@ -13,6 +14,7 @@ type AgentUIFooterProps = ComponentProps< typeof ChatInput > & {
 export function AgentUIFooter( props: AgentUIFooterProps ) {
 	return (
 		<AgentUIProvider value={ {} as any }>
+			<IntroSuggestions />
 			<motion.div
 				data-slot="chat-footer"
 				className="agenttic--chat-footer-container"

--- a/packages/odie-client/src/components/message/intro-suggestions.scss
+++ b/packages/odie-client/src/components/message/intro-suggestions.scss
@@ -1,0 +1,36 @@
+/* Pin agenttic-ui Suggestions (vertical layout) in normal flow. The library's
+   base container class is position:absolute at the same specificity as the
+   vertical layout's position:static, so stylesheet order decides — this rule
+   out-specifies both deterministically. data-slot is the library's stable hook. */
+.odie-intro-suggestions[data-slot='suggestions'] {
+	position: static;
+	margin-bottom: 8px;
+	/* The component is a framer-motion div that floats itself up via an inline
+	   translateY transform even in vertical layout; !important is required to
+	   beat the inline style. Paired with translateY={0} on the component. */
+	transform: none !important;
+
+	/* Follow-up mode: compact horizontal pill row above the composer. The
+	   library's base container provides the row + horizontal scroll; drop its
+	   inset padding so pills align with the composer edges, size the pills
+	   down to reference proportions, and fade the right edge so a clipped
+	   pill reads as "scrolls" rather than "broken". */
+	&.odie-intro-suggestions--followups {
+		/* The library container is overflow-y: hidden — zero padding clips the
+		   pills' top borders. Keep a few px vertical, keep left flush with the
+		   composer, and leave right room so the last pill can scroll clear of
+		   the fade. */
+		padding: 3px 24px 3px 0;
+		mask-image: linear-gradient( to right, #000 calc( 100% - 24px ), transparent );
+
+		button {
+			height: auto;
+			padding: 8px 14px;
+			border-radius: 8px;
+			font-size: 13px;
+			line-height: 1.3;
+			white-space: nowrap;
+			flex-shrink: 0;
+		}
+	}
+}

--- a/packages/odie-client/src/components/message/intro-suggestions.tsx
+++ b/packages/odie-client/src/components/message/intro-suggestions.tsx
@@ -1,0 +1,87 @@
+import { Suggestions } from '@automattic/agenttic-ui';
+import clsx from 'clsx';
+import { useState } from 'react';
+import { PLANS_PRESALES_LAUNCHER_CONTEXT } from '../../constants';
+import { useOdieAssistantContext } from '../../context';
+import { useSendChatMessage } from '../../hooks';
+import type { Message } from '../../types';
+import './intro-suggestions.scss';
+
+/**
+ * EXPERIMENT (Ilona, 2026-08-20): starter-prompt chips for the plans-presales
+ * assistant, rendered with agenttic-ui's Suggestions component.
+ *
+ * Two modes, one component:
+ * - Before the conversation starts: vertical stacked list under the greeting.
+ * - Once a prompt is chosen (or the visitor types): the not-yet-asked prompts
+ *   move into a compact horizontal follow-up row above the composer.
+ * Clicking marks the prompt as asked locally, so the swap is instant — the
+ * chat store round-trip is too slow to gate visibility on.
+ *
+ * Known library issues (report to Agenttic UI owners):
+ * - Base container is position:absolute at the same specificity as vertical's
+ *   position:static; the winner depends on stylesheet order, which Calypso's
+ *   build does not preserve. Companion .scss pins it in-flow via data-slot.
+ * - translateY defaults to "-100%" in every layout (floats over content).
+ * - onSubmit silently requires `prompt` on each suggestion; `label` alone
+ *   renders but never fires.
+ *
+ * Prototype gaps: untranslated copy, no analytics event on chip click.
+ */
+const PLANS_PRESALES_SUGGESTIONS = [
+	{ id: 'compare-plans', label: 'Compare the plans for me', prompt: 'Compare the plans for me' },
+	{ id: 'plan-payments', label: 'Which plan has payments?', prompt: 'Which plan has payments?' },
+	{
+		id: 'business-benefits',
+		label: 'What are the main benefits of the Business plan?',
+		prompt: 'What are the main benefits of the Business plan?',
+	},
+];
+
+export const IntroSuggestions = () => {
+	const { chat, launcherContext } = useOdieAssistantContext();
+	const { sendMessage } = useSendChatMessage();
+	const [ askedIds, setAskedIds ] = useState< string[] >( [] );
+
+	if ( launcherContext !== PLANS_PRESALES_LAUNCHER_CONTEXT ) {
+		return null;
+	}
+
+	const conversationStarted = ( chat?.messages?.length ?? 0 ) > 1 || askedIds.length > 0;
+	// A prompt counts as asked if clicked this session OR already present in the
+	// conversation history — history survives panel close/reopen, local state doesn't.
+	const askedInHistory = ( prompt: string ): boolean =>
+		!! chat?.messages?.some( ( m ) => m.role === 'user' && String( m.content ).trim() === prompt );
+	const remaining = PLANS_PRESALES_SUGGESTIONS.filter(
+		( s ) => ! askedIds.includes( s.id ) && ! askedInHistory( s.prompt )
+	);
+
+	if ( remaining.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<Suggestions
+			className={ clsx(
+				'odie-intro-suggestions',
+				conversationStarted && 'odie-intro-suggestions--followups'
+			) }
+			layout={ conversationStarted ? 'horizontal' : 'vertical' }
+			translateY={ 0 }
+			suggestions={ remaining }
+			onSubmit={ ( selected ) => {
+				// The composer disables itself while the bot is busy; mirror that.
+				if ( chat?.status && chat.status !== 'loaded' ) {
+					return;
+				}
+				setAskedIds( [ ...askedIds, selected.id ] );
+				const messageObj = {
+					content: selected.prompt ?? selected.label,
+					role: 'user',
+					type: 'message',
+				} as Message;
+				sendMessage( messageObj );
+			} }
+		/>
+	);
+};

--- a/packages/odie-client/src/components/message/messages-container.tsx
+++ b/packages/odie-client/src/components/message/messages-container.tsx
@@ -29,7 +29,7 @@ interface ChatMessagesProps {
 }
 
 export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
-	const { chat, isChatLoaded, isUserEligibleForPaidSupport, forceEmailSupport } =
+	const { chat, isChatLoaded, isUserEligibleForPaidSupport, forceEmailSupport, launcherContext } =
 		useOdieAssistantContext();
 	const isTestMode = isTestModeEnvironment();
 	const hasEnTranslation = useHasEnTranslation();
@@ -150,7 +150,8 @@ export const MessagesContainer = ( { currentUser }: ChatMessagesProps ) => {
 						message={ getOdieInitialMessage(
 							supportInteraction?.bot_slug || ODIE_DEFAULT_BOT_SLUG_LEGACY,
 							currentUser?.display_name,
-							hasEnTranslation
+							hasEnTranslation,
+							launcherContext
 						) }
 						key={ 0 }
 					/>

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -8,6 +8,10 @@ type HasEnTranslation = ( single: string, context?: string, domain?: string ) =>
 // Set by the wpcom launcher on the pricing page so the assistant greets visitors as a pre-sales guide.
 export const PLANS_PRESALES_LAUNCHER_CONTEXT = 'plans-presales';
 
+// Shared with the panel title gate so greeting and title switch together per locale.
+export const PLANS_PRESALES_INTRO_MESSAGE =
+	"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.";
+
 export const getOdieErrorMessage = (): string =>
 	__(
 		"Sorry, I'm offline right now. Leave our Support team a note and they'll get back to you as soon as possible.",
@@ -271,10 +275,7 @@ const getOdieIntroMessage = (
 	hasEnTranslation?: HasEnTranslation
 ): string => {
 	if ( launcherContext === PLANS_PRESALES_LAUNCHER_CONTEXT ) {
-		const presalesIntro =
-			"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.";
-
-		if ( hasEnTranslation?.( presalesIntro, undefined, __i18n_text_domain__ ) ) {
+		if ( hasEnTranslation?.( PLANS_PRESALES_INTRO_MESSAGE, undefined, __i18n_text_domain__ ) ) {
 			return __(
 				"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.",
 				__i18n_text_domain__

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -5,6 +5,9 @@ declare const __i18n_text_domain__: string;
 
 type HasEnTranslation = ( single: string, context?: string, domain?: string ) => boolean;
 
+// Set by the wpcom launcher on the pricing page so the assistant greets visitors as a pre-sales guide.
+export const PLANS_PRESALES_LAUNCHER_CONTEXT = 'plans-presales';
+
 export const getOdieErrorMessage = (): string =>
 	__(
 		"Sorry, I'm offline right now. Leave our Support team a note and they'll get back to you as soon as possible.",
@@ -263,12 +266,23 @@ const getOdieInitialPromptContext = ( botNameSlug: OdieAllowedBots ): Context | 
 	}
 };
 
-export const getOdieInitialMessage = (
-	botNameSlug: OdieAllowedBots,
-	displayName: string,
-	hasEnTranslation?: ( single: string, context?: string, domain?: string ) => boolean
-): Message => {
-	const introMessage = hasEnTranslation?.(
+const getOdieIntroMessage = (
+	launcherContext?: string,
+	hasEnTranslation?: HasEnTranslation
+): string => {
+	if ( launcherContext === PLANS_PRESALES_LAUNCHER_CONTEXT ) {
+		const presalesIntro =
+			"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.";
+
+		if ( hasEnTranslation?.( presalesIntro, undefined, __i18n_text_domain__ ) ) {
+			return __(
+				"Not sure which plan fits? Tell me what kind of site you're building, and I'll help you choose.",
+				__i18n_text_domain__
+			);
+		}
+	}
+
+	return hasEnTranslation?.(
 		"I'm your personal Support Assistant. I can help with any questions about your site or account.",
 		undefined,
 		__i18n_text_domain__
@@ -281,6 +295,15 @@ export const getOdieInitialMessage = (
 				"I'm your personal AI assistant. I can help with any questions about your site or account.",
 				__i18n_text_domain__
 		  );
+};
+
+export const getOdieInitialMessage = (
+	botNameSlug: OdieAllowedBots,
+	displayName: string,
+	hasEnTranslation?: ( single: string, context?: string, domain?: string ) => boolean,
+	launcherContext?: string
+): Message => {
+	const introMessage = getOdieIntroMessage( launcherContext, hasEnTranslation );
 
 	return {
 		content: `**${ sprintf(

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -83,6 +83,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 	currentUser,
 	forceEmailSupport = false,
 	isChatRestricted = false,
+	launcherContext,
 	children,
 } ) => {
 	const { dynamicNewInteractionsBotSlug, isMinimized, isChatLoaded } = useSelect(
@@ -209,6 +210,7 @@ export const OdieAssistantProvider: React.FC< OdieAssistantProviderProps > = ( {
 				version: overriddenVersion,
 				forceEmailSupport,
 				isChatRestricted,
+				launcherContext,
 			} }
 		>
 			{ children }

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -27,6 +27,7 @@ export type OdieAssistantContextInterface = {
 	externalChatId?: string | null;
 	forceEmailSupport: boolean;
 	isChatRestricted: boolean;
+	launcherContext?: string;
 	setExperimentVariationName: ( variationName: string | null | undefined ) => void;
 	setChat: ( chat: Chat | SetStateAction< Chat > ) => void;
 	setChatStatus: ( status: ChatStatus ) => void;
@@ -53,6 +54,7 @@ export type OdieAssistantProviderProps = {
 	version?: string | null;
 	forceEmailSupport?: boolean;
 	isChatRestricted?: boolean;
+	launcherContext?: string;
 	children?: ReactNode;
 	setChatStatus?: ( status: ChatStatus ) => void;
 } & PropsWithChildren;


### PR DESCRIPTION
Part of https://linear.app/a8c/project/ai-assistant-on-pricing-is-always-visible-labeled-and-greets-plan-83badc05f073


https://github.com/user-attachments/assets/a8fab355-a6f3-4a1c-ad12-c7d3f25d7ad8


**Draft on purpose** — a working prototype stacked on #113647, sharing the suggestion-chips exploration for the plans-presales assistant so design + eng can react to running code. cc @claudiucelfilip — built directly on your branch; if the direction survives design sign-off, feel free to cherry-pick or fold it in.

## Proposed Changes

* Three starter-prompt chips render under the plans-presales greeting ("Compare the plans for me" / "Which plan has payments?" / "What are the main benefits of the Business plan?"). Clicking a chip sends it as the user's message through the composer's own send path — the assistant answers it like any typed question.
* Two-stage behavior: the moment a prompt is asked (clicked *or* typed), the stacked list collapses and the not-yet-asked prompts move into a compact horizontal row above the composer. Asked prompts stay hidden across panel close/reopen — asked-ness is derived from the conversation history, not just local state.
* Everything is gated on the same `PLANS_PRESALES_LAUNCHER_CONTEXT` signal as the greeting and title from #113647 — every other Help Center surface is untouched.
* One new component (`intro-suggestions.tsx` + `.scss`) mounted with a one-line addition in the chat footer, inside the existing `AgentUIProvider`.

## Why these choices

* The chips are agenttic-ui's own `Suggestions` component (vertical + horizontal layouts), not a lookalike — the panel is already built from this library.
* The companion `.scss` carries two deliberate workarounds for library behaviors that bite consumers outside agenttic-ui's own scaffolding: a `position` guard via the stable `data-slot="suggestions"` attribute (the component's base/vertical positioning is stylesheet-order-dependent), and a `translateY` neutralization (the component floats itself upward by default in every layout). A third gotcha is encoded in the data: `onSubmit` silently requires `prompt` on each suggestion. All three are being reported to the Agenttic UI owners.

## Prototype gaps (deliberate)

* Chip copy is hardcoded English — needs the same translation gate the greeting uses before shipping.
* No per-chip Tracks event yet — the composer's tracking is adjacent; small add, and it's what makes chips measurable for open→chat attribution.
* Which three prompts to offer is a product/copy decision, not locked by this code.

## Testing Instructions

* Same rig as #113647: a wpcom sandbox running the companion launcher branch, `apps/help-center` built and synced to the sandboxed `widgets.wp.com/help-center`.
* Open `wordpress.com/pricing` logged out → click the launcher → the panel shows the plans greeting with three stacked chips beneath it.
* Click a chip: it posts as your message, the assistant answers, and the remaining prompts appear as a horizontal row above the input. Ask another; the row shrinks. Close and reopen the panel: already-asked prompts do not come back.
* Any other Help Center surface (logged-in or out): no chips, no changes.
* Unit context: `yarn jest --config packages/odie-client/jest.config.js` still green.

Design context: https://www.figma.com/design/HyGhZYyGNShVe0x6BM2vGH/Help-center-launcher--FAB-always-visible-for-pricing-page?node-id=1-1924; P2 is coming
