### PR TITLE
Onboarding: Remove post-checkout-ai-step feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -1,5 +1,4 @@
 import { siteBySlugQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_BIG_SKY,
 	isBusiness,
@@ -62,7 +61,6 @@ const PostCheckoutOnboarding: StepType< {
 	} );
 
 	const showBigSkyChoice =
-		isEnabled( 'onboarding/post-checkout-ai-step' ) &&
 		!! site?.plan &&
 		( isPersonal( site.plan ) || isPremium( site.plan ) || isBusiness( site.plan ) ) &&
 		site.plan.features?.active?.includes( FEATURE_BIG_SKY );

--- a/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
+++ b/client/landing/stepper/hooks/use-is-site-big-sky-eligible.ts
@@ -17,7 +17,6 @@ import type { OnboardSelect } from '@automattic/data-stores';
 const { SiteGoal } = Onboard;
 
 const featureFlagEnabled = isEnabled( 'calypso/big-sky' );
-const featurePostCheckoutAiStepEnabled = isEnabled( 'onboarding/post-checkout-ai-step' );
 
 const invalidGoals = [
 	SiteGoal.PaidSubscribers,
@@ -51,12 +50,7 @@ export function useIsBigSkyEligible( flowName?: string ) {
 
 	if ( flowName === SITE_SETUP_FLOW ) {
 		return {
-			isEligible:
-				featureFlagEnabled &&
-				featurePostCheckoutAiStepEnabled &&
-				!! isOwner &&
-				siteHasBigSkyFeature &&
-				onSupportedDevice,
+			isEligible: featureFlagEnabled && !! isOwner && siteHasBigSkyFeature && onSupportedDevice,
 		};
 	}
 

--- a/config/development.json
+++ b/config/development.json
@@ -166,7 +166,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/post-checkout-ai-step": true,
 		"onboarding/user-on-stepper-hosting": true,
 		"onboarding/woo-hosting-post-purchase-setup-choice": true,
 		"p2/p2-plus": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -94,7 +94,6 @@
 		"migration/ssh-migration": false,
 		"oauth/unified-experience": false,
 		"onboarding/create-course": false,
-		"onboarding/post-checkout-ai-step": true,
 		"onboarding/woo-hosting-post-purchase-setup-choice": true,
 		"p2/p2-plus": true,
 		"performance/apm": false,

--- a/config/production.json
+++ b/config/production.json
@@ -119,7 +119,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/post-checkout-ai-step": true,
 		"onboarding/user-on-stepper-hosting": false,
 		"onboarding/woo-hosting-post-purchase-setup-choice": true,
 		"p2/p2-plus": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -118,7 +118,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/post-checkout-ai-step": true,
 		"onboarding/woo-hosting-post-purchase-setup-choice": true,
 		"p2/p2-plus": true,
 		"page/export": true,

--- a/config/test.json
+++ b/config/test.json
@@ -86,7 +86,6 @@
 		"onboarding/import-from-substack": true,
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
-		"onboarding/post-checkout-ai-step": false,
 		"onboarding/woo-hosting-post-purchase-setup-choice": false,
 		"plans/delayed-downgrade": true,
 		"plans/expired-downgrade": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -122,7 +122,6 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/post-checkout-ai-step": true,
 		"onboarding/user-on-stepper-hosting": true,
 		"onboarding/woo-hosting-post-purchase-setup-choice": true,
 		"p2/p2-plus": true,


### PR DESCRIPTION
## Related to

DOTCOM-15971

## Proposed Changes

- Removes the `onboarding/post-checkout-ai-step` feature flag now that the post-checkout AI (Big Sky) step has been validated and is ready for everyone.
- Deletes the flag from all environment configs: `development.json`, `horizon.json`, `production.json`, `stage.json`, `test.json`, `wpcalypso.json`.
- Removes the corresponding `isEnabled( 'onboarding/post-checkout-ai-step' )` checks from:
  - `post-checkout-onboarding.tsx` — `showBigSkyChoice` no longer gates on the flag.
  - `use-is-site-big-sky-eligible.ts` — `isEligible` for the Site Setup flow no longer gates on the flag.
- Eligibility for the Big Sky post-checkout step is now determined purely by plan/feature checks (owner, site plan tier, `FEATURE_BIG_SKY`, supported device), same as before minus the flag gate.

## Why

The flag was enabled by default in all environments except `test.json`, so it was effectively already live. Removing it cleans up dead config and simplifies the eligibility logic.

## Testing Instructions

- Purchase/checkout a plan (Personal, Premium, or Business) that includes `FEATURE_BIG_SKY` on a supported device, and confirm the post-checkout AI (Big Sky) onboarding step still appears as expected.
- Confirm the step does **not** appear for plans without the Big Sky feature, or on unsupported devices.
- Verify no references to `onboarding/post-checkout-ai-step` remain (`grep -r "post-checkout-ai-step"`).