### PR TITLE
A4A Sites Performance: Gate on site visibility instead of the blog_public setting

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -7,7 +7,6 @@ import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import { useEffect, useMemo, useState } from 'react';
-import { useSiteSettings } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-site-settings';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import {
@@ -55,9 +54,7 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 	const { activeTab, setActiveTab } = useDeviceTab();
 	const site = useSelector( getSelectedSite );
 	const siteId = site?.ID;
-	const { getSiteSetting } = useSiteSettings( site?.slug );
-	const blog_public = getSiteSetting( 'blog_public' );
-	const isSitePublic = site && blog_public === 1;
+	const isSitePublic = !! site && ! site.is_coming_soon && ! site.is_private;
 	const isSiteAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const isSiteFlex = useSelector( ( state ) => isWpcomFlexSite( state, siteId ) );
 


### PR DESCRIPTION
Fixes A4A-3112

> **Note:** this overlaps #113135, which fixes the same gate (extracted into an `isPublicSite()` helper with a unit test) and additionally guards the Performance and Details tabs behind the no-WP-admin-access check. This PR is the minimal, condition-only version of that fix. Only one of the two should land.

## Proposed Changes

* Decide whether the Performance tab shows performance stats or the "Launch your site" prompt from `site.is_coming_soon` / `site.is_private` on the site object, instead of the `blog_public` site setting.

## Why are these changes being made?

The Performance tab in the A4A site preview pane (`OverviewPreviewPane` → `SitePerformance`) either renders the performance report or an empty state reading "Launch your site to start measuring performance / Performance statistics are only available for public sites". Until now that branch was driven by:

```js
const { getSiteSetting } = useSiteSettings( site?.slug );
const blog_public = getSiteSetting( 'blog_public' );
const isSitePublic = site && blog_public === 1;
```

`useSiteSettings` reads `blog_public` from `GET /sites/<id>/settings`. Sourcing the gate from there fails in four ways:

1. **There is no loading or error state.** `getSiteSetting` returns `''` both when settings have not been fetched yet and when the fetch failed, and `''` is indistinguishable from "not public". The loading branch is itself gated on `isSitePublic`, so it never covers that unknown window — the launch prompt shows on every mount until the settings round-trip lands.
2. **The request 403s for `a4a_manager` users.** `/sites/<id>/settings` requires `manage_options`, which those users do not have. Combined with point 1, launched public sites show the launch prompt *permanently* for them, hiding the Performance tab's actual content.
3. **`blog_public` goes stale after an in-place launch.** The launch handler only refreshes `data.options`, and `blog_public` is not among them, so a site that was just launched keeps reporting its pre-launch value.
4. **`=== 1` is too strict.** A public site with "discourage search engines" enabled has `blog_public === 0`. It is launched and its performance can be measured, but it was treated as unlaunched.

Reported against a genuinely public, indexable Atomic site that rendered the launch prompt instead of its report.

`site.is_coming_soon` and `site.is_private` are already the fields the new dashboard uses for the same decision on the same screen (`client/dashboard/sites/performance/index.tsx`). Both are in `SITE_REQUEST_FIELDS`, and `client/state/sites/reducer.js` keeps them in sync when site settings are saved. Reading them removes the extra request, the 403, the loading hole, and the staleness window in one go.

`SitePerformance` is only rendered by the A4A site preview pane, so the blast radius is that one tab.

## Testing Instructions

Prerequisites: an A4A account with at least one connected Atomic site (the Performance tab only renders for `site.is_atomic`).

1. Run A4A locally: `yarn start-a8c-for-agencies`, then open `http://agencies.localhost:3000/sites`.
2. Pick a site that is **launched and public**, open its preview pane, and select the **Performance** tab.
3. Verify the performance report renders — page selector, device tabs, and metrics — and that the "Launch your site to start measuring performance" prompt does **not** appear, including on first mount before any settings request would have completed.
4. Repeat step 2 with a **private** site (Settings → Privacy → Private) and verify the launch prompt still appears.
5. Repeat step 2 with a **coming soon** site and verify the launch prompt still appears.
6. As an `a4a_manager` user (no `manage_options` on the site), repeat step 2 on a launched public site. Before this change the prompt showed permanently; verify the report now renders.
7. Optional, covers case 4 above: on a public site, enable Settings → Reading → "Discourage search engines from indexing this site", reload the Performance tab, and verify the report still renders rather than the launch prompt.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

<!--
No new tests: no visibility-gate logic is extracted here, and the screen is slated for migration
to the new dashboard. #113135 adds a test alongside its `isPublicSite()` extraction.
Not tested against a live A4A site — verified by type-check, lint, and code path review only.
-->
