### PR TITLE
E2E: make waitForAppShell() faster by not blocking on admin color endpoint

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -25,6 +25,7 @@ import { Nav2026UniversalHeader } from 'calypso/layout/nav-2026-universal-header
 import { isInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { ClassicColorSchemeProvider, withColorScheme } from 'calypso/lib/color-scheme';
+import { isE2ETest } from 'calypso/lib/e2e';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWcMobileApp, isWpMobileApp } from 'calypso/lib/mobile-app';
 import {
@@ -553,6 +554,7 @@ export default withCurrentRoute(
 					sectionName,
 			  } );
 		const needsColorScheme =
+			! isE2ETest() &&
 			! sidebarIsHidden &&
 			( sidebarType === SidebarType.UnifiedSiteDefault ||
 				sidebarType === SidebarType.UnifiedSiteClassic );


### PR DESCRIPTION
## Proposed Changes

When a PR modifies any E2E tests, the full test suite will run. Here's is an example PR: https://github.com/Automattic/wp-calypso/pull/113715

In such PR, the E2E tests are very flaky. The `waitForAppShell()` often times out:

```
    Error: Timed out waiting for an app shell: neither the classic Calypso sidebar nor the hosting dashboard rendered after logging in.
       at ../../../packages/calypso-e2e/src/lib/test-account.ts:93
      91 |       ] );
      92 |     } catch {
    > 93 |       throw new Error(
         |             ^
      94 |         'Timed out waiting for an app shell: neither the classic Calypso sidebar nor the hosting dashboard rendered after logging in.'
      95 |       );
      96 |     }
        at TestAccount.waitForAppShell (/home/teamcity-7/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/test-account.ts:93:10)
        at TestAccount.authenticate (/home/teamcity-7/buildAgent/work/c4a9d5b38c1dacde/packages/calypso-e2e/src/lib/test-account.ts:71:4)
        at /home/teamcity-7/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/flows/use-my-domain__transfer-or-connect.spec.ts:125:5
        at /home/teamcity-7/buildAgent/work/c4a9d5b38c1dacde/test/e2e/specs/flows/use-my-domain__transfer-or-connect.spec.ts:124:4
```

See the following example video from CI artifact:

https://github.com/user-attachments/assets/a5da89d6-8bfd-4371-80e6-54d9eae10fab

This is an attempt to make it faster by not waiting the call to the `admin-color` endpoint we're on E2E test. In production, it's a blocking request to avoid flash of wrong sidebar color. In E2E test, we don't need to be blocked on that.

## Testing Instructions

Go to `/home/:siteSlug`, verify your admin color is still applied.