### PR TITLE
Dashboard: top-align the activity log event icon with its text

### DIFF
--- a/client/dashboard/components/logs-activity/activity-event.scss
+++ b/client/dashboard/components/logs-activity/activity-event.scss
@@ -8,6 +8,9 @@
 	background-color: var(--wp-components-color-gray-100, $gray-100);
 	border-radius: $radius-small;
 	padding: 4px;
+	// The icon box is taller than a text line, so pull it up to sit centred on the
+	// first line rather than a few pixels below it.
+	margin-block-start: -4px;
 
 	@include ui-mixins.when-dark-theme {
 		background-color: var(--wp-components-color-gray-200);

--- a/client/dashboard/components/logs-activity/activity-event.tsx
+++ b/client/dashboard/components/logs-activity/activity-event.tsx
@@ -11,7 +11,7 @@ export function ActivityEvent( { activity }: { activity: Activity } ) {
 		: null;
 
 	return (
-		<HStack spacing="2" alignment="left" className="site-activity-logs__event">
+		<HStack spacing="2" alignment="topLeft" className="site-activity-logs__event">
 			{ activityIcon && (
 				<Icon
 					className="site-activity-logs__event-icon"


### PR DESCRIPTION
## Proposed Changes

* Activity log rows align their icon and text to the top of the cell instead of centring them against the whole cell.
* The icon is pulled up so it still sits centred on the first line of text, rather than a few pixels below it.

| Before | After |
| - | - |
|<img width="742" height="252" alt="image" src="https://github.com/user-attachments/assets/650a842c-046c-431a-a8ac-8402b4d4d27e" />|<img width="686" height="241" alt="image" src="https://github.com/user-attachments/assets/a0a41faf-690a-49eb-a55c-b0e37e12d6d8" />|

## Why are these changes being made?

When an event's text wraps to a second line — a login, or a backup summary in a narrow window — the icon floated to the vertical middle of the block, so it lined up with the gap between the two lines instead of with the event title. The date in the neighbouring column stays on the first line, so the row read as three things at three different heights.

Aligning to the top alone would have fixed the wrapped rows but nudged every single-line row 4px out, because the icon's box is taller than a line of text. Pulling the icon up by that difference keeps both cases right: the icon is centred on the first line whether or not the text wraps.

## Testing Instructions

* Open a site → Logs → Activity.
* Find a row whose text wraps to two lines (a "Login succeeded" entry, or narrow the window until the backup summaries wrap). The icon should sit alongside the event title, not between the two lines.
* Check that single-line rows are unchanged — icon, date and title still read as one line.
* Check the same in dark mode.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
