### PR TITLE
Profile: show the API's username error instead of a generic message

### DIFF
--- a/client/dashboard/me/profile-personal-details/username-section.tsx
+++ b/client/dashboard/me/profile-personal-details/username-section.tsx
@@ -49,7 +49,7 @@ export default function UsernameSection( {
 
 	const { mutate: updateUsername, isPending } = useMutation( {
 		...withSnackbar( updateUsernameMutation(), {
-			error: __( 'Failed to update username.' ),
+			error: { source: 'server' },
 		} ),
 		onSuccess: () => {
 			reloadWithFlashMessage( 'username' );


### PR DESCRIPTION
Fixes #113600
Fixes DOTSITE-149

## Proposed Changes

* Show the error message the username API returns, instead of the generic “Failed to update username.”

## Why are these changes being made?

Someone changing their username to one containing uppercase letters (`TheDriverTV`, `DavidBattrick79`, `beedellRoke`) gets “Failed to update username.” and no clue what to fix. Several assumed the name was taken, retried, and eventually contacted support. It has generated at least five Zendesk tickets.

The API already returns exactly what's wrong — “Usernames can only contain lowercase letters (a-z) and numbers.” — and the dashboard was throwing it away.

The reason the server is the one rejecting these at all: the field validates a lowercased copy of the input as you type, but submits what you actually typed. So `TheDriverTV` passes the inline check (as `thedrivertv`) and only fails on submit. Surfacing the server's message closes that gap without changing the validation behaviour.

There are around a dozen messages this endpoint can return. I read through all of them — length limits, reserved names, “usernames must have letters too”, and so on — and they're all written for end users and translated on the backend.

## Considerations

The alternative was catching the error client-side and mapping it to our own strings, but that duplicates backend validation rules that already drift (one of the twelve messages is unreachable today), and the backend messages are already translated.

`{ source: 'server' }` is the existing snackbar option for this, used by roughly 25 other dashboard mutations.

## Testing Instructions

1. Go to the profile page in the dashboard (`/me/profile`).
2. Change the username field to something with uppercase letters, e.g. `TheDriverTV`, and confirm the change.
3. The snackbar should read “Usernames can only contain lowercase letters (a-z) and numbers.” rather than “Failed to update username.”

Other messages worth spot-checking: a username over 50 characters, and one that's already taken.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


https://claude.ai/code/session_01PLkzdJ3ARDRfC6eDG6gxEw
