### PR TITLE
E2E: run Pre-Release tests against the trunk build image

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -1030,12 +1030,11 @@ object PreReleaseE2ETests : BuildType({
 	id("calypso_WebApp_Calypso_E2E_Pre_Release")
 	uuid = "9c2f634f-6582-4245-bb77-fb97d9f16533"
 	name = "Pre-Release E2E Tests"
-	description = "Runs pre-release suites of E2E tests against trunk on staging, intended to be run after PR merge, but before deployment to production."
+	description = "Runs pre-release suites of E2E tests against the trunk build image, intended to be run after PR merge, but before deployment to production."
 
 	params {
 		text("TEST_GROUP", "@calypso-release")
-		param("CALYPSO_BASE_URL", "https://wpcalypso.wordpress.com")
-		param("DASHBOARD_BASE_URL", "https://my.wordpress.com")
+		param("DOCKER_IMAGE_BUILD_NUMBER", "${BuildDockerImage.depParamRefs.buildNumber}")
 		param("env.AUTHENTICATE_ACCOUNTS", "atomicUser,calypsoPreReleaseUser,defaultUser,simpleSiteFreePlanUser,simpleSitePersonalPlanUser")
 	}
 
@@ -1059,6 +1058,12 @@ object PreReleaseE2ETests : BuildType({
 			buildFailed = true
 			buildFinishedSuccessfully = false
 			buildProbablyHanging = true
+		}
+	}
+
+	dependencies {
+		snapshot(BuildDockerImage) {
+			onDependencyFailure = FailureAction.FAIL_TO_START
 		}
 	}
 })


### PR DESCRIPTION
## Proposed Changes

* Point the Pre-Release E2E Tests build at the container built from the commit under test, instead of at the staging site.

## Why are these changes being made?

* This suite is meant to be the last gate after a PR merges and before deployment to production, but it was running against staging. Staging is whatever was last deployed there, so the suite could pass or fail for reasons unrelated to the commit that triggered it, and a regression merged into trunk was not necessarily exercised.
* The PR-level E2E builds already resolve their base URL from the Docker image build number via the shared E2E template. This applies the same mechanism here, so the pre-release run tests the same artifact that is about to ship.
* The template refuses to run when both a build number and an explicit base URL are set, so the pinned Calypso and Dashboard URLs are removed; it derives both from the image itself.

## Considerations

* The suite moves from the staging config to the production one. The container is built as a production environment, so the run now uses production feature flags rather than the staging flags the staging site serves. Around thirty flags are on in staging and off in production — checkout version, unified OAuth, email accounts, the plans dashboard, the notifications redesign, hundred-year domains — and a handful go the other way, mostly tracking: ad tracking, PostHog, JS error catching. That is the point of the change, since production flags are what ships, but specs written against staging flag state may need updating, and the tracking specs now run with those pixels live. Expect the first runs to surface some of that.
* One spec is lost: the WooCommerce-via-Google signup spec only runs when the base URL is exactly wordpress.com or wpcalypso.wordpress.com, because those are the only origins Google permits login from. No calypso.live URL can satisfy that, so the spec will skip silently from now on. Its coverage belongs on a build that still targets one of those origins.
* This suite also no longer touches the staging environment, so it stops catching problems that only appear there — deploy or environment configuration issues, as opposed to code issues. Those belong to a deployment check rather than to a suite gating a commit.

## Testing Instructions

* This only takes effect once the TeamCity settings are picked up. On the next Pre-Release E2E Tests run, confirm the build resolves a `*.calypso.live` URL for both Calypso and the Dashboard in its first steps, and that the suite runs against it.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

