### PR TITLE
Hand the customer off through Jetpack SSO

### DIFF
--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -316,9 +316,8 @@ export function getSiteEditorUrl(
  * login form for a site they had just made — asking them to sign in to
  * something they had not been told was separate. Jetpack SSO trades the session
  * they have for the one they need and forwards them on.
- *
  * @param adminUrl Absolute wp-admin URL to land on.
- * @return The SSO URL, or the original when it cannot be parsed.
+ * @returns The SSO URL, or the original when it cannot be parsed.
  */
 function withJetpackSso( adminUrl: string ): string {
 	let target: URL;

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -302,7 +302,50 @@ export function getSiteEditorUrl(
 	//
 	// Only set when the spec applied; there is nothing to personalize from
 	// otherwise.
-	return startWalkthrough ? addQueryArgs( url, { 'blueprint-walkthrough': 'go' } ) : url;
+	const editorUrl = startWalkthrough ? addQueryArgs( url, { 'blueprint-walkthrough': 'go' } ) : url;
+
+	return withJetpackSso( editorUrl );
+}
+
+/**
+ * Route an Atomic wp-admin URL through Jetpack SSO so the customer arrives
+ * logged in.
+ *
+ * They have a WordPress.com session, not a session on their Atomic site, and
+ * those are different things. Sending them straight to wp-admin showed them a
+ * login form for a site they had just made — asking them to sign in to
+ * something they had not been told was separate. Jetpack SSO trades the session
+ * they have for the one they need and forwards them on.
+ *
+ * @param adminUrl Absolute wp-admin URL to land on.
+ * @return The SSO URL, or the original when it cannot be parsed.
+ */
+function withJetpackSso( adminUrl: string ): string {
+	let target: URL;
+	try {
+		target = new URL( adminUrl );
+	} catch {
+		// Not something we can rewrite. Hand back what we were given rather than
+		// dropping the customer's redirect entirely.
+		return adminUrl;
+	}
+
+	// SSO lives on the site's own host. A *.wordpress.com address is the
+	// WordPress.com side of an Atomic site rather than the site itself, and
+	// logging in there does not produce a session for wp-admin.
+	if ( target.hostname.endsWith( '.wordpress.com' ) ) {
+		target.hostname = target.hostname.replace( '.wordpress.com', '.wpcomstaging.com' );
+	}
+
+	const login = new URL( target.href );
+	login.pathname = '/wp-login.php';
+	login.search = '';
+
+	return addQueryArgs( login.href, {
+		action: 'jetpack-sso',
+		// Relative, so the redirect cannot be pointed off-site.
+		redirect_to: `${ target.pathname }${ target.search }`,
+	} );
 }
 
 export function logBlueprintArchiveEvent(

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -81,16 +81,46 @@ describe( 'applyBlueprintSpec', () => {
 } );
 
 describe( 'getSiteEditorUrl', () => {
-	it( 'returns a plain site editor URL by default', () => {
-		expect( getSiteEditorUrl( 'https://example.com/wp-admin/' ) ).toBe(
-			'https://example.com/wp-admin/site-editor.php'
-		);
+	/**
+	 * The customer has a WordPress.com session, not one on their Atomic site.
+	 * Sending them straight to wp-admin showed them a login form for the site
+	 * they had just made, so the hand-off goes through Jetpack SSO.
+	 */
+	it( 'routes through Jetpack SSO so they arrive logged in', () => {
+		const url = getSiteEditorUrl( 'https://example.com/wp-admin/' );
+
+		expect( url ).toContain( 'https://example.com/wp-login.php' );
+		expect( url ).toContain( 'action=jetpack-sso' );
+		expect( url ).toContain( encodeURIComponent( '/wp-admin/site-editor.php' ) );
 	} );
 
 	it( 'tolerates an admin URL without a trailing slash', () => {
-		expect( getSiteEditorUrl( 'https://example.com/wp-admin' ) ).toBe(
-			'https://example.com/wp-admin/site-editor.php'
+		expect( getSiteEditorUrl( 'https://example.com/wp-admin' ) ).toContain(
+			encodeURIComponent( '/wp-admin/site-editor.php' )
 		);
+	} );
+
+	/**
+	 * SSO lives on the site's own host; a *.wordpress.com address is the
+	 * WordPress.com side of an Atomic site, and signing in there does not produce
+	 * a session for wp-admin.
+	 */
+	it( 'signs in on the site host rather than the WordPress.com one', () => {
+		const url = getSiteEditorUrl( 'https://example.wordpress.com/wp-admin/' );
+
+		expect( url ).toContain( 'https://example.wpcomstaging.com/wp-login.php' );
+	} );
+
+	/**
+	 * A relative redirect cannot be pointed off-site.
+	 */
+	it( 'keeps the redirect relative', () => {
+		const url = getSiteEditorUrl( 'https://example.com/wp-admin/', {
+			startWalkthrough: true,
+		} );
+		const redirect = new URL( url ).searchParams.get( 'redirect_to' );
+
+		expect( redirect ).toBe( '/wp-admin/site-editor.php?blueprint-walkthrough=go' );
 	} );
 
 	/**
@@ -98,9 +128,9 @@ describe( 'getSiteEditorUrl', () => {
 	 * waiting for the customer to speak first.
 	 */
 	it( 'flags the walkthrough when the spec was applied', () => {
-		expect( getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } ) ).toBe(
-			'https://example.com/wp-admin/site-editor.php?blueprint-walkthrough=go'
-		);
+		expect(
+			getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } )
+		).toContain( encodeURIComponent( 'blueprint-walkthrough=go' ) );
 	} );
 
 	/**


### PR DESCRIPTION
## The problem

Confirming a blueprint site drops the customer on the Atomic site's **login screen**. They have just made a site, been walked through a spec, and are then asked to sign in to something nobody told them was separate.

Seen on a production run: `jhnstn90.wpcomstaging.com`.

## Why

They hold a WordPress.com session, not a session on their Atomic site. The hand-off navigates straight to `{site}/wp-admin/site-editor.php`, and nothing along the way trades one session for the other, so wp-admin does what it does with an unauthenticated request.

## The fix

Route the redirect through Jetpack SSO:

```
https://{site}/wp-login.php?action=jetpack-sso&redirect_to=/wp-admin/site-editor.php?blueprint-walkthrough=go
```

Same thing the entrepreneur flow already does for the same reason (`use-entrepreneur-admin-destination.ts`), including moving a `*.wordpress.com` admin URL to the site's own domain first — SSO runs on the site host, and signing in on the WordPress.com side does not produce a session for wp-admin.

Two details:

- `redirect_to` is **relative**, so it cannot be pointed off-site.
- A URL that cannot be parsed is handed back untouched rather than dropped, so a parsing surprise degrades to today's behaviour instead of losing the redirect entirely.

## Testing

14 unit tests, four new: the hand-off goes through SSO, it signs in on the site host rather than the WordPress.com one, the redirect stays relative, and an admin URL without a trailing slash still resolves.

`URL.canParse()` — which the entrepreneur helper uses — is not available in the jest environment, so this parses with a try/catch instead.

## Not verified end to end

I have not run a hand-off with this build. The shape matches the existing precedent and the tests pin the URL, but whether Jetpack SSO completes cleanly for a site that has just finished transferring is the thing to watch on the next run — that is the case this flow hits and the entrepreneur flow does not.