### PR TITLE
E2E: clear the Jetpack SSO screen that kept the Atomic private variation red

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-component.ts
@@ -1,6 +1,14 @@
 import { Page, Locator } from 'playwright';
+import envVariables from '../../env-variables';
+import { completeJetpackSso } from '../pages/wp-admin/jetpack-sso';
 
 const EDITOR_TIMEOUT = 60 * 1000;
+
+// The SSO screen is the slow path: it is what a loaded Atomic site answers with when the two
+// waits below are already doomed. Giving it the same budget as its competitors makes it lose a
+// race it is meant to win — `Promise.any` rejects once all three are out, so a screen arriving
+// after EDITOR_TIMEOUT is never clicked. It must outlive them.
+const JETPACK_SSO_SCREEN_TIMEOUT = 2 * EDITOR_TIMEOUT;
 
 /**
  * Represents the Editor component.
@@ -28,12 +36,17 @@ export class EditorComponent {
 			return this.parentLocator;
 		}
 
+		const waits = [ this.waitForFramedEditor(), this.waitForUnframedEditor() ];
+
+		// Only Atomic wp-admin can answer with the SSO screen. Elsewhere this racer would
+		// just hold a wp-login.php wait open for the full timeout after the editor loaded.
+		if ( envVariables.TEST_ON_ATOMIC ) {
+			waits.push( this.waitForEditorBehindJetpackSso() );
+		}
+
 		try {
-			this.parentLocator = await Promise.any( [
-				this.waitForFramedEditor(),
-				this.waitForUnframedEditor(),
-			] );
-		} catch ( _error ) {
+			this.parentLocator = await Promise.any( waits );
+		} catch {
 			throw new Error( 'Timed out waiting for the Editor' );
 		}
 
@@ -52,9 +65,33 @@ export class EditorComponent {
 	async canvas(): Promise< Locator > {
 		try {
 			return await Promise.any( [ this.waitForFramedCanvas(), this.waitForUnframedCanvas() ] );
-		} catch ( _error ) {
+		} catch {
 			throw new Error( 'Timed out waiting for the Editor canvas' );
 		}
+	}
+
+	/**
+	 * If wp-admin answered with the Jetpack SSO screen, it will clear the screen and resolve
+	 * with the parent element locator once the Editor loads behind it. Otherwise, it will
+	 * time out.
+	 *
+	 * Atomic sites carrying local users serve this screen in place of the Editor. It arrives
+	 * after Calypso has redirected away from its own route, so no navigation the caller made
+	 * can check for it, and the two waits above see only a page that never becomes an Editor.
+	 * Racing it alongside them is what catches it; on the common path this branch simply loses
+	 * and `Promise.any` ignores it.
+	 *
+	 * The cost of the longer budget is paid only when the Editor never loads at all: that
+	 * failure now takes JETPACK_SSO_SCREEN_TIMEOUT to report instead of EDITOR_TIMEOUT.
+	 */
+	private async waitForEditorBehindJetpackSso() {
+		// Keyed on the URL, not on the link: the two waits above race this one and only one of
+		// the three may touch the page, so this branch must not act until the screen is
+		// certain.
+		await this.page.waitForURL( /wp-login\.php/, { timeout: JETPACK_SSO_SCREEN_TIMEOUT } );
+		await completeJetpackSso( this.page );
+
+		return await this.waitForUnframedEditor();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/pages-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/pages-page.ts
@@ -1,5 +1,7 @@
 import { Page, Response } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
+import envVariables from '../../env-variables';
+import { completeJetpackSso } from './wp-admin/jetpack-sso';
 
 const selectors = {
 	// General
@@ -93,7 +95,7 @@ export class PagesPage {
 		if ( addNewVisible ) {
 			await Promise.all( [
 				this.page.waitForFunction(
-					() => {
+					( onAtomic ) => {
 						const u = new URL( window.location.href );
 						if ( /^\/page(?:\/[^/?#]+)?\/?$/.test( u.pathname ) ) {
 							return true;
@@ -104,9 +106,15 @@ export class PagesPage {
 						) {
 							return true;
 						}
+						// The Jetpack SSO screen is where an Atomic site carrying local users settles
+						// instead. Count it as settled so the caller can clear it; leaving it out
+						// spends this whole timeout on a page that was never going to change.
+						if ( onAtomic && u.pathname === '/wp-login.php' ) {
+							return true;
+						}
 						return false;
 					},
-					undefined,
+					envVariables.TEST_ON_ATOMIC,
 					{ timeout: 20 * 1000 }
 				),
 				locator.click( { noWaitAfter: true } ),
@@ -116,6 +124,12 @@ export class PagesPage {
 				timeout: 30 * 1000,
 				waitUntil: 'domcontentloaded',
 			} );
+		}
+
+		// An Atomic site carrying local users answers the wp-admin editor route with the Jetpack
+		// SSO screen, which is a route of its own and would fail the check below.
+		if ( envVariables.TEST_ON_ATOMIC ) {
+			await completeJetpackSso( this.page );
 		}
 
 		if ( ! hasPageEditorUrl() ) {

--- a/packages/calypso-e2e/src/lib/pages/wp-admin/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/wp-admin/index.ts
@@ -1,1 +1,2 @@
 export * from './jetpack-dashboard-page';
+export * from './jetpack-sso';

--- a/packages/calypso-e2e/src/lib/pages/wp-admin/jetpack-dashboard-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/wp-admin/jetpack-dashboard-page.ts
@@ -1,4 +1,5 @@
 import { Page } from 'playwright';
+import { completeJetpackSso } from './jetpack-sso';
 
 export type DashboardTabs = 'At a Glance' | 'My Plan';
 export type SettingsTabs =
@@ -41,6 +42,7 @@ export class JetpackDashboardPage {
 		await this.page.goto( `https://${ siteSlug }/wp-admin/admin.php?page=jetpack#/dashboard`, {
 			timeout: 15 * 1000,
 		} );
+		await completeJetpackSso( this.page );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/wp-admin/jetpack-sso.ts
+++ b/packages/calypso-e2e/src/lib/pages/wp-admin/jetpack-sso.ts
@@ -1,0 +1,24 @@
+import { Page } from 'playwright';
+
+/**
+ * Clears the Jetpack SSO screen, if wp-admin answered with it.
+ *
+ * Atomic test sites can carry local users, so wp-admin sends the WordPress.com user to the
+ * Jetpack SSO screen instead of logging them straight in. It is served by wp-login.php, so the
+ * landing URL settles the question without polling for an element that is absent on the common
+ * path. Clearing an already-cleared screen is a no-op, and any wp-admin navigation can get one,
+ * so call this after each.
+ *
+ * Left unhandled, the screen fails nothing here: the caller finds out several steps later, at
+ * whatever it clicks next.
+ *
+ * @param {Page} page Page object.
+ */
+export async function completeJetpackSso( page: Page ): Promise< void > {
+	if ( ! page.url().includes( 'wp-login.php' ) ) {
+		return;
+	}
+
+	await page.getByRole( 'link', { name: 'Log in with WordPress.com' } ).click();
+	await page.waitForURL( /\/wp-admin\// );
+}

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -10,6 +10,16 @@ import {
 } from '@automattic/calypso-e2e';
 import { expect, tags as allTags, test } from '../../../lib/pw-base';
 
+// Publishing a post carrying a synced form saves two entities. On Atomic the second save
+// regularly outruns the cap that predates it, so only Atomic gets the longer one; Simple keeps
+// the tighter bound, where it still catches a regression. Omitting the argument would not lift
+// the cap either way: `waitForResponse` falls back to `actionTimeout` from playwright.config.ts.
+//
+// 60s was not enough: the Jetpack Forms flows overran it on the private variation, where four
+// workers share one site. Both values stay well inside the per-test budget set below.
+const PUBLISH_TIMEOUT = 15 * 1000;
+const ATOMIC_PUBLISH_TIMEOUT = 120 * 1000;
+
 /**
  * Creates a suite of block smoke tests for a set of block flows.
  *
@@ -93,7 +103,10 @@ export function createBlockTests(
 			}
 
 			await test.step( 'When I publish and visit the post', async () => {
-				await pageEditor.publish( { visit: true, timeout: 15 * 1000 } );
+				await pageEditor.publish( {
+					visit: true,
+					timeout: envVariables.TEST_ON_ATOMIC ? ATOMIC_PUBLISH_TIMEOUT : PUBLISH_TIMEOUT,
+				} );
 				publishedPostContext = {
 					browser: page.context().browser()!,
 					page,

--- a/test/e2e/specs/jetpack/jetpack__dashboard-smoke.spec.ts
+++ b/test/e2e/specs/jetpack/jetpack__dashboard-smoke.spec.ts
@@ -13,6 +13,7 @@ import {
 	JetpackDashboardPage,
 	SettingsTabs,
 	TestAccount,
+	completeJetpackSso,
 	envToFeatureKey,
 	envVariables,
 	getTestAccountByFeature,
@@ -36,13 +37,15 @@ test.describe(
 				await testAccount.authenticate( page );
 				jetpackDashboardPage = new JetpackDashboardPage( page );
 
-				// Atomic tests sites might have local users, so the Jetpack SSO login will
-				// show up when visiting the Jetpack dashboard directly.
-				const siteUrl = testAccount.getSiteURL( { protocol: true } );
-				await page.goto( `${ siteUrl }wp-admin/`, {
-					timeout: 45 * 1000,
+				// A referer that looks like Calypso gets the site to skip the Jetpack SSO screen
+				// most of the time; `completeJetpackSso` covers the rest. `domcontentloaded` is
+				// enough because the next step navigates away, while "load" would sit through the
+				// dashboard's Site widget iframing a whole front-end page.
+				await page.goto( `${ testAccount.getSiteURL( { protocol: true } ) }wp-admin/`, {
+					waitUntil: 'domcontentloaded',
 					referer: 'https://wordpress.com/',
 				} );
+				await completeJetpackSso( page );
 			} );
 
 			await test.step( 'Navigate to Jetpack dashboard', async () => {


### PR DESCRIPTION
## Proposed Changes

* Add `completeJetpackSso()`, which clears the Jetpack SSO screen when a wp-admin navigation lands on it. Keyed on the `wp-login.php` URL rather than on the link, so it costs nothing on the common path and is a no-op when called twice.
* Call it wherever an Atomic wp-admin navigation can land there: the editor, the Pages list, the Jetpack dashboard.
* In `EditorComponent.parent()`, race the SSO check alongside the two Editor waits, but only when `TEST_ON_ATOMIC` is set. Give it twice their budget — `Promise.any` rejects only once every racer is out, so a screen arriving after `EDITOR_TIMEOUT` would never be clicked.
* Raise the block smoke suite's publish cap to 120s **on Atomic only**; Simple keeps the 15s bound, where it still catches a regression.

## Why are these changes being made?

Jetpack Atomic Build Smoke E2E (desktop) failed 101 of its last 150 trunk builds. Grouped by site variation, `private` failed 26 of 28, and 27 of the 41 failures that survived the recent fix batches were the same one: `Timed out waiting for the Editor`.

The screen is not what the Editor waits were looking at. `waitForEditorLoadedRequests` accepts `wordpress.com/post/<slug>` as a settled editor route, so it returns before Calypso redirects to the site's own wp-admin; by the time the SSO screen arrives no caller is still watching, and both Editor waits sit on wp-login.php until they time out.

Two details are load-dependent rather than structural, and both were set from observed failures rather than guessed:

* The SSO racer needs a longer timeout than its competitors, not an equal one. A first cut gave all three `EDITOR_TIMEOUT` and still failed on `private` with the page sitting on the SSO screen — the screen had arrived, just too late to be clicked.
* 60s was not enough for the publish cap either. The Jetpack Forms flows overran it on `private`, where four workers share one site. Omitting the argument would not have lifted the cap: `waitForResponse` falls back to `actionTimeout` from `playwright.config.ts`.

## Testing Instructions

Personal builds off this branch. The variation is forced rather than left to the `mixed` rotation — **`ATOMIC_VARIATION_KEY` is `%build.vcs.number%`, so every push re-rolls it.** Any re-verification of this branch needs `-E ATOMIC_VARIATION=private` explicitly; an unforced run on a new head will almost certainly miss the variation this change is about.

All six runs below are on `5059190fc7e`, with zero failed test occurrences — nothing passed on retry:

| Suite | Variation | Result |
| --- | --- | --- |
| Jetpack Atomic Build Smoke (desktop) ×3 | `private`, forced | 17 passed, 0 failed |
| Jetpack Atomic Build Smoke (desktop) | `php-new` | 26 passed, 0 failed |
| Gutenberg atomic production (desktop) | unforced | 28 passed, 0 failed |
| Gutenberg atomic production (mobile) | unforced | 28 passed, 0 failed |

Baseline for comparison: `private` was failing 26 of 28 builds, most of them on `Timed out waiting for the Editor`.

The non-`private` runs are the regression check, not the fix check. `EditorComponent.parent()` gains a third racer on **every** Atomic variation, and the `@gutenberg` suites drive it far harder than build smoke does — so a regression surfaces there rather than on `private`. Neither the PR's own checks nor the Gutenberg suites publish a commit status for this, so none of the above appears on this PR.

Not covered anywhere: the `remote-site` Jetpack target also serves this screen, and the `TEST_ON_ATOMIC` guard excludes it. No `.teamcity` config sets that target today, so this is a latent caveat rather than a gap a build could close.

Reviewer's invariant: `EditorComponent.parent()` must not touch the page unless the URL is `wp-login.php`. Two of its three racers are read-only waits and the third clicks; keying that third on the link rather than on the URL would let it navigate away from an Editor that had already loaded.

Note for reviewers on the file rename: `visit-wp-admin.ts` became `jetpack-sso.ts`. The `visitWpAdmin` helper it held had a single remaining caller, so it is gone and its body is inlined into `jetpack__dashboard-smoke.spec.ts`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
