### PR TITLE
Stats: take the purchase screen and mini-carousel off Calypso buttons and pinned colours

### DIFF
--- a/client/my-sites/stats/_interactive-colors.scss
+++ b/client/my-sites/stats/_interactive-colors.scss
@@ -19,6 +19,13 @@
 
 	// Calypso's own Button takes the same two roles from --color-accent that a design-system primary
 	// takes from the components accent: the resting fill, and a darker shade on hover.
+	//
+	// Stats' own call sites are all gone, but this cannot go with them: the remaining primaries come
+	// from shared components Stats only renders — EmptyContent's action button, Banner's call to
+	// action, PromoCardBlock, and Dialog's button bar, which applies `is-primary` as a className
+	// rather than a prop and so reaches the react-modal portal root too. Converting those is a
+	// cross-cutting change well outside Stats, so the bridge outlives the call sites it was written
+	// for.
 	.button.is-primary {
 		--color-accent: var(--wp-admin-theme-color);
 		--color-accent-60: var(--wp-admin-theme-color-darker-10);

--- a/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
+++ b/client/my-sites/stats/mini-carousel/mini-carousel-block.jsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
-import { Button } from '@automattic/components';
+import { Button } from '@wordpress/components';
 import { Icon, chevronDown } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -50,11 +50,15 @@ const MiniCarouselBlock = ( {
 				/>
 				<p className="mini-carousel-block__content-text">{ contentText }</p>
 			</div>
-			<Button primary onClick={ onClick }>
+			<Button variant="primary" __next40pxDefaultSize onClick={ onClick }>
 				{ ctaText }
 			</Button>
 			{ dismissEvent && (
-				<Button onClick={ onDismiss } className="mini-carousel-block__close-button">
+				<Button
+					onClick={ onDismiss }
+					__next40pxDefaultSize
+					className="mini-carousel-block__close-button"
+				>
 					{ dismissText ? dismissText : translate( 'Hide this' ) }
 					<Icon
 						className="mini-carousel-block__close-button-icon"

--- a/client/my-sites/stats/mini-carousel/mini-carousel-block.scss
+++ b/client/my-sites/stats/mini-carousel/mini-carousel-block.scss
@@ -27,13 +27,13 @@
 		}
 	}
 
-	&__close-button {
-		border: 0 !important;
-		font-size: $font-body-extra-small !important;
+	// Compounded with the component's own class rather than raised with !important: both selectors
+	// are single-class, so source order alone would decide which font size wins.
+	&__close-button.components-button {
+		font-size: $font-body-extra-small;
 	}
 
 	&__close-button-icon {
-		vertical-align: middle;
-		margin-top: -4px;
+		margin-inline-start: 2px;
 	}
 }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { Button as CalypsoButton } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
@@ -10,7 +9,6 @@ import { useJetpackConnectionStatus } from 'calypso/my-sites/stats/hooks/use-jet
 import useStatsPurchases from 'calypso/my-sites/stats/hooks/use-stats-purchases';
 import useDismissPricingGrid from 'calypso/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid';
 import { useSelector } from 'calypso/state';
-import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import getIsSimpleSite from 'calypso/state/sites/selectors/is-simple-site';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
 import { COMPONENT_CLASS_NAME, MIN_STEP_SPLITS } from './stats-purchase-consts';
@@ -47,11 +45,8 @@ const PersonalPurchase = ( {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	const { hasAnyStatsPlan } = useStatsPurchases( siteId );
-	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 	const isSimpleSite = useSelector( ( state ) => getIsSimpleSite( state, siteId ) );
 	const { data: connectionStatus } = useJetpackConnectionStatus( siteId, !! isSimpleSite );
-	// The button of @automattic/components has built-in color scheme support for Calypso.
-	const ButtonComponent = isWPCOMSite ? CalypsoButton : Button;
 
 	const continueButtonText = translate( 'Contribute now and continue' );
 
@@ -130,9 +125,8 @@ const PersonalPurchase = ( {
 
 			{ subscriptionValue === 0 ? (
 				<div className={ `${ COMPONENT_CLASS_NAME }__actions` }>
-					<ButtonComponent
+					<Button
 						variant="primary"
-						primary={ isWPCOMSite ? true : undefined }
 						onClick={ () =>
 							gotoCheckoutPage( {
 								from,
@@ -148,21 +142,17 @@ const PersonalPurchase = ( {
 						{ translate( 'Continue with %(product)s for free', {
 							args: { product: STATS_PRODUCT_NAME },
 						} ) }
-					</ButtonComponent>
+					</Button>
 				</div>
 			) : (
 				<div className={ `${ COMPONENT_CLASS_NAME }__actions` }>
-					<ButtonComponent
-						variant="primary"
-						primary={ isWPCOMSite ? true : undefined }
-						onClick={ handleCheckoutRedirect }
-					>
+					<Button variant="primary" onClick={ handleCheckoutRedirect }>
 						{ continueButtonText }
-					</ButtonComponent>
+					</Button>
 
-					<ButtonComponent variant="secondary" onClick={ handleCheckoutPostponed }>
+					<Button variant="secondary" onClick={ handleCheckoutPostponed }>
 						{ translate( 'I will do it later' ) }
-					</ButtonComponent>
+					</Button>
 				</div>
 			) }
 		</div>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -6,7 +6,6 @@ import {
 	PLAN_JETPACK_BUSINESS,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Button as CalypsoButton } from '@automattic/components';
 import { formatNumberCompact } from '@automattic/number-formatters';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -15,7 +14,6 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { STATS_PRODUCT_NAME } from 'calypso/my-sites/stats/constants';
 import { useJetpackConnectionStatus } from 'calypso/my-sites/stats/hooks/use-jetpack-connection-status';
 import { useSelector } from 'calypso/state';
-import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import { getSiteAdminUrl, getSiteOption, getIsSimpleSite } from 'calypso/state/sites/selectors';
 import useAvailableUpgradeTiers from '../hooks/use-available-upgrade-tiers';
 import usePlanUsageQuery, { getUsageLimitStatus } from '../hooks/use-plan-usage-query';
@@ -238,7 +236,6 @@ const StatsCommercialPurchase = ( {
 	eventProps,
 }: StatsCommercialPurchaseProps ) => {
 	const translate = useTranslate();
-	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 	const tiers = useAvailableUpgradeTiers( siteId ) || [];
 	const haveTiers = tiers.length > 0;
 	const {
@@ -270,8 +267,6 @@ const StatsCommercialPurchase = ( {
 
 	const { isNearLimit, isOverLimit } = getUsageLimitStatus( usageData );
 
-	// The button of @automattic/components has built-in color scheme support for Calypso.
-	const ButtonComponent = isWPCOMSite ? CalypsoButton : Button;
 	const startingTierQuantity = haveTiers ? getTierQuantity( tiers[ 0 ] ) : 0;
 	const [ purchaseTierQuantity, setPurchaseTierQuantity ] = useState( startingTierQuantity ?? 0 );
 
@@ -392,9 +387,8 @@ const StatsCommercialPurchase = ( {
 				</div>
 			) }
 			<div className="stats-purchase-wizard__actions">
-				<ButtonComponent
+				<Button
 					variant="primary"
-					primary={ isWPCOMSite ? true : undefined }
 					disabled={ ! haveTiers || needsConnectionForUpgrade }
 					onClick={ () =>
 						gotoCheckoutPage( {
@@ -413,13 +407,13 @@ const StatsCommercialPurchase = ( {
 					}
 				>
 					{ continueButtonText }
-				</ButtonComponent>
-				<ButtonComponent variant="secondary" onClick={ handleCheckoutPostponed }>
+				</Button>
+				<Button variant="secondary" onClick={ handleCheckoutPostponed }>
 					{ postponeLabel ??
 						( needsConnectionForFreePlan
 							? translate( 'Start for free' )
 							: translate( 'I will do it later' ) ) }
-				</ButtonComponent>
+				</Button>
 			</div>
 			<div className="stats-purchase-page__footnotes">
 				<p>{ translate( '(*) 14-day money-back guarantee' ) }</p>

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -368,17 +368,10 @@ $button-padding: 8px 32px;
 	.components-button {
 		&.is-primary {
 			border-radius: 4px;
-			transition: all 0.25s ease-out;
 			font-size: var(--font-body);
 			line-height: 24px;
 			padding: $button-padding;
 			height: auto;
-
-			&[disabled],
-			&:disabled,
-			&.disabled {
-				opacity: 0.3;
-			}
 		}
 
 		&.is-secondary {

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -19,12 +19,6 @@ $button-padding: 8px 32px;
 // Adjust purchase page styling for WPCOM.
 .stats-purchase-page--is-wpcom {
 	.stats-purchase-wizard {
-		.components-button {
-			&.is-link {
-				color: var(--color-sidebar-menu-selected-background);
-			}
-		}
-
 		li.stats-purchase-wizard__benefits-item--included,
 		.stats-purchase-wizard__benefits--included li {
 			background-image: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPGcgaWQ9IkFjdGlvbnMgLyBkb25lXzI0cHgiPgo8bWFzayBpZD0ibWFzazBfMzgwMl81NDI1IiBzdHlsZT0ibWFzay10eXBlOmx1bWluYW5jZSIgbWFza1VuaXRzPSJ1c2VyU3BhY2VPblVzZSIgeD0iMyIgeT0iNSIgd2lkdGg9IjE4IiBoZWlnaHQ9IjE0Ij4KPHBhdGggaWQ9Imljb24vYWN0aW9uL2RvbmVfMjRweCIgZD0iTTguNzU2ODIgMTUuOUw0LjU3NzQzIDExLjdMMy4xODQzIDEzLjFMOC43NTY4MiAxOC43TDIwLjY5OCA2LjY5OTk5TDE5LjMwNDggNS4yOTk5OUw4Ljc1NjgyIDE1LjlaIiBmaWxsPSJ3aGl0ZSIvPgo8L21hc2s+CjxnIG1hc2s9InVybCgjbWFzazBfMzgwMl81NDI1KSI+CjxyZWN0IGlkPSJSZWN0YW5nbGUiIHdpZHRoPSIyMy44ODIzIiBoZWlnaHQ9IjI0IiBmaWxsPSIjMDY3NUM0Ii8+CjwvZz4KPC9nPgo8L3N2Zz4K);
@@ -411,7 +405,6 @@ $button-padding: 8px 32px;
 		}
 
 		&.is-link {
-			color: var(--jp-green-50);
 			font-size: inherit;
 			display: inline;
 		}

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -78,21 +78,6 @@ $button-padding: 8px 32px;
 		.stats-purchase-wizard__card-grid {
 			color: var(--studio-black);
 		}
-
-		.jp-components-pricing-slider__track.jp-components-pricing-slider__track-0 {
-			background-color: var(--color-primary);
-		}
-
-		.jp-components-pricing-slider__thumb {
-			border-color: var(--color-primary);
-		}
-
-		// On holding thumb styling
-		.jp-components-pricing-slider--is-holding {
-			.jp-components-pricing-slider__thumb {
-				box-shadow: 0 6px 8px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04), 0 0 0 3px color-mix(in srgb, var(--color-primary) 25%, transparent);
-			}
-		}
 	}
 }
 

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -20,10 +20,6 @@ $button-padding: 8px 32px;
 .stats-purchase-page--is-wpcom {
 	.stats-purchase-wizard {
 		.components-button {
-			&.is-primary {
-				background-color: var(--color-accent);
-				border-color: var(--color-accent);
-			}
 			&.is-link {
 				color: var(--color-sidebar-menu-selected-background);
 			}
@@ -393,21 +389,11 @@ $button-padding: 8px 32px;
 	.components-button {
 		&.is-primary {
 			border-radius: 4px;
-			color: var(--jp-white);
-			background-color: #1a1a1a;
-			border-color: #1a1a1a;
 			transition: all 0.25s ease-out;
 			font-size: var(--font-body);
 			line-height: 24px;
 			padding: $button-padding;
 			height: auto;
-
-			&:hover,
-			&:active,
-			&:focus {
-				background: var(--studio-gray-80);
-				border-color: var(--studio-gray-80);
-			}
 
 			&[disabled],
 			&:disabled,

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/pricing-slider/style.scss
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/pricing-slider/style.scss
@@ -20,13 +20,17 @@ $thumb-horizontal-padding: 16px;
 	--jp-green-40: #069e08;
 }
 
+// The slider follows the admin theme colour wherever one is published, falling back to the Jetpack
+// green it was vendored with so it still renders standalone, outside a Stats mount.
+$slider-accent: var( --wp-admin-theme-color, var( --jp-green-40 ) );
+
 // On holding thumb styling
 .jp-components-pricing-slider--is-holding {
 	.jp-components-pricing-slider__thumb {
 		box-shadow:
 			0 6px 8px rgba( 0, 0, 0, 0.08 ),
 			0 1px 2px rgba( 0, 0, 0, 0.04 ),
-			0 0 0 3px rgba( 6, 158, 8, 0.25 );
+			0 0 0 3px color-mix( in srgb, #{$slider-accent} 25%, transparent );
 	}
 }
 
@@ -41,7 +45,7 @@ $thumb-horizontal-padding: 16px;
 	background: var( --jp-gray );
 
 	&.jp-components-pricing-slider__track-0 {
-		background: var( --jp-green-40 );
+		background: #{$slider-accent};
 	}
 
 	&.jp-components-pricing-slider__track-1 {
@@ -54,7 +58,7 @@ $thumb-horizontal-padding: 16px;
 	align-items: center;
 	background-color: var( --jp-white );
 	border-radius: 4px;
-	border: 1.5px solid var( --jp-green-40 );
+	border: 1.5px solid #{$slider-accent};
 	box-shadow:
 		0 1px 2px rgba( 0, 0, 0, 0.04 ),
 		0 6px 8px rgba( 0, 0, 0, 0.08 );

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
@@ -52,11 +52,14 @@ $track-height: 4px;
 		}
 	}
 
+	// A filled circle rather than the bordered pill the slider ships, so the thumb, the filled track
+	// and the selected mark read as one selection. All three take the admin theme colour for the
+	// same reason the purchase CTA beside them does — they are one control group on one screen.
 	.jp-components-pricing-slider__thumb.tier-upgrade-slider__thumb {
 		width: $thumb-width;
 		height: $slider-height;
 		border-radius: 50%;
-		background-color: var(--jp-green-40);
+		background-color: var(--wp-admin-theme-color);
 		color: var(--jp-white);
 	}
 
@@ -96,22 +99,8 @@ $track-height: 4px;
 		}
 
 		.jp-components-pricing-slider__mark--selected {
-			background-color: var(--jp-green-40);
-			border-color: var(--jp-green-40);
-		}
-	}
-}
-
-// Override colors for WPCOM context.
-.stats-purchase-page--is-wpcom {
-	.jp-components-pricing-slider__thumb.tier-upgrade-slider__thumb {
-		background-color: var(--color-primary);
-	}
-
-	.jp-components-pricing-slider__control {
-		.jp-components-pricing-slider__mark--selected {
-			background-color: var(--color-primary);
-			border-color: var(--color-primary);
+			background-color: var(--wp-admin-theme-color);
+			border-color: var(--wp-admin-theme-color);
 		}
 	}
 }

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
@@ -55,11 +55,13 @@ $track-height: 4px;
 	// A filled circle rather than the bordered pill the slider ships, so the thumb, the filled track
 	// and the selected mark read as one selection. All three take the admin theme colour for the
 	// same reason the purchase CTA beside them does — they are one control group on one screen.
+	// The Jetpack green stays as the fallback the vendored slider uses, so the two stylesheets agree
+	// on what happens where no admin theme colour is published.
 	.jp-components-pricing-slider__thumb.tier-upgrade-slider__thumb {
 		width: $thumb-width;
 		height: $slider-height;
 		border-radius: 50%;
-		background-color: var(--wp-admin-theme-color);
+		background-color: var(--wp-admin-theme-color, var(--jp-green-40));
 		color: var(--jp-white);
 	}
 
@@ -99,8 +101,8 @@ $track-height: 4px;
 		}
 
 		.jp-components-pricing-slider__mark--selected {
-			background-color: var(--wp-admin-theme-color);
-			border-color: var(--wp-admin-theme-color);
+			background-color: var(--wp-admin-theme-color, var(--jp-green-40));
+			border-color: var(--wp-admin-theme-color, var(--jp-green-40));
 		}
 	}
 }


### PR DESCRIPTION
Part of STATS-434. Stacked on #113447, which is merged.

## Why are these changes being made?

Stats' interactive UI follows `--wp-admin-theme-color`, the colour WordPress publishes for controls, rather than `--color-accent` — wp-admin's decorative highlight, which fails WCAG AA on several admin colour schemes.

Three components were still holding out. They rendered `@automattic/components`' `Button` with `primary`, which fills from `--color-accent`, so a bridge rule in `_interactive-colors.scss` had to re-point that variable just for them. The source recorded why the Calypso button was there: in September 2023 a `@wordpress/components` primary ignored the admin colour scheme and rendered its own blue.

**That reason has expired.** `_wp-components-overrides.scss` has pinned `--wp-components-color-accent` on every button variant since `af4d5d552d9` (March 2025), so both buttons resolve the same fill. The branch was also keyed on the wrong question. `getIsSiteWPCOM` is `! isJetpackSite || isAtomicSite`, so every WordPress.com-backed site — Simple and Atomic alike — took the Calypso branch *inside wp-admin*, where nothing about Calypso's colour scheme applies. The condition it wanted was "am I in wp-admin", not "is this a WordPress.com site".

For an end user this means the purchase CTA now matches the admin colour scheme they chose, at a contrast ratio that passes AA, instead of rendering a hard-coded Jetpack black in Odyssey or the decorative olive on WordPress.com.

## Proposed Changes

* **Both purchase screens render `@wordpress/components`' `Button` unconditionally.** The `isWPCOMSite ? CalypsoButton : Button` branch and the now-unused `getIsSiteWPCOM` selector are gone from `stats-purchase-personal.tsx` and `stats-purchase-single-item.tsx`. The secondaries (`I will do it later` / `Start for free`) were already written as `variant="secondary"`, so they convert with no further change.
* **Removed two colour pins from `stats-purchase/styles.scss`** that sat past the token layer and disagreed with each other. `.stats-purchase-wizard .components-button.is-primary` set a `#1a1a1a` fill with a `--studio-gray-80` hover; the WPCOM-scoped selector above it re-stated the rest colour as `--color-accent` but declared no hover. Both tie at (0,4,0), so the black rule's hover won — on WordPress.com that button would have gone accent at rest and grey on hover. The fill, the text colour and every interaction state now come from the component. The shape declarations the wizard needs (radius, font size, padding, `height: auto`, the disabled opacity) stay.
* **Mini-carousel's CTA and dismiss button are design-system buttons.** `__next40pxDefaultSize` preserves the 40px height they have today.
* **Dropped two inline-block workarounds in `mini-carousel-block.scss`.** `border: 0 !important` is unnecessary — a design-system button carries no border of its own. The icon's `vertical-align: middle` / `margin-top: -4px` centred a chevron inside an inline-block button; the design-system button is a flex container that centres it already, so the negative margin would have pushed it 4px off. The `font-size` override drops its `!important` and compounds with `.components-button` instead, winning on specificity rather than force.
* **Removed two link-button colour pins** from the purchase wizard. The WPCOM one resolved `--color-sidebar-menu-selected-background`, which is `#a3b745` on ectoplasm — the decorative highlight, 2.29:1 on white; the other hard-coded `--jp-green-50`. Neither painted anything, because the only `variant="link"` on these screens sits inside `stats-purchase-wizard__notice`, which sets its own colour — but that rule and the WPCOM pin are both (0,4,0), so the notice was only winning on source order. Link buttons now fall through to the interactive-colours mixin like the secondaries and tertiaries.
* **The pricing slider takes the same colour as the CTA beside it.** It was pinned in three places, none of which tracked the admin theme: the vendored `pricing-slider/style.scss` hard-codes `--jp-green-40` for the filled track and thumb border plus a literal `rgba(6, 158, 8, 0.25)` shadow, and two `--is-wpcom` blocks re-pointed the thumb, selected mark and track to `--color-primary` — which resolves to the decorative accent. All now resolve `--wp-admin-theme-color`, with the Jetpack green kept as a `var()` fallback so the vendored slider still renders outside a Stats mount. Both purchase screens share one `TierUpgradeSlider`, so this is one change for both.

### It also fixes a layout bug in wp-admin on every WordPress.com-backed site

Not a colour problem, and worth calling out because the PR would otherwise fix it silently.

Calypso's `Button` renders `class="button"`. Inside wp-admin that is *WordPress core's own admin button class*, and core styles it from `load-styles.php`:

```
.wp-core-ui .button, .wp-core-ui .button-primary, .wp-core-ui .button-secondary
  → display: inline-block; min-height: 40px; margin: 0
.wp-core-ui .button, …
  → padding: 0 14px; line-height: 2.71429; min-height: 40px
```

`.wp-core-ui .button` is (0,2,0). The rule that lays these buttons out — `.stats-purchase-wizard__actions button { display: block; width: 100%; margin-bottom: 12px }` — is (0,1,1), so core outranks it and the layout is silently discarded. Measured on `trunk`: both buttons `display: inline-block`, `margin-bottom: 0`, height 65px, **gap 0** — they touch, and core's `min-height` / `line-height: 2.71` combined with the `padding: 8px 32px` the `--is-wpcom` block adds is what oversizes them.

It needs both conditions at once: `getIsSiteWPCOM` true, so `trunk` picks the Calypso button, *and* wp-admin present for `.wp-core-ui` to exist. Since `getIsSiteWPCOM` is `! isJetpackSite || isAtomicSite`, that covers **Simple and Atomic alike** — every WordPress.com-backed site. Calypso has no `.wp-core-ui`, and self-hosted Jetpack already renders the design-system button, so those two escape it.

Measured in Odyssey across five sites, before → after: Simple free, Simple business, a WordPress.com site and an Atomic site all go from **65px tall with a 0px gap** to **42px with the intended 12px gap**. Only the self-hosted Jetpack site was already correct. So this affects four of the five site types, not just Atomic.

Rendering the design-system button unconditionally removes the collision: `.components-button` does not match core's selector, so the Stats rule applies and the buttons get `display: block` and their 12px gap back. It also drops some dead markup — on `trunk` these render as `<button variant="primary" class="button is-primary">`, with `variant` leaking through as a raw DOM attribute because the ternary hands a `@wordpress/components` prop to Calypso's `Button`.

### The bridge rule stays — scope item 5 is not done

The issue's last step was to delete the `.button.is-primary` bridge once these call sites were converted. **It cannot be deleted.** Those three were the only Calypso primaries *written* in the Stats tree, but not the only ones that *render* inside it. A sweep of every root the mixin is applied at found six survivors, all from shared components outside Stats:

| Source | Reached from |
| --- | --- |
| `client/components/empty-content/index.tsx:42` | four Stats entry points — `site.jsx:806`, `wordads/index.jsx:190`, `stats-email-detail/index.jsx:302`, `stats-post-detail/index.jsx:295` |
| `client/components/banner/index.jsx:330` | `stats-no-content-banner`, via `stats-email-detail/index.jsx:383` |
| `client/blocks/promo-card-block/index.jsx:49` | the Blaze promo card on the annual stats page |
| `packages/components/src/dialog/button-bar.tsx:41` | applies `is-primary` as a **className, not a prop**, and `Dialog` portals into `.ReactModalPortal` — one of the roots the mixin covers. Two reachable: Mark as Spam, and the Blazepress quit prompt |

Converting those is a cross-cutting change across shared Calypso components, not a Stats-local one. The rule now carries a comment naming all four so the next person doesn't repeat the sweep and delete it.

**Separately, and not addressed here:** `client/components/web-preview/toolbar.jsx:210` renders a Calypso primary ("Visit site") that Stats opens from two detail pages, and the mixin has never reached it in either environment — `RootChild` from the `@automattic/components` barrel appends a bare classless `<div>` to `<body>`, matching neither `.stats-main` nor any portal root. Worth its own issue.

### Screenshots

Before / after in [#issuecomment-5406642837](https://github.com/Automattic/wp-calypso/pull/113795#issuecomment-5406642837) — three tables: Odyssey and Calypso, each across five site types and admin schemes, plus the mini-carousel.

## Testing Instructions

Verified locally on `/stats/purchase/:site` (commercial) and `?productType=personal` (pay-what-you-want), in Calypso.

1. Open `/stats/purchase/<site>`. The CTA should fill with your admin colour scheme's colour, **not** black and not the decorative accent.
2. Switch admin colour schemes to confirm it tracks. On **ectoplasm**, `--wp-admin-theme-color` is `#523f6d` while `--color-accent` is `#646c3e`; the button renders `#523f6d`.
3. Hover the CTA — it should darken to a shade of the same colour, never grey.
4. Check `I will do it later` — border and label follow the admin colour.
5. Drag the contribution slider to zero on the personal screen to reach `Continue with Jetpack Stats for free`.
6. In the console: `document.querySelector('.stats-main').querySelectorAll('.button.is-primary').length` returns `0` on both screens.

Measured (default scheme unless noted):

| | Result |
| --- | --- |
| CTA rest | `--wp-admin-theme-color`; changing `--color-accent` has no effect on it |
| CTA hover | `--wp-admin-theme-color-darker-10`, white label |
| CTA focus | 1.5px outline in the theme colour |
| CTA disabled | `opacity: 0.3` preserved |
| CTA text on fill | 6.87:1 |
| Secondary label on white | 5.61:1 |
| Both, on ectoplasm | 9.17:1 |
| Calypso `.button.is-primary` in `.stats-main` | 0, on both screens |

**Also verified in Odyssey**, on a sandbox serving this branch — the environment the `#1a1a1a` pin was actually visible in. Across a self-hosted Jetpack site, a WordPress.com site, an Atomic site and two Simple sites, the CTA, the filled track, the thumb and the selected mark all resolve `--wp-admin-theme-color`, and `.stats-main` holds no `.button.is-primary`. The self-hosted CTA goes from `#1a1a1a` to the admin theme colour; the rest keep their fill and gain the layout fix above.

**And the mini-carousel is now verified against the real component**, not just its compiled CSS. It needs a qualifying promo block, which the private-site banner provides. Before → after: CTA stays 40px (`__next40pxDefaultSize` holding) and takes the theme colour; the dismiss button goes from a white Calypso default to transparent with a `#1e1e1e` label and, importantly, **gains no box-shadow ring** — the specific risk the issue raised. The chevron's `margin-top: -4px` is gone and it sits centred in the flex button.

One caveat on reproducing the mini-carousel: the four promo blocks are dismissed via **account-level** user preferences (`dismissible-mini-carousel-block-*`), so a block dismissed once is hidden on every site. The dev preferences helper in the DEV badge clears them. With two or more blocks enabled the DotPager rotates every 5s, so leave exactly one if you want a stable view.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?



