### PR TITLE
Invites: fix the accept page for a logged-out visitor on an address-bound invite

### DIFF
--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -184,7 +184,11 @@ class InviteAccept extends Component {
 			redirectTo: getRedirectAfterAccept( invite, this.props.hasDashboardOptIn ),
 			decline: this.decline,
 			signInLink: this.signInLink(),
-			forceMatchingEmail: this.isMatchEmailError(),
+			// Logged in, this means the signed-in address differs from the invited one, so the
+			// mismatch notice applies. Logged out, there is no address to compare, and the flag
+			// simply means the invite is bound to a single address, which is what the logged-out
+			// form needs in order to pin the email field and offer signing in instead.
+			forceMatchingEmail: this.props.user ? this.isMatchEmailError() : !! invite.forceMatchingEmail,
 		};
 
 		return this.props.user ? (

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -127,7 +127,8 @@ class InviteAccept extends Component {
 
 	isMatchEmailError = () => {
 		const { invite } = this.state;
-		return invite && invite.forceMatchingEmail && this.props.user.email !== invite.sentTo;
+		const { user } = this.props;
+		return !! ( invite && invite.forceMatchingEmail && user && user.email !== invite.sentTo );
 	};
 
 	isInvalidInvite = () => {

--- a/client/my-sites/invites/invite-accept/test/index.jsx
+++ b/client/my-sites/invites/invite-accept/test/index.jsx
@@ -1,0 +1,155 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import InviteAccept from '../index';
+
+const mockLoggedIn = jest.fn();
+const mockLoggedOut = jest.fn();
+let mockCurrentUser = null;
+
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	getCurrentUser: () => mockCurrentUser,
+} ) );
+
+jest.mock( 'calypso/state/dashboard/selectors', () => ( {
+	hasDashboardOptIn: () => false,
+} ) );
+
+jest.mock( 'calypso/state/current-user/actions', () => ( {
+	redirectToLogout: () => ( { type: 'REDIRECT_TO_LOGOUT' } ),
+} ) );
+
+jest.mock( 'calypso/state/ui/actions', () => ( {
+	hideMasterbar: () => ( { type: 'HIDE_MASTERBAR' } ),
+} ) );
+
+jest.mock( 'calypso/state/notices/actions', () => ( {
+	successNotice: () => ( { type: 'SUCCESS_NOTICE' } ),
+	infoNotice: () => ( { type: 'INFO_NOTICE' } ),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: () => {},
+} ) );
+
+jest.mock( 'calypso/lib/wp', () => ( { req: { get: () => new Promise( () => {} ) } } ) );
+
+jest.mock( 'calypso/components/locale-suggestions', () => () => null );
+
+jest.mock( 'calypso/my-sites/invites/invite-accept-logged-in', () => ( {
+	__esModule: true,
+	default: ( props ) => {
+		mockLoggedIn( props );
+		return <div data-testid="logged-in-form" />;
+	},
+} ) );
+
+jest.mock( 'calypso/my-sites/invites/invite-accept-logged-out', () => ( {
+	__esModule: true,
+	default: ( props ) => {
+		mockLoggedOut( props );
+		return <div data-testid="logged-out-form" />;
+	},
+} ) );
+
+const SITE_ID = 12345;
+const INVITE_KEY = 'abc123';
+const SENT_TO = 'invited@example.com';
+
+function buildInvite( { forceMatchingEmail, known = true } ) {
+	return {
+		invite: {
+			invite_slug: INVITE_KEY,
+			invite_date: '2026-08-24T00:00:00+00:00',
+			blog_id: String( SITE_ID ),
+			meta: {
+				role: 'editor',
+				sent_to: SENT_TO,
+				force_matching_email: forceMatchingEmail,
+				known,
+			},
+		},
+		blog_details: { title: 'Example Site', domain: 'example.wordpress.com' },
+		inviter: { ID: 1, name: 'Inviter' },
+	};
+}
+
+function renderInvite( { forceMatchingEmail, known } = {} ) {
+	const store = configureStore()( {} );
+
+	return render(
+		<Provider store={ store }>
+			<InviteAccept
+				siteId={ SITE_ID }
+				inviteKey={ INVITE_KEY }
+				activationKey="activation"
+				authKey="auth"
+				prefetchedInvite={ buildInvite( { forceMatchingEmail, known } ) }
+			/>
+		</Provider>
+	);
+}
+
+describe( 'InviteAccept', () => {
+	beforeEach( () => {
+		mockCurrentUser = null;
+		mockLoggedIn.mockClear();
+		mockLoggedOut.mockClear();
+	} );
+
+	describe( 'logged out', () => {
+		it( 'renders the form for an invite bound to a single address', () => {
+			const { getByTestId } = renderInvite( { forceMatchingEmail: true } );
+
+			expect( getByTestId( 'logged-out-form' ) ).toBeVisible();
+		} );
+
+		it( 'tells the form the invite is bound to a single address', () => {
+			renderInvite( { forceMatchingEmail: true } );
+
+			expect( mockLoggedOut ).toHaveBeenCalledWith(
+				expect.objectContaining( { forceMatchingEmail: true } )
+			);
+		} );
+
+		it( 'leaves the form unconstrained for an unbound invite', () => {
+			renderInvite( { forceMatchingEmail: false } );
+
+			expect( mockLoggedOut ).toHaveBeenCalledWith(
+				expect.objectContaining( { forceMatchingEmail: false } )
+			);
+		} );
+	} );
+
+	describe( 'logged in', () => {
+		it( 'flags a signed-in address that differs from the invited one', () => {
+			mockCurrentUser = { email: 'someone.else@example.com' };
+			renderInvite( { forceMatchingEmail: true } );
+
+			expect( mockLoggedIn ).toHaveBeenCalledWith(
+				expect.objectContaining( { forceMatchingEmail: true } )
+			);
+		} );
+
+		it( 'does not flag a signed-in address that matches the invited one', () => {
+			mockCurrentUser = { email: SENT_TO };
+			renderInvite( { forceMatchingEmail: true } );
+
+			expect( mockLoggedIn ).toHaveBeenCalledWith(
+				expect.objectContaining( { forceMatchingEmail: false } )
+			);
+		} );
+
+		it( 'does not flag an unbound invite', () => {
+			mockCurrentUser = { email: 'someone.else@example.com' };
+			renderInvite( { forceMatchingEmail: false } );
+
+			expect( mockLoggedIn ).toHaveBeenCalledWith(
+				expect.objectContaining( { forceMatchingEmail: false } )
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
Part of DOTSITE-126. Client-side companion to Automattic/wpcom#235658.

## Proposed Changes

* Guard `isMatchEmailError()` against a logged-out visitor. It read `.email` off the current user without checking there is one.
* Pass the invite's address binding through to the logged-out form, rather than only the logged-in interpretation of it.
* Add render coverage for the accept page across signed-in state and address binding.

## Why are these changes being made?

`invite.forceMatchingEmail` comes from the `force_matching_email` meta on `/sites/$site/invites/$key`. Until now that flag was `false` for essentially everyone, so two problems in `invite-accept` never surfaced. Automattic/wpcom#235658 starts setting it in more cases, and both surface immediately.

**1. Null dereference when logged out.**

```js
return invite && invite.forceMatchingEmail && this.props.user.email !== invite.sentTo;
```

`user` is `null` for a logged-out visitor. While the flag was always `false`, `&&` short-circuited before the dereference. Once it can be `true`, this throws `TypeError: Cannot read properties of null (reading 'email')` during render, and the accept page renders blank. The notice in `render()` already guards on `user` the same way, so the guard is consistent with the rest of the file.

**2. One prop, two meanings.**

`renderForm()` passed `isMatchEmailError()` down as `forceMatchingEmail`, but the two forms want different things from it:

* `invite-accept-logged-in` wants "the signed-in address differs from the invited one" so it can show the mismatch notice.
* `invite-accept-logged-out` wants "this invite is bound to a single address" so it can pin the email field (`disableEmailInput`) and, for an address that already has an account, render the sign-in-only view with the "Sign in to continue:" header.

The logged-out meaning cannot be derived from a comparison against a user who is not there. So the logged-out form never received it, and offered a free-form signup for an address that already has an account. The behaviour it needs is already implemented in `invite-accept-logged-out` and `invite-form-header`, it just never received a `true`.

## Testing Instructions

Automated: `yarn jest --config=test/client/jest.config.js client/my-sites/invites/invite-accept`. The two logged-out cases fail against `trunk` with the `TypeError` above.

Manual, needs a sandbox running Automattic/wpcom#235658 so the endpoint returns `force_matching_email: true`:

1. Invite an address that already has a WordPress.com account.
2. Open the invite link in a logged-out window (incognito).
3. **Before:** blank page, `TypeError` in the console. **After:** the "Sign in to continue:" view with a Sign In button.
4. Log in as the invited address, reopen the link, confirm the invite is still acceptable.
5. Log in as a different address, reopen the link, confirm the existing mismatch notice still appears with its action.
6. Repeat 2 with an invited address that has no account, confirm the signup form still renders with the email pinned.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [x] Have you used memoizing on expensive computations?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? No new strings.

## Deploy note

This should land and deploy **before** Automattic/wpcom#235658, not after. That PR is what starts setting the flag, and without this change a logged-out visitor hitting an affected invite link gets a blank page.
