### PR TITLE
Stop sending canvas=edit on the blueprint hand-off

### DIFF
--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -294,14 +294,15 @@ export function getSiteEditorUrl(
 	// the editor URL, so a site that has already been personalized has to see it
 	// and do nothing. `reset` is the way to run it again.
 	//
-	// `canvas=edit` is required — Big Sky only mounts on the editing canvas, and
-	// the Site Editor opens in view mode.
+	// Deliberately no `canvas=edit`. Sending it made the Site Editor open its
+	// "Edit your site" welcome guide over the page and left a run of failed
+	// entity requests behind it; the same URL without it lands correctly and the
+	// personalization runs. The editor reaches its editing canvas on its own from
+	// here, so the parameter bought nothing and cost that.
 	//
 	// Only set when the spec applied; there is nothing to personalize from
 	// otherwise.
-	return startWalkthrough
-		? addQueryArgs( url, { canvas: 'edit', 'blueprint-walkthrough': 'go' } )
-		: url;
+	return startWalkthrough ? addQueryArgs( url, { 'blueprint-walkthrough': 'go' } ) : url;
 }
 
 export function logBlueprintArchiveEvent(

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -99,19 +99,19 @@ describe( 'getSiteEditorUrl', () => {
 	 */
 	it( 'flags the walkthrough when the spec was applied', () => {
 		expect( getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } ) ).toBe(
-			'https://example.com/wp-admin/site-editor.php?canvas=edit&blueprint-walkthrough=go'
+			'https://example.com/wp-admin/site-editor.php?blueprint-walkthrough=go'
 		);
 	} );
 
 	/**
-	 * Big Sky only mounts on the editing canvas, so a walkthrough hand-off that
-	 * lands in the Site Editor's default view mode is inert — the flag arrives
-	 * but nothing is listening for it.
+	 * `canvas=edit` used to ride along here. It made the Site Editor open its
+	 * welcome guide over the page on arrival, which is the first thing a customer
+	 * would have had to dismiss; the editor gets to its editing canvas without it.
 	 */
-	it( 'opens the editing canvas alongside the walkthrough flag', () => {
+	it( 'does not force the editing canvas', () => {
 		expect(
 			getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } )
-		).toContain( 'canvas=edit' );
+		).not.toContain( 'canvas=edit' );
 	} );
 
 	it( 'leaves the flag off when the spec did not apply', () => {


### PR DESCRIPTION
## The problem

Confirming a blueprint site now drops the customer into the Site Editor with its **"Edit your site" welcome guide** open over the page — a modal to dismiss before they can see the site they just made — and a run of failed `?context=edit&_locale=user` entity requests behind it.

Reported from a real hand-off, and narrowed to the parameter directly:

- `site-editor.php?canvas=edit&blueprint-walkthrough=go&p=%2F` → welcome guide, 404s
- `site-editor.php?blueprint-walkthrough=go&p=%2F` → lands correctly, personalization runs

## Why it was there

I added `canvas=edit` in #113693 on the evidence that Big Sky mounts only on the editing canvas:

```js
// use-should-load-big-sky.js
return ( isSiteEditor && canvasMode === 'edit' ) || …
```

and `canvasMode` is read from the `canvas` query parameter. That gate still reads the same way on plugin trunk, so the parameter was not inert — without it, the hand-off did nothing when I first tested it.

What changed since is that the editor now reaches its editing canvas from here on its own, so forcing it up front buys nothing and costs the welcome guide.

I have not pinned down precisely why supplying it up front triggers the guide, so this is a fix on the observed behaviour rather than on a mechanism I can point to. Both URLs above are reproducible.

## Risk

If some path does land in view mode, Big Sky will not mount and the personalization silently will not run — the failure this parameter originally prevented. Worth watching on the next few hand-offs; the visible symptom would be arriving at a site whose copy is never rewritten.

## Testing

12 unit tests. The one that asserted `canvas=edit` was present now asserts it is absent, with the reason.