### PR TITLE
Dashboard: gate paid+domain site launches behind the pre-launch modal

### DIFF
--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -459,6 +459,15 @@
 		background-color: var( --wp-components-color-gray-200 );
 		color: var( --dashboard__text-color );
 	}
+
+	.site-launch-pre-launch-modal__thumbnail,
+	.site-launch-pre-launch-modal__thumbnail::before {
+		background-color: var( --wp-components-color-gray-300 );
+	}
+
+	.site-launch-pre-launch-modal__meta svg {
+		fill: var( --dashboard__text-color );
+	}
 }
 
 // :root variables overridden for dark theme

--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -170,7 +170,7 @@ function ConnectedOmnibar( {
 	} );
 	const { node: shoppingCartNode, panel: shoppingCartPanel } = useShoppingCartPlugin( { site } );
 	const statsSparklineNode = useStatsSparklinePlugin( { site } );
-	const launchSiteNode = useLaunchSitePlugin( { site } );
+	const { node: launchSiteNode, panel: launchSitePanel } = useLaunchSitePlugin( { site } );
 	const dashboardNode = useDashboardPlugin( { site, sectionGroup } );
 	const siteNode = addDashboardNode( baseOmnibarNodes.site, dashboardNode );
 	const siteActions = [
@@ -217,6 +217,7 @@ function ConnectedOmnibar( {
 			/>
 			{ shoppingCartPanel }
 			{ languageSwitcherPanel }
+			{ launchSitePanel }
 		</>
 	);
 }

--- a/client/dashboard/app/omnibar/plugin-launch-site.tsx
+++ b/client/dashboard/app/omnibar/plugin-launch-site.tsx
@@ -23,7 +23,10 @@ function LaunchRocketIcon() {
 
 const NO_SITE = { ID: 0, slug: '', name: '' } as Site;
 
-export function useLaunchSitePlugin( { site }: { site?: Site } ): OmnibarNode | undefined {
+export function useLaunchSitePlugin( { site }: { site?: Site } ): {
+	node?: OmnibarNode;
+	panel?: React.ReactNode;
+} {
 	const { queries } = useAppContext();
 	const { recordTracksEvent } = useAnalytics();
 
@@ -35,30 +38,31 @@ export function useLaunchSitePlugin( { site }: { site?: Site } ): OmnibarNode | 
 	const launchSite = site ?? NO_SITE;
 	const siteOverviewUrl = `/sites/${ launchSite.slug }`;
 
-	const { isLoading, isExperimentLoading, isDisabled, isBusy, href, onClick } = useSiteLaunch(
-		launchSite,
-		{
+	const { isLoading, isExperimentLoading, isDisabled, isBusy, href, onClick, modal } =
+		useSiteLaunch( launchSite, {
 			tracksContext: 'omnibar',
 			backTo: siteOverviewUrl,
 			postLaunchUrl: dashboardLinkWithBackport( siteOverviewUrl ),
 			domainsOptions: { ...queries.domainsQuery(), enabled: isLaunchable },
 			recordTracksEvent,
-		}
-	);
+		} );
 
 	if ( ! isLaunchable ) {
-		return undefined;
+		return {};
 	}
 
 	const disabled = isLoading || isExperimentLoading || isDisabled || isBusy;
 
 	return {
-		id: 'launch-site',
-		title: __( 'Launch site' ),
-		icon: <LaunchRocketIcon />,
-		className: 'omnibar__launch-site color-scheme is-global',
-		disabled,
-		href,
-		onClick,
+		node: {
+			id: 'launch-site',
+			title: __( 'Launch site' ),
+			icon: <LaunchRocketIcon />,
+			className: 'omnibar__launch-site color-scheme is-global',
+			disabled,
+			href,
+			onClick,
+		},
+		panel: modal,
 	};
 }

--- a/client/dashboard/app/omnibar/test/plugin-launch-site.test.tsx
+++ b/client/dashboard/app/omnibar/test/plugin-launch-site.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import { useLaunchSitePlugin } from '../plugin-launch-site';
+import type { DomainSummary, Site } from '@automattic/api-core';
+
+const createMockSite = ( options: Partial< Site > = {} ): Site =>
+	( {
+		ID: 1,
+		slug: 'kaonashi.wordpress.com',
+		URL: 'https://kaonashi.wordpress.com',
+		name: 'Kaonashi',
+		launch_status: 'unlaunched' as const,
+		is_a4a_dev_site: false,
+		capabilities: { manage_options: true },
+		plan: {
+			product_slug: 'business-bundle',
+			product_name: 'Business plan',
+			is_free: false,
+		},
+		...options,
+	} ) as Site;
+
+const createMockDomain = ( domain: string, hasSubscription = true ): DomainSummary =>
+	( {
+		domain,
+		blog_id: 1,
+		subscription_id: hasSubscription ? 123 : null,
+	} ) as unknown as DomainSummary;
+
+const mockDomainsApi = ( domains: DomainSummary[] ) => {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.2/all-domains' )
+		.query( true )
+		.reply( 200, { domains } );
+};
+
+function LaunchHarness( { site }: { site: Site } ) {
+	const { node, panel } = useLaunchSitePlugin( { site } );
+	return (
+		<>
+			{ node && (
+				<button onClick={ node.onClick } disabled={ node.disabled }>
+					{ node.title }
+				</button>
+			) }
+			{ panel }
+		</>
+	);
+}
+
+describe( 'useLaunchSitePlugin', () => {
+	afterEach( () => nock.cleanAll() );
+
+	test( 'renders the pre-launch modal panel when a paid, custom-domain site is launched from the omnibar', async () => {
+		const user = userEvent.setup();
+		mockDomainsApi( [
+			createMockDomain( 'kaonashi.wordpress.com', false ),
+			createMockDomain( 'kaonashi.com' ),
+		] );
+
+		render( <LaunchHarness site={ createMockSite() } /> );
+
+		const launchButton = await screen.findByRole( 'button', { name: 'Launch site' } );
+		// The button is disabled until the domains query settles, which is what
+		// tells the hook the site has a custom domain and should open the modal.
+		await waitFor( () => expect( launchButton ).toBeEnabled() );
+		await user.click( launchButton );
+
+		expect(
+			await screen.findByRole( 'dialog', { name: 'Launching makes your site public' } )
+		).toBeVisible();
+	} );
+} );

--- a/client/dashboard/sites/site-launch-button/test/index.test.tsx
+++ b/client/dashboard/sites/site-launch-button/test/index.test.tsx
@@ -93,9 +93,6 @@ describe( '<SiteLaunchButton>', () => {
 	} );
 
 	test( 'does not open the modal for a paid site without a custom domain', async () => {
-		// A paid site whose only domain is its default *.wordpress.com address
-		// has domains.length === 1, so isSitePlanPaidWithDomains is false and the
-		// launch is not gated behind the modal — it routes to the launch flow.
 		mockDomainsApi( [ createMockDomain( 'kaonashi.wordpress.com', false ) ] );
 
 		render( <SiteLaunchButton site={ createMockSite() } tracksContext="test" /> );

--- a/client/dashboard/sites/site-launch-button/test/index.test.tsx
+++ b/client/dashboard/sites/site-launch-button/test/index.test.tsx
@@ -149,6 +149,33 @@ describe( '<SiteLaunchButton>', () => {
 		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
 	} );
 
+	test( 'launches a hosting-trial site immediately even when it has a custom domain', async () => {
+		const user = userEvent.setup();
+		mockDomainsApi( [
+			createMockDomain( 'kaonashi.wordpress.com', false ),
+			createMockDomain( 'kaonashi.com' ),
+		] );
+		const launchScope = mockLaunchApi();
+
+		render(
+			<SiteLaunchButton
+				site={ createMockSite( {
+					plan: {
+						product_slug: 'wp_bundle_hosting_trial_monthly',
+						product_name: 'Hosting Trial',
+						is_free: false,
+					},
+				} as Partial< Site > ) }
+				tracksContext="test"
+			/>
+		);
+
+		await user.click( await screen.findByRole( 'button', { name: 'Launch your site' } ) );
+
+		await waitFor( () => expect( launchScope.isDone() ).toBe( true ) );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
 	test( 'renders a link to the launch flow for a free site without an immediate launch', async () => {
 		mockDomainsApi( [ createMockDomain( 'kaonashi.wordpress.com', false ) ] );
 

--- a/client/dashboard/sites/site-launch-button/test/index.test.tsx
+++ b/client/dashboard/sites/site-launch-button/test/index.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { SiteLaunchButton } from '..';
+import { render } from '../../../test-utils';
+import type { DomainSummary, Site } from '@automattic/api-core';
+
+const createMockSite = ( options: Partial< Site > = {} ): Site =>
+	( {
+		ID: 1,
+		slug: 'kaonashi.wordpress.com',
+		URL: 'https://kaonashi.wordpress.com',
+		name: 'Kaonashi',
+		launch_status: 'unlaunched' as const,
+		plan: {
+			product_slug: 'business-bundle',
+			product_name: 'Business plan',
+			product_name_short: 'Business',
+			is_free: false,
+		},
+		...options,
+	} ) as Site;
+
+const createMockDomain = ( domain: string, hasSubscription = true ): DomainSummary =>
+	( {
+		domain,
+		blog_id: 1,
+		subscription_id: hasSubscription ? 123 : null,
+	} ) as unknown as DomainSummary;
+
+const mockDomainsApi = ( domains: DomainSummary[] = [] ) => {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.2/all-domains' )
+		.query( true )
+		.reply( 200, { domains } );
+};
+
+const mockLaunchApi = () =>
+	nock( 'https://public-api.wordpress.com' )
+		.post( /\/sites\/1\/launch$/ )
+		.reply( 200, {} );
+
+describe( '<SiteLaunchButton>', () => {
+	test( 'opens the pre-launch modal instead of launching immediately for a paid site with a custom domain', async () => {
+		const user = userEvent.setup();
+		mockDomainsApi( [
+			createMockDomain( 'kaonashi.wordpress.com', false ),
+			createMockDomain( 'kaonashi.com' ),
+		] );
+		const launchScope = mockLaunchApi();
+
+		render( <SiteLaunchButton site={ createMockSite() } tracksContext="test" /> );
+
+		await user.click( await screen.findByRole( 'button', { name: 'Launch your site' } ) );
+
+		expect(
+			await screen.findByRole( 'dialog', { name: 'Launching makes your site public' } )
+		).toBeVisible();
+		expect( launchScope.isDone() ).toBe( false );
+	} );
+
+	test( 'launches the site when the pre-launch modal is confirmed', async () => {
+		const user = userEvent.setup();
+		mockDomainsApi( [
+			createMockDomain( 'kaonashi.wordpress.com', false ),
+			createMockDomain( 'kaonashi.com' ),
+		] );
+		const launchScope = mockLaunchApi();
+
+		render( <SiteLaunchButton site={ createMockSite() } tracksContext="test" /> );
+
+		await user.click( await screen.findByRole( 'button', { name: 'Launch your site' } ) );
+		await user.click( await screen.findByRole( 'button', { name: 'Yes, launch site!' } ) );
+
+		await waitFor( () => expect( launchScope.isDone() ).toBe( true ) );
+	} );
+
+	test( 'does not open the modal and launches immediately for a hosting-trial site', async () => {
+		const user = userEvent.setup();
+		mockDomainsApi( [ createMockDomain( 'kaonashi.wordpress.com', false ) ] );
+		const launchScope = mockLaunchApi();
+
+		render(
+			<SiteLaunchButton
+				site={ createMockSite( {
+					plan: {
+						product_slug: 'wp_bundle_hosting_trial_monthly',
+						product_name: 'Hosting Trial',
+						is_free: false,
+					},
+				} as Partial< Site > ) }
+				tracksContext="test"
+			/>
+		);
+
+		await user.click( await screen.findByRole( 'button', { name: 'Launch your site' } ) );
+
+		await waitFor( () => expect( launchScope.isDone() ).toBe( true ) );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders a link to the launch flow for a free site without an immediate launch', async () => {
+		mockDomainsApi( [ createMockDomain( 'kaonashi.wordpress.com', false ) ] );
+
+		render(
+			<SiteLaunchButton
+				site={ createMockSite( {
+					plan: {
+						product_slug: 'free_plan',
+						product_name: 'Free',
+						is_free: true,
+					},
+				} as Partial< Site > ) }
+				tracksContext="test"
+			/>
+		);
+
+		const launchLink = await screen.findByRole( 'link', { name: 'Launch your site' } );
+		expect( launchLink ).toHaveAttribute( 'href', expect.stringContaining( '/start/launch-site' ) );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/sites/site-launch-button/test/index.test.tsx
+++ b/client/dashboard/sites/site-launch-button/test/index.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { SiteLaunchButton } from '..';
@@ -51,16 +51,22 @@ describe( '<SiteLaunchButton>', () => {
 			createMockDomain( 'kaonashi.wordpress.com', false ),
 			createMockDomain( 'kaonashi.com' ),
 		] );
-		const launchScope = mockLaunchApi();
+		// Deliberately no launch interceptor: nock.disableNetConnect() makes any
+		// premature launch request throw, so reaching the modal proves the launch
+		// was gated rather than merely not-yet-completed.
 
 		render( <SiteLaunchButton site={ createMockSite() } tracksContext="test" /> );
 
 		await user.click( await screen.findByRole( 'button', { name: 'Launch your site' } ) );
 
+		// The dialog's accessible name is "Launching makes your site public" only
+		// while not launching (it becomes "Launching site…" once the mutation
+		// runs), so finding it — with the confirm button still present — proves
+		// the flow paused for confirmation instead of launching.
 		expect(
 			await screen.findByRole( 'dialog', { name: 'Launching makes your site public' } )
 		).toBeVisible();
-		expect( launchScope.isDone() ).toBe( false );
+		expect( screen.getByRole( 'button', { name: 'Yes, launch site!' } ) ).toBeVisible();
 	} );
 
 	test( 'launches the site when the pre-launch modal is confirmed', async () => {
@@ -74,9 +80,49 @@ describe( '<SiteLaunchButton>', () => {
 		render( <SiteLaunchButton site={ createMockSite() } tracksContext="test" /> );
 
 		await user.click( await screen.findByRole( 'button', { name: 'Launch your site' } ) );
+		await screen.findByRole( 'dialog', { name: 'Launching makes your site public' } );
+
+		// The launch must fire from the confirm click, not from merely opening the
+		// modal: it hasn't happened yet with the modal open…
+		expect( launchScope.isDone() ).toBe( false );
+
 		await user.click( await screen.findByRole( 'button', { name: 'Yes, launch site!' } ) );
 
+		// …and only happens once the user confirms.
 		await waitFor( () => expect( launchScope.isDone() ).toBe( true ) );
+	} );
+
+	test( 'does not open the modal for a paid site without a custom domain', async () => {
+		// A paid site whose only domain is its default *.wordpress.com address
+		// has domains.length === 1, so isSitePlanPaidWithDomains is false and the
+		// launch is not gated behind the modal — it routes to the launch flow.
+		mockDomainsApi( [ createMockDomain( 'kaonashi.wordpress.com', false ) ] );
+
+		render( <SiteLaunchButton site={ createMockSite() } tracksContext="test" /> );
+
+		const launchLink = await screen.findByRole( 'link', { name: 'Launch your site' } );
+		expect( launchLink ).toHaveAttribute( 'href', expect.stringContaining( '/start/launch-site' ) );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'closing the pre-launch modal does not launch the site', async () => {
+		const user = userEvent.setup();
+		mockDomainsApi( [
+			createMockDomain( 'kaonashi.wordpress.com', false ),
+			createMockDomain( 'kaonashi.com' ),
+		] );
+		const launchScope = mockLaunchApi();
+
+		render( <SiteLaunchButton site={ createMockSite() } tracksContext="test" /> );
+
+		await user.click( await screen.findByRole( 'button', { name: 'Launch your site' } ) );
+		const dialog = await screen.findByRole( 'dialog', {
+			name: 'Launching makes your site public',
+		} );
+		await user.click( screen.getByRole( 'button', { name: 'Close' } ) );
+
+		await waitForElementToBeRemoved( dialog );
+		expect( launchScope.isDone() ).toBe( false );
 	} );
 
 	test( 'does not open the modal and launches immediately for a hosting-trial site', async () => {

--- a/client/dashboard/sites/site-launch-button/use-site-launch.tsx
+++ b/client/dashboard/sites/site-launch-button/use-site-launch.tsx
@@ -13,6 +13,7 @@ import {
 	isSitePlanBigSkyTrial,
 	isSitePlanPaid,
 } from '../plans';
+import SiteLaunchModal from '../site-launch-modal';
 import type { Site } from '@automattic/api-core';
 
 export type A4aLaunchModalComponent = ComponentType< {
@@ -76,8 +77,7 @@ export function useSiteLaunch(
 	const isSitePlanHostingTrial = site.plan?.product_slug === DotcomPlans.HOSTING_TRIAL_MONTHLY;
 	const isSitePlanPaidWithDomains = isSitePlanPaid( site ) && domains.length > 1;
 	const isDisabled = ! getIsSitePlanLaunchable( site );
-	const shouldImmediatelyLaunch =
-		isSitePlanPaidWithDomains || isSitePlanHostingTrial || site.is_wpcom_staging_site;
+	const shouldImmediatelyLaunch = isSitePlanHostingTrial || site.is_wpcom_staging_site;
 
 	const launchUrl = useMemo( () => {
 		if ( isSitePlanBigSkyTrial( site ) ) {
@@ -126,6 +126,15 @@ export function useSiteLaunch(
 		} );
 	};
 
+	const confirmPreLaunch = () => {
+		track();
+		launchMutation.mutate( undefined, {
+			onSuccess: () => redirectAfterLaunch(),
+			onError: onLaunchError,
+			onSettled: () => setIsModalOpen( false ),
+		} );
+	};
+
 	const baseResult = {
 		isLoading: isDomainsLoading,
 		isExperimentLoading,
@@ -160,6 +169,24 @@ export function useSiteLaunch(
 		}
 
 		return { ...baseResult, isHidden: true, onClick: () => {} };
+	}
+
+	if ( isSitePlanPaidWithDomains ) {
+		return {
+			...baseResult,
+			isHidden: false,
+			onClick: () => setIsModalOpen( true ),
+			modal: isModalOpen ? (
+				<SiteLaunchModal
+					variant="pre-launch"
+					isOpen
+					site={ site }
+					isLaunching={ launchMutation.isPending }
+					onClose={ () => setIsModalOpen( false ) }
+					onLaunch={ confirmPreLaunch }
+				/>
+			) : null,
+		};
 	}
 
 	if ( shouldImmediatelyLaunch ) {

--- a/client/dashboard/sites/site-launch-button/use-site-launch.tsx
+++ b/client/dashboard/sites/site-launch-button/use-site-launch.tsx
@@ -75,7 +75,8 @@ export function useSiteLaunch(
 	const [ isExperimentLoading, variant ] = useSiteLaunchGatingVariant();
 
 	const isSitePlanHostingTrial = site.plan?.product_slug === DotcomPlans.HOSTING_TRIAL_MONTHLY;
-	const isSitePlanPaidWithDomains = isSitePlanPaid( site ) && domains.length > 1;
+	const hasCustomDomain = domains.some( ( domain ) => domain.subscription_id !== null );
+	const isSitePlanPaidWithCustomDomain = isSitePlanPaid( site ) && hasCustomDomain;
 	const isDisabled = ! getIsSitePlanLaunchable( site );
 	const shouldImmediatelyLaunch = isSitePlanHostingTrial || site.is_wpcom_staging_site;
 
@@ -171,7 +172,21 @@ export function useSiteLaunch(
 		return { ...baseResult, isHidden: true, onClick: () => {} };
 	}
 
-	if ( isSitePlanPaidWithDomains ) {
+	if ( shouldImmediatelyLaunch ) {
+		return {
+			...baseResult,
+			isHidden: false,
+			onClick: () => {
+				track();
+				launchMutation.mutate( undefined, {
+					onSuccess: () => redirectAfterLaunch(),
+					onError: onLaunchError,
+				} );
+			},
+		};
+	}
+
+	if ( isSitePlanPaidWithCustomDomain ) {
 		return {
 			...baseResult,
 			isHidden: false,
@@ -186,20 +201,6 @@ export function useSiteLaunch(
 					onLaunch={ confirmPreLaunch }
 				/>
 			) : null,
-		};
-	}
-
-	if ( shouldImmediatelyLaunch ) {
-		return {
-			...baseResult,
-			isHidden: false,
-			onClick: () => {
-				track();
-				launchMutation.mutate( undefined, {
-					onSuccess: () => redirectAfterLaunch(),
-					onError: onLaunchError,
-				} );
-			},
 		};
 	}
 

--- a/client/dashboard/sites/site-launch-modal/index.tsx
+++ b/client/dashboard/sites/site-launch-modal/index.tsx
@@ -1,6 +1,7 @@
 import { PreLaunchModal, CelebrationModal } from '@automattic/site-launch-modals';
 import { useQuery } from '@tanstack/react-query';
 import { useResizeObserver } from '@wordpress/compose';
+import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useAppContext } from '../../app/context';
 import { getAddSiteDomainUrl } from '../../utils/domain-url';
@@ -46,6 +47,7 @@ export default function SiteLaunchModal( props: SiteLaunchModalProps ) {
 	} );
 	const [ previewResizeListener, { width: previewWidth, height: previewHeight } ] =
 		useResizeObserver();
+	const [ isPreviewLoaded, setIsPreviewLoaded ] = useState( false );
 
 	if ( ! isOpen ) {
 		return null;
@@ -76,13 +78,17 @@ export default function SiteLaunchModal( props: SiteLaunchModalProps ) {
 				onClose={ onClose }
 				preview={
 					site.URL ? (
-						<div className="site-launch-pre-launch-modal__thumbnail">
+						<div
+							className="site-launch-pre-launch-modal__thumbnail"
+							data-preview-loaded={ isPreviewLoaded }
+						>
 							{ previewResizeListener }
 							{ !! previewWidth && !! previewHeight && (
 								<SitePreview
 									url={ site.URL }
 									scale={ previewWidth / PREVIEW_BASE_WIDTH }
 									height={ previewHeight / ( previewWidth / PREVIEW_BASE_WIDTH ) }
+									onLoad={ () => setIsPreviewLoaded( true ) }
 								/>
 							) }
 						</div>

--- a/client/dashboard/sites/site-launch-modal/styles.scss
+++ b/client/dashboard/sites/site-launch-modal/styles.scss
@@ -9,4 +9,20 @@
 	block-size: 88px;
 	overflow: hidden;
 	border-radius: $radius-medium;
+	background-color: var( --color-neutral-5 );
+
+	// Static placeholder that covers the preview until the iframe has finished
+	// loading. A loading iframe paints an opaque viewport, so the placeholder
+	// must sit on top rather than behind it.
+	&::before {
+		content: "";
+		position: absolute;
+		inset: 0;
+		z-index: 1;
+		background-color: var( --color-neutral-5 );
+	}
+
+	&[data-preview-loaded="true"]::before {
+		display: none;
+	}
 }

--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -5,11 +5,13 @@ export default function SitePreview( {
 	scale = 1,
 	width = 1200,
 	height = 800,
+	onLoad,
 }: {
 	url: string;
 	scale?: number;
 	width?: number;
 	height?: number;
+	onLoad?: () => void;
 } ) {
 	// The /sites endpoint may return non-secure URLs. Often these _can_ be
 	// loaded securely, so it's worth trying to load over https. If it fails,
@@ -30,6 +32,7 @@ export default function SitePreview( {
 			// @ts-expect-error For some reason there's no inert type.
 			inert="true"
 			title={ __( 'Site Preview' ) }
+			onLoad={ onLoad }
 			// Hide banners + `preview` hides cookie banners + `iframe` hides
 			// admin bar for atomic sites.
 			src={ `${ secureUrl }/?hide_banners=true&preview=true&iframe=true` }


### PR DESCRIPTION
Part of DOTPROD-77

<img width="1526" height="885" alt="Screenshot 2026-08-24 at 17 41 24" src="https://github.com/user-attachments/assets/5097659c-937c-47c0-8e33-db425c6c0607" />

## Proposed Changes

* Wire the package-backed pre-launch `SiteLaunchModal` (which renders `PreLaunchModal` from `@automattic/site-launch-modals`) into the `useSiteLaunch` hook (`client/dashboard/sites/site-launch-button/use-site-launch.tsx`).
* Sites that **already have a paid plan and a custom domain** now open the pre-launch confirmation modal on click instead of launching in one click; the launch fires when the user confirms ("Yes, launch site!"). Post-launch behavior (mutation + redirect) is unchanged — it's just gated by a confirmation step.
* Hosting-trial and staging sites keep their existing **immediate-launch** behavior (no modal). Free sites still route to the `/start/launch-site` stepper.
* Add a consumer-side preview-load placeholder: the thumbnail iframe is covered until it finishes loading (`SitePreview` gains an `onLoad` prop; the wrapper tracks `isPreviewLoaded`). This stays out of the package to keep the modal purely presentational.
* No consumer changes required: `SiteLaunchButton` and the omnibar launch button already render the hook's `modal`.
* Add hook-level integration tests driving the real hook through `SiteLaunchButton`.

## Why are these changes being made?

One-click launching for plan+domain sites skips any confirmation, so it's easy to make a site public by accident. Gating that path behind the pre-launch modal gives the user a clear "launching makes your site public" confirmation with a preview of the site, name, domain, and plan.

## Testing Instructions

* In the dashboard, open a site that has a **paid plan and a custom domain** and is still unlaunched. Click **Launch your site** (from the site button, settings › visibility, performance page, or the omnibar). The pre-launch modal should appear; confirming launches the site as before.
* Verify a **hosting-trial** or **staging** site still launches immediately with no modal.
* Verify a **free** site still routes to the `/start/launch-site` stepper flow.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

