### PR TITLE
E2E: await Tracks event manager init before navigating to the LOHP

### DIFF
--- a/packages/calypso-e2e/src/lib/utils/tracks-event-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/tracks-event-manager.ts
@@ -26,10 +26,14 @@ export class TracksEventManager {
 
 	/**
 	 * Initialize the Tracks event manager
+	 *
+	 * Must be awaited before navigating: until the init script has landed,
+	 * `_tkAllowE2ETests` is unset and w.js drops every Tracks pixel because the
+	 * e2e user agent matches its bot filter.
 	 */
 	async init() {
-		this.maybeInterceptRequest();
-		this.allowTestsToFireEvents();
+		await this.maybeInterceptRequest();
+		await this.allowTestsToFireEvents();
 	}
 
 	/**
@@ -93,7 +97,7 @@ export class TracksEventManager {
 	/**
 	 * Intercept and modify some network requests
 	 */
-	maybeInterceptRequest() {
+	async maybeInterceptRequest() {
 		// Only allow specific requests needed for tests
 		// We're explicitly not allowing t.gif requests. We only need the request URL.
 		const urlContainsAllowList = [
@@ -108,7 +112,7 @@ export class TracksEventManager {
 			'.min.css',
 		];
 
-		this.page.route( '**/*', ( route, request ) => {
+		await this.page.route( '**/*', ( route, request ) => {
 			if (
 				urlContainsAllowList.some( ( allowedString ) => request.url().includes( allowedString ) )
 			) {

--- a/test/e2e/specs/tracks/tracks__lohp-to-signup-events.spec.ts
+++ b/test/e2e/specs/tracks/tracks__lohp-to-signup-events.spec.ts
@@ -10,7 +10,7 @@ test.describe(
 		test( 'Loading LOHP fires wpcom_page_view event', async ( { pageIncognito } ) => {
 			const page = pageIncognito.getPage();
 			const tracksEventManager = new TracksEventManager( page );
-			tracksEventManager.init();
+			await tracksEventManager.init();
 
 			const didEventFirePromise = tracksEventManager.didEventFire( 'wpcom_page_view' );
 			await tracksEventManager.navigateToUrl( lohpUrl );
@@ -20,7 +20,7 @@ test.describe(
 		test( 'Clicking link on LOHP fires wpcom_homepage_link_click', async ( { pageIncognito } ) => {
 			const page = pageIncognito.getPage();
 			const tracksEventManager = new TracksEventManager( page );
-			tracksEventManager.init();
+			await tracksEventManager.init();
 
 			await tracksEventManager.navigateToUrl( lohpUrl );
 
@@ -34,7 +34,7 @@ test.describe(
 		} ) => {
 			const page = pageIncognito.getPage();
 			const tracksEventManager = new TracksEventManager( page );
-			tracksEventManager.init();
+			await tracksEventManager.init();
 
 			let requestUrlPromise = tracksEventManager.getRequestUrlForEvent( 'wpcom_page_view' );
 			await tracksEventManager.navigateToUrl( lohpUrl );


### PR DESCRIPTION
## Proposed Changes

* `TracksEventManager.init()` now awaits `maybeInterceptRequest()` and
  `allowTestsToFireEvents()`; `maybeInterceptRequest()` awaits `page.route()`.
* The LOHP tracks spec awaits `init()` at its three call sites.

## Why are these changes being made?

All three tests in `tracks__lohp-to-signup-events.spec.ts` have been failing on
attempt 1 and passing only on retry. Green builds hide it; the suite goes red
whenever the retry is also slow, as in Pre-Release E2E build 19062808.

`init()` registers the init script that sets `_tkAllowE2ETests`. Without that
flag `w.js` drops every Tracks pixel, because the e2e user agent matches its bot
filter. Nothing awaited the registration, so `page.goto` raced it and usually
won. The LOHP document then fired no pixel at all and every `waitForRequest`
timed out at 10s.

Playwright tracing masked it — it delays navigation enough for the init script to
land. CI uses `trace: on-first-retry`, so attempt 1 fails and the retry passes.
Locally `trace: retain-on-failure` is always on, so the spec always passed.

## Testing Instructions

`--trace=off` reproduces the CI attempt-1 condition:

    yarn workspace @automattic/calypso-e2e build
    cd test/e2e
    npx playwright test specs/tracks/tracks__lohp-to-signup-events.spec.ts \
      --project=chrome --trace=off --repeat-each=5 --workers=1 --retries=0 --reporter=list

On trunk: 15/15 fail, each at ~10.9s on `waitForRequest`.
On this branch: 15/15 pass.

Reviewers should check the invariant: nothing may navigate before `init()` has
resolved. A future caller that drops the promise reintroduces the race, and only
CI will show it.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
