### PR TITLE
E2E: fix the WPCC signup spec timing out on the final /sites wait

### DIFF
--- a/test/e2e/specs/onboarding/signup__wpcc.spec.ts
+++ b/test/e2e/specs/onboarding/signup__wpcc.spec.ts
@@ -59,7 +59,7 @@ test.describe(
 
 			await test.step( 'User lands in CrowdSignal dashboard', async () => {
 				// This will be a production site instead of staging or wpcalypso.
-				await page.waitForSelector( 'div.welcome-main' );
+				await page.waitForSelector( 'div.welcome-main', { timeout: 30 * 1000 } );
 			} );
 
 			await test.step( 'Get activation link', async () => {
@@ -81,7 +81,7 @@ test.describe(
 				// Waiting for `load` is required so Calypso loading won't swallow up
 				// the click on navbar in the Close Account steps.
 				await Promise.all( [
-					page.waitForURL( '**/sites', { waitUntil: 'load' } ),
+					page.waitForURL( /\/sites(\?|$)/, { waitUntil: 'load' } ),
 					page.goto( DataHelper.getCalypsoURL() ),
 				] );
 			} );


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Wait for the post-activation `/sites` URL with a regex instead of a glob.
* Give the CrowdSignal dashboard check an explicit 30s timeout instead of the 10s default.

## Why are these changes being made?

The WPCC signup spec has been failing on the final step, timing out after the full 240s test budget while waiting to land on `/sites`.

The page was actually getting there. The wait used a glob, and Playwright matches globs against the whole URL including the query string — so a landing URL carrying Calypso Live's `image` and `env` parameters never matched, and the wait hung until the test timed out. Every other URL wait in the E2E suite already uses a regex or a predicate; this was the only glob left.

The retry attempt failed differently: the check for the CrowdSignal dashboard hit its 10s default while the page was still loading. That step navigates cross-origin to production CrowdSignal, which is slower and less predictable than the rest of the flow, and the test has a 240s budget to spend. A longer timeout there costs nothing when the page loads promptly.

## Testing Instructions

* This spec signs up a real account against production CrowdSignal and reads an activation email from Mailosaur, so it is only exercisable in CI. Watch the `@calypso-release` run.
* The glob-vs-regex fix is the confirmed root cause. The dashboard timeout is hardening against the flake seen on retry.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
