### PR TITLE
Calypso: gate classic launch surfaces behind the pre-launch modal

### DIFF
--- a/client/components/pre-launch-site-modal/index.tsx
+++ b/client/components/pre-launch-site-modal/index.tsx
@@ -1,0 +1,97 @@
+import { queryClient, siteByIdQuery, domainsQuery } from '@automattic/api-queries';
+import { QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useState } from 'react';
+import { AnalyticsProvider } from 'calypso/dashboard/app/analytics';
+import { isSitePlanPaid } from 'calypso/dashboard/sites/plans';
+import SiteLaunchModal from 'calypso/dashboard/sites/site-launch-modal';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+
+interface PreLaunchSiteModalProps {
+	siteId: number;
+	isOpen: boolean;
+	onClose: () => void;
+	// Where launch is handed off to. The caller owns this so the destination
+	// (and the `/start/launch-site` path) stays explicit at each call site.
+	launchUrl: string;
+}
+
+/**
+ * Shared bridge that gates the classic "launch site" surfaces behind the
+ * dashboard pre-launch modal.
+ *
+ * When a site already has a paid plan and a custom domain, the launch flow
+ * auto-skips its domain and plan steps and launches immediately. For those sites
+ * we show a confirmation modal first; on confirm we redirect to `launchUrl`.
+ * Every other site is sent straight to `launchUrl`, preserving today's behavior.
+ */
+function PreLaunchSiteModalContent( {
+	siteId,
+	isOpen,
+	onClose,
+	launchUrl,
+}: PreLaunchSiteModalProps ) {
+	const [ isRedirecting, setIsRedirecting ] = useState( false );
+
+	const { data: site } = useQuery( { ...siteByIdQuery( siteId ), enabled: isOpen } );
+	const domainsResult = useQuery( {
+		...domainsQuery(),
+		enabled: isOpen,
+		select: ( data ) => data.filter( ( domain ) => domain.blog_id === siteId ),
+	} );
+
+	// Wait until the site is loaded and the domains query has settled (success or
+	// error) before deciding. On a domains error we fall back to the flow so the
+	// launch action is never silently swallowed.
+	const isReady = isOpen && !! site && ( domainsResult.isSuccess || domainsResult.isError );
+	const hasCustomDomain = ( domainsResult.data ?? [] ).some(
+		( domain ) => domain.subscription_id !== null
+	);
+	const qualifiesForPreLaunch =
+		!! site && domainsResult.isSuccess && isSitePlanPaid( site ) && hasCustomDomain;
+
+	useEffect( () => {
+		if ( isReady && ! qualifiesForPreLaunch && launchUrl ) {
+			window.location.assign( launchUrl );
+		}
+	}, [ isReady, qualifiesForPreLaunch, launchUrl ] );
+
+	if ( ! isReady || ! qualifiesForPreLaunch || ! site ) {
+		return null;
+	}
+
+	return (
+		<SiteLaunchModal
+			variant="pre-launch"
+			isOpen
+			site={ site }
+			isLaunching={ isRedirecting }
+			onClose={ onClose }
+			onLaunch={ () => {
+				setIsRedirecting( true );
+				window.location.assign( launchUrl );
+			} }
+		/>
+	);
+}
+
+export default function PreLaunchSiteModal( props: PreLaunchSiteModalProps ) {
+	const analyticsClient = useMemo(
+		() => ( {
+			recordTracksEvent,
+			recordPageView() {},
+		} ),
+		[]
+	);
+
+	if ( ! props.isOpen ) {
+		return null;
+	}
+
+	return (
+		<QueryClientProvider client={ queryClient }>
+			<AnalyticsProvider client={ analyticsClient }>
+				<PreLaunchSiteModalContent { ...props } />
+			</AnalyticsProvider>
+		</QueryClientProvider>
+	);
+}

--- a/client/components/pre-launch-site-modal/index.tsx
+++ b/client/components/pre-launch-site-modal/index.tsx
@@ -32,10 +32,13 @@ function PreLaunchSiteModalContent( {
 }: PreLaunchSiteModalProps ) {
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
 
-	const { data: site } = useQuery( { ...siteByIdQuery( siteId ), enabled: isOpen } );
+	// Fetch as soon as there is a site (not only once open) so the qualification
+	// decision is already settled by the time the user clicks — otherwise the
+	// button appears unresponsive while these requests resolve.
+	const { data: site } = useQuery( { ...siteByIdQuery( siteId ), enabled: !! siteId } );
 	const domainsResult = useQuery( {
 		...domainsQuery(),
-		enabled: isOpen,
+		enabled: !! siteId,
 		select: ( data ) => data.filter( ( domain ) => domain.blog_id === siteId ),
 	} );
 
@@ -83,10 +86,12 @@ export default function PreLaunchSiteModal( props: PreLaunchSiteModalProps ) {
 		[]
 	);
 
-	if ( ! props.isOpen ) {
+	if ( ! props.siteId ) {
 		return null;
 	}
 
+	// Mounted (and prefetching) whenever a site is present, even while closed, so
+	// the modal can open instantly. It renders nothing until `isOpen`.
 	return (
 		<QueryClientProvider client={ queryClient }>
 			<AnalyticsProvider client={ analyticsClient }>

--- a/client/components/pre-launch-site-modal/index.tsx
+++ b/client/components/pre-launch-site-modal/index.tsx
@@ -6,6 +6,8 @@ import { isSitePlanPaid } from 'calypso/dashboard/sites/plans';
 import SiteLaunchModal from 'calypso/dashboard/sites/site-launch-modal';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
+import './style.scss';
+
 interface PreLaunchSiteModalProps {
 	siteId: number;
 	isOpen: boolean;

--- a/client/components/pre-launch-site-modal/style.scss
+++ b/client/components/pre-launch-site-modal/style.scss
@@ -1,0 +1,5 @@
+// Undo classic Calypso's global `iframe { max-width: 100% }`, which collapses
+// the scaled site-preview iframe to a sliver.
+.site-launch-pre-launch-modal__thumbnail iframe {
+	max-width: none;
+}

--- a/client/dashboard/sites/site-launch-modal/styles.scss
+++ b/client/dashboard/sites/site-launch-modal/styles.scss
@@ -5,7 +5,7 @@
 
 %launch-modal-card {
 	padding: $grid-unit-20 $grid-unit-20;
-	background-color: var( --color-primary-5 );
+	background-color: var( --studio-blue-5 );
 
 	@include ui-mixins.when-dark-theme {
 		background-color: var( --wp-components-color-gray-200 );

--- a/client/layout/masterbar/masterbar-launch-button.tsx
+++ b/client/layout/masterbar/masterbar-launch-button.tsx
@@ -52,8 +52,9 @@ export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 				as={ Button }
 				asProps={ {
 					variant: 'primary',
+					isBusy: isLaunchModalOpen,
 				} }
-				disabled={ isLoading }
+				disabled={ isLoading || isLaunchModalOpen }
 				// Keep the Launch button always in blueberry (default scheme: modern) like in wp-admin.
 				className={ clsx( 'masterbar__item-launch-site', 'color-scheme', 'is-global' ) }
 				icon={

--- a/client/layout/masterbar/masterbar-launch-button.tsx
+++ b/client/layout/masterbar/masterbar-launch-button.tsx
@@ -1,9 +1,9 @@
-import { siteLaunchMutation } from '@automattic/api-queries';
-import { useMutation } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import PreLaunchSiteModal from 'calypso/components/pre-launch-site-modal';
 import { useSiteLaunchGatingVariant } from 'calypso/lib/use-site-launch-gating-variant';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -16,54 +16,66 @@ export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 	const dispatch = useDispatch();
 	const site = useSelector( ( state ) => getSite( state, siteId ) );
 	const sectionName = useSelector( getSectionName );
-	const launchSiteMutation = useMutation( siteLaunchMutation( siteId ) );
 
 	const [ isLoading, variant ] = useSiteLaunchGatingVariant();
+	const [ isLaunchModalOpen, setIsLaunchModalOpen ] = useState( false );
+	const [ launchUrl, setLaunchUrl ] = useState( '' );
 
 	const onLaunchSiteClick = () => {
 		dispatch( recordTracksEvent( 'calypso_masterbar_launch_site', { source: sectionName } ) );
 
-		// Site launch gating: 'semi_gated_site_launch' is the shipped default.
-		// The other branches are scaffolding for future experiments; see
+		// Site launch gating: 'semi_gated_site_launch' is the shipped default — it
+		// routes to the `/start/launch-site` flow, but opens the shared pre-launch
+		// bridge first, which shows the confirmation modal for paid-plan +
+		// custom-domain sites and otherwise hands straight off to that flow. The
+		// other branches are scaffolding for future experiments; see
 		// useSiteLaunchGatingVariant().
 		switch ( variant ) {
 			case 'semi_gated_site_launch':
 			case null:
 			default: {
-				window.location.assign(
+				setLaunchUrl(
 					addQueryArgs( '/start/launch-site', {
 						siteSlug: site?.slug,
 						back_to: window.location.pathname,
 					} )
 				);
+				setIsLaunchModalOpen( true );
 				return;
 			}
 		}
 	};
 
 	return (
-		<Item
-			as={ Button }
-			asProps={ {
-				variant: 'primary',
-				isBusy: launchSiteMutation.isPending,
-			} }
-			disabled={ isLoading || launchSiteMutation.isPending }
-			// Keep the Launch button always in blueberry (default scheme: modern) like in wp-admin.
-			className={ clsx( 'masterbar__item-launch-site', 'color-scheme', 'is-global' ) }
-			icon={
-				<svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
-					<path
-						fillRule="evenodd"
-						clipRule="evenodd"
-						d="M10.6242 9.74354L7.62419 12.1261V13.2995C7.62419 13.4418 7.77653 13.5322 7.90147 13.4641L10.5265 12.0322C10.5867 11.9994 10.6242 11.9363 10.6242 11.8676V9.74354ZM6.49919 12.0875L3.91203 9.50037H2.7001C1.70383 9.50037 1.07079 8.43399 1.54786 7.55937L2.97968 4.93437C3.20967 4.51272 3.65161 4.25036 4.13191 4.25036H7.17569C9.1325 2.16798 11.3176 0.754637 14.1427 0.531305C14.9004 0.471402 15.5282 1.09911 15.4682 1.85687C15.2449 4.68199 13.8316 6.86706 11.7492 8.82386V11.8676C11.7492 12.3479 11.4868 12.7899 11.0652 13.0199L8.44018 14.4517C7.56557 14.9288 6.49919 14.2957 6.49919 13.2995V12.0875ZM6.25602 5.37536H4.13191C4.0633 5.37536 4.00017 5.41284 3.96731 5.47308L2.53549 8.09808C2.46734 8.22303 2.55777 8.37536 2.7001 8.37536H3.87344L6.25602 5.37536Z"
-					/>
-					<path d="M0.498047 13.3962C0.498047 12.2341 1.44011 11.2921 2.60221 11.2921C3.76431 11.2921 4.70638 12.2341 4.70638 13.3962C4.70638 14.5583 3.76431 15.5004 2.60221 15.5004H1.06055C0.749887 15.5004 0.498047 15.2486 0.498047 14.9379V13.3962Z" />
-				</svg>
-			}
-			onClick={ onLaunchSiteClick }
-		>
-			{ translate( 'Launch site' ) }
-		</Item>
+		<>
+			<Item
+				as={ Button }
+				asProps={ {
+					variant: 'primary',
+				} }
+				disabled={ isLoading }
+				// Keep the Launch button always in blueberry (default scheme: modern) like in wp-admin.
+				className={ clsx( 'masterbar__item-launch-site', 'color-scheme', 'is-global' ) }
+				icon={
+					<svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+						<path
+							fillRule="evenodd"
+							clipRule="evenodd"
+							d="M10.6242 9.74354L7.62419 12.1261V13.2995C7.62419 13.4418 7.77653 13.5322 7.90147 13.4641L10.5265 12.0322C10.5867 11.9994 10.6242 11.9363 10.6242 11.8676V9.74354ZM6.49919 12.0875L3.91203 9.50037H2.7001C1.70383 9.50037 1.07079 8.43399 1.54786 7.55937L2.97968 4.93437C3.20967 4.51272 3.65161 4.25036 4.13191 4.25036H7.17569C9.1325 2.16798 11.3176 0.754637 14.1427 0.531305C14.9004 0.471402 15.5282 1.09911 15.4682 1.85687C15.2449 4.68199 13.8316 6.86706 11.7492 8.82386V11.8676C11.7492 12.3479 11.4868 12.7899 11.0652 13.0199L8.44018 14.4517C7.56557 14.9288 6.49919 14.2957 6.49919 13.2995V12.0875ZM6.25602 5.37536H4.13191C4.0633 5.37536 4.00017 5.41284 3.96731 5.47308L2.53549 8.09808C2.46734 8.22303 2.55777 8.37536 2.7001 8.37536H3.87344L6.25602 5.37536Z"
+						/>
+						<path d="M0.498047 13.3962C0.498047 12.2341 1.44011 11.2921 2.60221 11.2921C3.76431 11.2921 4.70638 12.2341 4.70638 13.3962C4.70638 14.5583 3.76431 15.5004 2.60221 15.5004H1.06055C0.749887 15.5004 0.498047 15.2486 0.498047 14.9379V13.3962Z" />
+					</svg>
+				}
+				onClick={ onLaunchSiteClick }
+			>
+				{ translate( 'Launch site' ) }
+			</Item>
+			<PreLaunchSiteModal
+				siteId={ siteId }
+				isOpen={ isLaunchModalOpen }
+				onClose={ () => setIsLaunchModalOpen( false ) }
+				launchUrl={ launchUrl }
+			/>
+		</>
 	);
 };

--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -1,4 +1,6 @@
-import { useSiteLaunchGatingVariant } from 'calypso/lib/use-site-launch-gating-variant';
+import { addQueryArgs } from '@wordpress/url';
+import { useState } from 'react';
+import PreLaunchSiteModal from 'calypso/components/pre-launch-site-modal';
 import { useCelebrateLaunchModalSideEffects } from 'calypso/my-sites/customer-home/celebrate-site-launch-modal/use-side-effects';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
@@ -19,32 +21,36 @@ const LaunchpadPreLaunch = ( props: LaunchpadPreLaunchProps ): JSX.Element => {
 
 	const { onSiteLaunched } = useCelebrateLaunchModalSideEffects( siteId );
 
-	const [ , variant ] = useSiteLaunchGatingVariant();
+	const [ isLaunchModalOpen, setIsLaunchModalOpen ] = useState( false );
+
+	const launchUrl = addQueryArgs( '/start/launch-site', { siteSlug: site?.slug } );
 
 	const handleTaskClick = ( task: Task ) => {
 		if ( task.id !== 'site_launched' ) {
 			return;
 		}
 
-		// Site launch gating: 'semi_gated_site_launch' is the shipped default.
-		// The other branches are scaffolding for future experiments; see
-		// useSiteLaunchGatingVariant().
-		switch ( variant ) {
-			case 'semi_gated_site_launch':
-			case null:
-			default: {
-				window.location.assign( `/start/launch-site?siteSlug=${ site?.slug }` );
-				return false;
-			}
-		}
+		// Open the shared pre-launch bridge. It shows the confirmation modal for
+		// paid-plan + custom-domain sites and otherwise hands off to the
+		// `launchUrl` flow, matching the previous behavior.
+		setIsLaunchModalOpen( true );
+		return false;
 	};
 
 	return (
-		<CustomerHomeLaunchpad
-			checklistSlug={ props.checklistSlug ?? checklistSlug }
-			onTaskClick={ handleTaskClick }
-			onSiteLaunched={ () => onSiteLaunched( !! site?.is_wpcom_atomic ) }
-		/>
+		<>
+			<CustomerHomeLaunchpad
+				checklistSlug={ props.checklistSlug ?? checklistSlug }
+				onTaskClick={ handleTaskClick }
+				onSiteLaunched={ () => onSiteLaunched( !! site?.is_wpcom_atomic ) }
+			/>
+			<PreLaunchSiteModal
+				siteId={ siteId }
+				isOpen={ isLaunchModalOpen }
+				onClose={ () => setIsLaunchModalOpen( false ) }
+				launchUrl={ launchUrl }
+			/>
+		</>
 	);
 };
 


### PR DESCRIPTION
Part of DOTPROD-77

> **Stacked on #113717** (`add/pre-launch-modal-integration`). Review that first; this PR targets that branch and should be retargeted to `trunk` once it merges.

Extending the dashboard pre-launch modal to the **classic** launch surfaces (masterbar + customer-home Launchpad), which today redirect straight to `/start/launch-site`.

<img width="1728" height="634" alt="Screenshot 2026-08-20 at 22 39 05" src="https://github.com/user-attachments/assets/2bd391d7-9cc0-42dd-a6d2-7f07a9749322" />
<img width="1728" height="806" alt="Screenshot 2026-08-20 at 22 38 43" src="https://github.com/user-attachments/assets/9b3a2cfc-4522-413b-81a5-e33aae30fc45" />


## Proposed Changes

* Add a shared **`PreLaunchSiteModal`** bridge (`client/components/pre-launch-site-modal`) that renders the dashboard `SiteLaunchModal` (pre-launch variant) from classic Calypso, wrapped in the same `QueryClientProvider` + `AnalyticsProvider` pattern the celebration modal already uses.
* The bridge owns the gate: for a site with a **paid plan and a custom domain** it shows the confirmation modal; on confirm it redirects to the caller-provided `launchUrl`. Every other site (and any domains-query error) is sent straight to `launchUrl`, preserving today's behavior.
* The **destination is a prop** (`launchUrl`), so each call site keeps its explicit `/start/launch-site` path and its gating `switch` remains the extension point for future experiments.
* Wire it into the **customer-home Launchpad** task (`cards/launchpad/pre-launch.tsx`) and the **masterbar launch button** (`masterbar-launch-button.tsx`).

## Why are these changes being made?

The dashboard gates one-click launches for plan+domain sites behind a confirmation modal, but the classic surfaces still push even those sites into the full launch flow with no confirmation. Because `/start/launch-site` auto-skips its domain/plan steps for paid+domain sites (`isPlanFulfilled` / `isDomainFulfilled`), redirecting after the modal is effectively an immediate launch — so we get the same confirmation UX without re-implementing launch on the Redux surfaces.

## Testing Instructions

* On an unlaunched site with a **paid plan + custom domain**, click the masterbar **Launch site** button (and the Launchpad "Launch your site" task) → the pre-launch modal appears; confirming redirects to `/start/launch-site`, which launches immediately.
* On a site **without** a paid plan or without a custom domain → no modal; it goes straight to `/start/launch-site` as before.

## Known follow-ups / open questions

* The custom-domain signal (`subscription_id !== null`) approximates the flow's `!isWPCOMDomain` skip rule; consider aligning it exactly so the modal never appears and then lands on a domain step.
* Non-qualifying sites now briefly mount the bridge (fetch site + domains) before redirecting; a cheap paid-plan pre-check at the call site could keep free-site redirects instant.
* The **new omnibar** launch button (`useLaunchSitePlugin`, behind `dashboard/omnibar-radical`) is a separate consumer that still needs the `{ node, panel }` wiring — not covered here.
* Hosting-performance launch CTA (third classic surface) not yet wired.
* Tests pending for the bridge.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
