### PR TITLE
Bump @wordpress/dataviews to 18.0.0

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
 		"@wordpress/components": "^37.0.0",
 		"@wordpress/compose": "^8.2.0",
 		"@wordpress/data": "^10.48.0",
-		"@wordpress/dataviews": "^17.3.0",
+		"@wordpress/dataviews": "^18.0.0",
 		"@wordpress/element": "^8.0.0",
 		"@wordpress/i18n": "^6.21.0",
 		"@wordpress/icons": "^13.3.0",

--- a/client/package.json
+++ b/client/package.json
@@ -107,7 +107,7 @@
 		"@wordpress/components": "^37.0.0",
 		"@wordpress/compose": "^8.2.0",
 		"@wordpress/data": "^10.48.0",
-		"@wordpress/dataviews": "^16.0.0",
+		"@wordpress/dataviews": "^18.0.0",
 		"@wordpress/date": "^5.48.0",
 		"@wordpress/dom": "^4.48.0",
 		"@wordpress/edit-post": "^8.48.0",

--- a/package.json
+++ b/package.json
@@ -333,7 +333,6 @@
 		"yargs": "^17.0.1"
 	},
 	"resolutions": {
-		"@ariakit/react": "0.4.37",
 		"@babel/core@npm:7.25.7": "7.29.7",
 		"@babel/runtime@npm:7.25.7": "7.29.2",
 		"@opentelemetry/core@npm:2.2.0": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -406,7 +406,7 @@
 		"@wordpress/customize-widgets": "5.48.0",
 		"@wordpress/data-controls": "4.48.0",
 		"@wordpress/data": "^10.48.0",
-		"@wordpress/dataviews": "^17.3.0",
+		"@wordpress/dataviews": "^18.0.0",
 		"@wordpress/date": "5.48.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^6.24.0",
 		"@wordpress/deprecated": "4.48.0",

--- a/package.json
+++ b/package.json
@@ -333,6 +333,7 @@
 		"yargs": "^17.0.1"
 	},
 	"resolutions": {
+		"@ariakit/react": "0.4.37",
 		"@babel/core@npm:7.25.7": "7.29.7",
 		"@babel/runtime@npm:7.25.7": "7.29.2",
 		"@opentelemetry/core@npm:2.2.0": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -465,7 +465,7 @@
 		"@wordpress/url": "^4.48.0",
 		"@wordpress/viewport": "^6.48.0",
 		"@wordpress/theme": "1.0.0",
-		"@wordpress/ui": "0.18.0",
+		"@wordpress/ui": "0.20.0",
 		"@wordpress/warning": "3.48.0",
 		"@wordpress/widgets": "4.48.0",
 		"@wordpress/wordcount": "4.48.0",

--- a/packages/api-core/package.json
+++ b/packages/api-core/package.json
@@ -41,7 +41,7 @@
 		"@automattic/i18n-utils": "workspace:^",
 		"@automattic/languages": "workspace:^",
 		"@automattic/shopping-cart": "workspace:^",
-		"@wordpress/dataviews": "^17.3.0",
+		"@wordpress/dataviews": "^18.0.0",
 		"@wordpress/html-entities": "^4.48.0",
 		"@wordpress/i18n": "^6.21.0",
 		"@wordpress/url": "^4.48.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4881,10 +4881,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@date-fns/tz@npm:^1.4.1":
+  version: 1.5.0
+  resolution: "@date-fns/tz@npm:1.5.0"
+  checksum: 4ef25eedd55924938fa81b23b949a3425201597e2007f5323db54d50fc19283eca5e2a7963c3d82c99b3adf273e9ea9bc7adfd1c9076e15badd99c593a984ffa
+  languageName: node
+  linkType: hard
+
 "@date-fns/utc@npm:^2.1.1":
   version: 2.1.1
   resolution: "@date-fns/utc@npm:2.1.1"
   checksum: 796eaf66d4f2945ff336edad29714f5f6b3c64090f534febe0ca8359a61fba521076dd4974fe3a35ce8aeb964bf73d372a87eef5c2900d3334bcaa36fa1f0dd2
+  languageName: node
+  linkType: hard
+
+"@daypicker/react@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "@daypicker/react@npm:10.0.1"
+  dependencies:
+    react-day-picker: "npm:10.0.1"
+  peerDependencies:
+    "@types/react": ">=16.8.0"
+    react: ">=16.8.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 0a31153456a41c83b7af4eda0a050a0e92777871187e14b3be2000c8bf055dc4eb2e83a5a7def1ce055a79f15a521774ddfd56b527309468823d37ff66504dec
   languageName: node
   linkType: hard
 
@@ -13405,6 +13427,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@wordpress/style-runtime@npm:^0.9.0":
+  version: 0.9.0
+  resolution: "@wordpress/style-runtime@npm:0.9.0"
+  checksum: 4b5516291a91cc60844c2bc898a4c9525490412b4506c5baf6deba233bb19a91b14bba5369510944e13387bb289fa4c6425ff1b71825d4799e189690605e3b9d
+  languageName: node
+  linkType: hard
+
 "@wordpress/stylelint-config@npm:^23.40.0":
   version: 23.40.0
   resolution: "@wordpress/stylelint-config@npm:23.40.0"
@@ -13478,22 +13507,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/ui@npm:0.18.0":
-  version: 0.18.0
-  resolution: "@wordpress/ui@npm:0.18.0"
+"@wordpress/ui@npm:0.20.0":
+  version: 0.20.0
+  resolution: "@wordpress/ui@npm:0.20.0"
   dependencies:
     "@base-ui/react": "npm:^1.6.0"
-    "@wordpress/a11y": "npm:^4.51.0"
-    "@wordpress/compose": "npm:^8.4.0"
-    "@wordpress/element": "npm:^8.3.0"
-    "@wordpress/i18n": "npm:^6.24.0"
-    "@wordpress/icons": "npm:^15.2.0"
-    "@wordpress/keycodes": "npm:^4.51.0"
-    "@wordpress/primitives": "npm:^4.51.0"
-    "@wordpress/private-apis": "npm:^1.51.0"
-    "@wordpress/style-runtime": "npm:^0.7.0"
-    "@wordpress/theme": "npm:^1.0.0"
+    "@daypicker/react": "npm:^10.0.1"
+    "@wordpress/a11y": "npm:^4.53.0"
+    "@wordpress/compose": "npm:^8.6.0"
+    "@wordpress/element": "npm:^8.5.0"
+    "@wordpress/i18n": "npm:^6.26.0"
+    "@wordpress/icons": "npm:^15.4.0"
+    "@wordpress/keycodes": "npm:^4.53.0"
+    "@wordpress/primitives": "npm:^4.53.0"
+    "@wordpress/private-apis": "npm:^1.53.0"
+    "@wordpress/style-runtime": "npm:^0.9.0"
+    "@wordpress/theme": "npm:^1.2.0"
     clsx: "npm:^2.1.1"
+    date-fns: "npm:^4.4.0"
     tabbable: "npm:^6.4.0"
   peerDependencies:
     "@types/react": ^18 || ^19
@@ -13502,7 +13533,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: a2fcb7c5b183ece909e02c7adb915141489f8758ce808fbdc075f636d619f55eb2ae08a0bbcc2487edd01fb43fbdcf8dba8cea205406974fda9321b539f80f23
+  checksum: a397bce5e16af2b81df0e37b98d2fe08b7770ba090a35f77b11586d31e9cb8acfd48bf66fda7c0ea42398760b6edb4537a7c72d7b1f1ea889487c7053a396c97
   languageName: node
   linkType: hard
 
@@ -28672,6 +28703,22 @@ __metadata:
     react: ">=16.8.0"
     react-dom: ">=16.8.0"
   checksum: 48eb73cf71e10841c2a61b6b06ab81da9fffa9876134c239bfdebcf348ce2a47e56b146338e35dfb03512c85966bfc9a53844fc56bc50154e71f8daee59ff6f0
+  languageName: node
+  linkType: hard
+
+"react-day-picker@npm:10.0.1":
+  version: 10.0.1
+  resolution: "react-day-picker@npm:10.0.1"
+  dependencies:
+    "@date-fns/tz": "npm:^1.4.1"
+    date-fns: "npm:^4.1.0"
+  peerDependencies:
+    "@types/react": ">=16.8.0"
+    react: ">=16.8.0"
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 2ca2690f5e8c22b0fd24079b68959110ec199ec7d5ac74f26cfe6dad3cadf7d781458a9a654673dd47009e4fbb8548711ec0ae048e41dd3cf1d4ede16dadad55
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,6 +19,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ariakit/components@npm:0.1.10":
+  version: 0.1.10
+  resolution: "@ariakit/components@npm:0.1.10"
+  dependencies:
+    "@ariakit/store": "npm:0.1.8"
+    "@ariakit/utils": "npm:0.1.6"
+  checksum: 3ae16d98657bad8541c9a3e8156fac5c87aeb5df9de2a25eb8a08b519d14c82fce8206f24d8db2d8194ac436f004f5e243fdc69d59ce520a2b6c98feead17dd5
+  languageName: node
+  linkType: hard
+
 "@ariakit/components@npm:0.1.8":
   version: 0.1.8
   resolution: "@ariakit/components@npm:0.1.8"
@@ -53,6 +63,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ariakit/react-components@npm:0.4.1":
+  version: 0.4.1
+  resolution: "@ariakit/react-components@npm:0.4.1"
+  dependencies:
+    "@ariakit/components": "npm:0.1.10"
+    "@ariakit/react-store": "npm:0.1.9"
+    "@ariakit/react-utils": "npm:0.2.4"
+    "@ariakit/store": "npm:0.1.8"
+    "@ariakit/utils": "npm:0.1.6"
+    "@floating-ui/dom": "npm:^1.0.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: f2841740fac3e1635e9c39ebefd28cf43e2af3566b9895b4b30402dfd2b17a212cb46c80ac544dd5384ceba54d056daa367033a4e8241126d943e016dce98700
+  languageName: node
+  linkType: hard
+
 "@ariakit/react-store@npm:0.1.8":
   version: 0.1.8
   resolution: "@ariakit/react-store@npm:0.1.8"
@@ -64,6 +91,20 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 64ebcb01c52ec378b7aa72e96be35e0689bf505458ed7fb8c7c0f488c7fad6c6ebaa7dafb55a3dfa6d65e7a8c9438816a3673f0394c0fac33e5b2984696e23f2
+  languageName: node
+  linkType: hard
+
+"@ariakit/react-store@npm:0.1.9":
+  version: 0.1.9
+  resolution: "@ariakit/react-store@npm:0.1.9"
+  dependencies:
+    "@ariakit/react-utils": "npm:0.2.4"
+    "@ariakit/store": "npm:0.1.8"
+    "@ariakit/utils": "npm:0.1.6"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: f1e5c8754221979466c580702ce95ce47cab8043f70545c74f84a5f77eac52cb2696e3fbb7dae5c76372aefd2efc163be50d73fb5403c26286f64330cb8fc949
   languageName: node
   linkType: hard
 
@@ -79,6 +120,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ariakit/react-utils@npm:0.2.4":
+  version: 0.2.4
+  resolution: "@ariakit/react-utils@npm:0.2.4"
+  dependencies:
+    "@ariakit/store": "npm:0.1.8"
+    "@ariakit/utils": "npm:0.1.6"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 11604075e37d394fb868ec0d2dab46a7a053180329c1c4ab4e151c7b25236b57bc698f6a9b96d38d96587eb3e4060f657735f6e3f7648ea151c42df4b217e2a8
+  languageName: node
+  linkType: hard
+
 "@ariakit/react@npm:^0.4.15, @ariakit/react@npm:^0.4.32":
   version: 0.4.35
   resolution: "@ariakit/react@npm:0.4.35"
@@ -91,12 +144,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ariakit/react@npm:^0.4.35":
+  version: 0.4.37
+  resolution: "@ariakit/react@npm:0.4.37"
+  dependencies:
+    "@ariakit/react-components": "npm:0.4.1"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 2a11e018c23bbe0ff848c52bdbf124302c23532f28d48c0835674a292ba1fa235ac9f1fa3c150d1113a1c232ab760180ec8510b83a75de2160c1669f77b18b3c
+  languageName: node
+  linkType: hard
+
 "@ariakit/store@npm:0.1.7":
   version: 0.1.7
   resolution: "@ariakit/store@npm:0.1.7"
   dependencies:
     "@ariakit/utils": "npm:0.1.5"
   checksum: 33b12327c94edee876e9789e0fd6f3de0e0544cb69065bf2dd2c76de442d93b2d42ba12cfd0060e239841d1137c592d79f8496ab43dba26657e9a52eae89856b
+  languageName: node
+  linkType: hard
+
+"@ariakit/store@npm:0.1.8":
+  version: 0.1.8
+  resolution: "@ariakit/store@npm:0.1.8"
+  dependencies:
+    "@ariakit/utils": "npm:0.1.6"
+  checksum: df642861f6626e7abc7c21c9f92db388b20a690edf7b582d7ebb7840b8f09b0256205a420a89db45ac536289b6ccd26104701e889fd3c2616cf88ce810d2cb5d
   languageName: node
   linkType: hard
 
@@ -125,6 +199,13 @@ __metadata:
   version: 0.1.5
   resolution: "@ariakit/utils@npm:0.1.5"
   checksum: 4cf92b66e2261d99ea4dabbd541e39a8743fa20a0dfa399dae25e0c589df1c5bf8593eafa548ac5623a43da29ab6d12cc1b56701f6d2e4d685d177a7efb5b8c3
+  languageName: node
+  linkType: hard
+
+"@ariakit/utils@npm:0.1.6":
+  version: 0.1.6
+  resolution: "@ariakit/utils@npm:0.1.6"
+  checksum: 155e34d69e666ab54a3f2985a0c3f8aa2f49e0a8fd1b7da5cb93803d7febd427422340734366fbc5ff61afc7ce3bf252034c37f8b6dd640aa1cd9ba09fe12818
   languageName: node
   linkType: hard
 
@@ -496,7 +577,7 @@ __metadata:
     "@automattic/i18n-utils": "workspace:^"
     "@automattic/languages": "workspace:^"
     "@automattic/shopping-cart": "workspace:^"
-    "@wordpress/dataviews": "npm:^17.3.0"
+    "@wordpress/dataviews": "npm:^18.0.0"
     "@wordpress/html-entities": "npm:^4.48.0"
     "@wordpress/i18n": "npm:^6.21.0"
     "@wordpress/url": "npm:^4.48.0"
@@ -2009,7 +2090,7 @@ __metadata:
     "@wordpress/components": "npm:^37.0.0"
     "@wordpress/compose": "npm:^8.2.0"
     "@wordpress/data": "npm:^10.48.0"
-    "@wordpress/dataviews": "npm:^17.3.0"
+    "@wordpress/dataviews": "npm:^18.0.0"
     "@wordpress/element": "npm:^8.0.0"
     "@wordpress/i18n": "npm:^6.21.0"
     "@wordpress/icons": "npm:^13.3.0"
@@ -12240,27 +12321,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/dataviews@npm:^17.3.0":
-  version: 17.3.0
-  resolution: "@wordpress/dataviews@npm:17.3.0"
+"@wordpress/dataviews@npm:^18.0.0":
+  version: 18.0.0
+  resolution: "@wordpress/dataviews@npm:18.0.0"
   dependencies:
-    "@ariakit/react": "npm:^0.4.32"
-    "@wordpress/a11y": "npm:^4.52.0"
-    "@wordpress/base-styles": "npm:^12.0.0"
-    "@wordpress/components": "npm:^38.0.0"
-    "@wordpress/compose": "npm:^8.5.0"
-    "@wordpress/data": "npm:^10.52.0"
-    "@wordpress/date": "npm:^5.52.0"
-    "@wordpress/deprecated": "npm:^4.52.0"
-    "@wordpress/element": "npm:^8.4.0"
-    "@wordpress/i18n": "npm:^6.25.0"
-    "@wordpress/icons": "npm:^15.3.0"
-    "@wordpress/keycodes": "npm:^4.52.0"
-    "@wordpress/primitives": "npm:^4.52.0"
-    "@wordpress/private-apis": "npm:^1.52.0"
-    "@wordpress/rich-text": "npm:^7.52.0"
-    "@wordpress/ui": "npm:^0.19.0"
-    "@wordpress/warning": "npm:^3.52.0"
+    "@ariakit/react": "npm:^0.4.35"
+    "@wordpress/a11y": "npm:^4.53.0"
+    "@wordpress/base-styles": "npm:^12.1.0"
+    "@wordpress/components": "npm:^39.0.0"
+    "@wordpress/compose": "npm:^8.6.0"
+    "@wordpress/data": "npm:^10.53.0"
+    "@wordpress/date": "npm:^5.53.0"
+    "@wordpress/deprecated": "npm:^4.53.0"
+    "@wordpress/element": "npm:^8.5.0"
+    "@wordpress/i18n": "npm:^6.26.0"
+    "@wordpress/icons": "npm:^15.4.0"
+    "@wordpress/kebab-case": "npm:^1.0.0"
+    "@wordpress/keycodes": "npm:^4.53.0"
+    "@wordpress/primitives": "npm:^4.53.0"
+    "@wordpress/private-apis": "npm:^1.53.0"
+    "@wordpress/ui": "npm:^0.20.0"
+    "@wordpress/warning": "npm:^3.53.0"
     clsx: "npm:^2.1.1"
     colord: "npm:^2.9.3"
     date-fns: "npm:^4.4.0"
@@ -12274,7 +12355,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 6bee02df11f3c7a5625329271685008efb865441cd590c3bc4d5cc7f07822ed5eb242c3d9bf8b5620ef2612d4653f0db69b81d05a6abfce160b5d59e254616df
+  checksum: 5a8c3cc49eb4c6615b177060d3c8726ed5299fad048b75ed9f2d6577d2d673a002a3760d72510d44a622a26bfc04041a1563bdbc9120c5ea4d902c461e1ec081
   languageName: node
   linkType: hard
 
@@ -12879,6 +12960,15 @@ __metadata:
   version: 5.48.0
   resolution: "@wordpress/is-shallow-equal@npm:5.48.0"
   checksum: d57b56e9eaf431ea196f04fc735eec979f94c1f728ea631baa681bb59c5fb734df49e1a865b4687376d0adb3e8f091b3ffa7f053c91aea9b81995e43de8fe3bd
+  languageName: node
+  linkType: hard
+
+"@wordpress/kebab-case@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@wordpress/kebab-case@npm:1.0.0"
+  dependencies:
+    change-case: "npm:^4.1.2"
+  checksum: 260813a1aa9af11fa38a149cfa91176388302e0be47790964b703366330dab57453e325cc027181a23a814c7f3437bb367e4d028de327d5cd7fb92df4d2f6e63
   languageName: node
   linkType: hard
 
@@ -15322,7 +15412,7 @@ __metadata:
     "@wordpress/components": "npm:^37.0.0"
     "@wordpress/compose": "npm:^8.2.0"
     "@wordpress/data": "npm:^10.48.0"
-    "@wordpress/dataviews": "npm:^16.0.0"
+    "@wordpress/dataviews": "npm:^18.0.0"
     "@wordpress/date": "npm:^5.48.0"
     "@wordpress/dom": "npm:^4.48.0"
     "@wordpress/edit-post": "npm:^8.48.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,10 +29,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ariakit/components@npm:0.1.8":
+  version: 0.1.8
+  resolution: "@ariakit/components@npm:0.1.8"
+  dependencies:
+    "@ariakit/store": "npm:0.1.7"
+    "@ariakit/utils": "npm:0.1.5"
+  checksum: d189e687cd85f85450e8202c33ad7b1e9e05d922f236d1bc03725bff14b28f8563a479213896a0db8c0d8a2c61437126305dcbad4821942a881cd2e23979bef5
+  languageName: node
+  linkType: hard
+
 "@ariakit/core@npm:0.4.20":
   version: 0.4.20
   resolution: "@ariakit/core@npm:0.4.20"
   checksum: c9f90af371858a0251a58e6ed68263be25ef175e0710c867a2c30f04894c2cd81716ca450c60414004eb3ce962e76bfe039b381867bc92c1cef2c27c7eb13784
+  languageName: node
+  linkType: hard
+
+"@ariakit/react-components@npm:0.3.4":
+  version: 0.3.4
+  resolution: "@ariakit/react-components@npm:0.3.4"
+  dependencies:
+    "@ariakit/components": "npm:0.1.8"
+    "@ariakit/react-store": "npm:0.1.8"
+    "@ariakit/react-utils": "npm:0.2.3"
+    "@ariakit/store": "npm:0.1.7"
+    "@ariakit/utils": "npm:0.1.5"
+    "@floating-ui/dom": "npm:^1.0.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: b1ccb7827244f803a1d5c273679ed558c1fcb6309acfd647cdf4502eae9c50eeb33788737ad3d3cff8706d3751a0e67543575af79dcec41419be0d7f80cfc19e
   languageName: node
   linkType: hard
 
@@ -53,6 +80,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ariakit/react-store@npm:0.1.8":
+  version: 0.1.8
+  resolution: "@ariakit/react-store@npm:0.1.8"
+  dependencies:
+    "@ariakit/react-utils": "npm:0.2.3"
+    "@ariakit/store": "npm:0.1.7"
+    "@ariakit/utils": "npm:0.1.5"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 64ebcb01c52ec378b7aa72e96be35e0689bf505458ed7fb8c7c0f488c7fad6c6ebaa7dafb55a3dfa6d65e7a8c9438816a3673f0394c0fac33e5b2984696e23f2
+  languageName: node
+  linkType: hard
+
 "@ariakit/react-store@npm:0.1.9":
   version: 0.1.9
   resolution: "@ariakit/react-store@npm:0.1.9"
@@ -64,6 +105,18 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: f1e5c8754221979466c580702ce95ce47cab8043f70545c74f84a5f77eac52cb2696e3fbb7dae5c76372aefd2efc163be50d73fb5403c26286f64330cb8fc949
+  languageName: node
+  linkType: hard
+
+"@ariakit/react-utils@npm:0.2.3":
+  version: 0.2.3
+  resolution: "@ariakit/react-utils@npm:0.2.3"
+  dependencies:
+    "@ariakit/store": "npm:0.1.7"
+    "@ariakit/utils": "npm:0.1.5"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 20ae44ca3d69e09dda77ae8e3df64b82d8ffc5209ac81fd3618fd2982ecc4de0029eb234f07900a26305c477296392f3e42ae86406b25a12b837615deef6d352
   languageName: node
   linkType: hard
 
@@ -79,7 +132,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ariakit/react@npm:0.4.37":
+"@ariakit/react@npm:^0.4.15, @ariakit/react@npm:^0.4.32":
+  version: 0.4.35
+  resolution: "@ariakit/react@npm:0.4.35"
+  dependencies:
+    "@ariakit/react-components": "npm:0.3.4"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 620c0876a50e5947d8fa8be05d43751272d6c57da82a11cff6af5f66dff330cab1537eaca37d974464d3e7e83f7727a4acdccfaa8ffe611cb3c43d0c73ca782b
+  languageName: node
+  linkType: hard
+
+"@ariakit/react@npm:^0.4.35":
   version: 0.4.37
   resolution: "@ariakit/react@npm:0.4.37"
   dependencies:
@@ -88,6 +153,15 @@ __metadata:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 2a11e018c23bbe0ff848c52bdbf124302c23532f28d48c0835674a292ba1fa235ac9f1fa3c150d1113a1c232ab760180ec8510b83a75de2160c1669f77b18b3c
+  languageName: node
+  linkType: hard
+
+"@ariakit/store@npm:0.1.7":
+  version: 0.1.7
+  resolution: "@ariakit/store@npm:0.1.7"
+  dependencies:
+    "@ariakit/utils": "npm:0.1.5"
+  checksum: 33b12327c94edee876e9789e0fd6f3de0e0544cb69065bf2dd2c76de442d93b2d42ba12cfd0060e239841d1137c592d79f8496ab43dba26657e9a52eae89856b
   languageName: node
   linkType: hard
 
@@ -118,6 +192,13 @@ __metadata:
     react:
       optional: true
   checksum: c1cc6cc49f3db9b66e9f1c35cef4f32ddbbf105e36b14c538d67f607007c7dc08857890b511582c07585759a8ea88e909e4ae67b49dbf275711f6c91217beb1e
+  languageName: node
+  linkType: hard
+
+"@ariakit/utils@npm:0.1.5":
+  version: 0.1.5
+  resolution: "@ariakit/utils@npm:0.1.5"
+  checksum: 4cf92b66e2261d99ea4dabbd541e39a8743fa20a0dfa399dae25e0c589df1c5bf8593eafa548ac5623a43da29ab6d12cc1b56701f6d2e4d685d177a7efb5b8c3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,37 +29,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ariakit/components@npm:0.1.8":
-  version: 0.1.8
-  resolution: "@ariakit/components@npm:0.1.8"
-  dependencies:
-    "@ariakit/store": "npm:0.1.7"
-    "@ariakit/utils": "npm:0.1.5"
-  checksum: d189e687cd85f85450e8202c33ad7b1e9e05d922f236d1bc03725bff14b28f8563a479213896a0db8c0d8a2c61437126305dcbad4821942a881cd2e23979bef5
-  languageName: node
-  linkType: hard
-
 "@ariakit/core@npm:0.4.20":
   version: 0.4.20
   resolution: "@ariakit/core@npm:0.4.20"
   checksum: c9f90af371858a0251a58e6ed68263be25ef175e0710c867a2c30f04894c2cd81716ca450c60414004eb3ce962e76bfe039b381867bc92c1cef2c27c7eb13784
-  languageName: node
-  linkType: hard
-
-"@ariakit/react-components@npm:0.3.4":
-  version: 0.3.4
-  resolution: "@ariakit/react-components@npm:0.3.4"
-  dependencies:
-    "@ariakit/components": "npm:0.1.8"
-    "@ariakit/react-store": "npm:0.1.8"
-    "@ariakit/react-utils": "npm:0.2.3"
-    "@ariakit/store": "npm:0.1.7"
-    "@ariakit/utils": "npm:0.1.5"
-    "@floating-ui/dom": "npm:^1.0.0"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: b1ccb7827244f803a1d5c273679ed558c1fcb6309acfd647cdf4502eae9c50eeb33788737ad3d3cff8706d3751a0e67543575af79dcec41419be0d7f80cfc19e
   languageName: node
   linkType: hard
 
@@ -80,20 +53,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ariakit/react-store@npm:0.1.8":
-  version: 0.1.8
-  resolution: "@ariakit/react-store@npm:0.1.8"
-  dependencies:
-    "@ariakit/react-utils": "npm:0.2.3"
-    "@ariakit/store": "npm:0.1.7"
-    "@ariakit/utils": "npm:0.1.5"
-    use-sync-external-store: "npm:^1.6.0"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 64ebcb01c52ec378b7aa72e96be35e0689bf505458ed7fb8c7c0f488c7fad6c6ebaa7dafb55a3dfa6d65e7a8c9438816a3673f0394c0fac33e5b2984696e23f2
-  languageName: node
-  linkType: hard
-
 "@ariakit/react-store@npm:0.1.9":
   version: 0.1.9
   resolution: "@ariakit/react-store@npm:0.1.9"
@@ -105,18 +64,6 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: f1e5c8754221979466c580702ce95ce47cab8043f70545c74f84a5f77eac52cb2696e3fbb7dae5c76372aefd2efc163be50d73fb5403c26286f64330cb8fc949
-  languageName: node
-  linkType: hard
-
-"@ariakit/react-utils@npm:0.2.3":
-  version: 0.2.3
-  resolution: "@ariakit/react-utils@npm:0.2.3"
-  dependencies:
-    "@ariakit/store": "npm:0.1.7"
-    "@ariakit/utils": "npm:0.1.5"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 20ae44ca3d69e09dda77ae8e3df64b82d8ffc5209ac81fd3618fd2982ecc4de0029eb234f07900a26305c477296392f3e42ae86406b25a12b837615deef6d352
   languageName: node
   linkType: hard
 
@@ -132,19 +79,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ariakit/react@npm:^0.4.15, @ariakit/react@npm:^0.4.32":
-  version: 0.4.35
-  resolution: "@ariakit/react@npm:0.4.35"
-  dependencies:
-    "@ariakit/react-components": "npm:0.3.4"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 620c0876a50e5947d8fa8be05d43751272d6c57da82a11cff6af5f66dff330cab1537eaca37d974464d3e7e83f7727a4acdccfaa8ffe611cb3c43d0c73ca782b
-  languageName: node
-  linkType: hard
-
-"@ariakit/react@npm:^0.4.35":
+"@ariakit/react@npm:^0.4.15, @ariakit/react@npm:^0.4.32, @ariakit/react@npm:^0.4.35":
   version: 0.4.37
   resolution: "@ariakit/react@npm:0.4.37"
   dependencies:
@@ -153,15 +88,6 @@ __metadata:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 2a11e018c23bbe0ff848c52bdbf124302c23532f28d48c0835674a292ba1fa235ac9f1fa3c150d1113a1c232ab760180ec8510b83a75de2160c1669f77b18b3c
-  languageName: node
-  linkType: hard
-
-"@ariakit/store@npm:0.1.7":
-  version: 0.1.7
-  resolution: "@ariakit/store@npm:0.1.7"
-  dependencies:
-    "@ariakit/utils": "npm:0.1.5"
-  checksum: 33b12327c94edee876e9789e0fd6f3de0e0544cb69065bf2dd2c76de442d93b2d42ba12cfd0060e239841d1137c592d79f8496ab43dba26657e9a52eae89856b
   languageName: node
   linkType: hard
 
@@ -192,13 +118,6 @@ __metadata:
     react:
       optional: true
   checksum: c1cc6cc49f3db9b66e9f1c35cef4f32ddbbf105e36b14c538d67f607007c7dc08857890b511582c07585759a8ea88e909e4ae67b49dbf275711f6c91217beb1e
-  languageName: node
-  linkType: hard
-
-"@ariakit/utils@npm:0.1.5":
-  version: 0.1.5
-  resolution: "@ariakit/utils@npm:0.1.5"
-  checksum: 4cf92b66e2261d99ea4dabbd541e39a8743fa20a0dfa399dae25e0c589df1c5bf8593eafa548ac5623a43da29ab6d12cc1b56701f6d2e4d685d177a7efb5b8c3
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,37 +29,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ariakit/components@npm:0.1.8":
-  version: 0.1.8
-  resolution: "@ariakit/components@npm:0.1.8"
-  dependencies:
-    "@ariakit/store": "npm:0.1.7"
-    "@ariakit/utils": "npm:0.1.5"
-  checksum: d189e687cd85f85450e8202c33ad7b1e9e05d922f236d1bc03725bff14b28f8563a479213896a0db8c0d8a2c61437126305dcbad4821942a881cd2e23979bef5
-  languageName: node
-  linkType: hard
-
 "@ariakit/core@npm:0.4.20":
   version: 0.4.20
   resolution: "@ariakit/core@npm:0.4.20"
   checksum: c9f90af371858a0251a58e6ed68263be25ef175e0710c867a2c30f04894c2cd81716ca450c60414004eb3ce962e76bfe039b381867bc92c1cef2c27c7eb13784
-  languageName: node
-  linkType: hard
-
-"@ariakit/react-components@npm:0.3.4":
-  version: 0.3.4
-  resolution: "@ariakit/react-components@npm:0.3.4"
-  dependencies:
-    "@ariakit/components": "npm:0.1.8"
-    "@ariakit/react-store": "npm:0.1.8"
-    "@ariakit/react-utils": "npm:0.2.3"
-    "@ariakit/store": "npm:0.1.7"
-    "@ariakit/utils": "npm:0.1.5"
-    "@floating-ui/dom": "npm:^1.0.0"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: b1ccb7827244f803a1d5c273679ed558c1fcb6309acfd647cdf4502eae9c50eeb33788737ad3d3cff8706d3751a0e67543575af79dcec41419be0d7f80cfc19e
   languageName: node
   linkType: hard
 
@@ -80,20 +53,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ariakit/react-store@npm:0.1.8":
-  version: 0.1.8
-  resolution: "@ariakit/react-store@npm:0.1.8"
-  dependencies:
-    "@ariakit/react-utils": "npm:0.2.3"
-    "@ariakit/store": "npm:0.1.7"
-    "@ariakit/utils": "npm:0.1.5"
-    use-sync-external-store: "npm:^1.6.0"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 64ebcb01c52ec378b7aa72e96be35e0689bf505458ed7fb8c7c0f488c7fad6c6ebaa7dafb55a3dfa6d65e7a8c9438816a3673f0394c0fac33e5b2984696e23f2
-  languageName: node
-  linkType: hard
-
 "@ariakit/react-store@npm:0.1.9":
   version: 0.1.9
   resolution: "@ariakit/react-store@npm:0.1.9"
@@ -105,18 +64,6 @@ __metadata:
   peerDependencies:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: f1e5c8754221979466c580702ce95ce47cab8043f70545c74f84a5f77eac52cb2696e3fbb7dae5c76372aefd2efc163be50d73fb5403c26286f64330cb8fc949
-  languageName: node
-  linkType: hard
-
-"@ariakit/react-utils@npm:0.2.3":
-  version: 0.2.3
-  resolution: "@ariakit/react-utils@npm:0.2.3"
-  dependencies:
-    "@ariakit/store": "npm:0.1.7"
-    "@ariakit/utils": "npm:0.1.5"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 20ae44ca3d69e09dda77ae8e3df64b82d8ffc5209ac81fd3618fd2982ecc4de0029eb234f07900a26305c477296392f3e42ae86406b25a12b837615deef6d352
   languageName: node
   linkType: hard
 
@@ -132,19 +79,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ariakit/react@npm:^0.4.15, @ariakit/react@npm:^0.4.32":
-  version: 0.4.35
-  resolution: "@ariakit/react@npm:0.4.35"
-  dependencies:
-    "@ariakit/react-components": "npm:0.3.4"
-  peerDependencies:
-    react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 620c0876a50e5947d8fa8be05d43751272d6c57da82a11cff6af5f66dff330cab1537eaca37d974464d3e7e83f7727a4acdccfaa8ffe611cb3c43d0c73ca782b
-  languageName: node
-  linkType: hard
-
-"@ariakit/react@npm:^0.4.35":
+"@ariakit/react@npm:0.4.37":
   version: 0.4.37
   resolution: "@ariakit/react@npm:0.4.37"
   dependencies:
@@ -153,15 +88,6 @@ __metadata:
     react: ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 2a11e018c23bbe0ff848c52bdbf124302c23532f28d48c0835674a292ba1fa235ac9f1fa3c150d1113a1c232ab760180ec8510b83a75de2160c1669f77b18b3c
-  languageName: node
-  linkType: hard
-
-"@ariakit/store@npm:0.1.7":
-  version: 0.1.7
-  resolution: "@ariakit/store@npm:0.1.7"
-  dependencies:
-    "@ariakit/utils": "npm:0.1.5"
-  checksum: 33b12327c94edee876e9789e0fd6f3de0e0544cb69065bf2dd2c76de442d93b2d42ba12cfd0060e239841d1137c592d79f8496ab43dba26657e9a52eae89856b
   languageName: node
   linkType: hard
 
@@ -192,13 +118,6 @@ __metadata:
     react:
       optional: true
   checksum: c1cc6cc49f3db9b66e9f1c35cef4f32ddbbf105e36b14c538d67f607007c7dc08857890b511582c07585759a8ea88e909e4ae67b49dbf275711f6c91217beb1e
-  languageName: node
-  linkType: hard
-
-"@ariakit/utils@npm:0.1.5":
-  version: 0.1.5
-  resolution: "@ariakit/utils@npm:0.1.5"
-  checksum: 4cf92b66e2261d99ea4dabbd541e39a8743fa20a0dfa399dae25e0c589df1c5bf8593eafa548ac5623a43da29ab6d12cc1b56701f6d2e4d685d177a7efb5b8c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Bump `@wordpress/dataviews` from 17.3.0 to 18.0.0 across the root manifest, the client, `api-core`, and the notifications app.
* The client was still pinned a major behind the rest of the repo (16.x), so this brings every consumer onto the same version.
* Bump the `@wordpress/ui` resolution from 0.18.0 to 0.20.0, which DataViews 18 requires.
* Dedupe `@ariakit/react` in the lockfile so we ship one copy instead of two.

## Why are these changes being made?

Keeping DataViews current so the Dashboard and other consumers pick up upstream fixes and stay close to Gutenberg trunk, and so all workspaces resolve a single copy instead of two majors.

18.0.0's only breaking change removes the built-in `richtext` DataForm control and the package's `privateApis` export. Nothing in this repo used either, so no source changes were needed.

### The `@wordpress/ui` bump is required, not incidental

DataViews 18 moved its `date` and `datetime` form controls onto the public `Calendar` and `RangeCalendar` from `@wordpress/ui`, and raised its requirement to `^0.20.0`. Our `resolutions` block force-pins that package, so the bump alone left DataViews 18 running against 0.18.0, which has no `Calendar` export — every `date` and `datetime` field in a DataForm crashed on render with an invalid element type. Raising the pin to 0.20.0 fixes it.

That affects real screens: scheduled updates, site logs, activity logs, and scan history all declare `date` or `datetime` fields.

`@wordpress/ui` 0.20.0's own breaking change requires `shortcut.label` on its `IconButton`. Nothing here uses that component, so there is no fallout.

DataViews 18 also asks for `@wordpress/components` `^39.0.0` while we pin `^37.0.0`. Leaving that pin alone was deliberate — every DataForm control and layout renders fine against 37, so raising it would widen the blast radius for no gain here.

Worth knowing while reviewing:

* Grid and picker-grid layouts now use the public Badge from `@wordpress/ui` instead of the private one, so badges gain a border and a slightly different background. This is the main visual delta.
* New in 18.0.0: a `time` field type, an `aspectRatio` layout option for grid and table (defaults to the previous square), and fixes to `between` date filters, bulk-action eligibility, and validation of hidden fields.
* Pulls in `@wordpress/kebab-case` as a new transitive dependency.

### Ariakit dedupe

DataViews 18 depends on `@ariakit/react` `^0.4.35` while `@wordpress/components` asks for `^0.4.15`/`^0.4.32`, so the bump initially resolved two copies — 0.4.35 and 0.4.37 — and each one drags its own `react-components`, `react-store`, `react-utils`, `components`, `store`, and `utils`. That is fourteen packages where seven will do, and two copies of a library that keeps module-level state is a hazard beyond the bundle size.

All three ranges already admit 0.4.37, so `yarn dedupe` collapses the whole subtree back to a single copy on its own — no `resolutions` entry needed. Worth preferring over a pin: the ranges stay honest, and the next `@wordpress/components` bump can move Ariakit without anyone remembering to unpin it first.

## Testing Instructions

* Visit the Dashboard sites list and switch between table, grid, and list layouts. Confirm the grid view renders correctly and check the restyled badges.
* Open the screens with date fields — scheduled updates, site logs, activity logs, scan history — and confirm the date and datetime controls render and accept input. These are what broke without the `@wordpress/ui` bump.
* Exercise filtering and sorting, and confirm bulk actions still apply to the right items.

Verified locally: `yarn typecheck-client` shows no new errors (the 8 omnibar errors are present on trunk too), and all 344 `client/dashboard` and `client/components` unit test suites pass — the latter being the ones most likely to notice Ariakit moving from 0.4.35 to 0.4.37.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
