### PR TITLE
Login: keep challenge spacing tied to the rendered widget

### DIFF
--- a/client/blocks/login/blackbox-challenge.jsx
+++ b/client/blocks/login/blackbox-challenge.jsx
@@ -19,23 +19,19 @@ export default function BlackboxChallenge( { enabled, onSubmitBlockedChange } ) 
 	} );
 
 	useIsomorphicLayoutEffect( () => {
-		onSubmitBlockedChange( isChallengeActive || isLoading || hasChallengeContent );
-	}, [ isChallengeActive, isLoading, hasChallengeContent, onSubmitBlockedChange ] );
+		onSubmitBlockedChange( isChallengeActive || isLoading );
+	}, [ isChallengeActive, isLoading, onSubmitBlockedChange ] );
 
 	if ( ! enabled ) {
 		return null;
 	}
 
-	// The container always renders while enabled so the challenge has a mount
-	// point, but it only takes up space once a challenge is actually showing.
-	// Flag that state so the stylesheet reserves spacing only then.
-	const isChallengeVisible = isChallengeActive || hasChallengeContent;
-
+	// The container is a permanent mount point; only a rendered widget takes space.
 	return (
 		<div
 			ref={ containerRef }
 			className={ clsx( 'login__form-blackbox-challenge', {
-				'has-visible-challenge': isChallengeVisible,
+				'has-visible-challenge': hasChallengeContent,
 			} ) }
 		/>
 	);

--- a/client/blocks/login/test/blackbox-challenge.jsx
+++ b/client/blocks/login/test/blackbox-challenge.jsx
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render } from '@testing-library/react';
+import { useBlackbox } from 'calypso/blocks/login/utils/use-blackbox';
+import BlackboxChallenge from '../blackbox-challenge';
+
+jest.mock( 'calypso/blocks/login/utils/use-blackbox', () => ( {
+	useBlackbox: jest.fn(),
+} ) );
+
+function renderChallenge( state, onSubmitBlockedChange = jest.fn() ) {
+	useBlackbox.mockReturnValue( {
+		isChallengeActive: false,
+		isLoading: false,
+		hasChallengeContent: false,
+		...state,
+	} );
+
+	const { container } = render(
+		<BlackboxChallenge enabled onSubmitBlockedChange={ onSubmitBlockedChange } />
+	);
+
+	return container.querySelector( '.login__form-blackbox-challenge' );
+}
+
+describe( 'BlackboxChallenge', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'spaces the container while the widget occupies space', () => {
+		expect( renderChallenge( { hasChallengeContent: true } ) ).toHaveClass(
+			'has-visible-challenge'
+		);
+	} );
+
+	test( 'does not space the container before the widget has rendered', () => {
+		expect( renderChallenge( { isChallengeActive: true } ) ).not.toHaveClass(
+			'has-visible-challenge'
+		);
+	} );
+
+	test( 'unblocks submit once the challenge completes, even though the widget stays mounted', () => {
+		const onSubmitBlockedChange = jest.fn();
+
+		renderChallenge( { hasChallengeContent: true }, onSubmitBlockedChange );
+
+		expect( onSubmitBlockedChange ).toHaveBeenLastCalledWith( false );
+	} );
+
+	test( 'blocks submit while a challenge is active', () => {
+		const onSubmitBlockedChange = jest.fn();
+
+		renderChallenge( { isChallengeActive: true }, onSubmitBlockedChange );
+
+		expect( onSubmitBlockedChange ).toHaveBeenLastCalledWith( true );
+	} );
+} );

--- a/client/blocks/login/utils/test/use-blackbox.jsx
+++ b/client/blocks/login/utils/test/use-blackbox.jsx
@@ -32,17 +32,40 @@ function TestComponent( { enabled = true } ) {
 }
 
 describe( 'useBlackbox', () => {
+	let resizeCallbacks;
+
+	// jsdom has no layout and no ResizeObserver, so fake both.
+	function setContainerHeight( height ) {
+		Object.defineProperty( screen.getByTestId( 'blackbox-container' ), 'offsetHeight', {
+			configurable: true,
+			value: height,
+		} );
+		resizeCallbacks.forEach( ( callback ) => callback() );
+	}
+
 	beforeEach( () => {
 		jest.useFakeTimers();
 		jest.clearAllMocks();
 		window.Blackbox = {
 			configure: jest.fn(),
 		};
+		resizeCallbacks = new Set();
+		window.ResizeObserver = class {
+			constructor( callback ) {
+				this.callback = callback;
+				resizeCallbacks.add( callback );
+			}
+			observe() {}
+			disconnect() {
+				resizeCallbacks.delete( this.callback );
+			}
+		};
 	} );
 
 	afterEach( () => {
 		jest.useRealTimers();
 		delete window.Blackbox;
+		delete window.ResizeObserver;
 	} );
 
 	test( 'keeps Blackbox loading until configure has had time to settle', async () => {
@@ -97,7 +120,24 @@ describe( 'useBlackbox', () => {
 		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
 	} );
 
-	test( 'tracks challenge container content as a blocking signal', async () => {
+	test( 'tracks the rendered challenge widget by measuring the container', async () => {
+		render( <TestComponent /> );
+
+		await act( async () => {} );
+		act( () => jest.advanceTimersByTime( 500 ) );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+
+		act( () => setContainerHeight( 46 ) );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/content' );
+
+		act( () => setContainerHeight( 0 ) );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+	} );
+
+	test( 'keeps tracking the widget after a solve, since the SDK leaves it mounted', async () => {
 		let callbacks;
 		window.Blackbox.configure.mockImplementationOnce( ( config ) => {
 			callbacks = config;
@@ -106,19 +146,14 @@ describe( 'useBlackbox', () => {
 		render( <TestComponent /> );
 
 		await act( async () => {} );
-		act( () => jest.advanceTimersByTime( 500 ) );
+		act( () => callbacks.onChallengeStart() );
+		act( () => setContainerHeight( 46 ) );
 
-		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
-
-		await act( async () => {
-			screen.getByTestId( 'blackbox-container' ).appendChild( document.createElement( 'iframe' ) );
-		} );
-
-		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/content' );
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/active/content' );
 
 		act( () => callbacks.onChallengeComplete() );
 
-		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/content' );
 	} );
 
 	test( 'does not load the SDK while disabled', async () => {

--- a/client/blocks/login/utils/use-blackbox.js
+++ b/client/blocks/login/utils/use-blackbox.js
@@ -28,17 +28,17 @@ export function useBlackbox( { containerRef, enabled } ) {
 	useEffect( () => {
 		const container = containerRef.current;
 
-		if ( ! isEnabled || ! container || typeof window.MutationObserver !== 'function' ) {
+		if ( ! isEnabled || ! container || typeof window.ResizeObserver !== 'function' ) {
 			return;
 		}
 
 		const updateHasChallengeContent = () => {
-			setHasChallengeContent( container.childElementCount > 0 );
+			setHasChallengeContent( container.offsetHeight > 0 );
 		};
-		const observer = new window.MutationObserver( updateHasChallengeContent );
+		const observer = new window.ResizeObserver( updateHasChallengeContent );
 
 		updateHasChallengeContent();
-		observer.observe( container, { childList: true } );
+		observer.observe( container );
 
 		return () => {
 			observer.disconnect();
@@ -109,7 +109,6 @@ export function useBlackbox( { containerRef, enabled } ) {
 							if ( hasStartedChallenge ) {
 								stopLoading();
 							}
-							setHasChallengeContent( false );
 							setIsChallengeActive( false );
 						}
 					},
@@ -118,7 +117,6 @@ export function useBlackbox( { containerRef, enabled } ) {
 							if ( hasStartedChallenge ) {
 								stopLoading();
 							}
-							setHasChallengeContent( false );
 							setIsChallengeActive( false );
 						}
 					},


### PR DESCRIPTION
The SDK leaves an inline widget mounted after a solve, but `onChallengeComplete` cleared `hasChallengeContent`, so `has-visible-challenge` disappeared when the "Verified" state is reached and our margin disappears.

`hasChallengeContent` never fired anyway: it counted light-DOM children, and the widget renders into a closed shadow root. Measure the host with a `ResizeObserver` instead, which also covers the teardowns the SDK does without a callback (`reset()`, runner errors) and the bundle-load failure that leaves `onChallengeStart` unanswered.

### Before

Note the missing margin in verified state.

<img width="3436" height="884" alt="CleanShot 2026-08-25 at 10 16 25@2x" src="https://github.com/user-attachments/assets/2d3b34c5-5d38-4251-bfda-f90f8bf5ff08" />
<img width="3018" height="888" alt="CleanShot 2026-08-25 at 10 17 49@2x" src="https://github.com/user-attachments/assets/30e0c7cf-2906-4eb1-96eb-a8985b6490db" />

### After

<img width="3458" height="764" alt="CleanShot 2026-08-25 at 10 13 42@2x" src="https://github.com/user-attachments/assets/a21cfa3d-d3e1-4463-8300-deba5be63662" />
<img width="2978" height="958" alt="CleanShot 2026-08-25 at 10 18 16@2x" src="https://github.com/user-attachments/assets/fabe61d5-5601-468e-9bf5-fcded9d6da32" />

### Signups

The signup form was fine as is since it uses a slightly different mechanism for the margin:

<img width="3058" height="724" alt="CleanShot 2026-08-25 at 10 13 57@2x" src="https://github.com/user-attachments/assets/17183f6b-21d6-4b7d-abe2-c5ba2669081d" />