### PR TITLE
Agents Manager: write Tracks event names in full at the call sites

### DIFF
--- a/client/dashboard/app/omnibar/plugin-ai-chat.tsx
+++ b/client/dashboard/app/omnibar/plugin-ai-chat.tsx
@@ -2,7 +2,7 @@ import {
 	closeAgentsManagerChat,
 	isAgentsManagerChatVisible,
 	openAgentsManagerChat,
-	recordFullNameAgentsManagerTracksEvent,
+	recordAgentsManagerTracksEvent,
 	useShouldUseUnifiedAgent,
 } from '@automattic/agents-manager';
 import { __ } from '@wordpress/i18n';
@@ -38,7 +38,7 @@ export function useAiChatPlugin( {
 	const handleClick = () => {
 		const isChatVisible = isAgentsManagerChatVisible();
 
-		recordFullNameAgentsManagerTracksEvent( 'calypso_masterbar_agents_manager_ai_chat_clicked', {
+		recordAgentsManagerTracksEvent( 'calypso_masterbar_agents_manager_ai_chat_clicked', {
 			section: sectionName || 'unknown',
 			action: isChatVisible ? 'close' : 'open',
 		} );

--- a/client/dashboard/app/omnibar/test/plugin-ai-chat.test.tsx
+++ b/client/dashboard/app/omnibar/test/plugin-ai-chat.test.tsx
@@ -5,7 +5,7 @@ import {
 	closeAgentsManagerChat,
 	isAgentsManagerChatVisible,
 	openAgentsManagerChat,
-	recordFullNameAgentsManagerTracksEvent,
+	recordAgentsManagerTracksEvent,
 	useShouldUseUnifiedAgent,
 } from '@automattic/agents-manager';
 import { renderHook } from '@testing-library/react';
@@ -15,7 +15,7 @@ jest.mock( '@automattic/agents-manager', () => ( {
 	closeAgentsManagerChat: jest.fn(),
 	isAgentsManagerChatVisible: jest.fn( () => false ),
 	openAgentsManagerChat: jest.fn(),
-	recordFullNameAgentsManagerTracksEvent: jest.fn(),
+	recordAgentsManagerTracksEvent: jest.fn(),
 	useShouldUseUnifiedAgent: jest.fn( () => true ),
 } ) );
 
@@ -45,7 +45,7 @@ describe( 'useAiChatPlugin', () => {
 		const { result } = renderHook( () => useAiChatPlugin( { sectionName: 'sites' } ) );
 		result.current?.onClick?.( {} as React.MouseEvent );
 
-		expect( recordFullNameAgentsManagerTracksEvent ).toHaveBeenCalledWith(
+		expect( recordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
 			'calypso_masterbar_agents_manager_ai_chat_clicked',
 			{ section: 'sites', action: 'open' }
 		);
@@ -59,7 +59,7 @@ describe( 'useAiChatPlugin', () => {
 		const { result } = renderHook( () => useAiChatPlugin( {} ) );
 		result.current?.onClick?.( {} as React.MouseEvent );
 
-		expect( recordFullNameAgentsManagerTracksEvent ).toHaveBeenCalledWith(
+		expect( recordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
 			'calypso_masterbar_agents_manager_ai_chat_clicked',
 			{ section: 'unknown', action: 'close' }
 		);

--- a/client/layout/masterbar/masterbar-agents-manager/ai-chat-button.tsx
+++ b/client/layout/masterbar/masterbar-agents-manager/ai-chat-button.tsx
@@ -2,7 +2,7 @@ import {
 	AGENTS_MANAGER_STORE,
 	closeAgentsManagerChat,
 	openAgentsManagerChat,
-	recordFullNameAgentsManagerTracksEvent,
+	recordAgentsManagerTracksEvent,
 } from '@automattic/agents-manager';
 import { useSelect } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
@@ -26,7 +26,7 @@ const MasterbarAiChatButton = () => {
 	// Toggle: close the chat if it's already showing, otherwise resume the active
 	// conversation and open it.
 	const handleClick = () => {
-		recordFullNameAgentsManagerTracksEvent( 'calypso_masterbar_agents_manager_ai_chat_clicked', {
+		recordAgentsManagerTracksEvent( 'calypso_masterbar_agents_manager_ai_chat_clicked', {
 			section: sectionName || 'unknown',
 			action: isChatVisible ? 'close' : 'open',
 		} );

--- a/client/layout/masterbar/masterbar-agents-manager/test/ai-chat-button.tsx
+++ b/client/layout/masterbar/masterbar-agents-manager/test/ai-chat-button.tsx
@@ -4,7 +4,7 @@
 import {
 	closeAgentsManagerChat,
 	openAgentsManagerChat,
-	recordFullNameAgentsManagerTracksEvent,
+	recordAgentsManagerTracksEvent,
 } from '@automattic/agents-manager';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -21,7 +21,7 @@ jest.mock( '@automattic/agents-manager', () => ( {
 	AGENTS_MANAGER_STORE: 'automattic/agents-manager-test',
 	closeAgentsManagerChat: jest.fn(),
 	openAgentsManagerChat: jest.fn(),
-	recordFullNameAgentsManagerTracksEvent: jest.fn(),
+	recordAgentsManagerTracksEvent: jest.fn(),
 } ) );
 
 const testStore = createReduxStore( TEST_STORE, {
@@ -75,7 +75,7 @@ describe( 'MasterbarAiChatButton', () => {
 
 		expect( closeAgentsManagerChat ).toHaveBeenCalled();
 		expect( openAgentsManagerChat ).not.toHaveBeenCalled();
-		expect( recordFullNameAgentsManagerTracksEvent ).toHaveBeenCalledWith(
+		expect( recordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
 			'calypso_masterbar_agents_manager_ai_chat_clicked',
 			{ section: 'test-section', action: 'close' }
 		);
@@ -89,7 +89,7 @@ describe( 'MasterbarAiChatButton', () => {
 
 		expect( openAgentsManagerChat ).toHaveBeenCalled();
 		expect( closeAgentsManagerChat ).not.toHaveBeenCalled();
-		expect( recordFullNameAgentsManagerTracksEvent ).toHaveBeenCalledWith(
+		expect( recordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
 			'calypso_masterbar_agents_manager_ai_chat_clicked',
 			{ section: 'test-section', action: 'open' }
 		);
@@ -103,7 +103,7 @@ describe( 'MasterbarAiChatButton', () => {
 		} );
 		await userEvent.click( screen.getByRole( 'button' ) );
 
-		expect( recordFullNameAgentsManagerTracksEvent ).toHaveBeenCalledWith(
+		expect( recordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
 			'calypso_masterbar_agents_manager_ai_chat_clicked',
 			{ section: 'unknown', action: 'open' }
 		);

--- a/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-dock.test.tsx
@@ -414,8 +414,12 @@ describe( 'AgentDock', () => {
 		fireEvent.click( screen.getByText( 'Close chat' ) );
 
 		// Undocked close collapses the floating panel and tracks the back button.
-		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'dock_back_button_click' );
-		expect( mockRecordBigSkyTracksEvent ).not.toHaveBeenCalledWith( 'sidebar_close_click' );
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_dock_back_button_click'
+		);
+		expect( mockRecordBigSkyTracksEvent ).not.toHaveBeenCalledWith(
+			'jetpack_big_sky_sidebar_close_click'
+		);
 		expect( mockCloseSidebar ).not.toHaveBeenCalled();
 		expect( mockSetIsOpen ).toHaveBeenCalledWith( false, true );
 	} );
@@ -430,7 +434,9 @@ describe( 'AgentDock', () => {
 		// Docked close goes through closeSidebar, which fires sidebar_close_click
 		// via onCloseSidebar — so dock_back_button_click must not fire here.
 		expect( mockCloseSidebar ).toHaveBeenCalledTimes( 1 );
-		expect( mockRecordBigSkyTracksEvent ).not.toHaveBeenCalledWith( 'dock_back_button_click' );
+		expect( mockRecordBigSkyTracksEvent ).not.toHaveBeenCalledWith(
+			'jetpack_big_sky_dock_back_button_click'
+		);
 	} );
 
 	it( 'opens regular agents and saves shared Agents Manager state', () => {
@@ -477,14 +483,17 @@ describe( 'AgentDock', () => {
 		fireEvent.click( screen.getByText( 'New chat' ) );
 
 		expect( mockRecordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
-			'ai_chat_more_options_click',
+			'calypso_agents_manager_ai_chat_more_options_click',
 			{
 				menu_item: 'reset_chat',
 			}
 		);
-		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'ai_chat_more_options_click', {
-			type: 'reset_chat',
-		} );
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_ai_chat_more_options_click',
+			{
+				type: 'reset_chat',
+			}
+		);
 	} );
 
 	it( 'offers the guidelines and settings items when wp-admin injects the site', () => {
@@ -528,7 +537,7 @@ describe( 'AgentDock', () => {
 		fireEvent.click( screen.getByText( 'View history' ) );
 
 		expect( mockRecordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
-			'ai_chat_more_options_click',
+			'calypso_agents_manager_ai_chat_more_options_click',
 			{
 				menu_item: 'view_history',
 			}
@@ -559,7 +568,7 @@ describe( 'AgentDock', () => {
 		fireEvent.click( screen.getByText( 'Knowledge and memory' ) );
 
 		expect( mockRecordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
-			'ai_chat_more_options_click',
+			'calypso_agents_manager_ai_chat_more_options_click',
 			{
 				menu_item: 'knowledge_memory',
 			}
@@ -585,7 +594,7 @@ describe( 'AgentDock', () => {
 		fireEvent.click( screen.getByText( 'AI Agent settings' ) );
 
 		expect( mockRecordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
-			'ai_chat_more_options_click',
+			'calypso_agents_manager_ai_chat_more_options_click',
 			{
 				menu_item: 'ai_agent_settings',
 			}
@@ -657,7 +666,7 @@ describe( 'AgentDock', () => {
 			fireEvent.click( screen.getByRole( 'button', { name: label } ) );
 
 			expect( mockRecordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
-				'ai_chat_more_options_click',
+				'calypso_agents_manager_ai_chat_more_options_click',
 				{
 					menu_item: type,
 				}

--- a/packages/agents-manager/src/components/__tests__/chat-response-tracking.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/chat-response-tracking.test.tsx
@@ -32,11 +32,14 @@ describe( 'ChatResponseRenderedTracker', () => {
 			/>
 		);
 
-		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_response_rendered', {
-			component_type: 'title-picker',
-			tool_id: 'jetpack_ai__show_component',
-			tool_call_id: 'tool-call-1',
-		} );
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_response_rendered',
+			{
+				component_type: 'title-picker',
+				tool_id: 'jetpack_ai__show_component',
+				tool_call_id: 'tool-call-1',
+			}
+		);
 
 		rerender(
 			<ChatResponseRenderedTracker
@@ -57,11 +60,14 @@ describe( 'ChatResponseRenderedTracker', () => {
 		);
 
 		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledTimes( 2 );
-		expect( mockRecordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'chat_response_rendered', {
-			component_type: 'title-picker',
-			tool_id: 'jetpack_ai__show_component',
-			tool_call_id: 'tool-call-2',
-		} );
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenLastCalledWith(
+			'jetpack_big_sky_chat_response_rendered',
+			{
+				component_type: 'title-picker',
+				tool_id: 'jetpack_ai__show_component',
+				tool_call_id: 'tool-call-2',
+			}
+		);
 	} );
 
 	it( 'omits an unavailable tool call id', () => {
@@ -69,10 +75,13 @@ describe( 'ChatResponseRenderedTracker', () => {
 			<ChatResponseRenderedTracker componentType="proofread" toolId="jetpack_ai__show_component" />
 		);
 
-		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_response_rendered', {
-			component_type: 'proofread',
-			tool_id: 'jetpack_ai__show_component',
-		} );
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_response_rendered',
+			{
+				component_type: 'proofread',
+				tool_id: 'jetpack_ai__show_component',
+			}
+		);
 	} );
 
 	it( 'records supported response properties', () => {
@@ -91,16 +100,19 @@ describe( 'ChatResponseRenderedTracker', () => {
 			/>
 		);
 
-		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_response_rendered', {
-			component_type: 'ai-editorial-review',
-			tool_id: 'jetpack_ai__show_component',
-			suggested_edit_count: 2,
-			conflict_count: 1,
-			implication_count: 0,
-			guideline_violation_count: 3,
-			review_context: 'notes_and_guidelines',
-			cache_hit: true,
-		} );
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_response_rendered',
+			{
+				component_type: 'ai-editorial-review',
+				tool_id: 'jetpack_ai__show_component',
+				suggested_edit_count: 2,
+				conflict_count: 1,
+				implication_count: 0,
+				guideline_violation_count: 3,
+				review_context: 'notes_and_guidelines',
+				cache_hit: true,
+			}
+		);
 	} );
 
 	it( 'omits unsupported and invalid response properties', () => {
@@ -119,11 +131,14 @@ describe( 'ChatResponseRenderedTracker', () => {
 			/>
 		);
 
-		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_response_rendered', {
-			component_type: 'ai-editorial-review',
-			tool_id: 'jetpack_ai__show_component',
-			implication_count: 2,
-		} );
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_response_rendered',
+			{
+				component_type: 'ai-editorial-review',
+				tool_id: 'jetpack_ai__show_component',
+				implication_count: 2,
+			}
+		);
 	} );
 } );
 
@@ -142,15 +157,18 @@ describe( 'createChatResponseActionCallback', () => {
 			itemCount: 3,
 		} );
 
-		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_response_action', {
-			component_type: 'proofread',
-			tool_id: 'jetpack_ai__show_component',
-			tool_call_id: 'tool-call-1',
-			action: 'bulk_accept',
-			target: 'edit',
-			outcome: 'partial_failed',
-			item_count: 3,
-		} );
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_response_action',
+			{
+				component_type: 'proofread',
+				tool_id: 'jetpack_ai__show_component',
+				tool_call_id: 'tool-call-1',
+				action: 'bulk_accept',
+				target: 'edit',
+				outcome: 'partial_failed',
+				item_count: 3,
+			}
+		);
 	} );
 
 	it( 'omits unavailable optional properties', () => {
@@ -161,12 +179,15 @@ describe( 'createChatResponseActionCallback', () => {
 
 		onResponseAction( { action: 'accept', target: 'option', outcome: 'success' } );
 
-		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_response_action', {
-			component_type: 'title-picker',
-			tool_id: 'jetpack_ai__show_component',
-			action: 'accept',
-			target: 'option',
-			outcome: 'success',
-		} );
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_response_action',
+			{
+				component_type: 'title-picker',
+				tool_id: 'jetpack_ai__show_component',
+				action: 'accept',
+				target: 'option',
+				outcome: 'success',
+			}
+		);
 	} );
 } );

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -701,11 +701,14 @@ describe( 'OrchestratorChat', () => {
 			autoSubmit: false,
 			suggestionId: 'simplify-text',
 		} );
-		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestion_click', {
-			suggestion_text: 'Simplify this text to make it easier to read',
-			suggestion_id: 'simplify-text',
-			available_suggestions: '|simplify-text|',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_suggestion_click',
+			{
+				suggestion_text: 'Simplify this text to make it easier to read',
+				suggestion_id: 'simplify-text',
+				available_suggestions: '|simplify-text|',
+			}
+		);
 
 		window.removeEventListener( 'big-sky-inline-suggestion-click', listener );
 	} );
@@ -731,11 +734,14 @@ describe( 'OrchestratorChat', () => {
 			suggestionId: 'ai-editorial-review',
 		} );
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
-		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestion_click', {
-			suggestion_text: 'Run an AI Editorial Review',
-			suggestion_id: 'ai-editorial-review',
-			available_suggestions: '|ai-editorial-review|',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_suggestion_click',
+			{
+				suggestion_text: 'Run an AI Editorial Review',
+				suggestion_id: 'ai-editorial-review',
+				available_suggestions: '|ai-editorial-review|',
+			}
+		);
 
 		window.removeEventListener( 'big-sky-inline-suggestion-click', listener );
 	} );
@@ -775,7 +781,7 @@ describe( 'OrchestratorChat', () => {
 			suggestionId: 'weekly-brief',
 		} );
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
-			'chat_suggestion_click',
+			'jetpack_big_sky_chat_suggestion_click',
 			expect.objectContaining( { suggestion_id: 'weekly-brief' } )
 		);
 
@@ -806,12 +812,15 @@ describe( 'OrchestratorChat', () => {
 		fireEvent.click( screen.getByText( 'Click block suggestion' ) );
 
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
-		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestion_click', {
-			suggestion_text: 'Check the grammar and spelling of this text',
-			suggestion_id: 'check-grammar',
-			available_suggestions: '|check-grammar|',
-			block_type: 'core/paragraph',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_suggestion_click',
+			{
+				suggestion_text: 'Check the grammar and spelling of this text',
+				suggestion_id: 'check-grammar',
+				available_suggestions: '|check-grammar|',
+				block_type: 'core/paragraph',
+			}
+		);
 		expect( ( listener.mock.calls[ 0 ][ 0 ] as CustomEvent ).detail ).toEqual( {
 			value: 'Check the grammar and spelling of this text',
 			autoSubmit: false,
@@ -828,7 +837,7 @@ describe( 'OrchestratorChat', () => {
 		fireEvent.click( screen.getByText( 'Click suggestion' ) );
 
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
-			'chat_suggestion_click',
+			'jetpack_big_sky_chat_suggestion_click',
 			expect.objectContaining( { suggestion_id: 'simplify-text' } )
 		);
 	} );
@@ -864,13 +873,16 @@ describe( 'OrchestratorChat', () => {
 		fireEvent.click( screen.getByText( 'Click block dropdown suggestion' ) );
 
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
-		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestion_click', {
-			suggestion_text: 'Change the tone of this text to be more formal',
-			suggestion_id: 'change-tone',
-			available_suggestions: '|change-tone|',
-			option_id: 'formal',
-			block_type: 'core/paragraph',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_suggestion_click',
+			{
+				suggestion_text: 'Change the tone of this text to be more formal',
+				suggestion_id: 'change-tone',
+				available_suggestions: '|change-tone|',
+				option_id: 'formal',
+				block_type: 'core/paragraph',
+			}
+		);
 		expect( ( listener.mock.calls[ 0 ][ 0 ] as CustomEvent ).detail ).toEqual( {
 			value: 'Change the tone of this text to be more formal',
 			autoSubmit: false,
@@ -887,12 +899,15 @@ describe( 'OrchestratorChat', () => {
 		fireEvent.click( screen.getByText( 'Click post dropdown suggestion' ) );
 
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
-		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestion_click', {
-			suggestion_text: 'Generate an SEO title for this post',
-			suggestion_id: 'seo-enhancer',
-			available_suggestions: '|seo-enhancer|',
-			option_id: 'seo-title',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_suggestion_click',
+			{
+				suggestion_text: 'Generate an SEO title for this post',
+				suggestion_id: 'seo-enhancer',
+				available_suggestions: '|seo-enhancer|',
+				option_id: 'seo-title',
+			}
+		);
 	} );
 
 	it( 'records the option when the click carries no available suggestions', () => {
@@ -912,12 +927,15 @@ describe( 'OrchestratorChat', () => {
 
 		fireEvent.click( screen.getByText( 'Click feedback dropdown without context' ) );
 
-		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestion_click', {
-			suggestion_text: 'Proofread this saved post',
-			suggestion_id: 'get-feedback',
-			available_suggestions: '|get-feedback|',
-			option_id: 'proofread-content',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_suggestion_click',
+			{
+				suggestion_text: 'Proofread this saved post',
+				suggestion_id: 'get-feedback',
+				available_suggestions: '|get-feedback|',
+				option_id: 'proofread-content',
+			}
+		);
 	} );
 
 	it( 'passes the floating suggestion limit to external providers', () => {
@@ -954,12 +972,15 @@ describe( 'OrchestratorChat', () => {
 		rerender( chat( { useSuggestions } ) );
 		fireEvent.click( screen.getByText( 'Click block suggestion' ) );
 
-		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'chat_suggestion_click', {
-			suggestion_text: 'Check the grammar and spelling of this text',
-			suggestion_id: 'check-grammar',
-			available_suggestions: '|check-grammar|',
-			block_type: 'core/heading',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith(
+			'jetpack_big_sky_chat_suggestion_click',
+			{
+				suggestion_text: 'Check the grammar and spelling of this text',
+				suggestion_id: 'check-grammar',
+				available_suggestions: '|check-grammar|',
+				block_type: 'core/heading',
+			}
+		);
 	} );
 
 	it( 'keeps showing the provider suggestions in the empty view after the store is cleared', () => {
@@ -1084,10 +1105,13 @@ describe( 'OrchestratorChat', () => {
 		expect( screen.queryByText( 'Proofread' ) ).toBeNull();
 		expect( screen.getByText( 'Change tone' ) ).toBeTruthy();
 		expect( screen.getByText( 'Check grammar' ) ).toBeTruthy();
-		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestions_rendered', {
-			suggestions: '|change-tone|check-grammar|',
-			block_type: 'core/paragraph',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_suggestions_rendered',
+			{
+				suggestions: '|change-tone|check-grammar|',
+				block_type: 'core/paragraph',
+			}
+		);
 	} );
 
 	it( 'tracks the same contextual suggestions again when the selected block type changes', () => {
@@ -1104,20 +1128,26 @@ describe( 'OrchestratorChat', () => {
 
 		const { rerender } = render( chat( { useSuggestions } ) );
 
-		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'chat_suggestions_rendered', {
-			suggestions: '|change-tone|check-grammar|',
-			block_type: 'core/paragraph',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith(
+			'jetpack_big_sky_chat_suggestions_rendered',
+			{
+				suggestions: '|change-tone|check-grammar|',
+				block_type: 'core/paragraph',
+			}
+		);
 		rerender( chat( { useSuggestions } ) );
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
 
 		mockSelectedBlockType = 'core/heading';
 		rerender( chat( { useSuggestions } ) );
 
-		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'chat_suggestions_rendered', {
-			suggestions: '|change-tone|check-grammar|',
-			block_type: 'core/heading',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith(
+			'jetpack_big_sky_chat_suggestions_rendered',
+			{
+				suggestions: '|change-tone|check-grammar|',
+				block_type: 'core/heading',
+			}
+		);
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 2 );
 	} );
 
@@ -1163,9 +1193,12 @@ describe( 'OrchestratorChat', () => {
 
 		render( chat( { emptyViewSuggestions: staticDefaults } ) );
 
-		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestions_rendered', {
-			suggestions: '|getting-started|',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_suggestions_rendered',
+			{
+				suggestions: '|getting-started|',
+			}
+		);
 	} );
 
 	it( 'tracks suggestions without block context when the block editor store is unavailable', () => {
@@ -1181,9 +1214,12 @@ describe( 'OrchestratorChat', () => {
 
 		render( chat( { useSuggestions } ) );
 
-		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'chat_suggestions_rendered', {
-			suggestions: '|check-grammar|',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_chat_suggestions_rendered',
+			{
+				suggestions: '|check-grammar|',
+			}
+		);
 	} );
 
 	it( 'does not track chat_suggestions_rendered while the conversation is loading', () => {
@@ -1196,7 +1232,7 @@ describe( 'OrchestratorChat', () => {
 
 		expect( screen.queryByText( 'Getting started with WordPress' ) ).toBeNull();
 		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalledWith(
-			'chat_suggestions_rendered',
+			'jetpack_big_sky_chat_suggestions_rendered',
 			expect.anything()
 		);
 	} );
@@ -1212,7 +1248,7 @@ describe( 'OrchestratorChat', () => {
 
 		expect( screen.queryByText( 'Getting started with WordPress' ) ).toBeNull();
 		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalledWith(
-			'chat_suggestions_rendered',
+			'jetpack_big_sky_chat_suggestions_rendered',
 			expect.anything()
 		);
 	} );
@@ -1246,9 +1282,12 @@ describe( 'OrchestratorChat', () => {
 
 		await waitFor( () => {
 			expect( uploadImagesToWordPress ).toHaveBeenCalled();
-			expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'file_upload_success', {
-				count: 2,
-			} );
+			expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_big_sky_file_upload_success',
+				{
+					count: 2,
+				}
+			);
 		} );
 	} );
 
@@ -1302,9 +1341,12 @@ describe( 'OrchestratorChat', () => {
 		fireEvent.click( screen.getByText( 'Submit message' ) );
 
 		await waitFor( () => {
-			expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'file_upload_cancel', {
-				count: 1,
-			} );
+			expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_big_sky_file_upload_cancel',
+				{
+					count: 1,
+				}
+			);
 		} );
 		expect( onSubmit ).not.toHaveBeenCalled();
 	} );
@@ -1326,7 +1368,7 @@ describe( 'OrchestratorChat', () => {
 				'Failed to upload images. Please try again.'
 			);
 		} );
-		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'file_upload_error', {
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'jetpack_big_sky_file_upload_error', {
 			count: 1,
 		} );
 		expect( onSubmit ).not.toHaveBeenCalled();
@@ -1425,7 +1467,7 @@ describe( 'OrchestratorChat', () => {
 			expect( uploadImagesToWordPress ).toHaveBeenCalledTimes( 1 );
 		} );
 		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalledWith(
-			'file_upload_error',
+			'jetpack_big_sky_file_upload_error',
 			expect.anything()
 		);
 	} );
@@ -1445,7 +1487,7 @@ describe( 'OrchestratorChat', () => {
 
 		expect( uploadImagesToWordPress ).not.toHaveBeenCalled();
 		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalledWith(
-			'chat_input_send_message',
+			'jetpack_big_sky_chat_input_send_message',
 			expect.anything()
 		);
 	} );
@@ -2219,7 +2261,7 @@ describe( 'OrchestratorChat', () => {
 		expect( actionAfterDrift?.componentProps ).not.toHaveProperty( 'onRedo' );
 		expect( checkpoint.swapCheckpoint ).not.toHaveBeenCalled();
 		expect( recordBigSkyTracksEvent ).not.toHaveBeenCalledWith(
-			'restore_checkpoint_action',
+			'jetpack_big_sky_restore_checkpoint_action',
 			expect.objectContaining( { id: 'editor-drift-checkpoint', outcome: 'failed' } )
 		);
 

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -245,7 +245,7 @@ export default function AgentChat( {
 	const handleBrowse = useCallback(
 		( files: File[] ) => {
 			if ( trackImageUpload ) {
-				recordBigSkyTracksEvent( 'file_upload_click', {
+				recordBigSkyTracksEvent( 'jetpack_big_sky_file_upload_click', {
 					count: files.length,
 				} );
 			}
@@ -256,7 +256,7 @@ export default function AgentChat( {
 	const handleDrop = useCallback(
 		( files: File[] ) => {
 			if ( trackImageUpload ) {
-				recordBigSkyTracksEvent( 'file_upload_drop', {
+				recordBigSkyTracksEvent( 'jetpack_big_sky_file_upload_drop', {
 					count: files.length,
 				} );
 			}
@@ -267,7 +267,7 @@ export default function AgentChat( {
 	const handleRemoveImage = useCallback(
 		( image: UploadedImage ) => {
 			if ( trackImageUpload ) {
-				recordBigSkyTracksEvent( 'file_upload_remove', {
+				recordBigSkyTracksEvent( 'jetpack_big_sky_file_upload_remove', {
 					image_id: image.id,
 				} );
 			}
@@ -278,13 +278,13 @@ export default function AgentChat( {
 
 	const handleImageDragStart = useCallback( () => {
 		if ( trackImageUpload ) {
-			recordBigSkyTracksEvent( 'file_upload_drag_start' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_file_upload_drag_start' );
 		}
 	}, [ trackImageUpload ] );
 
 	const handleUploadError = useCallback( () => {
 		if ( trackImageUpload ) {
-			recordBigSkyTracksEvent( 'file_upload_invalid' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_file_upload_invalid' );
 		}
 	}, [ trackImageUpload ] );
 

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -136,18 +136,18 @@ export default function AgentDock( {
 		// Only open the sidebar; keep the current route. Admin-bar items
 		// set their own route (e.g. history) before opening it.
 		onOpenSidebar: () => {
-			recordBigSkyTracksEvent( 'sidebar_open_click' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_sidebar_open_click' );
 			setOpenState( true );
 		},
 		onCloseSidebar: () => {
-			recordBigSkyTracksEvent( 'sidebar_close_click' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_sidebar_close_click' );
 			setOpenState( false );
 		},
 		onDock: () => {
-			recordBigSkyTracksEvent( 'ai_chat_docked' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_ai_chat_docked' );
 		},
 		onUndock: () => {
-			recordBigSkyTracksEvent( 'ai_chat_undocked' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_ai_chat_undocked' );
 		},
 		isSplitScreen,
 	} );
@@ -158,7 +158,7 @@ export default function AgentDock( {
 		if ( isDocked ) {
 			closeSidebar();
 		} else {
-			recordBigSkyTracksEvent( 'dock_back_button_click' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_dock_back_button_click' );
 			setOpenState( false );
 		}
 	};
@@ -238,7 +238,7 @@ export default function AgentDock( {
 	);
 
 	const handleExpand = () => {
-		recordBigSkyTracksEvent( 'dock_assistant_icon_click' );
+		recordBigSkyTracksEvent( 'jetpack_big_sky_dock_assistant_icon_click' );
 		if ( isMinimized ) {
 			setIsMinimized( false );
 		}
@@ -274,7 +274,9 @@ export default function AgentDock( {
 		// Every item fires the unified AM event; items whose Big Sky event
 		// is already live also dual-fire it so those dashboards keep working.
 		const recordMoreOptionsClick = ( menuItem: string ) =>
-			recordAgentsManagerTracksEvent( 'ai_chat_more_options_click', { menu_item: menuItem } );
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_ai_chat_more_options_click', {
+				menu_item: menuItem,
+			} );
 
 		const options = [
 			{
@@ -283,7 +285,7 @@ export default function AgentDock( {
 				isDisabled: pathname === '/chat' && isOrchestratorChatEmpty,
 				onClick: () => {
 					recordMoreOptionsClick( 'reset_chat' );
-					recordBigSkyTracksEvent( 'ai_chat_more_options_click', {
+					recordBigSkyTracksEvent( 'jetpack_big_sky_ai_chat_more_options_click', {
 						type: 'reset_chat',
 					} );
 					navigate( '/' );
@@ -311,7 +313,7 @@ export default function AgentDock( {
 						: __( 'Split screen sidebar', __i18n_text_domain__ ),
 					onClick: () => {
 						recordMoreOptionsClick( isSplitScreen ? 'exit_split_screen' : 'split_screen' );
-						recordBigSkyTracksEvent( 'ai_chat_more_options_click', {
+						recordBigSkyTracksEvent( 'jetpack_big_sky_ai_chat_more_options_click', {
 							type: isSplitScreen ? 'exit_split_screen' : 'split_screen',
 						} );
 						setIsSplitScreen( ! isSplitScreen );
@@ -355,7 +357,7 @@ export default function AgentDock( {
 					title: __( 'Switch to floating', __i18n_text_domain__ ),
 					onClick: () => {
 						recordMoreOptionsClick( 'undock' );
-						recordBigSkyTracksEvent( 'ai_chat_more_options_click', {
+						recordBigSkyTracksEvent( 'jetpack_big_sky_ai_chat_more_options_click', {
 							type: 'undock',
 						} );
 						undock();
@@ -369,7 +371,7 @@ export default function AgentDock( {
 					title: __( 'Switch to sidebar', __i18n_text_domain__ ),
 					onClick: () => {
 						recordMoreOptionsClick( 'dock' );
-						recordBigSkyTracksEvent( 'ai_chat_more_options_click', {
+						recordBigSkyTracksEvent( 'jetpack_big_sky_ai_chat_more_options_click', {
 							type: 'dock',
 						} );
 						dock();

--- a/packages/agents-manager/src/components/chat-header/index.tsx
+++ b/packages/agents-manager/src/components/chat-header/index.tsx
@@ -52,7 +52,7 @@ export default function ChatHeader( { onClose, options, title, onBack, isDocked 
 						className="agents-manager-chat-header__minimize-btn"
 						icon={ <Minimize /> }
 						onClick={ () => {
-							recordAgentsManagerTracksEvent( 'chat_minimize' );
+							recordAgentsManagerTracksEvent( 'calypso_agents_manager_chat_minimize' );
 							setIsMinimized( true );
 						} }
 						label={ __( 'Minimize', __i18n_text_domain__ ) }

--- a/packages/agents-manager/src/components/chat-response-tracking.tsx
+++ b/packages/agents-manager/src/components/chat-response-tracking.tsx
@@ -73,7 +73,7 @@ export function createChatResponseActionCallback( {
 	toolCallId,
 }: ChatResponseIdentifiers ) {
 	return ( { action, target, outcome, itemCount }: ChatResponseAction ) => {
-		recordBigSkyTracksEvent( 'chat_response_action', {
+		recordBigSkyTracksEvent( 'jetpack_big_sky_chat_response_action', {
 			component_type: componentType,
 			tool_id: toolId,
 			...( toolCallId ? { tool_call_id: toolCallId } : {} ),
@@ -102,7 +102,7 @@ export default function ChatResponseRenderedTracker( {
 			return;
 		}
 		lastTrackedResponseRef.current = responseKey;
-		recordBigSkyTracksEvent( 'chat_response_rendered', {
+		recordBigSkyTracksEvent( 'jetpack_big_sky_chat_response_rendered', {
 			component_type: componentType,
 			tool_id: toolId,
 			...( toolCallId ? { tool_call_id: toolCallId } : {} ),

--- a/packages/agents-manager/src/components/custom-a-link/index.tsx
+++ b/packages/agents-manager/src/components/custom-a-link/index.tsx
@@ -38,7 +38,7 @@ export default function CustomALink( {
 					} );
 				}
 
-				recordAgentsManagerTracksEvent( 'link_click', {
+				recordAgentsManagerTracksEvent( 'calypso_agents_manager_link_click', {
 					href: transformedHref,
 					link_type: isSupportArticle ? 'support_article' : 'external',
 					source: isFromOrchestrator ? 'orchestrator' : 'zendesk',

--- a/packages/agents-manager/src/components/editor-ai-chat-button/index.tsx
+++ b/packages/agents-manager/src/components/editor-ai-chat-button/index.tsx
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 import { useAgentsManagerContext } from '../../contexts';
 import { AGENTS_MANAGER_STORE } from '../../stores';
 import { isEditorAiEntryEnabled } from '../../utils/editor-entry-points';
-import { recordFullNameAgentsManagerTracksEvent } from '../../utils/tracks';
+import { recordAgentsManagerTracksEvent } from '../../utils/tracks';
 import { AI } from '../icons';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
 import './style.scss';
@@ -36,7 +36,7 @@ export default function EditorAiChatButton( { onClose, onOpenChat }: Props ) {
 
 	// Mirrors the admin-bar button: close if showing, else resume the tab's conversation and open.
 	const handleToggle = () => {
-		recordFullNameAgentsManagerTracksEvent( 'calypso_editor_agents_manager_ai_chat_clicked', {
+		recordAgentsManagerTracksEvent( 'calypso_editor_agents_manager_ai_chat_clicked', {
 			section: sectionName || 'gutenberg',
 			action: isChatVisible ? 'close' : 'open',
 		} );

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -563,7 +563,7 @@ export default function OrchestratorChat( {
 		blockCurrentRequest();
 		abortCurrentRequest();
 
-		recordAgentsManagerTracksEvent( 'editor_canvas_move_request_aborted', {
+		recordAgentsManagerTracksEvent( 'calypso_agents_manager_editor_canvas_move_request_aborted', {
 			agent_id: agentConfig?.agentId,
 		} );
 
@@ -1214,7 +1214,7 @@ export default function OrchestratorChat( {
 			setHasUserSentMessage( true );
 			setUploadError( null );
 
-			recordBigSkyTracksEvent( 'chat_input_send_message', {
+			recordBigSkyTracksEvent( 'jetpack_big_sky_chat_input_send_message', {
 				message_length: message?.length || 0,
 				has_images: pendingImages.length > 0,
 			} );
@@ -1237,7 +1237,7 @@ export default function OrchestratorChat( {
 
 					const mediaObjects = await uploadImagesToWordPress();
 
-					recordBigSkyTracksEvent( 'file_upload_success', {
+					recordBigSkyTracksEvent( 'jetpack_big_sky_file_upload_success', {
 						count: mediaObjects.length,
 					} );
 
@@ -1260,13 +1260,13 @@ export default function OrchestratorChat( {
 					// composer-typed message stays in the input — the composer is
 					// back to its pre-send state.
 					if ( caughtError instanceof Error && caughtError.name === 'AbortError' ) {
-						recordBigSkyTracksEvent( 'file_upload_cancel', {
+						recordBigSkyTracksEvent( 'jetpack_big_sky_file_upload_cancel', {
 							count: pendingImages.length,
 						} );
 						return;
 					}
 
-					recordBigSkyTracksEvent( 'file_upload_error', {
+					recordBigSkyTracksEvent( 'jetpack_big_sky_file_upload_error', {
 						count: pendingImages.length,
 					} );
 					setUploadError(
@@ -1449,7 +1449,7 @@ export default function OrchestratorChat( {
 					: undefined;
 
 			if ( typeof suggestion !== 'string' ) {
-				recordBigSkyTracksEvent( 'chat_suggestion_click', {
+				recordBigSkyTracksEvent( 'jetpack_big_sky_chat_suggestion_click', {
 					suggestion_text: suggestion.prompt || '',
 					suggestion_id: suggestion.id || '',
 					available_suggestions: formatSuggestionIds( knownSuggestions ),
@@ -1780,7 +1780,7 @@ export default function OrchestratorChat( {
 		) {
 			return;
 		}
-		recordBigSkyTracksEvent( 'chat_suggestions_rendered', {
+		recordBigSkyTracksEvent( 'jetpack_big_sky_chat_suggestions_rendered', {
 			suggestions: formatSuggestionIds( displayedEmptyViewSuggestions ),
 			...( renderedSuggestionsBlockType ? { block_type: renderedSuggestionsBlockType } : {} ),
 		} );

--- a/packages/agents-manager/src/components/sources-display/index.tsx
+++ b/packages/agents-manager/src/components/sources-display/index.tsx
@@ -43,7 +43,7 @@ export default function SourcesDisplay( { sources }: Props ) {
 			} );
 		}
 
-		recordAgentsManagerTracksEvent( 'link_click', {
+		recordAgentsManagerTracksEvent( 'calypso_agents_manager_link_click', {
 			href: url,
 			link_type: isSupportArticle ? 'support_article' : 'external',
 			source: isFromOrchestrator ? 'orchestrator' : 'zendesk',

--- a/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-checkpoint-action.test.ts
@@ -163,11 +163,14 @@ describe( 'useCheckpointAction', () => {
 		await act( async () => resolveRestore() );
 
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
-		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'restore_checkpoint_action', {
-			action: 'undo',
-			id: 'tool-call-1',
-			outcome: 'success',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_restore_checkpoint_action',
+			{
+				action: 'undo',
+				id: 'tool-call-1',
+				outcome: 'success',
+			}
+		);
 		expect( screen.queryByRole( 'button', { name: 'Undo' } ) ).not.toBeInTheDocument();
 		expect( status ).toHaveTextContent( 'Reverted' );
 		expect( within( status ).getByTestId( 'icon-undo' ) ).toBeInTheDocument();
@@ -278,11 +281,14 @@ describe( 'useCheckpointAction', () => {
 		await act( async () => rejectRestore( new Error( 'Restore failed' ) ) );
 
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
-		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'restore_checkpoint_action', {
-			action: 'undo',
-			id: 'tool-call-failure',
-			outcome: 'failed',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith(
+			'jetpack_big_sky_restore_checkpoint_action',
+			{
+				action: 'undo',
+				id: 'tool-call-failure',
+				outcome: 'failed',
+			}
+		);
 		expect( undoButton ).toBeEnabled();
 		expect( status ).toHaveTextContent( 'Updated' );
 		expect( status ).not.toHaveClass( 'agents-manager-resolved-edit-action__status--reverted' );
@@ -297,11 +303,14 @@ describe( 'useCheckpointAction', () => {
 		await waitFor( () => expect( status ).toHaveTextContent( 'Reverted' ) );
 		expect( screen.queryByRole( 'button', { name: 'Undo' } ) ).not.toBeInTheDocument();
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 2 );
-		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith( 'restore_checkpoint_action', {
-			action: 'undo',
-			id: 'tool-call-failure',
-			outcome: 'success',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenLastCalledWith(
+			'jetpack_big_sky_restore_checkpoint_action',
+			{
+				action: 'undo',
+				id: 'tool-call-failure',
+				outcome: 'success',
+			}
+		);
 	} );
 
 	it( 'swaps a text checkpoint between Undo and Redo', async () => {
@@ -338,11 +347,15 @@ describe( 'useCheckpointAction', () => {
 		const redoButton = screen.getByRole( 'button', { name: 'Redo' } );
 		expect( status ).toHaveTextContent( 'Reverted' );
 		expect( within( redoButton ).getByTestId( 'icon-redo' ) ).toBeInTheDocument();
-		expect( recordBigSkyTracksEvent ).toHaveBeenNthCalledWith( 1, 'restore_checkpoint_action', {
-			action: 'undo',
-			id: 'swappable-tool-call',
-			outcome: 'success',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenNthCalledWith(
+			1,
+			'jetpack_big_sky_restore_checkpoint_action',
+			{
+				action: 'undo',
+				id: 'swappable-tool-call',
+				outcome: 'success',
+			}
+		);
 		( checkpoint.canSwapCheckpoint as jest.Mock ).mockReturnValue( false );
 		const driftedAction = getActions( registration, message )[ 0 ];
 		expect( driftedAction ).toMatchObject( { label: 'Reverted' } );
@@ -355,11 +368,15 @@ describe( 'useCheckpointAction', () => {
 		fireEvent.click( screen.getByRole( 'button', { name: 'Redo' } ) );
 		await waitFor( () => expect( screen.getByRole( 'button', { name: 'Undo' } ) ).toBeEnabled() );
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'Updated' );
-		expect( recordBigSkyTracksEvent ).toHaveBeenNthCalledWith( 2, 'restore_checkpoint_action', {
-			action: 'redo',
-			id: 'swappable-tool-call',
-			outcome: 'success',
-		} );
+		expect( recordBigSkyTracksEvent ).toHaveBeenNthCalledWith(
+			2,
+			'jetpack_big_sky_restore_checkpoint_action',
+			{
+				action: 'redo',
+				id: 'swappable-tool-call',
+				outcome: 'success',
+			}
+		);
 		expect( checkpoint.swapCheckpoint ).toHaveBeenNthCalledWith( 1, 'swappable-tool-call' );
 		expect( checkpoint.swapCheckpoint ).toHaveBeenNthCalledWith( 2, 'swappable-tool-call' );
 		expect( checkpoint.restoreCheckpoint ).not.toHaveBeenCalled();

--- a/packages/agents-manager/src/hooks/__tests__/use-feedback-action.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-feedback-action.test.ts
@@ -210,9 +210,12 @@ describe( 'useFeedbackAction', () => {
 			renderHook( () => useFeedbackAction( defaultConfig ) );
 			await triggerFeedback( 'msg-1', 'up' );
 
-			expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'response_action_thumbs_up', {
-				message_id: 'msg-1',
-			} );
+			expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_big_sky_response_action_thumbs_up',
+				{
+					message_id: 'msg-1',
+				}
+			);
 		} );
 
 		it( 'does not show feedback input', async () => {
@@ -247,9 +250,12 @@ describe( 'useFeedbackAction', () => {
 			renderHook( () => useFeedbackAction( defaultConfig ) );
 			await triggerFeedback( 'msg-1', 'down' );
 
-			expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'response_action_thumbs_down', {
-				message_id: 'msg-1',
-			} );
+			expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_big_sky_response_action_thumbs_down',
+				{
+					message_id: 'msg-1',
+				}
+			);
 		} );
 
 		it( 'shows feedback input', async () => {
@@ -346,7 +352,7 @@ describe( 'useFeedbackAction', () => {
 			} );
 
 			expect( mockRecordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
-				'response_feedback_submitted',
+				'calypso_agents_manager_response_feedback_submitted',
 				{
 					message_id: 'msg-1',
 				}

--- a/packages/agents-manager/src/hooks/__tests__/use-open-chat-url-param.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-open-chat-url-param.test.ts
@@ -76,7 +76,9 @@ describe( 'useOpenChatUrlParam', () => {
 
 			expect( setIsOpen.mock.calls ).toEqual( openCalls );
 			expect( setIsMinimized.mock.calls ).toEqual( minimizeCalls );
-			expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'ai_editor_menu_opened' );
+			expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith(
+				'jetpack_big_sky_ai_editor_menu_opened'
+			);
 			expect( window.location.search ).toBe( '' );
 			expect( result.current ).toBe( handled );
 		}

--- a/packages/agents-manager/src/hooks/__tests__/use-picker-variations.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-picker-variations.test.ts
@@ -146,9 +146,12 @@ describe( 'usePickerVariations', () => {
 
 		act( () => result.current.handleSelect( variations[ 0 ] ) );
 
-		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'button_variation_click', {
-			button: 'Bold',
-		} );
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_button_variation_click',
+			{
+				button: 'Bold',
+			}
+		);
 	} );
 
 	it( 'keeps the picked variation highlighted when several share the live value', () => {

--- a/packages/agents-manager/src/hooks/__tests__/use-styles.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-styles.test.ts
@@ -382,7 +382,7 @@ describe( 'useStyles', () => {
 		} );
 
 		expect( recordBigSkyTracksEvent ).toHaveBeenCalledTimes( 1 );
-		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'legacy_css_found', {
+		expect( recordBigSkyTracksEvent ).toHaveBeenCalledWith( 'jetpack_big_sky_legacy_css_found', {
 			block_count: 1,
 		} );
 		expect( warn ).toHaveBeenCalled();

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from '@wordpress/element';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAgentsManagerContext } from '../../contexts';
 import { AGENTS_MANAGER_STORE } from '../../stores';
-import { recordFullNameAgentsManagerTracksEvent } from '../../utils/tracks';
+import { recordAgentsManagerTracksEvent } from '../../utils/tracks';
 import useHasAiChatEntryButton, {
 	ADMIN_BAR_AI_CHAT_BUTTON_ID,
 } from '../use-has-ai-chat-entry-button';
@@ -139,7 +139,7 @@ export default function useAdminBarIntegration( {
 		}
 
 		const handleClick = () => {
-			recordFullNameAgentsManagerTracksEvent( 'calypso_admin_bar_agents_manager_ai_chat_clicked', {
+			recordAgentsManagerTracksEvent( 'calypso_admin_bar_agents_manager_ai_chat_clicked', {
 				section: sectionName || 'wp-admin',
 				action: isChatVisibleRef.current ? 'close' : 'open',
 			} );

--- a/packages/agents-manager/src/hooks/use-checkpoint-action.ts
+++ b/packages/agents-manager/src/hooks/use-checkpoint-action.ts
@@ -252,7 +252,7 @@ export default function useCheckpointAction(
 					);
 				}
 				if ( didAttemptAction ) {
-					recordBigSkyTracksEvent( 'restore_checkpoint_action', {
+					recordBigSkyTracksEvent( 'jetpack_big_sky_restore_checkpoint_action', {
 						action: revert ? 'undo' : 'redo',
 						id: checkpointInfo.checkpointId,
 						outcome,

--- a/packages/agents-manager/src/hooks/use-feedback-action.ts
+++ b/packages/agents-manager/src/hooks/use-feedback-action.ts
@@ -204,7 +204,9 @@ export default function useFeedbackAction( {
 			}
 
 			recordBigSkyTracksEvent(
-				feedback === 'up' ? 'response_action_thumbs_up' : 'response_action_thumbs_down',
+				feedback === 'up'
+					? 'jetpack_big_sky_response_action_thumbs_up'
+					: 'jetpack_big_sky_response_action_thumbs_down',
 				{ message_id: messageId }
 			);
 
@@ -317,7 +319,7 @@ export default function useFeedbackAction( {
 				traceId
 			);
 
-			recordAgentsManagerTracksEvent( 'response_feedback_submitted', {
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_response_feedback_submitted', {
 				message_id: currentMessageId,
 			} );
 		},

--- a/packages/agents-manager/src/hooks/use-help-search-query.ts
+++ b/packages/agents-manager/src/hooks/use-help-search-query.ts
@@ -52,7 +52,7 @@ const fetchArticlesAPI = async (
 	results.forEach( ( result, index ) => {
 		if ( result.railcar ) {
 			queueMicrotask( () => {
-				recordAgentsManagerTracksEvent( 'search_traintracks_render', {
+				recordAgentsManagerTracksEvent( 'calypso_agents_manager_search_traintracks_render', {
 					...result.railcar,
 					ui_algo: 'default',
 					ui_position: index,

--- a/packages/agents-manager/src/hooks/use-open-chat-url-param.ts
+++ b/packages/agents-manager/src/hooks/use-open-chat-url-param.ts
@@ -42,7 +42,7 @@ export function useOpenChatUrlParam(): boolean {
 			const isReaderChat = isReaderChatHost();
 
 			if ( ! isReaderChat ) {
-				recordBigSkyTracksEvent( 'ai_editor_menu_opened' );
+				recordBigSkyTracksEvent( 'jetpack_big_sky_ai_editor_menu_opened' );
 			}
 
 			if ( ! isOpen ) {

--- a/packages/agents-manager/src/hooks/use-picker-variations.ts
+++ b/packages/agents-manager/src/hooks/use-picker-variations.ts
@@ -14,6 +14,12 @@ import type { GlobalStyles, StyleVariation } from '../components/styles-preview'
 // list length comes from model-generated props.
 const MAX_VARIATIONS = 24;
 
+const VARIATION_CLICK_EVENTS = {
+	color: 'jetpack_big_sky_color_variation_click',
+	font: 'jetpack_big_sky_font_variation_click',
+	button: 'jetpack_big_sky_button_variation_click',
+} as const satisfies Record< StyleVariationType, `jetpack_big_sky_${ string }` >;
+
 interface Options {
 	variations?: StyleVariation[];
 	/**
@@ -114,7 +120,7 @@ export default function usePickerVariations( {
 			if ( variationType ) {
 				// Fire Big Sky's variation-click event name and props, so the
 				// existing dashboards keep working.
-				recordBigSkyTracksEvent( `${ variationType }_variation_click`, {
+				recordBigSkyTracksEvent( VARIATION_CLICK_EVENTS[ variationType ], {
 					[ variationType ]: variation.title,
 				} );
 			}

--- a/packages/agents-manager/src/hooks/use-styles.ts
+++ b/packages/agents-manager/src/hooks/use-styles.ts
@@ -98,7 +98,9 @@ export default function useStyles() {
 					( merged.styles as Record< string, unknown > | undefined )?.css
 				);
 				if ( blocks.length ) {
-					recordBigSkyTracksEvent( 'legacy_css_found', { block_count: blocks.length } );
+					recordBigSkyTracksEvent( 'jetpack_big_sky_legacy_css_found', {
+						block_count: blocks.length,
+					} );
 					// eslint-disable-next-line no-console
 					console.warn(
 						'[AgentsManager] Legacy Easy Site Editor CSS found — font picks may not be visible until it is removed.'

--- a/packages/agents-manager/src/index.ts
+++ b/packages/agents-manager/src/index.ts
@@ -8,7 +8,7 @@ export { AGENTS_MANAGER_STORE } from './stores';
 export { getAgentsManagerInlineData } from './utils/get-agents-manager-inline-data';
 
 // Tracks wrapper, so entry points outside the package attach the unified base props
-export { recordFullNameAgentsManagerTracksEvent } from './utils/tracks';
+export { recordAgentsManagerTracksEvent } from './utils/tracks';
 
 // Host-facing controls for the chat dock, for entry points outside it
 export {

--- a/packages/agents-manager/src/utils/__tests__/tracks.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/tracks.test.ts
@@ -4,9 +4,7 @@
 /* eslint-disable import/order -- jest.mock calls must precede imports */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 
-jest.mock( '@automattic/calypso-analytics', () => ( { recordTracksEvent: jest.fn() } ), {
-	virtual: true,
-} );
+jest.mock( '@automattic/calypso-analytics', () => ( { recordTracksEvent: jest.fn() } ) );
 jest.mock( '@wordpress/data', () => ( { select: jest.fn( () => ( {} ) ) } ) );
 jest.mock( '../agent-session', () => ( { getSessionId: jest.fn( () => 'session-xyz' ) } ) );
 jest.mock( '../is-reader-chat-agent', () => {
@@ -22,7 +20,6 @@ import {
 	getBigSkyTracksData,
 	recordAgentsManagerTracksEvent,
 	recordBigSkyTracksEvent,
-	recordFullNameAgentsManagerTracksEvent,
 } from '../tracks';
 
 const mockRecordTracksEvent = recordTracksEvent as jest.MockedFunction< typeof recordTracksEvent >;
@@ -53,7 +50,7 @@ describe( 'tracks wrappers', () => {
 
 	describe( 'recordBigSkyTracksEvent', () => {
 		it( 'falls back to honest defaults when bigSkyInitialState is absent', () => {
-			recordBigSkyTracksEvent( 'chat_input_send_message', {
+			recordBigSkyTracksEvent( 'jetpack_big_sky_chat_input_send_message', {
 				message_length: 5,
 			} );
 
@@ -81,7 +78,7 @@ describe( 'tracks wrappers', () => {
 				currentScreen: { screen: 'dashboard' },
 			};
 
-			recordBigSkyTracksEvent( 'chat_input_send_message' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_chat_input_send_message' );
 
 			expect( lastEventProps() ).toMatchObject( {
 				session_type: 'paid-user-session',
@@ -91,25 +88,25 @@ describe( 'tracks wrappers', () => {
 		} );
 
 		it( 'lets caller props win on collision', () => {
-			recordBigSkyTracksEvent( 'x', { sessionid: 'override' } );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_x', { sessionid: 'override' } );
 			expect( lastEventProps().sessionid ).toBe( 'override' );
 		} );
 
 		it( 'no-ops when the resolved agent id is a reader-chat agent', () => {
 			setResolvedAgentId( 'reader-chat' );
-			recordBigSkyTracksEvent( 'chat_input_send_message' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_chat_input_send_message' );
 			expect( mockRecordTracksEvent ).not.toHaveBeenCalled();
 		} );
 
 		it( 'fires when the resolved agent id is a non-reader agent', () => {
 			setResolvedAgentId( 'big-sky' );
-			recordBigSkyTracksEvent( 'chat_input_send_message' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_chat_input_send_message' );
 			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		it( 'fires when the resolved agent id is unset', () => {
 			setResolvedAgentId( undefined );
-			recordBigSkyTracksEvent( 'chat_input_send_message' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_chat_input_send_message' );
 			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
 		} );
 
@@ -119,13 +116,13 @@ describe( 'tracks wrappers', () => {
 				site: { ID: 12345 },
 			};
 
-			recordBigSkyTracksEvent( 'chat_input_send_message' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_chat_input_send_message' );
 
 			expect( lastEventProps().blog_id ).toBe( 12345 );
 		} );
 
 		it( 'duplicates the session ID into the standard ai_session_id', () => {
-			recordBigSkyTracksEvent( 'chat_input_send_message' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_chat_input_send_message' );
 
 			expect( lastEventProps() ).toMatchObject( {
 				sessionid: 'session-xyz',
@@ -136,7 +133,7 @@ describe( 'tracks wrappers', () => {
 		it( 'omits ai_session_id while no session exists yet', () => {
 			mockGetSessionId.mockReturnValueOnce( '' );
 
-			recordBigSkyTracksEvent( 'chat_input_send_message' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_chat_input_send_message' );
 
 			const props = lastEventProps();
 			expect( props.sessionid ).toBe( '' );
@@ -144,7 +141,7 @@ describe( 'tracks wrappers', () => {
 		} );
 
 		it( 'mirrors a caller-overridden sessionid into ai_session_id', () => {
-			recordBigSkyTracksEvent( 'x', { sessionid: 'override' } );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_x', { sessionid: 'override' } );
 
 			expect( lastEventProps() ).toMatchObject( {
 				sessionid: 'override',
@@ -153,13 +150,13 @@ describe( 'tracks wrappers', () => {
 		} );
 
 		it( 'omits ai_session_id when a caller overrides sessionid to empty', () => {
-			recordBigSkyTracksEvent( 'x', { sessionid: '' } );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_x', { sessionid: '' } );
 
 			expect( lastEventProps() ).not.toHaveProperty( 'ai_session_id' );
 		} );
 
 		it( 'lets a caller-supplied ai_session_id win over the mirror', () => {
-			recordBigSkyTracksEvent( 'x', { ai_session_id: 'custom' } );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_x', { ai_session_id: 'custom' } );
 
 			expect( lastEventProps() ).toMatchObject( {
 				sessionid: 'session-xyz',
@@ -168,7 +165,7 @@ describe( 'tracks wrappers', () => {
 		} );
 
 		it( 'labels editor-hosted parity events with the block_editor surface', () => {
-			recordBigSkyTracksEvent( 'chat_input_send_message' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_chat_input_send_message' );
 
 			expect( lastEventProps().surface ).toBe( 'block_editor' );
 		} );
@@ -179,7 +176,7 @@ describe( 'tracks wrappers', () => {
 					( store === 'core/editor' ? undefined : {} ) as unknown as ReturnType< typeof select >
 			);
 
-			recordBigSkyTracksEvent( 'chat_input_send_message' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_chat_input_send_message' );
 
 			expect( lastEventProps() ).not.toHaveProperty( 'surface' );
 		} );
@@ -190,7 +187,7 @@ describe( 'tracks wrappers', () => {
 				site: { ID: 0 },
 			};
 
-			recordBigSkyTracksEvent( 'chat_input_send_message' );
+			recordBigSkyTracksEvent( 'jetpack_big_sky_chat_input_send_message' );
 
 			expect( lastEventProps() ).not.toHaveProperty( 'blog_id' );
 		} );
@@ -198,7 +195,7 @@ describe( 'tracks wrappers', () => {
 
 	describe( 'recordAgentsManagerTracksEvent', () => {
 		it( 'injects the unified base-prop set', () => {
-			recordAgentsManagerTracksEvent( 'chat_minimize' );
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_chat_minimize' );
 
 			const [ eventName ] = mockRecordTracksEvent.mock.calls[ 0 ];
 			expect( eventName ).toBe( 'calypso_agents_manager_chat_minimize' );
@@ -215,19 +212,19 @@ describe( 'tracks wrappers', () => {
 
 		it( 'sends the resolved agent id as agent_name when one is set', () => {
 			setResolvedAgentId( 'plugin-compass' );
-			recordAgentsManagerTracksEvent( 'chat_minimize' );
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_chat_minimize' );
 			expect( lastEventProps().agent_name ).toBe( 'plugin-compass' );
 		} );
 
 		it( 'falls back to the Dolly agent id while no agent is resolved', () => {
 			setResolvedAgentId( undefined );
-			recordAgentsManagerTracksEvent( 'chat_minimize' );
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_chat_minimize' );
 			expect( lastEventProps().agent_name ).toBe( 'dolly' );
 		} );
 
 		it( 'uses the reader-chat surface token off the editor', () => {
 			mockIsReaderChatHost.mockReturnValue( true );
-			recordAgentsManagerTracksEvent( 'x' );
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_x' );
 			expect( lastEventProps().surface ).toBe( 'reader-chat' );
 		} );
 
@@ -237,7 +234,7 @@ describe( 'tracks wrappers', () => {
 				site: { ID: 12345 },
 			};
 
-			recordAgentsManagerTracksEvent( 'chat_minimize' );
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_chat_minimize' );
 
 			expect( lastEventProps().blog_id ).toBe( 12345 );
 		} );
@@ -248,21 +245,21 @@ describe( 'tracks wrappers', () => {
 				site: { ID: 0 },
 			};
 
-			recordAgentsManagerTracksEvent( 'chat_minimize' );
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_chat_minimize' );
 
 			expect( lastEventProps() ).not.toHaveProperty( 'blog_id' );
 		} );
 
 		it( 'fires even when the resolved agent id is a reader-chat agent', () => {
 			setResolvedAgentId( 'reader-chat' );
-			recordAgentsManagerTracksEvent( 'chat_minimize' );
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_chat_minimize' );
 			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 
-	describe( 'recordFullNameAgentsManagerTracksEvent', () => {
-		it( 'records under the given name with the unified base-prop set', () => {
-			recordFullNameAgentsManagerTracksEvent( 'calypso_editor_agents_manager_ai_chat_clicked', {
+	describe( 'entry-point event names', () => {
+		it( 'records a host-prefixed name verbatim with the unified base-prop set', () => {
+			recordAgentsManagerTracksEvent( 'calypso_editor_agents_manager_ai_chat_clicked', {
 				section: 'gutenberg',
 				action: 'open',
 			} );
@@ -283,8 +280,8 @@ describe( 'tracks wrappers', () => {
 
 	describe( 'is_a11n', () => {
 		const recorders = [
-			[ 'Big Sky', recordBigSkyTracksEvent ],
-			[ 'Agents Manager', recordAgentsManagerTracksEvent ],
+			[ 'Big Sky', () => recordBigSkyTracksEvent( 'jetpack_big_sky_x' ) ],
+			[ 'Agents Manager', () => recordAgentsManagerTracksEvent( 'calypso_agents_manager_x' ) ],
 		] as const;
 
 		it.each( recorders )(
@@ -295,7 +292,7 @@ describe( 'tracks wrappers', () => {
 					isA11n: true,
 				};
 
-				recordEvent( 'x' );
+				recordEvent();
 
 				expect( lastEventProps().is_a11n ).toBe( true );
 			}
@@ -309,7 +306,7 @@ describe( 'tracks wrappers', () => {
 					isA11n: false,
 				};
 
-				recordEvent( 'x' );
+				recordEvent();
 
 				expect( lastEventProps().is_a11n ).toBe( false );
 			}
@@ -322,7 +319,7 @@ describe( 'tracks wrappers', () => {
 					isDevMode: false,
 				};
 
-				recordEvent( 'x' );
+				recordEvent();
 
 				expect( lastEventProps() ).not.toHaveProperty( 'is_a11n' );
 			}
@@ -332,20 +329,20 @@ describe( 'tracks wrappers', () => {
 	describe( 'is_test (getIsTest)', () => {
 		it( 'is true when agentsManagerData asserts dev mode', () => {
 			( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = { isDevMode: true };
-			recordAgentsManagerTracksEvent( 'x' );
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_x' );
 			expect( lastEventProps().is_test ).toBe( true );
 		} );
 
 		it( 'falls through to bigSkyInitialState when agentsManagerData omits isDevMode', () => {
 			( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {};
 			( window as Window ).bigSkyInitialState = { isDevMode: '1' };
-			recordAgentsManagerTracksEvent( 'x' );
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_x' );
 			expect( lastEventProps().is_test ).toBe( true );
 		} );
 
 		it( 'is false when neither source asserts dev mode', () => {
 			( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {};
-			recordAgentsManagerTracksEvent( 'x' );
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_x' );
 			expect( lastEventProps().is_test ).toBe( false );
 		} );
 	} );
@@ -356,7 +353,9 @@ describe( 'tracks wrappers', () => {
 				throw new Error( 'store not registered' );
 			} );
 
-			expect( () => recordBigSkyTracksEvent( 'chat_input_send_message' ) ).not.toThrow();
+			expect( () =>
+				recordBigSkyTracksEvent( 'jetpack_big_sky_chat_input_send_message' )
+			).not.toThrow();
 			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
 			expect( lastEventProps() ).toMatchObject( { post_type: '', is_home_page: false } );
 			expect( lastEventProps() ).not.toHaveProperty( 'surface' );
@@ -372,7 +371,9 @@ describe( 'tracks wrappers', () => {
 				throw new Error( 'core-data selector failed' );
 			} );
 
-			expect( () => recordBigSkyTracksEvent( 'chat_input_send_message' ) ).not.toThrow();
+			expect( () =>
+				recordBigSkyTracksEvent( 'jetpack_big_sky_chat_input_send_message' )
+			).not.toThrow();
 			expect( lastEventProps() ).toMatchObject( {
 				surface: 'block_editor',
 				post_type: '',

--- a/packages/agents-manager/src/utils/tracks.ts
+++ b/packages/agents-manager/src/utils/tracks.ts
@@ -1,13 +1,14 @@
 /**
  * Central Tracks wrappers for the Agents Manager.
  *
- * Three record functions over two base-prop sets:
+ * Two record functions, one per base-prop set:
  * - `recordBigSkyTracksEvent` keeps Big Sky's exact event names and props so its
  *   live Looker dashboard keeps working. Removable once that parity is dropped.
  * - `recordAgentsManagerTracksEvent` uses the unified property schema shared across the new
- *   AI products, under the `calypso_agents_manager_` prefix.
- * - `recordFullNameAgentsManagerTracksEvent` sends the same unified props under a
- *   caller-supplied full event name, for entry points whose events carry a host prefix.
+ *   AI products.
+ *
+ * Callers pass event names in full — the template-literal parameter types enforce
+ * the namespace — so every event is findable by searching the code for its name.
  */
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { select } from '@wordpress/data';
@@ -29,9 +30,6 @@ type EditorSelectStore =
 type CoreSelectStore =
 	| { getEntityRecord?: ( kind: string, name: string, key?: number ) => unknown }
 	| undefined;
-
-const BIG_SKY_EVENT_PREFIX = 'jetpack_big_sky_';
-const AM_UNIFIED_EVENT_PREFIX = 'calypso_agents_manager_';
 
 /** Reads the optional server-provided Automattician tracking signal. */
 function getIsA11n(): boolean | undefined {
@@ -109,7 +107,10 @@ function getBigSkyPageProps(): TracksProps {
  * Records an event under Big Sky's exact name and props so the existing Big Sky
  * dashboards keep working.
  */
-export function recordBigSkyTracksEvent( eventName: string, props: TracksProps = {} ): void {
+export function recordBigSkyTracksEvent(
+	eventName: `jetpack_big_sky_${ string }`,
+	props: TracksProps = {}
+): void {
 	if ( isReaderChatAgent( getResolvedAgentId() ) ) {
 		return; // Big Sky parity events are editor-only; never on reader-chat.
 	}
@@ -141,7 +142,7 @@ export function recordBigSkyTracksEvent( eventName: string, props: TracksProps =
 		}
 	}
 
-	recordTracksEvent( `${ BIG_SKY_EVENT_PREFIX }${ eventName }`, mergedProps );
+	recordTracksEvent( eventName, mergedProps );
 }
 
 function getUnifiedBaseProps(): TracksProps {
@@ -160,19 +161,11 @@ function getUnifiedBaseProps(): TracksProps {
 
 /**
  * Records an Agents Manager event using the shared unified property names.
- * `eventName` is a suffix appended to the `calypso_agents_manager_` prefix.
+ * Most events live under `calypso_agents_manager_`; the entry-point events
+ * carry a host prefix instead (e.g. `calypso_editor_agents_manager_ai_chat_clicked`).
  */
-export function recordAgentsManagerTracksEvent( eventName: string, props: TracksProps = {} ): void {
-	recordFullNameAgentsManagerTracksEvent( `${ AM_UNIFIED_EVENT_PREFIX }${ eventName }`, props );
-}
-
-/**
- * Records an event under its full name with the same unified base props as
- * `recordAgentsManagerTracksEvent` — for the entry-point events that carry
- * their own host prefix (e.g. `calypso_editor_agents_manager_ai_chat_clicked`).
- */
-export function recordFullNameAgentsManagerTracksEvent(
-	eventName: string,
+export function recordAgentsManagerTracksEvent(
+	eventName: `calypso_${ string }`,
 	props: TracksProps = {}
 ): void {
 	recordTracksEvent( eventName, { ...getUnifiedBaseProps(), ...props } );


### PR DESCRIPTION
Part of AI-1121

## Proposed Changes

* Write every Agents Manager Tracks event name out in full at its call site, so any event is findable by searching the code for its name (the Fieldguide naming convention this product failed). Both recorders stop assembling names from a prefix + suffix at fire time.
* Collapse the unified recorders into one: `recordAgentsManagerTracksEvent( fullEventName, props )` now takes the full name (the former `recordFullNameAgentsManagerTracksEvent` behavior); the suffix-joining variant and the prefix constants are deleted.
* Enforce the namespaces at compile time with template-literal parameter types — `` `calypso_${ string }` `` for the unified recorder and `` `jetpack_big_sky_${ string }` `` for the Big Sky parity recorder — so passing a bare suffix is a type error rather than a silently wrong event name.
* Expand the one dynamically-built name: the style picker's `` `${ variationType }_variation_click` `` becomes a `VARIATION_CLICK_EVENTS` map with the three full names (`jetpack_big_sky_color_variation_click`, `…font…`, `…button…`) written out.
* Fix a latent test-infrastructure bug found while verifying: the `@automattic/calypso-analytics` mock in `tracks.test.ts` used `{ virtual: true }`, which stops intercepting whenever `packages/calypso-analytics/dist` exists (e.g. after running `tsc --build`) — the suite then failed with "recorder never called" errors, intermittently poisoning local runs. The module is real, so the flag is removed.

No event names or payloads change — this is a pure code-findability refactor; every event fires under exactly the same name as before.

## Why are these changes being made?

* The Tracks audit (AI-1108) found that searching wp-calypso for any Agents Manager event name (e.g. `calypso_agents_manager_link_click`) finds only a test, because both recorders joined a prefix to a suffix as the event fired. The Fieldguide asks for names written out in full so the sending code is findable. Same pattern filed for MCP as AIINT-578.

## Testing Instructions

* Behavior is unchanged, so the main check is that events still fire under their existing names: sync the agents-manager app with your WordPress.com sandbox (`cd apps/agents-manager && yarn dev --sync`), open DevTools → Network tab → filter by `t.gif`, then trigger a few events (open the AI chat from an entry point, minimize it, click a link in a response) and confirm the same event names as before, with unchanged payloads.
* Findability: `git grep calypso_agents_manager_link_click` (or any event from the audit inventory) now lands on the component that sends it, not just a test.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
