### PR TITLE
Agents Manager: send the resolved agent id as agent_name

### DIFF
--- a/packages/agents-manager/src/utils/__tests__/tracks.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/tracks.test.ts
@@ -148,6 +148,18 @@ describe( 'tracks wrappers', () => {
 			expect( props ).not.toHaveProperty( 'is_a11n' );
 		} );
 
+		it( 'sends the resolved agent id as agent_name when one is set', () => {
+			setResolvedAgentId( 'plugin-compass' );
+			recordAgentsManagerTracksEvent( 'chat_minimize' );
+			expect( lastEventProps().agent_name ).toBe( 'plugin-compass' );
+		} );
+
+		it( 'falls back to the Dolly agent id while no agent is resolved', () => {
+			setResolvedAgentId( undefined );
+			recordAgentsManagerTracksEvent( 'chat_minimize' );
+			expect( lastEventProps().agent_name ).toBe( 'dolly' );
+		} );
+
 		it( 'uses the reader-chat surface token off the editor', () => {
 			mockIsReaderChatHost.mockReturnValue( true );
 			recordAgentsManagerTracksEvent( 'x' );

--- a/packages/agents-manager/src/utils/tracks.ts
+++ b/packages/agents-manager/src/utils/tracks.ts
@@ -132,7 +132,7 @@ export function recordAgentsManagerTracksEvent( eventName: string, props: Tracks
 	const blogId = getBlogId();
 	const baseProps: TracksProps = {
 		ai_session_id: getSessionId(),
-		agent_name: DOLLY_AGENT_ID,
+		agent_name: getResolvedAgentId() ?? DOLLY_AGENT_ID,
 		surface: isReaderChatHost() ? 'reader-chat' : 'editor',
 		path: typeof window !== 'undefined' ? window.location.pathname : '',
 		is_test: getIsTest(),


### PR DESCRIPTION
Part of AI-1119

## Proposed Changes

* Set `agent_name` on Agents Manager Tracks events from `getResolvedAgentId()` instead of the hardcoded `DOLLY_AGENT_ID` constant, falling back to the Dolly id while no agent has been resolved yet.

## Why are these changes being made?

* `agent_name` was the literal string `dolly` on every fire that carried it — correct while Dolly is the only agent, but it breaks silently in the wrapper the moment a second agent exists. `getResolvedAgentId()` was already imported in `tracks.ts` and used by the Big Sky parity recorder; this uses the same resolved identifier for the unified events. The fallback preserves today's value for events firing before the provider publishes a resolved id, so there is no data discontinuity.

## Testing Instructions

* Sync the agents-manager app with your WordPress.com sandbox (`cd apps/agents-manager && yarn dev --sync`).
* Open the browser DevTools, switch to the **Network** tab, and filter requests by `t.gif`.
* On a wp-admin page, open the AI chat and trigger any chat event (e.g. minimize the chat).
* Inspect the request payload: `agent_name` should be present and reflect the resolved agent (`dolly` for the default agent today, rather than being hardcoded).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
