### PR TITLE
Dashboard: gate paid+domain site launches behind the pre-launch modal

### DIFF
--- a/client/dashboard/sites/site-launch-button/test/index.test.tsx
+++ b/client/dashboard/sites/site-launch-button/test/index.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { SiteLaunchButton } from '..';
+import { render } from '../../../test-utils';
+import type { DomainSummary, Site } from '@automattic/api-core';
+
+const createMockSite = ( options: Partial< Site > = {} ): Site =>
+	( {
+		ID: 1,
+		slug: 'kaonashi.wordpress.com',
+		URL: 'https://kaonashi.wordpress.com',
+		name: 'Kaonashi',
+		launch_status: 'unlaunched' as const,
+		plan: {
+			product_slug: 'business-bundle',
+			product_name: 'Business plan',
+			product_name_short: 'Business',
+			is_free: false,
+		},
+		...options,
+	} ) as Site;
+
+const createMockDomain = ( domain: string, hasSubscription = true ): DomainSummary =>
+	( {
+		domain,
+		blog_id: 1,
+		subscription_id: hasSubscription ? 123 : null,
+	} ) as unknown as DomainSummary;
+
+const mockDomainsApi = ( domains: DomainSummary[] = [] ) => {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.2/all-domains' )
+		.query( true )
+		.reply( 200, { domains } );
+};
+
+const mockLaunchApi = () =>
+	nock( 'https://public-api.wordpress.com' )
+		.post( /\/sites\/1\/launch$/ )
+		.reply( 200, {} );
+
+describe( '<SiteLaunchButton>', () => {
+	test( 'opens the pre-launch modal instead of launching immediately for a paid site with a custom domain', async () => {
+		const user = userEvent.setup();
+		mockDomainsApi( [
+			createMockDomain( 'kaonashi.wordpress.com', false ),
+			createMockDomain( 'kaonashi.com' ),
+		] );
+		const launchScope = mockLaunchApi();
+
+		render( <SiteLaunchButton site={ createMockSite() } tracksContext="test" /> );
+
+		await user.click( await screen.findByRole( 'button', { name: 'Launch your site' } ) );
+
+		expect(
+			await screen.findByRole( 'dialog', { name: 'Launching makes your site public' } )
+		).toBeVisible();
+		expect( launchScope.isDone() ).toBe( false );
+	} );
+
+	test( 'launches the site when the pre-launch modal is confirmed', async () => {
+		const user = userEvent.setup();
+		mockDomainsApi( [
+			createMockDomain( 'kaonashi.wordpress.com', false ),
+			createMockDomain( 'kaonashi.com' ),
+		] );
+		const launchScope = mockLaunchApi();
+
+		render( <SiteLaunchButton site={ createMockSite() } tracksContext="test" /> );
+
+		await user.click( await screen.findByRole( 'button', { name: 'Launch your site' } ) );
+		await user.click( await screen.findByRole( 'button', { name: 'Yes, launch site!' } ) );
+
+		await waitFor( () => expect( launchScope.isDone() ).toBe( true ) );
+	} );
+
+	test( 'does not open the modal and launches immediately for a hosting-trial site', async () => {
+		const user = userEvent.setup();
+		mockDomainsApi( [ createMockDomain( 'kaonashi.wordpress.com', false ) ] );
+		const launchScope = mockLaunchApi();
+
+		render(
+			<SiteLaunchButton
+				site={ createMockSite( {
+					plan: {
+						product_slug: 'wp_bundle_hosting_trial_monthly',
+						product_name: 'Hosting Trial',
+						is_free: false,
+					},
+				} as Partial< Site > ) }
+				tracksContext="test"
+			/>
+		);
+
+		await user.click( await screen.findByRole( 'button', { name: 'Launch your site' } ) );
+
+		await waitFor( () => expect( launchScope.isDone() ).toBe( true ) );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders a link to the launch flow for a free site without an immediate launch', async () => {
+		mockDomainsApi( [ createMockDomain( 'kaonashi.wordpress.com', false ) ] );
+
+		render(
+			<SiteLaunchButton
+				site={ createMockSite( {
+					plan: {
+						product_slug: 'free_plan',
+						product_name: 'Free',
+						is_free: true,
+					},
+				} as Partial< Site > ) }
+				tracksContext="test"
+			/>
+		);
+
+		const launchLink = await screen.findByRole( 'link', { name: 'Launch your site' } );
+		expect( launchLink ).toHaveAttribute( 'href', expect.stringContaining( '/start/launch-site' ) );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/sites/site-launch-button/use-site-launch.tsx
+++ b/client/dashboard/sites/site-launch-button/use-site-launch.tsx
@@ -13,6 +13,7 @@ import {
 	isSitePlanBigSkyTrial,
 	isSitePlanPaid,
 } from '../plans';
+import SiteLaunchModal from '../site-launch-modal';
 import type { Site } from '@automattic/api-core';
 
 export type A4aLaunchModalComponent = ComponentType< {
@@ -76,8 +77,7 @@ export function useSiteLaunch(
 	const isSitePlanHostingTrial = site.plan?.product_slug === DotcomPlans.HOSTING_TRIAL_MONTHLY;
 	const isSitePlanPaidWithDomains = isSitePlanPaid( site ) && domains.length > 1;
 	const isDisabled = ! getIsSitePlanLaunchable( site );
-	const shouldImmediatelyLaunch =
-		isSitePlanPaidWithDomains || isSitePlanHostingTrial || site.is_wpcom_staging_site;
+	const shouldImmediatelyLaunch = isSitePlanHostingTrial || site.is_wpcom_staging_site;
 
 	const launchUrl = useMemo( () => {
 		if ( isSitePlanBigSkyTrial( site ) ) {
@@ -126,6 +126,15 @@ export function useSiteLaunch(
 		} );
 	};
 
+	const confirmPreLaunch = () => {
+		track();
+		launchMutation.mutate( undefined, {
+			onSuccess: () => redirectAfterLaunch(),
+			onError: onLaunchError,
+			onSettled: () => setIsModalOpen( false ),
+		} );
+	};
+
 	const baseResult = {
 		isLoading: isDomainsLoading,
 		isExperimentLoading,
@@ -160,6 +169,24 @@ export function useSiteLaunch(
 		}
 
 		return { ...baseResult, isHidden: true, onClick: () => {} };
+	}
+
+	if ( isSitePlanPaidWithDomains ) {
+		return {
+			...baseResult,
+			isHidden: false,
+			onClick: () => setIsModalOpen( true ),
+			modal: isModalOpen ? (
+				<SiteLaunchModal
+					variant="pre-launch"
+					isOpen
+					site={ site }
+					isLaunching={ launchMutation.isPending }
+					onClose={ () => setIsModalOpen( false ) }
+					onLaunch={ confirmPreLaunch }
+				/>
+			) : null,
+		};
 	}
 
 	if ( shouldImmediatelyLaunch ) {

--- a/client/dashboard/sites/site-launch-modal/index.tsx
+++ b/client/dashboard/sites/site-launch-modal/index.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useResizeObserver } from '@wordpress/compose';
+import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useAppContext } from '../../app/context';
 import { getAddSiteDomainUrl } from '../../utils/domain-url';
@@ -47,6 +48,7 @@ export default function SiteLaunchModal( props: SiteLaunchModalProps ) {
 	} );
 	const [ previewResizeListener, { width: previewWidth, height: previewHeight } ] =
 		useResizeObserver();
+	const [ isPreviewLoaded, setIsPreviewLoaded ] = useState( false );
 
 	if ( ! isOpen ) {
 		return null;
@@ -77,13 +79,17 @@ export default function SiteLaunchModal( props: SiteLaunchModalProps ) {
 				onClose={ onClose }
 				preview={
 					site.URL ? (
-						<div className="site-launch-pre-launch-modal__thumbnail">
+						<div
+							className="site-launch-pre-launch-modal__thumbnail"
+							data-preview-loaded={ isPreviewLoaded }
+						>
 							{ previewResizeListener }
 							{ !! previewWidth && !! previewHeight && (
 								<SitePreview
 									url={ site.URL }
 									scale={ previewWidth / PREVIEW_BASE_WIDTH }
 									height={ previewHeight / ( previewWidth / PREVIEW_BASE_WIDTH ) }
+									onLoad={ () => setIsPreviewLoaded( true ) }
 								/>
 							) }
 						</div>

--- a/client/dashboard/sites/site-launch-modal/styles.scss
+++ b/client/dashboard/sites/site-launch-modal/styles.scss
@@ -48,7 +48,7 @@
 .site-launch-pre-launch-modal__preview-card {
 	@extend %launch-modal-card;
 
-	border-radius: 4px;
+	border-radius: $radius-medium;
 }
 
 .site-launch-pre-launch-modal__thumbnail {
@@ -57,7 +57,23 @@
 	inline-size: 114px;
 	block-size: 88px;
 	overflow: hidden;
-	border-radius: 4px;
+	border-radius: $radius-medium;
+	background-color: var( --color-neutral-5 );
+
+	// Static placeholder that covers the preview until the iframe has finished
+	// loading. A loading iframe paints an opaque viewport, so the placeholder
+	// must sit on top rather than behind it.
+	&::before {
+		content: "";
+		position: absolute;
+		inset: 0;
+		z-index: 1;
+		background-color: var( --color-neutral-5 );
+	}
+
+	&[data-preview-loaded="true"]::before {
+		display: none;
+	}
 }
 
 .site-launch-pre-launch-modal__meta {

--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -5,11 +5,13 @@ export default function SitePreview( {
 	scale = 1,
 	width = 1200,
 	height = 800,
+	onLoad,
 }: {
 	url: string;
 	scale?: number;
 	width?: number;
 	height?: number;
+	onLoad?: () => void;
 } ) {
 	// The /sites endpoint may return non-secure URLs. Often these _can_ be
 	// loaded securely, so it's worth trying to load over https. If it fails,
@@ -30,6 +32,7 @@ export default function SitePreview( {
 			// @ts-expect-error For some reason there's no inert type.
 			inert="true"
 			title={ __( 'Site Preview' ) }
+			onLoad={ onLoad }
 			// Hide banners + `preview` hides cookie banners + `iframe` hides
 			// admin bar for atomic sites.
 			src={ `${ secureUrl }/?hide_banners=true&preview=true&iframe=true` }


### PR DESCRIPTION
Part of DOTPROD-77

Follow-up to #113508 (which introduced the pre-launch `SiteLaunchModal` component). This PR wires that modal into the launch flow.

<img width="1728" height="653" alt="Screenshot 2026-08-20 at 22 40 21" src="https://github.com/user-attachments/assets/67fe008e-292a-45b2-9a96-cef6071da58b" />

## Proposed Changes

* Wire the pre-launch `SiteLaunchModal` into the `useSiteLaunch` hook (`client/dashboard/sites/site-launch-button/use-site-launch.tsx`).
* Sites that **already have a paid plan and a custom domain** now open the pre-launch confirmation modal on click instead of launching in one click; the launch fires when the user confirms ("Yes, launch site!"). Post-launch behavior (mutation + redirect) is unchanged — it's just gated by a confirmation step.
* Hosting-trial and staging sites keep their existing **immediate-launch** behavior (no modal).
* No consumer changes required: `SiteLaunchButton` and the omnibar launch button already render the hook's `modal`.
* Add hook-level integration tests driving the real hook through `SiteLaunchButton`.

## Why are these changes being made?

One-click launching for plan+domain sites skips any confirmation, so it's easy to make a site public by accident. Gating that path behind the pre-launch modal gives the user a clear "launching makes your site public" confirmation with a preview of the site, name, domain, and plan.

## Testing Instructions

* `yarn test-client client/dashboard/sites/site-launch-button` — 4 pass.
* In the dashboard, open a site that has a **paid plan and a custom domain** and is still unlaunched. Click **Launch your site** (from the site button, settings › visibility, performance page, or the omnibar). The pre-launch modal should appear; confirming launches the site as before.
* Verify a **hosting-trial** or **staging** site still launches immediately with no modal.
* Verify a **free** site still routes to the `/start/launch-site` stepper flow.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
