### PR TITLE
Agents Manager: rename the type Tracks property to link_type and menu_item

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -479,7 +479,7 @@ describe( 'AgentDock', () => {
 		expect( mockRecordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
 			'ai_chat_more_options_click',
 			{
-				type: 'reset_chat',
+				menu_item: 'reset_chat',
 			}
 		);
 		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'ai_chat_more_options_click', {
@@ -530,7 +530,7 @@ describe( 'AgentDock', () => {
 		expect( mockRecordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
 			'ai_chat_more_options_click',
 			{
-				type: 'view_history',
+				menu_item: 'view_history',
 			}
 		);
 		expect( screen.getByTestId( 'location' ) ).toHaveTextContent( '/history' );
@@ -561,7 +561,7 @@ describe( 'AgentDock', () => {
 		expect( mockRecordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
 			'ai_chat_more_options_click',
 			{
-				type: 'knowledge_memory',
+				menu_item: 'knowledge_memory',
 			}
 		);
 		expect( openSpy ).toHaveBeenCalledWith(
@@ -587,7 +587,7 @@ describe( 'AgentDock', () => {
 		expect( mockRecordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
 			'ai_chat_more_options_click',
 			{
-				type: 'ai_agent_settings',
+				menu_item: 'ai_agent_settings',
 			}
 		);
 		expect( openSpy ).toHaveBeenCalledWith(
@@ -659,7 +659,7 @@ describe( 'AgentDock', () => {
 			expect( mockRecordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
 				'ai_chat_more_options_click',
 				{
-					type,
+					menu_item: type,
 				}
 			);
 			expect( mockSetIsSplitScreen ).toHaveBeenCalledWith( nextState );

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -273,8 +273,8 @@ export default function AgentDock( {
 
 		// Every item fires the unified AM event; items whose Big Sky event
 		// is already live also dual-fire it so those dashboards keep working.
-		const recordMoreOptionsClick = ( type: string ) =>
-			recordAgentsManagerTracksEvent( 'ai_chat_more_options_click', { type } );
+		const recordMoreOptionsClick = ( menuItem: string ) =>
+			recordAgentsManagerTracksEvent( 'ai_chat_more_options_click', { menu_item: menuItem } );
 
 		const options = [
 			{

--- a/packages/agents-manager/src/components/custom-a-link/index.tsx
+++ b/packages/agents-manager/src/components/custom-a-link/index.tsx
@@ -40,7 +40,7 @@ export default function CustomALink( {
 
 				recordAgentsManagerTracksEvent( 'link_click', {
 					href: transformedHref,
-					type: isSupportArticle ? 'support_article' : 'external',
+					link_type: isSupportArticle ? 'support_article' : 'external',
 					source: isFromOrchestrator ? 'orchestrator' : 'zendesk',
 				} );
 			} }

--- a/packages/agents-manager/src/components/sources-display/index.tsx
+++ b/packages/agents-manager/src/components/sources-display/index.tsx
@@ -45,7 +45,7 @@ export default function SourcesDisplay( { sources }: Props ) {
 
 		recordAgentsManagerTracksEvent( 'link_click', {
 			href: url,
-			type: isSupportArticle ? 'support_article' : 'external',
+			link_type: isSupportArticle ? 'support_article' : 'external',
 			source: isFromOrchestrator ? 'orchestrator' : 'zendesk',
 		} );
 	};


### PR DESCRIPTION
Part of AI-1116

## Proposed Changes

* Rename the generic `type` Tracks property on the unified Agents Manager events:
  * `calypso_agents_manager_link_click` — `type` → `link_type` (values `support_article` / `external`), in `custom-a-link` and `sources-display`.
  * `calypso_agents_manager_ai_chat_more_options_click` — `type` → `menu_item` (values `reset_chat`, `view_history`, `dock`, `undock`, `split_screen`, `exit_split_screen`, `knowledge_memory`, `ai_agent_settings`), in `agent-dock`.
* The Big Sky parity event (`jetpack_big_sky_ai_chat_more_options_click`) keeps its `type` property untouched, so the existing Big Sky Looker dashboard keeps working.

## Why are these changes being made?

* One property name (`type`) carried two unrelated concepts — kinds of link and kinds of menu action — so grouping by `type` across the product mixed link kinds with menu clicks. Splitting them into `link_type` and `menu_item` makes each property mean one thing.
* This is one of the event-shape changes sequenced before registering the Agents Manager events (AI-1117).

## Testing Instructions

* Sync the agents-manager app with your WordPress.com sandbox (`cd apps/agents-manager && yarn dev --sync`).
* Open the browser DevTools, switch to the **Network** tab, and filter requests by `t.gif`.
* Open the AI chat on a wp-admin page:
  * Click a link inside a chat response (or a source in the sources list) — `calypso_agents_manager_link_click` should carry `link_type` (and no `type`).
  * Open the chat's "more options" menu and click an item (e.g. New chat) — `calypso_agents_manager_ai_chat_more_options_click` should carry `menu_item` (and no `type`), while the `jetpack_big_sky_ai_chat_more_options_click` parity event still carries `type`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
