### PR TITLE
Plugins: redirect retired marketplace products to /plugins

### DIFF
--- a/client/lib/plugins/test/utils.js
+++ b/client/lib/plugins/test/utils.js
@@ -59,6 +59,21 @@ describe( 'Plugins Utils', () => {
 			};
 			expect( PluginUtils.getAllowedPluginData( plugin ) ).toEqual( plugin );
 		} );
+
+		test( 'should keep is_retired so the detail page can redirect retired products', () => {
+			expect( PluginUtils.getAllowedPluginData( { is_retired: true } ) ).toEqual( {
+				is_retired: true,
+			} );
+			expect( PluginUtils.getAllowedPluginData( { is_retired: false } ) ).toEqual( {
+				is_retired: false,
+			} );
+		} );
+
+		test( 'should not add is_retired when the API omits it', () => {
+			expect( PluginUtils.getAllowedPluginData( { slug: 'developer' } ) ).toEqual( {
+				slug: 'developer',
+			} );
+		} );
 	} );
 
 	describe( 'extractAuthorName', () => {

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -100,6 +100,7 @@ export function getAllowedPluginData( plugin ) {
 		'homepage',
 		'icons',
 		'id',
+		'is_retired',
 		'last_updated',
 		'name',
 		'network',

--- a/client/my-sites/plugins/controller-logged-out.js
+++ b/client/my-sites/plugins/controller-logged-out.js
@@ -94,6 +94,22 @@ const prefetchPlugin = async ( queryClient, store, { locale, pluginSlug } ) => {
 	return data;
 };
 
+/**
+ * Read the marketplace product that `prefetchPlugin` just cached.
+ *
+ * `prefetchPlugin` cannot hand the product back directly: it caches through
+ * `queryClient.prefetchQuery`, which resolves to `undefined` by design. The
+ * cache is the only place the prefetched product is readable.
+ *
+ * `pluginSlug` must be the same value that was passed to `prefetchPlugin`,
+ * because that value builds the query key.
+ * @param {Object} queryClient The react-query client holding the prefetched data
+ * @param {string} pluginSlug The plugin slug used for the prefetch
+ * @returns {Object|undefined} The normalized product, or undefined for a non-marketplace plugin
+ */
+const getPrefetchedMarketplaceProduct = ( queryClient, pluginSlug ) =>
+	queryClient.getQueryData( getWPCOMPluginQueryParams( pluginSlug ).queryKey );
+
 const prefetchTimebox = ( prefetchPromises, context ) => {
 	const racingPromises = [ Promise.all( prefetchPromises ) ];
 	const isBot = context.res?.req?.useragent?.isBot;
@@ -245,6 +261,13 @@ export async function fetchPlugin( context, next ) {
 		if ( dataOrError.message !== PREFETCH_TIMEOUT_ERROR ) {
 			return next( 'route' );
 		}
+	}
+
+	// A retired marketplace product cannot be bought any more, so its detail page
+	// is a dead end. Send the request to the plugin browser instead. The redirect
+	// is temporary because a product can stop being retired.
+	if ( getPrefetchedMarketplaceProduct( queryClient, options.pluginSlug )?.is_retired ) {
+		return context.res.redirect( 302, '/plugins' );
 	}
 
 	next();

--- a/client/my-sites/plugins/controller-logged-out.js
+++ b/client/my-sites/plugins/controller-logged-out.js
@@ -267,7 +267,10 @@ export async function fetchPlugin( context, next ) {
 	// is a dead end. Send the request to the plugin browser instead. The redirect
 	// is temporary because a product can stop being retired.
 	if ( getPrefetchedMarketplaceProduct( queryClient, options.pluginSlug )?.is_retired ) {
-		return context.res.redirect( 302, '/plugins' );
+		// `ssrSetupLocale` has already redirected any locale that is not a
+		// magnificent one, so a `lang` param here is safe to keep in the path.
+		const { lang } = context.params;
+		return context.res.redirect( 302, lang ? `/${ lang }/plugins` : '/plugins' );
 	}
 
 	next();

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -5,7 +5,7 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import { Icon, download } from '@wordpress/icons';
 import clsx from 'clsx';
 import { fixMe, useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Banner from 'calypso/components/banner';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -26,6 +26,7 @@ import { useESPlugin } from 'calypso/data/marketplace/use-es-query';
 import { useMarketplaceReviewsQuery } from 'calypso/data/marketplace/use-marketplace-reviews';
 import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getSoftwareSlug } from 'calypso/lib/plugins/utils';
 import { MarketplaceReviewsCards } from 'calypso/my-sites/marketplace/components/reviews-cards';
 import { ReviewsModal } from 'calypso/my-sites/marketplace/components/reviews-modal';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
@@ -56,6 +57,7 @@ import { canPublishProductReviews } from 'calypso/state/marketplace/selectors';
 import {
 	getPluginOnSites,
 	isRequestingForAllSites,
+	isRequestingForSites,
 } from 'calypso/state/plugins/installed/selectors';
 import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/wporg/actions';
 import {
@@ -190,11 +192,48 @@ function PluginDetails( props ) {
 	const isRetiredProduct =
 		isMarketplaceProduct && isWpComPluginFetched && !! wpComPluginData?.is_retired;
 
+	// Retiring a product cancels its subscriptions but leaves the plugin installed,
+	// and this page is where a site owner deactivates or removes it. So the redirect
+	// must wait for the installed-plugins fetch that `QueryPlugins` starts on mount,
+	// and must stand down when the plugin is installed on a site in scope. The
+	// installed-plugins state is keyed by the software slug, not the product slug.
+	const isRequestingInstalledPlugins = useSelector(
+		( state ) => isRequestingForAllSites( state ) || isRequestingForSites( state, siteIds )
+	);
+	const isRetiredPluginInstalled = useSelector(
+		( state ) =>
+			isRetiredProduct &&
+			!! getPluginOnSites( state, siteIds, getSoftwareSlug( wpComPluginData, true ) )
+	);
+	const hasRequestedInstalledPlugins = useRef( false );
+	const canHaveInstalledPlugins = sitesWithPlugins.length > 0;
+	const retiredRedirectPath = localizePath(
+		selectedSite?.slug ? `/plugins/${ selectedSite.slug }` : '/plugins'
+	);
+
 	useEffect( () => {
-		if ( isRetiredProduct ) {
-			page.redirect( '/plugins' );
+		if ( isRequestingInstalledPlugins ) {
+			hasRequestedInstalledPlugins.current = true;
+			return;
 		}
-	}, [ isRetiredProduct ] );
+		if ( ! isRetiredProduct || isRequestingSites ) {
+			return;
+		}
+		if (
+			canHaveInstalledPlugins &&
+			( isRetiredPluginInstalled || ! hasRequestedInstalledPlugins.current )
+		) {
+			return;
+		}
+		page.redirect( retiredRedirectPath );
+	}, [
+		isRequestingInstalledPlugins,
+		isRetiredProduct,
+		isRetiredPluginInstalled,
+		isRequestingSites,
+		canHaveInstalledPlugins,
+		retiredRedirectPath,
+	] );
 
 	// Unify plugin details
 	const fullPlugin = useMemo( () => {

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
@@ -182,6 +183,18 @@ function PluginDetails( props ) {
 		isFetched: isWpComPluginFetched,
 		isFetching: isWpComPluginFetching,
 	} = useWPCOMPlugin( props.pluginSlug, { enabled: isProductListFetched && isMarketplaceProduct } );
+
+	// A retired marketplace product cannot be bought any more, so its detail page
+	// is a dead end. Wait for the marketplace fetch to resolve so that a plugin is
+	// never treated as retired on partial data.
+	const isRetiredProduct =
+		isMarketplaceProduct && isWpComPluginFetched && !! wpComPluginData?.is_retired;
+
+	useEffect( () => {
+		if ( isRetiredProduct ) {
+			page.redirect( '/plugins' );
+		}
+	}, [ isRetiredProduct ] );
 
 	// Unify plugin details
 	const fullPlugin = useMemo( () => {

--- a/client/my-sites/plugins/test/controller-logged-out.js
+++ b/client/my-sites/plugins/test/controller-logged-out.js
@@ -1,7 +1,8 @@
 /**
  * @jest-environment jsdom
  */
-import { setBrowsePluginsNoindex } from '../controller-logged-out';
+import { getWPCOMPluginQueryParams } from 'calypso/data/marketplace/use-wpcom-plugins-query';
+import { fetchPlugin, setBrowsePluginsNoindex } from '../controller-logged-out';
 
 function makeContext( category, { isServerSide = true, loggedIn = false, meta = [] } = {} ) {
 	const dispatched = [];
@@ -94,5 +95,107 @@ describe( 'setBrowsePluginsNoindex', () => {
 		expect( meta.filter( ( { name } ) => name === 'robots' ) ).toEqual( [
 			{ name: 'robots', content: 'noindex' },
 		] );
+	} );
+} );
+
+const PLUGIN_SLUG = 'sensei-pro';
+
+/**
+ * A stand-in for the react-query client that serves data the test seeds.
+ *
+ * `fetchPlugin` reads the prefetched product back out of the query cache, so
+ * the fake only has to answer `getQueryData` for the seeded key. The prefetch
+ * methods resolve empty, which keeps the test off the network.
+ * @param {Object|undefined} cachedProduct The product to serve for PLUGIN_SLUG
+ * @returns {Object} The fake query client
+ */
+function makeQueryClient( cachedProduct ) {
+	const { queryKey } = getWPCOMPluginQueryParams( PLUGIN_SLUG );
+	const cacheKey = JSON.stringify( queryKey );
+
+	return {
+		fetchQuery: () => Promise.resolve( {} ),
+		prefetchQuery: () => Promise.resolve(),
+		prefetchInfiniteQuery: () => Promise.resolve(),
+		getQueryData: ( key ) => ( JSON.stringify( key ) === cacheKey ? cachedProduct : undefined ),
+	};
+}
+
+function makePluginContext( { cachedProduct, isMarketplaceProduct = true } = {} ) {
+	// `isMarketplaceProduct` reads the products list, which routes the prefetch
+	// to the marketplace API instead of WordPress.org.
+	const items = isMarketplaceProduct
+		? {
+				[ PLUGIN_SLUG ]: {
+					product_type: 'marketplace_plugin',
+					billing_product_slug: PLUGIN_SLUG,
+				},
+		  }
+		: {};
+
+	return {
+		isServerSide: true,
+		path: `/plugins/${ PLUGIN_SLUG }`,
+		lang: 'en',
+		params: { plugin: PLUGIN_SLUG },
+		queryClient: makeQueryClient( cachedProduct ),
+		store: {
+			getState: () => ( {
+				productsList: { items },
+				plugins: { wporg: { items: {}, fetchingItems: {} } },
+			} ),
+			dispatch: () => {},
+		},
+		res: {
+			redirect: jest.fn(),
+			status: jest.fn(),
+			req: { logger: { error: jest.fn() }, useragent: { isBot: false } },
+		},
+	};
+}
+
+describe( 'fetchPlugin', () => {
+	test( 'redirects a retired marketplace product to /plugins', async () => {
+		const next = jest.fn();
+		const context = makePluginContext( {
+			cachedProduct: { slug: PLUGIN_SLUG, is_retired: true },
+		} );
+
+		await fetchPlugin( context, next );
+
+		expect( context.res.redirect ).toHaveBeenCalledWith( 302, '/plugins' );
+		expect( next ).not.toHaveBeenCalled();
+	} );
+
+	test( 'renders normally when is_retired is false', async () => {
+		const next = jest.fn();
+		const context = makePluginContext( {
+			cachedProduct: { slug: PLUGIN_SLUG, is_retired: false },
+		} );
+
+		await fetchPlugin( context, next );
+
+		expect( context.res.redirect ).not.toHaveBeenCalled();
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'renders normally when the API omits is_retired', async () => {
+		const next = jest.fn();
+		const context = makePluginContext( { cachedProduct: { slug: PLUGIN_SLUG } } );
+
+		await fetchPlugin( context, next );
+
+		expect( context.res.redirect ).not.toHaveBeenCalled();
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'renders normally for a WordPress.org plugin with no cached product', async () => {
+		const next = jest.fn();
+		const context = makePluginContext( { isMarketplaceProduct: false } );
+
+		await fetchPlugin( context, next );
+
+		expect( context.res.redirect ).not.toHaveBeenCalled();
+		expect( next ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/client/my-sites/plugins/test/controller-logged-out.js
+++ b/client/my-sites/plugins/test/controller-logged-out.js
@@ -167,6 +167,22 @@ describe( 'fetchPlugin', () => {
 		expect( next ).not.toHaveBeenCalled();
 	} );
 
+	test( 'keeps the locale in the redirect for a localized request', async () => {
+		const next = jest.fn();
+		const context = makePluginContext( {
+			isMarketplaceProduct: true,
+			cachedProduct: { slug: PLUGIN_SLUG, is_retired: true },
+		} );
+		context.path = `/de/plugins/${ PLUGIN_SLUG }`;
+		context.lang = 'de';
+		context.params.lang = 'de';
+
+		await fetchPlugin( context, next );
+
+		expect( context.res.redirect ).toHaveBeenCalledWith( 302, '/de/plugins' );
+		expect( next ).not.toHaveBeenCalled();
+	} );
+
 	test( 'renders normally when is_retired is false', async () => {
 		const next = jest.fn();
 		const context = makePluginContext( {

--- a/client/my-sites/plugins/test/plugin-details.jsx
+++ b/client/my-sites/plugins/test/plugin-details.jsx
@@ -13,6 +13,12 @@ jest.mock( 'calypso/data/marketplace/use-es-query', () => ( {
 
 jest.mock( 'calypso/data/marketplace/use-marketplace-reviews', () => ( {
 	useMarketplaceReviewsQuery: () => ( { data: [] } ),
+	useInfiniteMarketplaceReviewsQuery: () => ( { data: { pages: [] }, fetchNextPage: () => {} } ),
+	useMarketplaceReviewsStatsQuery: () => ( { data: undefined } ),
+	useCreateMarketplaceReviewMutation: () => ( { mutate: () => {} } ),
+	useUpdateMarketplaceReviewMutation: () => ( { mutate: () => {} } ),
+	useDeleteMarketplaceReviewMutation: () => ( { mutate: () => {} } ),
+	useIsUserAllowedToReview: () => ( { data: false } ),
 } ) );
 
 jest.mock( 'calypso/my-sites/plugins/use-plugin-is-maintained', () => ( {
@@ -23,31 +29,60 @@ jest.mock( 'calypso/my-sites/plugins/hooks/use-is-marketplace-redesign-enabled',
 	useIsMarketplaceRedesignEnabled: () => false,
 } ) );
 
+// The tests drive the installed-plugins fetch lifecycle through the store, so
+// the query component must not start a real request.
+jest.mock( 'calypso/components/data/query-plugins', () => () => null );
+
+// `localizePath` prefixes the locale for logged-out visitors on a magnificent
+// locale. The stub makes that prefix visible without loading translations.
+let mockLocalePrefix = '';
+jest.mock( 'calypso/my-sites/plugins/utils', () => ( {
+	...jest.requireActual( 'calypso/my-sites/plugins/utils' ),
+	useLocalizedPlugins: () => ( {
+		localizePath: ( path ) => `${ mockLocalePrefix }${ path }`,
+	} ),
+} ) );
+
 import page from '@automattic/calypso-router';
 import { merge } from '@automattic/js-utils';
+import { act } from '@testing-library/react';
+import { applyMiddleware, createStore } from 'redux';
+import { thunk } from 'redux-thunk';
+import {
+	PLUGINS_RECEIVE,
+	PLUGINS_REQUEST,
+	PLUGINS_REQUEST_SUCCESS,
+} from 'calypso/state/action-types';
 import breadcrumb from 'calypso/state/breadcrumb/reducer';
 import documentHead from 'calypso/state/document-head/reducer';
 import plugins from 'calypso/state/plugins/reducer';
+import preferences from 'calypso/state/preferences/reducer';
 import productsList from 'calypso/state/products-list/reducer';
 import purchases from 'calypso/state/purchases/reducer';
+import initialReducer from 'calypso/state/reducer';
 import siteConnection from 'calypso/state/site-connection/reducer';
 import { reducer as ui } from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import PluginDetails from '../plugin-details';
 
-const PLUGIN_SLUG = 'sensei-pro';
+// Start Booking: the marketplace product slug differs from the slug the plugin
+// is installed under, which is what the installed-plugins state uses.
+const PLUGIN_SLUG = 'calendar-booking-wpcom';
+const SOFTWARE_SLUG = 'calendar-booking';
+const SITE_ID = 1;
+const SITE_SLUG = 'example.wordpress.com';
 
 // The component renders `NoPermissionsError` and stops when the current user
 // cannot manage plugins. That early return sits below the redirect effect, so
 // this state exercises the effect without building the whole detail page.
 const initialReduxState = {
-	ui: { selectedSiteId: 1 },
+	ui: { selectedSiteId: SITE_ID },
 	sites: {
-		items: { 1: { ID: 1, title: 'Test Site', slug: 'example.wordpress.com' } },
+		items: { [ SITE_ID ]: { ID: SITE_ID, title: 'Test Site', URL: `https://${ SITE_SLUG }` } },
 		requestingAll: false,
 	},
-	currentUser: { id: 12, capabilities: { 1: { manage_options: false } } },
-	siteConnection: { items: { 1: true } },
+	currentUser: { id: 12, capabilities: { [ SITE_ID ]: { manage_options: false } } },
+	siteConnection: { items: { [ SITE_ID ]: true } },
 	purchases: {
 		data: [],
 		hasLoadedUserPurchasesFromServer: false,
@@ -62,31 +97,103 @@ const initialReduxState = {
 		},
 	},
 	plugins: { installed: { isRequesting: {}, plugins: {}, status: {} } },
+	preferences: { remoteValues: {}, localValues: {} },
 	breadcrumb: [],
 };
 
-const render = () =>
-	renderWithProvider( <PluginDetails pluginSlug={ PLUGIN_SLUG } />, {
-		initialState: merge( {}, initialReduxState ),
-		reducers: { ui, plugins, productsList, breadcrumb, siteConnection, purchases, documentHead },
+// A Jetpack site the user can manage passes `getSelectedOrAllSitesWithPlugins`,
+// so the page must wait for that site's installed plugins before it redirects.
+const jetpackSiteState = {
+	sites: {
+		items: {
+			[ SITE_ID ]: {
+				ID: SITE_ID,
+				title: 'Test Site',
+				URL: `https://${ SITE_SLUG }`,
+				jetpack: true,
+				visible: true,
+			},
+		},
+	},
+	currentUser: { capabilities: { [ SITE_ID ]: { manage_options: true } } },
+};
+
+const retiredProduct = {
+	data: { slug: PLUGIN_SLUG, org_slug: SOFTWARE_SLUG, is_retired: true },
+	isFetched: true,
+	isFetching: false,
+};
+
+const reducers = {
+	ui,
+	plugins,
+	preferences,
+	productsList,
+	breadcrumb,
+	siteConnection,
+	purchases,
+	documentHead,
+};
+
+// Build the store here so that a test can dispatch into it after the render.
+const createTestStore = ( stateOverrides ) => {
+	const reducer = Object.entries( reducers ).reduce(
+		( combined, [ key, keyReducer ] ) => combined.addReducer( [ key ], keyReducer ),
+		initialReducer
+	);
+	return createStore(
+		reducer,
+		merge( {}, initialReduxState, stateOverrides ),
+		applyMiddleware( thunk )
+	);
+};
+
+const render = ( stateOverrides = {} ) => {
+	const store = createTestStore( stateOverrides );
+	renderWithProvider( <PluginDetails pluginSlug={ PLUGIN_SLUG } />, { store } );
+	return { store };
+};
+
+const receiveInstalledPlugins = ( store, installedPlugins ) => {
+	act( () => {
+		store.dispatch( { type: PLUGINS_REQUEST, siteId: SITE_ID } );
 	} );
+	act( () => {
+		store.dispatch( { type: PLUGINS_RECEIVE, siteId: SITE_ID, data: installedPlugins } );
+		store.dispatch( { type: PLUGINS_REQUEST_SUCCESS, siteId: SITE_ID } );
+	} );
+};
 
 describe( 'PluginDetails retired product redirect', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockLocalePrefix = '';
 		window.__i18n_text_domain__ = JSON.stringify( 'default' );
 	} );
 
-	test( 'redirects to /plugins once a retired product has been fetched', () => {
-		mockWpComPlugin = {
-			data: { slug: PLUGIN_SLUG, is_retired: true },
-			isFetched: true,
-			isFetching: false,
-		};
+	test( 'redirects to the plugin browser for the selected site once a retired product has been fetched', () => {
+		mockWpComPlugin = retiredProduct;
 
 		render();
 
+		expect( page.redirect ).toHaveBeenCalledWith( `/plugins/${ SITE_SLUG }` );
+	} );
+
+	test( 'redirects to /plugins when no site is selected', () => {
+		mockWpComPlugin = retiredProduct;
+
+		render( { ui: { selectedSiteId: null } } );
+
 		expect( page.redirect ).toHaveBeenCalledWith( '/plugins' );
+	} );
+
+	test( 'keeps the locale prefix for a logged-out visitor', () => {
+		mockWpComPlugin = retiredProduct;
+		mockLocalePrefix = '/de';
+
+		render( { ui: { selectedSiteId: null }, currentUser: { id: null, capabilities: {} } } );
+
+		expect( page.redirect ).toHaveBeenCalledWith( '/de/plugins' );
 	} );
 
 	test( 'does not redirect when the product is not retired', () => {
@@ -118,6 +225,30 @@ describe( 'PluginDetails retired product redirect', () => {
 		};
 
 		render();
+
+		expect( page.redirect ).not.toHaveBeenCalled();
+	} );
+
+	test( 'waits for the installed-plugins fetch on a site that can have plugins', () => {
+		mockWpComPlugin = retiredProduct;
+
+		const { store } = render( jetpackSiteState );
+
+		expect( page.redirect ).not.toHaveBeenCalled();
+
+		receiveInstalledPlugins( store, [] );
+
+		expect( page.redirect ).toHaveBeenCalledWith( `/plugins/${ SITE_SLUG }` );
+	} );
+
+	test( 'keeps the page when the retired plugin is installed on the selected site', () => {
+		mockWpComPlugin = retiredProduct;
+
+		const { store } = render( jetpackSiteState );
+
+		receiveInstalledPlugins( store, [
+			{ slug: SOFTWARE_SLUG, id: `${ SOFTWARE_SLUG }/${ SOFTWARE_SLUG }.php`, active: true },
+		] );
 
 		expect( page.redirect ).not.toHaveBeenCalled();
 	} );

--- a/client/my-sites/plugins/test/plugin-details.jsx
+++ b/client/my-sites/plugins/test/plugin-details.jsx
@@ -1,0 +1,124 @@
+/** @jest-environment jsdom */
+
+jest.mock( '@automattic/calypso-router' );
+
+let mockWpComPlugin = { data: undefined, isFetched: false, isFetching: true };
+jest.mock( 'calypso/data/marketplace/use-wpcom-plugins-query', () => ( {
+	useWPCOMPlugin: () => mockWpComPlugin,
+} ) );
+
+jest.mock( 'calypso/data/marketplace/use-es-query', () => ( {
+	useESPlugin: () => ( { data: {} } ),
+} ) );
+
+jest.mock( 'calypso/data/marketplace/use-marketplace-reviews', () => ( {
+	useMarketplaceReviewsQuery: () => ( { data: [] } ),
+} ) );
+
+jest.mock( 'calypso/my-sites/plugins/use-plugin-is-maintained', () => ( {
+	usePluginIsMaintained: () => true,
+} ) );
+
+jest.mock( 'calypso/my-sites/plugins/hooks/use-is-marketplace-redesign-enabled', () => ( {
+	useIsMarketplaceRedesignEnabled: () => false,
+} ) );
+
+import page from '@automattic/calypso-router';
+import { merge } from '@automattic/js-utils';
+import breadcrumb from 'calypso/state/breadcrumb/reducer';
+import documentHead from 'calypso/state/document-head/reducer';
+import plugins from 'calypso/state/plugins/reducer';
+import productsList from 'calypso/state/products-list/reducer';
+import purchases from 'calypso/state/purchases/reducer';
+import siteConnection from 'calypso/state/site-connection/reducer';
+import { reducer as ui } from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import PluginDetails from '../plugin-details';
+
+const PLUGIN_SLUG = 'sensei-pro';
+
+// The component renders `NoPermissionsError` and stops when the current user
+// cannot manage plugins. That early return sits below the redirect effect, so
+// this state exercises the effect without building the whole detail page.
+const initialReduxState = {
+	ui: { selectedSiteId: 1 },
+	sites: {
+		items: { 1: { ID: 1, title: 'Test Site', slug: 'example.wordpress.com' } },
+		requestingAll: false,
+	},
+	currentUser: { id: 12, capabilities: { 1: { manage_options: false } } },
+	siteConnection: { items: { 1: true } },
+	purchases: {
+		data: [],
+		hasLoadedUserPurchasesFromServer: false,
+		hasLoadedSitePurchasesFromServer: false,
+	},
+	productsList: {
+		items: {
+			[ PLUGIN_SLUG ]: {
+				product_type: 'marketplace_plugin',
+				billing_product_slug: PLUGIN_SLUG,
+			},
+		},
+	},
+	plugins: { installed: { isRequesting: {}, plugins: {}, status: {} } },
+	breadcrumb: [],
+};
+
+const render = () =>
+	renderWithProvider( <PluginDetails pluginSlug={ PLUGIN_SLUG } />, {
+		initialState: merge( {}, initialReduxState ),
+		reducers: { ui, plugins, productsList, breadcrumb, siteConnection, purchases, documentHead },
+	} );
+
+describe( 'PluginDetails retired product redirect', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		window.__i18n_text_domain__ = JSON.stringify( 'default' );
+	} );
+
+	test( 'redirects to /plugins once a retired product has been fetched', () => {
+		mockWpComPlugin = {
+			data: { slug: PLUGIN_SLUG, is_retired: true },
+			isFetched: true,
+			isFetching: false,
+		};
+
+		render();
+
+		expect( page.redirect ).toHaveBeenCalledWith( '/plugins' );
+	} );
+
+	test( 'does not redirect when the product is not retired', () => {
+		mockWpComPlugin = {
+			data: { slug: PLUGIN_SLUG, is_retired: false },
+			isFetched: true,
+			isFetching: false,
+		};
+
+		render();
+
+		expect( page.redirect ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not redirect when the API omits is_retired', () => {
+		mockWpComPlugin = { data: { slug: PLUGIN_SLUG }, isFetched: true, isFetching: false };
+
+		render();
+
+		expect( page.redirect ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not redirect on partial data, before the fetch resolves', () => {
+		// A stale or in-flight response must never trigger the redirect.
+		mockWpComPlugin = {
+			data: { slug: PLUGIN_SLUG, is_retired: true },
+			isFetched: false,
+			isFetching: true,
+		};
+
+		render();
+
+		expect( page.redirect ).not.toHaveBeenCalled();
+	} );
+} );


### PR DESCRIPTION
Related to #DOTMKT-29

## Proposed changes

Redirect the detail page of a retired marketplace product to the plugin browser, on both the logged-out and the logged-in path. The redirect keeps the locale and the selected site, and it stands down when the plugin is still installed on a site the user manages.

- Add `is_retired` to the `getAllowedPluginData()` allowlist in `client/lib/plugins/utils.js`. The allowlist is a `pick()` that runs inside `normalizePluginData`, so a field that is absent from it never reaches any consumer. Both paths read the product through that function.
- Redirect on the server in `fetchPlugin` (`client/my-sites/plugins/controller-logged-out.js`). When the prefetched marketplace product has `is_retired`, redirect with `302` to `/plugins`, or to `/<lang>/plugins` when the request path has a locale, and do not continue to the render. `ssrSetupLocale` runs earlier in the route and has already redirected any locale that is not a magnificent one.
- Redirect on the client in `PluginDetails` (`client/my-sites/plugins/plugin-details.jsx`). When the marketplace fetch has resolved and the product has `is_retired`, call `page.redirect()` with `localizePath( '/plugins/<site>' )`, so a logged-out visitor keeps the locale and a logged-in user keeps the selected site.
- Do not redirect while the plugin is installed. Retiring a product cancels its subscriptions but leaves the plugin on the site (the reinstall step in `marketplace-manage-retired-product.php` is disabled on purpose), and the detail page is where the owner deactivates or removes it. The client redirect waits for the installed-plugins fetch that `QueryPlugins` starts on mount, then stands down when `getPluginOnSites()` finds the plugin on a site in scope. The installed-plugins state is keyed by the software slug (`calendar-booking`), not the product slug (`calendar-booking-wpcom`), so the lookup uses `getSoftwareSlug()`.

A missing `is_retired` field counts as false everywhere.

The status is 302 and not 301 because a product can stop being retired.

## Why

A retired marketplace product is excluded from plugin search and from the browse listings, but its direct URL still renders a full detail page with a working purchase call to action. A customer who arrives from a bookmark, a search engine result, or a support link sees a product that looks buyable and is not.

The server already blocks the purchase, so this changes navigation only. It does not gate the call to action.

Products that are hidden but not retired keep their current behaviour. `is_hidden` alone means the product is unlisted, not withdrawn, and its detail page is still a valid destination.

## Merge order

This depends on the wpcom PR that adds `is_retired` to `/wpcom/v2/marketplace/products` (236400-ghe-Automattic/wpcom). Merge this one only after that PR deploys.

Merging earlier is inert rather than harmful. Until the API returns the field, `is_retired` is `undefined` on every product, so the allowlist entry drops out and neither redirect can fire.

## Testing

Both redirects have unit coverage, and each new test was confirmed to fail against the unpatched code.

The server-side test needs one piece of context. `prefetchPlugin` caches the product through `queryClient.prefetchQuery`, which resolves to `undefined` by design, so `fetchPlugin` cannot read the product from the value it awaits. It reads the product back out of the query cache with `getQueryData` instead. The test seeds a fake query client rather than mocking the network.

New coverage:

- `client/lib/plugins/test/utils.js` — `is_retired` survives `getAllowedPluginData` as both `true` and `false`, and is not invented when the API omits it.
- `client/my-sites/plugins/test/controller-logged-out.js` — five cases for `fetchPlugin`: retired redirects with `302` and does not call `next()`; a request with `lang: 'de'` redirects to `/de/plugins`; `false`, absent, and a WordPress.org plugin with no cached product all continue to the render.
- `client/my-sites/plugins/test/plugin-details.jsx` — eight cases for the client effect: redirect to `/plugins/<site>` with a selected site and to `/plugins` without one; the locale prefix for a logged-out visitor; no redirect for `false`, absent, or unresolved data; on a Jetpack site the redirect waits for the installed-plugins fetch and then fires when the plugin is absent; no redirect when the retired plugin is installed under its software slug.

<details>
<summary>Test run</summary>

```
yarn test-client client/lib/plugins client/my-sites/plugins

Test Suites: 28 passed, 28 total
Tests:       727 passed, 727 total
Snapshots:   0 total
```

</details>

## Test instructions

Test branch: `dotmkt-29-combined-test` (wpcom). It is `trunk` plus 236402-ghe-Automattic/wpcom and 236400-ghe-Automattic/wpcom merged, so the three PRs can be tested together. The Calypso side is branch `dotmkt-29-redirect-retired-plugins` (this PR).

Start Booking (`calendar-booking-wpcom`, store products 10001/10002) is already in `WPCOM_MARKETPLACE_RETIRED_PRODUCTS`, so no data setup is needed. Recurring Donations for GiveWP (`give-recurring`) is hidden but not retired. Use it as the control: it must keep its current behaviour.

### Setup

1. Deploy `dotmkt-29-combined-test` to your sandbox.
2. Point `public-api.wordpress.com` and `wordpress.com` at your sandbox in `/etc/hosts`.
3. For the Calypso checks, run a local dev server on `dotmkt-29-redirect-retired-plugins` (`yarn start`, node 24). Do not use calypso.live for these: its server does not receive your login cookie, so it renders the page logged-out against production, which has no `is_retired` yet, and the client hydrates that render.

### 1. API (236400-ghe-Automattic/wpcom)

```
curl -s https://public-api.wordpress.com/wpcom/v2/marketplace/products/calendar-booking-wpcom | jq '{is_hidden, is_retired}'
curl -s https://public-api.wordpress.com/wpcom/v2/marketplace/products/give-recurring | jq '{is_hidden, is_retired}'
curl -s 'https://public-api.wordpress.com/wpcom/v2/marketplace/products?type=launched' | jq '[.results[] | select(.is_hidden)] | length'
```

Expected: Start Booking `is_hidden: true, is_retired: true`; GiveWP `is_hidden: true, is_retired: false`; the launched listing still has 0 hidden products and every product has an `is_retired` key.

### 2. Detail page, logged out (PR 113782, SSR)

```
curl -sI http://calypso.localhost:3000/plugins/calendar-booking-wpcom | grep -i '^HTTP\|^location'
curl -sI http://calypso.localhost:3000/de/plugins/calendar-booking-wpcom | grep -i '^HTTP\|^location'
curl -sI http://calypso.localhost:3000/plugins/give-recurring | grep -i '^HTTP'
```

Expected: `302` with `Location: /plugins` for Start Booking, `302` with `Location: /de/plugins` for the localized URL; `200` for GiveWP. In a private window the same URLs show the plugin browser (in German for `/de/`) and the GiveWP page.

### 3. Detail page, logged in (PR 113782, client)

Log in to the local dev server. If you loaded either page earlier, clear site data for `calypso.localhost` first: the product query is cached for 2 hours.

1. Load `/plugins/calendar-booking-wpcom`. Expected: you land on `/plugins`.
2. Load `/plugins/calendar-booking-wpcom/<site>` for a site that does not have Start Booking installed. Expected: you land on `/plugins/<site>`.
3. Load `/plugins/calendar-booking-wpcom/<site>` for an Atomic site that has the `calendar-booking` plugin installed. Expected: the page stays and shows the installed state with the manage menu, so the plugin can be deactivated or removed.
4. Load `/plugins/give-recurring`. Expected: the page renders with its price and CTA.

### 4. Purchase block (236402-ghe-Automattic/wpcom)

Use a Simple site with a Business plan. P2 sites are rejected by a different rule.

1. Open `/checkout/<site>/calendar_booking_wpcom_monthly`. Expected: the item is removed and checkout shows "Sorry, that product is no longer available". The cart error code is `invalid-product-marketplace-retired`.
2. Open `/checkout/<site>/woocommerce_subscriptions_monthly`. Expected: the item stays in the cart.

Renewals of an existing Start Booking subscription and the siteless vendor checkout are covered by the unit tests in 236402-ghe-Automattic/wpcom (`RetiredMarketplaceProductTest`, `MarketplaceVendorBillingIntentSitelessRestEndpointTest`).

### 5. Unit tests

```
cd ~/public_html; phpunit --colors -c bin/tests/isolated/phpunit.xml --testsuite=marketplace; cd -
cd ~/public_html; phpunit --colors -c bin/tests/isolated/phpunit.xml --testsuite=shoppingcart-1 --filter=RetiredMarketplaceProductTest; cd -
```

