### PR TITLE
Dashboard: size the Active upgrades media to 48px and mute its description links

### DIFF
--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -74,8 +74,10 @@ export function BillingPurchaseInfoPopover( { children }: { children: ReactNode 
 }
 
 function ProductIcon( { icon, label }: { icon: ReactElement; label: string } ) {
-	const containerSize = 36;
-	const iconSize = 20;
+	// Matches the media size the other dashboard DataViews use, and the ratio
+	// SiteIcon's letter fallback draws its initial at.
+	const containerSize = 48;
+	const iconSize = 24;
 	return (
 		<span
 			aria-label={ label }
@@ -97,7 +99,7 @@ function ProductIcon( { icon, label }: { icon: ReactElement; label: string } ) {
 }
 
 function PurchaseItemSiteIcon( { site, purchase }: { site?: Site; purchase: Purchase } ) {
-	const size = 36;
+	const size = 48;
 
 	if ( purchase.is_jetpack_plan_or_product ) {
 		return (

--- a/client/dashboard/me/billing-purchases/purchase-product.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-product.tsx
@@ -22,7 +22,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 					  sprintf( __( 'View %(siteName)s' ), { siteName: site.name } );
 			const linkText = site.name === site.slug ? __( 'View site' ) : site.slug;
 			return (
-				<div className="billing-purchase__product">
+				<div>
 					{ createInterpolateElement(
 						sprintf(
 							// translators: %(purchaseType)s: the product name. The string also contains the name of the site and the URL for the site e.g. Premium plan for Block Store (blockstore.com)
@@ -34,6 +34,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 						{
 							siteName: (
 								<RouterLinkButton
+									className="billing-purchase__site-link"
 									variant="link"
 									to={ purchasesRoute.fullPath }
 									search={ { site: site.ID } }
@@ -48,7 +49,12 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 								</RouterLinkButton>
 							),
 							siteDomain: (
-								<ExternalLink href={ 'https://' + site.slug } rel="noreferrer" title={ linkTitle }>
+								<ExternalLink
+									className="billing-purchase__site-url"
+									href={ 'https://' + site.slug }
+									rel="noreferrer"
+									title={ linkTitle }
+								>
 									{ linkText }
 								</ExternalLink>
 							),
@@ -60,7 +66,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 
 		if ( productType && site.slug ) {
 			return (
-				<div className="billing-purchase__product">
+				<div>
 					{ createInterpolateElement(
 						// translators: %(purchaseType)s: the product name. The string also contains the URL of the site and a link to visit the site (e.g. "Premium plan for blockstore.com (view site)")
 						sprintf( __( '%(purchaseType)s for <siteDomain /> (<viewSite />)' ), {
@@ -69,6 +75,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 						{
 							siteDomain: (
 								<RouterLinkButton
+									className="billing-purchase__site-link"
 									variant="link"
 									to={ purchasesRoute.fullPath }
 									search={ { site: site.ID } }
@@ -84,6 +91,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 							),
 							viewSite: (
 								<ExternalLink
+									className="billing-purchase__site-url"
 									href={ 'https://' + site.slug }
 									rel="noreferrer"
 									title={ __( 'View site' ) }
@@ -105,13 +113,14 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 					  sprintf( __( 'View %(siteName)s' ), { siteName: site.name } );
 			const linkText = site.name === site.slug ? __( 'View site' ) : site.slug;
 			return (
-				<div className="billing-purchase__product">
+				<div>
 					{ createInterpolateElement(
 						// translators: The string contains the name of the site, and the URL of the site e.g. for Block Store (blockstore.com)
 						__( 'for <siteName /> (<viewSite />)' ),
 						{
 							siteName: (
 								<RouterLinkButton
+									className="billing-purchase__site-link"
 									variant="link"
 									to={ purchasesRoute.fullPath }
 									search={ { site: site.ID } }
@@ -126,7 +135,12 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 								</RouterLinkButton>
 							),
 							viewSite: (
-								<ExternalLink href={ 'https://' + site.slug } rel="noreferrer" title={ linkTitle }>
+								<ExternalLink
+									className="billing-purchase__site-url"
+									href={ 'https://' + site.slug }
+									rel="noreferrer"
+									title={ linkTitle }
+								>
 									{ linkText }
 								</ExternalLink>
 							),
@@ -139,7 +153,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 
 	if ( ! site && productType ) {
 		return (
-			<div className="billing-purchase__product">
+			<div>
 				{ createInterpolateElement(
 					sprintf(
 						// translators: %(purchaseType)s: the product name, %(site)s: the site domain, followed by a link to view the site (e.g. "Premium plan for blockstore.com (view site)")
@@ -152,6 +166,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 					{
 						viewSite: (
 							<ExternalLink
+								className="billing-purchase__site-url"
 								href={ 'https://' + purchase.domain }
 								rel="noreferrer"
 								title={ __( 'View site' ) }

--- a/client/dashboard/me/billing-purchases/purchase-product.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-product.tsx
@@ -22,7 +22,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 					  sprintf( __( 'View %(siteName)s' ), { siteName: site.name } );
 			const linkText = site.name === site.slug ? __( 'View site' ) : site.slug;
 			return (
-				<div>
+				<div className="billing-purchase__product">
 					{ createInterpolateElement(
 						sprintf(
 							// translators: %(purchaseType)s: the product name. The string also contains the name of the site and the URL for the site e.g. Premium plan for Block Store (blockstore.com)
@@ -60,7 +60,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 
 		if ( productType && site.slug ) {
 			return (
-				<div>
+				<div className="billing-purchase__product">
 					{ createInterpolateElement(
 						// translators: %(purchaseType)s: the product name. The string also contains the URL of the site and a link to visit the site (e.g. "Premium plan for blockstore.com (view site)")
 						sprintf( __( '%(purchaseType)s for <siteDomain /> (<viewSite />)' ), {
@@ -105,7 +105,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 					  sprintf( __( 'View %(siteName)s' ), { siteName: site.name } );
 			const linkText = site.name === site.slug ? __( 'View site' ) : site.slug;
 			return (
-				<div>
+				<div className="billing-purchase__product">
 					{ createInterpolateElement(
 						// translators: The string contains the name of the site, and the URL of the site e.g. for Block Store (blockstore.com)
 						__( 'for <siteName /> (<viewSite />)' ),
@@ -139,7 +139,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 
 	if ( ! site && productType ) {
 		return (
-			<div>
+			<div className="billing-purchase__product">
 				{ createInterpolateElement(
 					sprintf(
 						// translators: %(purchaseType)s: the product name, %(site)s: the site domain, followed by a link to view the site (e.g. "Premium plan for blockstore.com (view site)")

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -84,6 +84,11 @@ button.purchase-payment-method__update {
 .billing-purchase__site-url,
 .billing-purchase__site-url:visited {
 	text-decoration: none;
+
+	// `ExternalLink` underlines its inner span rather than the anchor.
+	.components-external-link__contents {
+		text-decoration: none;
+	}
 }
 
 .billing-purchase__site-link,

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -77,24 +77,29 @@ button.purchase-payment-method__update {
 	padding: 0 12px 12px 12px;
 }
 
-// The product description is secondary text, so its links stay muted until hover —
-// the same treatment `a.dataviews-url-field` gives URLs on the Sites list. The
-// `is-link` selectors are there to outweigh `Button`'s own link styling.
-.billing-purchase__product {
-	a,
-	a:visited,
-	a.is-link,
-	a.is-link:visited {
-		color: var(--dashboard__text-muted-color);
+// The description line is secondary text, so neither of its links gets the
+// underlined brand blue a link would normally take: the site name reads as part
+// of the sentence, and only the site URL stays coloured. The `is-link` selectors
+// are there to outweigh `Button`'s own link styling.
+.billing-purchase__site-url,
+.billing-purchase__site-url:visited {
+	text-decoration: none;
+}
+
+.billing-purchase__site-link,
+.billing-purchase__site-link:visited,
+a.is-link.billing-purchase__site-link,
+a.is-link.billing-purchase__site-link:visited {
+	color: var( --dashboard__text-color );
+	font-weight: 500;
+	text-decoration: none;
+
+	span {
 		text-decoration: none;
 	}
+}
 
-	a:hover,
-	a.is-link:hover {
-		color: var(--wp-admin-theme-color);
-	}
-
-	a span {
-		text-decoration: none;
-	}
+.billing-purchase__site-link:hover,
+a.is-link.billing-purchase__site-link:hover {
+	color: var( --wp-admin-theme-color );
 }

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -76,3 +76,25 @@ button.purchase-payment-method__update {
 .paypal-fields {
 	padding: 0 12px 12px 12px;
 }
+
+// The product description is secondary text, so its links stay muted until hover —
+// the same treatment `a.dataviews-url-field` gives URLs on the Sites list. The
+// `is-link` selectors are there to outweigh `Button`'s own link styling.
+.billing-purchase__product {
+	a,
+	a:visited,
+	a.is-link,
+	a.is-link:visited {
+		color: var(--dashboard__text-muted-color);
+		text-decoration: none;
+	}
+
+	a:hover,
+	a.is-link:hover {
+		color: var(--wp-admin-theme-color);
+	}
+
+	a span {
+		text-decoration: none;
+	}
+}


### PR DESCRIPTION
## Proposed Changes

* The product icon on Active upgrades is 48px, matching the media on the other dashboard lists. The generic product icons (email, plugin, theme, storage, domain) grow with it.
* Neither link inside the product description is underlined any more. The site name is dark and semibold so it reads as part of the sentence, and takes the theme colour on hover; the site URL keeps the link colour.

| Before | After |
| - | - |
|<img width="1049" height="118" alt="image" src="https://github.com/user-attachments/assets/1d0bce95-d463-43d0-9c01-8fadc4de0d41" />|<img width="1186" height="124" alt="image" src="https://github.com/user-attachments/assets/3de8bc9e-46aa-4311-87ab-fc73897a5813" />|

## Why are these changes being made?

Active upgrades hardcoded its icon at 36px, which is its own number — the Sites list and the scheduled-updates site picker both render their media at the shared 48px default, and DataViews' own list layout uses 48px too. A row on Active upgrades therefore sat on a slightly different rhythm to every other list in the dashboard.

The generic product icons drew their glyph at 20px inside a 36px box. They now use half the box, the same ratio the site icon's letter fallback uses for its initial, so a lettered site icon and a product glyph read at the same weight side by side.

The DataViews table caps primary-column media at 60px, so 48px stays within what the layout expects.

The description line carried two brand-blue underlined links, which pulled more attention than the product title above them. The underlines are gone from both — the same thing the shared `dataviews-url-field` rule does for URLs on the Sites list.

The two links are doing different jobs, so they don't get the same colour. The site name filters the list in place; it belongs to the sentence around it, so it takes the dashboard's own text colour and a little extra weight, which also gives the row a second anchor next to the product title. The site URL leaves the dashboard, so it keeps the link colour that says so. Both colours come from tokens rather than fixed values, so dark mode follows without a separate override.

## Testing Instructions

* Go to Me → Billing → Active upgrades.
* Icons should be 48px and line up with the product title beside them, matching the icon size on the Sites list.
* In the description, the site name should be dark and semibold and the site URL blue, neither underlined; the site name should turn blue on hover. Both should still navigate — the site name filters the list to that site, the URL opens the site in a new tab.
* Check a few different purchase types if you have them — a plan on a site (site icon), a domain (globe), email, a marketplace plugin, a theme, a storage add-on, and a Jetpack/Akismet product.
* Check the same in dark mode.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

