### PR TITLE
E2E: stop the Forms folder filter from killing the renderer

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -373,11 +373,11 @@ export class FeedbackInboxPage {
 			await listResponse;
 
 			// Selecting a folder leaves the popover open over the table, where it
-			// swallows clicks on the rows underneath. Dismiss unconditionally:
-			// isVisible() is point-in-time, so polled mid-transition it reports
-			// false and the popover survives — the state this block exists to
-			// prevent. Escape on an already-closed popover is a no-op.
-			await this.page.keyboard.press( 'Escape' );
+			// swallows clicks on the rows underneath. Toggle it shut with the chip:
+			// an Escape landing within ~500ms of the filter's re-render segfaults the
+			// renderer on Atomic (SIGSEGV, null deref on CrRendererMain), and the run
+			// then dies at whatever call comes next.
+			await folderChip.click();
 			await folderOption.waitFor( { state: 'hidden', timeout: 5000 } );
 			return;
 		}


### PR DESCRIPTION
Part of Automattic/jetpack#51127

## Proposed Changes

* `clickFolderTab` closes the DataViews folder popover by clicking the filter chip instead of pressing `Escape`.

## Why are these changes being made?

Enabling `forms__submissions.spec.ts` in #113637 exposes a renderer crash on Atomic desktop. It is not in that PR's new code: the `Escape` has been in `clickFolderTab` since the CFM migration, and the spec was `fixme`'d until now, so nothing ever ran it.

The renderer dies outright, so the run fails at whatever call comes next rather than where the fault is. The crash report:

```
EXC_BAD_ACCESS (SIGSEGV)
KERN_INVALID_ADDRESS at 0x0000000000000004
faultingThread: CrRendererMain (com.apple.main-thread)
```

A null deref on the renderer main thread, so a Chromium bug; page JavaScript can't produce one. The binary is stripped and Playwright ships no symbols, so there are no usable frames. What the trigger is, though, is pinned. Same spec, Atomic desktop, varying only the dismissal:

| Dismissal | SIGSEGV |
| --- | --- |
| `Escape` immediately | yes (2/2) |
| `Escape` after `networkidle` | yes |
| `Escape` after 500ms | no |
| `Escape` after 3s | no |
| `Shift` immediately | no |
| chip click | no |

So it isn't a race with in-flight requests; `networkidle` still crashes. And it isn't input dispatch during teardown generally; a modifier key at the same instant is harmless. It's `Escape` specifically, landing inside a roughly sub-500ms window after the filter re-renders. A 500ms sleep also clears it, but that's a magic number layered over a renderer bug. Clicking the chip closes the popover through the control that opened it and has no window to lose.

The two other `Escape` presses in this page object dismiss row action menus, not the filter popover. Both run in every passing run and neither crashes, so they're left alone.

## Testing Instructions

```
yarn workspace @automattic/calypso-e2e build
cd test/e2e
VIEWPORT_NAME=desktop JETPACK_TARGET=wpcom-deployment TEST_ON_ATOMIC=true \
ATOMIC_VARIATION=default CALYPSO_BASE_URL=<production> DEBUG=pw:browser \
yarn test:pw:desktop --grep=@jetpack-wpcom-integration
```

With `DEBUG=pw:browser`, a crashed run prints `Received signal 11 SEGV_ACCERR`; that line is the check. Revert this commit to see it, and note `--repeat-each` is useless on this spec, since the response addresses are module-scope and repeats collide on the same site.

Run so far: Atomic desktop 3/3 green on the `default` variation, Atomic mobile green. Simple and self-hosted are untested against this commit.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
