### PR TITLE
E2E: recover when saved auth cookies are no longer a live session

### DIFF
--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -55,17 +55,49 @@ export class TestAccount {
 		const browserContext = page.context();
 		await browserContext.clearCookies();
 
-		if ( await this.hasFreshAuthCookies() ) {
+		const hasFreshCookies = await this.hasFreshAuthCookies();
+
+		if ( hasFreshCookies ) {
 			this.log( 'Found fresh cookies, skipping log in' );
 			await browserContext.addCookies( await this.getAuthCookies() );
 			await page.goto( getCalypsoURL( '/' ) );
-		} else {
+		}
+
+		// Freshness is read off the cookie file's age, but the session behind it can be gone
+		// well inside that window, having expired or been invalidated by another run logging
+		// in as the same account. WordPress.com answers a rejected session by redirecting to
+		// the login page, which otherwise surfaces much later as a missing app shell.
+		const cookiesRejected = hasFreshCookies && TestAccount.isLoginPage( page.url() );
+
+		if ( cookiesRejected ) {
+			this.log( 'Saved cookies were rejected, discarding them' );
+			await browserContext.clearCookies();
+		}
+
+		if ( ! hasFreshCookies || cookiesRejected ) {
 			this.log( 'Logging in via Login Page' );
 			await this.logInViaLoginPage( page );
 		}
 
+		if ( cookiesRejected ) {
+			// Replace the file the rejected cookies came from, so the workers still to
+			// start reuse this session instead of tripping over the same dead one.
+			await this.saveAuthCookies( browserContext );
+		}
+
 		if ( url ) {
 			await page.waitForURL( url, { timeout: 20 * 1000 } );
+		}
+	}
+
+	/**
+	 * Whether a URL is the login page, including its locale-suffixed forms.
+	 */
+	private static isLoginPage( url: string ): boolean {
+		try {
+			return new URL( url ).pathname.startsWith( '/log-in' );
+		} catch {
+			return false;
 		}
 	}
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Detect that saved authentication cookies were rejected, log in for real instead, and replace the stale cookie file.

## Why are these changes being made?

A spec failed in CI with "neither the classic Calypso sidebar nor the hosting dashboard rendered after logging in". The account had never logged in — it was sitting on the login page the whole time.

Cookie freshness is judged from the cookie file's age against a two-day window. The session behind that file can be gone well inside the window, either expired or invalidated by another run logging in as the same shared account. When it is, the saved cookies get loaded, WordPress.com redirects to the login page, and nothing notices. The run continues logged out and fails 20 seconds later on a missing app shell, an error that names neither cookies nor login and sends you looking in the wrong place.

Reproduced locally with a cookie file about nine hours old and comfortably inside the freshness window: three runs out of three failed this way, and loading those cookies against `/` lands on `/log-in?redirect_to=...` every time.

So notice the redirect, drop the dead cookies, log in, and write the new session back over the file it came from — otherwise every remaining worker repeats the same failure against the same dead file.

This overlaps with #113725, which chased the same error message on this same spec from the other end, by making the app shell render faster. The two causes are independent: that one is a shell that renders too slowly, this one is a shell that is never going to render because nobody is logged in.

## Testing Instructions

Requires a cookie file whose session is dead but whose file age is under two days, which is what an overnight-old `test/e2e/cookies/<account>.json` gives you.

```
CALYPSO_BASE_URL=https://wordpress.com yarn playwright test specs/flows/use-my-domain__transfer-or-connect.spec.ts --project=chrome --reporter=list --grep "Reblogging"
```

Before: fails in `Given I am authenticated`, three runs out of three. After: recovers and passes. With `DEBUG=true` the recovery is visible in the log:

```
TestAccount:defaultUser => Found fresh cookies, skipping log in
TestAccount:defaultUser => Saved cookies were rejected, discarding them
TestAccount:defaultUser => Logging in via Login Page
TestAccount:defaultUser => Saving auth cookies to .../cookies/defaultUser.json
```

## Considerations

The alternative is to validate the session up front, before trusting the file — an API call per account, on every authenticate. Reacting to the redirect costs nothing on the healthy path, which is nearly every path, so this recovers only when there is something to recover from.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
