### PR TITLE
Onboarding progress: move the purchase-flow stepper into the step top bar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/style.scss
@@ -1,20 +1,8 @@
 @import '@wordpress/theme/design-tokens.css';
 
-// The stepper carries its own vertical spacing, so drop the wrapper's
-// top padding to avoid doubling up the space above it.
-.step-container-v2__content-wrapper.axis-vertical:has( .onboarding-progress ) {
-	padding-top: 0;
-}
-
 .onboarding-progress {
 	display: flex;
 	justify-content: center;
-	padding: 8px 0;
-	margin-block-end: 32px;
-	// Ensure the stepper paints above the sticky checkout sidebar, which is positioned
-	// and would otherwise overlap the heading row at the same stacking level.
-	position: relative;
-	z-index: 1;
 
 	.onboarding-progress-step {
 		display: flex;
@@ -24,6 +12,6 @@
 	.onboarding-progress-trigger {
 		display: flex;
 		align-items: center;
-		padding: 12px 16px;
+		padding: 4px 12px;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -581,6 +581,9 @@ const DomainSearchStep: StepType< {
 				topBar={
 					<Step.TopBar
 						leftElement={ getTopBarLeftElement() }
+						centerElement={
+							showProgress ? <OnboardingProgress currentStep="domains" /> : undefined
+						}
 						rightElement={ getTopBarRightElement() }
 					/>
 				}
@@ -592,12 +595,9 @@ const DomainSearchStep: StepType< {
 					// page's primary affordance — the H1/subText are dropped so
 					// high-quality results can fill the limited vertical space.
 					// The empty/initial state keeps the heading on mobile.
-					<>
-						{ showProgress && <OnboardingProgress currentStep="domains" /> }
-						{ ! ( isMobileViewport && query ) && (
-							<Step.Heading text={ headerText } subText={ subHeaderText } />
-						) }
-					</>
+					! ( isMobileViewport && query ) && (
+						<Step.Heading text={ headerText } subText={ subHeaderText } />
+					)
 				}
 			>
 				{ domainSearchElement }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -747,6 +747,14 @@ function UnifiedPlansStep( {
 										<Step.BackButton onClick={ goBack }>{ backLabelText }</Step.BackButton>
 									) : undefined
 								}
+								centerElement={
+									showProgress ? (
+										<OnboardingProgress
+											currentStep="plans"
+											onStepSelect={ () => wrapperProps.goBack?.() }
+										/>
+									) : undefined
+								}
 								rightElement={
 									isOnboardingFlow( flowName ) ? (
 										<>
@@ -766,12 +774,6 @@ function UnifiedPlansStep( {
 						}
 						heading={
 							<>
-								{ showProgress && (
-									<OnboardingProgress
-										currentStep="plans"
-										onStepSelect={ () => wrapperProps.goBack?.() }
-									/>
-								) }
 								{ ( intent === 'plans-website-builder' ||
 									intent === 'plans-wordpress-hosting' ) && (
 									<IntentToggle

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1132,21 +1132,6 @@ export default function CheckoutMainContent( {
 				<Step.TwoColumnLayout
 					firstColumnWidth={ 8 }
 					secondColumnWidth={ 4 }
-					heading={
-						showProgress ? (
-							<OnboardingProgress
-								currentStep="checkout"
-								onStepSelect={ ( step ) =>
-									handleProgressStepSelect( step, {
-										forceCheckoutBackUrlDomains,
-										forceCheckoutBackUrl,
-										clickStepBack: leaveModalProps.clickStepBack,
-										clickClose: leaveModalProps.clickClose,
-									} )
-								}
-							/>
-						) : undefined
-					}
 					topBar={ ( { isLargeViewport } ) => {
 						const topBar = (
 							<Step.TopBar
@@ -1154,6 +1139,21 @@ export default function CheckoutMainContent( {
 									showProgress ? undefined : (
 										<Step.BackButton onClick={ leaveModalProps.clickClose } />
 									)
+								}
+								centerElement={
+									showProgress ? (
+										<OnboardingProgress
+											currentStep="checkout"
+											onStepSelect={ ( step ) =>
+												handleProgressStepSelect( step, {
+													forceCheckoutBackUrlDomains,
+													forceCheckoutBackUrl,
+													clickStepBack: leaveModalProps.clickStepBack,
+													clickClose: leaveModalProps.clickClose,
+												} )
+											}
+										/>
+									) : undefined
 								}
 								rightElement={
 									<>

--- a/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/TopBar.tsx
@@ -7,6 +7,12 @@ import './style.scss';
 
 export interface TopBarProps {
 	leftElement?: ReactNode;
+	/**
+	 * Rendered horizontally centered in the bar, independent of the width of
+	 * the left/right elements. Desktop-oriented: it overlaps the side elements
+	 * on narrow viewports.
+	 */
+	centerElement?: ReactNode;
 	rightElement?: ReactNode;
 
 	/**
@@ -31,6 +37,7 @@ export interface TopBarProps {
 
 export const TopBar = ( {
 	leftElement,
+	centerElement,
 	rightElement,
 	logo,
 	compactLogo,
@@ -103,6 +110,9 @@ export const TopBar = ( {
 
 			{ leftElement && (
 				<div className="step-container-v2__top-bar-left-element">{ leftElement }</div>
+			) }
+			{ centerElement && (
+				<div className="step-container-v2__top-bar-center-element">{ centerElement }</div>
 			) }
 			{ rightElement && (
 				<div className="step-container-v2__top-bar-right-element">{ rightElement }</div>

--- a/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
+++ b/packages/onboarding/src/step-container-v2/components/TopBar/style.scss
@@ -2,6 +2,7 @@
 @import '@wordpress/base-styles/mixins';
 
 .step-container-v2__top-bar {
+	position: relative;
 	width: 100%;
 	box-sizing: border-box;
 	display: flex;
@@ -26,6 +27,15 @@
 
 .step-container-v2__top-bar-left-element,
 .step-container-v2__top-bar-right-element {
+	display: flex;
+	align-items: center;
+}
+
+.step-container-v2__top-bar-center-element {
+	position: absolute;
+	inset-block-start: 50%;
+	inset-inline-start: 50%;
+	transform: translate( -50%, -50% );
 	display: flex;
 	align-items: center;
 }


### PR DESCRIPTION
Follow-up to #113780.
Slack thread: p1787586539939029/1786736229.907649-slack-C06FCT6EEHH

## Proposed Changes

* Add an optional `centerElement` slot to `Step.TopBar` (`@automattic/onboarding` step-container-v2). It renders as `.step-container-v2__top-bar-center-element`, absolutely centered in the bar so it stays centered regardless of the width of the logo / back button / “Need help?” elements.
* Render the purchase-flow `OnboardingProgress` stepper in that slot — inside `.step-container-v2__top-bar-wrapper` — on the domain search, plans, and checkout steps, instead of above the step heading.
* Drop the stepper’s stand-alone spacing (`padding`, `margin-block-end`), the `:has()` content-wrapper padding hack, and the z-index workaround, none of which are needed now that it lives in the top bar. Tighten the trigger padding so it fits the 56px bar.

## Why are these changes being made?

* The stepper is a navigation affordance for the whole purchase flow, so it belongs in the header alongside the other flow-level controls rather than in the content column. Moving it there also frees the vertical space it was taking above each step’s heading and removes the layout hacks that were needed to make it sit correctly there.

## Testing Instructions

1. Start the onboarding flow at `/setup/onboarding` on a desktop-sized viewport.
2. On the domain search step, verify the “Select a domain / Select a plan / Complete payment” stepper is rendered in the top bar, centered between the WordPress logo and the “Need help?” link, and no longer appears above the step heading.
3. Continue to the plans step and checkout and verify the same placement; verify the completed steps remain clickable and navigate back as before (checkout still shows the leave-checkout confirmation when applicable).
4. In checkout, verify the stepper is not covered by the sticky order-summary sidebar.
5. Resize to a mobile viewport and verify the stepper is not shown (the existing top-bar step counter remains).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)