### PR TITLE
Jetpack Atomic build smoke E2E: run 4 workers, not 14

### DIFF
--- a/.teamcity/_self/projects/WPComTests.kt
+++ b/.teamcity/_self/projects/WPComTests.kt
@@ -366,7 +366,9 @@ fun jetpackAtomicBuildSmokeE2eBuildType( targetDevice: String, buildUuid: String
 			runTaggedPlaywrightSpecs(
 				tag = "@jetpack-wpcom-integration",
 				targetDevice = targetDevice,
-				additionalEnvVars = mapOf( "PW_WORKERS" to "14" ),
+				// Every worker in this build shares one Atomic site and one account, so the
+				// count is bounded by what that single site serves, not by the agent's cores.
+				additionalEnvVars = mapOf( "PW_WORKERS" to "4" ),
 			)
 		}
 


### PR DESCRIPTION
Fixes TESTOPS-275

## Proposed Changes

* `PW_WORKERS` on `jetpack_atomic_build_smoke_e2e_desktop`: 14 → 4.

## Why are these changes being made?

The job is 236/300 red on trunk since 2026-08-06 and has been red between 45% and 100% every day in that window — the ~76% figure people are quoting is the baseline, not a regression. It runs 14 workers against the single Atomic site and single account its variation resolves to.

58 of the 60 failed tests across the 22 reds of 08-20/21 are timeouts or connection errors, none is a product assertion, and the rate is 60–92% on all seven variations with no spec failing deterministically on any of them. The same tag on Simple sites is 9% red. The sibling `jetpackAtomicDeploymentE2eBuildType` already runs it at 5.

## Testing Instructions

* A personal build cannot carry this: the value lives in the run step, which beats `-P env.PW_WORKERS`, and versioned settings do not load from a personal build's local changes. Evidence is instead the local runs on the private variation — 0 failures ×2 at 4 workers, 5–12 per run at 14.
* **The invariant to check:** watch `jetpack_atomic_build_smoke_e2e_desktop` on trunk for ~24h (roughly 30 builds at current cadence). Red rate should drop from ~79% toward the Simple job's ~9%. Any failure that survives is a real one worth a spec fix; today none of them are legible as such.
* Build wall-clock goes from ~1.8m to roughly 3m. The 27 tests sum to 764s with the slowest at 57s, so 4 workers floors at ~3.2m — an over-estimate, since per-test time drops as contention does.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
