### PR TITLE
Omnibar: fix Fresh color scheme variables

### DIFF
--- a/client/layout/masterbar/omnibar.scss
+++ b/client/layout/masterbar/omnibar.scss
@@ -18,7 +18,12 @@ body:has( .omnibar:not( .is-support-session ) ) {
 		--color-masterbar-submenu-hover-text,
 		var( --color-masterbar-highlight )
 	);
+	--omnibar-icon-color: var( --color-masterbar-icon );
 	--omnibar-avatar-ring-color: var( --color-masterbar-border );
+	--omnibar-avatar-background: var(
+		--color-masterbar-avatar-background,
+		var( --color-masterbar-border )
+	);
 	--omnibar-secondary-group-background: var( --color-masterbar-submenu-group-background );
 }
 

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_fresh.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_fresh.scss
@@ -36,7 +36,7 @@
 	/* WP Admin Default Theme */
 	--theme-text-color: #f0f0f1; /* Direct from wp-admin */
 	--theme-base-color: #1d2327; /* Direct from wp-admin */
-	--theme-submenu-background-color: #131619; /* $menu-submenu-background */
+	--theme-submenu-background-color: #2c3338; /* $menu-submenu-background */
 	--theme-submenu-text-color: #c3c4c7; /* $menu-submenu-text */
 	--theme-icon-color: rgba(240, 246, 252, 0.6); /* $icon-color */
 	--theme-highlight-color: #72aee6; /* $highlight-color */
@@ -44,11 +44,13 @@
 
 	/* Masterbar */
 	--color-masterbar-background: var(--theme-base-color);
-	--color-masterbar-border: #8c8f94; /* $adminbar-avatar-frame */
+	--color-masterbar-border: #2c353b; /* $adminbar-avatar-frame */
+	--color-masterbar-avatar-background: #f0f0f1; /* Direct from wp-admin */
 	--color-masterbar-text: var(--theme-text-color);
 	--color-masterbar-submenu-text: var(--theme-submenu-text-color);
 	--color-masterbar-icon: var(--theme-icon-color);
 	--color-masterbar-highlight: var(--theme-highlight-color);
+	--color-masterbar-submenu-group-background: #3c434a; /* Direct from wp-admin */
 	--color-masterbar-unread-dot-background: var(--color-accent-20);
 
 	--color-masterbar-item-hover-background: #2c3338; /* $menu-submenu-background: darken( $base-color, 7% ) */
@@ -74,7 +76,7 @@
 	--color-sidebar-menu-hover-text: #00b9eb; /* theme-default */
 
 	/* Sidebar Submenu - Nav Unification */
-	--color-sidebar-submenu-background: #32373c; /* theme-default */
+	--color-sidebar-submenu-background: var(--theme-submenu-background-color);
 	--color-sidebar-submenu-text: #b4b9be;
 	--color-sidebar-submenu-hover-background: transparent; /* theme-default */
 	--color-sidebar-submenu-hover-text: var(--theme-highlight-color);

--- a/packages/omnibar/src/components/omnibar-user.scss
+++ b/packages/omnibar/src/components/omnibar-user.scss
@@ -32,7 +32,7 @@
 			display: block;
 			object-fit: cover;
 			border-radius: 50%;
-			background: var( --omnibar-avatar-ring-color );
+			background: var( --omnibar-avatar-background );
 		}
 	}
 
@@ -79,6 +79,10 @@
 			width: 64px;
 			height: 64px;
 			border: 0;
+
+			> * {
+				background: none;
+			}
 		}
 
 		[role='group']:has( .omnibar__user ) [role='menuitem'] {

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -11,7 +11,9 @@ body:has( .omnibar ) {
 	--omnibar-submenu-text-color: #{$omnibar-submenu-text-color};
 	--omnibar-highlight-color: #{$omnibar-highlight-color};
 	--omnibar-submenu-highlight-color: #{$omnibar-highlight-color};
+	--omnibar-icon-color: var( --omnibar-text-color );
 	--omnibar-avatar-ring-color: #{$omnibar-avatar-ring-color};
+	--omnibar-avatar-background: var( --omnibar-avatar-ring-color );
 	--omnibar-secondary-group-background: #{$omnibar-secondary-group-background};
 
 	@media ( min-width: 782px ) {
@@ -26,6 +28,7 @@ body:has( .omnibar ) {
 		align-items: center;
 		justify-content: center;
 		height: 20px;
+		color: var( --omnibar-icon-color );
 
 		&::before {
 			position: relative;
@@ -110,6 +113,7 @@ body:has( .omnibar ) {
 
 		svg {
 			display: block;
+			color: var( --omnibar-icon-color );
 			fill: currentColor;
 			width: 32px;
 			height: 32px;


### PR DESCRIPTION
## Proposed Changes

In this PR, we fix certain colors in the Fresh color scheme for the new omnibar: avatar ring, icon color, secondary background colors. We match the color with wp-admin's.