### PR TITLE
Stats: pad the summary nav only when the date picker is stacked

### DIFF
--- a/client/my-sites/stats/stats-module/summary-nav.scss
+++ b/client/my-sites/stats/stats-module/summary-nav.scss
@@ -25,8 +25,13 @@ $summary-nav-swap-width: 661px;
 		}
 	}
 
+	// The padding compensates for the date picker stacking above the heading
+	// at this width; a title-only nav (e.g. the Emails summary page) has
+	// nothing stacked, and the padding would render as a bare blank strip.
 	@media ( min-width: $break-medium ) and ( max-width: 1160px ) {
-		padding-bottom: 24px;
+		&:has( .stats-summary-nav__date-control ) {
+			padding-bottom: 24px;
+		}
 	}
 
 	@media ( max-width: $summary-nav-swap-width ) {

--- a/client/my-sites/stats/stats-module/summary-nav.scss
+++ b/client/my-sites/stats/stats-module/summary-nav.scss
@@ -1,46 +1,46 @@
-@import "@wordpress/base-styles/breakpoints";
-@import "calypso/assets/stylesheets/shared/mixins/breakpoints";
-@import "@automattic/components/src/styles/mixins";
-@import "../modernized-mixins";
+@import '@wordpress/base-styles/breakpoints';
+@import 'calypso/assets/stylesheets/shared/mixins/breakpoints';
+@import '@automattic/components/src/styles/mixins';
+@import '../modernized-mixins';
 
 $summary-small-padding: 0 16px;
 $summary-medium-padding: 0 32px;
-$summary-small-border: 1px solid var(--studio-gray-5);
+$summary-small-border: 1px solid var( --studio-gray-5 );
 $summary-nav-swap-width: 661px;
 
 .stats-summary-nav {
 	display: flex;
 	justify-content: space-between;
 
-	@include navigation-segment-control-buttons( "auto" );
+	@include navigation-segment-control-buttons( 'auto' );
 
-	@media (min-width: 1160px) {
+	@media ( min-width: 1160px ) {
 		flex-wrap: wrap;
 		flex-direction: row-reverse;
 	}
 
-	@media (max-width: 1160px) {
-		&:not(.stats-summary-nav--with-button) {
+	@media ( max-width: 1160px ) {
+		&:not( .stats-summary-nav--with-button ) {
 			display: block;
 		}
 	}
 
-	@media (min-width: $break-medium) and (max-width: 1160px) {
+	@media ( min-width: $break-medium ) and ( max-width: 1160px ) {
 		padding-bottom: 24px;
 	}
 
-	@media (max-width: $summary-nav-swap-width) {
+	@media ( max-width: $summary-nav-swap-width ) {
 		padding: 0;
 		border-bottom: $summary-small-border;
 	}
 
 	.stats-section-title {
-		@include breakpoint-deprecated( "<660px" ) {
+		@include breakpoint-deprecated( '<660px' ) {
 			margin-left: 0;
 			margin-right: 0;
 		}
 
-		@include breakpoint-deprecated( "<480px" ) {
+		@include breakpoint-deprecated( '<480px' ) {
 			text-align: left;
 		}
 	}
@@ -49,11 +49,11 @@ $summary-nav-swap-width: 661px;
 		flex-direction: row;
 		border-bottom: 0;
 
-		@media (max-width: $break-medium) {
+		@media ( max-width: $break-medium ) {
 			padding: $summary-medium-padding;
 		}
 
-		@media (max-width: $break-small) {
+		@media ( max-width: $break-small ) {
 			padding: $summary-small-padding;
 			display: block;
 		}
@@ -63,11 +63,11 @@ $summary-nav-swap-width: 661px;
 .stats-summary-nav__header {
 	@include section-header-with-siblings;
 
-	@media (min-width: $summary-nav-swap-width) and  (max-width: $break-medium) {
+	@media ( min-width: $summary-nav-swap-width ) and ( max-width: $break-medium ) {
 		padding: 0;
 	}
 
-	@media (max-width: $break-small) {
+	@media ( max-width: $break-small ) {
 		padding: $summary-small-padding;
 	}
 
@@ -75,7 +75,7 @@ $summary-nav-swap-width: 661px;
 	// bottom padding provides the gap; drop the heading's own top margins
 	// so the spacing stays even. The h3 margin only exists in Odyssey,
 	// where wp-admin core styles aren't reset.
-	@media (max-width: 1160px) {
+	@media ( max-width: 1160px ) {
 		.stats-summary-nav__date-control + & {
 			margin-top: 0;
 
@@ -101,14 +101,14 @@ $summary-nav-swap-width: 661px;
 
 	// No top padding: .stats-summary__positioned already separates the
 	// content from the page header with a 32px margin from $break-small up.
-	@media (max-width: 1160px) {
+	@media ( max-width: 1160px ) {
 		padding: 0 0 16px;
 	}
 
 	// Below $break-small that page-level margin is gone, so the picker
 	// carries its own spacing. $summary-small-padding is horizontal-only
 	// and would zero the vertical padding here.
-	@media (max-width: $break-small) {
+	@media ( max-width: $break-small ) {
 		padding: 16px;
 	}
 }
@@ -135,7 +135,7 @@ $summary-nav-swap-width: 661px;
 		vertical-align: middle;
 	}
 
-	@media (max-width: $break-small) {
+	@media ( max-width: $break-small ) {
 		padding: $summary-small-padding;
 	}
 }


### PR DESCRIPTION
Related to #113651 (spotted while testing the Emails summary page).

## Proposed Changes

* Scope the summary nav's 24px bottom padding (applied between 782px and 1160px) to navs that actually contain a stacked date picker, using `:has(.stats-summary-nav__date-control)`.
* Prettier-format `summary-nav.scss` in a separate, rule-change-free commit (the file predated formatting enforcement), so the fix commit stays a three-line diff.

## Why are these changes being made?

* In the 782–1160px range, `.stats-summary-nav` switches from a side-by-side flex row to a stacked block, and the 24px bottom padding compensates for the taller stacked date picker + heading layout.
* The Emails summary page (`/stats/emails/:site`) reuses `.stats-summary-nav` with only a title and no date picker, so the padding rendered as an unexplained blank strip under the "Stats for Emails" heading — it appeared when narrowing past 1160px and disappeared again below 782px.
* `:has()` keeps the rule self-documenting and is already used elsewhere in the Stats styles. Browsers without `:has()` support simply keep slightly tighter spacing on the Traffic summary pages, with no layout breakage.

## Testing Instructions

1. Go to Stats → Subscribers, and click **View all** on the Emails card to reach `/stats/emails/:site`.
2. Resize the viewport into the 782–1160px range: there should no longer be an extra blank strip between the "Stats for Emails" heading and the list card. Compare with trunk to see the difference.
3. Go to a Traffic summary page (e.g. Stats → Traffic → Posts & pages → **View all**) at the same widths: the date picker stacks above the heading and the 24px gap below the nav is unchanged.
4. Check below 782px and above 1160px on both pages: no changes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector (PCYsg-9pS-p2) and Using memoizing selectors (PCYsg-9pS-p2#using-memoizing-selectors)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
