### PR TITLE
E2E: unskip the plugin Get started signup spec

### DIFF
--- a/test/e2e/specs/plugins/plugins__get-started-signup.spec.ts
+++ b/test/e2e/specs/plugins/plugins__get-started-signup.spec.ts
@@ -22,11 +22,6 @@ test.describe(
 		let newSiteDetails: NewSiteResponse | undefined;
 		let accountUsed: TestAccount;
 
-		test.skip(
-			true,
-			'calypsoPreReleaseUser owns thousands of leftover sites, so /me/sites takes about a minute and signup cannot reach checkout inside the 90s wait. Unskip once the backlog sweep in CHE-452 is done.'
-		);
-
 		test.afterAll( 'Delete the created site', async () => {
 			if ( ! newSiteDetails || ! accountUsed ) {
 				return;


### PR DESCRIPTION
Part of CHE-452

## Proposed Changes

* Unskip `plugins__get-started-signup.spec.ts`.

## Why are these changes being made?

The spec was skipped in #113710 because signup could not reach checkout inside the 90 second wait in `SignupPickPlanPage.selectPlan` — `/me/sites` took 48 to 59 seconds for calypsoPreReleaseUser while the account held 5847 leftover sites. That account is now swept, so the wait holds again.

## Testing Instructions

* Run the spec against the pre-release gate and confirm it reaches checkout with the Personal plan and Sensei Pro in the cart:
  `yarn playwright test specs/plugins/plugins__get-started-signup.spec.ts --reporter=list`
* Confirm the run leaves no site behind on calypsoPreReleaseUser.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?
