### PR TITLE
Dashboard: align DataViews media and primary column content

### DIFF
--- a/client/dashboard/app/dataviews-overrides.scss
+++ b/client/dashboard/app/dataviews-overrides.scss
@@ -52,13 +52,19 @@ a.dataviews-url-field {
 	}
 }
 
-// The 32px minimum cell height forces the primary column's text to sit lower than the
-// media thumbnail next to it. Let the content size itself and tighten the gap so the
-// media and the primary column line up.
-.dataviews-view-table tbody .dataviews-view-table__cell-content-wrapper {
-	min-height: auto !important;
+// DataViews gives every cell a 32px content box, which leaves the primary column's text
+// sitting lower than the media thumbnail beside it. Shrink the box rather than removing
+// it, and match the line box to it: every cell then resolves to the same height and its
+// contents share a center line, while the title and description stack on the same rhythm
+// without needing a gap of their own.
+.dataviews-view-table tbody .dataviews-view-table__cell-content-wrapper,
+.dataviews-view-table tbody .dataviews-title-field ~ * {
+	min-height: var( --wpds-dimension-size-sm, 24px ) !important;
+	line-height: var( --wpds-dimension-size-sm, 24px ) !important;
 }
 
-.dataviews-view-table__primary-column-content:not( .dataviews-column-primary__media ) {
-	gap: 6px;
+// The actions cell has no content wrapper of its own, so the rule above can't reach it and
+// its compact buttons keep a 32px box that sits below everything else in the row.
+.dataviews-view-table tbody .dataviews-item-actions .components-button.is-compact {
+	height: var( --wpds-dimension-size-sm, 24px );
 }

--- a/client/dashboard/app/dataviews-overrides.scss
+++ b/client/dashboard/app/dataviews-overrides.scss
@@ -51,3 +51,14 @@ a.dataviews-url-field {
 		padding-inline: #{$grid-unit-20} !important;
 	}
 }
+
+// The 32px minimum cell height forces the primary column's text to sit lower than the
+// media thumbnail next to it. Let the content size itself and tighten the gap so the
+// media and the primary column line up.
+.dataviews-view-table tbody .dataviews-view-table__cell-content-wrapper {
+	min-height: auto !important;
+}
+
+.dataviews-view-table__primary-column-content:not( .dataviews-column-primary__media ) {
+	gap: 6px;
+}


### PR DESCRIPTION
Fixes p1786347701123699-slack-CNGQYA3B9

## Proposed Changes

* Put the Dashboard's DataViews tables on a 24px line grid: cell content boxes and their line height both drop from 32px to 24px, and the row action buttons come down to match.

## Why are these changes being made?

* Content in a table row doesn't line up. DataViews sizes every cell's content box at 32px, so the primary column's title sits lower than the media thumbnail beside it.
* The box is what keeps a row aligned — each cell centers its contents in it, so they only share a center line while every cell resolves to the same height. Removing it isn't an option: the selection checkbox is 16px and a line of text is 20px, so they'd drift apart by a couple of pixels.
* Shrinking the box to 24px keeps that guarantee while tightening the rows. Matching the line height to it lets the title and description stack on the same rhythm without a gap of their own.
* The actions column needs its own rule. DataViews renders it without a cell content wrapper, so nothing else reaches it, and its buttons are compact-sized at 32px — which left them sitting below the rest of the row.

## Considerations

* The media thumbnail is fixed at 32px and still exceeds the 24px box, so it centers slightly below the title line. Resolving it means either shrinking thumbnails or centering the media against the whole title/description block — both are design decisions rather than alignment fixes, so they're left out here.
* The overrides use `!important` because they match the upstream selectors exactly, and equal specificity would otherwise leave the outcome down to stylesheet order.

## Testing Instructions

* Open Dashboard screens with table views — the Sites list (media in the primary column), and a screen with row actions such as Billing → Purchases.
* Confirm the selection checkbox, the primary column title, other columns, and the row action buttons all sit on the same line.
* Confirm the title and description in the primary column read as one unit, and that rows are tighter than before without feeling cramped.
* Check light and dark mode, and a narrow viewport (below 600px the checkbox grows to 24px, so it should still line up).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRTbaMxM3krqCeKKb9UMZB