### PR TITLE
Signup e2e: fix the Blackbox signup specs on the Authentication build

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -215,7 +215,11 @@ export class UserSignupPage {
 	 */
 	async visit( { path }: { path: string } = { path: '' } ): Promise< void > {
 		const targetUrl = path ? `start/${ path }` : 'start';
-		await this.page.goto( getCalypsoURL( targetUrl ), { waitUntil: 'networkidle' } );
+		// Not 'networkidle': the bot-protection client keeps the signup page
+		// busy, and no navigationTimeout is configured, so waiting for idle
+		// burns the whole test budget. waitForSignupForm() does the real
+		// readiness wait, bounded.
+		await this.page.goto( getCalypsoURL( targetUrl ), { waitUntil: 'domcontentloaded' } );
 	}
 	/**
 	 * Captures the response from the user creation API endpoint.

--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -512,13 +512,18 @@ export class UserSignupPage {
 		handleActiveThrottles( [ 'signup' ] );
 		await this.emailInput.fill( email );
 
-		const responsePromise = this.page.waitForResponse(
-			( response ) => /\/users\/new\?[^?]*$/.test( response.url() ) && response.ok()
-		);
-		await this.continueButton.click();
-		const response = await responsePromise;
+		// Read the response body as soon as it arrives; the accept-invite
+		// navigation that follows a successful signup evicts it from the
+		// browser cache before a later json() can get to it.
+		const responseBodyPromise = this.page
+			.waitForResponse(
+				( response ) => /\/users\/new\?[^?]*$/.test( response.url() ) && response.ok()
+			)
+			.then( ( response ): Promise< NewUserResponse > => response.json() );
 
-		return await response.json();
+		await this.continueButton.click();
+
+		return await responseBodyPromise;
 	}
 
 	/**

--- a/test/e2e/lib/blackbox-test-key.ts
+++ b/test/e2e/lib/blackbox-test-key.ts
@@ -11,6 +11,29 @@ export const BLACKBOX_TEST_COLLECT_KEYS = {
 
 export type BlackboxTestCollectOutcome = keyof typeof BLACKBOX_TEST_COLLECT_KEYS;
 
+export type BlackboxCollectBody = {
+	data?: { session_id?: string; challenge?: unknown };
+};
+
+/**
+ * Resolves with the parsed body of the next Blackbox collect POST.
+ *
+ * The body is read as it arrives, not from the resolved Response: once the
+ * signup succeeds and Calypso navigates, the browser evicts the body and a
+ * later response.json() fails with "No resource with given identifier found"
+ * or "Target page, context or browser has been closed".
+ */
+export function waitForCollectData( page: Page ): Promise< BlackboxCollectBody > {
+	return page
+		.waitForResponse(
+			( response ) =>
+				response.request().method() === 'POST' &&
+				response.url().includes( 'blackbox-api.wp.com/v1/collect' ),
+			{ timeout: 60 * 1000 }
+		)
+		.then( ( response ) => response.json() );
+}
+
 export async function useBlackboxTestKeyForCollect(
 	page: Page,
 	outcome: BlackboxTestCollectOutcome = 'allow'

--- a/test/e2e/specs/authentication/authentication__blackbox-signup-invite.spec.ts
+++ b/test/e2e/specs/authentication/authentication__blackbox-signup-invite.spec.ts
@@ -5,7 +5,7 @@ import {
 	SecretsManager,
 	UserSignupPage,
 } from '@automattic/calypso-e2e';
-import { useBlackboxTestKeyForCollect } from '../../lib/blackbox-test-key';
+import { useBlackboxTestKeyForCollect, waitForCollectData } from '../../lib/blackbox-test-key';
 import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 import { apiCloseAccount } from '../shared';
 import type { NewTestUserDetails, NewUserResponse } from '@automattic/calypso-e2e';
@@ -105,14 +105,6 @@ test.describe( 'Signup: Blackbox invite accept', { tag: [ tags.AUTHENTICATION ] 
 		return DataHelper.getCalypsoURL( acceptInviteURL.pathname + acceptInviteURL.search );
 	};
 
-	const waitForCollectResponse = ( page: Page ) =>
-		page.waitForResponse(
-			( response ) =>
-				response.request().method() === 'POST' &&
-				response.url().includes( 'blackbox-api.wp.com/v1/collect' ),
-			{ timeout: 60 * 1000 }
-		);
-
 	const waitForUsersNewRequest = ( page: Page ): Promise< Request > =>
 		page.waitForRequest(
 			( request ) => request.method() === 'POST' && /\/users\/new\?/.test( request.url() ),
@@ -143,12 +135,12 @@ test.describe( 'Signup: Blackbox invite accept', { tag: [ tags.AUTHENTICATION ] 
 			await useBlackboxTestKeyForCollect( page, 'allow' );
 		} );
 
-		const collectResponse = waitForCollectResponse( page );
+		const collectData = waitForCollectData( page );
 
 		await test.step( 'When I visit the accept-invite page', async function () {
 			await page.goto( acceptInviteURL );
 
-			const collectBody = await ( await collectResponse ).json();
+			const collectBody = await collectData;
 			expect( collectBody?.data?.session_id ).toBe( 'bbtest_allow__________' );
 		} );
 
@@ -196,12 +188,12 @@ test.describe( 'Signup: Blackbox invite accept', { tag: [ tags.AUTHENTICATION ] 
 			await useBlackboxTestKeyForCollect( page, 'challenge' );
 		} );
 
-		const collectResponse = waitForCollectResponse( page );
+		const collectData = waitForCollectData( page );
 
 		await test.step( 'When I visit the accept-invite page', async function () {
 			await page.goto( acceptInviteURL );
 
-			const collectBody = await ( await collectResponse ).json();
+			const collectBody = await collectData;
 			expect( collectBody?.data?.session_id ).toBe( 'bbtest_challenge______' );
 			expect( collectBody?.data?.challenge ).toBeTruthy();
 		} );
@@ -240,12 +232,12 @@ test.describe( 'Signup: Blackbox invite accept', { tag: [ tags.AUTHENTICATION ] 
 			await useBlackboxTestKeyForCollect( page, 'block' );
 		} );
 
-		const collectResponse = waitForCollectResponse( page );
+		const collectData = waitForCollectData( page );
 
 		await test.step( 'When I visit the accept-invite page', async function () {
 			await page.goto( acceptInviteURL );
 
-			const collectBody = await ( await collectResponse ).json();
+			const collectBody = await collectData;
 			expect( collectBody?.data?.session_id ).toBe( 'bbtest_block__________' );
 		} );
 

--- a/test/e2e/specs/authentication/authentication__blackbox-signup-jetpack-connect.spec.ts
+++ b/test/e2e/specs/authentication/authentication__blackbox-signup-jetpack-connect.spec.ts
@@ -1,5 +1,5 @@
 import { DataHelper, RestAPIClient, UserSignupPage } from '@automattic/calypso-e2e';
-import { useBlackboxTestKeyForCollect } from '../../lib/blackbox-test-key';
+import { useBlackboxTestKeyForCollect, waitForCollectData } from '../../lib/blackbox-test-key';
 import { expect, tags, test } from '../../lib/pw-base';
 import { apiCloseAccount } from '../shared';
 import type { NewUserResponse } from '@automattic/calypso-e2e';
@@ -50,14 +50,6 @@ test.describe( 'Signup: Blackbox Jetpack Connect', { tag: [ tags.AUTHENTICATION 
 		}
 	} );
 
-	const waitForCollectResponse = ( page: Page ) =>
-		page.waitForResponse(
-			( response ) =>
-				response.request().method() === 'POST' &&
-				response.url().includes( 'blackbox-api.wp.com/v1/collect' ),
-			{ timeout: 60 * 1000 }
-		);
-
 	const waitForUsersNewRequest = ( page: Page ): Promise< Request > =>
 		page.waitForRequest(
 			( request ) => request.method() === 'POST' && /\/users\/new\?/.test( request.url() ),
@@ -79,12 +71,12 @@ test.describe( 'Signup: Blackbox Jetpack Connect', { tag: [ tags.AUTHENTICATION 
 			await useBlackboxTestKeyForCollect( page, 'allow' );
 		} );
 
-		const collectResponse = waitForCollectResponse( page );
+		const collectData = waitForCollectData( page );
 
 		await test.step( 'When I visit the Jetpack Connect authorize page', async function () {
 			await page.goto( jetpackAuthorizeURL );
 
-			const collectBody = await ( await collectResponse ).json();
+			const collectBody = await collectData;
 			expect( collectBody?.data?.session_id ).toBe( 'bbtest_allow__________' );
 		} );
 
@@ -121,12 +113,12 @@ test.describe( 'Signup: Blackbox Jetpack Connect', { tag: [ tags.AUTHENTICATION 
 			await useBlackboxTestKeyForCollect( page, 'challenge' );
 		} );
 
-		const collectResponse = waitForCollectResponse( page );
+		const collectData = waitForCollectData( page );
 
 		await test.step( 'When I visit the Jetpack Connect authorize page', async function () {
 			await page.goto( jetpackAuthorizeURL );
 
-			const collectBody = await ( await collectResponse ).json();
+			const collectBody = await collectData;
 			expect( collectBody?.data?.session_id ).toBe( 'bbtest_challenge______' );
 			expect( collectBody?.data?.challenge ).toBeTruthy();
 		} );
@@ -156,12 +148,12 @@ test.describe( 'Signup: Blackbox Jetpack Connect', { tag: [ tags.AUTHENTICATION 
 			await useBlackboxTestKeyForCollect( page, 'block' );
 		} );
 
-		const collectResponse = waitForCollectResponse( page );
+		const collectData = waitForCollectData( page );
 
 		await test.step( 'When I visit the Jetpack Connect authorize page', async function () {
 			await page.goto( jetpackAuthorizeURL );
 
-			const collectBody = await ( await collectResponse ).json();
+			const collectBody = await collectData;
 			expect( collectBody?.data?.session_id ).toBe( 'bbtest_block__________' );
 		} );
 

--- a/test/e2e/specs/authentication/authentication__blackbox-signup-start-account.spec.ts
+++ b/test/e2e/specs/authentication/authentication__blackbox-signup-start-account.spec.ts
@@ -1,5 +1,5 @@
 import { DataHelper, RestAPIClient, UserSignupPage } from '@automattic/calypso-e2e';
-import { useBlackboxTestKeyForCollect } from '../../lib/blackbox-test-key';
+import { useBlackboxTestKeyForCollect, waitForCollectData } from '../../lib/blackbox-test-key';
 import { expect, tags, test } from '../../lib/pw-base';
 import { apiCloseAccount } from '../shared';
 import type { NewUserResponse } from '@automattic/calypso-e2e';
@@ -31,14 +31,6 @@ test.describe( 'Signup: Blackbox /start/account', { tag: [ tags.AUTHENTICATION ]
 		}
 	} );
 
-	const waitForCollectResponse = ( page: Page ) =>
-		page.waitForResponse(
-			( response ) =>
-				response.request().method() === 'POST' &&
-				response.url().includes( 'blackbox-api.wp.com/v1/collect' ),
-			{ timeout: 60 * 1000 }
-		);
-
 	const waitForUsersNewRequest = ( page: Page ): Promise< Request > =>
 		page.waitForRequest(
 			( request ) => request.method() === 'POST' && /\/users\/new\?/.test( request.url() ),
@@ -67,7 +59,7 @@ test.describe( 'Signup: Blackbox /start/account', { tag: [ tags.AUTHENTICATION ]
 		await test.step( 'And I sign up with my email', async function () {
 			// Blackbox is suspended until the email form becomes the active
 			// surface, so the collect only fires during the signup interaction.
-			const collectResponse = waitForCollectResponse( page );
+			const collectData = waitForCollectData( page );
 			const usersNewRequest = waitForUsersNewRequest( page );
 
 			newUserDetails = await new UserSignupPage( page ).signupSocialFirstWithEmail(
@@ -80,7 +72,7 @@ test.describe( 'Signup: Blackbox /start/account', { tag: [ tags.AUTHENTICATION ]
 				email: testUser.email,
 			} );
 
-			const collectBody = await ( await collectResponse ).json();
+			const collectBody = await collectData;
 			expect( collectBody?.data?.session_id ).toBe( 'bbtest_allow__________' );
 
 			const request = await usersNewRequest;
@@ -105,7 +97,7 @@ test.describe( 'Signup: Blackbox /start/account', { tag: [ tags.AUTHENTICATION ]
 			await useBlackboxTestKeyForCollect( page, 'challenge' );
 		} );
 
-		const collectResponse = waitForCollectResponse( page );
+		const collectData = waitForCollectData( page );
 
 		await test.step( 'When I visit the signup page and reveal the email form', async function () {
 			await new UserSignupPage( page ).visit( { path: 'account' } );
@@ -127,7 +119,7 @@ test.describe( 'Signup: Blackbox /start/account', { tag: [ tags.AUTHENTICATION ]
 				await continueWithEmailButton.click();
 			}
 
-			const collectBody = await ( await collectResponse ).json();
+			const collectBody = await collectData;
 			expect( collectBody?.data?.session_id ).toBe( 'bbtest_challenge______' );
 			expect( collectBody?.data?.challenge ).toBeTruthy();
 		} );
@@ -162,7 +154,7 @@ test.describe( 'Signup: Blackbox /start/account', { tag: [ tags.AUTHENTICATION ]
 		} );
 
 		await test.step( 'And I sign up with my email', async function () {
-			const collectResponse = waitForCollectResponse( page );
+			const collectData = waitForCollectData( page );
 			const usersNewRequest = waitForUsersNewRequest( page );
 
 			newUserDetails = await new UserSignupPage( page ).signupSocialFirstWithEmail(
@@ -174,7 +166,7 @@ test.describe( 'Signup: Blackbox /start/account', { tag: [ tags.AUTHENTICATION ]
 				email: testUser.email,
 			} );
 
-			const collectBody = await ( await collectResponse ).json();
+			const collectBody = await collectData;
 			expect( collectBody?.data?.session_id ).toBe( 'bbtest_block__________' );
 
 			const request = await usersNewRequest;


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Read the `/users/new` and Blackbox collect response bodies at the wait instead of after the signup has navigated.
* Drop `networkidle` from `UserSignupPage.visit()`.

## Why are these changes being made?

The Blackbox signup specs have been red on Calypso E2E Authentication since their
first scheduled run, 6 of the last 7: 19035637, 19038617, 19043686, 19057005,
19059840 and 19065395, with only 19052087 green. Two separate causes, both in the
test code.

The common one is a body read that lands after the page has moved on. It surfaces
as `Network.getResponseBody: No resource with given identifier found` or
`Target page, context or browser has been closed`, always at a `response.json()`.
The account was created on every one of those runs; the throw just happened before
the caller could queue it for teardown, so the failing tests also leaked their
accounts.

The other one showed up once, in 19059840, where all three `/start/account` tests
spent the full 120s inside `goto`. Blackbox has been on for signup in production
since #113663, the page keeps talking, and idle never lands. Nothing configures
`navigationTimeout`, so `goto` is bounded by the test budget and nothing else.

Worth stating since the specs assert it: the shadow-mode tests are still honest.
Enforcement is still off server side, and the block-verdict tests create an account
on every run.

## Testing Instructions

The pass is confirmed with three successful personal Calypso E2E Authentication
builds run on this branch. All three green, 24 tests each, no failure artifacts:

* https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Authentication/19067618
* https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Authentication/19068349
* https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_Calypso_E2E_Authentication/19068932

Against a 6-in-7 failure rate that's about a 0.3% coincidence.

The one thing to check on review: `visit()` no longer promises a quiet network, so
callers have to wait for whatever they need themselves. `waitForSignupForm()` does,
and the `/start/account` spec is its only caller today.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
