### PR TITLE
Validate Apple login redirect URLs by origin

### DIFF
--- a/client/server/api/sign-in-with-apple.js
+++ b/client/server/api/sign-in-with-apple.js
@@ -6,24 +6,26 @@ import wpcom from 'calypso/lib/wp';
 
 const ALLOWED_ORIGINS = [ 'https://my.wordpress.com' ];
 
-// Placeholder base for parsing relative redirect paths; never a real destination.
-const RELATIVE_URL_BASE = 'https://relative-url.invalid';
+const RELATIVE_URL_BASES = [ 'https://relative-url-a.invalid', 'https://relative-url-b.invalid' ];
 
+/**
+ * Only origins from `ALLOWED_ORIGINS` or relative URLs are allowed.
+ * For completeness, we need two placeholder base URLs to check for relative URL-ness.
+ * It prevents us from incorrectly allowing a URL that actually did use `relative-url.invalid`.
+ */
 export function isAllowedRedirectUrl( url ) {
-	let origin;
+	let parsed;
 	try {
-		( { origin } = new URL( url, RELATIVE_URL_BASE ) );
+		parsed = RELATIVE_URL_BASES.map( ( base ) => new URL( url, base ) );
 	} catch {
 		return false;
 	}
 
-	if ( ALLOWED_ORIGINS.includes( origin ) ) {
+	if ( ALLOWED_ORIGINS.includes( parsed[ 0 ].origin ) ) {
 		return true;
 	}
 
-	// A same-site path: resolves against the placeholder base, so it isn't absolute
-	// or protocol-relative (URL parsing also treats `\` as `/`, catching `/\evil.com`).
-	return origin === RELATIVE_URL_BASE && url.startsWith( '/' );
+	return url.startsWith( '/' ) && parsed.every( ( p, i ) => p.origin === RELATIVE_URL_BASES[ i ] );
 }
 
 function loginEndpointData() {

--- a/client/server/api/sign-in-with-apple.js
+++ b/client/server/api/sign-in-with-apple.js
@@ -6,6 +6,26 @@ import wpcom from 'calypso/lib/wp';
 
 const ALLOWED_ORIGINS = [ 'https://my.wordpress.com' ];
 
+// Placeholder base for parsing relative redirect paths; never a real destination.
+const RELATIVE_URL_BASE = 'https://relative-url.invalid';
+
+export function isAllowedRedirectUrl( url ) {
+	let origin;
+	try {
+		( { origin } = new URL( url, RELATIVE_URL_BASE ) );
+	} catch {
+		return false;
+	}
+
+	if ( ALLOWED_ORIGINS.includes( origin ) ) {
+		return true;
+	}
+
+	// A same-site path: resolves against the placeholder base, so it isn't absolute
+	// or protocol-relative (URL parsing also treats `\` as `/`, catching `/\evil.com`).
+	return origin === RELATIVE_URL_BASE && url.startsWith( '/' );
+}
+
 function loginEndpointData() {
 	return {
 		client_id: config( 'wpcom_signup_id' ),
@@ -68,11 +88,7 @@ function redirectToCalypso( request, response, next ) {
 		state: state.oauth2State,
 	} );
 
-	const isRelativeUrl = originalUrlPath.startsWith( '/' ) && ! originalUrlPath.startsWith( '//' );
-	if (
-		! isRelativeUrl &&
-		! ALLOWED_ORIGINS.some( ( origin ) => originalUrlPath.startsWith( origin ) )
-	) {
+	if ( ! isAllowedRedirectUrl( originalUrlPath ) ) {
 		return next();
 	}
 

--- a/client/server/api/sign-in-with-apple.js
+++ b/client/server/api/sign-in-with-apple.js
@@ -21,6 +21,10 @@ export function isAllowedRedirectUrl( url ) {
 		return false;
 	}
 
+	if ( ! [ 'https:', 'http:' ].includes( parsed[ 0 ].protocol ) ) {
+		return false;
+	}
+
 	if ( ALLOWED_ORIGINS.includes( parsed[ 0 ].origin ) ) {
 		return true;
 	}

--- a/client/server/api/test/sign-in-with-apple.js
+++ b/client/server/api/test/sign-in-with-apple.js
@@ -25,7 +25,11 @@ describe( 'isAllowedRedirectUrl', () => {
 		'https:/evil.com',
 		'javascript:alert(1)',
 		'relative-path',
-		'https://relative-url.invalid/path',
+		'https://relative-url-a.invalid/path',
+		'//relative-url-a.invalid/path',
+		'/\\relative-url-a.invalid/path',
+		'///relative-url-a.invalid/path',
+		'//relative-url-b.invalid/path',
 		'',
 	] )( 'rejects %s', ( url ) => {
 		expect( isAllowedRedirectUrl( url ) ).toBe( false );

--- a/client/server/api/test/sign-in-with-apple.js
+++ b/client/server/api/test/sign-in-with-apple.js
@@ -1,0 +1,33 @@
+import { isAllowedRedirectUrl } from '../sign-in-with-apple';
+
+describe( 'isAllowedRedirectUrl', () => {
+	test.each( [
+		'/',
+		'/log-in/apple/callback',
+		'/me/security/social-login',
+		'/start/user?foo=bar',
+		'https://my.wordpress.com',
+		'https://my.wordpress.com/v2/me/security',
+	] )( 'allows %s', ( url ) => {
+		expect( isAllowedRedirectUrl( url ) ).toBe( true );
+	} );
+
+	test.each( [
+		'https://evil.com',
+		'https://my.wordpress.com.evil.com/path',
+		'https://my.wordpress.com@evil.com/path',
+		'https://my.wordpress.com.evil.com',
+		'http://my.wordpress.com',
+		'//evil.com/path',
+		'/\\evil.com/path',
+		'\\/evil.com/path',
+		'\\\\evil.com/path',
+		'https:/evil.com',
+		'javascript:alert(1)',
+		'relative-path',
+		'https://relative-url.invalid/path',
+		'',
+	] )( 'rejects %s', ( url ) => {
+		expect( isAllowedRedirectUrl( url ) ).toBe( false );
+	} );
+} );

--- a/client/server/api/test/sign-in-with-apple.js
+++ b/client/server/api/test/sign-in-with-apple.js
@@ -24,6 +24,8 @@ describe( 'isAllowedRedirectUrl', () => {
 		'\\\\evil.com/path',
 		'https:/evil.com',
 		'javascript:alert(1)',
+		'blob:https://my.wordpress.com/x',
+		'filesystem:https://my.wordpress.com/temporary/x',
 		'relative-path',
 		'https://relative-url-a.invalid/path',
 		'//relative-url-a.invalid/path',


### PR DESCRIPTION
Part of DOTMSD-1534

## Proposed Changes

* In the Sign in with Apple callback, validate the redirect destination by parsing it with `new URL()` and comparing the resulting origin against the allowlist, instead of checking string prefixes.
* Add unit tests covering allowed and rejected destinations.

## Why are these changes being made?

* The previous check used `startsWith()`, which accepts external destinations whose URL merely begins with an allowed origin string. Since the callback places the Apple `id_token` in the redirect's URL fragment, a crafted destination could leak it off-site.
* Parsing the URL and comparing exact origins also lets the browser's own URL semantics (e.g. `\` treated as `/`) be handled by the parser rather than ad-hoc string checks, while still permitting any path on an allowed origin.

## Testing Instructions

**Note: This is tricky to test in dev due to Apple auth being allowed on specific domains.** Will need to test once we're on staging.

* `yarn test-server client/server/api/test/sign-in-with-apple.js`
* Regression check: on the Multi-site Dashboard, go to Security → Social Logins and connect an Apple account. After the Apple flow you should land back on the security page with the connection completed.
* Regression check: log in to Calypso with an Apple account via `/log-in/apple` and confirm login completes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01An9ZUy9pSMGVBwNcXaSDcx