### PR TITLE
Help Center: refresh support eligibility after a purchase

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -2,10 +2,11 @@ import { receiptQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
+import { SUPPORT_STATUS_QUERY_KEY } from '@automattic/help-center/src/data/use-support-status';
 import { Step } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { invokeSurvicateEvent } from '@automattic/survicate';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState, useEffect, useRef } from 'react';
@@ -214,6 +215,7 @@ function useRedirectOnTransactionSuccess( {
 		orderId ? getOrderTransactionError( state, orderId ) : null
 	);
 	const reduxDispatch = useDispatch();
+	const queryClient = useQueryClient();
 	const cartKey = useCartKey();
 	const { reloadFromServer: reloadCart } = useShoppingCart( cartKey );
 
@@ -364,6 +366,8 @@ function useRedirectOnTransactionSuccess( {
 			reduxDispatch( requestSite( blogId ) );
 		}
 
+		queryClient.invalidateQueries( { queryKey: SUPPORT_STATUS_QUERY_KEY } );
+
 		// For plan + domain purchases the `domain-and-plan` flow sends the user to
 		// `/home/<site>` instead of the thank-you page. Tag the destination URL with
 		// a `notice` query param so the destination can dispatch a success toast on
@@ -402,6 +406,7 @@ function useRedirectOnTransactionSuccess( {
 		receipt,
 		receiptId,
 		redirectTo,
+		queryClient,
 		reduxDispatch,
 		reloadCart,
 		siteSlug,

--- a/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-submitted-and-processing-callback.tsx
@@ -1,4 +1,6 @@
+import { SUPPORT_STATUS_QUERY_KEY } from '@automattic/help-center/src/data/use-support-status';
 import { useShoppingCart } from '@automattic/shopping-cart';
+import { useQueryClient } from '@tanstack/react-query';
 import { isURL } from '@wordpress/url';
 import debugFactory from 'debug';
 import { useCallback } from 'react';
@@ -108,6 +110,7 @@ export default function useCreatePaymentSubmittedAndProcessingCallback( {
 	);
 
 	const domains = useSiteDomains( siteId ?? undefined );
+	const queryClient = useQueryClient();
 
 	return useCallback(
 		async ( { transactionLastResponse }: PaymentEventCallbackArguments ) => {
@@ -179,6 +182,7 @@ export default function useCreatePaymentSubmittedAndProcessingCallback( {
 			debug( 'transactionResult was', transactionResult );
 
 			reduxDispatch( clearPurchases() );
+			queryClient.invalidateQueries( { queryKey: SUPPORT_STATUS_QUERY_KEY } );
 
 			// Removes the destination cookie only if redirecting to the signup destination.
 			// (e.g. if the destination is an upsell nudge, it does not remove the cookie).
@@ -288,6 +292,7 @@ export default function useCreatePaymentSubmittedAndProcessingCallback( {
 			isComingFromUpsell,
 			isInModal,
 			reduxDispatch,
+			queryClient,
 			siteId,
 			responseCart,
 			createUserAndSiteBeforeTransaction,

--- a/packages/help-center/src/data/use-support-status.ts
+++ b/packages/help-center/src/data/use-support-status.ts
@@ -7,6 +7,8 @@ import { SupportStatus } from '../types';
 // Bump me to invalidate the cache.
 const VERSION = 3;
 
+export const SUPPORT_STATUS_QUERY_KEY = [ 'support-status', VERSION ];
+
 interface APIFetchOptions {
 	global: boolean;
 	path: string;
@@ -16,7 +18,7 @@ export function useSupportStatus( enabled = true ) {
 	const { currentUser } = useHelpCenterContext();
 
 	return useQuery< SupportStatus, Error >( {
-		queryKey: [ 'support-status', VERSION ],
+		queryKey: SUPPORT_STATUS_QUERY_KEY,
 		queryFn: async () =>
 			canAccessWpcomApis()
 				? await wpcomRequest( { path: '/help/support-status', apiNamespace: 'wpcom/v2' } )


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-538/support-eligibility-cache-issues

## Proposed Changes

**The Help Center now re-checks support eligibility as soon as a purchase completes.**

- Exposes the `support-status` query key from `use-support-status`.
- Invalidates that query on checkout success, both in the direct payment callback and on the pending page used by redirect payment methods (PayPal, …).

## Why are these changes being made?

The Help Center asks the server once whether the user is eligible for paid support, then keeps the answer in memory. While the Help Center stays open (or minimized) that answer is never refreshed, so a user who just bought a plan keeps being treated as a free user until they reload the page ([DOTSUP-538](https://linear.app/a8c/issue/DOTSUP-538/support-eligibility-cache-issues)).

## Testing Instructions

1. `yarn start`, log in as a user with no plan, open the Help Center and leave it open or minimized.
2. Buy a plan for one of the user’s sites and land on the thank-you page.
3. Back in the Help Center, chat should offer live human support and the `calypso_helpcenter_page_open` Tracks event should report `is_free_user: false` without a page reload.
