### PR TITLE
Omnibar: update E2E tests to work with old masterbar and new omnibar

### DIFF
--- a/packages/calypso-e2e/src/lib/components/me/dashboard-me-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/me/dashboard-me-sidebar-component.ts
@@ -28,10 +28,7 @@ export class DashboardMeSidebarComponent {
 			return;
 		}
 
-		// The toggle is an icon-only button whose accessible name is empty (the
-		// icon is a CSS pseudo-element and it carries no aria-label), so matching
-		// by role and name never resolves it. Match its `title` instead.
-		const menuToggle = this.page.getByTitle( 'Menu' ).first();
+		const menuToggle = this.page.getByRole( 'button', { name: 'Menu', exact: true } ).first();
 		// The overlay is portalled into place only while the sidebar is open, so
 		// its presence is a reliable "sidebar is open" signal.
 		const openSidebar = this.page.getByTestId( 'dashboard-responsive-sidebar-overlay' );

--- a/packages/calypso-e2e/src/lib/components/navbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/navbar-component.ts
@@ -3,9 +3,7 @@ import { Page } from 'playwright';
 const selectors = {
 	// Buttons on navbar
 	mySiteButton: '[data-tip-target="my-sites"]',
-	mobileMenuButton: '[data-tip-target="mobile-menu"]',
 	editorBackButton: '[data-tip-target="back-home"]',
-	notificationsButton: 'a.masterbar-notifications',
 	meButton: 'a[data-tip-target="me"]',
 };
 /**
@@ -38,7 +36,7 @@ export class NavbarComponent {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickMobileMenu(): Promise< void > {
-		await this.page.click( selectors.mobileMenuButton );
+		await this.page.getByRole( 'button', { name: 'Menu', exact: true } ).first().click();
 	}
 
 	/**
@@ -73,7 +71,9 @@ export class NavbarComponent {
 			return await this.page.keyboard.type( 'n' );
 		}
 
-		const notificationsButtonLocator = this.page.locator( selectors.notificationsButton );
+		const notificationsButtonLocator = this.page
+			.getByLabel( 'Notifications', { exact: true } )
+			.first();
 
 		return await notificationsButtonLocator.click();
 	}

--- a/packages/calypso-e2e/src/lib/components/sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/sidebar-component.ts
@@ -40,8 +40,8 @@ export class SidebarComponent {
 		const sidebarLocator = this.page.locator( `${ selectors.sidebar }, .global-sidebar` ).first();
 
 		await Promise.all( [
-			this.page.waitForLoadState( 'load', { timeout: 20 * 1000 } ),
-			sidebarLocator.waitFor( { timeout: 20 * 1000 } ),
+			this.page.waitForLoadState( 'load', { timeout: 30 * 1000 } ),
+			sidebarLocator.waitFor( { timeout: 30 * 1000 } ),
 		] );
 
 		// If the sidebar is collapsed (via the Collapse Menu toggle),

--- a/test/e2e/specs/dashboard/dashboard__rum-tracking.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__rum-tracking.spec.ts
@@ -136,7 +136,7 @@ test.describe( 'Dashboard: RUM Performance Tracking', { tag: [ tags.DASHBOARD_PR
 				// With omnibar: click Domains in the responsive sidebar.
 				// On mobile, open the sidebar first via the masterbar menu button.
 				if ( viewportName === 'mobile' ) {
-					await page.getByTitle( 'Menu', { exact: true } ).click();
+					await page.getByRole( 'button', { name: 'Menu', exact: true } ).first().click();
 				}
 				await page.locator( '#wpcom' ).getByRole( 'link', { name: 'Domains' } ).click();
 			} else if ( viewportName === 'mobile' ) {


### PR DESCRIPTION

## Proposed Changes

A continuation of https://github.com/Automattic/wp-calypso/pull/113709, where we actually update the tests in this PR.

## Why are these changes being made?

We want to replace the old masterbar with the new omnibar.

We had to split the PRs because it seems prerelease tests are running against dashboard production, not staging (this should be fixed).

## Testing Instructions

Verify the tests pass.