### PR TITLE
Reader onboarding discover modal - fix scrolling

### DIFF
--- a/client/reader/onboarding-rsm/subscribe-modal/index.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/index.tsx
@@ -284,19 +284,23 @@ const SubscribeModal: React.FC< SubscribeModalProps > = ( { promptVerification, 
 												}
 											/>
 										</div>
-										<div
-											className="subscribe-modal__preview-stream-container"
-											// `inert` removes preview stream from tab order + a11y tree (preview is non-interactive).
-											inert
-										>
-											<TypedStream
-												streamKey={ `feed:${ selectedSite.feed_ID }` }
-												className="is-site-stream subscribe-modal__preview-stream no-padding"
-												followSource="reader_subscribe_modal"
-												useCompactCards
-												showBylineSecondarySiteLink={ false }
-												trackScrollPage={ trackScrollPage.bind( null ) }
-											/>
+										<div className="subscribe-modal__preview-stream-container">
+											{ /* `inert` removes the preview stream from tab order + the a11y
+											     tree (preview is non-interactive). It lives on this inner
+											     wrapper — NOT the scroll container — because an inert element
+											     hit-tests as `pointer-events: none`, which would make wheel/
+											     touch scrolls fall through the scroll container to its
+											     `overflow: hidden` parent and stop the column scrolling. */ }
+											<div className="subscribe-modal__preview-stream-inner" inert>
+												<TypedStream
+													streamKey={ `feed:${ selectedSite.feed_ID }` }
+													className="is-site-stream subscribe-modal__preview-stream no-padding"
+													followSource="reader_subscribe_modal"
+													useCompactCards
+													showBylineSecondarySiteLink={ false }
+													trackScrollPage={ trackScrollPage.bind( null ) }
+												/>
+											</div>
 										</div>
 									</>
 								) }

--- a/client/reader/onboarding-rsm/subscribe-modal/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/test/index.test.tsx
@@ -263,6 +263,33 @@ describe( 'SubscribeModal – site preview analytics', () => {
 		);
 	} );
 
+	it( 'places `inert` on the preview stream wrapper, not the scroll container', () => {
+		const recommendations = [ makeRecommendation( 0 ) ];
+		mockedRecommendationsHook.mockReturnValue( {
+			...defaultRecommendationsHookValue,
+			combinedRecommendations: recommendations,
+			recommendations,
+		} );
+
+		const { container } = renderWithProvider(
+			<SubscribeModal onFinish={ jest.fn() } promptVerification={ false } />
+		);
+
+		const scrollContainer = container.querySelector( '.subscribe-modal__preview-stream-container' );
+		const inertWrapper = container.querySelector( '.subscribe-modal__preview-stream-inner' );
+
+		// The scroll container must NOT be inert: an inert element hit-tests as
+		// `pointer-events: none`, so wheel/touch scrolls fall through it to its
+		// `overflow: hidden` parent and the preview column stops scrolling. (This
+		// regressed once React 19 began emitting the `inert` attribute for real —
+		// under React 18 the boolean prop was silently dropped.)
+		expect( scrollContainer ).not.toBeNull();
+		expect( scrollContainer ).not.toHaveAttribute( 'inert' );
+		// `inert` still removes the non-interactive preview content from the tab
+		// order + a11y tree — just one level in, on the wrapper around the stream.
+		expect( inertWrapper ).toHaveAttribute( 'inert' );
+	} );
+
 	it( 'prefetches recommendation streams through the React Query stream cache', () => {
 		const recommendations = [ makeRecommendation( 0 ), makeRecommendation( 1 ) ];
 		mockedRecommendationsHook.mockReturnValue( {

--- a/client/reader/onboarding-rsm/subscribe-modal/test/index.test.tsx
+++ b/client/reader/onboarding-rsm/subscribe-modal/test/index.test.tsx
@@ -275,8 +275,12 @@ describe( 'SubscribeModal – site preview analytics', () => {
 			<SubscribeModal onFinish={ jest.fn() } promptVerification={ false } />
 		);
 
-		const scrollContainer = container.querySelector( '.subscribe-modal__preview-stream-container' );
-		const inertWrapper = container.querySelector( '.subscribe-modal__preview-stream-inner' );
+		const scrollContainer = container.querySelector< HTMLElement >(
+			'.subscribe-modal__preview-stream-container'
+		);
+		const inertWrapper = container.querySelector< HTMLElement >(
+			'.subscribe-modal__preview-stream-inner'
+		);
 
 		// The scroll container must NOT be inert: an inert element hit-tests as
 		// `pointer-events: none`, so wheel/touch scrolls fall through it to its
@@ -284,6 +288,7 @@ describe( 'SubscribeModal – site preview analytics', () => {
 		// regressed once React 19 began emitting the `inert` attribute for real —
 		// under React 18 the boolean prop was silently dropped.)
 		expect( scrollContainer ).not.toBeNull();
+		expect( inertWrapper ).not.toBeNull();
 		expect( scrollContainer ).not.toHaveAttribute( 'inert' );
 		// `inert` still removes the non-interactive preview content from the tab
 		// order + a11y tree — just one level in, on the wrapper around the stream.


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes # a bug i noticed

## Proposed Changes

fixes scrolling on the feed preview of reader onboarding discover step.

* Moved inert onto an inner wrapper (.subscribe-modal__preview-stream-inner) around the stream. This preserves the original intent — the non‑interactive preview stays out of the tab order and a11y tree — while restoring normal scrolling on the container.
* Added a regression test asserting inert lives on the inner wrapper and not on the scroll container. 

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* react 19 upgrade caused this to break the scrolling on the container

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/reader?flags=reader/force-onboarding`
* open the last step, discover step
* verify you can scroll the feed preview container.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
