### PR TITLE
Sites: label expired plans as "Business (expired)"

### DIFF
--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -448,7 +448,7 @@ export function Plan( {
 				<Text intent="error">
 					{ sprintf(
 						/* translators: %s: plan name */
-						__( '%s-expired' ),
+						__( '%s (expired)' ),
 						value
 					) }
 				</Text>

--- a/client/dashboard/sites/site-fields/test/plan.tsx
+++ b/client/dashboard/sites/site-fields/test/plan.tsx
@@ -64,7 +64,7 @@ describe( '<Plan>', () => {
 		expect( container.textContent ).toBe( 'Business' );
 	} );
 
-	test( 'for sites with expired plan, it renders the plan name with "-expired" suffix', () => {
+	test( 'for sites with expired plan, it renders the plan name with an "(expired)" suffix', () => {
 		const site = {
 			plan: {
 				product_name_short: 'Business',
@@ -79,10 +79,10 @@ describe( '<Plan>', () => {
 				nag={ { isExpired: true, site } }
 			/>
 		);
-		expect( container.textContent ).toBe( 'Business-expired' );
+		expect( container.textContent ).toBe( 'Business (expired)' );
 	} );
 
-	test( 'for sites with expired plan, it renders the plan name with "-expired" suffix and a renewal nag for the site owner', () => {
+	test( 'for sites with expired plan, it renders the plan name with an "(expired)" suffix and a renewal nag for the site owner', () => {
 		const site = {
 			slug: 'test.wordpress.com',
 			site_owner: userId,
@@ -101,14 +101,14 @@ describe( '<Plan>', () => {
 				nag={ { isExpired: true, site } }
 			/>
 		);
-		expect( getByText( 'Business-expired' ) ).toBeInTheDocument();
+		expect( getByText( 'Business (expired)' ) ).toBeInTheDocument();
 		expect( getByRole( 'link', { name: /Renew plan/ } ) ).toHaveAttribute(
 			'href',
 			wpcomLink( '/checkout/test.wordpress.com/business-bundle' )
 		);
 	} );
 
-	test( 'for Trial sites with expired plan, it renders the plan name with "-expired" suffix and an upgrade nag for the site owner', () => {
+	test( 'for Trial sites with expired plan, it renders the plan name with an "(expired)" suffix and an upgrade nag for the site owner', () => {
 		const site = {
 			slug: 'test.wordpress.com',
 			site_owner: userId,
@@ -127,7 +127,7 @@ describe( '<Plan>', () => {
 				nag={ { isExpired: true, site } }
 			/>
 		);
-		expect( getByText( 'Trial-expired' ) ).toBeInTheDocument();
+		expect( getByText( 'Trial (expired)' ) ).toBeInTheDocument();
 		expect( getByRole( 'link', { name: /Upgrade/ } ) ).toHaveAttribute(
 			'href',
 			wpcomLink( '/plans/test.wordpress.com' )


### PR DESCRIPTION
## Proposed Changes

* Change the expired-plan label in the Sites list from `%s-expired` to `%s (expired)`, so an expired Business plan now reads **Business (expired)** instead of **Business-expired**.
* Update the three assertions and test titles in `client/dashboard/sites/site-fields/test/plan.tsx` that pinned the old literal strings.

## Screenshots

*Before*
<img width="1115" height="93" alt="Screenshot 2026-08-22 at 13 03 24" src="https://github.com/user-attachments/assets/d0125a95-4c46-44df-aa95-41dac91c3475" />


*After*
<img width="1113" height="93" alt="Screenshot 2026-08-22 at 13 03 38" src="https://github.com/user-attachments/assets/e233bc3e-7ed6-4267-9cf8-d7a0a52040eb" />



## Testing Instructions

The expired branch only renders when `site.plan.expired` is `true`, so a healthy site will not show it.

1. Run the Dashboard (`yarn start-dashboard`) and open the Sites list.
2. Find a site with an expired plan, or temporarily force it — in `client/dashboard/sites/dataviews/fields.tsx`, hardcode the `plan` field's `nag` prop to `{ isExpired: true, site: item }`.
3. Confirm the Plan column reads **Business (expired)** (or the relevant plan name) in red, and that the "Renew plan" link still renders beneath it when you are the site owner.
4. Check both the table and list view types — the string is a little wider than before, so it is worth confirming it does not wrap awkwardly in the narrow Plan column.

Unit tests:

```
yarn test-client client/dashboard/sites/site-fields/test/plan.tsx
```

All 7 tests pass.


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?