### PR TITLE
Staging sites: handle inaccessible staging site gracefully

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -189,11 +189,11 @@ export const siteRoute = createRoute( {
 		queryClient.prefetchQuery( siteAdminMenuQuery( site.ID ) );
 		queryClient.prefetchQuery( siteAdminBarQuery( site.ID ) );
 
-		await Promise.all( [
-			otherEnvironmentSiteId &&
-				queryClient.ensureQueryData( siteByIdQuery( otherEnvironmentSiteId ) ),
-			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
-		] );
+		if ( otherEnvironmentSiteId ) {
+			queryClient.prefetchQuery( siteByIdQuery( otherEnvironmentSiteId ) );
+		}
+
+		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 
 		return { site };
 	},

--- a/client/dashboard/sites/site/environment-switcher-dropdown.tsx
+++ b/client/dashboard/sites/site/environment-switcher-dropdown.tsx
@@ -49,6 +49,7 @@ const StagingSiteActionButton = ( {
 const EnvironmentSwitcherDropdown = ( {
 	currentSite,
 	productionSite,
+	stagingSiteId,
 	stagingSite,
 	onClose,
 	onAddStagingSite,
@@ -57,6 +58,7 @@ const EnvironmentSwitcherDropdown = ( {
 }: {
 	currentSite: Site;
 	productionSite: Site | undefined;
+	stagingSiteId: number | undefined;
 	stagingSite: Site | undefined;
 	onClose: () => void;
 	onAddStagingSite: () => void;
@@ -75,7 +77,7 @@ const EnvironmentSwitcherDropdown = ( {
 		! isStagingSiteCreating;
 
 	const showActionButton =
-		( ! currentSite.is_wpcom_staging_site && productionSite && ! stagingSite ) ||
+		( ! currentSite.is_wpcom_staging_site && productionSite && ! stagingSiteId ) ||
 		isStagingSiteCreating ||
 		isStagingSiteDeleting;
 

--- a/client/dashboard/sites/site/environment-switcher.tsx
+++ b/client/dashboard/sites/site/environment-switcher.tsx
@@ -9,6 +9,7 @@ import type { Site } from '@automattic/api-core';
 const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
 	const {
 		productionSite,
+		stagingSiteId,
 		stagingSite,
 		isStagingSiteCreating,
 		isStagingSiteDeleting,
@@ -50,6 +51,7 @@ const EnvironmentSwitcher = ( { site }: { site: Site } ) => {
 					<EnvironmentSwitcherDropdown
 						currentSite={ site }
 						productionSite={ productionSite }
+						stagingSiteId={ stagingSiteId }
 						stagingSite={ stagingSite }
 						onClose={ onClose }
 						onAddStagingSite={ handleAddStagingSite }

--- a/client/dashboard/sites/site/sidebar-environment-switcher.tsx
+++ b/client/dashboard/sites/site/sidebar-environment-switcher.tsx
@@ -12,6 +12,7 @@ import './sidebar-environment-switcher.scss';
 const SidebarEnvironmentSwitcher = ( { site }: { site: Site } ) => {
 	const {
 		productionSite,
+		stagingSiteId,
 		stagingSite,
 		isStagingSiteCreating,
 		isStagingSiteDeleting,
@@ -52,6 +53,7 @@ const SidebarEnvironmentSwitcher = ( { site }: { site: Site } ) => {
 						<EnvironmentSwitcherDropdown
 							currentSite={ site }
 							productionSite={ productionSite }
+							stagingSiteId={ stagingSiteId }
 							stagingSite={ stagingSite }
 							onClose={ onClose }
 							onAddStagingSite={ handleAddStagingSite }

--- a/client/dashboard/sites/site/use-staging-site.ts
+++ b/client/dashboard/sites/site/use-staging-site.ts
@@ -54,13 +54,13 @@ export default function useStagingSite( site: Site ) {
 	const { data: stagingSite } = useQuery( {
 		...siteByIdQuery( stagingSiteId ?? 0 ),
 		refetchInterval: ( query ) => {
-			if ( ! query.state.data ) {
+			if ( ! query.state.data || transferStatus !== 'completed' ) {
 				return 0;
 			}
 
 			return isAtomicTransferredSite( query.state.data ) ? false : 2000;
 		},
-		enabled: !! stagingSiteId && transferStatus === 'completed',
+		enabled: !! stagingSiteId,
 	} );
 
 	const { data: isStagingSiteDeleting } = useQuery( {
@@ -244,6 +244,7 @@ export default function useStagingSite( site: Site ) {
 
 	return {
 		productionSite,
+		stagingSiteId,
 		stagingSite,
 		isStagingSiteCreating: !! isStagingSiteCreating,
 		isStagingSiteDeleting: !! isStagingSiteDeleting,


### PR DESCRIPTION
Fixes DOTMSD-1532

## Proposed Changes

This PR made 3 changes to handle inaccessible staging site:

---

Ensure the staging site is always fetched on page load, instead of relying on `siteByIdQuery()` cache. There is a bug where the staging site is fetched only once during creation, then cached forever and `siteByIdQuery()` only gets from cache. This made the actual bug sometimes hard to reproduce. The fix:

```diff
diff --git a/client/dashboard/sites/site/use-staging-site.ts b/client/dashboard/sites/site/use-staging-site.ts
index f38796b755b..a999a0989ea 100644
--- a/client/dashboard/sites/site/use-staging-site.ts
+++ b/client/dashboard/sites/site/use-staging-site.ts
@@ -54,13 +54,13 @@ export default function useStagingSite( site: Site ) {
 	const { data: stagingSite } = useQuery( {
 		...siteByIdQuery( stagingSiteId ?? 0 ),
 		refetchInterval: ( query ) => {
-			if ( ! query.state.data ) {
+			if ( ! query.state.data || transferStatus !== 'completed' ) {
 				return 0;
 			}
 
 			return isAtomicTransferredSite( query.state.data ) ? false : 2000;
 		},
-		enabled: !! stagingSiteId && transferStatus === 'completed',
+		enabled: !! stagingSiteId,
 	} );
 ```

---

Prefetch the staging site (if any), instead of `ensureQueryData()`. This is the change that avoids crash when the staging site fetch returns 403:

```diff
diff --git a/client/dashboard/app/router/sites.tsx b/client/dashboard/app/router/sites.tsx
index a2b7740fdc8..e77b2a23671 100644
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -189,11 +189,11 @@ export const siteRoute = createRoute( {
 		queryClient.prefetchQuery( siteAdminMenuQuery( site.ID ) );
 		queryClient.prefetchQuery( siteAdminBarQuery( site.ID ) );
 
-		await Promise.all( [
-			otherEnvironmentSiteId &&
-				queryClient.ensureQueryData( siteByIdQuery( otherEnvironmentSiteId ) ),
-			queryClient.ensureQueryData( rawUserPreferencesQuery() ),
-		] );
+		if ( otherEnvironmentSiteId ) {
+			queryClient.prefetchQuery( siteByIdQuery( otherEnvironmentSiteId ) );
+		}
+
+		await queryClient.ensureQueryData( rawUserPreferencesQuery() );
 
 		return { site };
 	},
``` 

The downside is that there might be a VERY SMALL chance that the staging site option is not visible yet in the environment switcher. But:

- it does not cause any layout shift in MSD (Staging option is after Production option)
- the chance of it happening is very small, as the query is preloaded / prefetched when the user hovers on the site row from the site list as well.

I considered an alternative where we render a spinner / loading state. However it makes the experience worse on sites with inaccessible staging site. The spinner will be shown then disappear, which feels broken.

---

When a site already has staging site, but the user can't access it, don't show the option to add new staging site:

```diff
diff --git a/client/dashboard/sites/site/environment-switcher-dropdown.tsx b/client/dashboard/sites/site/environment-switcher-dropdown.tsx
index 513e8cd4c5e..d5c0711caf1 100644
--- a/client/dashboard/sites/site/environment-switcher-dropdown.tsx
+++ b/client/dashboard/sites/site/environment-switcher-dropdown.tsx
@@ -75,7 +77,7 @@ const EnvironmentSwitcherDropdown = ( {
 		! isStagingSiteCreating;
 
 	const showActionButton =
-		( ! currentSite.is_wpcom_staging_site && productionSite && ! stagingSite ) ||
+		( ! currentSite.is_wpcom_staging_site && productionSite && ! stagingSiteId ) ||
 		isStagingSiteCreating ||
 		isStagingSiteDeleting;
```

## Testing Instructions

1. Prepare a NEW Business Wow site, and another user (non-a11n).
2. (important) launch the site first.
3. Create a NEW staging site for the site. (Use this PR link/branch to do that as well as regression testing).
    - Note that creating staging site can take long time.
5. Invite another user to your production site as administrator.
    - Using the tangled Calypso `https://wordpress.com/people/team/:productionSiteSlug` is easier 🙈 
6. Now, your other user only has access to the production site but not the staging site.
    - The browser can fetch the staging site normally, just that `site.capabilities` won't be returned.
7. Verify that the other user can visit the production site overview normally.
8. Verify the environment switcher dropdown
    - Before this PR, in production, there will be `+ Add staging site` option which will just crash when clicked.
    - With this PR, the user does not see the option to add another staging site in the switcher dropdown.
9. Using your owner user, change the staging site's visibility to Private.
10. Verify that the other use can still visit the production site overview normally.
    - When the browser tries to fetch the staging site, the endpoint will return 403:
       - Before this PR, in production, the entire site overview will crash with 500 error `User cannot access this private blog.`
       - With this PR, there is no crash.