### PR TITLE
Marketplace: surface a failed install instead of waiting out the deadline

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
@@ -232,8 +232,7 @@ describe( 'useProductInstall', () => {
 			}
 		);
 
-		// Statuses live under the plugin id the dispatches carry ('uploaded/uploaded'), which for an
-		// upload is the only identity there is — the flow has no route slug.
+		// Upload flow has no route slug; statuses live under the dispatched plugin id.
 		it( 'surfaces a failed activation instead of waiting out the deadline', () => {
 			jest.useFakeTimers();
 			try {
@@ -301,8 +300,7 @@ describe( 'useProductInstall', () => {
 
 				expect( result.current.error ).toBeNull();
 
-				// The retry's own request overwrites the status but keeps the old `error` field
-				// around; the attempt in flight must not be condemned by it.
+				// The retry's request overwrites the status but keeps the stale `error` field.
 				act( () => {
 					jest.advanceTimersByTime( 2000 );
 				} );
@@ -312,7 +310,7 @@ describe( 'useProductInstall', () => {
 			}
 		} );
 
-		// The component instance survives an SPA navigation to another product's install page.
+		// The component instance survives SPA navigation to another product's install page.
 		it( 'drops a latched failure when the product changes', () => {
 			const { result, store, rerender } = renderHookWithProvider(
 				( { slug }: { slug: string } ) => useProductInstall( { pluginSlug: slug } ),
@@ -346,8 +344,7 @@ describe( 'useProductInstall', () => {
 			expect( result.current.error ).toBeNull();
 		} );
 
-		// Arriving mid-request: the swap lands while both products read as in-progress, so the new
-		// product's failure must still be seen as a transition from its own baseline.
+		// The swap lands while both installs are in-progress; the new product's failure must still register.
 		it( 'still catches a failure after swapping products between two in-progress installs', () => {
 			const activationRequest = ( pluginId: string ) => ( {
 				type: PLUGIN_ACTIVATE_REQUEST,

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
@@ -2,6 +2,10 @@
  * @jest-environment jsdom
  */
 import { act } from '@testing-library/react';
+import {
+	PLUGIN_ACTIVATE_REQUEST,
+	PLUGIN_ACTIVATE_REQUEST_FAILURE,
+} from 'calypso/state/action-types';
 import marketplaceReducer from 'calypso/state/marketplace/reducer';
 import pluginsReducer from 'calypso/state/plugins/reducer';
 import themesReducer from 'calypso/state/themes/reducer';
@@ -227,6 +231,157 @@ describe( 'useProductInstall', () => {
 				expect( result.current.error ).toEqual( { type: 'rejected-upload', reason } );
 			}
 		);
+
+		// Statuses live under the plugin id the dispatches carry ('uploaded/uploaded'), which for an
+		// upload is the only identity there is — the flow has no route slug.
+		it( 'surfaces a failed activation instead of waiting out the deadline', () => {
+			jest.useFakeTimers();
+			try {
+				const { result, store } = renderHookWithProvider( () => useProductInstall( {} ), {
+					reducers,
+					initialState: {
+						...uploadAwaitingActivation( 'direct' ),
+						marketplace: {
+							purchaseFlow: {
+								primaryDomain: 'example.wordpress.com',
+								pluginInstallationStatus: 'in-progress',
+							},
+						},
+					},
+				} );
+
+				act( () => {
+					jest.advanceTimersByTime( 2000 );
+				} );
+				expect( result.current.error ).toBeNull();
+
+				act( () => {
+					store.dispatch( {
+						type: PLUGIN_ACTIVATE_REQUEST_FAILURE,
+						action: 'ACTIVATE_PLUGIN',
+						siteId: SITE_ID,
+						pluginId: 'uploaded/uploaded',
+						error: { message: 'Plugin file does not exist.' },
+					} );
+				} );
+
+				expect( result.current.error ).toEqual( { type: 'generic' } );
+			} finally {
+				jest.useRealTimers();
+			}
+		} );
+
+		it( 'ignores a failure left behind by an earlier attempt on a fresh mount', () => {
+			jest.useFakeTimers();
+			try {
+				const staleFailure = uploadAwaitingActivation( 'direct' );
+				const { result } = renderHookWithProvider( () => useProductInstall( {} ), {
+					reducers,
+					initialState: {
+						...staleFailure,
+						marketplace: {
+							purchaseFlow: {
+								primaryDomain: 'example.wordpress.com',
+								pluginInstallationStatus: 'in-progress',
+							},
+						},
+						plugins: {
+							...staleFailure.plugins,
+							installed: {
+								...staleFailure.plugins.installed,
+								status: {
+									[ SITE_ID ]: {
+										'uploaded/uploaded': { status: 'error', error: { message: 'stale' } },
+									},
+								},
+							},
+						},
+					},
+				} );
+
+				expect( result.current.error ).toBeNull();
+
+				// The retry's own request overwrites the status but keeps the old `error` field
+				// around; the attempt in flight must not be condemned by it.
+				act( () => {
+					jest.advanceTimersByTime( 2000 );
+				} );
+				expect( result.current.error ).toBeNull();
+			} finally {
+				jest.useRealTimers();
+			}
+		} );
+
+		// The component instance survives an SPA navigation to another product's install page.
+		it( 'drops a latched failure when the product changes', () => {
+			const { result, store, rerender } = renderHookWithProvider(
+				( { slug }: { slug: string } ) => useProductInstall( { pluginSlug: slug } ),
+				{
+					reducers,
+					initialState: { ui: { selectedSiteId: SITE_ID } },
+					initialProps: { slug: 'plugin-a' },
+				}
+			);
+
+			act( () => {
+				store.dispatch( {
+					type: PLUGIN_ACTIVATE_REQUEST,
+					action: 'ACTIVATE_PLUGIN',
+					siteId: SITE_ID,
+					pluginId: 'plugin-a',
+				} );
+			} );
+			act( () => {
+				store.dispatch( {
+					type: PLUGIN_ACTIVATE_REQUEST_FAILURE,
+					action: 'ACTIVATE_PLUGIN',
+					siteId: SITE_ID,
+					pluginId: 'plugin-a',
+					error: { message: 'activation failed' },
+				} );
+			} );
+			expect( result.current.error ).toEqual( { type: 'generic' } );
+
+			rerender( { slug: 'plugin-b' } );
+			expect( result.current.error ).toBeNull();
+		} );
+
+		// Arriving mid-request: the swap lands while both products read as in-progress, so the new
+		// product's failure must still be seen as a transition from its own baseline.
+		it( 'still catches a failure after swapping products between two in-progress installs', () => {
+			const activationRequest = ( pluginId: string ) => ( {
+				type: PLUGIN_ACTIVATE_REQUEST,
+				action: 'ACTIVATE_PLUGIN',
+				siteId: SITE_ID,
+				pluginId,
+			} );
+			const { result, store, rerender } = renderHookWithProvider(
+				( { slug }: { slug: string } ) => useProductInstall( { pluginSlug: slug } ),
+				{
+					reducers,
+					initialState: { ui: { selectedSiteId: SITE_ID } },
+					initialProps: { slug: 'plugin-a' },
+				}
+			);
+
+			act( () => {
+				store.dispatch( activationRequest( 'plugin-a' ) );
+				store.dispatch( activationRequest( 'plugin-b' ) );
+			} );
+			rerender( { slug: 'plugin-b' } );
+			expect( result.current.error ).toBeNull();
+
+			act( () => {
+				store.dispatch( {
+					type: PLUGIN_ACTIVATE_REQUEST_FAILURE,
+					action: 'ACTIVATE_PLUGIN',
+					siteId: SITE_ID,
+					pluginId: 'plugin-b',
+					error: { message: 'activation failed' },
+				} );
+			} );
+			expect( result.current.error ).toEqual( { type: 'generic' } );
+		} );
 
 		it( 'reports the dedicated timeout error when the wait runs out', () => {
 			mockUseInstallDeadline.mockImplementation(

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -262,23 +262,16 @@ export function useProductInstall( {
 		[ hasCurrentTransferAttempt, persistedTransferAttempt ]
 	);
 
-	// Statuses are keyed by the plugin id the install/activate dispatches carry (e.g.
-	// 'akismet/akismet'), not by the route slug — and the upload flow has no route slug at all.
-	// Read them under that same key, or a failed install or activation never surfaces and the
-	// page waits out the full deadline to report a real failure as a timeout.
+	// Statuses are keyed by the plugin id the dispatches carry (e.g. 'akismet/akismet'), not by
+	// the route slug — and the upload flow has no route slug at all.
 	const pluginInstallStatus = useSelector( ( state ) =>
 		getStatusForPlugin( state, siteId, installedPlugin?.id ?? wporgPlugin?.id ?? pluginSlug )
 	);
 
-	// Only a failure watched happening counts: the slice outlives the page, so a record left by an
-	// earlier attempt is already in the error state when this mounts, and the `error` field even
-	// survives the next request overwriting the status. Watching the in-progress → error transition
-	// attributes the failure to a request made while this page was open, whichever hook made it.
-	//
-	// Observed during render, as the transfer-attempt ref above is: this component instance
-	// survives an SPA navigation to another product's install, so on an identity change the new
-	// product's current status becomes the baseline — whatever state it is already in predates
-	// this page watching it — and the previous product's latch is dropped.
+	// Only an in-progress → error transition counts: the plugins slice outlives the page, so a
+	// record (or `error` field) left by an earlier attempt must not condemn a fresh one. The
+	// component survives SPA navigation, so an identity change resets the latch and makes the new
+	// product's current status the baseline.
 	const [ installFailureSeen, setInstallFailureSeen ] = useState( false );
 	const previousInstallStatusRef = useRef< string | undefined >( undefined );
 	const installIdentity = `${ siteId }:${ pluginSlug }:${ themeSlug }`;

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -22,6 +22,10 @@ import {
 	getStatusForPlugin,
 	isPluginActive,
 } from 'calypso/state/plugins/installed/selectors-ts';
+import {
+	PLUGIN_INSTALLATION_ERROR,
+	PLUGIN_INSTALLATION_IN_PROGRESS,
+} from 'calypso/state/plugins/installed/status/constants';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
@@ -258,9 +262,41 @@ export function useProductInstall( {
 		[ hasCurrentTransferAttempt, persistedTransferAttempt ]
 	);
 
+	// Statuses are keyed by the plugin id the install/activate dispatches carry (e.g.
+	// 'akismet/akismet'), not by the route slug — and the upload flow has no route slug at all.
+	// Read them under that same key, or a failed install or activation never surfaces and the
+	// page waits out the full deadline to report a real failure as a timeout.
 	const pluginInstallStatus = useSelector( ( state ) =>
-		getStatusForPlugin( state, siteId, pluginSlug )
+		getStatusForPlugin( state, siteId, installedPlugin?.id ?? wporgPlugin?.id ?? pluginSlug )
 	);
+
+	// Only a failure watched happening counts: the slice outlives the page, so a record left by an
+	// earlier attempt is already in the error state when this mounts, and the `error` field even
+	// survives the next request overwriting the status. Watching the in-progress → error transition
+	// attributes the failure to a request made while this page was open, whichever hook made it.
+	//
+	// Observed during render, as the transfer-attempt ref above is: this component instance
+	// survives an SPA navigation to another product's install, so on an identity change the new
+	// product's current status becomes the baseline — whatever state it is already in predates
+	// this page watching it — and the previous product's latch is dropped.
+	const [ installFailureSeen, setInstallFailureSeen ] = useState( false );
+	const previousInstallStatusRef = useRef< string | undefined >( undefined );
+	const installIdentity = `${ siteId }:${ pluginSlug }:${ themeSlug }`;
+	const installIdentityRef = useRef( installIdentity );
+	const observedInstallStatus = pluginInstallStatus?.status;
+	if ( installIdentityRef.current !== installIdentity ) {
+		installIdentityRef.current = installIdentity;
+		if ( installFailureSeen ) {
+			setInstallFailureSeen( false );
+		}
+	} else if (
+		observedInstallStatus === PLUGIN_INSTALLATION_ERROR &&
+		previousInstallStatusRef.current === PLUGIN_INSTALLATION_IN_PROGRESS &&
+		! installFailureSeen
+	) {
+		setInstallFailureSeen( true );
+	}
+	previousInstallStatusRef.current = observedInstallStatus;
 
 	const wpOrgTheme = useSelector( ( state ) => getTheme( state, 'wporg', themeSlug ) );
 	const isThemeActive = useSelector( ( state ) => getThemeActive( state, themeSlug, siteId ) );
@@ -342,7 +378,7 @@ export function useProductInstall( {
 		}
 		if (
 			pluginUploadError ||
-			pluginInstallStatus?.error ||
+			installFailureSeen ||
 			( atomicFlow && automatedTransferStatus === transferStates.FAILURE )
 		) {
 			return { type: 'generic' };


### PR DESCRIPTION
## Proposed Changes

**A plugin install or activation that fails on the server now surfaces its error screen immediately, instead of hanging on the progress bar for the full five-minute deadline and calling the failure a timeout.**

- The page read failure statuses with the route slug, but Redux keys them by the plugin id the dispatches carry (e.g. `akismet/akismet`) — the lookup never matched, and the zip-upload flow has no route slug at all. The lookup now uses the id actually dispatched.
- Only a failure watched happening counts: the error state is latched on the in-progress → error transition, so a stale record left by an earlier attempt — whose `error` field even survives the next request — cannot condemn a fresh retry, and a failure raised by the recovery paths is caught at any step.
- The latch is scoped to the product being installed, since the component instance survives an SPA navigation from one product's install page to another's.

## Why are these changes being made?

When a plugin fails to install or activate — most often a hand-uploaded zip whose activation errors out — the install page never learned about it. The customer watched a progress bar do nothing for five minutes and then got a generic “this took too long” error, which points them at the wrong culprit and wastes five minutes of their time.

Production telemetry puts this at ~574 waits over ten days (about 57 users per day), two thirds of them on the zip-upload flow on sites that are already Atomic, all running the full 300 seconds before dying.

## Testing Instructions

1. Run `yarn start`.
2. On an Atomic site, go to Plugins → Upload and upload a plugin zip that installs but fails to activate (e.g. one whose main file throws on activation).
3. The error screen should appear as soon as the activation fails. Before this fix, the progress bar ran for the full five minutes and then showed the timeout error.
4. Retry the same install: the fresh attempt should start normally, not inherit the previous failure's error screen.
5. Install a regular marketplace plugin on an Atomic site and verify the happy path is unchanged (progress → thank-you redirect).
