### PR TITLE
E2E: stop the SSR spec waiting on subresources it never asserts on

### DIFF
--- a/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.spec.ts
+++ b/test/e2e/specs/infrastructure/infrastructure__ssr-enabled.spec.ts
@@ -4,7 +4,14 @@ import { tags, test } from '../../lib/pw-base';
 test.describe( 'Server-side Rendering', { tag: [ tags.CALYPSO_PR ] }, () => {
 	for ( const endpoint of [ 'log-in', 'themes', 'theme/twentytwentythree' ] ) {
 		test( `Check SSR endpoint: ${ endpoint }`, async ( { page } ) => {
-			await page.goto( DataHelper.getCalypsoURL( endpoint ), { timeout: 20 * 1000 } );
+			// The marker this asserts on is in the server response, so stop at
+			// `domcontentloaded`. The theme endpoint mounts a live block-preview
+			// iframe and a dozen other frames, and the default `load` waits on
+			// every one of them before the assertion the test cares about.
+			await page.goto( DataHelper.getCalypsoURL( endpoint ), {
+				waitUntil: 'domcontentloaded',
+				timeout: 20 * 1000,
+			} );
 			await page.locator( '#wpcom[data-calypso-ssr="true"]' ).waitFor( { timeout: 15 * 1000 } );
 		} );
 	}


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Stop the server-side rendering spec's navigation at `domcontentloaded` instead of the default `load`.

## Why are these changes being made?

The theme endpoint in this spec timed out in CI on both the first attempt and the retry, 20 seconds each time, while the two lighter endpoints in the same spec passed.

`page.goto` defaults to waiting for `load`, which does not fire until every child frame and subresource has settled. Measured on the theme page, that means thirteen child frames, including a live block-preview render fetched from public-api that alone took about six seconds on a fast local connection. So the navigation budget was being spent on a theme preview, and the assertion never got to run.

None of that is what the spec is checking. It asserts on a marker that is part of the server response, and that marker is already in the DOM at `domcontentloaded` for all three endpoints. The wait on the rest was never buying anything, and on a cold or loaded agent it is what breaks the test.

This also explains why only the theme endpoint failed: it is by far the heaviest of the three.

## Testing Instructions

```
CALYPSO_BASE_URL=https://wordpress.com yarn playwright test specs/infrastructure/infrastructure__ssr-enabled.spec.ts --reporter=list
```

All six tests pass across both viewports. Per-endpoint timings measured while investigating, showing the marker is present well before `load`:

| Endpoint | domcontentloaded | load | marker present at DCL |
| --- | --- | --- | --- |
| log-in | 6.4s | 8.1s | yes |
| themes | 4.5s | 6.5s | yes |
| theme/twentytwentythree | 2.7s | 4.0s | yes |

Note that running this spec with a high `--repeat-each` against production trips rate limiting and fails regardless of this change; run it as CI does.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
