### PR TITLE
Dashboard: render the plugin switcher with the DataViews list layout

### DIFF
--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -391,36 +391,6 @@
 		border-top-color: var( --dashboard-surface__border-color );
 	}
 
-	.plugin-switcher-item {
-		border-top-color: var( --dashboard-surface__border-color );
-
-		&:focus-visible:not( :disabled ) {
-			box-shadow: inset 0 0 0 2px var( --wp-admin-theme-color );
-			outline: none;
-		}
-
-		&:hover {
-			background-color: color-mix(
-				in srgb,
-				var( --dashboard-surface__background-color ) 82%,
-				var( --wp-admin-theme-color )
-			);
-		}
-
-		&.is-selected {
-			background: var( --dashboard-item-selected__background-color );
-			border-top-color: var( --dashboard-item-selected__border-color );
-
-			&:hover {
-				background: var( --dashboard-item-selected-hover__background-color );
-			}
-		}
-
-		&.is-selected + .plugin-switcher-item {
-			border-top-color: var( --dashboard-item-selected__border-color );
-		}
-	}
-
 	.plugin-icon-wrapper.is-fallback {
 		background: var( --wp-components-color-gray-200 );
 		border-color: var( --wp-components-color-gray-300 );

--- a/client/dashboard/plugins/manage/components/plugin-switcher.scss
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.scss
@@ -1,13 +1,16 @@
 @import '@wordpress/base-styles/breakpoints';
+@import '@wordpress/base-styles/variables';
 @import './variables.scss';
 
 .plugin-switcher-card {
 	overflow-y: hidden;
 }
 
-.plugin-switcher-card-body {
+// The shared DataViews override neutralizes CardBody padding and hides overflow;
+// here the body is the scroll container the list pages into as it grows.
+.components-card__body.plugin-switcher-card-body {
 	max-height: $card-height;
-	padding: 8px 0 0;
+	padding: $grid-unit-10 0 0;
 	overflow-y: auto;
 
 	@media ( max-width: $break-medium ) {
@@ -15,50 +18,15 @@
 	}
 }
 
-.plugin-switcher-search {
-	flex: 1 1 auto;
-	padding: calc(4px * 4) calc(4px * 1) calc(4px * 4) calc(4px * 6);
-	width: fit-content;
+.plugin-switcher-header {
+	padding: $grid-unit-20 $grid-unit-05 $grid-unit-20 $grid-unit-30;
+
+	.dataviews-search {
+		flex: 1 1 auto;
+	}
 }
 
-// Align the empty-state message with the search box and the plugin rows.
-.plugin-switcher-card-body .switcher-content__no-results {
-	padding: calc(4px * 4) calc(4px * 6);
-}
-
-.plugin-switcher-item {
-	border-top: 1px solid #f0f0f0;
-	border-radius: 0;
-	padding: calc(4px * 4) calc(4px * 6);
-
-	&.is-selected {
-		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-		border-top: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
-
-		&:hover {
-			background: rgba(var(--wp-admin-theme-color--rgb), 0.08);
-		}
-
-		.switcher-item__description {
-			color: var(--wp-admin-theme-color);
-		}
-	}
-
-	&.is-selected + & {
-		border-top: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
-	}
-
-	&:hover {
-		background-color: #f8f8f8;
-
-		.switcher-item__description {
-			color: var(--wp-admin-theme-color);
-		}
-	}
-
-	&:focus:not(:disabled),
-	&:focus-visible:not(:disabled) {
-		box-shadow: none;
-		outline: none;
-	}
+.plugin-switcher-no-results {
+	display: block;
+	padding: $grid-unit-20 $grid-unit-30;
 }

--- a/client/dashboard/plugins/manage/components/plugin-switcher.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-switcher.tsx
@@ -1,13 +1,12 @@
+import { useNavigate } from '@tanstack/react-router';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { throttle } from '@wordpress/compose';
-import { Field, View } from '@wordpress/dataviews';
-import { decodeEntities } from '@wordpress/html-entities';
+import { DataViews, filterSortAndPaginate, Field, View } from '@wordpress/dataviews';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import clsx from 'clsx';
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { pluginRoute } from '../../../app/router/plugins';
 import { Card, CardBody } from '../../../components/card';
-import SwitcherContent from '../../../components/switcher/switcher-content';
-import SwitcherItem from '../../../components/switcher/switcher-item';
+import { Text } from '../../../components/text';
 import { PluginListRow } from '../types';
 import { PluginIcon } from './plugin-icon';
 import { PluginUpdatesFilter } from './plugin-updates-filter';
@@ -20,24 +19,86 @@ export const PluginSwitcher = ( {
 	selectedPluginSlug = '',
 	view,
 	onChangeView,
-	paginationInfo,
 }: {
 	pluginsWithIcon: PluginListRow[];
 	searchableFields: Field< PluginListRow >[];
 	selectedPluginSlug?: string;
 	view: View;
 	onChangeView: Dispatch< SetStateAction< View > >;
-	paginationInfo: { totalItems: number; totalPages: number };
 } ) => {
+	const navigate = useNavigate();
 	const scrollRef = useRef< HTMLDivElement >( null );
 	const [ itemsPerPage ] = useState( view.perPage );
 
+	const updatesField = useMemo(
+		() => ( {
+			id: 'hasUpdates',
+			label: __( 'Updates' ),
+			type: 'boolean' as const,
+			elements: [
+				{ value: true, label: __( 'Has updates' ) },
+				{ value: false, label: __( 'No updates' ) },
+			],
+			getValue: ( { item }: { item: PluginListRow } ) => item.sitesWithPluginUpdate.length > 0,
+		} ),
+		[]
+	);
+
+	const fields: Field< PluginListRow >[] = useMemo(
+		() => [
+			...searchableFields.map( ( searchableField ) => ( {
+				...searchableField,
+				enableGlobalSearch: true,
+			} ) ),
+			{
+				id: 'icon',
+				label: __( 'Plugin icon' ),
+				render: ( { item }: { item: PluginListRow } ) => <PluginIcon item={ item } />,
+				enableSorting: false,
+			},
+			{
+				id: 'sites',
+				label: __( 'Sites' ),
+				getValue: ( { item }: { item: PluginListRow } ) => item.sitesCount,
+				render: ( { item }: { item: PluginListRow } ) => {
+					const sitesText = sprintf(
+						// translators: %(siteCount)d is the number of sites the plugin is installed on.
+						_n( '%(siteCount)d site', '%(siteCount)d sites', item.sitesCount ),
+						{ siteCount: item.sitesCount }
+					);
+
+					const updatesText = item.sitesWithPluginUpdate.length
+						? sprintf(
+								// translators: %(updateCount)d is the number of updates available.
+								_n(
+									'%(updateCount)d update available',
+									'%(updateCount)d updates available',
+									item.sitesWithPluginUpdate.length
+								),
+								{ updateCount: item.sitesWithPluginUpdate.length }
+						  )
+						: '';
+
+					return (
+						<Text truncate numberOfLines={ 1 }>
+							{ updatesText ? `${ sitesText }, ${ updatesText }` : sitesText }
+						</Text>
+					);
+				},
+				enableSorting: false,
+			},
+			updatesField,
+		],
+		[ searchableFields, updatesField ]
+	);
+
+	const { data, paginationInfo } = useMemo(
+		() => filterSortAndPaginate( pluginsWithIcon, view, fields ),
+		[ pluginsWithIcon, view, fields ]
+	);
+
 	// Load next page when scrolling near bottom
 	const handleLoadMore = useCallback( () => {
-		if ( ! paginationInfo ) {
-			return;
-		}
-
 		if ( paginationInfo.totalPages > 1 ) {
 			onChangeView( ( currentView ) => ( {
 				...currentView,
@@ -51,7 +112,7 @@ export const PluginSwitcher = ( {
 	useEffect( () => {
 		const menuElement = scrollRef.current;
 
-		if ( ! menuElement || ! paginationInfo ) {
+		if ( ! menuElement ) {
 			return;
 		}
 
@@ -70,76 +131,33 @@ export const PluginSwitcher = ( {
 
 		menuElement.addEventListener( 'scroll', handleScroll );
 		return () => menuElement.removeEventListener( 'scroll', handleScroll );
-	}, [ handleLoadMore, paginationInfo ] );
-
-	const itemClassName = useCallback(
-		( item: PluginListRow ) =>
-			clsx( 'plugin-switcher-item', {
-				'is-selected': selectedPluginSlug === item.slug,
-			} ),
-		[ selectedPluginSlug ]
-	);
-
-	const renderItem = useCallback( ( { item }: { item: PluginListRow } ) => {
-		const sitesText = sprintf(
-			// translators: %(siteCount)d is the number of sites the plugin is installed on.
-			_n( '%(siteCount)d site', '%(siteCount)d sites', item.sitesCount ),
-			{ siteCount: item.sitesCount }
-		);
-
-		const updatesText = item.sitesWithPluginUpdate.length
-			? sprintf(
-					// translators: %(updateCount)d is the number of updates available.
-					_n(
-						'%(updateCount)d update available',
-						'%(updateCount)d updates available',
-						item.sitesWithPluginUpdate.length
-					),
-					{ updateCount: item.sitesWithPluginUpdate.length }
-			  )
-			: '';
-
-		return (
-			<SwitcherItem
-				alignment="start"
-				spacing={ 3 }
-				media={ <PluginIcon item={ item } /> }
-				title={ decodeEntities( item.name ) }
-				description={ updatesText ? `${ sitesText }, ${ updatesText }` : sitesText }
-			/>
-		);
-	}, [] );
-
-	const updatesField = useMemo(
-		() => ( {
-			id: 'hasUpdates',
-			type: 'boolean' as const,
-			elements: [
-				{ value: true, label: __( 'Has updates' ) },
-				{ value: false, label: __( 'No updates' ) },
-			],
-			getValue: ( { item }: { item: PluginListRow } ) => item.sitesWithPluginUpdate.length > 0,
-		} ),
-		[]
-	);
+	}, [ handleLoadMore ] );
 
 	return (
 		<Card className="plugin-switcher-card">
 			<CardBody className="plugin-switcher-card-body" ref={ scrollRef }>
-				<SwitcherContent
-					itemClassName={ itemClassName }
-					searchClassName="plugin-switcher-search"
+				<DataViews< PluginListRow >
+					data={ data }
+					fields={ fields }
 					view={ view }
 					onChangeView={ onChangeView }
-					items={ pluginsWithIcon }
-					resetScroll={ false }
-					getItemUrl={ ( item ) => pluginRoute.to.replace( '$pluginId', item.slug ) }
-					renderItem={ renderItem }
-					searchableFields={ searchableFields }
-					noResultsText={ __( 'No plugins found.' ) }
-					onClose={ () => {} }
-					width="auto"
-					filter={
+					paginationInfo={ paginationInfo }
+					defaultLayouts={ { list: {} } }
+					getItemId={ ( item ) => item.slug }
+					selection={ selectedPluginSlug ? [ selectedPluginSlug ] : [] }
+					onChangeSelection={ ( slugs ) => {
+						if ( slugs[ 0 ] ) {
+							navigate( { to: pluginRoute.to, params: { pluginId: slugs[ 0 ] } } );
+						}
+					} }
+					empty={
+						<Text variant="muted" className="plugin-switcher-no-results">
+							{ __( 'No plugins found.' ) }
+						</Text>
+					}
+				>
+					<HStack className="plugin-switcher-header" justify="flex-start" spacing={ 1 }>
+						<DataViews.Search label={ __( 'Search' ) } />
 						<PluginUpdatesFilter
 							siteCount={
 								pluginsWithIcon.filter( ( plugin ) => plugin.sitesWithPluginUpdate.length > 0 )
@@ -149,9 +167,9 @@ export const PluginSwitcher = ( {
 							view={ view }
 							onChangeView={ onChangeView }
 						/>
-					}
-					filterField={ updatesField }
-				/>
+					</HStack>
+					<DataViews.Layout />
+				</DataViews>
 			</CardBody>
 		</Card>
 	);

--- a/client/dashboard/plugins/manage/components/test/plugin-switcher.test.tsx
+++ b/client/dashboard/plugins/manage/components/test/plugin-switcher.test.tsx
@@ -24,6 +24,10 @@ const baseView: View = {
 	page: 1,
 	perPage: 100,
 	sort: { field: 'name', direction: 'asc' },
+	fields: [],
+	mediaField: 'icon',
+	titleField: 'name',
+	descriptionField: 'sites',
 };
 
 describe( '<PluginSwitcher> – no-results empty state (DOTMSD-1343)', () => {
@@ -34,7 +38,6 @@ describe( '<PluginSwitcher> – no-results empty state (DOTMSD-1343)', () => {
 				searchableFields={ searchableFields }
 				view={ { ...baseView, search: 'zzznotarealplugin' } }
 				onChangeView={ () => {} }
-				paginationInfo={ { totalItems: 0, totalPages: 0 } }
 			/>
 		);
 
@@ -50,7 +53,6 @@ describe( '<PluginSwitcher> – no-results empty state (DOTMSD-1343)', () => {
 				searchableFields={ searchableFields }
 				view={ baseView }
 				onChangeView={ () => {} }
-				paginationInfo={ { totalItems: 0, totalPages: 0 } }
 			/>
 		);
 

--- a/client/dashboard/plugins/manage/index.tsx
+++ b/client/dashboard/plugins/manage/index.tsx
@@ -9,6 +9,7 @@ import { useParams } from '@tanstack/react-router';
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { filterSortAndPaginate, View } from '@wordpress/dataviews';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { useMemo, useState } from 'react';
 import Breadcrumbs from '../../app/breadcrumbs';
@@ -29,11 +30,15 @@ const DEFAULT_VIEW: View = {
 	page: 1,
 	perPage: 100,
 	sort: { field: 'name', direction: 'asc' },
+	fields: [],
+	mediaField: 'icon',
+	titleField: 'name',
+	descriptionField: 'sites',
 };
 const searchableFields = [
 	{
 		id: 'name',
-		getValue: ( { item }: { item: PluginListRow } ) => item.name,
+		getValue: ( { item }: { item: PluginListRow } ) => decodeEntities( item.name ),
 	},
 	{
 		id: 'slug',
@@ -53,7 +58,7 @@ export default function PluginsList() {
 			enableGlobalSearch: true,
 		} ) );
 	}, [] );
-	const { data: plugins, paginationInfo } = useMemo(
+	const { data: plugins } = useMemo(
 		() =>
 			filterSortAndPaginate(
 				mapApiPluginsToDataViewPlugins( sitesById, sitesPlugins ),
@@ -154,7 +159,6 @@ export default function PluginsList() {
 						searchableFields={ searchableFields }
 						view={ view }
 						onChangeView={ setView }
-						paginationInfo={ paginationInfo }
 					/>
 				) }
 				{ ! sitesPluginsLoading && <PerformanceTrackerStop /> }
@@ -179,7 +183,6 @@ export default function PluginsList() {
 					selectedPluginSlug={ selectedPluginSlug }
 					view={ view }
 					onChangeView={ setView }
-					paginationInfo={ paginationInfo }
 				/>
 
 				<PluginSites selectedPluginSlug={ selectedPluginSlug } />


### PR DESCRIPTION
## Proposed Changes

* The plugin list on Manage plugins is now a real DataViews list layout, with the plugin icon as the media field, the plugin name as the title field, and the site/update count as a description field.
* Selecting a row navigates to that plugin; the current plugin is the list's selection, which is what gives the row its highlight.
* Most of the switcher's bespoke styling is gone — row borders, padding, hover and selected states, and the dark-mode overrides now come from the shared list layout.

## Why are these changes being made?

Stacked on #113796, which split the plugin *site tables* into title and description fields. The list on the left looked like it followed the same pattern but didn't: it declared `type: 'list'` while rendering through a hand-built menu, so the view's title/media/description settings were inert and every visual detail was reproduced locally in CSS. This makes the declaration real, so the list picks up the shared list styling — including the dark mode and alignment work — instead of tracking it by hand.

## Considerations

The one behavioral trade-off: DataViews' list layout drives rows through selection, not links. Previously each row was an anchor, so plugins could be opened in a new tab, middle-clicked, or have their link copied. Rows are now buttons that navigate on click, matching how the list layout works everywhere else in the dashboard. Keyboard navigation, the selected-row highlight, and scroll-into-view for the selected plugin come from the layout and are unchanged or better.

Kept deliberately out of scope: the other five switchers (sites, agency sites, domains, referrals, omnibar) still render through the shared `SwitcherContent`. They live in dropdowns where the popover, keyboard handling and link semantics matter more, so they're worth converting — or not — on their own evidence rather than in this PR.

Infinite scroll still uses the existing scroll listener that grows `perPage`; DataViews' own infinite scroll is a separate follow-up.

## Testing Instructions

* Go to Plugins → Manage plugins. The list should look the same as before: 48px icons, name over the site count, one row highlighted.
* Click through several plugins — the URL and the right-hand pane should follow, and the highlight should move.
* Navigate the list with the arrow keys and Enter.
* Search for something that matches nothing; you should get "No plugins found."
* Toggle the "Update available" filter.
* Check the same screen in dark mode, including hover and the selected row.
* Narrow the window below the xlarge breakpoint — the list should still work as the full-width plugin picker.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRTbaMxM3krqCeKKb9UMZB