### PR TITLE
Calypso: gate classic launch surfaces behind the package pre-launch modal

### DIFF
--- a/client/components/pre-launch-site-modal/index.tsx
+++ b/client/components/pre-launch-site-modal/index.tsx
@@ -1,3 +1,4 @@
+import { DomainSubtype } from '@automattic/api-core';
 import { queryClient, siteByIdQuery, domainsQuery } from '@automattic/api-queries';
 import { PreLaunchModal } from '@automattic/site-launch-modals';
 import { QueryClientProvider, useQuery } from '@tanstack/react-query';
@@ -59,8 +60,14 @@ function PreLaunchSiteModalContent( {
 		isOpen &&
 		( siteResult.isSuccess || siteResult.isError ) &&
 		( domainsResult.isSuccess || domainsResult.isError );
+	// Mirror the launch flow's domain-skip rule so the modal's "custom domain"
+	// set matches the set of sites for which `/start/launch-site` skips its
+	// domain step. That flow's `isDomainFulfilled` skips the step when the site
+	// has any non-WPCOM domain (`! isWPCOMDomain`) — i.e. anything other than the
+	// default `*.wordpress.com` address. Gating on the same signal guarantees
+	// that confirming "launch" never drops the user onto a domain step.
 	const customDomains = ( domainsResult.data ?? [] ).filter(
-		( domain ) => domain.subscription_id !== null
+		( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
 	);
 	const hasCustomDomain = customDomains.length > 0;
 	const qualifiesForPreLaunch =

--- a/client/components/pre-launch-site-modal/index.tsx
+++ b/client/components/pre-launch-site-modal/index.tsx
@@ -22,13 +22,11 @@ interface PreLaunchSiteModalProps {
 }
 
 /**
- * Shared bridge that gates the classic "launch site" surfaces behind the
- * pre-launch modal.
+ * Gates the classic "launch site" surfaces behind the pre-launch modal.
  *
- * When a site already has a paid plan and a custom domain, the launch flow
- * auto-skips its domain and plan steps and launches immediately. For those sites
- * we show a confirmation modal first; on confirm we redirect to `launchUrl`.
- * Every other site is sent straight to `launchUrl`, preserving today's behavior.
+ * A paid plan + custom domain makes the launch flow auto-skip its steps and
+ * launch immediately, so those sites get a confirmation modal first (on confirm
+ * we redirect to `launchUrl`). Every other site goes straight to `launchUrl`.
  */
 function PreLaunchSiteModalContent( {
 	siteId,
@@ -57,12 +55,9 @@ function PreLaunchSiteModalContent( {
 	const isSettled =
 		( siteResult.isSuccess || siteResult.isError ) &&
 		( domainsResult.isSuccess || domainsResult.isError );
-	// Mirror the launch flow's domain-skip rule so the modal's "custom domain"
-	// set matches the set of sites for which `/start/launch-site` skips its
-	// domain step. That flow's `isDomainFulfilled` skips the step when the site
-	// has any non-WPCOM domain (`! isWPCOMDomain`) — i.e. anything other than the
-	// default `*.wordpress.com` address. Gating on the same signal guarantees
-	// that confirming "launch" never drops the user onto a domain step.
+	// A "custom domain" is any non-default address, mirroring the launch flow's
+	// domain-skip rule (`isDomainFulfilled` / `! isWPCOMDomain`) so confirming
+	// "launch" never drops the user onto a domain step.
 	const customDomains = ( domainsResult.data ?? [] ).filter(
 		( domain ) => domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
 	);

--- a/client/components/pre-launch-site-modal/index.tsx
+++ b/client/components/pre-launch-site-modal/index.tsx
@@ -43,23 +43,32 @@ function PreLaunchSiteModalContent( {
 	// Fetch as soon as there is a site (not only once open) so the qualification
 	// decision is already settled by the time the user clicks — otherwise the
 	// button appears unresponsive while these requests resolve.
-	const { data: site } = useQuery( { ...siteByIdQuery( siteId ), enabled: !! siteId } );
+	const siteResult = useQuery( { ...siteByIdQuery( siteId ), enabled: !! siteId } );
+	const site = siteResult.data;
 	const domainsResult = useQuery( {
 		...domainsQuery(),
 		enabled: !! siteId,
 		select: ( data ) => data.filter( ( domain ) => domain.blog_id === siteId ),
 	} );
 
-	// Wait until the site is loaded and the domains query has settled (success or
-	// error) before deciding. On a domains error we fall back to the flow so the
-	// launch action is never silently swallowed.
-	const isReady = isOpen && !! site && ( domainsResult.isSuccess || domainsResult.isError );
+	// Wait until both queries have settled (success or error) before deciding. On
+	// either error we fall back to the flow so the launch action is never silently
+	// swallowed — otherwise a failed site/domains fetch would leave the caller
+	// stuck with the modal neither open nor redirecting.
+	const isReady =
+		isOpen &&
+		( siteResult.isSuccess || siteResult.isError ) &&
+		( domainsResult.isSuccess || domainsResult.isError );
 	const customDomains = ( domainsResult.data ?? [] ).filter(
 		( domain ) => domain.subscription_id !== null
 	);
 	const hasCustomDomain = customDomains.length > 0;
 	const qualifiesForPreLaunch =
-		!! site && domainsResult.isSuccess && isSitePlanPaid( site ) && hasCustomDomain;
+		!! site &&
+		siteResult.isSuccess &&
+		domainsResult.isSuccess &&
+		isSitePlanPaid( site ) &&
+		hasCustomDomain;
 
 	useEffect( () => {
 		if ( isReady && ! qualifiesForPreLaunch && launchUrl ) {

--- a/client/components/pre-launch-site-modal/index.tsx
+++ b/client/components/pre-launch-site-modal/index.tsx
@@ -1,0 +1,122 @@
+import { queryClient, siteByIdQuery, domainsQuery } from '@automattic/api-queries';
+import { PreLaunchModal } from '@automattic/site-launch-modals';
+import { QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { useResizeObserver } from '@wordpress/compose';
+import { useEffect, useState } from 'react';
+import { isSitePlanPaid } from 'calypso/dashboard/sites/plans';
+import SitePreview from 'calypso/dashboard/sites/site-preview';
+import { getSitePlanDisplayName } from 'calypso/dashboard/utils/site-plan';
+
+import './style.scss';
+
+const PREVIEW_BASE_WIDTH = 1200;
+
+interface PreLaunchSiteModalProps {
+	siteId: number;
+	isOpen: boolean;
+	onClose: () => void;
+	// Where launch is handed off to. The caller owns this so the destination
+	// (and the `/start/launch-site` path) stays explicit at each call site.
+	launchUrl: string;
+}
+
+/**
+ * Shared bridge that gates the classic "launch site" surfaces behind the
+ * pre-launch modal.
+ *
+ * When a site already has a paid plan and a custom domain, the launch flow
+ * auto-skips its domain and plan steps and launches immediately. For those sites
+ * we show a confirmation modal first; on confirm we redirect to `launchUrl`.
+ * Every other site is sent straight to `launchUrl`, preserving today's behavior.
+ */
+function PreLaunchSiteModalContent( {
+	siteId,
+	isOpen,
+	onClose,
+	launchUrl,
+}: PreLaunchSiteModalProps ) {
+	const [ isRedirecting, setIsRedirecting ] = useState( false );
+	const [ previewResizeListener, { width: previewWidth, height: previewHeight } ] =
+		useResizeObserver();
+	const [ isPreviewLoaded, setIsPreviewLoaded ] = useState( false );
+
+	// Fetch as soon as there is a site (not only once open) so the qualification
+	// decision is already settled by the time the user clicks — otherwise the
+	// button appears unresponsive while these requests resolve.
+	const { data: site } = useQuery( { ...siteByIdQuery( siteId ), enabled: !! siteId } );
+	const domainsResult = useQuery( {
+		...domainsQuery(),
+		enabled: !! siteId,
+		select: ( data ) => data.filter( ( domain ) => domain.blog_id === siteId ),
+	} );
+
+	// Wait until the site is loaded and the domains query has settled (success or
+	// error) before deciding. On a domains error we fall back to the flow so the
+	// launch action is never silently swallowed.
+	const isReady = isOpen && !! site && ( domainsResult.isSuccess || domainsResult.isError );
+	const customDomains = ( domainsResult.data ?? [] ).filter(
+		( domain ) => domain.subscription_id !== null
+	);
+	const hasCustomDomain = customDomains.length > 0;
+	const qualifiesForPreLaunch =
+		!! site && domainsResult.isSuccess && isSitePlanPaid( site ) && hasCustomDomain;
+
+	useEffect( () => {
+		if ( isReady && ! qualifiesForPreLaunch && launchUrl ) {
+			window.location.assign( launchUrl );
+		}
+	}, [ isReady, qualifiesForPreLaunch, launchUrl ] );
+
+	if ( ! isReady || ! qualifiesForPreLaunch || ! site ) {
+		return null;
+	}
+
+	const siteDomain = hasCustomDomain ? customDomains[ 0 ].domain : site.slug;
+	const planName = site.plan?.product_name ?? getSitePlanDisplayName( site );
+
+	return (
+		<PreLaunchModal
+			siteName={ site.name }
+			siteDomain={ siteDomain }
+			planName={ planName }
+			isLaunching={ isRedirecting }
+			onClose={ onClose }
+			onLaunch={ () => {
+				setIsRedirecting( true );
+				window.location.assign( launchUrl );
+			} }
+			preview={
+				site.URL ? (
+					<div
+						className="site-launch-pre-launch-modal__thumbnail"
+						data-preview-loaded={ isPreviewLoaded }
+					>
+						{ previewResizeListener }
+						{ !! previewWidth && !! previewHeight && (
+							<SitePreview
+								url={ site.URL }
+								scale={ previewWidth / PREVIEW_BASE_WIDTH }
+								height={ previewHeight / ( previewWidth / PREVIEW_BASE_WIDTH ) }
+								onLoad={ () => setIsPreviewLoaded( true ) }
+							/>
+						) }
+					</div>
+				) : null
+			}
+		/>
+	);
+}
+
+export default function PreLaunchSiteModal( props: PreLaunchSiteModalProps ) {
+	if ( ! props.siteId ) {
+		return null;
+	}
+
+	// Mounted (and prefetching) whenever a site is present, even while closed, so
+	// the modal can open instantly. It renders nothing until `isOpen`.
+	return (
+		<QueryClientProvider client={ queryClient }>
+			<PreLaunchSiteModalContent { ...props } />
+		</QueryClientProvider>
+	);
+}

--- a/client/components/pre-launch-site-modal/index.tsx
+++ b/client/components/pre-launch-site-modal/index.tsx
@@ -52,12 +52,9 @@ function PreLaunchSiteModalContent( {
 		select: ( data ) => data.filter( ( domain ) => domain.blog_id === siteId ),
 	} );
 
-	// Wait until both queries have settled (success or error) before deciding. On
-	// either error we fall back to the flow so the launch action is never silently
-	// swallowed — otherwise a failed site/domains fetch would leave the caller
+	// On either error we fall back to the flow rather than leaving the caller
 	// stuck with the modal neither open nor redirecting.
-	const isReady =
-		isOpen &&
+	const isSettled =
 		( siteResult.isSuccess || siteResult.isError ) &&
 		( domainsResult.isSuccess || domainsResult.isError );
 	// Mirror the launch flow's domain-skip rule so the modal's "custom domain"
@@ -77,13 +74,24 @@ function PreLaunchSiteModalContent( {
 		isSitePlanPaid( site ) &&
 		hasCustomDomain;
 
+	// Decide once and freeze it: after the modal is shown, a later refetch error
+	// must not re-decide and redirect a qualifying site into an unconfirmed launch.
+	const [ decision, setDecision ] = useState< 'pending' | 'modal' | 'redirect' >( 'pending' );
+
 	useEffect( () => {
-		if ( isReady && ! qualifiesForPreLaunch && launchUrl ) {
+		if ( decision !== 'pending' || ! isOpen || ! isSettled ) {
+			return;
+		}
+		setDecision( qualifiesForPreLaunch ? 'modal' : 'redirect' );
+	}, [ decision, isOpen, isSettled, qualifiesForPreLaunch ] );
+
+	useEffect( () => {
+		if ( decision === 'redirect' && launchUrl ) {
 			window.location.assign( launchUrl );
 		}
-	}, [ isReady, qualifiesForPreLaunch, launchUrl ] );
+	}, [ decision, launchUrl ] );
 
-	if ( ! isReady || ! qualifiesForPreLaunch || ! site ) {
+	if ( decision !== 'modal' || ! isOpen || ! site ) {
 		return null;
 	}
 

--- a/client/components/pre-launch-site-modal/style.scss
+++ b/client/components/pre-launch-site-modal/style.scss
@@ -1,0 +1,34 @@
+@import '@wordpress/base-styles/variables';
+
+// The preview thumbnail is rendered by this app and passed into the modal's
+// `preview` prop, so its styling stays here rather than in the package.
+.site-launch-pre-launch-modal__thumbnail {
+	position: relative;
+	flex-shrink: 0;
+	inline-size: 114px;
+	block-size: 88px;
+	overflow: hidden;
+	border-radius: $radius-medium;
+	background-color: var( --color-neutral-5 );
+
+	// Static placeholder that covers the preview until the iframe has finished
+	// loading. A loading iframe paints an opaque viewport, so the placeholder
+	// must sit on top rather than behind it.
+	&::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		z-index: 1;
+		background-color: var( --color-neutral-5 );
+	}
+
+	&[data-preview-loaded='true']::before {
+		display: none;
+	}
+
+	// Undo classic Calypso's global `iframe { max-width: 100% }`, which collapses
+	// the scaled site-preview iframe to a sliver.
+	iframe {
+		max-width: none;
+	}
+}

--- a/client/components/pre-launch-site-modal/test/index.test.tsx
+++ b/client/components/pre-launch-site-modal/test/index.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import PreLaunchSiteModal from '../index';
+
+let mockSite: unknown;
+let mockDomains: unknown;
+let mockDomainsError = false;
+let mockIsPaid = true;
+
+jest.mock( '@automattic/api-queries', () => ( {
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	queryClient: new ( require( '@tanstack/react-query' ).QueryClient )( {
+		defaultOptions: { queries: { retry: false } },
+	} ),
+	siteByIdQuery: ( siteId: number ) => ( {
+		queryKey: [ 'site', siteId ],
+		queryFn: async () => mockSite,
+	} ),
+	domainsQuery: () => ( {
+		queryKey: [ 'domains' ],
+		queryFn: async () => {
+			if ( mockDomainsError ) {
+				throw new Error( 'boom' );
+			}
+			return mockDomains;
+		},
+	} ),
+} ) );
+
+jest.mock( 'calypso/dashboard/sites/plans', () => ( {
+	isSitePlanPaid: () => mockIsPaid,
+} ) );
+
+jest.mock( 'calypso/dashboard/utils/site-plan', () => ( {
+	getSitePlanDisplayName: () => 'Business',
+} ) );
+
+jest.mock( 'calypso/dashboard/sites/site-preview', () => ( {
+	__esModule: true,
+	default: () => <div data-testid="site-preview" />,
+} ) );
+
+jest.mock( '@automattic/site-launch-modals', () => ( {
+	__esModule: true,
+	PreLaunchModal: ( { siteName, siteDomain, planName }: Record< string, string > ) => (
+		<div data-testid="pre-launch-modal">
+			<span>{ siteName }</span>
+			<span>{ siteDomain }</span>
+			<span>{ planName }</span>
+		</div>
+	),
+} ) );
+
+const customDomain = { blog_id: 1, domain: 'example.com', subscription_id: 42 };
+const wpcomDomain = { blog_id: 1, domain: 'example.wordpress.com', subscription_id: null };
+
+describe( 'PreLaunchSiteModal', () => {
+	const assign = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		Object.defineProperty( window, 'location', {
+			configurable: true,
+			value: { assign, pathname: '/home' },
+		} );
+		mockSite = {
+			ID: 1,
+			name: 'My Site',
+			slug: 'example.wordpress.com',
+			URL: 'https://example.com',
+		};
+		mockDomains = [ customDomain ];
+		mockDomainsError = false;
+		mockIsPaid = true;
+	} );
+
+	it( 'shows the modal for a paid plan + custom domain site', async () => {
+		render(
+			<PreLaunchSiteModal
+				siteId={ 1 }
+				isOpen
+				onClose={ jest.fn() }
+				launchUrl="/start/launch-site?siteSlug=example.wordpress.com"
+			/>
+		);
+
+		expect( await screen.findByTestId( 'pre-launch-modal' ) ).toBeVisible();
+		expect( screen.getByText( 'My Site' ) ).toBeVisible();
+		expect( screen.getByText( 'example.com' ) ).toBeVisible();
+		expect( assign ).not.toHaveBeenCalled();
+	} );
+
+	it( 'redirects straight to the launch flow when the plan is not paid', async () => {
+		mockIsPaid = false;
+
+		render(
+			<PreLaunchSiteModal
+				siteId={ 1 }
+				isOpen
+				onClose={ jest.fn() }
+				launchUrl="/start/launch-site?siteSlug=example.wordpress.com"
+			/>
+		);
+
+		await waitFor( () =>
+			expect( assign ).toHaveBeenCalledWith( '/start/launch-site?siteSlug=example.wordpress.com' )
+		);
+		expect( screen.queryByTestId( 'pre-launch-modal' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'redirects when the site has no custom domain', async () => {
+		mockDomains = [ wpcomDomain ];
+
+		render(
+			<PreLaunchSiteModal
+				siteId={ 1 }
+				isOpen
+				onClose={ jest.fn() }
+				launchUrl="/start/launch-site?siteSlug=example.wordpress.com"
+			/>
+		);
+
+		await waitFor( () => expect( assign ).toHaveBeenCalled() );
+		expect( screen.queryByTestId( 'pre-launch-modal' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'falls back to the launch flow when the domains query errors', async () => {
+		mockDomainsError = true;
+
+		render(
+			<PreLaunchSiteModal
+				siteId={ 1 }
+				isOpen
+				onClose={ jest.fn() }
+				launchUrl="/start/launch-site?siteSlug=example.wordpress.com"
+			/>
+		);
+
+		await waitFor( () => expect( assign ).toHaveBeenCalled() );
+		expect( screen.queryByTestId( 'pre-launch-modal' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders nothing while closed', () => {
+		render(
+			<PreLaunchSiteModal
+				siteId={ 1 }
+				isOpen={ false }
+				onClose={ jest.fn() }
+				launchUrl="/start/launch-site?siteSlug=example.wordpress.com"
+			/>
+		);
+
+		expect( screen.queryByTestId( 'pre-launch-modal' ) ).not.toBeInTheDocument();
+		expect( assign ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/components/pre-launch-site-modal/test/index.test.tsx
+++ b/client/components/pre-launch-site-modal/test/index.test.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { DomainSubtype } from '@automattic/api-core';
 import { queryClient } from '@automattic/api-queries';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -82,8 +83,21 @@ jest.mock( '@automattic/site-launch-modals', () => ( {
 } ) );
 
 const LAUNCH_URL = '/start/launch-site?siteSlug=example.wordpress.com';
-const customDomain = { blog_id: 1, domain: 'example.com', subscription_id: 42 };
-const wpcomDomain = { blog_id: 1, domain: 'example.wordpress.com', subscription_id: null };
+const registeredDomain = {
+	blog_id: 1,
+	domain: 'example.com',
+	subtype: { id: DomainSubtype.DOMAIN_REGISTRATION },
+};
+const connectedDomain = {
+	blog_id: 1,
+	domain: 'connected.example',
+	subtype: { id: DomainSubtype.DOMAIN_CONNECTION },
+};
+const wpcomDomain = {
+	blog_id: 1,
+	domain: 'example.wordpress.com',
+	subtype: { id: DomainSubtype.DEFAULT_ADDRESS },
+};
 
 function renderBridge( props: Partial< ComponentProps< typeof PreLaunchSiteModal > > = {} ) {
 	return render(
@@ -115,7 +129,7 @@ describe( 'PreLaunchSiteModal', () => {
 			slug: 'example.wordpress.com',
 			URL: 'https://example.com',
 		};
-		mockDomains = [ customDomain ];
+		mockDomains = [ registeredDomain ];
 		mockSiteError = false;
 		mockDomainsError = false;
 		mockIsPaid = true;
@@ -176,13 +190,26 @@ describe( 'PreLaunchSiteModal', () => {
 		expect( screen.queryByTestId( 'pre-launch-modal' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'redirects when the site has no custom domain', async () => {
+	it( 'redirects when the site only has the default WPCOM address', async () => {
 		mockDomains = [ wpcomDomain ];
 
 		renderBridge();
 
 		await waitFor( () => expect( assign ).toHaveBeenCalledWith( LAUNCH_URL ) );
 		expect( screen.queryByTestId( 'pre-launch-modal' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the modal for a connected (mapped) domain, matching the flow skip rule', async () => {
+		// A connected domain has no subscription of its own, but the launch flow
+		// still skips its domain step because it is not a WPCOM address — so the
+		// modal must appear here too.
+		mockDomains = [ wpcomDomain, connectedDomain ];
+
+		renderBridge();
+
+		expect( await screen.findByTestId( 'pre-launch-modal' ) ).toBeVisible();
+		expect( screen.getByText( 'connected.example' ) ).toBeVisible();
+		expect( assign ).not.toHaveBeenCalled();
 	} );
 
 	it( 'falls back to the launch flow when the domains query errors', async () => {

--- a/client/components/pre-launch-site-modal/test/index.test.tsx
+++ b/client/components/pre-launch-site-modal/test/index.test.tsx
@@ -3,7 +3,7 @@
  */
 import { DomainSubtype } from '@automattic/api-core';
 import { queryClient } from '@automattic/api-queries';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { type ComponentProps } from 'react';
 import PreLaunchSiteModal from '../index';
@@ -15,8 +15,7 @@ let mockDomainsError = false;
 let mockIsPaid = true;
 
 jest.mock( '@automattic/api-queries', () => ( {
-	// eslint-disable-next-line @typescript-eslint/no-require-imports
-	queryClient: new ( require( '@tanstack/react-query' ).QueryClient )( {
+	queryClient: new ( jest.requireActual( '@tanstack/react-query' ).QueryClient )( {
 		defaultOptions: { queries: { retry: false } },
 	} ),
 	siteByIdQuery: ( siteId: number ) => ( {
@@ -209,6 +208,22 @@ describe( 'PreLaunchSiteModal', () => {
 
 		expect( await screen.findByTestId( 'pre-launch-modal' ) ).toBeVisible();
 		expect( screen.getByText( 'connected.example' ) ).toBeVisible();
+		expect( assign ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps the modal up and never redirects if a later refetch errors', async () => {
+		renderBridge();
+		await screen.findByTestId( 'pre-launch-modal' );
+
+		// Simulate a background refetch (e.g. window refocus) that fails after the
+		// modal is already showing. The decision must stay frozen on "modal" — a
+		// redirect here would launch the site with no confirmation.
+		mockDomainsError = true;
+		await act( async () => {
+			await queryClient.refetchQueries( { queryKey: [ 'domains' ] } );
+		} );
+
+		expect( screen.getByTestId( 'pre-launch-modal' ) ).toBeVisible();
 		expect( assign ).not.toHaveBeenCalled();
 	} );
 

--- a/client/components/pre-launch-site-modal/test/index.test.tsx
+++ b/client/components/pre-launch-site-modal/test/index.test.tsx
@@ -1,11 +1,13 @@
 /**
  * @jest-environment jsdom
  */
+import { queryClient } from '@automattic/api-queries';
 import { render, screen, waitFor } from '@testing-library/react';
 import PreLaunchSiteModal from '../index';
 
 let mockSite: unknown;
 let mockDomains: unknown;
+let mockSiteError = false;
 let mockDomainsError = false;
 let mockIsPaid = true;
 
@@ -16,7 +18,12 @@ jest.mock( '@automattic/api-queries', () => ( {
 	} ),
 	siteByIdQuery: ( siteId: number ) => ( {
 		queryKey: [ 'site', siteId ],
-		queryFn: async () => mockSite,
+		queryFn: async () => {
+			if ( mockSiteError ) {
+				throw new Error( 'boom' );
+			}
+			return mockSite;
+		},
 	} ),
 	domainsQuery: () => ( {
 		queryKey: [ 'domains' ],
@@ -61,6 +68,9 @@ describe( 'PreLaunchSiteModal', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		// The mocked queryClient is a module-level singleton, so clear its cache
+		// between tests to keep them isolated and order-independent.
+		queryClient.clear();
 		Object.defineProperty( window, 'location', {
 			configurable: true,
 			value: { assign, pathname: '/home' },
@@ -72,6 +82,7 @@ describe( 'PreLaunchSiteModal', () => {
 			URL: 'https://example.com',
 		};
 		mockDomains = [ customDomain ];
+		mockSiteError = false;
 		mockDomainsError = false;
 		mockIsPaid = true;
 	} );
@@ -128,6 +139,22 @@ describe( 'PreLaunchSiteModal', () => {
 
 	it( 'falls back to the launch flow when the domains query errors', async () => {
 		mockDomainsError = true;
+
+		render(
+			<PreLaunchSiteModal
+				siteId={ 1 }
+				isOpen
+				onClose={ jest.fn() }
+				launchUrl="/start/launch-site?siteSlug=example.wordpress.com"
+			/>
+		);
+
+		await waitFor( () => expect( assign ).toHaveBeenCalled() );
+		expect( screen.queryByTestId( 'pre-launch-modal' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'falls back to the launch flow when the site query errors', async () => {
+		mockSiteError = true;
 
 		render(
 			<PreLaunchSiteModal

--- a/client/components/pre-launch-site-modal/test/index.test.tsx
+++ b/client/components/pre-launch-site-modal/test/index.test.tsx
@@ -3,9 +3,11 @@
  */
 import { queryClient } from '@automattic/api-queries';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { type ComponentProps } from 'react';
 import PreLaunchSiteModal from '../index';
 
-let mockSite: unknown;
+let mockSite: Record< string, unknown >;
 let mockDomains: unknown;
 let mockSiteError = false;
 let mockDomainsError = false;
@@ -49,19 +51,51 @@ jest.mock( 'calypso/dashboard/sites/site-preview', () => ( {
 	default: () => <div data-testid="site-preview" />,
 } ) );
 
+// Stub the presentational package modal, but keep every prop the bridge is
+// responsible for wiring (name/domain/plan, the launch + close callbacks, and
+// the launching state) observable so this suite can assert the wiring.
 jest.mock( '@automattic/site-launch-modals', () => ( {
 	__esModule: true,
-	PreLaunchModal: ( { siteName, siteDomain, planName }: Record< string, string > ) => (
-		<div data-testid="pre-launch-modal">
+	PreLaunchModal: ( {
+		siteName,
+		siteDomain,
+		planName,
+		isLaunching,
+		onLaunch,
+		onClose,
+	}: {
+		siteName: string;
+		siteDomain: string;
+		planName: string;
+		isLaunching: boolean;
+		onLaunch: () => void;
+		onClose: () => void;
+	} ) => (
+		<div data-testid="pre-launch-modal" data-launching={ isLaunching }>
 			<span>{ siteName }</span>
 			<span>{ siteDomain }</span>
 			<span>{ planName }</span>
+			<button onClick={ onLaunch }>Yes, launch site!</button>
+			<button onClick={ onClose }>Close</button>
 		</div>
 	),
 } ) );
 
+const LAUNCH_URL = '/start/launch-site?siteSlug=example.wordpress.com';
 const customDomain = { blog_id: 1, domain: 'example.com', subscription_id: 42 };
 const wpcomDomain = { blog_id: 1, domain: 'example.wordpress.com', subscription_id: null };
+
+function renderBridge( props: Partial< ComponentProps< typeof PreLaunchSiteModal > > = {} ) {
+	return render(
+		<PreLaunchSiteModal
+			siteId={ 1 }
+			isOpen
+			onClose={ jest.fn() }
+			launchUrl={ LAUNCH_URL }
+			{ ...props }
+		/>
+	);
+}
 
 describe( 'PreLaunchSiteModal', () => {
 	const assign = jest.fn();
@@ -88,96 +122,99 @@ describe( 'PreLaunchSiteModal', () => {
 	} );
 
 	it( 'shows the modal for a paid plan + custom domain site', async () => {
-		render(
-			<PreLaunchSiteModal
-				siteId={ 1 }
-				isOpen
-				onClose={ jest.fn() }
-				launchUrl="/start/launch-site?siteSlug=example.wordpress.com"
-			/>
-		);
+		renderBridge();
 
 		expect( await screen.findByTestId( 'pre-launch-modal' ) ).toBeVisible();
 		expect( screen.getByText( 'My Site' ) ).toBeVisible();
 		expect( screen.getByText( 'example.com' ) ).toBeVisible();
+		// No `plan` on the fixture, so the display-name fallback is what renders.
+		expect( screen.getByText( 'Business' ) ).toBeVisible();
+		expect( assign ).not.toHaveBeenCalled();
+	} );
+
+	it( 'prefers the plan product name over the display-name fallback', async () => {
+		mockSite.plan = { product_name: 'Commerce' };
+
+		renderBridge();
+
+		expect( await screen.findByTestId( 'pre-launch-modal' ) ).toBeVisible();
+		expect( screen.getByText( 'Commerce' ) ).toBeVisible();
+		expect( screen.queryByText( 'Business' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'redirects to the launch flow on confirm, showing the launching state', async () => {
+		const user = userEvent.setup();
+		renderBridge();
+
+		const modal = await screen.findByTestId( 'pre-launch-modal' );
+		expect( modal ).toHaveAttribute( 'data-launching', 'false' );
+
+		await user.click( screen.getByRole( 'button', { name: 'Yes, launch site!' } ) );
+
+		expect( assign ).toHaveBeenCalledWith( LAUNCH_URL );
+		expect( screen.getByTestId( 'pre-launch-modal' ) ).toHaveAttribute( 'data-launching', 'true' );
+	} );
+
+	it( 'passes the caller onClose through to the modal', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		renderBridge( { onClose } );
+
+		await screen.findByTestId( 'pre-launch-modal' );
+		await user.click( screen.getByRole( 'button', { name: 'Close' } ) );
+
+		expect( onClose ).toHaveBeenCalledTimes( 1 );
 		expect( assign ).not.toHaveBeenCalled();
 	} );
 
 	it( 'redirects straight to the launch flow when the plan is not paid', async () => {
 		mockIsPaid = false;
 
-		render(
-			<PreLaunchSiteModal
-				siteId={ 1 }
-				isOpen
-				onClose={ jest.fn() }
-				launchUrl="/start/launch-site?siteSlug=example.wordpress.com"
-			/>
-		);
+		renderBridge();
 
-		await waitFor( () =>
-			expect( assign ).toHaveBeenCalledWith( '/start/launch-site?siteSlug=example.wordpress.com' )
-		);
+		await waitFor( () => expect( assign ).toHaveBeenCalledWith( LAUNCH_URL ) );
 		expect( screen.queryByTestId( 'pre-launch-modal' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'redirects when the site has no custom domain', async () => {
 		mockDomains = [ wpcomDomain ];
 
-		render(
-			<PreLaunchSiteModal
-				siteId={ 1 }
-				isOpen
-				onClose={ jest.fn() }
-				launchUrl="/start/launch-site?siteSlug=example.wordpress.com"
-			/>
-		);
+		renderBridge();
 
-		await waitFor( () => expect( assign ).toHaveBeenCalled() );
+		await waitFor( () => expect( assign ).toHaveBeenCalledWith( LAUNCH_URL ) );
 		expect( screen.queryByTestId( 'pre-launch-modal' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'falls back to the launch flow when the domains query errors', async () => {
 		mockDomainsError = true;
 
-		render(
-			<PreLaunchSiteModal
-				siteId={ 1 }
-				isOpen
-				onClose={ jest.fn() }
-				launchUrl="/start/launch-site?siteSlug=example.wordpress.com"
-			/>
-		);
+		renderBridge();
 
-		await waitFor( () => expect( assign ).toHaveBeenCalled() );
+		await waitFor( () => expect( assign ).toHaveBeenCalledWith( LAUNCH_URL ) );
 		expect( screen.queryByTestId( 'pre-launch-modal' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'falls back to the launch flow when the site query errors', async () => {
 		mockSiteError = true;
 
-		render(
-			<PreLaunchSiteModal
-				siteId={ 1 }
-				isOpen
-				onClose={ jest.fn() }
-				launchUrl="/start/launch-site?siteSlug=example.wordpress.com"
-			/>
-		);
+		renderBridge();
 
-		await waitFor( () => expect( assign ).toHaveBeenCalled() );
+		await waitFor( () => expect( assign ).toHaveBeenCalledWith( LAUNCH_URL ) );
 		expect( screen.queryByTestId( 'pre-launch-modal' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'renders nothing and never redirects without a site id', async () => {
+		renderBridge( { siteId: 0 } );
+
+		// Give the effect/queries a chance to run so a missing guard would surface.
+		await Promise.resolve();
+
+		expect( screen.queryByTestId( 'pre-launch-modal' ) ).not.toBeInTheDocument();
+		expect( assign ).not.toHaveBeenCalled();
+	} );
+
 	it( 'renders nothing while closed', () => {
-		render(
-			<PreLaunchSiteModal
-				siteId={ 1 }
-				isOpen={ false }
-				onClose={ jest.fn() }
-				launchUrl="/start/launch-site?siteSlug=example.wordpress.com"
-			/>
-		);
+		renderBridge( { isOpen: false } );
 
 		expect( screen.queryByTestId( 'pre-launch-modal' ) ).not.toBeInTheDocument();
 		expect( assign ).not.toHaveBeenCalled();

--- a/client/dashboard/sites/site-preview/index.tsx
+++ b/client/dashboard/sites/site-preview/index.tsx
@@ -5,11 +5,13 @@ export default function SitePreview( {
 	scale = 1,
 	width = 1200,
 	height = 800,
+	onLoad,
 }: {
 	url: string;
 	scale?: number;
 	width?: number;
 	height?: number;
+	onLoad?: () => void;
 } ) {
 	// The /sites endpoint may return non-secure URLs. Often these _can_ be
 	// loaded securely, so it's worth trying to load over https. If it fails,
@@ -30,6 +32,7 @@ export default function SitePreview( {
 			// @ts-expect-error For some reason there's no inert type.
 			inert="true"
 			title={ __( 'Site Preview' ) }
+			onLoad={ onLoad }
 			// Hide banners + `preview` hides cookie banners + `iframe` hides
 			// admin bar for atomic sites.
 			src={ `${ secureUrl }/?hide_banners=true&preview=true&iframe=true` }

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -160,9 +160,8 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 
 	const [ isExperimentLoading, experimentVariant ] = useSiteLaunchGatingVariant();
 
-	// A free, already-public, or A4A dev site never opens the pre-launch modal, so
-	// skip mounting the bridge for those — the CTA redirect stays instant with no
-	// site/domains fetch.
+	// A free, already-public, or A4A dev site never qualifies, so skip the bridge
+	// and let the CTA redirect instantly.
 	const isFreePlan = site?.plan?.is_free ?? false;
 	const canOfferPreLaunch = ! isSitePublic && ! site?.is_a4a_dev_site && ! isFreePlan;
 	const [ isLaunchModalOpen, setIsLaunchModalOpen ] = useState( false );
@@ -198,11 +197,9 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 			path,
 		} );
 
-		// Site launch gating: 'semi_gated_site_launch' is the shipped default — it
-		// routes to the `/start/launch-site` flow, but opens the shared pre-launch
-		// bridge first for paid-plan + custom-domain sites and otherwise hands
-		// straight off to that flow. The other branches are scaffolding for future
-		// experiments; see useSiteLaunchGatingVariant().
+		// Gating: 'semi_gated_site_launch' is the shipped default, routing to
+		// `/start/launch-site` via the pre-launch bridge. Other branches are
+		// scaffolding for future experiments; see useSiteLaunchGatingVariant().
 		switch ( experimentVariant ) {
 			case 'semi_gated_site_launch':
 			case null:

--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useSiteSettings } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-site-settings';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
+import PreLaunchSiteModal from 'calypso/components/pre-launch-site-modal';
 import {
 	DeviceTabProvider,
 	useDeviceTab,
@@ -158,6 +159,15 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 	} );
 
 	const [ isExperimentLoading, experimentVariant ] = useSiteLaunchGatingVariant();
+
+	// A free, already-public, or A4A dev site never opens the pre-launch modal, so
+	// skip mounting the bridge for those — the CTA redirect stays instant with no
+	// site/domains fetch.
+	const isFreePlan = site?.plan?.is_free ?? false;
+	const canOfferPreLaunch = ! isSitePublic && ! site?.is_a4a_dev_site && ! isFreePlan;
+	const [ isLaunchModalOpen, setIsLaunchModalOpen ] = useState( false );
+	const [ launchUrl, setLaunchUrl ] = useState( '' );
+
 	const retestPage = () => {
 		recordTracksEvent( 'calypso_performance_profiler_test_again_click' );
 		performance.mark( 'test-started' );
@@ -188,19 +198,27 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 			path,
 		} );
 
-		// Site launch gating: 'semi_gated_site_launch' is the shipped default.
-		// The other branches are scaffolding for future experiments; see
-		// useSiteLaunchGatingVariant().
+		// Site launch gating: 'semi_gated_site_launch' is the shipped default — it
+		// routes to the `/start/launch-site` flow, but opens the shared pre-launch
+		// bridge first for paid-plan + custom-domain sites and otherwise hands
+		// straight off to that flow. The other branches are scaffolding for future
+		// experiments; see useSiteLaunchGatingVariant().
 		switch ( experimentVariant ) {
 			case 'semi_gated_site_launch':
 			case null:
 			default: {
-				window.location.assign(
-					addQueryArgs( '/start/launch-site', {
-						siteSlug: site?.slug,
-						back_to: window.location.pathname,
-					} )
-				);
+				const url = addQueryArgs( '/start/launch-site', {
+					siteSlug: site?.slug,
+					back_to: window.location.pathname,
+				} );
+
+				if ( ! canOfferPreLaunch ) {
+					window.location.assign( url );
+					return;
+				}
+
+				setLaunchUrl( url );
+				setIsLaunchModalOpen( true );
 				return;
 			}
 		}
@@ -351,7 +369,7 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 				<>
 					{ ! isSitePublic ? (
 						<ReportUnavailable
-							isLaunching={ siteIsLaunching || isExperimentLoading }
+							isLaunching={ siteIsLaunching || isExperimentLoading || isLaunchModalOpen }
 							onLaunchSiteClick={ onLaunchSiteClick }
 							ctaText={
 								site?.is_a4a_dev_site
@@ -375,6 +393,14 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 						</>
 					) }
 				</>
+			) }
+			{ canOfferPreLaunch && (
+				<PreLaunchSiteModal
+					siteId={ siteId ?? 0 }
+					isOpen={ isLaunchModalOpen }
+					onClose={ () => setIsLaunchModalOpen( false ) }
+					launchUrl={ launchUrl }
+				/>
 			) }
 		</div>
 	);

--- a/client/layout/masterbar/masterbar-launch-button.tsx
+++ b/client/layout/masterbar/masterbar-launch-button.tsx
@@ -21,6 +21,12 @@ export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 	const [ isLaunchModalOpen, setIsLaunchModalOpen ] = useState( false );
 	const [ launchUrl, setLaunchUrl ] = useState( '' );
 
+	// A free site can never qualify for the pre-launch modal (it needs a paid
+	// plan), so skip mounting the bridge for it — the redirect stays instant with
+	// no site/domains fetch. Unknown plans (site not loaded yet) fall through to
+	// the bridge, which settles the decision against authoritative data.
+	const isFreePlan = site?.plan?.is_free ?? false;
+
 	const onLaunchSiteClick = () => {
 		dispatch( recordTracksEvent( 'calypso_masterbar_launch_site', { source: sectionName } ) );
 
@@ -34,12 +40,17 @@ export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 			case 'semi_gated_site_launch':
 			case null:
 			default: {
-				setLaunchUrl(
-					addQueryArgs( '/start/launch-site', {
-						siteSlug: site?.slug,
-						back_to: window.location.pathname,
-					} )
-				);
+				const url = addQueryArgs( '/start/launch-site', {
+					siteSlug: site?.slug,
+					back_to: window.location.pathname,
+				} );
+
+				if ( isFreePlan ) {
+					window.location.assign( url );
+					return;
+				}
+
+				setLaunchUrl( url );
 				setIsLaunchModalOpen( true );
 				return;
 			}
@@ -71,12 +82,14 @@ export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 			>
 				{ translate( 'Launch site' ) }
 			</Item>
-			<PreLaunchSiteModal
-				siteId={ siteId }
-				isOpen={ isLaunchModalOpen }
-				onClose={ () => setIsLaunchModalOpen( false ) }
-				launchUrl={ launchUrl }
-			/>
+			{ ! isFreePlan && (
+				<PreLaunchSiteModal
+					siteId={ siteId }
+					isOpen={ isLaunchModalOpen }
+					onClose={ () => setIsLaunchModalOpen( false ) }
+					launchUrl={ launchUrl }
+				/>
+			) }
 		</>
 	);
 };

--- a/client/layout/masterbar/masterbar-launch-button.tsx
+++ b/client/layout/masterbar/masterbar-launch-button.tsx
@@ -1,9 +1,9 @@
-import { siteLaunchMutation } from '@automattic/api-queries';
-import { useMutation } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import PreLaunchSiteModal from 'calypso/components/pre-launch-site-modal';
 import { useSiteLaunchGatingVariant } from 'calypso/lib/use-site-launch-gating-variant';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -16,54 +16,67 @@ export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 	const dispatch = useDispatch();
 	const site = useSelector( ( state ) => getSite( state, siteId ) );
 	const sectionName = useSelector( getSectionName );
-	const launchSiteMutation = useMutation( siteLaunchMutation( siteId ) );
 
 	const [ isLoading, variant ] = useSiteLaunchGatingVariant();
+	const [ isLaunchModalOpen, setIsLaunchModalOpen ] = useState( false );
+	const [ launchUrl, setLaunchUrl ] = useState( '' );
 
 	const onLaunchSiteClick = () => {
 		dispatch( recordTracksEvent( 'calypso_masterbar_launch_site', { source: sectionName } ) );
 
-		// Site launch gating: 'semi_gated_site_launch' is the shipped default.
-		// The other branches are scaffolding for future experiments; see
+		// Site launch gating: 'semi_gated_site_launch' is the shipped default — it
+		// routes to the `/start/launch-site` flow, but opens the shared pre-launch
+		// bridge first, which shows the confirmation modal for paid-plan +
+		// custom-domain sites and otherwise hands straight off to that flow. The
+		// other branches are scaffolding for future experiments; see
 		// useSiteLaunchGatingVariant().
 		switch ( variant ) {
 			case 'semi_gated_site_launch':
 			case null:
 			default: {
-				window.location.assign(
+				setLaunchUrl(
 					addQueryArgs( '/start/launch-site', {
 						siteSlug: site?.slug,
 						back_to: window.location.pathname,
 					} )
 				);
+				setIsLaunchModalOpen( true );
 				return;
 			}
 		}
 	};
 
 	return (
-		<Item
-			as={ Button }
-			asProps={ {
-				variant: 'primary',
-				isBusy: launchSiteMutation.isPending,
-			} }
-			disabled={ isLoading || launchSiteMutation.isPending }
-			// Keep the Launch button always in blueberry (default scheme: modern) like in wp-admin.
-			className={ clsx( 'masterbar__item-launch-site', 'color-scheme', 'is-global' ) }
-			icon={
-				<svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
-					<path
-						fillRule="evenodd"
-						clipRule="evenodd"
-						d="M10.6242 9.74354L7.62419 12.1261V13.2995C7.62419 13.4418 7.77653 13.5322 7.90147 13.4641L10.5265 12.0322C10.5867 11.9994 10.6242 11.9363 10.6242 11.8676V9.74354ZM6.49919 12.0875L3.91203 9.50037H2.7001C1.70383 9.50037 1.07079 8.43399 1.54786 7.55937L2.97968 4.93437C3.20967 4.51272 3.65161 4.25036 4.13191 4.25036H7.17569C9.1325 2.16798 11.3176 0.754637 14.1427 0.531305C14.9004 0.471402 15.5282 1.09911 15.4682 1.85687C15.2449 4.68199 13.8316 6.86706 11.7492 8.82386V11.8676C11.7492 12.3479 11.4868 12.7899 11.0652 13.0199L8.44018 14.4517C7.56557 14.9288 6.49919 14.2957 6.49919 13.2995V12.0875ZM6.25602 5.37536H4.13191C4.0633 5.37536 4.00017 5.41284 3.96731 5.47308L2.53549 8.09808C2.46734 8.22303 2.55777 8.37536 2.7001 8.37536H3.87344L6.25602 5.37536Z"
-					/>
-					<path d="M0.498047 13.3962C0.498047 12.2341 1.44011 11.2921 2.60221 11.2921C3.76431 11.2921 4.70638 12.2341 4.70638 13.3962C4.70638 14.5583 3.76431 15.5004 2.60221 15.5004H1.06055C0.749887 15.5004 0.498047 15.2486 0.498047 14.9379V13.3962Z" />
-				</svg>
-			}
-			onClick={ onLaunchSiteClick }
-		>
-			{ translate( 'Launch site' ) }
-		</Item>
+		<>
+			<Item
+				as={ Button }
+				asProps={ {
+					variant: 'primary',
+					isBusy: isLaunchModalOpen,
+				} }
+				disabled={ isLoading || isLaunchModalOpen }
+				// Keep the Launch button always in blueberry (default scheme: modern) like in wp-admin.
+				className={ clsx( 'masterbar__item-launch-site', 'color-scheme', 'is-global' ) }
+				icon={
+					<svg viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+						<path
+							fillRule="evenodd"
+							clipRule="evenodd"
+							d="M10.6242 9.74354L7.62419 12.1261V13.2995C7.62419 13.4418 7.77653 13.5322 7.90147 13.4641L10.5265 12.0322C10.5867 11.9994 10.6242 11.9363 10.6242 11.8676V9.74354ZM6.49919 12.0875L3.91203 9.50037H2.7001C1.70383 9.50037 1.07079 8.43399 1.54786 7.55937L2.97968 4.93437C3.20967 4.51272 3.65161 4.25036 4.13191 4.25036H7.17569C9.1325 2.16798 11.3176 0.754637 14.1427 0.531305C14.9004 0.471402 15.5282 1.09911 15.4682 1.85687C15.2449 4.68199 13.8316 6.86706 11.7492 8.82386V11.8676C11.7492 12.3479 11.4868 12.7899 11.0652 13.0199L8.44018 14.4517C7.56557 14.9288 6.49919 14.2957 6.49919 13.2995V12.0875ZM6.25602 5.37536H4.13191C4.0633 5.37536 4.00017 5.41284 3.96731 5.47308L2.53549 8.09808C2.46734 8.22303 2.55777 8.37536 2.7001 8.37536H3.87344L6.25602 5.37536Z"
+						/>
+						<path d="M0.498047 13.3962C0.498047 12.2341 1.44011 11.2921 2.60221 11.2921C3.76431 11.2921 4.70638 12.2341 4.70638 13.3962C4.70638 14.5583 3.76431 15.5004 2.60221 15.5004H1.06055C0.749887 15.5004 0.498047 15.2486 0.498047 14.9379V13.3962Z" />
+					</svg>
+				}
+				onClick={ onLaunchSiteClick }
+			>
+				{ translate( 'Launch site' ) }
+			</Item>
+			<PreLaunchSiteModal
+				siteId={ siteId }
+				isOpen={ isLaunchModalOpen }
+				onClose={ () => setIsLaunchModalOpen( false ) }
+				launchUrl={ launchUrl }
+			/>
+		</>
 	);
 };

--- a/client/layout/masterbar/masterbar-launch-button.tsx
+++ b/client/layout/masterbar/masterbar-launch-button.tsx
@@ -21,21 +21,16 @@ export const MasterbarLaunchButton = ( { siteId }: { siteId: number } ) => {
 	const [ isLaunchModalOpen, setIsLaunchModalOpen ] = useState( false );
 	const [ launchUrl, setLaunchUrl ] = useState( '' );
 
-	// A free site can never qualify for the pre-launch modal (it needs a paid
-	// plan), so skip mounting the bridge for it — the redirect stays instant with
-	// no site/domains fetch. Unknown plans (site not loaded yet) fall through to
-	// the bridge, which settles the decision against authoritative data.
+	// A free site can never qualify (needs a paid plan), so skip the bridge and
+	// redirect instantly. Unknown plans fall through and settle in the bridge.
 	const isFreePlan = site?.plan?.is_free ?? false;
 
 	const onLaunchSiteClick = () => {
 		dispatch( recordTracksEvent( 'calypso_masterbar_launch_site', { source: sectionName } ) );
 
-		// Site launch gating: 'semi_gated_site_launch' is the shipped default — it
-		// routes to the `/start/launch-site` flow, but opens the shared pre-launch
-		// bridge first, which shows the confirmation modal for paid-plan +
-		// custom-domain sites and otherwise hands straight off to that flow. The
-		// other branches are scaffolding for future experiments; see
-		// useSiteLaunchGatingVariant().
+		// Gating: 'semi_gated_site_launch' is the shipped default, routing to
+		// `/start/launch-site` via the pre-launch bridge. Other branches are
+		// scaffolding for future experiments; see useSiteLaunchGatingVariant().
 		switch ( variant ) {
 			case 'semi_gated_site_launch':
 			case null:

--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -25,6 +25,12 @@ const LaunchpadPreLaunch = ( props: LaunchpadPreLaunchProps ): JSX.Element => {
 
 	const launchUrl = addQueryArgs( '/start/launch-site', { siteSlug: site?.slug } );
 
+	// A free site can never qualify for the pre-launch modal (it needs a paid
+	// plan), so skip mounting the bridge for it — the redirect stays instant with
+	// no site/domains fetch. Unknown plans (site not loaded yet) fall through to
+	// the bridge, which settles the decision against authoritative data.
+	const isFreePlan = site?.plan?.is_free ?? false;
+
 	const handleTaskClick = ( task: Task ) => {
 		if ( task.id !== 'site_launched' ) {
 			return;
@@ -33,6 +39,11 @@ const LaunchpadPreLaunch = ( props: LaunchpadPreLaunchProps ): JSX.Element => {
 		// Open the shared pre-launch bridge. It shows the confirmation modal for
 		// paid-plan + custom-domain sites and otherwise hands off to the
 		// `launchUrl` flow, matching the previous behavior.
+		if ( isFreePlan ) {
+			window.location.assign( launchUrl );
+			return false;
+		}
+
 		setIsLaunchModalOpen( true );
 		return false;
 	};
@@ -44,12 +55,14 @@ const LaunchpadPreLaunch = ( props: LaunchpadPreLaunchProps ): JSX.Element => {
 				onTaskClick={ handleTaskClick }
 				onSiteLaunched={ () => onSiteLaunched( !! site?.is_wpcom_atomic ) }
 			/>
-			<PreLaunchSiteModal
-				siteId={ siteId }
-				isOpen={ isLaunchModalOpen }
-				onClose={ () => setIsLaunchModalOpen( false ) }
-				launchUrl={ launchUrl }
-			/>
+			{ ! isFreePlan && (
+				<PreLaunchSiteModal
+					siteId={ siteId }
+					isOpen={ isLaunchModalOpen }
+					onClose={ () => setIsLaunchModalOpen( false ) }
+					launchUrl={ launchUrl }
+				/>
+			) }
 		</>
 	);
 };

--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -25,10 +25,8 @@ const LaunchpadPreLaunch = ( props: LaunchpadPreLaunchProps ): JSX.Element => {
 
 	const launchUrl = addQueryArgs( '/start/launch-site', { siteSlug: site?.slug } );
 
-	// A free site can never qualify for the pre-launch modal (it needs a paid
-	// plan), so skip mounting the bridge for it — the redirect stays instant with
-	// no site/domains fetch. Unknown plans (site not loaded yet) fall through to
-	// the bridge, which settles the decision against authoritative data.
+	// A free site can never qualify (needs a paid plan), so skip the bridge and
+	// redirect instantly. Unknown plans fall through and settle in the bridge.
 	const isFreePlan = site?.plan?.is_free ?? false;
 
 	const handleTaskClick = ( task: Task ) => {
@@ -36,9 +34,7 @@ const LaunchpadPreLaunch = ( props: LaunchpadPreLaunchProps ): JSX.Element => {
 			return;
 		}
 
-		// Open the shared pre-launch bridge. It shows the confirmation modal for
-		// paid-plan + custom-domain sites and otherwise hands off to the
-		// `launchUrl` flow, matching the previous behavior.
+		// Hand off to the pre-launch bridge, which confirms for qualifying sites.
 		if ( isFreePlan ) {
 			window.location.assign( launchUrl );
 			return false;

--- a/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/pre-launch.tsx
@@ -1,4 +1,6 @@
-import { useSiteLaunchGatingVariant } from 'calypso/lib/use-site-launch-gating-variant';
+import { addQueryArgs } from '@wordpress/url';
+import { useState } from 'react';
+import PreLaunchSiteModal from 'calypso/components/pre-launch-site-modal';
 import { useCelebrateLaunchModalSideEffects } from 'calypso/my-sites/customer-home/celebrate-site-launch-modal/use-side-effects';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
@@ -19,32 +21,36 @@ const LaunchpadPreLaunch = ( props: LaunchpadPreLaunchProps ): JSX.Element => {
 
 	const { onSiteLaunched } = useCelebrateLaunchModalSideEffects( siteId );
 
-	const [ , variant ] = useSiteLaunchGatingVariant();
+	const [ isLaunchModalOpen, setIsLaunchModalOpen ] = useState( false );
+
+	const launchUrl = addQueryArgs( '/start/launch-site', { siteSlug: site?.slug } );
 
 	const handleTaskClick = ( task: Task ) => {
 		if ( task.id !== 'site_launched' ) {
 			return;
 		}
 
-		// Site launch gating: 'semi_gated_site_launch' is the shipped default.
-		// The other branches are scaffolding for future experiments; see
-		// useSiteLaunchGatingVariant().
-		switch ( variant ) {
-			case 'semi_gated_site_launch':
-			case null:
-			default: {
-				window.location.assign( `/start/launch-site?siteSlug=${ site?.slug }` );
-				return false;
-			}
-		}
+		// Open the shared pre-launch bridge. It shows the confirmation modal for
+		// paid-plan + custom-domain sites and otherwise hands off to the
+		// `launchUrl` flow, matching the previous behavior.
+		setIsLaunchModalOpen( true );
+		return false;
 	};
 
 	return (
-		<CustomerHomeLaunchpad
-			checklistSlug={ props.checklistSlug ?? checklistSlug }
-			onTaskClick={ handleTaskClick }
-			onSiteLaunched={ () => onSiteLaunched( !! site?.is_wpcom_atomic ) }
-		/>
+		<>
+			<CustomerHomeLaunchpad
+				checklistSlug={ props.checklistSlug ?? checklistSlug }
+				onTaskClick={ handleTaskClick }
+				onSiteLaunched={ () => onSiteLaunched( !! site?.is_wpcom_atomic ) }
+			/>
+			<PreLaunchSiteModal
+				siteId={ siteId }
+				isOpen={ isLaunchModalOpen }
+				onClose={ () => setIsLaunchModalOpen( false ) }
+				launchUrl={ launchUrl }
+			/>
+		</>
 	);
 };
 


### PR DESCRIPTION
Part of DOTPROD-77

<img width="1660" height="981" alt="Screenshot 2026-08-25 at 12 30 42" src="https://github.com/user-attachments/assets/ecfe058a-575c-4a3d-b6bf-347b8a564670" />

## Proposed Changes

* Add a shared **`PreLaunchSiteModal`** bridge (`client/components/pre-launch-site-modal`) that renders the presentational **`PreLaunchModal`** from `@automattic/site-launch-modals` in classic Calypso, wrapped in a `QueryClientProvider` so it can use `@automattic/api-queries`.
* The bridge owns the gate: for a site with a **paid plan and a custom domain** (a domain whose subtype isn't the default `*.wordpress.com` address — the same `! isWPCOMDomain` signal the launch flow uses to skip its domain step) it shows the confirmation modal; on confirm it redirects to the caller-provided `launchUrl`. Every other site (and any site- or domains-query error) is sent straight to `launchUrl`, preserving today's behavior.
* Because the package modal is purely presentational, the bridge derives its props itself — `siteName`, `siteDomain` (custom domain, else slug), `planName`, and the `preview` thumbnail (via the shared `SitePreview`). It no longer depends on the dashboard's `SiteLaunchModal` wrapper.
* The **destination is a prop** (`launchUrl`), so each call site keeps its explicit `/start/launch-site` path and its gating `switch` remains the extension point for future experiments.
* Wire it into the three classic launch surfaces: the **masterbar launch button** (`masterbar-launch-button.tsx`), the **customer-home Launchpad** task (`cards/launchpad/pre-launch.tsx`), and the **hosting-performance** page's launch CTA (`hosting/performance/site-performance.tsx`). Each call site does a cheap `site.plan.is_free` pre-check: a known-free site (also public/A4A sites on the performance page) redirects instantly and never mounts the bridge (no site/domains fetch); paid or not-yet-loaded sites engage the bridge.
* Add an optional `onLoad` prop to the shared `SitePreview` so the bridge's preview thumbnail can reveal once the iframe finishes loading. This converges with the same addition on the dashboard side.

## Why are these changes being made?

The dashboard gates one-click launches for plan+domain sites behind a confirmation modal, but the classic surfaces still push even those sites into the full launch flow with no confirmation. Because `/start/launch-site` auto-skips its domain/plan steps for paid+domain sites, redirecting after the modal is effectively an immediate launch — so we get the same confirmation UX without re-implementing launch on the Redux surfaces. Consuming the shared package (rather than importing the dashboard wrapper) means classic Calypso, the dashboard, and Jetpack's wp-admin runtime can all share one modal UI.

## Testing Instructions

* On an unlaunched site with a **paid plan + custom domain**, trigger a launch from any of these entry points → the pre-launch modal appears; confirming redirects to `/start/launch-site`, which launches immediately:
    * the masterbar **Launch site** button (make sure that feature flag `dashboard/omnibar-radical` is `false`)
    * the customer-home Launchpad **"Launch your site"** task
    * the **hosting → Performance** page's **"Launch your site"** CTA (old hosting dashboard, set feature flag `dashboard/enable-percentage-rollout` to `false`)
* On a site **without** a paid plan or without a custom domain → no modal; it goes straight to `/start/launch-site` as before.
* On a **free** site → no modal and no extra fetch; the launch button/task/CTA redirects to `/start/launch-site` immediately.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
