### PR TITLE
Marketplace: read the transfer's created_at as UTC

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/transfer-created-at.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/transfer-created-at.ts
@@ -1,0 +1,38 @@
+import { parseTransferCreatedAt } from '../transfer-created-at';
+
+describe( 'parseTransferCreatedAt', () => {
+	test( 'reads the endpoint’s timezone-naive format as UTC', () => {
+		expect( parseTransferCreatedAt( '2026-08-12 13:11:10' ) ).toBe(
+			Date.UTC( 2026, 7, 12, 13, 11, 10 )
+		);
+	} );
+
+	test( 'is unaffected by the local timezone', () => {
+		// Date.parse would read the naive format in the runner's local zone; the UTC
+		// anchor must not move with it.
+		expect( parseTransferCreatedAt( '2026-08-12 13:11:10' ) ).toBe(
+			Date.parse( '2026-08-12T13:11:10Z' )
+		);
+	} );
+
+	test( 'leaves a timestamp that declares its zone alone', () => {
+		expect( parseTransferCreatedAt( '2026-08-12T13:11:10+02:00' ) ).toBe(
+			Date.parse( '2026-08-12T13:11:10+02:00' )
+		);
+		expect( parseTransferCreatedAt( '2026-08-12T13:11:10Z' ) ).toBe(
+			Date.parse( '2026-08-12T13:11:10Z' )
+		);
+	} );
+
+	test( 'reads a negative offset as declared', () => {
+		expect( parseTransferCreatedAt( '2026-08-12T13:11:10-07:00' ) ).toBe(
+			Date.parse( '2026-08-12T13:11:10-07:00' )
+		);
+	} );
+
+	test( 'returns NaN for an unparseable value', () => {
+		expect( parseTransferCreatedAt( 'not-a-date' ) ).toBeNaN();
+		expect( parseTransferCreatedAt( '' ) ).toBeNaN();
+		expect( parseTransferCreatedAt( '2026-13-40 99:99:99' ) ).toBeNaN();
+	} );
+} );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/transfer-created-at.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/transfer-created-at.ts
@@ -1,0 +1,12 @@
+// The transfers endpoint serializes `created_at` as a timezone-naive UTC string
+// ('2026-08-12 13:11:10'). Date.parse reads that shape as local time — or NaN on
+// some engines — which shifts a fresh transfer's apparent age by the viewer's UTC
+// offset: east of UTC that alone exceeds the five-minute install deadline.
+const NAIVE_UTC = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+
+export function parseTransferCreatedAt( createdAt: string ): number {
+	if ( NAIVE_UTC.test( createdAt ) ) {
+		return Date.parse( createdAt.replace( ' ', 'T' ) + 'Z' );
+	}
+	return Date.parse( createdAt );
+}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-install-deadline.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-install-deadline.ts
@@ -7,6 +7,7 @@ import {
 	transferStates,
 } from 'calypso/landing/stepper/utils/atomic-transfer-outcome';
 import { useInterval } from 'calypso/lib/interval';
+import { parseTransferCreatedAt } from './transfer-created-at';
 import type { AtomicTransfer } from '@automattic/api-core';
 
 // Matches the wait in Stepper's useWaitForAtomic (1000 * 300), so both places give up on a transfer
@@ -143,7 +144,7 @@ export function useInstallDeadline( {
 			seenInFlightId.current = transfer.atomic_transfer_id;
 			return;
 		}
-		const startedDuringThisWait = Date.parse( transfer.created_at ) >= waitBeganAt;
+		const startedDuringThisWait = parseTransferCreatedAt( transfer.created_at ) >= waitBeganAt;
 		const isKnownAttempt =
 			isFetchedAfterMount && isSuccess && !! isTransferFromAttempt?.( transfer );
 		const isOurs =
@@ -161,7 +162,9 @@ export function useInstallDeadline( {
 
 	// A live transfer is the thing being waited on, so it owns the clock; its start survives a
 	// refresh where a mount-anchored timer would not.
-	const transferStartedAt = hasFreshInFlightTransfer ? Date.parse( transfer.created_at ) : NaN;
+	const transferStartedAt = hasFreshInFlightTransfer
+		? parseTransferCreatedAt( transfer.created_at )
+		: NaN;
 	const waitStartedAt =
 		waitBeganAt === null
 			? null
@@ -192,7 +195,10 @@ export function useInstallDeadline( {
 	// What the wait could see when it ended. `is_stuck` is the server's own verdict on the same
 	// question this hook answers — in flight and older than its threshold — so recording both says
 	// whether five minutes is measuring what the backend's thirty are.
-	const transferAgeMs = transfer?.created_at ? now - Date.parse( transfer.created_at ) : null;
+	const transferCreatedAt = transfer?.created_at
+		? parseTransferCreatedAt( transfer.created_at )
+		: NaN;
+	const transferAgeMs = Number.isFinite( transferCreatedAt ) ? now - transferCreatedAt : null;
 	const diagnostics: InstallWaitDiagnostics = {
 		has_transfer: !! transfer,
 		transfer_status: transfer?.status ?? null,

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -44,6 +44,7 @@ import {
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 import { chooseInstallStrategy } from './install-strategy';
+import { parseTransferCreatedAt } from './transfer-created-at';
 import { useDelayedCondition } from './use-delayed-condition';
 import { INSTALL_DEADLINE_MS, isSettled, useInstallDeadline } from './use-install-deadline';
 import useMarketplaceAdditionalSteps from './use-marketplace-additional-steps';
@@ -235,7 +236,7 @@ export function useProductInstall( {
 				return false;
 			}
 
-			const createdAt = Date.parse( candidate.created_at );
+			const createdAt = parseTransferCreatedAt( candidate.created_at );
 			const age = Date.now() - createdAt;
 			// Our own transfer is created after we ask for it, so clock skew is the only thing that can
 			// date it before this attempt. The grace for that is safe to give except when the lookup


### PR DESCRIPTION
## Proposed Changes

**The marketplace install wait now reads the transfer’s `created_at` timestamp as UTC, so users east of UTC no longer hit an instant timeout error while their install is actually succeeding.**

- Adds `parseTransferCreatedAt`, which parses the endpoint’s timezone-naive `YYYY-MM-DD HH:mm:ss` format as the UTC it means, and leaves timestamps that declare a zone untouched.
- Swaps the `Date.parse` call sites in `use-install-deadline.ts` (deadline anchor, failure attribution, diagnostics) and `use-product-install.tsx` (transfer-attempt adoption).
- Keeps `NaN` out of the wait diagnostics when the timestamp is unparseable.

## Why are these changes being made?

The transfers endpoint returns `created_at` without a timezone marker. Browsers interpret such a bare timestamp in the user’s local timezone, but the server means UTC. For anyone east of UTC — Europe, India, Asia — a transfer that started seconds ago therefore looks hours old, and since the install page anchors its 5-minute give-up deadline to the transfer’s start time, the deadline is already blown on arrival: the user gets an error screen within seconds while their transfer completes normally behind it.

Production telemetry confirms it: roughly 150 users per day hit this, and the “transfer ages” recorded at timeout cluster exactly at UTC offsets (1h, 2h, 5h30m for India, 8h, 9h) rather than at real ages. Users west of UTC were unaffected by accident — their misparsed timestamp lands in the future and a `Math.min` fallback quietly ignores it.

## Testing Instructions

1. Set your system timezone to one east of UTC (e.g. Europe/Rome or Asia/Kolkata) and restart the browser.
2. Run `yarn start`.
3. On a Simple site with a Business plan, install any marketplace plugin (e.g. from `/plugins/<site>`), landing on `/marketplace/plugin/<slug>/install/<site>`.
4. The wait should run through the transfer and finish on the thank-you redirect. Before this fix, the “taking longer than expected” error appeared within a few seconds of the wait starting.
5. Repeat in a timezone west of UTC (e.g. America/New_York) and verify the behavior is unchanged.
