### PR TITLE
Login: forward the Blackbox session id on two-step requests

### DIFF
--- a/client/blocks/login/test/push-notification-approval-poller.jsx
+++ b/client/blocks/login/test/push-notification-approval-poller.jsx
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { thunk } from 'redux-thunk';
+import PushNotificationApprovalPoller from 'calypso/blocks/login/two-factor-authentication/push-notification-approval-poller';
+
+jest.mock( 'calypso/state/login/actions/remote-login-user', () => ( {
+	remoteLoginUser: jest.fn( () => Promise.resolve() ),
+} ) );
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const mockStore = configureStore( [ thunk ] );
+
+const loginState = ( consumedBlackboxSessionId ) => ( {
+	login: {
+		twoFactorAuth: {
+			user_id: 123456,
+			two_step_nonce_push: 'a-push-nonce',
+			push_web_token: 'a-push-token',
+		},
+		consumedBlackboxSessionId,
+	},
+} );
+
+const renderPoller = ( consumedBlackboxSessionId ) =>
+	render(
+		<Provider store={ mockStore( loginState( consumedBlackboxSessionId ) ) }>
+			<PushNotificationApprovalPoller onSuccess={ () => {} } />
+		</Provider>
+	);
+
+/**
+ * Returns the body of the first poll as a URLSearchParams.
+ */
+const firstPollBody = () => mockFetch.mock.calls[ 0 ][ 1 ].body;
+
+describe( 'PushNotificationApprovalPoller', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockFetch.mockResolvedValue( {
+			json: () => Promise.resolve( { success: true, data: { token_links: [] } } ),
+		} );
+	} );
+
+	test( 'forwards the session id the password step spent', async () => {
+		renderPoller( 'ABCDEFGHIJKLMNOPQRSTuv' );
+
+		await waitFor( () => expect( mockFetch ).toHaveBeenCalled() );
+
+		const [ url, options ] = mockFetch.mock.calls[ 0 ];
+		expect( url ).toContain( 'action=two-step-authentication-endpoint' );
+		expect( options.method ).toBe( 'POST' );
+		expect( firstPollBody().get( 'blackbox_session_id' ) ).toBe( 'ABCDEFGHIJKLMNOPQRSTuv' );
+	} );
+
+	test( 'omits the field when the password step spent no session', async () => {
+		renderPoller( null );
+
+		await waitFor( () => expect( mockFetch ).toHaveBeenCalled() );
+
+		expect( firstPollBody().has( 'blackbox_session_id' ) ).toBe( false );
+	} );
+
+	test( 'leaves the rest of the push payload intact', async () => {
+		renderPoller( 'ABCDEFGHIJKLMNOPQRSTuv' );
+
+		await waitFor( () => expect( mockFetch ).toHaveBeenCalled() );
+
+		const body = firstPollBody();
+		expect( body.get( 'user_id' ) ).toBe( '123456' );
+		expect( body.get( 'auth_type' ) ).toBe( 'push' );
+		expect( body.get( 'two_step_nonce' ) ).toBe( 'a-push-nonce' );
+		expect( body.get( 'two_step_push_token' ) ).toBe( 'a-push-token' );
+	} );
+} );

--- a/client/blocks/login/two-factor-authentication/push-notification-approval-poller.jsx
+++ b/client/blocks/login/two-factor-authentication/push-notification-approval-poller.jsx
@@ -5,6 +5,7 @@ import { useDispatch } from 'react-redux';
 import { updateNonce } from 'calypso/state/login/actions';
 import { remoteLoginUser } from 'calypso/state/login/actions/remote-login-user';
 import {
+	getConsumedBlackboxSessionId,
 	getTwoFactorAuthNonce,
 	getTwoFactorPushToken,
 	getTwoFactorUserId,
@@ -16,6 +17,11 @@ async function request( state ) {
 	const url = localizeUrl(
 		'https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint'
 	);
+	// An approval reports a two-step success on the wpcom side, which is recorded
+	// against the session the password step spent. Without it that success is
+	// dropped and the login reads downstream as a second factor never completed.
+	const blackboxSessionId = getConsumedBlackboxSessionId( state );
+
 	const body = new URLSearchParams( {
 		user_id: getTwoFactorUserId( state ),
 		auth_type: 'push',
@@ -24,6 +30,7 @@ async function request( state ) {
 		two_step_push_token: getTwoFactorPushToken( state ),
 		client_id: config( 'wpcom_signup_id' ),
 		client_secret: config( 'wpcom_signup_key' ),
+		...( blackboxSessionId && { blackbox_session_id: blackboxSessionId } ),
 	} );
 
 	const response = await fetch( url, {

--- a/client/state/login/actions/login-user-with-two-factor-verification-code.js
+++ b/client/state/login/actions/login-user-with-two-factor-verification-code.js
@@ -7,7 +7,7 @@ import {
 import { remoteLoginUser } from 'calypso/state/login/actions/remote-login-user';
 import { updateNonce } from 'calypso/state/login/actions/update-nonce';
 import {
-	getBlackboxSessionId,
+	getConsumedBlackboxSessionId,
 	getTwoFactorAuthNonce,
 	getTwoFactorUserId,
 } from 'calypso/state/login/selectors';
@@ -25,7 +25,7 @@ export const loginUserWithTwoFactorVerificationCode =
 	( twoStepCode, twoFactorAuthType ) => ( dispatch, getState ) => {
 		dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST } );
 
-		const blackboxSessionId = getBlackboxSessionId( getState() );
+		const blackboxSessionId = getConsumedBlackboxSessionId( getState() );
 
 		return postLoginRequest( 'two-step-authentication-endpoint', {
 			user_id: getTwoFactorUserId( getState() ),

--- a/client/state/login/actions/login-user-with-two-factor-verification-code.js
+++ b/client/state/login/actions/login-user-with-two-factor-verification-code.js
@@ -6,7 +6,11 @@ import {
 } from 'calypso/state/action-types';
 import { remoteLoginUser } from 'calypso/state/login/actions/remote-login-user';
 import { updateNonce } from 'calypso/state/login/actions/update-nonce';
-import { getTwoFactorAuthNonce, getTwoFactorUserId } from 'calypso/state/login/selectors';
+import {
+	getBlackboxSessionId,
+	getTwoFactorAuthNonce,
+	getTwoFactorUserId,
+} from 'calypso/state/login/selectors';
 import { getErrorFromHTTPError, postLoginRequest } from 'calypso/state/login/utils';
 
 import 'calypso/state/login/init';
@@ -21,6 +25,8 @@ export const loginUserWithTwoFactorVerificationCode =
 	( twoStepCode, twoFactorAuthType ) => ( dispatch, getState ) => {
 		dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST } );
 
+		const blackboxSessionId = getBlackboxSessionId( getState() );
+
 		return postLoginRequest( 'two-step-authentication-endpoint', {
 			user_id: getTwoFactorUserId( getState() ),
 			auth_type: twoFactorAuthType,
@@ -29,6 +35,7 @@ export const loginUserWithTwoFactorVerificationCode =
 			remember_me: true,
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
+			...( blackboxSessionId && { blackbox_session_id: blackboxSessionId } ),
 		} )
 			.then( ( response ) => {
 				return remoteLoginUser( response?.body?.data?.token_links ?? [] ).then( () => {

--- a/client/state/login/actions/login-user.js
+++ b/client/state/login/actions/login-user.js
@@ -71,9 +71,12 @@ export const loginUser =
 					} );
 				}
 
+				// Carried through state so the two-step request can forward it
+				// without collecting a new session.
 				return dispatch( {
 					type: LOGIN_REQUEST_SUCCESS,
 					data: response.body && response.body.data,
+					blackboxSessionId,
 				} );
 			} )
 			.catch( ( httpError ) => {

--- a/client/state/login/actions/test/login-user-with-two-factor-verification-code.js
+++ b/client/state/login/actions/test/login-user-with-two-factor-verification-code.js
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+import configureStore from 'redux-mock-store';
+import { thunk } from 'redux-thunk';
+import { getBlackboxSessionId } from 'calypso/blocks/login/utils/get-blackbox-session-id';
+import { postLoginRequest } from 'calypso/state/login/utils';
+import { loginUserWithTwoFactorVerificationCode } from '../login-user-with-two-factor-verification-code';
+
+jest.mock( 'calypso/state/login/utils', () => ( {
+	postLoginRequest: jest.fn( () => Promise.resolve( { body: { data: {} } } ) ),
+	getErrorFromHTTPError: jest.fn( () => ( { code: 'error', message: 'error' } ) ),
+} ) );
+
+jest.mock( 'calypso/state/login/actions/remote-login-user', () => ( {
+	remoteLoginUser: jest.fn( () => Promise.resolve() ),
+} ) );
+
+jest.mock( 'calypso/blocks/login/utils/get-blackbox-session-id', () => ( {
+	getBlackboxSessionId: jest.fn( () => Promise.resolve( 'a-freshly-collected-session' ) ),
+} ) );
+
+const mockStore = configureStore( [ thunk ] );
+
+const loginState = ( blackboxSessionId ) => ( {
+	login: {
+		twoFactorAuth: {
+			user_id: 123456,
+			two_step_nonce_authenticator: 'a-two-step-nonce',
+		},
+		blackboxSessionId,
+	},
+} );
+
+const dispatchVerificationCode = ( blackboxSessionId ) =>
+	mockStore( loginState( blackboxSessionId ) ).dispatch(
+		loginUserWithTwoFactorVerificationCode( '123456', 'authenticator' )
+	);
+
+describe( 'loginUserWithTwoFactorVerificationCode', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'forwards the session id captured on the password step', async () => {
+		await dispatchVerificationCode( 'ABCDEFGHIJKLMNOPQRSTuv' );
+
+		const [ action, body ] = postLoginRequest.mock.calls[ 0 ];
+		expect( action ).toBe( 'two-step-authentication-endpoint' );
+		expect( body.blackbox_session_id ).toBe( 'ABCDEFGHIJKLMNOPQRSTuv' );
+	} );
+
+	test( 'omits the field when the password step captured no session', async () => {
+		await dispatchVerificationCode( null );
+
+		const [ , body ] = postLoginRequest.mock.calls[ 0 ];
+		expect( body ).not.toHaveProperty( 'blackbox_session_id' );
+	} );
+
+	test( 'reads the id from state rather than collecting a new session', async () => {
+		await dispatchVerificationCode( 'ABCDEFGHIJKLMNOPQRSTuv' );
+
+		// Collecting here would flush the code entry form's behavioral data and
+		// mint a session unrelated to the one /verify scored.
+		expect( getBlackboxSessionId ).not.toHaveBeenCalled();
+	} );
+
+	test( 'leaves the rest of the two-step payload intact', async () => {
+		await dispatchVerificationCode( 'ABCDEFGHIJKLMNOPQRSTuv' );
+
+		const [ , body ] = postLoginRequest.mock.calls[ 0 ];
+		expect( body ).toMatchObject( {
+			user_id: 123456,
+			auth_type: 'authenticator',
+			two_step_code: '123456',
+			two_step_nonce: 'a-two-step-nonce',
+			remember_me: true,
+		} );
+	} );
+} );

--- a/client/state/login/actions/test/login-user-with-two-factor-verification-code.js
+++ b/client/state/login/actions/test/login-user-with-two-factor-verification-code.js
@@ -28,7 +28,7 @@ const loginState = ( blackboxSessionId ) => ( {
 			user_id: 123456,
 			two_step_nonce_authenticator: 'a-two-step-nonce',
 		},
-		blackboxSessionId,
+		consumedBlackboxSessionId: blackboxSessionId,
 	},
 } );
 

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -321,6 +321,22 @@ export const twoFactorAuth = ( state = null, action ) => {
 	return state;
 };
 
+export const blackboxSessionId = ( state = null, action ) => {
+	switch ( action.type ) {
+		case LOGIN_REQUEST_SUCCESS:
+			return action.blackboxSessionId ?? null;
+		case LOGIN_REQUEST:
+		case LOGIN_REQUEST_FAILURE:
+		case SOCIAL_LOGIN_REQUEST:
+		case SOCIAL_LOGIN_REQUEST_FAILURE:
+		case SOCIAL_LOGIN_REQUEST_SUCCESS:
+		case TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS:
+			return null;
+	}
+
+	return state;
+};
+
 export const twoFactorAuthRequestError = ( state = null, action ) => {
 	switch ( action.type ) {
 		case TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST:
@@ -438,6 +454,7 @@ export const lastCheckedUsernameOrEmail = ( state = null, action ) => {
 
 const combinedReducer = combineReducers( {
 	authAccountType,
+	blackboxSessionId,
 	isFormDisabled,
 	isRequesting,
 	lastCheckedUsernameOrEmail,

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -321,7 +321,7 @@ export const twoFactorAuth = ( state = null, action ) => {
 	return state;
 };
 
-export const blackboxSessionId = ( state = null, action ) => {
+export const consumedBlackboxSessionId = ( state = null, action ) => {
 	switch ( action.type ) {
 		case LOGIN_REQUEST_SUCCESS:
 			return action.blackboxSessionId ?? null;
@@ -454,7 +454,7 @@ export const lastCheckedUsernameOrEmail = ( state = null, action ) => {
 
 const combinedReducer = combineReducers( {
 	authAccountType,
-	blackboxSessionId,
+	consumedBlackboxSessionId,
 	isFormDisabled,
 	isRequesting,
 	lastCheckedUsernameOrEmail,

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -19,6 +19,18 @@ export const getTwoFactorAuthNonce = ( state, nonceType ) =>
 	state.login.twoFactorAuth?.[ `two_step_nonce_${ nonceType }` ] ?? null;
 
 /**
+ * Retrieve the Blackbox session id captured on the password step of this login.
+ * Returns null if the password step did not produce one.
+ *
+ * Blackbox correlates the two-step outcome with the session that scored the
+ * password request, so consumers must read this rather than collect a new
+ * session id at the two-step step.
+ * @param  {Object}   state  Global state tree
+ * @returns {?string}         The Blackbox session id.
+ */
+export const getBlackboxSessionId = ( state ) => state.login.blackboxSessionId ?? null;
+
+/**
  * Retrieve the type of notification sent for the two factor authentication process.
  * Returns null if there is no such information yet, or user does not have 2FA enabled.
  * @param  {Object}   state  Global state tree

--- a/client/state/login/selectors.js
+++ b/client/state/login/selectors.js
@@ -19,16 +19,18 @@ export const getTwoFactorAuthNonce = ( state, nonceType ) =>
 	state.login.twoFactorAuth?.[ `two_step_nonce_${ nonceType }` ] ?? null;
 
 /**
- * Retrieve the Blackbox session id captured on the password step of this login.
- * Returns null if the password step did not produce one.
+ * Retrieve the Blackbox session id the password step already spent on /verify.
+ * Returns null if that step did not produce one.
  *
- * Blackbox correlates the two-step outcome with the session that scored the
- * password request, so consumers must read this rather than collect a new
- * session id at the two-step step.
+ * This id is spent: /verify has scored it, and it is carried forward only so a
+ * later step in the same login can be correlated with it. It is not a source of
+ * a live session, and nothing may verify with it. To obtain a live session, use
+ * getBlackboxSessionId() from calypso/blocks/login/utils/get-blackbox-session-id.
  * @param  {Object}   state  Global state tree
- * @returns {?string}         The Blackbox session id.
+ * @returns {?string}         The spent Blackbox session id.
  */
-export const getBlackboxSessionId = ( state ) => state.login.blackboxSessionId ?? null;
+export const getConsumedBlackboxSessionId = ( state ) =>
+	state.login.consumedBlackboxSessionId ?? null;
 
 /**
  * Retrieve the type of notification sent for the two factor authentication process.

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -20,6 +20,7 @@ import {
 	CURRENT_USER_RECEIVE,
 } from 'calypso/state/action-types';
 import reducer, {
+	blackboxSessionId,
 	isRequesting,
 	isFormDisabled,
 	requestError,
@@ -36,6 +37,7 @@ describe( 'reducer', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(
 			expect.arrayContaining( [
 				'authAccountType',
+				'blackboxSessionId',
 				'isFormDisabled',
 				'isRequesting',
 				'lastCheckedUsernameOrEmail',
@@ -198,6 +200,61 @@ describe( 'reducer', () => {
 		test( 'should reset the error to null when switching routes', () => {
 			const state = requestError( 'some error', {
 				type: ROUTE_SET,
+			} );
+
+			expect( state ).toBeNull();
+		} );
+	} );
+
+	describe( 'blackboxSessionId', () => {
+		test( 'should default to null', () => {
+			expect( blackboxSessionId( undefined, {} ) ).toBeNull();
+		} );
+
+		test( 'should store the id carried by a successful password step', () => {
+			const state = blackboxSessionId( null, {
+				type: LOGIN_REQUEST_SUCCESS,
+				data: { two_step_notification_sent: 'sms' },
+				blackboxSessionId: 'ABCDEFGHIJKLMNOPQRSTuv',
+			} );
+
+			expect( state ).toBe( 'ABCDEFGHIJKLMNOPQRSTuv' );
+		} );
+
+		test( 'should reset to null when a password step carries no id', () => {
+			const state = blackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', {
+				type: LOGIN_REQUEST_SUCCESS,
+				data: { two_step_notification_sent: 'sms' },
+			} );
+
+			expect( state ).toBeNull();
+		} );
+
+		test( 'should clear on a new login request', () => {
+			expect( blackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', { type: LOGIN_REQUEST } ) ).toBeNull();
+		} );
+
+		test( 'should clear on a failed login request', () => {
+			expect(
+				blackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', { type: LOGIN_REQUEST_FAILURE } )
+			).toBeNull();
+		} );
+
+		test( 'should clear on a social login, which carries no Blackbox session', () => {
+			expect(
+				blackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', { type: SOCIAL_LOGIN_REQUEST } )
+			).toBeNull();
+			expect(
+				blackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', { type: SOCIAL_LOGIN_REQUEST_FAILURE } )
+			).toBeNull();
+			expect(
+				blackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', { type: SOCIAL_LOGIN_REQUEST_SUCCESS } )
+			).toBeNull();
+		} );
+
+		test( 'should clear once the two-step step completes', () => {
+			const state = blackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', {
+				type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS,
 			} );
 
 			expect( state ).toBeNull();

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -20,7 +20,7 @@ import {
 	CURRENT_USER_RECEIVE,
 } from 'calypso/state/action-types';
 import reducer, {
-	blackboxSessionId,
+	consumedBlackboxSessionId,
 	isRequesting,
 	isFormDisabled,
 	requestError,
@@ -37,7 +37,7 @@ describe( 'reducer', () => {
 		expect( Object.keys( reducer( undefined, {} ) ) ).toEqual(
 			expect.arrayContaining( [
 				'authAccountType',
-				'blackboxSessionId',
+				'consumedBlackboxSessionId',
 				'isFormDisabled',
 				'isRequesting',
 				'lastCheckedUsernameOrEmail',
@@ -206,13 +206,13 @@ describe( 'reducer', () => {
 		} );
 	} );
 
-	describe( 'blackboxSessionId', () => {
+	describe( 'consumedBlackboxSessionId', () => {
 		test( 'should default to null', () => {
-			expect( blackboxSessionId( undefined, {} ) ).toBeNull();
+			expect( consumedBlackboxSessionId( undefined, {} ) ).toBeNull();
 		} );
 
 		test( 'should store the id carried by a successful password step', () => {
-			const state = blackboxSessionId( null, {
+			const state = consumedBlackboxSessionId( null, {
 				type: LOGIN_REQUEST_SUCCESS,
 				data: { two_step_notification_sent: 'sms' },
 				blackboxSessionId: 'ABCDEFGHIJKLMNOPQRSTuv',
@@ -222,7 +222,7 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should reset to null when a password step carries no id', () => {
-			const state = blackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', {
+			const state = consumedBlackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', {
 				type: LOGIN_REQUEST_SUCCESS,
 				data: { two_step_notification_sent: 'sms' },
 			} );
@@ -231,29 +231,35 @@ describe( 'reducer', () => {
 		} );
 
 		test( 'should clear on a new login request', () => {
-			expect( blackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', { type: LOGIN_REQUEST } ) ).toBeNull();
+			expect(
+				consumedBlackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', { type: LOGIN_REQUEST } )
+			).toBeNull();
 		} );
 
 		test( 'should clear on a failed login request', () => {
 			expect(
-				blackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', { type: LOGIN_REQUEST_FAILURE } )
+				consumedBlackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', { type: LOGIN_REQUEST_FAILURE } )
 			).toBeNull();
 		} );
 
 		test( 'should clear on a social login, which carries no Blackbox session', () => {
 			expect(
-				blackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', { type: SOCIAL_LOGIN_REQUEST } )
+				consumedBlackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', { type: SOCIAL_LOGIN_REQUEST } )
 			).toBeNull();
 			expect(
-				blackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', { type: SOCIAL_LOGIN_REQUEST_FAILURE } )
+				consumedBlackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', {
+					type: SOCIAL_LOGIN_REQUEST_FAILURE,
+				} )
 			).toBeNull();
 			expect(
-				blackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', { type: SOCIAL_LOGIN_REQUEST_SUCCESS } )
+				consumedBlackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', {
+					type: SOCIAL_LOGIN_REQUEST_SUCCESS,
+				} )
 			).toBeNull();
 		} );
 
 		test( 'should clear once the two-step step completes', () => {
-			const state = blackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', {
+			const state = consumedBlackboxSessionId( 'ABCDEFGHIJKLMNOPQRSTuv', {
 				type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_SUCCESS,
 			} );
 

--- a/client/state/login/test/selectors.js
+++ b/client/state/login/test/selectors.js
@@ -1,7 +1,7 @@
 import deepFreeze from 'deep-freeze';
 import reducer from '../reducer';
 import {
-	getBlackboxSessionId,
+	getConsumedBlackboxSessionId,
 	getRequestError,
 	getTwoFactorAuthNonce,
 	getTwoFactorAuthRequestError,
@@ -25,19 +25,19 @@ const EMPTY_STATE = {
 };
 
 describe( 'selectors', () => {
-	describe( 'getBlackboxSessionId()', () => {
+	describe( 'getConsumedBlackboxSessionId()', () => {
 		test( 'should return null if the password step captured no session', () => {
-			expect( getBlackboxSessionId( EMPTY_STATE ) ).toBeNull();
+			expect( getConsumedBlackboxSessionId( EMPTY_STATE ) ).toBeNull();
 		} );
 
 		test( 'should return the session id captured on the password step', () => {
 			const state = deepFreeze( {
 				login: {
-					blackboxSessionId: 'ABCDEFGHIJKLMNOPQRSTuv',
+					consumedBlackboxSessionId: 'ABCDEFGHIJKLMNOPQRSTuv',
 				},
 			} );
 
-			expect( getBlackboxSessionId( state ) ).toBe( 'ABCDEFGHIJKLMNOPQRSTuv' );
+			expect( getConsumedBlackboxSessionId( state ) ).toBe( 'ABCDEFGHIJKLMNOPQRSTuv' );
 		} );
 	} );
 

--- a/client/state/login/test/selectors.js
+++ b/client/state/login/test/selectors.js
@@ -1,6 +1,7 @@
 import deepFreeze from 'deep-freeze';
 import reducer from '../reducer';
 import {
+	getBlackboxSessionId,
 	getRequestError,
 	getTwoFactorAuthNonce,
 	getTwoFactorAuthRequestError,
@@ -24,6 +25,22 @@ const EMPTY_STATE = {
 };
 
 describe( 'selectors', () => {
+	describe( 'getBlackboxSessionId()', () => {
+		test( 'should return null if the password step captured no session', () => {
+			expect( getBlackboxSessionId( EMPTY_STATE ) ).toBeNull();
+		} );
+
+		test( 'should return the session id captured on the password step', () => {
+			const state = deepFreeze( {
+				login: {
+					blackboxSessionId: 'ABCDEFGHIJKLMNOPQRSTuv',
+				},
+			} );
+
+			expect( getBlackboxSessionId( state ) ).toBe( 'ABCDEFGHIJKLMNOPQRSTuv' );
+		} );
+	} );
+
 	describe( 'getTwoFactorUserId()', () => {
 		test( 'should return null if there is no information yet', () => {
 			const id = getTwoFactorUserId( EMPTY_STATE );

--- a/test/e2e/specs/authentication/authentication__blackbox-login-unavailable.spec.ts
+++ b/test/e2e/specs/authentication/authentication__blackbox-login-unavailable.spec.ts
@@ -1,0 +1,145 @@
+import { expect, tags, test } from '../../lib/pw-base';
+import type { LoginPage } from '@automattic/calypso-e2e';
+import type { Page } from 'playwright';
+
+/**
+ * Blackbox must never block login. Both tests here take a surface away from the
+ * SDK and assert the login still completes, with `blackbox_session_id` omitted
+ * from the request rather than sent empty.
+ *
+ * The submit button starts disabled while Blackbox loads and is released by the
+ * fail-open timeout in `useBlackbox()`, so the waits below budget past it.
+ */
+const BLACKBOX_FAIL_OPEN_BUDGET_MS = 30 * 1000;
+
+/**
+ * Submits the password step and asserts the request carried no Blackbox session
+ * id and was accepted.
+ */
+async function expectPasswordLoginSucceedsWithoutSessionId(
+	page: Page,
+	pageLogin: LoginPage,
+	username: string,
+	password: string
+): Promise< void > {
+	await pageLogin.fillUsername( username );
+	await pageLogin.clickSubmit();
+	await pageLogin.fillPassword( password );
+
+	await expect( page.locator( 'button[type="submit"]' ) ).toBeEnabled( {
+		timeout: BLACKBOX_FAIL_OPEN_BUDGET_MS,
+	} );
+
+	const loginResponse = page.waitForResponse(
+		( response ) =>
+			response.request().method() === 'POST' && response.url().includes( 'action=login-endpoint' )
+	);
+	const loginRequest = page.waitForRequest(
+		( request ) => request.method() === 'POST' && request.url().includes( 'action=login-endpoint' )
+	);
+
+	await pageLogin.clickSubmit();
+	const request = await loginRequest;
+	const response = await loginResponse;
+	const body = await response.json();
+	const postData = new URLSearchParams( request.postData() ?? '' );
+
+	expect( postData.get( 'blackbox_session_id' ) ).toBeNull();
+	expect( response.status() ).toBe( 200 );
+	expect( body?.success ).toBe( true );
+}
+
+test.describe(
+	'Authentication: Blackbox login when the SDK is unavailable',
+	{ tag: [ tags.AUTHENTICATION ] },
+	() => {
+		test( 'As a WordPress.com user, I can log in when Blackbox is unreachable', async ( {
+			page,
+			pageLogin,
+			secrets,
+		}, workerInfo ) => {
+			test.skip(
+				workerInfo.project.name !== 'authentication',
+				'The authentication project is the only one that has the right browser settings for authentication tests'
+			);
+
+			const credentials = secrets.testAccounts.defaultUser;
+
+			await test.step( 'Given every Blackbox request fails', async function () {
+				await page.route( '**/blackbox-api.wp.com/**', ( route ) => route.abort() );
+			} );
+
+			await test.step( 'When I visit the login page', async function () {
+				await pageLogin.visit();
+				await page.waitForURL( /log-in/ );
+			} );
+
+			await test.step( 'And I submit valid credentials', async function () {
+				await expectPasswordLoginSucceedsWithoutSessionId(
+					page,
+					pageLogin,
+					credentials.username as string,
+					credentials.password
+				);
+			} );
+
+			await test.step( 'Then I leave the login page', async function () {
+				// The redirect only fires once remoteLoginUser has settled its token-link
+				// iframes, which it allows 25s each, and is then a full page load. Budget
+				// past that and wait for the URL to change rather than for it to load.
+				await page.waitForURL( ( url ) => ! url.pathname.includes( '/log-in' ), {
+					waitUntil: 'commit',
+					timeout: 60 * 1000,
+				} );
+			} );
+		} );
+
+		test( 'As a WordPress.com user, I can log in when a Blackbox collect never settles', async ( {
+			page,
+			pageLogin,
+			secrets,
+		}, workerInfo ) => {
+			test.skip(
+				workerInfo.project.name !== 'authentication',
+				'The authentication project is the only one that has the right browser settings for authentication tests'
+			);
+
+			const credentials = secrets.testAccounts.defaultUser;
+
+			await test.step( 'Given collect() hangs instead of resolving', async function () {
+				// The SDK is kept off the page so the stub below survives, standing in
+				// for a load that succeeds and then stalls mid-collect. getSessionId()
+				// races collect() against its own timeout and gives up on it.
+				await page.route( '**/blackbox-api.wp.com/**', ( route ) => route.abort() );
+				await page.addInitScript( () => {
+					( window as unknown as { Blackbox: unknown } ).Blackbox = {
+						configure: () => undefined,
+						collect: () => new Promise( () => undefined ),
+						reset: () => undefined,
+					};
+				} );
+			} );
+
+			await test.step( 'When I visit the login page', async function () {
+				await pageLogin.visit();
+				await page.waitForURL( /log-in/ );
+			} );
+
+			await test.step( 'And I submit valid credentials', async function () {
+				await expectPasswordLoginSucceedsWithoutSessionId(
+					page,
+					pageLogin,
+					credentials.username as string,
+					credentials.password
+				);
+			} );
+
+			await test.step( 'Then I leave the login page', async function () {
+				await page.waitForURL( ( url ) => ! url.pathname.includes( '/log-in' ), {
+					waitUntil: 'commit',
+					timeout: 60 * 1000,
+				} );
+			} );
+		} );
+	}
+);


### PR DESCRIPTION
## Proposed Changes

* `login-user.js`: carry the Blackbox session id captured on the password step into the `LOGIN_REQUEST_SUCCESS` action dispatched on the two-factor branch.
* `reducer.js`: hold it in a `blackboxSessionId` reducer. Set only from the password step, cleared when a login starts, fails, runs through a social provider, or completes its second factor. It is deliberately not cleared on `TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST_FAILURE`, so a retry after a wrong code still carries the id. That repeated-failure sequence is the signal this work exists to capture.
* `selectors.js`: add `getBlackboxSessionId()`.
* `login-user-with-two-factor-verification-code.js`: read the id and spread `blackbox_session_id` into the two-step POST body, matching the pattern the password request already uses.
* Unit tests for the reducer, the selector, and the two-step action's request body.

## Testing Instructions

Unit tests:

```
yarn test-client client/state/login
```

(119 tests across 4 suites.)

Manually, against a 2FA-enabled account:

1. Log in with a correct password and open the Network tab.
2. On the `wp-login.php?action=login-endpoint` request, note the `blackbox_session_id` form field.
3. Enter a deliberately wrong verification code. The `wp-login.php?action=two-step-authentication-endpoint` request should carry a `blackbox_session_id` field with the same value.
4. Enter the correct code. The retry request should still carry that same value.
5. Log in to an account without 2FA and confirm the password request is unchanged.

After deploy, `wpcom-blackbox-two-step-report / no-session-id` should fall and the status-code buckets should rise.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
