### PR TITLE
Marketplace install: track the error screen

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -27,6 +27,7 @@ const MarketplaceProductInstall = ( {
 		steps,
 		additionalSteps,
 		error,
+		errorTrackingProps,
 		isTransferWait,
 		transferStatus,
 		transferStartedAt,
@@ -69,6 +70,7 @@ const MarketplaceProductInstall = ( {
 						error={ error }
 						pluginSlug={ pluginSlug }
 						themeSlug={ themeSlug }
+						trackingProps={ errorTrackingProps }
 						onActivateTheme={ onActivateTheme }
 					/>
 				) }

--- a/client/my-sites/marketplace/pages/marketplace-product-install/product-install-error.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/product-install-error.tsx
@@ -1,6 +1,7 @@
 import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import EmptyContent from 'calypso/components/empty-content';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector, useDispatch } from 'calypso/state';
 import { clearPluginUpload } from 'calypso/state/plugins/upload/actions';
 import { getTheme } from 'calypso/state/themes/selectors';
@@ -10,17 +11,19 @@ import {
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
 import ThemeDirectInstall from './theme-direct-install';
-import type { ProductInstallError } from './use-product-install';
+import type { InstallErrorTrackingProps, ProductInstallError } from './use-product-install';
 
 export default function ProductInstallErrorView( {
 	error,
 	pluginSlug,
 	themeSlug,
+	trackingProps,
 	onActivateTheme,
 }: {
 	error: ProductInstallError;
 	pluginSlug: string;
 	themeSlug: string;
+	trackingProps: InstallErrorTrackingProps;
 	onActivateTheme: () => void;
 } ) {
 	const translate = useTranslate();
@@ -35,6 +38,10 @@ export default function ProductInstallErrorView( {
 	// that cannot accept a file.
 	const onRetryUpload = () => {
 		dispatch( clearPluginUpload( siteId ) );
+	};
+
+	const recordCtaClick = ( action: string ) => {
+		recordTracksEvent( 'calypso_marketplace_install_error_click', { ...trackingProps, action } );
 	};
 
 	const uploadPageURL = `/plugins/upload/${ selectedSiteSlug }`;
@@ -59,6 +66,7 @@ export default function ProductInstallErrorView( {
 						args: { planName: businessPlanName },
 					} ) }
 					actionURL={ `/checkout/${ selectedSite?.slug }/business?redirect_to=/marketplace/plugin/${ pluginSlug }/install/${ selectedSite?.slug }#step2` }
+					actionCallback={ () => recordCtaClick( 'upgrade_plan' ) }
 				/>
 			);
 		}
@@ -71,6 +79,7 @@ export default function ProductInstallErrorView( {
 					) }
 					action={ translate( 'Go to the upload page' ) }
 					actionURL={ `/plugins/upload/${ selectedSite?.slug }` }
+					actionCallback={ () => recordCtaClick( 'go_to_upload' ) }
 				/>
 			);
 		case 'theme-direct-install':
@@ -81,6 +90,7 @@ export default function ProductInstallErrorView( {
 					siteSlug={ selectedSite?.slug }
 					theme={ wpOrgTheme }
 					onActivate={ onActivateTheme }
+					onCtaClick={ recordCtaClick }
 				/>
 			);
 		case 'rejected-upload': {
@@ -109,8 +119,10 @@ export default function ProductInstallErrorView( {
 					line={ line }
 					secondaryAction={ translate( 'Back' ) }
 					secondaryActionURL={ uploadPageURL }
+					secondaryActionCallback={ () => recordCtaClick( 'back' ) }
 					action={ translate( 'Re-upload plugin' ) }
 					actionURL={ wpAdminUploadURL }
+					actionCallback={ () => recordCtaClick( 'reupload_wp_admin' ) }
 				/>
 			);
 		}
@@ -134,8 +146,10 @@ export default function ProductInstallErrorView( {
 						}
 						secondaryAction={ translate( 'Contact support' ) }
 						secondaryActionURL="/help/contact"
+						secondaryActionCallback={ () => recordCtaClick( 'contact_support' ) }
 						action={ translate( 'Go to themes' ) }
 						actionURL={ `/themes/${ selectedSiteSlug }` }
+						actionCallback={ () => recordCtaClick( 'go_to_themes' ) }
 					/>
 				);
 			}
@@ -154,11 +168,17 @@ export default function ProductInstallErrorView( {
 					}
 					secondaryAction={ translate( 'Contact support' ) }
 					secondaryActionURL="/help/contact"
+					secondaryActionCallback={ () => recordCtaClick( 'contact_support' ) }
 					action={
 						isPluginUploadFlow ? translate( 'Try uploading again' ) : translate( 'Go to plugins' )
 					}
 					actionURL={ isPluginUploadFlow ? uploadPageURL : pluginsPageURL }
-					actionCallback={ isPluginUploadFlow ? onRetryUpload : undefined }
+					actionCallback={ () => {
+						recordCtaClick( isPluginUploadFlow ? 'retry_upload' : 'go_to_plugins' );
+						if ( isPluginUploadFlow ) {
+							onRetryUpload();
+						}
+					} }
 				/>
 			);
 		}
@@ -175,8 +195,10 @@ export default function ProductInstallErrorView( {
 							? uploadPageURL
 							: `/plugins/${ pluginSlug }/${ selectedSiteSlug }`
 					}
+					secondaryActionCallback={ () => recordCtaClick( 'back' ) }
 					action={ translate( 'Upload from WP Admin' ) }
 					actionURL={ wpAdminUploadURL }
+					actionCallback={ () => recordCtaClick( 'reupload_wp_admin' ) }
 				/>
 			);
 	}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { act } from '@testing-library/react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import marketplaceReducer from 'calypso/state/marketplace/reducer';
 import pluginsReducer from 'calypso/state/plugins/reducer';
 import themesReducer from 'calypso/state/themes/reducer';
@@ -54,6 +55,15 @@ jest.mock( '../use-install-deadline', () => ( {
 	...jest.requireActual( '../use-install-deadline' ),
 	useInstallDeadline: ( args: DeadlineArgs ) => mockUseInstallDeadline( args ),
 } ) );
+
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+const errorViewEvents = () =>
+	jest
+		.mocked( recordTracksEvent )
+		.mock.calls.filter( ( [ name ] ) => name === 'calypso_marketplace_install_error_view' );
 
 const SITE_ID = 1;
 
@@ -278,6 +288,49 @@ describe( 'useProductInstall', () => {
 			expect( mockUseInstallDeadline.mock.calls.at( -1 )?.[ 0 ] ).toMatchObject( {
 				enabled: true,
 			} );
+		} );
+	} );
+
+	describe( 'error view impression', () => {
+		beforeEach( () => {
+			jest.mocked( recordTracksEvent ).mockClear();
+		} );
+		afterEach( () => {
+			mockUseInstallDeadline.mockImplementation( noDeadlineVerdict );
+		} );
+
+		it( 'fires once for a preflight error, which never reaches the wait telemetry', () => {
+			jest.useFakeTimers();
+			try {
+				const { rerender } = renderProductInstall( { pluginSlug: 'give' } );
+				expect( errorViewEvents() ).toHaveLength( 0 );
+
+				act( () => {
+					jest.advanceTimersByTime( 2000 );
+				} );
+				rerender();
+
+				expect( errorViewEvents() ).toHaveLength( 1 );
+				expect( errorViewEvents()[ 0 ][ 1 ] ).toMatchObject( {
+					error_type: 'non-installable-plan',
+					flow: 'plugin',
+					product_slug: 'give',
+				} );
+			} finally {
+				jest.useRealTimers();
+			}
+		} );
+
+		it( 'fires once for a transfer failure', () => {
+			mockUseInstallDeadline.mockImplementation(
+				deadlineVerdict( { hasTimedOut: true, hasTransferFailed: true } )
+			);
+
+			const { rerender } = renderProductInstall( {}, uploadAwaitingActivation( 'direct' ) );
+			rerender();
+
+			expect( errorViewEvents() ).toHaveLength( 1 );
+			expect( errorViewEvents()[ 0 ][ 1 ] ).toMatchObject( { error_type: 'transfer-failed' } );
 		} );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/theme-direct-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/theme-direct-install.tsx
@@ -21,12 +21,14 @@ export default function ThemeDirectInstall( {
 	siteSlug,
 	theme,
 	onActivate,
+	onCtaClick,
 }: {
 	themeSlug: string;
 	pluginSlug: string;
 	siteSlug?: string | null;
 	theme?: { name?: string; screenshot?: string };
 	onActivate: () => void;
+	onCtaClick?: ( action: string ) => void;
 } ) {
 	const translate = useTranslate();
 	const productsList = useSelector( getProductsList );
@@ -57,20 +59,30 @@ export default function ThemeDirectInstall( {
 			>
 				{ isProductListFetched && (
 					<div className="marketplace-plugin-install__direct-install-actions">
-						<Button href={ `/themes/${ themeSlug }/${ siteSlug }` }>
+						<Button
+							href={ `/themes/${ themeSlug }/${ siteSlug }` }
+							onClick={ () => onCtaClick?.( 'go_to_theme' ) }
+						>
 							{ translate( 'Go to the theme page' ) }
 						</Button>
 
 						{ ! isMarketplaceProduct ? (
-							<Button primary onClick={ onActivate }>
+							<Button
+								primary
+								onClick={ () => {
+									onCtaClick?.( 'activate_theme' );
+									onActivate();
+								} }
+							>
 								{ translate( 'Activate theme' ) }
 							</Button>
 						) : (
 							<Button
 								primary
-								onClick={ () =>
-									page( `/checkout/${ siteSlug || '' }/${ marketplaceProductSlug }?#step2` )
-								}
+								onClick={ () => {
+									onCtaClick?.( 'purchase_and_activate' );
+									page( `/checkout/${ siteSlug || '' }/${ marketplaceProductSlug }?#step2` );
+								} }
 							>
 								{ translate( 'Purchase and activate plugin' ) }
 							</Button>

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -142,6 +142,16 @@ export type ProductInstallError =
 	| { type: 'timeout' }
 	| { type: 'generic' };
 
+export type InstallErrorTrackingProps = {
+	error_type: string | null;
+	flow: string;
+	product_slug: string | null;
+	site_id: number | null;
+	current_step: number;
+	install_strategy: string;
+	wait_variant: string | null;
+};
+
 export function useProductInstall( {
 	pluginSlug = '',
 	themeSlug = '',
@@ -673,6 +683,41 @@ export function useProductInstall( {
 		currentStep,
 	] );
 
+	// Covers every error screen, preflight errors included — those never arm the wait, so the
+	// heartbeat and wait_ended above cannot see them. Thin on purpose: wait_ended already carries
+	// the diagnostics for failures that ended a wait.
+	const errorTrackingProps: InstallErrorTrackingProps = useMemo(
+		() => ( {
+			error_type: error?.type ?? null,
+			flow: installFlowName( { themeSlug, isPluginUploadFlow } ),
+			product_slug: pluginSlug || themeSlug || null,
+			site_id: siteId,
+			current_step: currentStep,
+			install_strategy: installStrategy,
+			wait_variant: isTransferWait ? getWaitVariant() : null,
+		} ),
+		[
+			error?.type,
+			themeSlug,
+			isPluginUploadFlow,
+			pluginSlug,
+			siteId,
+			currentStep,
+			installStrategy,
+			isTransferWait,
+		]
+	);
+
+	const reportedErrorViewRef = useRef< string | null >( null );
+	useEffect( () => {
+		const errorType = errorTrackingProps.error_type;
+		if ( ! errorType || reportedErrorViewRef.current === errorType ) {
+			return;
+		}
+		reportedErrorViewRef.current = errorType;
+		recordTracksEvent( 'calypso_marketplace_install_error_view', errorTrackingProps );
+	}, [ errorTrackingProps ] );
+
 	useThankYouRedirect( {
 		siteId,
 		selectedSiteSlug,
@@ -712,6 +757,7 @@ export function useProductInstall( {
 		steps,
 		additionalSteps,
 		error,
+		errorTrackingProps,
 		isTransferWait,
 		transferStatus: honestTransferStatus,
 		transferStartedAt,


### PR DESCRIPTION
## Proposed Changes

**Adds Tracks events to the marketplace install error screen: an impression and CTA clicks.**

- `calypso_marketplace_install_error_view` — once per distinct error, with `error_type`, `flow`, `product_slug`, `site_id`, `current_step`, `install_strategy`, `wait_variant`.
- `calypso_marketplace_install_error_click` — same properties plus `action` (`upgrade_plan`, `retry_upload`, `contact_support`, …).

## Why are these changes being made?

Part of DOTCOM-17970. Errors shown before the install wait starts (e.g. wrong plan) fire no event at all, and no error screen tracks what people do next. This makes the error funnel measurable.

## Testing Instructions

1. `yarn start`, watch Tracks events.
2. On a Free-plan site, open `/marketplace/plugin/jetpack-search/install/<site>`: one `calypso_marketplace_install_error_view` with `error_type: non-installable-plan`.
3. Click “Upgrade to Business Plan”: `calypso_marketplace_install_error_click` with `action: upgrade_plan`.
