### PR TITLE
Marketplace: bound the activation phase instead of disabling the deadline

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/product-install-error.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/product-install-error.tsx
@@ -126,8 +126,7 @@ export default function ProductInstallErrorView( {
 				/>
 			);
 		}
-		// Only the plugin transfer flow can reach this: the completion latch that starts the
-		// activation phase exists solely on that path, so the copy can name the plugin outright.
+		// Only the plugin transfer flow reaches this state, so the copy can name the plugin.
 		case 'activation-timeout':
 			return (
 				<EmptyContent

--- a/client/my-sites/marketplace/pages/marketplace-product-install/product-install-error.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/product-install-error.tsx
@@ -126,6 +126,23 @@ export default function ProductInstallErrorView( {
 				/>
 			);
 		}
+		// Only the plugin transfer flow can reach this: the completion latch that starts the
+		// activation phase exists solely on that path, so the copy can name the plugin outright.
+		case 'activation-timeout':
+			return (
+				<EmptyContent
+					title={ null }
+					line={ translate(
+						'Your site is ready, but we could not confirm the plugin was installed and activated. It may still finish on its own — check your installed plugins in a few minutes.'
+					) }
+					secondaryAction={ translate( 'Contact support' ) }
+					secondaryActionURL="/help/contact"
+					secondaryActionCallback={ () => recordCtaClick( 'contact_support' ) }
+					action={ translate( 'Go to plugins' ) }
+					actionURL={ pluginsPageURL }
+					actionCallback={ () => recordCtaClick( 'go_to_plugins' ) }
+				/>
+			);
 		case 'timeout':
 		case 'transfer-failed': {
 			// This screen also serves themes and zip uploads, so plugin-worded copy and a link to

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -419,8 +419,6 @@ describe( 'useProductInstall progression', () => {
 		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
 	} );
 
-	// The transfer's own deadline must not condemn a transfer that completed — but the wait is not
-	// over, so the activation phase gets a fresh deadline of the same length rather than none.
 	it( 'gives activation its own deadline after a completed recovery', async () => {
 		await beginAtomicPluginTransfer();
 		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'completed' ) );
@@ -467,8 +465,7 @@ describe( 'useProductInstall progression', () => {
 		expect( result.current.error ).toBeNull();
 	} );
 
-	// This component survives an SPA navigation from one install to the next, and one install's
-	// success must not leave the next install's activation phase unbounded.
+	// The component survives SPA navigation between installs; one success must not disarm the next.
 	it( 'arms the activation deadline again for the next product after a success', async () => {
 		await beginAtomicPluginTransfer();
 		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'completed' ) );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -467,6 +467,46 @@ describe( 'useProductInstall progression', () => {
 		expect( result.current.error ).toBeNull();
 	} );
 
+	// This component survives an SPA navigation from one install to the next, and one install's
+	// success must not leave the next install's activation phase unbounded.
+	it( 'arms the activation deadline again for the next product after a success', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'completed' ) );
+
+		const { result, store, rerender } = renderHookWithProvider(
+			( { pluginSlug }: { pluginSlug: string } ) => useProductInstall( { pluginSlug } ),
+			{
+				reducers,
+				initialState: {
+					...directInstallAuthorization,
+					...simpleAtomicEligibleSite,
+					plugins: { wporg: { items: wporgItems } },
+				},
+				initialProps: { pluginSlug: 'give' },
+			}
+		);
+		await waitFor( () => expect( result.current.currentStep ).toBe( 2 ) );
+		await act( async () => {
+			store.dispatch(
+				receiveSitePlugins( SITE_ID, [ { slug: 'give', id: 'give/give', active: true } ] )
+			);
+		} );
+
+		window.sessionStorage.setItem(
+			`marketplace-product-install-transfer:${ SITE_ID }:akismet`,
+			JSON.stringify( {
+				initiatedAt: Date.now() - 5000,
+				previousTransferId: null,
+				lookupSettled: true,
+			} )
+		);
+		rerender( { pluginSlug: 'akismet' } );
+
+		await advance( INSTALL_DEADLINE_MS + 10000 );
+
+		expect( result.current.error ).toEqual( { type: 'activation-timeout' } );
+	} );
+
 	it( 'does not carry a completed transfer latch across products', async () => {
 		await beginAtomicPluginTransfer();
 		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'completed' ) );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install-progress.tsx
@@ -419,7 +419,9 @@ describe( 'useProductInstall progression', () => {
 		expect( initiatePluginTransfer ).not.toHaveBeenCalled();
 	} );
 
-	it( 'keeps a completed recovery latched after its marker expires', async () => {
+	// The transfer's own deadline must not condemn a transfer that completed — but the wait is not
+	// over, so the activation phase gets a fresh deadline of the same length rather than none.
+	it( 'gives activation its own deadline after a completed recovery', async () => {
 		await beginAtomicPluginTransfer();
 		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'completed' ) );
 
@@ -433,9 +435,35 @@ describe( 'useProductInstall progression', () => {
 		);
 		await waitFor( () => expect( result.current.currentStep ).toBe( 2 ) );
 
+		await advance( INSTALL_DEADLINE_MS - 10000 );
+		expect( result.current.currentStep ).toBe( 2 );
+		expect( result.current.error ).toBeNull();
+
+		await advance( 20000 );
+		expect( result.current.error ).toEqual( { type: 'activation-timeout' } );
+	} );
+
+	it( 'reaches no activation verdict once the plugin is active', async () => {
+		await beginAtomicPluginTransfer();
+		mockFetchLatestAtomicTransfer.mockResolvedValue( latestTransfer( 'completed' ) );
+
+		const { result, store } = renderProgress(
+			{ pluginSlug: 'give' },
+			{
+				...directInstallAuthorization,
+				...simpleAtomicEligibleSite,
+				plugins: { wporg: { items: wporgItems } },
+			}
+		);
+		await waitFor( () => expect( result.current.currentStep ).toBe( 2 ) );
+
+		await act( async () => {
+			store.dispatch(
+				receiveSitePlugins( SITE_ID, [ { slug: 'give', id: 'give/give', active: true } ] )
+			);
+		} );
 		await advance( INSTALL_DEADLINE_MS + 10000 );
 
-		expect( result.current.currentStep ).toBe( 2 );
 		expect( result.current.error ).toBeNull();
 	} );
 

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -440,23 +440,15 @@ export function useProductInstall( {
 	const transferHasFailed = hasTransferFailed || durableTransferFailed;
 	const transferTimedOut = ! durableTransferCompleted && ( hasTimedOut || hasTransferTimedOut );
 
-	// The product is on the site and switched on: the wait is over, whatever the redirect below does
-	// next. Retiring it here rather than on unmount is what separates a finished install from a
-	// closed tab — the plugin flow leaves by full-page navigation, which React never sees.
-	//
-	// Latched, because an install does not un-succeed — but only for this install: the identity
-	// block above clears it when an SPA navigation brings the next product to this same mount,
-	// whose own wait must arm from scratch. The plugin list refetches while the redirect resolves,
-	// and the gap where it reads empty would otherwise close this wait and open a second one that
-	// lives for a second.
+	// The product is on the site and switched on: the wait is over. Latched, because an install does
+	// not un-succeed (the plugin list briefly reads empty while the redirect resolves); reset by the
+	// identity block above so the next product's wait arms from scratch.
 	hasSucceededRef.current =
 		hasSucceededRef.current || ( themeSlug ? isThemeActive : !! installedPlugin && pluginActive );
 	const hasSucceeded = hasSucceededRef.current;
 
-	// The completion latch above ends the transfer phase, but not the wait: activation still has to
-	// land, and nothing else bounds it — the transfer poll has stopped and the deadline hook's clock
-	// is anchored to a phase that is over. Restart the deadline for this phase rather than leaving
-	// it unbounded, so every wait still ends in a verdict.
+	// A completed transfer ends the transfer deadline, not the wait: activation still has to land.
+	// Restart the deadline for that phase so every wait ends in a verdict.
 	const activationTimedOut = useDelayedCondition(
 		durableTransferCompleted && ! preflightError && ! transferHasFailed && ! hasSucceeded,
 		INSTALL_DEADLINE_MS

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -148,6 +148,7 @@ export type ProductInstallError =
 	| { type: 'rejected-upload'; reason: 'exists' | 'malicious' | 'too-big' }
 	| { type: 'transfer-failed' }
 	| { type: 'timeout' }
+	| { type: 'activation-timeout' }
 	| { type: 'generic' };
 
 export type InstallErrorTrackingProps = {
@@ -436,6 +437,27 @@ export function useProductInstall( {
 	const durableTransferFailed = durableTransferFailedRef.current;
 	const transferHasFailed = hasTransferFailed || durableTransferFailed;
 	const transferTimedOut = ! durableTransferCompleted && ( hasTimedOut || hasTransferTimedOut );
+
+	// The product is on the site and switched on: the wait is over, whatever the redirect below does
+	// next. Retiring it here rather than on unmount is what separates a finished install from a
+	// closed tab — the plugin flow leaves by full-page navigation, which React never sees.
+	//
+	// Latched, because an install does not un-succeed. The plugin list refetches while the redirect
+	// resolves, and the gap where it reads empty would otherwise close this wait and open a second
+	// one that lives for a second.
+	const hasSucceededRef = useRef( false );
+	hasSucceededRef.current =
+		hasSucceededRef.current || ( themeSlug ? isThemeActive : !! installedPlugin && pluginActive );
+	const hasSucceeded = hasSucceededRef.current;
+
+	// The completion latch above ends the transfer phase, but not the wait: activation still has to
+	// land, and nothing else bounds it — the transfer poll has stopped and the deadline hook's clock
+	// is anchored to a phase that is over. Restart the deadline for this phase rather than leaving
+	// it unbounded, so every wait still ends in a verdict.
+	const activationTimedOut = useDelayedCondition(
+		durableTransferCompleted && ! preflightError && ! transferHasFailed && ! hasSucceeded,
+		INSTALL_DEADLINE_MS
+	);
 	const transferLookupGraceElapsed = useDelayedCondition(
 		installStrategy === 'atomic-transfer' &&
 			!! pluginSlug &&
@@ -639,18 +661,10 @@ export function useProductInstall( {
 	if ( ! error && transferTimedOut ) {
 		error = { type: 'timeout' };
 	}
+	if ( ! error && activationTimedOut ) {
+		error = { type: 'activation-timeout' };
+	}
 
-	// The product is on the site and switched on: the wait is over, whatever the redirect below does
-	// next. Retiring it here rather than on unmount is what separates a finished install from a
-	// closed tab — the plugin flow leaves by full-page navigation, which React never sees.
-	//
-	// Latched, because an install does not un-succeed. The plugin list refetches while the redirect
-	// resolves, and the gap where it reads empty would otherwise close this wait and open a second
-	// one that lives for a second.
-	const hasSucceededRef = useRef( false );
-	hasSucceededRef.current =
-		hasSucceededRef.current || ( themeSlug ? isThemeActive : !! installedPlugin && pluginActive );
-	const hasSucceeded = hasSucceededRef.current;
 	const transferAttemptEnded =
 		hasSucceeded || ( !! error && error.type !== 'non-installable-plan' );
 	useEffect( () => {
@@ -689,6 +703,8 @@ export function useProductInstall( {
 			outcome = 'transfer_failed';
 		} else if ( transferTimedOut ) {
 			outcome = 'timeout';
+		} else if ( activationTimedOut ) {
+			outcome = 'activation_timeout';
 		}
 		if ( ! outcome || reportedOutcomeRef.current === outcome ) {
 			return;
@@ -710,6 +726,7 @@ export function useProductInstall( {
 		hasTimedOut,
 		hasTransferTimedOut,
 		transferTimedOut,
+		activationTimedOut,
 		transferHasFailed,
 		themeSlug,
 		installStrategy,

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -289,11 +289,13 @@ export function useProductInstall( {
 	// product's current status the baseline.
 	const [ installFailureSeen, setInstallFailureSeen ] = useState( false );
 	const previousInstallStatusRef = useRef< string | undefined >( undefined );
+	const hasSucceededRef = useRef( false );
 	const installIdentity = `${ siteId }:${ pluginSlug }:${ themeSlug }`;
 	const installIdentityRef = useRef( installIdentity );
 	const observedInstallStatus = pluginInstallStatus?.status;
 	if ( installIdentityRef.current !== installIdentity ) {
 		installIdentityRef.current = installIdentity;
+		hasSucceededRef.current = false;
 		if ( installFailureSeen ) {
 			setInstallFailureSeen( false );
 		}
@@ -442,10 +444,11 @@ export function useProductInstall( {
 	// next. Retiring it here rather than on unmount is what separates a finished install from a
 	// closed tab — the plugin flow leaves by full-page navigation, which React never sees.
 	//
-	// Latched, because an install does not un-succeed. The plugin list refetches while the redirect
-	// resolves, and the gap where it reads empty would otherwise close this wait and open a second
-	// one that lives for a second.
-	const hasSucceededRef = useRef( false );
+	// Latched, because an install does not un-succeed — but only for this install: the identity
+	// block above clears it when an SPA navigation brings the next product to this same mount,
+	// whose own wait must arm from scratch. The plugin list refetches while the redirect resolves,
+	// and the gap where it reads empty would otherwise close this wait and open a second one that
+	// lives for a second.
 	hasSucceededRef.current =
 		hasSucceededRef.current || ( themeSlug ? isThemeActive : !! installedPlugin && pluginActive );
 	const hasSucceeded = hasSucceededRef.current;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18290/marketplace-install-wait-has-no-deadline-once-the-transfer-completes

## Proposed Changes

**The marketplace install wait now gets a fresh five-minute deadline for the activation phase, instead of losing its deadline entirely the moment the Atomic transfer completes.**

The install wait has two phases: the Atomic transfer, then plugin activation. Only the transfer was bounded — once it completed, the deadline switched off for good.

- When the transfer completes and the plugin is not yet confirmed active, a new five-minute clock starts.
- If it expires, a new `activation-timeout` error screen says exactly what happened — “Your site is ready, but we could not confirm the plugin was installed and activated” — with a “Go to plugins” button as the way out.
- If activation lands in time (the normal case), nothing changes: same redirect as today.
- The new outcome is recorded in the existing wait telemetry as `activation_timeout`, so activation hangs can be told apart from transfer timeouts.
- Follow-up commit: the “this install succeeded” flag now resets when navigating from one install to the next on the same mounted screen, so a finished install can no longer disarm the next one's deadline (or its heartbeat telemetry).

## Why are these changes being made?

If plugin activation never finished, the customer was left on the waiting screen forever: no error, no way out. Telemetry shows 2–4 customers a day stuck in exactly this state, some sitting there for 15 minutes before giving up ([DOTCOM-18290](https://linear.app/a8c/issue/DOTCOM-18290)).

The deadline was originally switched off at transfer completion for a good reason: it used to ring *after* the transfer had already succeeded, wrongly telling customers their install timed out. But that fix removed the deadline instead of restarting it — it traded a false error for an infinite wait. This PR keeps the false error fixed and restores the guarantee that every wait ends in a verdict.

## Testing Instructions

1. Run `yarn start`.
2. On a Simple site with a Business plan, buy or install a marketplace plugin so the install screen at `/marketplace/plugin/<slug>/install/<site>` runs an Atomic transfer.
3. Let the transfer complete but prevent activation from finishing (e.g. block the plugins API requests in DevTools once the staged wait reaches the finishing stage).
4. Within five minutes of the transfer completing, the new error screen should appear, with “Go to plugins” leading to the site's plugin list.
5. Repeat without blocking anything: the install should complete and redirect as before, with no error.
