### PR TITLE
E2E: target the inline inserter where it actually renders

### DIFF
--- a/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.spec.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.spec.ts
@@ -24,7 +24,7 @@ test.describe(
 			const editorTracksEventManager = new EditorTracksEventManager( page );
 
 			await test.step( 'Given I am authenticated', async () => {
-				await testAccount.authenticate( page, { waitUntilStable: false } );
+				await testAccount.authenticate( page );
 			} );
 
 			await test.step( 'When I start a new page', async () => {

--- a/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.spec.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.spec.ts
@@ -37,11 +37,21 @@ test.describe(
 			const patternName = 'About: Profile';
 			const patternNameInEventProperty = 'a8c/about-profile';
 
-			// From the sidebar inserter. This runs first because the inline step below
-			// needs the trailing "Add block" appender, which the canvas only grows once
-			// it holds a block.
-			await test.step( `When I add pattern "${ patternName }" from sidebar inserter`, async () => {
-				await pageEditor.addPatternFromSidebar( patternName );
+			// From the inline inserter. It is only rendered while an empty default
+			// block is selected, so the canvas is clicked first, and it is rendered
+			// as a popover in the editor parent rather than inside the canvas.
+			await test.step( `When I add pattern "${ patternName }" from inline inserter`, async () => {
+				const editorCanvas = await pageEditor.getEditorCanvas();
+				await editorCanvas
+					.locator( 'p[data-title="Paragraph"][data-empty="true"]' )
+					.first()
+					.click();
+
+				const editorParent = await pageEditor.getEditorParent();
+				const inserterLocator = editorParent.locator(
+					'.block-editor-block-list__empty-block-inserter button[aria-label="Add block"]'
+				);
+				await pageEditor.addPatternInline( patternName, inserterLocator );
 			} );
 
 			await test.step( `Then "wpcom_pattern_inserted" event fires with "pattern_name" === "${ patternNameInEventProperty }"`, async () => {
@@ -60,11 +70,9 @@ test.describe(
 				await editorTracksEventManager.clearEvents();
 			} );
 
-			// From the inline inserter
-			await test.step( `When I add pattern "${ patternName }" from inline inserter`, async () => {
-				const editorCanvas = await pageEditor.getEditorCanvas();
-				const inserterLocator = editorCanvas.locator( 'button[aria-label="Add block"]' ).last();
-				await pageEditor.addPatternInline( patternName, inserterLocator );
+			// From the sidebar inserter
+			await test.step( `When I add pattern "${ patternName }" from sidebar inserter`, async () => {
+				await pageEditor.addPatternFromSidebar( patternName );
 			} );
 
 			await test.step( `Then "wpcom_pattern_inserted" event fires with "pattern_name" === "${ patternNameInEventProperty }"`, async () => {

--- a/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.spec.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.spec.ts
@@ -24,7 +24,7 @@ test.describe(
 			const editorTracksEventManager = new EditorTracksEventManager( page );
 
 			await test.step( 'Given I am authenticated', async () => {
-				await testAccount.authenticate( page );
+				await testAccount.authenticate( page, { waitUntilStable: false } );
 			} );
 
 			await test.step( 'When I start a new page', async () => {

--- a/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.spec.ts
+++ b/test/e2e/specs/editor-tracking/editor-tracking__pattern-events.spec.ts
@@ -33,17 +33,15 @@ test.describe(
 			} );
 
 			// Both inserters use the same a8c pattern; "pattern_name" in the
-			// Tracks event is the pattern slug. The inline inserter relies on the
-			// empty-canvas "Add block" appender, so it must run before the sidebar
-			// insert fills the canvas.
+			// Tracks event is the pattern slug.
 			const patternName = 'About: Profile';
 			const patternNameInEventProperty = 'a8c/about-profile';
 
-			// From the inline inserter
-			await test.step( `When I add pattern "${ patternName }" from inline inserter`, async () => {
-				const editorCanvas = await pageEditor.getEditorCanvas();
-				const inserterLocator = editorCanvas.locator( 'button[aria-label="Add block"]' );
-				await pageEditor.addPatternInline( patternName, inserterLocator );
+			// From the sidebar inserter. This runs first because the inline step below
+			// needs the trailing "Add block" appender, which the canvas only grows once
+			// it holds a block.
+			await test.step( `When I add pattern "${ patternName }" from sidebar inserter`, async () => {
+				await pageEditor.addPatternFromSidebar( patternName );
 			} );
 
 			await test.step( `Then "wpcom_pattern_inserted" event fires with "pattern_name" === "${ patternNameInEventProperty }"`, async () => {
@@ -62,9 +60,11 @@ test.describe(
 				await editorTracksEventManager.clearEvents();
 			} );
 
-			// From the sidebar inserter
-			await test.step( `When I add pattern "${ patternName }" from sidebar inserter`, async () => {
-				await pageEditor.addPatternFromSidebar( patternName );
+			// From the inline inserter
+			await test.step( `When I add pattern "${ patternName }" from inline inserter`, async () => {
+				const editorCanvas = await pageEditor.getEditorCanvas();
+				const inserterLocator = editorCanvas.locator( 'button[aria-label="Add block"]' ).last();
+				await pageEditor.addPatternInline( patternName, inserterLocator );
 			} );
 
 			await test.step( `Then "wpcom_pattern_inserted" event fires with "pattern_name" === "${ patternNameInEventProperty }"`, async () => {


### PR DESCRIPTION
## Proposed Changes

* Select the empty paragraph in the canvas before opening the inline inserter, and look for the inserter in the editor parent rather than in the canvas.
* Keep the original step order: inline inserter first, sidebar inserter second.

## Why are these changes being made?

`"wpcom_pattern_inserted" event fires from sidebar and inline inserters` fails on both attempts at its inline insertion step:

```
TimeoutError: locator.click: Timeout 10000ms exceeded.
  - waiting for ... .locator('button[aria-label="Add block"]')
```

Nothing resolved — the button is not in the canvas at all.

What the spec calls the inline inserter is Gutenberg's empty-block side inserter, and two things about it break the old locator:

* It is only mounted while an empty default block is **selected**. On a freshly loaded editor nothing is selected, so it does not exist yet.
* It renders as a popover in the editor parent document, not inside the canvas iframe.

Measured in a running editor, before and after clicking the canvas's empty paragraph:

```
loaded       canvas: 0 buttons   parent: 0 buttons   selected: none
after click  canvas: 0 buttons   parent: 1 button    selected: core/paragraph
```

An earlier revision of this PR tried reordering the two insertions so the inline step ran against a canvas that already held a block. That does not help: after a pattern is inserted the selected block is no longer an empty default block, so the inserter is not mounted at all, and the canvas still never holds it. The order was not the problem, so it is left as it was.

Worth knowing for anyone wondering how this went unnoticed: no build type selects `@editor-tracking`. These specs only run when a PR touches E2E files and the Calypso PR matrix widens its grep, so the suite is exercised rarely and has been failing since the Playwright migration.

## Testing Instructions

* Run `editor-tracking__pattern-events` on both the `chrome` and `mobile` projects. Both insertion steps should fire `wpcom_pattern_inserted` with `pattern_name` of `a8c/about-profile`.
* Touching any E2E file is enough to make the PR matrix pick the spec up, so this PR runs it.

Both insertion steps were verified locally on `chrome` and `mobile` against a personal test site, driving the same page objects the spec uses: each inserts its pattern with no locator timeout. The Tracks assertions could not be verified there — they report no event on a site that is not one of the e2e accounts, including for the sidebar insertion that already passes in CI — so CI is the first place they run for real.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
