### PR TITLE
Sites: keep the overview rendering when the storage lookup fails

### DIFF
--- a/client/dashboard/app/router/me.tsx
+++ b/client/dashboard/app/router/me.tsx
@@ -346,7 +346,9 @@ export const purchaseSettingsIndexRoute = createRoute( {
 					// Some sites cannot be reached; like disconnected Jetpack sites. We can safely ignore those.
 				} ),
 				isDotcomPlan( purchase )
-					? queryClient.ensureQueryData( siteMediaStorageQuery( purchase.blog_id ) )
+					? queryClient
+							.ensureQueryData( siteMediaStorageQuery( purchase.blog_id ) )
+							.catch( () => undefined )
 					: undefined,
 			] );
 		}

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -227,8 +227,9 @@ export const siteOverviewRoute = createRoute( {
 		await Promise.all( [
 			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
 
-			// Ensure storage specifically is loaded because the warning notice can cause a layout shift
-			queryClient.ensureQueryData( siteMediaStorageQuery( site.ID ) ),
+			// Ensure storage specifically is loaded because the warning notice can cause a layout
+			// shift. The notice is optional, so a failure here must not error the whole route.
+			queryClient.ensureQueryData( siteMediaStorageQuery( site.ID ) ).catch( () => undefined ),
 		] );
 	},
 } ).lazy( () =>

--- a/client/dashboard/app/router/test/sites.test.tsx
+++ b/client/dashboard/app/router/test/sites.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { queryClient } from '@automattic/api-queries';
+import nock from 'nock';
+import { siteOverviewRoute } from '../sites';
+
+const site = {
+	ID: 1,
+	slug: 'test-site.wordpress.com',
+	URL: 'https://test-site.wordpress.com',
+	name: 'Test Site',
+};
+
+function runOverviewLoader() {
+	const loader = siteOverviewRoute.options.loader;
+	if ( ! loader ) {
+		throw new Error( 'siteOverviewRoute has no loader' );
+	}
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	return ( loader as any )( { params: { siteSlug: site.slug }, preload: false } );
+}
+
+beforeEach( () => {
+	queryClient.clear();
+
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( `/rest/v1.1/sites/${ site.slug }` )
+		.query( true )
+		.reply( 200, site );
+
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( '/rest/v1.1/me/preferences' )
+		.query( true )
+		.reply( 200, { calypso_preferences: {} } );
+} );
+
+describe( 'siteOverviewRoute', () => {
+	test( 'resolves when the media storage request fails', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( `/rest/v1.1/sites/${ site.ID }/media-storage` )
+			.query( true )
+			.reply( 403, { error: 'unauthorized', message: 'User cannot access this private blog.' } );
+
+		await expect( runOverviewLoader() ).resolves.not.toThrow();
+	} );
+
+	test( 'resolves when the media storage request succeeds', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( `/rest/v1.1/sites/${ site.ID }/media-storage` )
+			.query( true )
+			.reply( 200, { max_storage_bytes: 1073741824, storage_used_bytes: 100000000 } );
+
+		await expect( runOverviewLoader() ).resolves.not.toThrow();
+	} );
+} );

--- a/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
@@ -18,11 +18,20 @@ import type { Site } from '@automattic/api-core';
 const MINIMUM_DISPLAYED_USAGE = 2.5;
 
 export default function SiteStorageStat( { site }: { site: Site } ) {
-	const { data: mediaStorage } = useQuery( siteMediaStorageQuery( site.ID ) );
+	const { data: mediaStorage, isLoading } = useQuery( siteMediaStorageQuery( site.ID ) );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
+	// Keep the stat in place when the usage figure is missing, so the card doesn't
+	// reflow while loading and doesn't silently lose a row when the request fails.
 	if ( ! mediaStorage ) {
-		return null;
+		return (
+			<Stat
+				density="high"
+				strapline={ __( 'Storage' ) }
+				metric={ isLoading ? undefined : __( 'Unavailable' ) }
+				isLoading={ isLoading }
+			/>
+		);
 	}
 
 	const storageUsagePercent = Math.round(

--- a/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
@@ -1,5 +1,5 @@
 import { siteMediaStorageQuery } from '@automattic/api-queries';
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import {
 	Button,
 	__experimentalVStack as VStack,
@@ -18,8 +18,12 @@ import type { Site } from '@automattic/api-core';
 const MINIMUM_DISPLAYED_USAGE = 2.5;
 
 export default function SiteStorageStat( { site }: { site: Site } ) {
-	const { data: mediaStorage } = useSuspenseQuery( siteMediaStorageQuery( site.ID ) );
+	const { data: mediaStorage } = useQuery( siteMediaStorageQuery( site.ID ) );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
+
+	if ( ! mediaStorage ) {
+		return null;
+	}
 
 	const storageUsagePercent = Math.round(
 		( ( mediaStorage.storage_used_bytes / mediaStorage.max_storage_bytes ) * 1000 ) / 10

--- a/client/dashboard/sites/overview/storage-warning-banner.tsx
+++ b/client/dashboard/sites/overview/storage-warning-banner.tsx
@@ -3,7 +3,7 @@ import {
 	userPreferenceMutation,
 	siteMediaStorageQuery,
 } from '@automattic/api-queries';
-import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { sprintf, __ } from '@wordpress/i18n';
 import filesize from 'filesize';
 import { useState } from 'react';
@@ -19,10 +19,14 @@ import type { Site } from '@automattic/api-core';
  * In-session dismissal is handled inside the component itself.
  */
 export function useShouldShowStorageWarningBanner( site: Site ) {
-	const { data: mediaStorage } = useSuspenseQuery( siteMediaStorageQuery( site.ID ) );
+	const { data: mediaStorage } = useQuery( siteMediaStorageQuery( site.ID ) );
 	const { data: isDismissedPersisted } = useSuspenseQuery(
 		userPreferenceQuery( `hosting-dashboard-overview-storage-notice-dismissed-${ site.ID }` )
 	);
+
+	if ( ! mediaStorage ) {
+		return false;
+	}
 
 	const alertLevel = getStorageAlertLevel( mediaStorage );
 	return alertLevel !== 'none' && ! ( alertLevel === 'warning' && isDismissedPersisted );
@@ -30,16 +34,20 @@ export function useShouldShowStorageWarningBanner( site: Site ) {
 
 export function StorageWarningBanner( { site }: { site: Site } ) {
 	const shouldShow = useShouldShowStorageWarningBanner( site );
-	const { data: mediaStorage } = useSuspenseQuery( siteMediaStorageQuery( site.ID ) );
+	const { data: mediaStorage } = useQuery( siteMediaStorageQuery( site.ID ) );
 	const { mutate: updateDismissed, isPending: isDismissing } = useMutation(
 		userPreferenceMutation( `hosting-dashboard-overview-storage-notice-dismissed-${ site.ID }` )
 	);
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
+	if ( ! shouldShow || ! mediaStorage ) {
+		return null;
+	}
+
 	const alertLevel = getStorageAlertLevel( mediaStorage );
 
 	// Optimistically hide the banner while the dismissal preference is saving.
-	if ( ! shouldShow || ( alertLevel === 'warning' && isDismissing ) ) {
+	if ( alertLevel === 'warning' && isDismissing ) {
 		return null;
 	}
 

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -208,7 +208,14 @@ describe( '<SiteOverview>', () => {
 		render( <SiteOverview siteSlug={ site.slug } /> );
 		await screen.findByRole( 'heading', { name: 'Test Site' } );
 
-		expect( await getCard( 'Plan' ) ).toBeVisible();
+		// The storage figure is unknown, so the stat says so rather than vanishing.
+		await screen.findByText( 'Unavailable' );
+		const planCard = await getCard( 'Plan' );
+		expect( planCard ).toBeVisible();
+		expect( within( planCard ).getByText( 'Storage' ) ).toBeVisible();
+		expect( within( planCard ).getByText( 'Unavailable' ) ).toBeVisible();
+
+		// Without a usage figure there is nothing to warn about.
 		expect( screen.queryByText( 'Your site is low on storage' ) ).not.toBeInTheDocument();
 	} );
 

--- a/client/dashboard/sites/overview/test/index.test.tsx
+++ b/client/dashboard/sites/overview/test/index.test.tsx
@@ -53,6 +53,8 @@ const site = {
 	},
 } as unknown as Site;
 
+let mediaStorageResponse: [ number, unknown ];
+
 function mockSite( mockedSite: Site ) {
 	nock( 'https://public-api.wordpress.com' )
 		.get( `/rest/v1.1/sites/${ mockedSite.slug }` )
@@ -120,10 +122,15 @@ describe( '<SiteOverview>', () => {
 			.query( true )
 			.reply( 200, { pages: [] } );
 
+		mediaStorageResponse = [
+			200,
+			{ max_storage_bytes: 1073741824, storage_used_bytes: 100000000 },
+		];
 		nock( 'https://public-api.wordpress.com' )
+			.persist()
 			.get( `/rest/v1.1/sites/${ site.ID }/media-storage` )
 			.query( true )
-			.reply( 200, { max_storage_bytes: 1073741824, storage_used_bytes: 100000000 } );
+			.reply( () => mediaStorageResponse );
 
 		nock( 'https://public-api.wordpress.com' )
 			.get( `/rest/v1.4/sites/${ site.ID }/plans` )
@@ -189,6 +196,20 @@ describe( '<SiteOverview>', () => {
 		expect( await getCard( 'Plan' ) ).toBeVisible();
 		expect( await getCard( 'Latest activity' ) ).toBeVisible();
 		expect( await getCard( 'The perfect domain awaits' ) ).toBeVisible();
+	} );
+
+	test( 'renders the overview when the media storage request fails', async () => {
+		mediaStorageResponse = [
+			403,
+			{ error: 'unauthorized', message: 'User cannot access this private blog.' },
+		];
+		mockSite( site );
+
+		render( <SiteOverview siteSlug={ site.slug } /> );
+		await screen.findByRole( 'heading', { name: 'Test Site' } );
+
+		expect( await getCard( 'Plan' ) ).toBeVisible();
+		expect( screen.queryByText( 'Your site is low on storage' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'renders the overview of a site with a paid plan on Atomic', async () => {


### PR DESCRIPTION
Related to DOTMSD-1532 — this does **not** fix that issue. I found it while investigating that report; the customer's 500 has a different cause, fixed separately.

## Proposed Changes

* Make the site overview tolerate a failed storage lookup. The route keeps rendering, and the Plan card shows the storage stat as `Unavailable` instead of dropping the row.

## Screenshot

| Before | After |
|--------|--------|
| <img width="1138" height="259" alt="Screenshot 2026-08-23 at 12 09 31 PM" src="https://github.com/user-attachments/assets/794fedff-862d-49ce-b270-42bdd4b1cd65" /> | <img width="374" height="371" alt="Screenshot 2026-08-23 at 12 07 01 PM" src="https://github.com/user-attachments/assets/ad8ab635-5689-4ddf-a28c-a2099b903630" /> | 


## Why are these changes being made?

* If that query fails, the whole overview page crashes. The loader awaited it and both consuming components read it through suspense queries, so one failure escalated to the route error boundary. Storage feeds one stat and a dismissible banner — neither is worth losing settings, monitoring and backups over.

## Testing Instructions

Force the endpoint to fail by throwing before the request in `packages/api-core/src/site-media-storage/fetchers.ts`:

```js
export async function fetchSiteMediaStorage( siteId: number ): Promise< SiteMediaStorage > {
	const error = new Error( 'User cannot access this private blog.' );
	error.name = 'UnauthorizedError';
	Object.assign( error, { status: 403, statusCode: 403, error: 'unauthorized' } );
	throw error;
	// ...existing request
}
```

Then open any site's overview. On `trunk` the page is replaced by "500 Error"; on this branch it renders with `Storage / Unavailable` in the Plan card. Blocking `*/media-storage*` in devtools reproduces the broken route too, but not the exact error copy.

Both the loader and component paths are covered by tests that fail without the fix.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)