### PR TITLE
Blueprint hand-off: restore canvas=edit and route through Jetpack SSO

### DIFF
--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -296,18 +296,65 @@ export function getSiteEditorUrl(
 	//
 	// `canvas=edit` is load-bearing: Big Sky's assembler only mounts on the
 	// editing canvas (useShouldLoadBigSky requires canvasMode === 'edit'), and a
-	// plain site-editor.php load stays in view mode — the kickoff, the copy
-	// mask, and the walkthrough all silently never run without it. The
-	// welcome-guide overlay this parameter was once blamed for came from sites
-	// where Big Sky had not been enabled by hand-off time (the enable race since
-	// fixed on the WordPress.com side); when Big Sky mounts, it suppresses the
-	// guide itself.
+	// plain site-editor.php load stays in view mode — the kickoff, the copy mask,
+	// and the walkthrough all silently never run without it. The welcome-guide
+	// overlay this parameter was once blamed for came from sites where Big Sky
+	// had not been enabled by hand-off time (the enable race fixed on the wpcom
+	// side); when Big Sky mounts, it suppresses the guide itself.
 	//
 	// Only set when the spec applied; there is nothing to personalize from
 	// otherwise.
-	return startWalkthrough
+	const editorUrl = startWalkthrough
 		? addQueryArgs( url, { 'blueprint-walkthrough': 'go', canvas: 'edit' } )
 		: url;
+
+	return withJetpackSso( editorUrl );
+}
+
+/**
+ * Route an Atomic wp-admin URL through Jetpack SSO so the customer arrives
+ * logged in.
+ *
+ * They have a WordPress.com session, not a session on their Atomic site, and
+ * those are different things. Sending them straight to wp-admin showed them a
+ * login form for a site they had just made — asking them to sign in to
+ * something they had not been told was separate. Jetpack SSO trades the session
+ * they have for the one they need and forwards them on.
+ * @param adminUrl Absolute wp-admin URL to land on.
+ * @returns The SSO URL, or the original when it cannot be parsed.
+ */
+function withJetpackSso( adminUrl: string ): string {
+	let target: URL;
+	try {
+		target = new URL( adminUrl );
+	} catch {
+		// Not something we can rewrite. Hand back what we were given rather than
+		// dropping the customer's redirect entirely.
+		return adminUrl;
+	}
+
+	// SSO lives on the site's own host. A *.wordpress.com address is the
+	// WordPress.com side of an Atomic site rather than the site itself, and
+	// logging in there does not produce a session for wp-admin.
+	if ( target.hostname.endsWith( '.wordpress.com' ) ) {
+		target.hostname = target.hostname.replace( '.wordpress.com', '.wpcomstaging.com' );
+	}
+
+	const login = new URL( target.href );
+	login.pathname = '/wp-login.php';
+	login.search = '';
+
+	// Deliberately NOT `action=jetpack-sso`. Jetpack only saves the
+	// `jetpack_sso_redirect_to` cookie — the sole carrier of the destination
+	// across the WordPress.com round trip — on the plain login path; a direct
+	// `action=jetpack-sso` entry skips save_cookies() and the return leg falls
+	// back to admin_url(), landing the customer on /wp-admin with the deep link
+	// gone. A plain wp-login.php?redirect_to=… saves the cookie, and wpcomsh
+	// auto-forwards Calypso-referred visitors to WordPress.com SSO anyway.
+	return addQueryArgs( login.href, {
+		// Relative, so the redirect cannot be pointed off-site.
+		redirect_to: `${ target.pathname }${ target.search }`,
+	} );
 }
 
 export function logBlueprintArchiveEvent(

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -294,15 +294,20 @@ export function getSiteEditorUrl(
 	// the editor URL, so a site that has already been personalized has to see it
 	// and do nothing. `reset` is the way to run it again.
 	//
-	// Deliberately no `canvas=edit`. Sending it made the Site Editor open its
-	// "Edit your site" welcome guide over the page and left a run of failed
-	// entity requests behind it; the same URL without it lands correctly and the
-	// personalization runs. The editor reaches its editing canvas on its own from
-	// here, so the parameter bought nothing and cost that.
+	// `canvas=edit` is load-bearing: Big Sky's assembler only mounts on the
+	// editing canvas (useShouldLoadBigSky requires canvasMode === 'edit'), and a
+	// plain site-editor.php load stays in view mode — the kickoff, the copy
+	// mask, and the walkthrough all silently never run without it. The
+	// welcome-guide overlay this parameter was once blamed for came from sites
+	// where Big Sky had not been enabled by hand-off time (the enable race since
+	// fixed on the WordPress.com side); when Big Sky mounts, it suppresses the
+	// guide itself.
 	//
 	// Only set when the spec applied; there is nothing to personalize from
 	// otherwise.
-	return startWalkthrough ? addQueryArgs( url, { 'blueprint-walkthrough': 'go' } ) : url;
+	return startWalkthrough
+		? addQueryArgs( url, { 'blueprint-walkthrough': 'go', canvas: 'edit' } )
+		: url;
 }
 
 export function logBlueprintArchiveEvent(

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -99,19 +99,19 @@ describe( 'getSiteEditorUrl', () => {
 	 */
 	it( 'flags the walkthrough when the spec was applied', () => {
 		expect( getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } ) ).toBe(
-			'https://example.com/wp-admin/site-editor.php?blueprint-walkthrough=go'
+			'https://example.com/wp-admin/site-editor.php?blueprint-walkthrough=go&canvas=edit'
 		);
 	} );
 
 	/**
-	 * `canvas=edit` used to ride along here. It made the Site Editor open its
-	 * welcome guide over the page on arrival, which is the first thing a customer
-	 * would have had to dismiss; the editor gets to its editing canvas without it.
+	 * Big Sky's assembler only mounts on the editing canvas; a plain
+	 * site-editor.php load stays in view mode and the walkthrough silently
+	 * never starts. The hand-off must force edit mode.
 	 */
-	it( 'does not force the editing canvas', () => {
+	it( 'forces the editing canvas so Big Sky mounts', () => {
 		expect(
 			getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } )
-		).not.toContain( 'canvas=edit' );
+		).toContain( 'canvas=edit' );
 	} );
 
 	it( 'leaves the flag off when the spec did not apply', () => {

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -81,16 +81,57 @@ describe( 'applyBlueprintSpec', () => {
 } );
 
 describe( 'getSiteEditorUrl', () => {
-	it( 'returns a plain site editor URL by default', () => {
-		expect( getSiteEditorUrl( 'https://example.com/wp-admin/' ) ).toBe(
-			'https://example.com/wp-admin/site-editor.php'
+	/**
+	 * The customer has a WordPress.com session, not one on their Atomic site.
+	 * Sending them straight to wp-admin showed them a login form for the site
+	 * they had just made, so the hand-off goes through Jetpack SSO.
+	 */
+	it( 'routes through Jetpack SSO so they arrive logged in', () => {
+		const url = getSiteEditorUrl( 'https://example.com/wp-admin/' );
+
+		expect( url ).toContain( 'https://example.com/wp-login.php' );
+		expect( url ).toContain( encodeURIComponent( '/wp-admin/site-editor.php' ) );
+	} );
+
+	/**
+	 * Jetpack only saves the jetpack_sso_redirect_to cookie — the sole carrier
+	 * of the destination across the WordPress.com round trip — on the plain
+	 * login path. A direct action=jetpack-sso entry skips save_cookies() and
+	 * the return leg falls back to /wp-admin, dropping the deep link.
+	 */
+	it( 'uses the plain login path so the redirect survives the SSO round trip', () => {
+		expect( getSiteEditorUrl( 'https://example.com/wp-admin/' ) ).not.toContain(
+			'action=jetpack-sso'
 		);
 	} );
 
 	it( 'tolerates an admin URL without a trailing slash', () => {
-		expect( getSiteEditorUrl( 'https://example.com/wp-admin' ) ).toBe(
-			'https://example.com/wp-admin/site-editor.php'
+		expect( getSiteEditorUrl( 'https://example.com/wp-admin' ) ).toContain(
+			encodeURIComponent( '/wp-admin/site-editor.php' )
 		);
+	} );
+
+	/**
+	 * SSO lives on the site's own host; a *.wordpress.com address is the
+	 * WordPress.com side of an Atomic site, and signing in there does not produce
+	 * a session for wp-admin.
+	 */
+	it( 'signs in on the site host rather than the WordPress.com one', () => {
+		const url = getSiteEditorUrl( 'https://example.wordpress.com/wp-admin/' );
+
+		expect( url ).toContain( 'https://example.wpcomstaging.com/wp-login.php' );
+	} );
+
+	/**
+	 * A relative redirect cannot be pointed off-site.
+	 */
+	it( 'keeps the redirect relative', () => {
+		const url = getSiteEditorUrl( 'https://example.com/wp-admin/', {
+			startWalkthrough: true,
+		} );
+		const redirect = new URL( url ).searchParams.get( 'redirect_to' );
+
+		expect( redirect ).toBe( '/wp-admin/site-editor.php?blueprint-walkthrough=go&canvas=edit' );
 	} );
 
 	/**
@@ -98,9 +139,9 @@ describe( 'getSiteEditorUrl', () => {
 	 * waiting for the customer to speak first.
 	 */
 	it( 'flags the walkthrough when the spec was applied', () => {
-		expect( getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } ) ).toBe(
-			'https://example.com/wp-admin/site-editor.php?blueprint-walkthrough=go&canvas=edit'
-		);
+		expect(
+			getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } )
+		).toContain( encodeURIComponent( 'blueprint-walkthrough=go' ) );
 	} );
 
 	/**
@@ -111,7 +152,7 @@ describe( 'getSiteEditorUrl', () => {
 	it( 'forces the editing canvas so Big Sky mounts', () => {
 		expect(
 			getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } )
-		).toContain( 'canvas=edit' );
+		).toContain( encodeURIComponent( 'canvas=edit' ) );
 	} );
 
 	it( 'leaves the flag off when the spec did not apply', () => {


### PR DESCRIPTION
## Proposed Changes

Two fixes to the editor URL the blueprint-archive flow hands the customer to after spec confirm:

**1. Restore `canvas=edit`** (reverts #113751). The parameter turned out to be load-bearing: Big Sky's assembler only mounts on the editing canvas (`useShouldLoadBigSky` requires `canvasMode === 'edit'`), and a plain `site-editor.php` load opens in view mode. Without it the copy-walkthrough kickoff, the copy mask, and the walkthrough itself silently never run — no error anywhere, the agent is simply never invoked. The welcome-guide overlay that motivated the removal came from sites where Big Sky had not been enabled by hand-off time — an enable race fixed separately on the WordPress.com side (`236148-ghe-Automattic/wpcom`). When Big Sky mounts, it suppresses the guide itself.

**2. Route the hand-off through Jetpack SSO.** The customer has a WordPress.com session, not a session on their Atomic site; nothing in the hand-off traded one for the other, and the implicit auth bounce has proven flaky on freshly provisioned sites (landing on `/wp-admin` with the deep link gone). The redirect now goes through the site's `wp-login.php?redirect_to=<relative editor path>`.

Deliberately **not** `action=jetpack-sso`: Jetpack only saves the `jetpack_sso_redirect_to` cookie — the sole carrier of the destination across the WordPress.com round trip — on the plain login path (`login_init()` only calls `save_cookies()` there), and the outbound URL to WordPress.com carries no `redirect_to` at all. A direct `action=jetpack-sso` entry therefore always falls back to `admin_url()` on return. The plain path saves the cookie, and wpcomsh auto-forwards Calypso-referred visitors to WordPress.com SSO anyway, so the logged-out case still signs in seamlessly while a logged-in arrival is redirected straight through.

## Why are these changes being made?

The blueprint copy walkthrough stopped starting for sites created after #113751 deployed, and the hand-off intermittently landed customers on `/wp-admin` instead of the editor. Verified live on an Atomic blueprint site: without `canvas=edit` the editor sits in view mode with the walkthrough dead; with it the copy masks on arrival and the personalization runs end to end. Also verified the login hop: `wp-login.php?redirect_to=%2Fwp-admin%2Fsite-editor.php%3Fcanvas%3Dedit` lands exactly on the encoded destination.

## Testing Instructions

1. Run the blueprint-archive onboarding flow through spec confirm on a blueprint vertical.
2. After the transfer/import completes you should be handed to the site's `wp-login.php` and arrive signed in on `{site}/wp-admin/site-editor.php?blueprint-walkthrough=go&canvas=edit`.
3. The page copy should mask into placeholders and the assistant should begin personalizing the copy from your spec without being spoken to.
4. Unit tests: `yarn test-client client/landing/stepper/utils/test/blueprint-archive-import.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)