### PR TITLE
Use my domain step: make domain input card background transparent

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/style.scss
@@ -14,6 +14,10 @@
 .use-my-domain:has(.step-container-v2) {
 	padding: 0;
 
+	.components-card.use-my-domain {
+		background: transparent;
+	}
+
 	.domain-transfer-or-connect__content {
 		&.card {
 			padding: 0;


### PR DESCRIPTION
Part of DOMENG-1075

## Proposed Changes

* Make the domain-input card (`.components-card.use-my-domain`) background transparent in the `use-my-domain` Stepper step when rendered inside the Step Container V2 layout.

<img width="1202" height="650" alt="image" src="https://github.com/user-attachments/assets/378e0bca-0759-49fb-8e58-75cfa9fc4f1d" />


## Why are these changes being made?

When reaching `/setup/domain/use-my-domain` (e.g. from the new dashboard's Domains page → "Add domain name" → "Use a domain I own"), the domain input is wrapped in a `@wordpress/components` `Card`, whose default white surface background stands out as a white box against the off-white Step Container V2 page background. The override is scoped to the V2 container (`.use-my-domain:has(.step-container-v2)`) so other consumers of the shared `UseMyDomain` component are unaffected.

## Testing Instructions

1. Go to `https://my.wordpress.com/sites/{site}/domains`.
2. Click **Add domain name** (top right) → **Use a domain I own**.
3. On the "Enter your domain" screen, verify the area around the domain input no longer shows a white box — the card background is now transparent, matching the page background.
4. Verify the domain-input screen still renders correctly in other entry points to the same component (e.g. `/domains/add/use-my-domain/{site}` in Calypso), where the page background is white.

Note: local `yarn typecheck-client` was skipped (no `node_modules` in this worktree); the change is SCSS-only, CI covers it.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)