### PR TITLE
E2E: wait out the login form's disabled state before filling it

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -81,23 +81,35 @@ export class LoginPage {
 	}
 
 	/**
-	 * Fills the username input.
+	 * Fills an input on the login form, waiting out the disabled state first.
+	 *
+	 * The form renders its inputs disabled until Calypso mounts, and disables
+	 * them again while it checks the submitted username. Both windows are
+	 * normally a few milliseconds, but a cold app can hold one open for longer
+	 * than the default action timeout, and `fill` would spend that budget
+	 * retrying instead of waiting.
 	 */
-	async fillUsername( value: string ): Promise< Locator > {
-		const locator = await this.page.locator( 'input[name="usernameOrEmail"]' );
+	private async fillInput( selector: string, value: string ): Promise< Locator > {
+		await this.page.waitForSelector( `${ selector }:not([disabled])`, { timeout: 30 * 1000 } );
+
+		const locator = this.page.locator( selector );
 		await locator.fill( value );
 
 		return locator;
 	}
 
 	/**
+	 * Fills the username input.
+	 */
+	async fillUsername( value: string ): Promise< Locator > {
+		return this.fillInput( 'input[name="usernameOrEmail"]', value );
+	}
+
+	/**
 	 * Fills the password input.
 	 */
 	async fillPassword( value: string ): Promise< Locator > {
-		const locator = await this.page.locator( 'input#password' );
-		await locator.fill( value );
-
-		return locator;
+		return this.fillInput( 'input#password', value );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Wait for the login form's username and password inputs to be enabled before filling them, instead of letting the fill spend the action timeout retrying a disabled element.

## Why are these changes being made?

The FSE smoke test failed in CI while logging in: the username input was present but disabled for the whole 10 second action timeout, so the fill never landed.

The login form disables its inputs in two windows — until Calypso mounts, since the server-rendered markup starts disabled, and again while the submitted username is being checked. Both are normally a couple of dozen milliseconds; measured locally, the field goes from attached to enabled in about 20ms. On a cold or loaded CI agent one of those windows can outlast the action timeout, and `fill` spends that entire budget retrying rather than waiting.

The password field has the same exposure, and it is filled at exactly the moment the username check is in flight.

This does not make a degraded agent healthy — the same run also timed out later waiting for an app shell, which is a separate wait. What it fixes is that the first interaction with a cold app had the default 10 second budget and no explicit wait, which is out of step with the rest of the suite, where a 30 second wait before acting on a freshly navigated page is the established pattern.

## Testing Instructions

The affected path is any spec that logs in through the UI rather than reusing primed cookies:

```
CALYPSO_BASE_URL=https://wordpress.com yarn playwright test specs/fse/fse__temp-smoke-test.spec.ts specs/onboarding/onboarding__write.spec.ts --project=chrome --reporter=list --repeat-each=2 --workers=1
```

12 of 12 passed across those two specs. The change only adds a wait, so it cannot make a passing login fail; it is the timeout budget on a slow agent that changes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
