### PR TITLE
A4A: drop the unmatchable sites/need-setup manifest path

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -868,7 +868,7 @@ const sections = [
 	},
 	{
 		name: 'a8c-for-agencies-sites',
-		paths: [ '/sites', 'sites/need-setup' ],
+		paths: [ '/sites' ],
 		module: 'calypso/a8c-for-agencies/sections/sites',
 		group: 'a8c-for-agencies',
 	},


### PR DESCRIPTION
## Proposed Changes

* Remove `'sites/need-setup'` from the `a8c-for-agencies-sites` paths in `client/sections.js`. It has no leading slash and can never match a request.

## Why are these changes being made?

`pathToRegExp` (`client/utils.ts:6`) builds `/^sites\/need-setup(\/.*)?$/`, and page.js tests that against `context.path`, which always begins with `/`. The pattern has never matched. The entry was created with the same typo as `'sites/favorite'` in #87452 and renamed in place by #90078.

Removing it rather than adding the slash: the sibling `'/sites'` pattern compiles to `/^\/sites(\/.*)?$/`, which already prefix-matches `/sites/need-setup` and loads the section — so the page has worked all along. Adding the slash would register a second page.js route for the same chunk.

The route itself is untouched. `sections/sites/index.tsx:15` registers `A4A_SITES_LINK_NEEDS_SETUP` with `needsSetupContext`, and the URL is linked from the sidebar, license assignment, and checkout success redirects.

Found in a route-surface audit of `client/sections.js`.

## Testing Instructions

In A4A, confirm `/sites/need-setup` still loads the Needs Setup screen — via the sidebar item, and by entering the URL directly. Confirm `/sites` and its other sub-routes are unaffected.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
