### PR TITLE
Logged in LOHP: Send login and dashboard-return flows to their destination instead of /

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -86,7 +86,7 @@ export default function ContinueAsUser( {
 					variant="primary"
 					className="continue-as-user__continue-button"
 					isBusy={ validatingPath }
-					href={ validatedPath || '/' }
+					href={ validatedPath || '/home' }
 					__next40pxDefaultSize
 				>
 					{ translate( 'Continue' ) }
@@ -110,7 +110,7 @@ export default function ContinueAsUser( {
 				<Button
 					variant="primary"
 					isBusy={ validatingPath }
-					href={ validatedPath || '/' }
+					href={ validatedPath || '/home' }
 					__next40pxDefaultSize
 					className="continue-as-user__continue-button"
 				>

--- a/client/jetpack-connect/authorize.jsx
+++ b/client/jetpack-connect/authorize.jsx
@@ -574,7 +574,7 @@ export class JetpackAuthorize extends Component {
 					const { redirect_to: redirectTo } = await this.props.logoutUser( targetLoginURL );
 					disablePersistence();
 					await clearStore();
-					window.location.href = redirectTo || '/';
+					window.location.href = redirectTo || '/log-in';
 				} catch ( error ) {
 					// The logout endpoint might fail if the nonce has expired.
 					// In this case, redirect to wp-login.php?action=logout to get a new nonce generated

--- a/client/landing/stepper/declarative-flow/flows/artpromo/artpromo.ts
+++ b/client/landing/stepper/declarative-flow/flows/artpromo/artpromo.ts
@@ -1,5 +1,7 @@
 import { DomainAvailabilityStatus, fetchDomainAvailability } from '@automattic/api-core';
 import { ART_PROMO_FLOW, addProductsToCart } from '@automattic/onboarding';
+import { navigateToLandingPage } from 'calypso/lib/landing-page';
+import { useDispatch } from 'calypso/state';
 import { useQuery } from '../../../hooks/use-query';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import { STEPS } from '../../internals/steps';
@@ -19,10 +21,11 @@ const artPromoFlow: FlowV2< typeof initialize > = {
 		const flowName = this.name;
 		const queryParams = useQuery();
 		const domain = queryParams.get( 'new' ) || '';
+		const dispatch = useDispatch();
 
 		const submit = async () => {
 			if ( ! domain ) {
-				return window.location.assign( '/' );
+				return dispatch( navigateToLandingPage() );
 			}
 
 			const availability = await fetchDomainAvailability( domain, {

--- a/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
+++ b/client/landing/stepper/declarative-flow/flows/plan-upgrade/plan-upgrade.ts
@@ -10,8 +10,10 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { getCurrentQueryParams } from 'calypso/landing/stepper/utils/get-current-query-params';
 import { stepsWithRequiredLogin } from 'calypso/landing/stepper/utils/steps-with-required-login';
+import { goToLandingPage } from 'calypso/lib/landing-page';
 import { isExternal } from 'calypso/lib/url';
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
+import type { Store } from 'redux';
 
 const BASE_STEPS = [ STEPS.UNIFIED_PLANS ];
 
@@ -44,11 +46,11 @@ async function checkUserHasAccess(): Promise< boolean > {
 	}
 }
 
-async function initialize() {
+async function initialize( reduxStore: Store ) {
 	const hasAccess = await checkUserHasAccess();
 
 	if ( ! hasAccess ) {
-		window.location.assign( '/' );
+		goToLandingPage( reduxStore, ( destination ) => window.location.assign( destination ) );
 		return false;
 	}
 

--- a/client/lib/landing-page/index.js
+++ b/client/lib/landing-page/index.js
@@ -1,0 +1,111 @@
+import { dashboardLink } from 'calypso/dashboard/utils/link';
+import { bumpStat } from 'calypso/lib/analytics/mc';
+import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
+import { fetchPreferences } from 'calypso/state/preferences/actions';
+import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import getIsSubscriptionOnly from 'calypso/state/selectors/get-is-subscription-only';
+import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
+import { requestSite } from 'calypso/state/sites/actions';
+import {
+	canCurrentUserUseCustomerHome,
+	getSite,
+	getSiteSlug,
+	getSiteAdminUrl,
+	isAdminInterfaceWPAdmin,
+} from 'calypso/state/sites/selectors';
+import { hasReadersAsLandingPage } from 'calypso/state/sites/selectors/has-reader-as-landing-page';
+import { hasSitesAsLandingPage } from 'calypso/state/sites/selectors/has-sites-as-landing-page';
+
+// Helper thunk that ensures that the requested site info is fetched into Redux state before we
+// continue working with it.
+// The `siteSelection` handler in `my-sites/controller` contains similar code.
+const waitForSite = ( siteId ) => async ( dispatch, getState ) => {
+	if ( getSite( getState(), siteId ) ) {
+		return;
+	}
+
+	try {
+		await dispatch( requestSite( siteId ) );
+	} catch {
+		// if the fetching of site info fails, return gracefully and proceed to redirect to Reader
+	}
+};
+
+// Helper thunk that ensures that the user preferences has been fetched into Redux state before we
+// continue working with it.
+const waitForPrefs = () => async ( dispatch, getState ) => {
+	if ( hasReceivedRemotePreferences( getState() ) ) {
+		return;
+	}
+
+	try {
+		await dispatch( fetchPreferences() );
+	} catch {
+		// if the fetching of preferences fails, return gracefully and proceed to the next landing page candidate
+	}
+};
+
+const getSitesLink = ( isDashboardOptIn ) => {
+	if ( isDashboardOptIn ) {
+		bumpStat( 'dashboard-redirect', 'landing-page' );
+		return dashboardLink( '/sites' );
+	}
+
+	return '/sites';
+};
+
+// Resolves the account's normal landing destination. Requires a booted Calypso
+// store; the login app's store has no `sites` reducer.
+export async function getLoggedInLandingPage( { dispatch, getState } ) {
+	await dispatch( waitForPrefs() );
+	const useSitesAsLandingPage = hasSitesAsLandingPage( getState() );
+	const dashboardOptIn = hasDashboardOptIn( getState() );
+
+	if ( useSitesAsLandingPage ) {
+		return getSitesLink( dashboardOptIn );
+	}
+
+	const useReaderAsLandingPage = hasReadersAsLandingPage( getState() );
+
+	if ( useReaderAsLandingPage ) {
+		return '/reader';
+	}
+
+	// determine the primary site ID (it's a property of "current user" object) and then
+	// ensure that the primary site info is loaded into Redux before proceeding.
+	const primarySiteId = getPrimarySiteId( getState() );
+	await dispatch( waitForSite( primarySiteId ) );
+	const primarySiteSlug = getSiteSlug( getState(), primarySiteId );
+
+	if ( ! primarySiteSlug ) {
+		if ( getIsSubscriptionOnly( getState() ) ) {
+			return '/reader';
+		}
+
+		// there is no primary site or the site info couldn't be fetched. Redirect to Sites Dashboard.
+		return getSitesLink( dashboardOptIn );
+	}
+
+	const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( getState(), primarySiteId );
+
+	if ( isCustomerHomeEnabled ) {
+		if ( isAdminInterfaceWPAdmin( getState(), primarySiteId ) ) {
+			return getSiteAdminUrl( getState(), primarySiteId );
+		}
+		return `/home/${ primarySiteSlug }`;
+	}
+
+	return `/stats/day/${ primarySiteSlug }`;
+}
+
+// Sends the user to their normal landing destination. Absolute URLs (wp-admin)
+// can't go through the in-app router.
+export async function navigateToLandingPage( store, page ) {
+	const destination = await getLoggedInLandingPage( store );
+
+	if ( destination.startsWith( '/' ) ) {
+		page( destination );
+	} else {
+		window.location.assign( destination );
+	}
+}

--- a/client/lib/landing-page/index.js
+++ b/client/lib/landing-page/index.js
@@ -99,6 +99,10 @@ export async function getLoggedInLandingPage( { dispatch, getState } ) {
 }
 
 // Absolute wp-admin URLs can't go through the in-app router.
+/**
+ * @param {{ dispatch: Function, getState: Function }} store
+ * @param {( destination: string ) => void} [navigate]
+ */
 export async function goToLandingPage( store, navigate = pageRouter ) {
 	const destination = await getLoggedInLandingPage( store );
 

--- a/client/lib/landing-page/index.js
+++ b/client/lib/landing-page/index.js
@@ -1,3 +1,4 @@
+import pageRouter from '@automattic/calypso-router';
 import { dashboardLink } from 'calypso/dashboard/utils/link';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
@@ -54,8 +55,7 @@ const getSitesLink = ( isDashboardOptIn ) => {
 	return '/sites';
 };
 
-// Resolves the account's normal landing destination. Requires a booted Calypso
-// store; the login app's store has no `sites` reducer.
+// Resolves the account's normal landing destination. Needs a booted Calypso store.
 export async function getLoggedInLandingPage( { dispatch, getState } ) {
 	await dispatch( waitForPrefs() );
 	const useSitesAsLandingPage = hasSitesAsLandingPage( getState() );
@@ -98,14 +98,17 @@ export async function getLoggedInLandingPage( { dispatch, getState } ) {
 	return `/stats/day/${ primarySiteSlug }`;
 }
 
-// Sends the user to their normal landing destination. Absolute URLs (wp-admin)
-// can't go through the in-app router.
-export async function navigateToLandingPage( store, page ) {
+// Absolute wp-admin URLs can't go through the in-app router.
+export async function goToLandingPage( store, navigate = pageRouter ) {
 	const destination = await getLoggedInLandingPage( store );
 
 	if ( destination.startsWith( '/' ) ) {
-		page( destination );
+		navigate( destination );
 	} else {
 		window.location.assign( destination );
 	}
 }
+
+// Thunk form, for connected components and anything holding a `dispatch`.
+export const navigateToLandingPage = () => ( dispatch, getState ) =>
+	goToLandingPage( { dispatch, getState } );

--- a/client/lib/landing-page/test/index.js
+++ b/client/lib/landing-page/test/index.js
@@ -1,0 +1,228 @@
+/**
+ * @jest-environment jsdom
+ */
+import { isEnabled } from '@automattic/calypso-config';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
+import { getLoggedInLandingPage, goToLandingPage } from '../index';
+
+// The resolver's own thunks only fetch data that these fixtures already provide,
+// so a no-op dispatch matches how the state would look once they resolved.
+function createStore( state ) {
+	return { getState: jest.fn( () => state ), dispatch: jest.fn() };
+}
+
+describe( 'getLoggedInLandingPage', () => {
+	if ( isEnabled( 'dashboard/enable-percentage-rollout' ) ) {
+		test( 'rollout cohort user with no sites goes to Sites Dashboard', async () => {
+			const state = { currentUser: { id: 1 }, sites: { items: {} }, ui: {} };
+
+			await expect( getLoggedInLandingPage( createStore( state ) ) ).resolves.toBe(
+				dashboardLink( '/sites' )
+			);
+		} );
+	}
+
+	test( 'user with a primary site but no permissions goes to day stats', async () => {
+		const state = {
+			currentUser: { id: 1, capabilities: { 1: {} }, user: { primary_blog: 1 } },
+			ui: {},
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://test.wordpress.com',
+					},
+				},
+			},
+		};
+
+		await expect( getLoggedInLandingPage( createStore( state ) ) ).resolves.toBe(
+			'/stats/day/test.wordpress.com'
+		);
+	} );
+
+	test( 'user with a primary site and edit permissions goes to My Home', async () => {
+		const state = {
+			currentUser: { id: 1, capabilities: { 1: { edit_posts: true } }, user: { primary_blog: 1 } },
+			ui: {},
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://test.wordpress.com',
+					},
+				},
+			},
+		};
+
+		await expect( getLoggedInLandingPage( createStore( state ) ) ).resolves.toBe(
+			'/home/test.wordpress.com'
+		);
+	} );
+
+	test( 'user with a Jetpack site set as their primary site goes to day stats', async () => {
+		const state = {
+			currentUser: { id: 1, capabilities: { 1: { edit_posts: true } }, user: { primary_blog: 1 } },
+			ui: {},
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://test.jurassic.ninja',
+						jetpack: true,
+					},
+				},
+			},
+		};
+
+		await expect( getLoggedInLandingPage( createStore( state ) ) ).resolves.toBe(
+			'/stats/day/test.jurassic.ninja'
+		);
+	} );
+
+	if ( isEnabled( 'dashboard/enable-percentage-rollout' ) ) {
+		test( 'rollout cohort user who opts in goes to sites page', async () => {
+			const state = {
+				currentUser: {
+					id: 1,
+					capabilities: { 1: { edit_posts: true } },
+					user: { primary_blog: 1, site_count: 2 },
+				},
+				preferences: {
+					localValues: {
+						'sites-landing-page': { useSitesAsLandingPage: true, updatedAt: 1111 },
+						'reader-landing-page': { useReaderAsLandingPage: false, updatedAt: 1111 },
+					},
+				},
+				ui: {},
+				sites: {
+					items: {
+						1: {
+							ID: 1,
+							URL: 'https://test.wordpress.com',
+						},
+						2: {
+							ID: 2,
+							URL: 'https://test.jurassic.ninja',
+							jetpack: true,
+						},
+					},
+				},
+			};
+
+			await expect( getLoggedInLandingPage( createStore( state ) ) ).resolves.toBe(
+				dashboardLink( '/sites' )
+			);
+		} );
+	}
+
+	test( 'user who opts in goes to reader page', async () => {
+		const state = {
+			currentUser: {
+				id: 1,
+				capabilities: { 1: { edit_posts: true } },
+				user: { primary_blog: 1, site_count: 2 },
+			},
+			preferences: {
+				localValues: {
+					'sites-landing-page': { useSitesAsLandingPage: false, updatedAt: 1111 },
+					'reader-landing-page': { useReaderAsLandingPage: true, updatedAt: 1111 },
+				},
+			},
+			ui: {},
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://test.wordpress.com',
+					},
+					2: {
+						ID: 2,
+						URL: 'https://test.jurassic.ninja',
+						jetpack: true,
+					},
+				},
+			},
+		};
+
+		await expect( getLoggedInLandingPage( createStore( state ) ) ).resolves.toBe( '/reader' );
+	} );
+
+	test( 'user with a primary site using the Classic interface goes to WP Admin Dashboard', async () => {
+		const state = {
+			currentUser: {
+				id: 1,
+				capabilities: { 1: { edit_posts: true } },
+				user: { primary_blog: 1 },
+			},
+			ui: {},
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://test.wordpress.com',
+						options: {
+							wpcom_admin_interface: 'wp-admin',
+							admin_url: 'https://test.wordpress.com/wp-admin/',
+						},
+					},
+				},
+			},
+		};
+
+		await expect( getLoggedInLandingPage( createStore( state ) ) ).resolves.toBe(
+			'https://test.wordpress.com/wp-admin/'
+		);
+	} );
+} );
+
+describe( 'goToLandingPage', () => {
+	const originalLocation = window.location;
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', {
+			value: originalLocation,
+			configurable: true,
+		} );
+	} );
+
+	test( 'routes relative destinations through the supplied navigator', async () => {
+		const state = {
+			currentUser: { id: 1, capabilities: { 1: { edit_posts: true } }, user: { primary_blog: 1 } },
+			ui: {},
+			sites: { items: { 1: { ID: 1, URL: 'https://test.wordpress.com' } } },
+		};
+		const navigate = jest.fn();
+
+		await goToLandingPage( createStore( state ), navigate );
+
+		expect( navigate ).toHaveBeenCalledWith( '/home/test.wordpress.com' );
+	} );
+
+	test( 'sends absolute wp-admin destinations through a full page load', async () => {
+		const state = {
+			currentUser: { id: 1, capabilities: { 1: { edit_posts: true } }, user: { primary_blog: 1 } },
+			ui: {},
+			sites: {
+				items: {
+					1: {
+						ID: 1,
+						URL: 'https://test.wordpress.com',
+						options: {
+							wpcom_admin_interface: 'wp-admin',
+							admin_url: 'https://test.wordpress.com/wp-admin/',
+						},
+					},
+				},
+			},
+		};
+		const assign = jest.fn();
+		Object.defineProperty( window, 'location', { value: { assign }, configurable: true } );
+		const navigate = jest.fn();
+
+		await goToLandingPage( createStore( state ), navigate );
+
+		expect( assign ).toHaveBeenCalledWith( 'https://test.wordpress.com/wp-admin/' );
+		expect( navigate ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/login/magic-login/emailed-login-link-expired.jsx
+++ b/client/login/magic-login/emailed-login-link-expired.jsx
@@ -175,7 +175,7 @@ class EmailedLoginLinkExpired extends Component {
 
 		return (
 			<div>
-				<RedirectWhenLoggedIn delayAtMount={ 3500 } redirectTo="/" replaceCurrentLocation />
+				<RedirectWhenLoggedIn delayAtMount={ 3500 } redirectTo="/home" replaceCurrentLocation />
 				<EmptyContent
 					action={ action }
 					actionCallback={ this.onClickTryAgainLink }

--- a/client/me/account-close/closed.jsx
+++ b/client/me/account-close/closed.jsx
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { BlankCanvas } from 'calypso/components/blank-canvas';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Loading from 'calypso/components/loading';
+import { navigateToLandingPage } from 'calypso/lib/landing-page';
 import { restoreAccount } from 'calypso/state/account/actions';
 import { getIsRestoring, getRestoreToken } from 'calypso/state/account/selectors';
 import isAccountDeleting from 'calypso/state/selectors/is-account-deleting';
@@ -34,7 +35,7 @@ function AccountDeletedPage() {
 	}, [ storedToken, urlToken ] );
 
 	const onCancelClick = () => {
-		window.location.href = '/';
+		dispatch( navigateToLandingPage() );
 	};
 
 	const onRestoreClick = () => {

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -76,7 +76,7 @@ class MeSidebar extends Component {
 			const { redirect_to } = await this.props.logoutUser( redirectTo );
 			disablePersistence();
 			await clearStore();
-			window.location.href = redirect_to || '/';
+			window.location.href = redirect_to || '/log-in';
 		} catch {
 			// The logout endpoint might fail if the nonce has expired.
 			// In this case, redirect to wp-login.php?action=logout to get a new nonce generated

--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -42,17 +42,16 @@ const VideoContainer = styled.div< { isMobile: boolean } >`
 		min-height: ${ ( { isMobile } ) => ( isMobile ? '100%' : 'unset' ) };
 	}
 `;
-const hundredYearProducts = [
-	PLAN_100_YEARS,
-	domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION,
-	domainProductSlugs.TRANSFER_IN,
-] as const;
+type HundredYearProduct =
+	| typeof PLAN_100_YEARS
+	| typeof domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION
+	| typeof domainProductSlugs.TRANSFER_IN;
 
 interface Props {
 	siteId?: number;
 	siteSlug?: string;
 	receiptId: number;
-	productSlug: ( typeof hundredYearProducts )[ number ];
+	productSlug: HundredYearProduct;
 }
 
 const MasterBar = styled.div`

--- a/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/hundred-year-thank-you/index.tsx
@@ -17,6 +17,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import HundredYearLoaderView from 'calypso/components/hundred-year-loader-view';
+import { navigateToLandingPage } from 'calypso/lib/landing-page';
 import { useDispatch, useSelector } from 'calypso/state';
 import { fetchReceipt } from 'calypso/state/receipts/actions';
 import { getReceiptById } from 'calypso/state/receipts/selectors';
@@ -221,7 +222,7 @@ export default function HundredYearThankYou( {
 		// and blog created after the purchase (siteId != null).
 		resolvedProductSlug !== domainProductSlugs.TRANSFER_IN
 	) {
-		page( '/' );
+		dispatch( navigateToLandingPage() );
 	}
 
 	const primaryDomainFromState = siteDomains.find( ( domain ) => domain.isPrimary )?.domain;

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -6,8 +6,8 @@ import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-
 import { isRemovedFlow } from 'calypso/landing/stepper/utils/flow-redirect-handler';
 import { LAUNCHPAD_PERSONALIZATION_EXPERIMENT, normalizeVariation } from 'calypso/lib/ai-launchpad';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
-import { getQueryArgs } from 'calypso/lib/query-args';
 import { getLoggedInLandingPage } from 'calypso/lib/landing-page';
+import { getQueryArgs } from 'calypso/lib/query-args';
 import { getSiteFragment } from 'calypso/lib/route';
 import { bumpStat } from 'calypso/state/analytics/actions';
 import { requestSite } from 'calypso/state/sites/actions';
@@ -55,7 +55,9 @@ export async function redirectToLandingPage( context, next ) {
 	}
 
 	if ( destination.startsWith( '/' ) ) {
-		page.redirect( destination );
+		page.redirect(
+			context.querystring ? `${ destination }?${ context.querystring }` : destination
+		);
 	} else {
 		window.location.assign( destination );
 	}

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -54,10 +54,12 @@ export async function redirectToLandingPage( context, next ) {
 		return;
 	}
 
+	if ( context.querystring ) {
+		destination += ( destination.includes( '?' ) ? '&' : '?' ) + context.querystring;
+	}
+
 	if ( destination.startsWith( '/' ) ) {
-		page.redirect(
-			context.querystring ? `${ destination }?${ context.querystring }` : destination
-		);
+		page.redirect( destination );
 	} else {
 		window.location.assign( destination );
 	}

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -7,6 +7,7 @@ import { isRemovedFlow } from 'calypso/landing/stepper/utils/flow-redirect-handl
 import { LAUNCHPAD_PERSONALIZATION_EXPERIMENT, normalizeVariation } from 'calypso/lib/ai-launchpad';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getQueryArgs } from 'calypso/lib/query-args';
+import { getLoggedInLandingPage } from 'calypso/lib/landing-page';
 import { getSiteFragment } from 'calypso/lib/route';
 import { bumpStat } from 'calypso/state/analytics/actions';
 import { requestSite } from 'calypso/state/sites/actions';
@@ -36,6 +37,28 @@ export default async function renderHome( context, next ) {
 	context.primary = <CustomerHome key={ site.ID } site={ site } />;
 
 	next();
+}
+
+// Bare /home sends the user where they'd normally land, not to the site picker.
+export async function redirectToLandingPage( context, next ) {
+	let destination;
+
+	try {
+		destination = await getLoggedInLandingPage( context.store );
+	} catch ( error ) {
+		captureException( error );
+	}
+
+	if ( ! destination || destination === context.pathname ) {
+		next();
+		return;
+	}
+
+	if ( destination.startsWith( '/' ) ) {
+		page.redirect( destination );
+	} else {
+		window.location.assign( destination );
+	}
 }
 
 export async function maybeRedirect( context, next ) {

--- a/client/my-sites/customer-home/index.js
+++ b/client/my-sites/customer-home/index.js
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
-import renderHome, { maybeRedirect } from './controller';
+import renderHome, { maybeRedirect, redirectToLandingPage } from './controller';
 
 export default function () {
 	// Redirect old view routes to home
@@ -9,7 +9,7 @@ export default function () {
 	page( '/view/:siteId', ( context ) => page.redirect( `/home/${ context.params.siteId }` ) );
 
 	// Home routes
-	page( '/home', siteSelection, sites, makeLayout, clientRender );
+	page( '/home', siteSelection, redirectToLandingPage, sites, makeLayout, clientRender );
 
 	page(
 		'/home/:site',

--- a/client/my-sites/customer-home/index.js
+++ b/client/my-sites/customer-home/index.js
@@ -9,7 +9,7 @@ export default function () {
 	page( '/view/:siteId', ( context ) => page.redirect( `/home/${ context.params.siteId }` ) );
 
 	// Home routes
-	page( '/home', siteSelection, redirectToLandingPage, sites, makeLayout, clientRender );
+	page( '/home', redirectToLandingPage, siteSelection, sites, makeLayout, clientRender );
 
 	page(
 		'/home/:site',

--- a/client/my-sites/customer-home/test/controller.js
+++ b/client/my-sites/customer-home/test/controller.js
@@ -87,6 +87,18 @@ describe( 'redirectToLandingPage', () => {
 		expect( next ).not.toHaveBeenCalled();
 	} );
 
+	it( 'carries the querystring across to an absolute destination', async () => {
+		getLoggedInLandingPage.mockResolvedValue( 'https://my.wordpress.com/sites' );
+		const assign = jest.fn();
+		Object.defineProperty( window, 'location', { value: { assign }, configurable: true } );
+		const next = jest.fn();
+
+		redirectToLandingPage( buildContext( { querystring: 'verified=1' } ), next );
+		await flushPromises();
+
+		expect( assign ).toHaveBeenCalledWith( 'https://my.wordpress.com/sites?verified=1' );
+	} );
+
 	it( 'carries the querystring across to the resolved destination', async () => {
 		getLoggedInLandingPage.mockResolvedValue( '/home/test.wordpress.com' );
 		const next = jest.fn();

--- a/client/my-sites/customer-home/test/controller.js
+++ b/client/my-sites/customer-home/test/controller.js
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import page from '@automattic/calypso-router';
+import configureStore from 'redux-mock-store';
+import { thunk } from 'redux-thunk';
+import { getLoggedInLandingPage } from 'calypso/lib/landing-page';
+import { redirectToLandingPage } from '../controller';
+
+jest.mock( 'calypso/lib/landing-page', () => ( {
+	...jest.requireActual( 'calypso/lib/landing-page' ),
+	getLoggedInLandingPage: jest.fn(),
+} ) );
+
+const mockStore = configureStore( [ thunk ] );
+
+// Flush only the microtask queue, never a macrotask: `page.redirect` schedules its
+// real `page.replace` on a timer, which would tear down the jsdom document.
+const flushPromises = async () => {
+	for ( let i = 0; i < 10; i++ ) {
+		await Promise.resolve();
+	}
+};
+
+const buildContext = () => ( {
+	store: mockStore( {
+		currentUser: { id: 1, user: { primary_blog: 1, site_count: 3, visible_site_count: 3 } },
+		sites: { items: {} },
+		ui: {},
+	} ),
+	path: '/home',
+	pathname: '/home',
+	querystring: '',
+	query: {},
+	params: {},
+} );
+
+describe( 'redirectToLandingPage', () => {
+	let redirect;
+
+	beforeEach( () => {
+		redirect = jest.spyOn( page, 'redirect' ).mockImplementation( () => {} );
+		// Neutralize the timer `page.redirect` schedules, so a leaked navigation
+		// cannot tear down the jsdom document while promises flush.
+		jest.spyOn( page, 'replace' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'sends a multi-site Customer Home account to their primary site', async () => {
+		getLoggedInLandingPage.mockResolvedValue( '/home/test.wordpress.com' );
+		const next = jest.fn();
+
+		redirectToLandingPage( buildContext(), next );
+		await flushPromises();
+
+		expect( redirect ).toHaveBeenCalledWith( '/home/test.wordpress.com' );
+		expect( next ).not.toHaveBeenCalled();
+	} );
+
+	it( 'honors the sites-as-landing-page preference', async () => {
+		getLoggedInLandingPage.mockResolvedValue( '/sites' );
+		const next = jest.fn();
+
+		redirectToLandingPage( buildContext(), next );
+		await flushPromises();
+
+		expect( redirect ).toHaveBeenCalledWith( '/sites' );
+		expect( next ).not.toHaveBeenCalled();
+	} );
+
+	it( 'sends an absolute hosting-dashboard destination through a full page load', async () => {
+		const destination = 'https://my.wordpress.com/sites';
+		getLoggedInLandingPage.mockResolvedValue( destination );
+		const assign = jest.fn();
+		Object.defineProperty( window, 'location', { value: { assign }, configurable: true } );
+		const next = jest.fn();
+
+		redirectToLandingPage( buildContext(), next );
+		await flushPromises();
+
+		expect( assign ).toHaveBeenCalledWith( destination );
+		expect( redirect ).not.toHaveBeenCalled();
+		expect( next ).not.toHaveBeenCalled();
+	} );
+
+	it( 'falls through to the site picker when the resolver produces nothing usable', async () => {
+		getLoggedInLandingPage.mockResolvedValue( undefined );
+		const next = jest.fn();
+
+		redirectToLandingPage( buildContext(), next );
+		await flushPromises();
+
+		expect( next ).toHaveBeenCalled();
+		expect( redirect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'falls through to the site picker when the resolver throws', async () => {
+		getLoggedInLandingPage.mockRejectedValue( new Error( 'resolver failed' ) );
+		const next = jest.fn();
+
+		redirectToLandingPage( buildContext(), next );
+		await flushPromises();
+
+		expect( next ).toHaveBeenCalled();
+		expect( redirect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'falls through rather than redirecting to the route it is already on', async () => {
+		getLoggedInLandingPage.mockResolvedValue( '/home' );
+		const next = jest.fn();
+
+		redirectToLandingPage( buildContext(), next );
+		await flushPromises();
+
+		expect( next ).toHaveBeenCalled();
+		expect( redirect ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/my-sites/customer-home/test/controller.js
+++ b/client/my-sites/customer-home/test/controller.js
@@ -23,7 +23,7 @@ const flushPromises = async () => {
 	}
 };
 
-const buildContext = () => ( {
+const buildContext = ( { querystring = '' } = {} ) => ( {
 	store: mockStore( {
 		currentUser: { id: 1, user: { primary_blog: 1, site_count: 3, visible_site_count: 3 } },
 		sites: { items: {} },
@@ -31,7 +31,7 @@ const buildContext = () => ( {
 	} ),
 	path: '/home',
 	pathname: '/home',
-	querystring: '',
+	querystring,
 	query: {},
 	params: {},
 } );
@@ -85,6 +85,16 @@ describe( 'redirectToLandingPage', () => {
 		expect( assign ).toHaveBeenCalledWith( destination );
 		expect( redirect ).not.toHaveBeenCalled();
 		expect( next ).not.toHaveBeenCalled();
+	} );
+
+	it( 'carries the querystring across to the resolved destination', async () => {
+		getLoggedInLandingPage.mockResolvedValue( '/home/test.wordpress.com' );
+		const next = jest.fn();
+
+		redirectToLandingPage( buildContext( { querystring: 'verified=1' } ), next );
+		await flushPromises();
+
+		expect( redirect ).toHaveBeenCalledWith( '/home/test.wordpress.com?verified=1' );
 	} );
 
 	it( 'falls through to the site picker when the resolver produces nothing usable', async () => {

--- a/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
@@ -1,4 +1,3 @@
-import page from '@automattic/calypso-router';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Step } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
@@ -10,6 +9,7 @@ import { UserCard, type UserCardUser } from 'calypso/components/connect-screen/u
 import DocumentHead from 'calypso/components/data/document-head';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { navigateToLandingPage } from 'calypso/lib/landing-page';
 import { navigate } from 'calypso/lib/navigate';
 import {
 	detectPartnerConfig,
@@ -218,7 +218,7 @@ export function AcceptInviteScreen( { invite }: AcceptInviteScreenProps ) {
 	const handleDecline = useCallback( () => {
 		recordTracksEvent( 'calypso_invite_accept_logged_in_decline_button_click', trackingProps );
 		dispatch( infoNotice( translate( 'You declined to join.' ), { displayOnNextPage: true } ) );
-		page( '/' );
+		dispatch( navigateToLandingPage() );
 	}, [ dispatch, trackingProps, translate ] );
 
 	const getLoginUrl = useCallback( () => {

--- a/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
@@ -136,6 +136,11 @@ jest.mock( 'calypso/lib/navigate', () => ( {
 	navigate: ( url: string ) => mockNavigate( url ),
 } ) );
 
+const mockNavigateToLandingPage = jest.fn( () => ( { type: 'TEST_NAVIGATE_TO_LANDING_PAGE' } ) );
+jest.mock( 'calypso/lib/landing-page', () => ( {
+	navigateToLandingPage: ( ...args: unknown[] ) => mockNavigateToLandingPage( ...args ),
+} ) );
+
 const mockWooBranding = {
 	windowTitleSuffix: 'Woo',
 	logo: {
@@ -482,8 +487,7 @@ describe( 'AcceptInviteScreen', () => {
 	} );
 
 	describe( 'decline flow', () => {
-		test( 'redirects to home on decline', () => {
-			const page = require( '@automattic/calypso-router' ).default;
+		test( 'navigates to the landing destination on decline', () => {
 			const store = createStore();
 			const invite = createInvite();
 
@@ -495,7 +499,7 @@ describe( 'AcceptInviteScreen', () => {
 
 			fireEvent.click( screen.getByTestId( 'secondary-button' ) );
 
-			expect( page ).toHaveBeenCalledWith( '/' );
+			expect( mockNavigateToLandingPage ).toHaveBeenCalled();
 		} );
 
 		test( 'tracks decline button click', () => {

--- a/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
@@ -138,7 +138,7 @@ jest.mock( 'calypso/lib/navigate', () => ( {
 
 const mockNavigateToLandingPage = jest.fn( () => ( { type: 'TEST_NAVIGATE_TO_LANDING_PAGE' } ) );
 jest.mock( 'calypso/lib/landing-page', () => ( {
-	navigateToLandingPage: ( ...args: unknown[] ) => mockNavigateToLandingPage( ...args ),
+	navigateToLandingPage: () => mockNavigateToLandingPage(),
 } ) );
 
 const mockWooBranding = {

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -1,4 +1,3 @@
-import page from '@automattic/calypso-router';
 import clsx from 'clsx';
 import Debug from 'debug';
 import { localize, default as i18n } from 'i18n-calypso';
@@ -9,6 +8,7 @@ import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { navigateToLandingPage } from 'calypso/lib/landing-page';
 import { login } from 'calypso/lib/paths';
 import wpcom from 'calypso/lib/wp';
 import LoggedIn from 'calypso/my-sites/invites/invite-accept-logged-in';
@@ -142,7 +142,7 @@ class InviteAccept extends Component {
 		this.props.infoNotice( this.props.translate( 'You declined to join.' ), {
 			displayOnNextPage: true,
 		} );
-		page( '/' );
+		this.props.navigateToLandingPage();
 	};
 
 	signInLink = () => {
@@ -324,5 +324,6 @@ export default connect(
 		infoNotice,
 		hideMasterbar,
 		redirectToLogout,
+		navigateToLandingPage,
 	}
 )( localize( InviteAccept ) );

--- a/client/root.js
+++ b/client/root.js
@@ -1,23 +1,7 @@
 import config from '@automattic/calypso-config';
 import globalPageInstance from '@automattic/calypso-router';
-import { dashboardLink } from 'calypso/dashboard/utils/link';
-import { bumpStat } from 'calypso/lib/analytics/mc';
+import { getLoggedInLandingPage } from 'calypso/lib/landing-page';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
-import { fetchPreferences } from 'calypso/state/preferences/actions';
-import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
-import getIsSubscriptionOnly from 'calypso/state/selectors/get-is-subscription-only';
-import getPrimarySiteId from 'calypso/state/selectors/get-primary-site-id';
-import { requestSite } from 'calypso/state/sites/actions';
-import {
-	canCurrentUserUseCustomerHome,
-	getSite,
-	getSiteSlug,
-	getSiteAdminUrl,
-	isAdminInterfaceWPAdmin,
-} from 'calypso/state/sites/selectors';
-import { hasReadersAsLandingPage } from 'calypso/state/sites/selectors/has-reader-as-landing-page';
-import { hasSitesAsLandingPage } from 'calypso/state/sites/selectors/has-sites-as-landing-page';
 
 /**
  * @param clientRouter Unused. We can't use the isomorphic router because we want to do redirects.
@@ -58,84 +42,4 @@ async function handleLoggedIn( page, context ) {
 		// Case for wp-admin redirection when primary site has classic admin interface.
 		window.location.assign( redirectPath );
 	}
-}
-
-// Helper thunk that ensures that the requested site info is fetched into Redux state before we
-// continue working with it.
-// The `siteSelection` handler in `my-sites/controller` contains similar code.
-const waitForSite = ( siteId ) => async ( dispatch, getState ) => {
-	if ( getSite( getState(), siteId ) ) {
-		return;
-	}
-
-	try {
-		await dispatch( requestSite( siteId ) );
-	} catch {
-		// if the fetching of site info fails, return gracefully and proceed to redirect to Reader
-	}
-};
-
-// Helper thunk that ensures that the user preferences has been fetched into Redux state before we
-// continue working with it.
-const waitForPrefs = () => async ( dispatch, getState ) => {
-	if ( hasReceivedRemotePreferences( getState() ) ) {
-		return;
-	}
-
-	try {
-		await dispatch( fetchPreferences() );
-	} catch {
-		// if the fetching of preferences fails, return gracefully and proceed to the next landing page candidate
-	}
-};
-
-const getSitesLink = ( isDashboardOptIn ) => {
-	if ( isDashboardOptIn ) {
-		bumpStat( 'dashboard-redirect', 'landing-page' );
-		return dashboardLink( '/sites' );
-	}
-
-	return '/sites';
-};
-
-async function getLoggedInLandingPage( { dispatch, getState } ) {
-	await dispatch( waitForPrefs() );
-	const useSitesAsLandingPage = hasSitesAsLandingPage( getState() );
-	const dashboardOptIn = hasDashboardOptIn( getState() );
-
-	if ( useSitesAsLandingPage ) {
-		return getSitesLink( dashboardOptIn );
-	}
-
-	const useReaderAsLandingPage = hasReadersAsLandingPage( getState() );
-
-	if ( useReaderAsLandingPage ) {
-		return '/reader';
-	}
-
-	// determine the primary site ID (it's a property of "current user" object) and then
-	// ensure that the primary site info is loaded into Redux before proceeding.
-	const primarySiteId = getPrimarySiteId( getState() );
-	await dispatch( waitForSite( primarySiteId ) );
-	const primarySiteSlug = getSiteSlug( getState(), primarySiteId );
-
-	if ( ! primarySiteSlug ) {
-		if ( getIsSubscriptionOnly( getState() ) ) {
-			return '/reader';
-		}
-
-		// there is no primary site or the site info couldn't be fetched. Redirect to Sites Dashboard.
-		return getSitesLink( dashboardOptIn );
-	}
-
-	const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( getState(), primarySiteId );
-
-	if ( isCustomerHomeEnabled ) {
-		if ( isAdminInterfaceWPAdmin( getState(), primarySiteId ) ) {
-			return getSiteAdminUrl( getState(), primarySiteId );
-		}
-		return `/home/${ primarySiteSlug }`;
-	}
-
-	return `/stats/day/${ primarySiteSlug }`;
 }

--- a/client/sites/settings/administration/tools/delete-site/index.jsx
+++ b/client/sites/settings/administration/tools/delete-site/index.jsx
@@ -12,6 +12,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import { Panel, PanelCard, PanelCardHeading } from 'calypso/components/panel';
 import withP2HubP2Count from 'calypso/data/p2/with-p2-hub-p2-count';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { navigateToLandingPage } from 'calypso/lib/landing-page';
 import { resetBreadcrumbs, updateBreadcrumbs } from 'calypso/state/breadcrumb/actions';
 import { hasLoadedSitePurchasesFromServer } from 'calypso/state/purchases/selectors';
 import hasCancelableSitePurchases from 'calypso/state/selectors/has-cancelable-site-purchases';
@@ -176,7 +177,7 @@ class DeleteSite extends Component {
 			if ( useSitesAsLandingPage ) {
 				page.redirect( '/sites' );
 			} else {
-				page.redirect( '/' );
+				this.props.navigateToLandingPage();
 			}
 		}
 	}
@@ -265,5 +266,6 @@ export default connect(
 		setSelectedSiteId,
 		updateBreadcrumbs,
 		resetBreadcrumbs,
+		navigateToLandingPage,
 	}
 )( localize( withP2HubP2Count( DeleteSite ) ) );

--- a/client/sites/settings/administration/tools/delete-site/index.jsx
+++ b/client/sites/settings/administration/tools/delete-site/index.jsx
@@ -158,7 +158,6 @@ class DeleteSite extends Component {
 		try {
 			this.setState( { isDeletingSite: true } );
 			await this.props.deleteSite( this.props.siteId );
-			page.redirect( '/sites' );
 		} finally {
 			this.setState( { isDeletingSite: false } );
 		}

--- a/client/state/login/actions/reboot-after-login.ts
+++ b/client/state/login/actions/reboot-after-login.ts
@@ -13,8 +13,8 @@ export const rebootAfterLogin =
 			} )
 		);
 
-		// Redirects to / if no redirect url is available
-		const url = getRedirectToSanitized( getState() ) || '/';
+		// The login app's store has no sites state, so the landing resolver can't run here.
+		const url = getRedirectToSanitized( getState() ) || '/home';
 
 		// user ID is persisted in localstorage
 		// therefore we need to reset it before we redirect, otherwise we'll get

--- a/packages/calypso-e2e/src/lib/test-account.ts
+++ b/packages/calypso-e2e/src/lib/test-account.ts
@@ -60,7 +60,7 @@ export class TestAccount {
 		if ( hasFreshCookies ) {
 			this.log( 'Found fresh cookies, skipping log in' );
 			await browserContext.addCookies( await this.getAuthCookies() );
-			await page.goto( getCalypsoURL( '/' ) );
+			await page.goto( getCalypsoURL( '/home' ) );
 		}
 
 		// Freshness is read off the cookie file's age, but the session behind it can be gone


### PR DESCRIPTION
Related to DOTCOM-17998

## Proposed Changes

* WordPress.com is taking over `wordpress.com/` for logged-in visitors, so Calypso can no longer use `/` as the "figure out where I land" step.
* Logging in without a destination, and the flows that sent people to `/` (declining an invite, closing an account, deleting a site, logging out, and similar), now go straight to the right place.
* Behavior change: bare `/home` now applies your landing preference — your primary site's Home for most accounts, or the dashboard/Reader if that's your setting — instead of the "select a site" picker.
* The e2e login helper follows the same path; no test expectations changed.

## Why are these changes being made?

* Logged-in requests to `wordpress.com/` will soon be served by WordPress (the homepage for eligible users, a dashboard redirect for everyone else). Every Calypso flow that leaned on `/` needs to name its real destination so people keep landing exactly where they do today.

## Testing Instructions

* The key property: none of these flows should pass through bare `/` anymore — each goes straight to its destination (watch the URL bar / network tab). That's also how to review this as if the logged-in homepage were already live: after the platform change `/` no longer reaches Calypso, so any flow still touching `/` is a bug.
  * Log in with no redirect → My Home on your primary site (or your chosen landing: Sites dashboard / Reader).
  * Visit `/home` with a multi-site account → your primary site's Home, not the site picker; `/home?verified=1` keeps its query.
  * Decline a pending invite → your normal landing.
  * Cancel on the account-closed screen → your normal landing.
  * Delete a (test!) site → your normal landing, or Sites if that's your preference.
  * Log out → login page.


