### PR TITLE
Dashboard: format storage sizes like wp-admin

### DIFF
--- a/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
@@ -6,11 +6,15 @@ import {
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
-import filesize from 'filesize';
 import { useState } from 'react';
 import { Stat } from '../../components/stat';
 import { hasStagingSite } from '../../utils/site-staging-site';
-import { getStorageAlertLevel } from '../../utils/site-storage';
+import {
+	formatStorage,
+	getSharedStorageTotal,
+	getStorageAlertLevel,
+	getStorageUsagePercent,
+} from '../../utils/site-storage';
 import { isStagingSite } from '../../utils/site-types';
 import { AddStorageModal } from '../storage/add-storage-modal';
 import type { Site } from '@automattic/api-core';
@@ -21,9 +25,7 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 	const { data: mediaStorage } = useSuspenseQuery( siteMediaStorageQuery( site.ID ) );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 
-	const storageUsagePercent = Math.round(
-		( ( mediaStorage.storage_used_bytes / mediaStorage.max_storage_bytes ) * 1000 ) / 10
-	);
+	const storageUsagePercent = getStorageUsagePercent( mediaStorage );
 
 	// Ensure that the displayed usage is never fully empty to avoid a confusing UI.
 	const progressBarValue = Math.max(
@@ -47,8 +49,8 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 			<Stat
 				density="high"
 				strapline={ __( 'Storage' ) }
-				metric={ filesize( mediaStorage.storage_used_bytes, { round: 0 } ) }
-				description={ filesize( mediaStorage.max_storage_bytes, { round: 0 } ) }
+				metric={ formatStorage( mediaStorage.storage_used_bytes ) }
+				description={ formatStorage( mediaStorage.max_storage_bytes ) }
 				progressValue={ progressBarValue }
 				progressColor={ storageWarningColor }
 				progressLabel={ `${ storageUsagePercent }%` }
@@ -56,24 +58,20 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 			{ isSharedQuota && (
 				<Text variant="muted" lineHeight="16px" size={ 12 }>
 					{ sprintf(
-						// translators: %s is the total storage quota (e.g., "53 GB")
-						__( 'Production and staging share a total storage quota of %s.' ),
-						filesize( mediaStorage.max_storage_bytes * 2, { round: 0 } )
+						// translators: %s is the plan's total storage quota (e.g., "6.0 GB")
+						__( 'Your plan’s %s of storage is split evenly between production and staging.' ),
+						formatStorage( getSharedStorageTotal( mediaStorage ) )
 					) }
 				</Text>
 			) }
-			{ alertLevel !== 'none' && (
-				<>
-					<Button variant="link" onClick={ () => setIsModalOpen( true ) }>
-						{ __( 'Add more storage' ) }
-					</Button>
-					<AddStorageModal
-						site={ site }
-						isOpen={ isModalOpen }
-						onClose={ () => setIsModalOpen( false ) }
-					/>
-				</>
-			) }
+			<Button variant="link" onClick={ () => setIsModalOpen( true ) }>
+				{ __( 'Add more storage' ) }
+			</Button>
+			<AddStorageModal
+				site={ site }
+				isOpen={ isModalOpen }
+				onClose={ () => setIsModalOpen( false ) }
+			/>
 		</VStack>
 	);
 }

--- a/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
+++ b/client/dashboard/sites/overview-plan-card/site-storage-stat.tsx
@@ -64,14 +64,18 @@ export default function SiteStorageStat( { site }: { site: Site } ) {
 					) }
 				</Text>
 			) }
-			<Button variant="link" onClick={ () => setIsModalOpen( true ) }>
-				{ __( 'Add more storage' ) }
-			</Button>
-			<AddStorageModal
-				site={ site }
-				isOpen={ isModalOpen }
-				onClose={ () => setIsModalOpen( false ) }
-			/>
+			{ alertLevel !== 'none' && (
+				<>
+					<Button variant="link" onClick={ () => setIsModalOpen( true ) }>
+						{ __( 'Add more storage' ) }
+					</Button>
+					<AddStorageModal
+						site={ site }
+						isOpen={ isModalOpen }
+						onClose={ () => setIsModalOpen( false ) }
+					/>
+				</>
+			) }
 		</VStack>
 	);
 }

--- a/client/dashboard/sites/overview/storage-warning-banner.tsx
+++ b/client/dashboard/sites/overview/storage-warning-banner.tsx
@@ -5,11 +5,10 @@ import {
 } from '@automattic/api-queries';
 import { useSuspenseQuery, useMutation } from '@tanstack/react-query';
 import { sprintf, __ } from '@wordpress/i18n';
-import filesize from 'filesize';
 import { useState } from 'react';
 import Notice from '../../components/notice';
 import UpsellCTAButton from '../../components/upsell-cta-button';
-import { getStorageAlertLevel } from '../../utils/site-storage';
+import { formatStorage, getStorageAlertLevel } from '../../utils/site-storage';
 import { AddStorageModal } from '../storage/add-storage-modal';
 import type { Site } from '@automattic/api-core';
 
@@ -83,8 +82,8 @@ export function StorageWarningBanner( { site }: { site: Site } ) {
 						'%(used)s of your %(available)s storage limit has been used. Upgrade to continue storing media, plugins, themes, and backups.'
 					),
 					{
-						used: filesize( mediaStorage.storage_used_bytes, { round: 0 } ),
-						available: filesize( mediaStorage.max_storage_bytes, { round: 0 } ),
+						used: formatStorage( mediaStorage.storage_used_bytes ),
+						available: formatStorage( mediaStorage.max_storage_bytes ),
 					}
 				) }
 			</Notice>

--- a/client/dashboard/sites/storage/add-storage-modal.tsx
+++ b/client/dashboard/sites/storage/add-storage-modal.tsx
@@ -11,10 +11,10 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import filesize from 'filesize';
 import { useState } from 'react';
 import { getCurrentDashboard } from '../../app/routing';
 import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
+import { formatStorage } from '../../utils/site-storage';
 import { StorageCapacityStat } from './storage-capacity-stat';
 import {
 	getStorageAddOnProduct,
@@ -156,7 +156,11 @@ export function AddStorageModal( { site, isOpen, onClose }: AddStorageModalProps
 				<VStack spacing={ 2 }>
 					<Text weight={ 600 }>{ __( 'New storage capacity' ) }</Text>
 					<StorageCapacityStat
-						description={ filesize( mediaStorage.storage_used_bytes, { round: 0 } ) + ' used' }
+						description={ sprintf(
+							// translators: %s is the amount of storage used, e.g. "546.6 MB"
+							__( '%s used' ),
+							formatStorage( mediaStorage.storage_used_bytes )
+						) }
 						currentCapacityBytes={ planStorageBytes }
 						addOnCapacityBytes={ selectedAddOnStorageBytes }
 					/>

--- a/client/dashboard/sites/storage/storage-capacity-stat.tsx
+++ b/client/dashboard/sites/storage/storage-capacity-stat.tsx
@@ -1,6 +1,6 @@
 import { __experimentalHStack as HStack, __experimentalText as Text } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import filesize from 'filesize';
+import { formatStorage } from '../../utils/site-storage';
 import './storage-capacity-stat.scss';
 
 const MINIMUM_SEGMENT_WIDTH = 0.5; // Minimum width in % to ensure visibility
@@ -29,7 +29,7 @@ export function StorageCapacityStat( {
 }: StorageCapacityStatProps ) {
 	// Calculate total and percentages
 	const totalBytes = currentCapacityBytes + addOnCapacityBytes;
-	const totalCapacity = filesize( totalBytes, { round: 0 } );
+	const totalCapacity = formatStorage( totalBytes );
 	const currentCapacityPercent = ( currentCapacityBytes / totalBytes ) * 100;
 	const addOnCapacityPercent = ( addOnCapacityBytes / totalBytes ) * 100;
 
@@ -66,7 +66,7 @@ export function StorageCapacityStat( {
 					{ sprintf(
 						// translators: %s is the plan storage amount
 						__( '%s plan storage' ),
-						filesize( currentCapacityBytes, { round: 0 } )
+						formatStorage( currentCapacityBytes )
 					) }
 				</Text>
 				<Text
@@ -77,7 +77,7 @@ export function StorageCapacityStat( {
 					{ sprintf(
 						// translators: %s is the storage add-on amount
 						__( '%s storage add-on' ),
-						filesize( addOnCapacityBytes, { round: 0 } )
+						formatStorage( addOnCapacityBytes )
 					) }
 				</Text>
 			</HStack>

--- a/client/dashboard/utils/site-storage.ts
+++ b/client/dashboard/utils/site-storage.ts
@@ -1,11 +1,16 @@
+import { formatNumber } from '@automattic/number-formatters';
 import type { SiteMediaStorage } from '@automattic/api-core';
 
 const ALERT_FRACTION = 0.8;
 
+const STORAGE_UNITS = [ 'B', 'KB', 'MB', 'GB', 'TB', 'PB' ];
+
+type StorageBytes = Pick< SiteMediaStorage, 'storage_used_bytes' | 'max_storage_bytes' >;
+
 export function getStorageAlertLevel( {
 	storage_used_bytes,
 	max_storage_bytes,
-}: SiteMediaStorage ): 'none' | 'warning' | 'exceeded' {
+}: StorageBytes ): 'none' | 'warning' | 'exceeded' {
 	const storageFraction = storage_used_bytes / max_storage_bytes;
 
 	if ( storageFraction > 1 ) {
@@ -14,4 +19,33 @@ export function getStorageAlertLevel( {
 		return 'warning';
 	}
 	return 'none';
+}
+
+export function getStorageUsagePercent( {
+	storage_used_bytes,
+	max_storage_bytes,
+}: StorageBytes ): number {
+	return Math.round( ( storage_used_bytes / max_storage_bytes ) * 100 );
+}
+
+/**
+ * Mirrors WordPress core's `size_format()` so storage figures match wp-admin.
+ */
+export function formatStorage( bytes: number, decimals = 1 ): string {
+	let value = Math.max( bytes, 0 );
+	let unitIndex = 0;
+	while ( value >= 1024 && unitIndex < STORAGE_UNITS.length - 1 ) {
+		value /= 1024;
+		unitIndex++;
+	}
+	return `${ formatNumber( value, { decimals } ) } ${ STORAGE_UNITS[ unitIndex ] }`;
+}
+
+/**
+ * The API reports each environment's half of the plan quota; production and staging split it evenly.
+ */
+export function getSharedStorageTotal( {
+	max_storage_bytes,
+}: Pick< SiteMediaStorage, 'max_storage_bytes' > ): number {
+	return max_storage_bytes * 2;
 }

--- a/client/dashboard/utils/site-storage.ts
+++ b/client/dashboard/utils/site-storage.ts
@@ -29,7 +29,7 @@ export function getStorageUsagePercent( {
 }
 
 /**
- * Mirrors WordPress core's `size_format()` so storage figures match wp-admin.
+ * Mirrors WordPress core's `size_format()` so storage figures match wp-admin, minus a trailing `.0`.
  */
 export function formatStorage( bytes: number, decimals = 1 ): string {
 	let value = Math.max( bytes, 0 );
@@ -38,7 +38,10 @@ export function formatStorage( bytes: number, decimals = 1 ): string {
 		value /= 1024;
 		unitIndex++;
 	}
-	return `${ formatNumber( value, { decimals } ) } ${ STORAGE_UNITS[ unitIndex ] }`;
+	const isWhole = Number( value.toFixed( decimals ) ) % 1 === 0;
+	return `${ formatNumber( value, { decimals: isWhole ? 0 : decimals } ) } ${
+		STORAGE_UNITS[ unitIndex ]
+	}`;
 }
 
 /**

--- a/client/dashboard/utils/test/site-storage.ts
+++ b/client/dashboard/utils/test/site-storage.ts
@@ -1,0 +1,37 @@
+import { formatStorage, getStorageUsagePercent } from '../site-storage';
+
+const KB = 1024;
+const MB = KB * 1024;
+const GB = MB * 1024;
+
+describe( 'formatStorage', () => {
+	test( 'matches wp-admin size_format output', () => {
+		expect( formatStorage( 573_175_398 ) ).toBe( '546.6 MB' );
+		expect( formatStorage( 3.1 * GB ) ).toBe( '3.1 GB' );
+		expect( formatStorage( 3 * GB ) ).toBe( '3.0 GB' );
+		expect( formatStorage( 6 * GB ) ).toBe( '6.0 GB' );
+	} );
+
+	test( 'picks the largest unit the value reaches, like size_format', () => {
+		expect( formatStorage( 0 ) ).toBe( '0.0 B' );
+		expect( formatStorage( 1023 ) ).toBe( '1,023.0 B' );
+		expect( formatStorage( KB ) ).toBe( '1.0 KB' );
+		expect( formatStorage( 1023.99 * MB ) ).toBe( '1,024.0 MB' );
+		expect( formatStorage( 1024 * GB ) ).toBe( '1.0 TB' );
+	} );
+
+	test( 'accepts a decimals override', () => {
+		expect( formatStorage( 3 * GB, 0 ) ).toBe( '3 GB' );
+	} );
+} );
+
+describe( 'getStorageUsagePercent', () => {
+	test( 'rounds to a whole percent like wp-admin', () => {
+		expect(
+			getStorageUsagePercent( { storage_used_bytes: 573_175_398, max_storage_bytes: 3.1 * GB } )
+		).toBe( 17 );
+		expect( getStorageUsagePercent( { storage_used_bytes: 50, max_storage_bytes: 100 } ) ).toBe(
+			50
+		);
+	} );
+} );

--- a/client/dashboard/utils/test/site-storage.ts
+++ b/client/dashboard/utils/test/site-storage.ts
@@ -8,20 +8,23 @@ describe( 'formatStorage', () => {
 	test( 'matches wp-admin size_format output', () => {
 		expect( formatStorage( 573_175_398 ) ).toBe( '546.6 MB' );
 		expect( formatStorage( 3.1 * GB ) ).toBe( '3.1 GB' );
-		expect( formatStorage( 3 * GB ) ).toBe( '3.0 GB' );
-		expect( formatStorage( 6 * GB ) ).toBe( '6.0 GB' );
+		expect( formatStorage( 3 * GB ) ).toBe( '3 GB' );
+		expect( formatStorage( 6 * GB ) ).toBe( '6 GB' );
 	} );
 
 	test( 'picks the largest unit the value reaches, like size_format', () => {
-		expect( formatStorage( 0 ) ).toBe( '0.0 B' );
-		expect( formatStorage( 1023 ) ).toBe( '1,023.0 B' );
-		expect( formatStorage( KB ) ).toBe( '1.0 KB' );
-		expect( formatStorage( 1023.99 * MB ) ).toBe( '1,024.0 MB' );
-		expect( formatStorage( 1024 * GB ) ).toBe( '1.0 TB' );
+		expect( formatStorage( 0 ) ).toBe( '0 B' );
+		expect( formatStorage( 1023 ) ).toBe( '1,023 B' );
+		expect( formatStorage( KB ) ).toBe( '1 KB' );
+		expect( formatStorage( 1023.99 * MB ) ).toBe( '1,024 MB' );
+		expect( formatStorage( 1024 * GB ) ).toBe( '1 TB' );
 	} );
 
-	test( 'accepts a decimals override', () => {
-		expect( formatStorage( 3 * GB, 0 ) ).toBe( '3 GB' );
+	test( 'drops a trailing .0 but keeps real decimals', () => {
+		expect( formatStorage( 3 * GB ) ).toBe( '3 GB' );
+		expect( formatStorage( 3.04 * GB ) ).toBe( '3 GB' );
+		expect( formatStorage( 3.07 * GB ) ).toBe( '3.1 GB' );
+		expect( formatStorage( 3.1 * GB, 0 ) ).toBe( '3 GB' );
 	} );
 } );
 


### PR DESCRIPTION
Part of DSGCOM-715
Related: DOTDEV-246 (introduced the shared-quota note this PR rewords)

## Proposed Changes

* Format every storage figure in the dashboard the way WordPress core's `size_format()` does (1024 base, largest unit reached, one decimal, with a trailing `.0` dropped), via a single `formatStorage()` helper.
* Round storage usage to a whole percent.
* Reword the production/staging quota note to say the plan's storage is split evenly between the two environments.
* Make the "used" label in the add-storage modal translatable.

## Screenshots

| Before | After |
|--------|--------|
| <img width="454" height="340" alt="Screenshot 2026-08-23 at 9 26 15 PM" src="https://github.com/user-attachments/assets/7f34741c-4b2e-49f3-8cc0-3aa8ddc12f47" /> | <img width="454" height="362" alt="Screenshot 2026-08-23 at 9 26 10 PM" src="https://github.com/user-attachments/assets/7dd1864c-e609-4bda-a214-af72d6642494" /> | 
| <img width="470" height="359" alt="Screenshot 2026-09-01 at 11 21 01 AM" src="https://github.com/user-attachments/assets/d737d83c-9300-4a18-a4e0-2d6fc2d4fe50" /> | <img width="467" height="353" alt="Screenshot 2026-09-01 at 11 19 48 AM" src="https://github.com/user-attachments/assets/df9fd41c-7e32-4122-9ce3-138bc2fac393" /> |


## Why are these changes being made?

* The plan card showed `547 MB of 3 GB` while wp-admin's Media Library showed `546.6 MB of 3.1 GB` for the same site — same bytes, different rounding. That notice (wpcomsh on Atomic, the wpcom mu-plugin on Simple) formats with WordPress core's `size_format( $bytes, 1 )`, so core's formatter is the reference and the dashboard now matches it.
* "Production and staging share a total storage quota of 6 GB" sat directly under a "3 GB" limit and read as a contradiction; the quota is halved per environment, so the copy now says so.

## Testing Instructions

1. Open the Overview of a site with a staging site and compare the storage stat against wp-admin → Media Library on the same site: used/limit should match to one decimal (whole values show no decimal, e.g. `3 GB`) and the percent should match.
2. Check the staging quota note reads "Your plan’s X of storage is split evenly between production and staging." on both the production and staging site.
3. Push a site above 80% usage and confirm the warning banner's used/limit numbers use the same format, and that the "N used" label in the add-storage modal still renders.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


