### PR TITLE
Reader: remove the dead site-subscriptions-manager section entry

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -580,17 +580,6 @@ const sections = [
 		enableLoggedOut: false,
 	},
 	{
-		name: 'reader',
-		paths: [
-			'/reader/subscriptions',
-			'/reader/subscriptions/comments',
-			'/reader/subscriptions/pending',
-			'^/reader/subscriptions/(\\d+)(/)?$',
-		],
-		module: 'calypso/reader/site-subscriptions-manager',
-		group: 'reader',
-	},
-	{
 		name: 'auth',
 		paths: [ '/api/oauth/token' ],
 		module: 'calypso/auth',


### PR DESCRIPTION
## Proposed Changes

* Remove the `calypso/reader/site-subscriptions-manager` entry from `client/sections.js`. It registers no routes.

## Why are these changes being made?

`sections-middleware.js:34` calls `requiredModule.default( controller.clientRouter )`, but that module default-exports a React component — so the call ignores the router and returns an element that is discarded.

The four paths it claims are already served by `calypso/reader` (`client/reader/index.ts:179-209`), whose own entry matches `/reader/subscriptions*` via its `/reader` prefix pattern and is registered first. The deleted entry also omitted `enableLoggedOut`, which wrapped it in a `redirectLoggedOut` redundant with the guard already on each of the four routes.

The component tree stays reachable: `client/reader/controller.jsx:45` async-loads the same module and renders it through `AsyncLoad`, which is the intended usage.

Found in a route-surface audit of `client/sections.js`.

## Testing Instructions

Logged in, confirm each of these still loads its screen:

* `/reader/subscriptions`
* `/reader/subscriptions/comments`
* `/reader/subscriptions/pending`
* `/reader/subscriptions/<id>`

Logged out, confirm they still redirect to login. Check the console for routing errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
