### PR TITLE
Omnibar: fix Reader icon color

### DIFF
--- a/client/dashboard/app/omnibar/plugin-reader.scss
+++ b/client/dashboard/app/omnibar/plugin-reader.scss
@@ -31,6 +31,7 @@ $omnibar-reader-active-radius: 4px;
 .is-global-sidebar-visible .omnibar .omnibar__menu.omnibar__reader.is-active {
 	--omnibar-text-color: var( --color-sidebar-menu-selected-text );
 	--omnibar-highlight-color: var( --color-sidebar-menu-selected-text );
+	--omnibar-icon-color: var( --color-sidebar-menu-selected-text );
 
 	background: var( --color-sidebar-background );
 	border-start-start-radius: $omnibar-reader-active-radius;


### PR DESCRIPTION
## Proposed Changes

Fixes Reader icon color in the omnibar on Reader screens:

Before

<img width="107" height="37" alt="image" src="https://github.com/user-attachments/assets/47daed4c-b2e0-4fe9-ab39-131b9270649c" />

After

<img width="112" height="42" alt="image" src="https://github.com/user-attachments/assets/c5a9a6dd-9e95-4e43-ac60-37ba4752efc4" />
