### PR TITLE
Sites: don't error the site route when an environment is inaccessible

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -185,8 +185,12 @@ export const siteRoute = createRoute( {
 		queryClient.prefetchQuery( siteAdminBarQuery( site.ID ) );
 
 		await Promise.all( [
+			// Only the environment switcher needs the sibling environment, and a user with
+			// access to one environment doesn't necessarily have access to the other.
 			otherEnvironmentSiteId &&
-				queryClient.ensureQueryData( siteByIdQuery( otherEnvironmentSiteId ) ),
+				queryClient
+					.ensureQueryData( siteByIdQuery( otherEnvironmentSiteId ) )
+					.catch( () => undefined ),
 			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
 		] );
 

--- a/client/dashboard/app/router/test/sites.test.tsx
+++ b/client/dashboard/app/router/test/sites.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { queryClient } from '@automattic/api-queries';
+import nock from 'nock';
+import { siteRoute } from '../sites';
+
+const SITE_SLUG = 'production.example.com';
+const SITE_ID = 1;
+const STAGING_SITE_ID = 2;
+
+function runSiteLoader() {
+	const loader = siteRoute.options.loader;
+	if ( ! loader ) {
+		throw new Error( 'siteRoute has no loader' );
+	}
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	return ( loader as any )( { params: { siteSlug: SITE_SLUG }, cause: 'enter' } );
+}
+
+beforeEach( () => {
+	queryClient.clear();
+
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( `/rest/v1.1/sites/${ SITE_SLUG }` )
+		.query( true )
+		.reply( 200, {
+			ID: SITE_ID,
+			slug: SITE_SLUG,
+			name: 'Production',
+			URL: `https://${ SITE_SLUG }`,
+			is_wpcom_staging_site: false,
+			options: { wpcom_staging_blog_ids: [ STAGING_SITE_ID ] },
+		} );
+
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( '/rest/v1.1/me/preferences' )
+		.query( true )
+		.reply( 200, { calypso_preferences: {} } );
+} );
+
+describe( 'siteRoute', () => {
+	test( 'loads when the staging site is inaccessible to this user', async () => {
+		// The proxied request fails, and the caller is not a member of the private
+		// staging blog, so the wpcom fallback is refused too.
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( `/rest/v1.1/sites/${ STAGING_SITE_ID }` )
+			.query( ( q ) => q.force === undefined )
+			.reply( 403, {
+				error: 'unauthorized',
+				message: 'The Jetpack site is inaccessible or returned an error: transport error.',
+			} );
+
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( `/rest/v1.1/sites/${ STAGING_SITE_ID }` )
+			.query( ( q ) => q.force === 'wpcom' )
+			.reply( 403, {
+				error: 'unauthorized',
+				message: 'User cannot access this private blog.',
+			} );
+
+		const result = await runSiteLoader();
+
+		expect( result.site.ID ).toBe( SITE_ID );
+	} );
+
+	test( 'loads when the staging site is reachable', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( `/rest/v1.1/sites/${ STAGING_SITE_ID }` )
+			.query( true )
+			.reply( 200, {
+				ID: STAGING_SITE_ID,
+				slug: 'staging.example.com',
+				name: 'Staging',
+				URL: 'https://staging.example.com',
+				is_wpcom_staging_site: true,
+				options: { wpcom_production_blog_id: SITE_ID },
+			} );
+
+		const result = await runSiteLoader();
+
+		expect( result.site.ID ).toBe( SITE_ID );
+	} );
+} );

--- a/packages/api-queries/src/__tests__/site-inaccessible-jetpack.test.ts
+++ b/packages/api-queries/src/__tests__/site-inaccessible-jetpack.test.ts
@@ -1,0 +1,78 @@
+import nock from 'nock';
+import { queryClient } from '../query-client';
+import { siteByIdQuery } from '../site';
+import type { Site } from '@automattic/api-core';
+
+// Same-instance query client so site.ts and the test share state.
+jest.mock( '../query-client', () => {
+	const { QueryClient: QC } = jest.requireActual( '@tanstack/react-query' );
+	const qc = new QC( { defaultOptions: { queries: { retry: false } } } );
+	return { queryClient: qc };
+} );
+
+jest.mock( '@tanstack/react-router', () => ( {
+	notFound: () => Object.assign( new Error( 'Not found' ), { isNotFound: true } ),
+} ) );
+
+function mockProxiedFetchFails( siteId: number ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( `/rest/v1.1/sites/${ siteId }` )
+		.query( ( q ) => q.force === undefined )
+		.reply( 403, {
+			error: 'unauthorized',
+			message: 'The Jetpack site is inaccessible or returned an error: transport error.',
+		} );
+}
+
+function mockForcedFetch( siteId: number, status: number, body: object ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( `/rest/v1.1/sites/${ siteId }` )
+		.query( ( q ) => q.force === 'wpcom' )
+		.reply( status, body );
+}
+
+describe( 'siteByIdQuery for an inaccessible Jetpack site', () => {
+	afterEach( () => {
+		nock.cleanAll();
+		queryClient.clear();
+	} );
+
+	test( 'reports not found when the caller cannot access the site on wpcom either', async () => {
+		mockProxiedFetchFails( 243314791 );
+		mockForcedFetch( 243314791, 403, {
+			error: 'unauthorized',
+			message: 'User cannot access this private blog.',
+		} );
+
+		await expect( queryClient.fetchQuery( siteByIdQuery( 243314791 ) ) ).rejects.toMatchObject( {
+			isNotFound: true,
+		} );
+	} );
+
+	test( 'keeps the Jetpack error when the wpcom copy fails for another reason', async () => {
+		mockProxiedFetchFails( 90011 );
+		mockForcedFetch( 90011, 500, { error: 'server_error', message: 'Something went wrong.' } );
+
+		await expect( queryClient.fetchQuery( siteByIdQuery( 90011 ) ) ).rejects.toThrow(
+			/The Jetpack site is inaccessible/
+		);
+	} );
+
+	test( 'still returns the wpcom copy when the caller can access the site', async () => {
+		mockProxiedFetchFails( 90010 );
+		mockForcedFetch( 90010, 200, {
+			ID: 90010,
+			slug: 'example.com',
+			name: 'Test',
+			URL: 'https://example.com',
+			options: {},
+		} );
+
+		const site = ( await queryClient.fetchQuery( siteByIdQuery( 90010 ) ) ) as Site;
+
+		expect( site.ID ).toBe( 90010 );
+		expect( site.__inaccessible_jetpack_error ).toBeDefined();
+	} );
+} );

--- a/packages/api-queries/src/site.ts
+++ b/packages/api-queries/src/site.ts
@@ -41,7 +41,15 @@ async function getSite( siteIdOrSlug: number | string ) {
 	} catch ( e ) {
 		// Force the site to be retrieved from wpcom if there is any issue with the Jetpack connection.
 		if ( isInaccessibleJetpackError( e ) ) {
-			const site = await fetchSite( siteIdOrSlug, { force: 'wpcom' } );
+			// wpcom applies its own access checks, so this fallback can fail where the proxied
+			// request didn't — a private staging site the caller isn't a member of, say. Without
+			// this, that rejection escapes uncaught and surfaces as a generic error page.
+			const site = await fetchSite( siteIdOrSlug, { force: 'wpcom' } ).catch( ( wpcomError ) => {
+				if ( isSiteNotFoundError( wpcomError ) ) {
+					throw notFound();
+				}
+				throw e;
+			} );
 
 			// Throw an error if site.slug is not available because it means there is a site slug collision.
 			if ( ! site.slug ) {


### PR DESCRIPTION
Fixes DOTMSD-1532

## Proposed Changes

* Stop a site's whole hosting dashboard from failing when its staging environment is private and the current user isn't a member of it.

## Why are these changes being made?

* A customer lost every page under their site — settings, monitoring, backups — to a "500 Error / Something wrong happened." showing `User cannot access this private blog.` Support reproduced it on their own account and disabling every plugin made no difference.

  The site route loads the *other* environment so the environment switcher can render. That fetch is proxied to the sibling site's Jetpack; when the proxy fails, `getSite()` retries against wpcom directly. wpcom then applies its own access checks — and staging sites are private. The user was an admin on production but had never been added to staging, so the retry came back 403. That rejection was thrown from inside the `catch` block, so it skipped the not-found mapping three lines below it and escaped raw, taking out the shared parent route.

  Staging membership doesn't track production: anyone added to a site after its staging environment was created is in this state, so it's the default outcome of adding a teammate rather than an edge case.

## Testing Instructions

Point a site's `wpcom_staging_blog_ids` at a blog the current user can't read, or force both site fetches to fail in `packages/api-core/src/site/fetchers.ts`:

```js
export async function fetchSite( siteIdOrSlug, options = {} ) {
	if ( String( siteIdOrSlug ) === '<staging blog id>' ) {
		const error = new Error(
			options.force === 'wpcom'
				? 'User cannot access this private blog.'
				: 'The Jetpack site is inaccessible or returned an error: transport error.'
		);
		error.name = 'UnauthorizedError';
		throw Object.assign( error, { status: 403, statusCode: 403, error: 'unauthorized' } );
	}
	// ...existing request
}
```

Open that site's overview. On `trunk` every page under `/sites/<slug>/` shows "500 Error"; on this branch they render normally, with the environment switcher simply not offering the unreachable environment.

Two tests cover it, and both fail without the fix: one on the query (`site-inaccessible-jetpack.test.ts`) and one on the route loader (`app/router/test/sites.test.tsx`). The loader test also fails with only the query fix applied — it turns the 500 into a 404 on the user's own production site, which is why both halves are needed.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)