### PR TITLE
Omnibar: add flag-gated “Free domain” upsell chip

### DIFF
--- a/client/dashboard/app/free-domain-upsell/index.ts
+++ b/client/dashboard/app/free-domain-upsell/index.ts
@@ -8,32 +8,48 @@ export const FREE_DOMAIN_UPSELL_ID = 'omnibar-free-domain';
 
 export type FreeDomainUpsellSurface = 'msd' | 'calypso';
 
+export type FreeDomainUpsellSource = 'free_to_paid_plan' | 'monthly_to_annual_plan';
+
 /**
+ * Which sidebar JITM this site would qualify for, or null if not eligible.
+ *
  * Mirrors the conditions of the two sidebar JITMs this chip is tested against,
  * which share the "Free domain with an annual plan" message and CTA:
  * - `free_to_paid_plan`: Free plan, Simple, admin, not a domain-only site, no
- *   mapped domain.
+ *   mapped primary domain.
  * - `monthly_to_annual_plan`: any monthly plan, Simple, admin, no mapped
- *   domain.
- * A Simple site with a mapped domain keeps its custom-domain slug, so the
- * `.wordpress.com` check covers the mapped-domain rule — and keeps the "Free
- * domain" copy truthful.
+ *   primary domain.
+ * A Simple site with a mapped primary domain keeps its custom-domain slug, so
+ * the `.wordpress.com` check covers the mapped-domain rule — and keeps the
+ * "Free domain" copy truthful.
  */
-export function isFreeDomainUpsellEligible( site?: Site ): site is Site {
+export function getFreeDomainUpsellSource( site?: Site ): FreeDomainUpsellSource | null {
 	if ( ! isEnabled( 'dashboard/omnibar-free-domain-chip' ) || ! site ) {
-		return false;
+		return null;
 	}
 
-	const matchesFreeToPaid = !! site.plan?.is_free && ! site.options?.is_domain_only;
-	const matchesMonthlyToAnnual = site.plan?.billing_period === 'Monthly';
+	if (
+		! isSimple( site ) ||
+		site.is_wpcom_staging_site ||
+		! site.capabilities?.manage_options ||
+		! site.slug.endsWith( '.wordpress.com' )
+	) {
+		return null;
+	}
 
-	return (
-		( matchesFreeToPaid || matchesMonthlyToAnnual ) &&
-		isSimple( site ) &&
-		! site.is_wpcom_staging_site &&
-		!! site.capabilities?.manage_options &&
-		site.slug.endsWith( '.wordpress.com' )
-	);
+	if ( site.plan?.is_free && ! site.options?.is_domain_only ) {
+		return 'free_to_paid_plan';
+	}
+
+	if ( site.plan?.billing_period === 'Monthly' ) {
+		return 'monthly_to_annual_plan';
+	}
+
+	return null;
+}
+
+export function isFreeDomainUpsellEligible( site?: Site ): site is Site {
+	return getFreeDomainUpsellSource( site ) !== null;
 }
 
 export function getFreeDomainUpsellHref( site: Site ) {

--- a/client/dashboard/app/free-domain-upsell/index.ts
+++ b/client/dashboard/app/free-domain-upsell/index.ts
@@ -6,13 +6,33 @@ import type { Site } from '@automattic/api-core';
 
 export const FREE_DOMAIN_UPSELL_ID = 'omnibar-free-domain';
 
+export type FreeDomainUpsellSurface = 'msd' | 'calypso';
+
+/**
+ * Mirrors the conditions of the two sidebar JITMs this chip is tested against,
+ * which share the "Free domain with an annual plan" message and CTA:
+ * - `free_to_paid_plan`: Free plan, Simple, admin, not a domain-only site, no
+ *   mapped domain.
+ * - `monthly_to_annual_plan`: any monthly plan, Simple, admin, no mapped
+ *   domain.
+ * A Simple site with a mapped domain keeps its custom-domain slug, so the
+ * `.wordpress.com` check covers the mapped-domain rule — and keeps the "Free
+ * domain" copy truthful.
+ */
 export function isFreeDomainUpsellEligible( site?: Site ): site is Site {
+	if ( ! isEnabled( 'dashboard/omnibar-free-domain-chip' ) || ! site ) {
+		return false;
+	}
+
+	const matchesFreeToPaid = !! site.plan?.is_free && ! site.options?.is_domain_only;
+	const matchesMonthlyToAnnual = site.plan?.billing_period === 'Monthly';
+
 	return (
-		isEnabled( 'dashboard/omnibar-free-domain-chip' ) &&
-		!! site &&
-		!! site.plan?.is_free &&
+		( matchesFreeToPaid || matchesMonthlyToAnnual ) &&
 		isSimple( site ) &&
-		! site.is_wpcom_staging_site
+		! site.is_wpcom_staging_site &&
+		!! site.capabilities?.manage_options &&
+		site.slug.endsWith( '.wordpress.com' )
 	);
 }
 

--- a/client/dashboard/app/free-domain-upsell/index.ts
+++ b/client/dashboard/app/free-domain-upsell/index.ts
@@ -1,0 +1,21 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { addQueryArgs } from '@wordpress/url';
+import { wpcomLink } from '../../utils/link';
+import { isSimple } from '../../utils/site-types';
+import type { Site } from '@automattic/api-core';
+
+export const FREE_DOMAIN_UPSELL_ID = 'omnibar-free-domain';
+
+export function isFreeDomainUpsellEligible( site?: Site ): site is Site {
+	return (
+		isEnabled( 'dashboard/omnibar-free-domain-chip' ) &&
+		!! site &&
+		!! site.plan?.is_free &&
+		isSimple( site ) &&
+		! site.is_wpcom_staging_site
+	);
+}
+
+export function getFreeDomainUpsellHref( site: Site ) {
+	return wpcomLink( addQueryArgs( '/setup/domain-and-plan', { siteSlug: site.slug } ) );
+}

--- a/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
+++ b/client/dashboard/app/interim-omnibar/interim-omnibar.tsx
@@ -22,6 +22,7 @@ import { getSitePlanUrl } from '../../utils/site-url';
 import { logout } from '../auth';
 import { omnibarEvents, useOmnibarEvent } from '../omnibar/events';
 import { getUserLanguage } from '../shared-locale-loader';
+import { OmnibarFreeDomainChip } from './omnibar-free-domain-chip';
 import { OmnibarLaunchButton } from './omnibar-launch-button';
 import { createOmnibarStore } from './omnibar-store';
 import type { User, Site } from '@automattic/api-core';
@@ -174,6 +175,7 @@ export function InterimOmnibar( {
 					}
 					isUnlaunchedSite={ isUnlaunchedSite }
 					launchButton={ isUnlaunchedSite && site ? <OmnibarLaunchButton site={ site } /> : null }
+					freeDomainChip={ site ? <OmnibarFreeDomainChip site={ site } /> : null }
 					isTrial={ false }
 					isSiteP2={ !! site?.options?.is_wpforteams_site }
 					isP2Hub={ !! site?.options?.p2_hub_blog_id && site.options.p2_hub_blog_id === site.ID }

--- a/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.scss
+++ b/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.scss
@@ -22,11 +22,13 @@
 .masterbar__free-domain-chip-pill {
 	display: inline-flex;
 	align-items: center;
-	gap: 6px;
+	/* The upsell glyph carries ~3px of intrinsic whitespace at 16px, so the
+	   icon-side padding and gap are smaller to read as visually even. */
+	gap: 4px;
 	height: 24px;
-	padding: 0 10px;
-	/* stylelint-disable-next-line scales/radii -- pill radius is half its 24px height */
-	border-radius: 12px;
+	padding-block: 0;
+	padding-inline: 4px 8px;
+	border-radius: 4px;
 	background: var( --free-domain-chip-bg );
 	box-shadow: inset 0 0 0 1px var( --free-domain-chip-ring );
 	color: var( --free-domain-chip-text );

--- a/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.scss
+++ b/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.scss
@@ -1,0 +1,65 @@
+/* Quiet translucent pill: the bar is chrome, so the chip borrows the blue for
+   the icon and ring rather than filling solid like a page-level CTA would. */
+
+.masterbar__item.masterbar__item-free-domain-chip {
+	--free-domain-chip-bg: rgba( 56, 88, 233, 0.22 );
+	--free-domain-chip-bg-hover: rgba( 56, 88, 233, 0.42 );
+	--free-domain-chip-ring: rgba( 120, 150, 255, 0.45 );
+	--free-domain-chip-ring-hover: rgba( 150, 175, 255, 0.8 );
+	--free-domain-chip-text: #dcdcde;
+	--free-domain-chip-text-hover: var( --color-masterbar-text, #fff );
+	--free-domain-chip-icon: #8ba4ff;
+	--free-domain-chip-icon-hover: #b8c8ff;
+
+	padding: 0 8px;
+
+	&:hover,
+	&:focus {
+		background: transparent;
+	}
+}
+
+.masterbar__free-domain-chip-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	height: 24px;
+	padding: 0 10px;
+	/* stylelint-disable-next-line scales/radii -- pill radius is half its 24px height */
+	border-radius: 12px;
+	background: var( --free-domain-chip-bg );
+	box-shadow: inset 0 0 0 1px var( --free-domain-chip-ring );
+	color: var( --free-domain-chip-text );
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 24px;
+	white-space: nowrap;
+	transition: background 0.12s linear, box-shadow 0.12s linear, color 0.12s linear;
+
+	svg {
+		fill: var( --free-domain-chip-icon );
+		transition: fill 0.12s linear;
+	}
+}
+
+.masterbar__item-free-domain-chip:hover .masterbar__free-domain-chip-pill,
+.masterbar__item-free-domain-chip:focus-visible .masterbar__free-domain-chip-pill {
+	background: var( --free-domain-chip-bg-hover );
+	box-shadow: inset 0 0 0 1px var( --free-domain-chip-ring-hover );
+	color: var( --free-domain-chip-text-hover );
+}
+
+.masterbar__item-free-domain-chip:hover .masterbar__free-domain-chip-pill svg,
+.masterbar__item-free-domain-chip:focus-visible .masterbar__free-domain-chip-pill svg {
+	fill: var( --free-domain-chip-icon-hover );
+}
+
+/* The full pill stays at every width; --always-show-content opts it out of the
+   masterbar's 46px mobile item squeeze. It keeps its own metrics against the
+   mobile font-size bump. */
+@media only screen and (max-width: 781px) {
+	.masterbar__free-domain-chip-pill {
+		font-size: 12px;
+		line-height: 24px;
+	}
+}

--- a/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.tsx
@@ -15,18 +15,20 @@ import './omnibar-free-domain-chip.scss';
 
 export function OmnibarFreeDomainChip( { site }: { site: Site } ) {
 	const isEligible = isFreeDomainUpsellEligible( site );
+	const siteId = site.ID;
 
-	const hasRecordedImpression = useRef( false );
+	// One impression per site: switching sites in the same mount re-fires.
+	const impressionSiteIds = useRef( new Set< number >() );
 	useEffect( () => {
-		if ( ! isEligible || hasRecordedImpression.current ) {
+		if ( ! isEligible || impressionSiteIds.current.has( siteId ) ) {
 			return;
 		}
-		hasRecordedImpression.current = true;
+		impressionSiteIds.current.add( siteId );
 		recordTracksEvent( 'calypso_omnibar_upsell_impression', {
 			upsell_id: FREE_DOMAIN_UPSELL_ID,
-			surface: 'calypso',
+			surface: 'msd',
 		} );
-	}, [ isEligible ] );
+	}, [ isEligible, siteId ] );
 
 	if ( ! isEligible ) {
 		return null;
@@ -40,7 +42,7 @@ export function OmnibarFreeDomainChip( { site }: { site: Site } ) {
 				onClick={ () =>
 					recordTracksEvent( 'calypso_omnibar_upsell_click', {
 						upsell_id: FREE_DOMAIN_UPSELL_ID,
-						surface: 'calypso',
+						surface: 'msd',
 					} )
 				}
 			>

--- a/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.tsx
@@ -1,24 +1,20 @@
 /* eslint-disable no-restricted-imports */
-import { isEnabled } from '@automattic/calypso-config';
 import { Icon, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useRef } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains/get-domain-and-plan-upsell-url';
 import { upsell } from '../../components/icons';
-import { isSimple } from '../../utils/site-types';
+import {
+	FREE_DOMAIN_UPSELL_ID,
+	getFreeDomainUpsellHref,
+	isFreeDomainUpsellEligible,
+} from '../free-domain-upsell';
 import type { Site } from '@automattic/api-core';
 
 import './omnibar-free-domain-chip.scss';
 
-const UPSELL_ID = 'omnibar-free-domain';
-
 export function OmnibarFreeDomainChip( { site }: { site: Site } ) {
-	const isEligible =
-		isEnabled( 'dashboard/omnibar-free-domain-chip' ) &&
-		!! site.plan?.is_free &&
-		isSimple( site ) &&
-		! site.is_wpcom_staging_site;
+	const isEligible = isFreeDomainUpsellEligible( site );
 
 	const hasRecordedImpression = useRef( false );
 	useEffect( () => {
@@ -26,7 +22,10 @@ export function OmnibarFreeDomainChip( { site }: { site: Site } ) {
 			return;
 		}
 		hasRecordedImpression.current = true;
-		recordTracksEvent( 'calypso_omnibar_upsell_impression', { upsell_id: UPSELL_ID } );
+		recordTracksEvent( 'calypso_omnibar_upsell_impression', {
+			upsell_id: FREE_DOMAIN_UPSELL_ID,
+			surface: 'calypso',
+		} );
 	}, [ isEligible ] );
 
 	if ( ! isEligible ) {
@@ -37,9 +36,12 @@ export function OmnibarFreeDomainChip( { site }: { site: Site } ) {
 		<Tooltip text={ __( 'Free domain with an annual plan' ) } placement="bottom">
 			<a
 				className="masterbar__item masterbar__item--always-show-content masterbar__item-free-domain-chip"
-				href={ getDomainAndPlanUpsellUrl( { siteSlug: site.slug } ) }
+				href={ getFreeDomainUpsellHref( site ) }
 				onClick={ () =>
-					recordTracksEvent( 'calypso_omnibar_upsell_click', { upsell_id: UPSELL_ID } )
+					recordTracksEvent( 'calypso_omnibar_upsell_click', {
+						upsell_id: FREE_DOMAIN_UPSELL_ID,
+						surface: 'calypso',
+					} )
 				}
 			>
 				<span className="masterbar__free-domain-chip-pill">

--- a/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.tsx
@@ -7,30 +7,31 @@ import { upsell } from '../../components/icons';
 import {
 	FREE_DOMAIN_UPSELL_ID,
 	getFreeDomainUpsellHref,
-	isFreeDomainUpsellEligible,
+	getFreeDomainUpsellSource,
 } from '../free-domain-upsell';
 import type { Site } from '@automattic/api-core';
 
 import './omnibar-free-domain-chip.scss';
 
 export function OmnibarFreeDomainChip( { site }: { site: Site } ) {
-	const isEligible = isFreeDomainUpsellEligible( site );
+	const upsellSource = getFreeDomainUpsellSource( site );
 	const siteId = site.ID;
 
 	// One impression per site: switching sites in the same mount re-fires.
 	const impressionSiteIds = useRef( new Set< number >() );
 	useEffect( () => {
-		if ( ! isEligible || impressionSiteIds.current.has( siteId ) ) {
+		if ( ! upsellSource || impressionSiteIds.current.has( siteId ) ) {
 			return;
 		}
 		impressionSiteIds.current.add( siteId );
 		recordTracksEvent( 'calypso_omnibar_upsell_impression', {
 			upsell_id: FREE_DOMAIN_UPSELL_ID,
 			surface: 'msd',
+			upsell_source: upsellSource,
 		} );
-	}, [ isEligible, siteId ] );
+	}, [ upsellSource, siteId ] );
 
-	if ( ! isEligible ) {
+	if ( ! upsellSource ) {
 		return null;
 	}
 
@@ -43,6 +44,7 @@ export function OmnibarFreeDomainChip( { site }: { site: Site } ) {
 					recordTracksEvent( 'calypso_omnibar_upsell_click', {
 						upsell_id: FREE_DOMAIN_UPSELL_ID,
 						surface: 'msd',
+						upsell_source: upsellSource,
 					} )
 				}
 			>

--- a/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.tsx
@@ -1,0 +1,52 @@
+/* eslint-disable no-restricted-imports */
+import { isEnabled } from '@automattic/calypso-config';
+import { Icon, Tooltip } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useRef } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getDomainAndPlanUpsellUrl } from 'calypso/lib/domains/get-domain-and-plan-upsell-url';
+import { upsell } from '../../components/icons';
+import { isSimple } from '../../utils/site-types';
+import type { Site } from '@automattic/api-core';
+
+import './omnibar-free-domain-chip.scss';
+
+const UPSELL_ID = 'omnibar-free-domain';
+
+export function OmnibarFreeDomainChip( { site }: { site: Site } ) {
+	const isEligible =
+		isEnabled( 'dashboard/omnibar-free-domain-chip' ) &&
+		!! site.plan?.is_free &&
+		isSimple( site ) &&
+		! site.is_wpcom_staging_site;
+
+	const hasRecordedImpression = useRef( false );
+	useEffect( () => {
+		if ( ! isEligible || hasRecordedImpression.current ) {
+			return;
+		}
+		hasRecordedImpression.current = true;
+		recordTracksEvent( 'calypso_omnibar_upsell_impression', { upsell_id: UPSELL_ID } );
+	}, [ isEligible ] );
+
+	if ( ! isEligible ) {
+		return null;
+	}
+
+	return (
+		<Tooltip text={ __( 'Free domain with an annual plan' ) } placement="bottom">
+			<a
+				className="masterbar__item masterbar__item--always-show-content masterbar__item-free-domain-chip"
+				href={ getDomainAndPlanUpsellUrl( { siteSlug: site.slug } ) }
+				onClick={ () =>
+					recordTracksEvent( 'calypso_omnibar_upsell_click', { upsell_id: UPSELL_ID } )
+				}
+			>
+				<span className="masterbar__free-domain-chip-pill">
+					<Icon icon={ upsell } size={ 16 } />
+					{ __( 'Free domain' ) }
+				</span>
+			</a>
+		</Tooltip>
+	);
+}

--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -17,6 +17,7 @@ import { omnibarEvents } from './events';
 import { OmnibarHomeIcon } from './home';
 import { useAiChatPlugin } from './plugin-ai-chat';
 import { addDashboardNode, useDashboardPlugin } from './plugin-dashboard';
+import { useFreeDomainPlugin } from './plugin-free-domain';
 import { useHelpCenterPlugin } from './plugin-help-center';
 import { useLanguageSwitcherPlugin } from './plugin-language-switcher';
 import { useLaunchSitePlugin } from './plugin-launch-site';
@@ -171,12 +172,14 @@ function ConnectedOmnibar( {
 	const { node: shoppingCartNode, panel: shoppingCartPanel } = useShoppingCartPlugin( { site } );
 	const statsSparklineNode = useStatsSparklinePlugin( { site } );
 	const launchSiteNode = useLaunchSitePlugin( { site } );
+	const freeDomainNode = useFreeDomainPlugin( { site } );
 	const dashboardNode = useDashboardPlugin( { site, sectionGroup } );
 	const siteNode = addDashboardNode( baseOmnibarNodes.site, dashboardNode );
 	const siteActions = [
 		...( baseOmnibarNodes.siteActions ?? [] ),
 		statsSparklineNode,
 		launchSiteNode,
+		freeDomainNode,
 	].filter( ( node ) => node !== undefined );
 
 	const plugins = baseOmnibarNodes.user

--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -30,6 +30,7 @@ import { useStatsSparklinePlugin } from './plugin-stats-sparkline';
 import { buildWpcomAccountNode } from './plugin-wpcom-account';
 import { RESPONSIVE_MENU_NODE_ID, trackOmnibarNodes, useRecordOmnibarNodeClick } from './tracking';
 import type { AppConfig } from '../context';
+import type { FreeDomainUpsellSurface } from '../free-domain-upsell';
 import type { User } from '@automattic/api-core';
 import type { OmnibarNodeBuilders } from '@automattic/omnibar';
 import type { ShoppingCartManagerClient } from '@automattic/shopping-cart';
@@ -68,15 +69,23 @@ export default function OmnibarContainer( {
 	cartManagerClient,
 	sectionGroup,
 	sectionName,
+	surface = 'msd',
 }: {
 	user?: User;
 	cartManagerClient: ShoppingCartManagerClient;
 	sectionGroup?: string;
 	sectionName?: string;
+	/** Which app hosts this omnibar; used for per-surface tracking props. */
+	surface?: FreeDomainUpsellSurface;
 } ) {
 	return (
 		<ShoppingCartProvider managerClient={ cartManagerClient }>
-			<ConnectedOmnibar user={ user } sectionGroup={ sectionGroup } sectionName={ sectionName } />
+			<ConnectedOmnibar
+				user={ user }
+				sectionGroup={ sectionGroup }
+				sectionName={ sectionName }
+				surface={ surface }
+			/>
 		</ShoppingCartProvider>
 	);
 }
@@ -85,10 +94,12 @@ function ConnectedOmnibar( {
 	user,
 	sectionGroup,
 	sectionName,
+	surface,
 }: {
 	user?: User;
 	sectionGroup?: string;
 	sectionName?: string;
+	surface: FreeDomainUpsellSurface;
 } ) {
 	const { supports } = useAppContext();
 	const recordNodeClick = useRecordOmnibarNodeClick();
@@ -172,7 +183,7 @@ function ConnectedOmnibar( {
 	const { node: shoppingCartNode, panel: shoppingCartPanel } = useShoppingCartPlugin( { site } );
 	const statsSparklineNode = useStatsSparklinePlugin( { site } );
 	const launchSiteNode = useLaunchSitePlugin( { site } );
-	const freeDomainNode = useFreeDomainPlugin( { site } );
+	const freeDomainNode = useFreeDomainPlugin( { site, surface } );
 	const dashboardNode = useDashboardPlugin( { site, sectionGroup } );
 	const siteNode = addDashboardNode( baseOmnibarNodes.site, dashboardNode );
 	const siteActions = [

--- a/client/dashboard/app/omnibar/plugin-free-domain.scss
+++ b/client/dashboard/app/omnibar/plugin-free-domain.scss
@@ -1,0 +1,75 @@
+/* Quiet translucent pill: the bar is chrome, so the chip borrows the admin
+   theme blue for the fill and the omnibar highlight for the ring/icon rather
+   than filling solid like a page-level CTA would. */
+
+.omnibar .omnibar__menu.omnibar__free-domain {
+	--free-domain-chip-accent: var( --wp-admin-theme-color, #3858e9 );
+	--free-domain-chip-bg: color-mix( in srgb, var( --free-domain-chip-accent ) 22%, transparent );
+	--free-domain-chip-bg-hover: color-mix(
+		in srgb,
+		var( --free-domain-chip-accent ) 42%,
+		transparent
+	);
+	--free-domain-chip-ring: color-mix( in srgb, var( --omnibar-highlight-color ) 45%, transparent );
+	--free-domain-chip-ring-hover: color-mix(
+		in srgb,
+		var( --omnibar-highlight-color ) 80%,
+		transparent
+	);
+	--free-domain-chip-text: color-mix( in srgb, var( --omnibar-text-color ) 87%, transparent );
+	--free-domain-chip-text-hover: var( --omnibar-text-color );
+	--free-domain-chip-icon: var( --omnibar-highlight-color );
+	--free-domain-chip-icon-hover: color-mix(
+		in srgb,
+		var( --omnibar-highlight-color ) 70%,
+		var( --omnibar-text-color )
+	);
+
+	padding-inline: 8px;
+
+	&:hover,
+	&:focus-visible,
+	&:active {
+		background-color: transparent;
+	}
+}
+
+.omnibar .omnibar__menu.omnibar__free-domain .omnibar__free-domain-chip {
+	display: inline-flex;
+	align-items: center;
+	/* The upsell glyph carries ~3px of intrinsic whitespace at 16px, so the
+	   icon-side padding and gap are smaller to read as visually even. */
+	gap: 4px;
+	height: 24px;
+	padding-block: 0;
+	padding-inline: 4px 8px;
+	border-radius: 4px;
+	background: var( --free-domain-chip-bg );
+	box-shadow: inset 0 0 0 1px var( --free-domain-chip-ring );
+	color: var( --free-domain-chip-text );
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 24px;
+	white-space: nowrap;
+	transition: background 0.12s linear, box-shadow 0.12s linear, color 0.12s linear;
+
+	svg {
+		width: 16px;
+		height: 16px;
+		fill: var( --free-domain-chip-icon );
+		color: var( --free-domain-chip-icon );
+		transition: fill 0.12s linear;
+	}
+}
+
+.omnibar .omnibar__menu.omnibar__free-domain:hover .omnibar__free-domain-chip,
+.omnibar .omnibar__menu.omnibar__free-domain:focus-visible .omnibar__free-domain-chip {
+	background: var( --free-domain-chip-bg-hover );
+	box-shadow: inset 0 0 0 1px var( --free-domain-chip-ring-hover );
+	color: var( --free-domain-chip-text-hover );
+
+	svg {
+		fill: var( --free-domain-chip-icon-hover );
+		color: var( --free-domain-chip-icon-hover );
+	}
+}

--- a/client/dashboard/app/omnibar/plugin-free-domain.tsx
+++ b/client/dashboard/app/omnibar/plugin-free-domain.tsx
@@ -8,26 +8,35 @@ import {
 	getFreeDomainUpsellHref,
 	isFreeDomainUpsellEligible,
 } from '../free-domain-upsell';
+import type { FreeDomainUpsellSurface } from '../free-domain-upsell';
 import type { Site } from '@automattic/api-core';
 import type { OmnibarNode } from '@automattic/omnibar';
 
 import './plugin-free-domain.scss';
 
-export function useFreeDomainPlugin( { site }: { site?: Site } ): OmnibarNode | undefined {
+export function useFreeDomainPlugin( {
+	site,
+	surface,
+}: {
+	site?: Site;
+	surface: FreeDomainUpsellSurface;
+} ): OmnibarNode | undefined {
 	const { recordTracksEvent } = useAnalytics();
 	const isEligible = isFreeDomainUpsellEligible( site );
+	const siteId = site?.ID;
 
-	const hasRecordedImpression = useRef( false );
+	// One impression per site: switching sites in the same mount re-fires.
+	const impressionSiteIds = useRef( new Set< number >() );
 	useEffect( () => {
-		if ( ! isEligible || hasRecordedImpression.current ) {
+		if ( ! isEligible || ! siteId || impressionSiteIds.current.has( siteId ) ) {
 			return;
 		}
-		hasRecordedImpression.current = true;
+		impressionSiteIds.current.add( siteId );
 		recordTracksEvent( 'calypso_omnibar_upsell_impression', {
 			upsell_id: FREE_DOMAIN_UPSELL_ID,
-			surface: 'calypso',
+			surface,
 		} );
-	}, [ isEligible, recordTracksEvent ] );
+	}, [ isEligible, siteId, surface, recordTracksEvent ] );
 
 	if ( ! isEligible ) {
 		return undefined;
@@ -41,7 +50,7 @@ export function useFreeDomainPlugin( { site }: { site?: Site } ): OmnibarNode | 
 		onClick: () =>
 			recordTracksEvent( 'calypso_omnibar_upsell_click', {
 				upsell_id: FREE_DOMAIN_UPSELL_ID,
-				surface: 'calypso',
+				surface,
 			} ),
 		render: () => (
 			<span className="omnibar__free-domain-chip">

--- a/client/dashboard/app/omnibar/plugin-free-domain.tsx
+++ b/client/dashboard/app/omnibar/plugin-free-domain.tsx
@@ -6,7 +6,7 @@ import { useAnalytics } from '../analytics';
 import {
 	FREE_DOMAIN_UPSELL_ID,
 	getFreeDomainUpsellHref,
-	isFreeDomainUpsellEligible,
+	getFreeDomainUpsellSource,
 } from '../free-domain-upsell';
 import type { FreeDomainUpsellSurface } from '../free-domain-upsell';
 import type { Site } from '@automattic/api-core';
@@ -22,23 +22,24 @@ export function useFreeDomainPlugin( {
 	surface: FreeDomainUpsellSurface;
 } ): OmnibarNode | undefined {
 	const { recordTracksEvent } = useAnalytics();
-	const isEligible = isFreeDomainUpsellEligible( site );
+	const upsellSource = getFreeDomainUpsellSource( site );
 	const siteId = site?.ID;
 
 	// One impression per site: switching sites in the same mount re-fires.
 	const impressionSiteIds = useRef( new Set< number >() );
 	useEffect( () => {
-		if ( ! isEligible || ! siteId || impressionSiteIds.current.has( siteId ) ) {
+		if ( ! upsellSource || ! siteId || impressionSiteIds.current.has( siteId ) ) {
 			return;
 		}
 		impressionSiteIds.current.add( siteId );
 		recordTracksEvent( 'calypso_omnibar_upsell_impression', {
 			upsell_id: FREE_DOMAIN_UPSELL_ID,
 			surface,
+			upsell_source: upsellSource,
 		} );
-	}, [ isEligible, siteId, surface, recordTracksEvent ] );
+	}, [ upsellSource, siteId, surface, recordTracksEvent ] );
 
-	if ( ! isEligible ) {
+	if ( ! site || ! upsellSource ) {
 		return undefined;
 	}
 
@@ -51,6 +52,7 @@ export function useFreeDomainPlugin( {
 			recordTracksEvent( 'calypso_omnibar_upsell_click', {
 				upsell_id: FREE_DOMAIN_UPSELL_ID,
 				surface,
+				upsell_source: upsellSource,
 			} ),
 		render: () => (
 			<span className="omnibar__free-domain-chip">

--- a/client/dashboard/app/omnibar/plugin-free-domain.tsx
+++ b/client/dashboard/app/omnibar/plugin-free-domain.tsx
@@ -1,0 +1,53 @@
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useRef } from 'react';
+import { upsell } from '../../components/icons';
+import { useAnalytics } from '../analytics';
+import {
+	FREE_DOMAIN_UPSELL_ID,
+	getFreeDomainUpsellHref,
+	isFreeDomainUpsellEligible,
+} from '../free-domain-upsell';
+import type { Site } from '@automattic/api-core';
+import type { OmnibarNode } from '@automattic/omnibar';
+
+import './plugin-free-domain.scss';
+
+export function useFreeDomainPlugin( { site }: { site?: Site } ): OmnibarNode | undefined {
+	const { recordTracksEvent } = useAnalytics();
+	const isEligible = isFreeDomainUpsellEligible( site );
+
+	const hasRecordedImpression = useRef( false );
+	useEffect( () => {
+		if ( ! isEligible || hasRecordedImpression.current ) {
+			return;
+		}
+		hasRecordedImpression.current = true;
+		recordTracksEvent( 'calypso_omnibar_upsell_impression', {
+			upsell_id: FREE_DOMAIN_UPSELL_ID,
+			surface: 'calypso',
+		} );
+	}, [ isEligible, recordTracksEvent ] );
+
+	if ( ! isEligible ) {
+		return undefined;
+	}
+
+	return {
+		id: 'free-domain',
+		href: getFreeDomainUpsellHref( site ),
+		label: __( 'Free domain with an annual plan' ),
+		className: 'omnibar__free-domain',
+		onClick: () =>
+			recordTracksEvent( 'calypso_omnibar_upsell_click', {
+				upsell_id: FREE_DOMAIN_UPSELL_ID,
+				surface: 'calypso',
+			} ),
+		render: () => (
+			<span className="omnibar__free-domain-chip">
+				<Icon icon={ upsell } size={ 16 } />
+				{ __( 'Free domain' ) }
+			</span>
+		),
+	};
+}

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -115,6 +115,7 @@ class MasterbarLoggedIn extends Component {
 		statsSparkline: PropTypes.node,
 		useUnifiedAgent: PropTypes.bool,
 		launchButton: PropTypes.node,
+		freeDomainChip: PropTypes.node,
 		sitePlanUrl: PropTypes.string,
 		commandPalette: PropTypes.bool,
 	};
@@ -1027,6 +1028,7 @@ class MasterbarLoggedIn extends Component {
 					{ this.renderSidebarMobileMenu() }
 					{ this.renderMySites() }
 					{ this.renderSiteMenu() }
+					{ this.props.freeDomainChip }
 					{ this.props.commandPalette && this.renderCommandPalette() }
 					{ this.renderUpdatesMenu() }
 					{ this.renderCommentsMenu() }

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -1028,7 +1028,6 @@ class MasterbarLoggedIn extends Component {
 					{ this.renderSidebarMobileMenu() }
 					{ this.renderMySites() }
 					{ this.renderSiteMenu() }
-					{ this.props.freeDomainChip }
 					{ this.props.commandPalette && this.renderCommandPalette() }
 					{ this.renderUpdatesMenu() }
 					{ this.renderCommentsMenu() }
@@ -1036,6 +1035,7 @@ class MasterbarLoggedIn extends Component {
 					{ this.renderStatsSparkline() }
 					{ this.renderLanguageSwitcher() }
 					{ this.renderLaunchButton() }
+					{ this.props.freeDomainChip }
 				</div>
 				<div className="masterbar__section masterbar__section--right">
 					{ this.renderCart() }

--- a/client/layout/masterbar/omnibar.tsx
+++ b/client/layout/masterbar/omnibar.tsx
@@ -92,6 +92,7 @@ export default function Omnibar( {
 							cartManagerClient={ cartManagerClient }
 							sectionGroup={ sectionGroup }
 							sectionName={ sectionName ?? undefined }
+							surface="calypso"
 						/>
 					</div>
 				</AnalyticsProvider>

--- a/config/dashboard-development.json
+++ b/config/dashboard-development.json
@@ -33,6 +33,7 @@
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": true,
+		"dashboard/omnibar-free-domain-chip": true,
 		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -28,6 +28,7 @@
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": true,
+		"dashboard/omnibar-free-domain-chip": false,
 		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -35,6 +35,7 @@
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": false,
 		"dashboard/enable-percentage-rollout": true,
+		"dashboard/omnibar-free-domain-chip": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -33,6 +33,7 @@
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": true,
+		"dashboard/omnibar-free-domain-chip": false,
 		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/simulate-full-rollout": true,

--- a/config/development.json
+++ b/config/development.json
@@ -74,6 +74,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": true,
+		"dashboard/omnibar-free-domain-chip": true,
 		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -34,6 +34,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
+		"dashboard/omnibar-free-domain-chip": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,
 		"dashboard/rollout-advance-notice": true,

--- a/config/production.json
+++ b/config/production.json
@@ -46,6 +46,7 @@
 		"current-site/notice": true,
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
+		"dashboard/omnibar-free-domain-chip": false,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -44,6 +44,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
+		"dashboard/omnibar-free-domain-chip": false,
 		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": true,

--- a/config/test.json
+++ b/config/test.json
@@ -40,6 +40,7 @@
 		"current-site/notice": true,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
+		"dashboard/omnibar-free-domain-chip": false,
 		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -43,6 +43,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
+		"dashboard/omnibar-free-domain-chip": false,
 		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,


### PR DESCRIPTION
Part of DOTMSD-1529.

## Proposed Changes

* Add an `OmnibarFreeDomainChip` slot component to the interim omnibar: a quiet rounded-rectangle chip (4px radius) labeled “Free domain” with the dashboard’s `upsell` diamond icon and a `Tooltip` (“Free domain with an annual plan”), linking into the domain-and-plan flow via `getDomainAndPlanUpsellUrl()`. Inner spacing uses DS-scale values: 4px padding on the icon side, 8px on the text side, with a 4px gap that balances the diamond glyph’s intrinsic whitespace so the chip reads visually even.
* The chip renders only when the new `dashboard/omnibar-free-domain-chip` feature flag is enabled and the current site is on a Free plan, Simple, and not a staging site. Otherwise it renders nothing.
* Add a `freeDomainChip` slot prop to `MasterbarLoggedIn`, rendered at the end of the left section, right after the launch button — same slot pattern as the existing `launchButton`, and the omnibar’s original order stays untouched. Calypso proper does not pass the prop, so nothing changes outside the Multi-site Dashboard.
* Tracks: `calypso_omnibar_upsell_impression` on first render and `calypso_omnibar_upsell_click` on click, both with `upsell_id: 'omnibar-free-domain'`.
* The full chip stays visible at every viewport width (`masterbar__item--always-show-content` opts it out of the masterbar’s 46px mobile item squeeze).
* The flag is added to all config files, enabled only in `development` and `dashboard-development`.
* **Update:** the chip now also ships on the new omnibar (`dashboard/omnibar-radical`) as a hook plugin, `client/dashboard/app/omnibar/plugin-free-domain.tsx`, rendered at the end of the left group after the launch site button — so the chip survives the InterimOmnibar deprecation and shows on every surface the new omnibar covers (MSD and Calypso). Shared eligibility, upsell id, and href builder moved to `client/dashboard/app/free-domain-upsell`, consumed by both chips. The plugin uses the omnibar CSS tokens (`--omnibar-*`, `--wp-admin-theme-color`) via `color-mix()`, `label` for the accessible name instead of a `Tooltip`, and `useAnalytics()` for Tracks with a `surface` prop on both events.
* **Update (review round):** eligibility now mirrors the two sidebar JITMs the chip replaces, which share the same copy and CTA — `free_to_paid_plan` (Free plan, not domain-only) and `monthly_to_annual_plan` (any monthly plan) — both requiring Simple, admin, and no mapped primary domain (`.wordpress.com` slug check). The tracking `surface` prop now reports the hosting app (`msd` or `calypso`, passed from the omnibar mount point), and impressions fire once per site instead of once per mount.
* **Update:** the chip href now routes through `wpcomLink()`, fixing the previous relative `/setup/domain-and-plan` link that resolved to the wrong origin on `my.wordpress.com`.
* **Update:** both chips now attach an `upsell_source` prop (`free_to_paid_plan` or `monthly_to_annual_plan`, from the new `getFreeDomainUpsellSource()`) to impression and click events, so the Free and monthly cohorts can be analyzed separately — Free volume would otherwise drown a monthly signal.

## Why are these changes being made?

* This is the UI groundwork for the DOTMSD-1529 AB test: moving the “Free domain with an annual plan” upsell from the wp-admin sidebar banner to a persistent omnibar chip. The test covers the two sidebar JITMs that share this copy and CTA: `free_to_paid_plan` (Free sites, ~73% of sidebar upsell revenue) and `monthly_to_annual_plan` (monthly-plan sites).
* UI-only by design: eligibility is computed from the site object already available in the omnibar (no new queries). Wiring the ExPlat experiment assignment is a follow-up (#113823), so this can be reviewed as a small, self-contained change that ships dark.

## Testing Instructions

* `yarn start-dashboard` (the flag is on by default in development configs).
* Select a site on a Free plan (Simple, not staging, no mapped primary domain). The “Free domain” chip appears at the end of the omnibar’s left group, after the launch button when one is shown.
* Select a Simple site on a monthly plan (e.g. Personal monthly): the chip also appears.
* Hover the chip: tooltip “Free domain with an annual plan”; the chip brightens.
* Click: navigates to `/setup/domain-and-plan?siteSlug=…`.
* Narrow the viewport below 782px: the full chip stays visible and vertically centered in the 46px bar.
* Select a yearly-paid, Atomic, or staging site, a site with a mapped primary domain (non-`.wordpress.com` slug), or a site where you are not an admin: no chip. Disable the flag: no chip.
* Verify no console errors and that SSR hydration is clean (the chip mounts post-hydration because the server renders with `site: null`, same as the command palette).

Screenshots to follow.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)



