### PR TITLE
Site generation: speak as the WordPress Agent

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/view.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/view.tsx
@@ -94,7 +94,7 @@ describe( 'SiteGenerationView progress and fallback states', () => {
 		);
 
 		expect( getByRole( 'heading', { name: 'This is taking longer than expected' } ) ).toBeVisible();
-		expect( getByText( 'Your brief is saved.' ) ).toBeVisible();
+		expect( getByText( 'I’ve saved your brief.' ) ).toBeVisible();
 		expect( getByRole( 'button', { name: 'Check again' } ) ).toBeVisible();
 
 		rerender(
@@ -213,7 +213,7 @@ describe( 'SiteGenerationView server recovery', () => {
 		);
 
 		expect( screen.getByText( 'This is taking longer than expected' ) ).toBeVisible();
-		expect( screen.getByText( 'Your brief is saved.' ) ).toBeVisible();
+		expect( screen.getByText( 'I’ve saved your brief.' ) ).toBeVisible();
 	} );
 
 	it( 'disables the rebuild button while the retry request is in flight', () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/view.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/view.tsx
@@ -104,11 +104,11 @@ function WaitingCanvas() {
 			<BuildVisualization />
 			<div className="site-generation__waiting-copy">
 				<h1 className="site-generation__waiting-title">
-					{ translate( 'We’re building your site' ) }
+					{ translate( 'All good things are worth the wait' ) }
 				</h1>
 				<p className="site-generation__waiting-description">
 					{ translate(
-						'This can take a few minutes. We’ll take you to the editor when your site is ready.'
+						'This can take up to 10 minutes. No worries, you’ll receive an email when the site is ready.'
 					) }
 				</p>
 			</div>
@@ -120,13 +120,13 @@ function ErrorCanvas( { state, onReload }: { state: SiteGenerationState; onReloa
 	const translate = useTranslate();
 	const failureReason = state.failureReason ?? 'missing-parameters';
 
-	let title = translate( 'We couldn’t check your site' );
-	let description = translate( 'The site or editor destination is missing from this page.' );
+	let title = translate( 'I couldn’t check your site' );
+	let description = translate( 'I’m missing the site or editor destination for this page.' );
 	let actionLabel = translate( 'Reload' );
 
 	if ( failureReason === 'timed-out' || failureReason === 'build-failed' ) {
 		title = translate( 'This is taking longer than expected' );
-		description = translate( 'Your brief is saved.' );
+		description = translate( 'I’ve saved your brief.' );
 		actionLabel = translate( 'Check again' );
 	}
 
@@ -173,7 +173,7 @@ function BuildProgress( { state }: { state: SiteGenerationState } ) {
 		<div className="site-build-progress">
 			<div className="site-build-progress__header">
 				<span className="site-build-progress__title" id="site-generation-progress-title">
-					{ translate( 'Generating your site' ) }
+					{ translate( 'Follow my progress:' ) }
 				</span>
 			</div>
 			<p className="site-build-progress__announcement" role="status">
@@ -209,7 +209,7 @@ function BuildProgress( { state }: { state: SiteGenerationState } ) {
 			{ hasFailed && (
 				<Notice className="site-generation__sidebar-notice" isDismissible={ false } status="info">
 					<div className="site-generation__sidebar-notice-content">
-						<strong>{ translate( 'Your brief is saved' ) }</strong>
+						<strong>{ translate( 'I’ve saved your brief' ) }</strong>
 						<span className="site-generation__sidebar-notice-detail">
 							{ translate( 'You can safely check its status again.' ) }
 						</span>
@@ -254,7 +254,7 @@ export function SiteGenerationView( {
 				</div>
 				<div className="site-generation__conversation">
 					<p className="site-generation__conversation-message">
-						{ translate( 'Your site is being prepared. You can follow its progress here.' ) }
+						{ translate( 'Hello! I’m the WordPress Agent, and I’m building your site right now.' ) }
 					</p>
 					<BuildProgress state={ state } />
 				</div>


### PR DESCRIPTION
Part of BIGR-875

## Proposed Changes

Rewrite the copy on the AI site builder's generation screen (`site-generation` step, used by the `ai-site-builder-spec` flow) so a single narrator — the WordPress Agent — introduces itself and speaks in first person across the waiting, progress, and failure states.

| State | Element | Before | After |
| --- | --- | --- | --- |
| Building | Canvas heading | We're building your site | All good things are worth the wait |
| | Canvas body | This can take a few minutes. We'll take you to the editor when your site is ready. | This can take up to 10 minutes. No worries, you'll receive an email when the site is ready. |
| | Sidebar message | Your site is being prepared. You can follow its progress here. | Hello! I'm the WordPress Agent, and I'm building your site right now. |
| | Sidebar list header | Generating your site | Follow my progress: |
| Missing params | Canvas heading | We couldn't check your site | I couldn't check your site |
| | Canvas body | The site or editor destination is missing from this page. | I'm missing the site or editor destination for this page. |
| Timed out / failed | Canvas body | Your brief is saved. | I've saved your brief. |
| | Sidebar notice | Your brief is saved | I've saved your brief |

The six progress step labels ("Preparing your site", "Choosing your design", …) are unchanged.

## Why are these changes being made?

Two problems with the copy as it stood on trunk:

1. **The canvas and the sidebar duplicated each other.** They render at the same time — canvas on the left, agent sidebar on the right — and both restated "your site is being generated." The sidebar was also redundant with itself: "Your site is being prepared. You can follow its progress here." sat directly above a header reading "Generating your site", which sat directly above the visible progress list.
2. **There was no narrator.** The sidebar has the Big Sky sparkle icon but the copy spoke impersonally, so the agent was never introduced. This is the first place in onboarding where we can establish who is building the site.

Copy is now split by job rather than saying the same thing twice: the canvas carries how long the build takes and that an email is coming, and the sidebar carries what is happening right now. Failure copy moves to the same voice so the narrator doesn't switch back to "we" the moment something goes wrong.

`WordPress Agent` is title-cased to match the existing product surfaces in `client/dashboard/sites/settings-ai-tools/` and `client/dashboard/me/mcp/`.

**One thing to flag for review:** on a `build-failed` failure the canvas renders the server's copy verbatim via `state.failureLabel` / `state.failureDetail`. Test fixtures show that string as "We couldn't finish building your site" — so a real build failure still speaks as "we" until that's changed server-side. Out of scope here; see BIGR-875 for the open question.

## Testing Instructions

1. Start the AI site builder flow and submit a brief (`/setup/ai-site-builder-spec`).
2. On the generation screen, confirm the canvas and sidebar no longer repeat each other, and that the sidebar opens with the WordPress Agent introducing itself.
3. Confirm the progress list header reads "Follow my progress:" and the six step labels are unchanged.
4. Error states: force a `timed-out` / `build-failed` state and confirm the canvas and sidebar notice both read "I've saved your brief". Load the step without the required params to confirm the "I couldn't check your site" state.

Unit tests: `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/` — 49 passing.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? <!-- Copy-only change; existing assertions updated to the new strings. -->
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? <!-- The progress list header is the aria-labelledby target for the step list; it stays descriptive. -->
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? <!-- Every string on this screen is new — needs the label. -->
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
