### PR TITLE
E2E: match the Free plan CTA by its plan class, not by button text

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -26,14 +26,7 @@ const selectors = {
 	},
 	addOnComboboxButton: 'button[role="combobox"]',
 	addOnComboboxOption: ( addOn: string ) => `[role="option"]:has-text("${ addOn }")`,
-	selectPlanButton: ( name: Plans ) => {
-		if ( name === 'Free' ) {
-			// Free plan is a pseudo-button presented as a
-			// link.
-			return `button:text-matches("${ name }", "i"):visible`;
-		}
-		return `button.is-${ name.toLowerCase() }-plan:visible`;
-	},
+	selectPlanButton: ( name: Plans ) => `button.is-${ name.toLowerCase() }-plan:visible`,
 
 	// Navigation
 	mobileNavTabsToggle: 'button.section-nav__mobile-header',


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Select the Free plan CTA by the same `is-<plan>-plan` class every paid plan already uses, instead of a case-insensitive match on button text.

## Why are these changes being made?

The write onboarding spec fails intermittently, timing out for 90 seconds waiting for the redirect after the Free plan is picked. It fails on both the initial attempt and the retry often enough to block release runs; locally it reproduced 2 runs out of 3.

The Free plan was the only plan matched by button text rather than by class. That text match also matches the domains step's "Skip purchase" button, whose visible label is "Start Free". The domains step stays mounted for a moment after the URL flips to the plans step, and the plans grid takes roughly a second to render, so the selector resolves on the leftover button first. Whether the test passed came down to whether that button had unmounted in the few milliseconds between the visibility wait and the click:

* Unmounted in time — the locator re-resolves onto the real grid CTA, and the test passes.
* Still mounted — the click lands on a button that was already submitted a step earlier, so nothing happens and the wait for the redirect times out.

The text match dates back to when the Free plan was rendered as a link rather than a button. It is now an ordinary plan button carrying `is-free-plan`, so the special case is no longer needed. That class only exists on the plans grid, so the visibility wait that was already there now waits out the step transition instead of resolving early.

## Testing Instructions

Run the affected spec against production a few times — it exercises the Free plan path:

```
CALYPSO_BASE_URL=https://wordpress.com yarn playwright test specs/onboarding/onboarding__write.spec.ts --project=chrome --reporter=list --repeat-each=3 --workers=1
```

Before the change: 2 of 3 runs time out at the plan step. After: 6 of 6 runs passed across two batches, and traces confirm the click now fires site creation immediately instead of being swallowed.

Paid plan selection is unaffected — those already used the class selector, and the only other consumers of it are the availability assertions in the plugins signup spec, which is currently skipped.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
