### PR TITLE
Onboarding: bring back the purchase-flow progress indicator

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/index.tsx
@@ -1,0 +1,61 @@
+import { Stepper as UIStepper } from '@automattic/ui';
+import { useI18n } from '@wordpress/react-i18n';
+
+import './style.scss';
+
+type Props = {
+	currentStep: 'domains' | 'plans' | 'checkout';
+	onStepSelect?: ( step: 'domains' | 'plans' ) => void;
+};
+
+export function OnboardingProgress( { currentStep, onStepSelect }: Props ) {
+	const { __ } = useI18n();
+
+	const domainsStepStatus = currentStep !== 'domains' ? ( 'completed' as const ) : undefined;
+	const plansStepStatus = currentStep === 'checkout' ? ( 'completed' as const ) : undefined;
+
+	return (
+		<UIStepper.Root
+			orientation="horizontal"
+			value={ currentStep }
+			onValueChange={ ( value ) => {
+				if ( value === 'domains' || value === 'plans' ) {
+					onStepSelect?.( value );
+				}
+			} }
+			aria-label={ __( 'Purchase steps' ) }
+			indicatorVariant="number"
+			linear
+			className="onboarding-progress"
+		>
+			<UIStepper.List>
+				<UIStepper.Step
+					value="domains"
+					status={ domainsStepStatus }
+					className="onboarding-progress-step"
+				>
+					<UIStepper.Trigger className="onboarding-progress-trigger">
+						<UIStepper.Indicator />
+						<UIStepper.Title>{ __( 'Select a domain' ) }</UIStepper.Title>
+					</UIStepper.Trigger>
+				</UIStepper.Step>
+				<UIStepper.Step
+					value="plans"
+					status={ plansStepStatus }
+					className="onboarding-progress-step"
+				>
+					<UIStepper.Trigger className="onboarding-progress-trigger">
+						<UIStepper.Indicator />
+						<UIStepper.Title>{ __( 'Select a plan' ) }</UIStepper.Title>
+					</UIStepper.Trigger>
+				</UIStepper.Step>
+				<UIStepper.Step value="checkout" className="onboarding-progress-step">
+					<UIStepper.Trigger className="onboarding-progress-trigger">
+						<UIStepper.Indicator />
+						<UIStepper.Title>{ __( 'Complete payment' ) }</UIStepper.Title>
+					</UIStepper.Trigger>
+				</UIStepper.Step>
+			</UIStepper.List>
+		</UIStepper.Root>
+	);
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/style.scss
@@ -1,0 +1,23 @@
+@import '@wordpress/theme/design-tokens.css';
+
+.onboarding-progress {
+	display: flex;
+	justify-content: center;
+	padding: 8px 0;
+	margin-block-end: 32px;
+	// Ensure the stepper paints above the sticky checkout sidebar, which is positioned
+	// and would otherwise overlap the heading row at the same stacking level.
+	position: relative;
+	z-index: 1;
+
+	.onboarding-progress-step {
+		display: flex;
+		justify-content: center;
+	}
+
+	.onboarding-progress-trigger {
+		display: flex;
+		align-items: center;
+		padding: 12px 16px;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/style.scss
@@ -1,5 +1,11 @@
 @import '@wordpress/theme/design-tokens.css';
 
+// The stepper carries its own vertical spacing, so drop the wrapper's
+// top padding to avoid doubling up the space above it.
+.step-container-v2__content-wrapper.axis-vertical:has( .onboarding-progress ) {
+	padding-top: 0;
+}
+
 .onboarding-progress {
 	display: flex;
 	justify-content: center;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/onboarding-progress.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/onboarding-progress.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { OnboardingProgress } from '..';
+
+describe( 'OnboardingProgress', () => {
+	it( 'calls onStepSelect with the clicked previous step on checkout', async () => {
+		const onStepSelect = jest.fn();
+		render( <OnboardingProgress currentStep="checkout" onStepSelect={ onStepSelect } /> );
+
+		await userEvent.click( screen.getByRole( 'tab', { name: /Select a domain/ } ) );
+		expect( onStepSelect ).toHaveBeenCalledWith( 'domains' );
+
+		await userEvent.click( screen.getByRole( 'tab', { name: /Select a plan/ } ) );
+		expect( onStepSelect ).toHaveBeenCalledWith( 'plans' );
+	} );
+
+	it( 'does not call onStepSelect for the current step', async () => {
+		const onStepSelect = jest.fn();
+		render( <OnboardingProgress currentStep="checkout" onStepSelect={ onStepSelect } /> );
+
+		await userEvent.click( screen.getByRole( 'tab', { name: /Complete payment/ } ) );
+		expect( onStepSelect ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/use-show-onboarding-progress.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/use-show-onboarding-progress.test.tsx
@@ -16,10 +16,10 @@ describe( 'useShowOnboardingProgress', () => {
 		mockViewport.mockReset();
 	} );
 
-	it( 'hides on desktop onboarding while the indicator is disabled', () => {
+	it( 'shows on desktop onboarding', () => {
 		mockViewport.mockReturnValue( true );
 		const { result } = renderHook( () => useShowOnboardingProgress( true ) );
-		expect( result.current ).toBe( false );
+		expect( result.current ).toBe( true );
 	} );
 
 	it( 'hides when not onboarding flow', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/use-show-onboarding-progress.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/use-show-onboarding-progress.test.tsx
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock( '@wordpress/compose', () => ( {
+	useViewportMatch: jest.fn(),
+} ) );
+
+import { renderHook } from '@testing-library/react';
+import { useViewportMatch } from '@wordpress/compose';
+import { useShowOnboardingProgress } from '../use-show-onboarding-progress';
+
+const mockViewport = useViewportMatch as unknown as jest.Mock;
+
+describe( 'useShowOnboardingProgress', () => {
+	beforeEach( () => {
+		mockViewport.mockReset();
+	} );
+
+	it( 'hides on desktop onboarding while the indicator is disabled', () => {
+		mockViewport.mockReturnValue( true );
+		const { result } = renderHook( () => useShowOnboardingProgress( true ) );
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'hides when not onboarding flow', () => {
+		mockViewport.mockReturnValue( true );
+		const { result } = renderHook( () => useShowOnboardingProgress( false ) );
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'hides on mobile', () => {
+		mockViewport.mockReturnValue( false );
+		const { result } = renderHook( () => useShowOnboardingProgress( true ) );
+		expect( result.current ).toBe( false );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/use-show-onboarding-progress.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/use-show-onboarding-progress.ts
@@ -1,0 +1,17 @@
+import { useViewportMatch } from '@wordpress/compose';
+
+/**
+ * Temporarily disabled — flip to false to bring the indicator back.
+ */
+const IS_ONBOARDING_PROGRESS_DISABLED = true;
+
+/**
+ * Single source of truth for whether the onboarding progress indicator shows.
+ *
+ * Desktop-only. Mobile keeps the existing top-bar step counter.
+ */
+export function useShowOnboardingProgress( isOnboardingFlow: boolean ): boolean {
+	const isDesktop = useViewportMatch( 'large' );
+
+	return ! IS_ONBOARDING_PROGRESS_DISABLED && isOnboardingFlow && isDesktop;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/use-show-onboarding-progress.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/use-show-onboarding-progress.ts
@@ -1,11 +1,6 @@
 import { useViewportMatch } from '@wordpress/compose';
 
 /**
- * Temporarily disabled — flip to false to bring the indicator back.
- */
-const IS_ONBOARDING_PROGRESS_DISABLED = true;
-
-/**
  * Single source of truth for whether the onboarding progress indicator shows.
  *
  * Desktop-only. Mobile keeps the existing top-bar step counter.
@@ -13,5 +8,5 @@ const IS_ONBOARDING_PROGRESS_DISABLED = true;
 export function useShowOnboardingProgress( isOnboardingFlow: boolean ): boolean {
 	const isDesktop = useViewportMatch( 'large' );
 
-	return ! IS_ONBOARDING_PROGRESS_DISABLED && isOnboardingFlow && isDesktop;
+	return isOnboardingFlow && isDesktop;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -49,6 +49,8 @@ import { useSiteIdParam } from '../../../../hooks/use-site-id-param';
 import { useSiteSlugParam } from '../../../../hooks/use-site-slug-param';
 import { useOnboardingStepCounter } from '../../../flows/onboarding/use-onboarding-step-counter';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+import { OnboardingProgress } from '../components/onboarding-progress';
+import { useShowOnboardingProgress } from '../components/onboarding-progress/use-show-onboarding-progress';
 import HundredYearPlanStepWrapper from '../hundred-year-plan-step-wrapper';
 import { getSkipSuggestionCopy } from './get-skip-suggestion-copy';
 import type { Step as StepType } from '../../types';
@@ -136,6 +138,7 @@ const DomainSearchStep: StepType< {
 
 	const isCiab = dashboard === 'ciab';
 	const isWooHostingSolutions = queryParams.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF;
+	const showProgress = useShowOnboardingProgress( isOnboardingFlow( flow ) );
 	const stepCounter = useOnboardingStepCounter( flow, 'domains' );
 
 	const storedSiteTitle = useSelect(
@@ -469,6 +472,10 @@ const DomainSearchStep: StepType< {
 
 	if ( shouldUseStepContainerV2( flow ) ) {
 		const getTopBarLeftElement = () => {
+			if ( showProgress ) {
+				return;
+			}
+
 			if ( isNewHostedSiteCreationFlow( flow ) ) {
 				return;
 			}
@@ -585,9 +592,12 @@ const DomainSearchStep: StepType< {
 					// page's primary affordance — the H1/subText are dropped so
 					// high-quality results can fill the limited vertical space.
 					// The empty/initial state keeps the heading on mobile.
-					! ( isMobileViewport && query ) ? (
-						<Step.Heading text={ headerText } subText={ subHeaderText } />
-					) : undefined
+					<>
+						{ showProgress && <OnboardingProgress currentStep="domains" /> }
+						{ ! ( isMobileViewport && query ) && (
+							<Step.Heading text={ headerText } subText={ subHeaderText } />
+						) }
+					</>
 				}
 			>
 				{ domainSearchElement }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -51,6 +51,8 @@ import {
 import { getSiteBySlug } from 'calypso/state/sites/selectors';
 import { ONBOARD_STORE } from '../../../../stores';
 import { useOnboardingStepCounter } from '../../../flows/onboarding/use-onboarding-step-counter';
+import { OnboardingProgress } from '../components/onboarding-progress';
+import { useShowOnboardingProgress } from '../components/onboarding-progress/use-show-onboarding-progress';
 import { getIntervalType } from './util';
 import type { OnboardSelect, SiteDetails } from '@automattic/data-stores';
 import type { StepState } from 'calypso/state/signup/progress/schema';
@@ -289,6 +291,7 @@ function UnifiedPlansStep( {
 		setShowHelpCenter( ! isHelpCenterShown );
 	};
 	const stepCounter = useOnboardingStepCounter( flowName, 'plans' );
+	const showProgress = useShowOnboardingProgress( isOnboardingFlow( flowName ) );
 	const initializedSitesBackUrl = useSelector( ( state ) => {
 		if ( getCurrentUserSiteCount( state ) ) {
 			return null;
@@ -715,7 +718,7 @@ function UnifiedPlansStep( {
 	);
 
 	if ( useStepContainerV2 && wrapperProps ) {
-		const goBack = wrapperProps.hideBack ? undefined : wrapperProps.goBack;
+		const goBack = wrapperProps.hideBack || showProgress ? undefined : wrapperProps.goBack;
 
 		return (
 			<>
@@ -763,6 +766,12 @@ function UnifiedPlansStep( {
 						}
 						heading={
 							<>
+								{ showProgress && (
+									<OnboardingProgress
+										currentStep="plans"
+										onStepSelect={ () => wrapperProps.goBack?.() }
+									/>
+								) }
 								{ ( intent === 'plans-website-builder' ||
 									intent === 'plans-wordpress-hosting' ) && (
 									<IntentToggle

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -24,7 +24,7 @@ import {
 	TransactionStatus,
 } from '@automattic/composite-checkout';
 import { formatCurrency } from '@automattic/number-formatters';
-import { Step } from '@automattic/onboarding';
+import { ONBOARDING_FLOW, Step } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	styled,
@@ -51,6 +51,8 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import Loading from 'calypso/components/loading';
+import { OnboardingProgress } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress';
+import { useShowOnboardingProgress } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/use-show-onboarding-progress';
 import { useInitialIsInStepContainerV2FlowContext } from 'calypso/layout/utils';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import {
@@ -107,6 +109,7 @@ import CheckoutProcessorNotice from './checkout-processor-notice';
 import { CheckoutSidebarPlanUpsell } from './checkout-sidebar-plan-upsell';
 import CheckoutTrustCards from './checkout-trust-cards';
 import { EmptyCart, shouldShowEmptyCartPage } from './empty-cart';
+import { handleProgressStepSelect } from './handle-progress-step-select';
 import JetpackAkismetCheckoutSidebarPlanUpsell from './jetpack-akismet-checkout-sidebar-plan-upsell';
 import { LeaveCheckoutModal, useCheckoutLeaveModal } from './leave-checkout-modal';
 import { MobileCheckoutStickySummary } from './mobile-checkout-sticky-summary';
@@ -468,6 +471,13 @@ export default function CheckoutMainContent( {
 	);
 
 	const searchParams = new URLSearchParams( window.location.search );
+	const isOnboardingFlowCheckout = searchParams.get( 'flow' ) === ONBOARDING_FLOW;
+	const showProgress = useShowOnboardingProgress( isOnboardingFlowCheckout );
+	const forceCheckoutBackUrlDomains = useValidCheckoutBackUrl(
+		siteUrl ?? '',
+		undefined,
+		'checkoutBackUrlDomains'
+	);
 	const isDIFMInCart = hasDIFMProduct( responseCart );
 	const isSignupCheckout = searchParams.get( 'signup' ) === '1';
 	// The flow that redirected to checkout may pass a step indicator via the
@@ -1122,10 +1132,29 @@ export default function CheckoutMainContent( {
 				<Step.TwoColumnLayout
 					firstColumnWidth={ 8 }
 					secondColumnWidth={ 4 }
+					heading={
+						showProgress ? (
+							<OnboardingProgress
+								currentStep="checkout"
+								onStepSelect={ ( step ) =>
+									handleProgressStepSelect( step, {
+										forceCheckoutBackUrlDomains,
+										forceCheckoutBackUrl,
+										clickStepBack: leaveModalProps.clickStepBack,
+										clickClose: leaveModalProps.clickClose,
+									} )
+								}
+							/>
+						) : undefined
+					}
 					topBar={ ( { isLargeViewport } ) => {
 						const topBar = (
 							<Step.TopBar
-								leftElement={ <Step.BackButton onClick={ leaveModalProps.clickClose } /> }
+								leftElement={
+									showProgress ? undefined : (
+										<Step.BackButton onClick={ leaveModalProps.clickClose } />
+									)
+								}
 								rightElement={
 									<>
 										{ stepCounter && (

--- a/client/my-sites/checkout/src/components/handle-progress-step-select.ts
+++ b/client/my-sites/checkout/src/components/handle-progress-step-select.ts
@@ -1,0 +1,33 @@
+type HandleProgressStepSelectOptions = {
+	forceCheckoutBackUrlDomains: string | undefined;
+	forceCheckoutBackUrl: string | undefined;
+	clickStepBack: ( destinationUrl: string ) => void;
+	clickClose: () => void;
+};
+
+/**
+ * Routes a click on the onboarding progress indicator to the correct
+ * leave-checkout action. Clicking the "domains" or "plans" step navigates back
+ * to that step via `clickStepBack` (preserving the step-back analytics signal),
+ * but only when a validated back URL is available for it. When no valid URL
+ * exists, it falls back to the standard close flow.
+ */
+export function handleProgressStepSelect(
+	step: 'domains' | 'plans',
+	{
+		forceCheckoutBackUrlDomains,
+		forceCheckoutBackUrl,
+		clickStepBack,
+		clickClose,
+	}: HandleProgressStepSelectOptions
+): void {
+	if ( step === 'domains' && forceCheckoutBackUrlDomains ) {
+		clickStepBack( forceCheckoutBackUrlDomains );
+		return;
+	}
+	if ( step === 'plans' && forceCheckoutBackUrl ) {
+		clickStepBack( forceCheckoutBackUrl );
+		return;
+	}
+	clickClose();
+}

--- a/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
+++ b/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
@@ -11,11 +11,13 @@ import { leaveCheckout } from '../lib/leave-checkout';
 
 export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
+	const [ stepBackUrl, setStepBackUrl ] = useState< string | undefined >( undefined );
 	const forceCheckoutBackUrl = useValidCheckoutBackUrl( siteUrl );
 	// When a flow supplies a dedicated "back to domains" URL, emptying the cart
 	// sends the user there rather than to the plan-step back URL — the plan they
 	// were choosing no longer exists, so the domain step is the right restart
-	// point.
+	// point. An explicit step-back URL still wins so the user's chosen step is
+	// honored.
 	const forceCheckoutBackUrlDomains = useValidCheckoutBackUrl(
 		siteUrl,
 		undefined,
@@ -49,7 +51,7 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 		}
 		leaveCheckout( {
 			siteSlug: siteUrl,
-			forceCheckoutBackUrl: options?.forceBackUrl ?? forceCheckoutBackUrl,
+			forceCheckoutBackUrl: options?.forceBackUrl ?? stepBackUrl ?? forceCheckoutBackUrl,
 			previousPath,
 			tracksEvent: 'calypso_masterbar_close_clicked',
 			userHasClearedCart: userHasClearedCart,
@@ -61,6 +63,9 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 	);
 
 	const clickClose = () => {
+		// A plain close must use the default back URL, not a step-back URL left
+		// over from an earlier `clickStepBack` whose modal was dismissed.
+		setStepBackUrl( undefined );
 		if ( shouldClearCartWhenLeaving && responseCart.products.length > 0 ) {
 			recordTracksEvent( 'calypso_masterbar_checkout_close_modal_displayed' );
 			setIsModalVisible( true );
@@ -69,6 +74,16 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 		closeAndLeave( {
 			closedWithoutConfirmation: true,
 		} );
+	};
+
+	const clickStepBack = ( destinationUrl: string ) => {
+		setStepBackUrl( destinationUrl );
+		if ( shouldClearCartWhenLeaving && responseCart.products.length > 0 ) {
+			recordTracksEvent( 'calypso_masterbar_checkout_close_modal_displayed' );
+			setIsModalVisible( true );
+			return;
+		}
+		closeAndLeave( { closedWithoutConfirmation: true, forceBackUrl: destinationUrl } );
 	};
 
 	const clearCartAndLeave = async () => {
@@ -100,7 +115,7 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 		}
 		closeAndLeave( {
 			userHasClearedCart: true,
-			forceBackUrl: forceCheckoutBackUrlDomains,
+			forceBackUrl: stepBackUrl ?? forceCheckoutBackUrlDomains,
 		} );
 	};
 
@@ -108,6 +123,7 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 		isModalVisible,
 		setIsModalVisible,
 		clickClose,
+		clickStepBack,
 		closeAndLeave,
 		clearCartAndLeave,
 	};

--- a/client/my-sites/checkout/src/components/test/handle-progress-step-select.test.ts
+++ b/client/my-sites/checkout/src/components/test/handle-progress-step-select.test.ts
@@ -1,0 +1,64 @@
+import { handleProgressStepSelect } from '../handle-progress-step-select';
+
+const DOMAINS_URL = 'https://example.wordpress.com/setup/onboarding/domains';
+const PLANS_URL = 'https://example.wordpress.com/setup/onboarding/plans';
+
+describe( 'handleProgressStepSelect', () => {
+	let clickStepBack: jest.Mock;
+	let clickClose: jest.Mock;
+
+	beforeEach( () => {
+		clickStepBack = jest.fn();
+		clickClose = jest.fn();
+	} );
+
+	it( 'steps back to the domains URL when the domains step is clicked', () => {
+		handleProgressStepSelect( 'domains', {
+			forceCheckoutBackUrlDomains: DOMAINS_URL,
+			forceCheckoutBackUrl: PLANS_URL,
+			clickStepBack,
+			clickClose,
+		} );
+
+		expect( clickStepBack ).toHaveBeenCalledTimes( 1 );
+		expect( clickStepBack ).toHaveBeenCalledWith( DOMAINS_URL );
+		expect( clickClose ).not.toHaveBeenCalled();
+	} );
+
+	it( 'steps back to the plans URL when the plans step is clicked', () => {
+		handleProgressStepSelect( 'plans', {
+			forceCheckoutBackUrlDomains: DOMAINS_URL,
+			forceCheckoutBackUrl: PLANS_URL,
+			clickStepBack,
+			clickClose,
+		} );
+
+		expect( clickStepBack ).toHaveBeenCalledTimes( 1 );
+		expect( clickStepBack ).toHaveBeenCalledWith( PLANS_URL );
+		expect( clickClose ).not.toHaveBeenCalled();
+	} );
+
+	it( 'falls back to close when the domains step has no valid back URL', () => {
+		handleProgressStepSelect( 'domains', {
+			forceCheckoutBackUrlDomains: undefined,
+			forceCheckoutBackUrl: PLANS_URL,
+			clickStepBack,
+			clickClose,
+		} );
+
+		expect( clickClose ).toHaveBeenCalledTimes( 1 );
+		expect( clickStepBack ).not.toHaveBeenCalled();
+	} );
+
+	it( 'falls back to close when the plans step has no valid back URL', () => {
+		handleProgressStepSelect( 'plans', {
+			forceCheckoutBackUrlDomains: DOMAINS_URL,
+			forceCheckoutBackUrl: undefined,
+			clickStepBack,
+			clickClose,
+		} );
+
+		expect( clickClose ).toHaveBeenCalledTimes( 1 );
+		expect( clickStepBack ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/my-sites/checkout/src/components/test/leave-checkout-modal.test.tsx
+++ b/client/my-sites/checkout/src/components/test/leave-checkout-modal.test.tsx
@@ -294,3 +294,125 @@ describe( 'useCheckoutLeaveModal.clearCartAndLeave', () => {
 		expect( setCallsByKey ).toContain( 'no-user' );
 	} );
 } );
+
+describe( 'useCheckoutLeaveModal.clickStepBack', () => {
+	beforeEach( () => {
+		( useCartKey as jest.Mock ).mockReset();
+		( useValidCheckoutBackUrl as jest.Mock ).mockReset();
+		( leaveCheckout as jest.Mock ).mockReset();
+		( useCartKey as jest.Mock ).mockReturnValue( NEW_SITE_CART_KEY );
+		( useValidCheckoutBackUrl as jest.Mock ).mockReturnValue(
+			'https://mynewsite.wordpress.com/setup/onboarding/plans'
+		);
+	} );
+
+	it( 'leaves directly to the step destination when the cart is empty', async () => {
+		const { getCart, setCart } = createFakeCartBackend( { [ NEW_SITE_CART_KEY ]: [] } );
+		const client = createShoppingCartManagerClient( { getCart, setCart } );
+		const Wrapper = buildWrapper( client );
+
+		const { result } = renderHook( () => useCheckoutLeaveModal( { siteUrl: NEW_SITE_SLUG } ), {
+			wrapper: Wrapper,
+		} );
+
+		await act( async () => {
+			result.current.clickStepBack( 'https://mynewsite.wordpress.com/setup/onboarding/domains' );
+		} );
+
+		expect( leaveCheckout ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				forceCheckoutBackUrl: 'https://mynewsite.wordpress.com/setup/onboarding/domains',
+			} )
+		);
+		expect( result.current.isModalVisible ).toBe( false );
+	} );
+
+	it( 'opens the modal when the cart has products, then leaves to the step destination', async () => {
+		const { getCart, setCart } = createFakeCartBackend( {
+			[ NEW_SITE_CART_KEY ]: [ domainProduct, planProduct ],
+		} );
+		const client = createShoppingCartManagerClient( { getCart, setCart } );
+		const Wrapper = buildWrapper( client );
+
+		const { result } = renderHook( () => useCheckoutLeaveModal( { siteUrl: NEW_SITE_SLUG } ), {
+			wrapper: Wrapper,
+		} );
+
+		await waitFor( () =>
+			expect(
+				client.forCartKey( NEW_SITE_CART_KEY ).getState().responseCart.products
+			).toHaveLength( 2 )
+		);
+
+		act( () => {
+			result.current.clickStepBack( 'https://mynewsite.wordpress.com/setup/onboarding/domains' );
+		} );
+
+		expect( result.current.isModalVisible ).toBe( true );
+		expect( leaveCheckout ).not.toHaveBeenCalled();
+
+		await act( async () => {
+			result.current.closeAndLeave();
+		} );
+
+		expect( leaveCheckout ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				forceCheckoutBackUrl: 'https://mynewsite.wordpress.com/setup/onboarding/domains',
+			} )
+		);
+	} );
+
+	it( 'does not leak the step-back URL into a later plain close', async () => {
+		// Regression: clicking a step opens the modal and stores the step-back
+		// URL. If the user dismisses that modal (no navigation) and later hits
+		// the plain close button, the close must use the default back URL — not
+		// the stale step-back URL from the earlier `clickStepBack`.
+		const { getCart, setCart } = createFakeCartBackend( {
+			[ NEW_SITE_CART_KEY ]: [ domainProduct, planProduct ],
+		} );
+		const client = createShoppingCartManagerClient( { getCart, setCart } );
+		const Wrapper = buildWrapper( client );
+
+		const { result } = renderHook( () => useCheckoutLeaveModal( { siteUrl: NEW_SITE_SLUG } ), {
+			wrapper: Wrapper,
+		} );
+
+		await waitFor( () =>
+			expect(
+				client.forCartKey( NEW_SITE_CART_KEY ).getState().responseCart.products
+			).toHaveLength( 2 )
+		);
+
+		// Step back to domains opens the modal and records the step URL.
+		act( () => {
+			result.current.clickStepBack( 'https://mynewsite.wordpress.com/setup/onboarding/domains' );
+		} );
+		expect( result.current.isModalVisible ).toBe( true );
+
+		// User dismisses the modal without confirming (no navigation).
+		act( () => {
+			result.current.setIsModalVisible( false );
+		} );
+
+		// Plain close re-opens the modal; confirming must use the default back
+		// URL, not the stale domains step URL.
+		act( () => {
+			result.current.clickClose();
+		} );
+		expect( result.current.isModalVisible ).toBe( true );
+
+		await act( async () => {
+			result.current.closeAndLeave();
+		} );
+
+		// Exactly one navigation must fire, with the default URL. Asserting the
+		// call count closes the loophole where an erroneous earlier leave with
+		// the stale step URL would still satisfy a bare `toHaveBeenCalledWith`.
+		expect( leaveCheckout ).toHaveBeenCalledTimes( 1 );
+		expect( leaveCheckout ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				forceCheckoutBackUrl: 'https://mynewsite.wordpress.com/setup/onboarding/plans',
+			} )
+		);
+	} );
+} );


### PR DESCRIPTION
Reverts #113608
Slack thread: p1787586539939029/1786736229.907649-slack-C06FCT6EEHH

## Proposed Changes

* Revert #113608 to bring back the purchase-flow progress indicator in the onboarding flow.
* Remove the temporary `IS_ONBOARDING_PROGRESS_DISABLED` kill switch so the indicator is enabled again on desktop viewports.* Drop the step content wrapper’s top padding when the indicator is shown, so its built-in spacing doesn’t stack with the wrapper’s and push the content too far down.

## Why are these changes being made?

* We want to bring the onboarding progress indicator back. The revert restores the component and its wiring, and dropping the kill switch re-enables it without any further flag flip.

## Testing Instructions

1. Start the onboarding flow at `/setup/onboarding` on a desktop-sized viewport.
2. Verify the progress indicator is visible as you move through the steps (domains → plans → checkout).
3. Resize to a mobile viewport and verify the indicator is not shown there (the existing top-bar step counter remains).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)