### PR TITLE
E2E: stop the inserter focus wait eating the action timeout

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-sidebar-block-inserter-component.ts
@@ -152,18 +152,13 @@ export class EditorSidebarBlockInserterComponent {
 				.first();
 		}
 
-		// Hover is best-effort: on mobile/CI it occasionally hangs after the
-		// element resolves and the auto-wait reports the element visible and
-		// stable, exhausting the action timeout for no useful reason. The
-		// click below does not require a prior hover, so swallow timeouts.
-		try {
-			await locator.hover( { timeout: 2000 } );
-		} catch {
-			// Hover unavailable; proceed with focus + click.
-		}
-		await locator.focus();
 		// Pattern insertion does not navigate but can emit events that Playwright
 		// treats as "scheduled navigation" on slow CI, hanging the click auto-wait.
+		// Keep it off the block path: noWaitAfter also drops the post-click check
+		// that the pointer landed here, so a click the re-rendering list eats is
+		// never retried. Patterns can afford that (they assert on a block-count
+		// delta); blocks assert on ".is-selected", which a block of the same type
+		// left selected by an earlier step can satisfy.
 		await locator.click( type === 'pattern' ? { noWaitAfter: true } : undefined );
 
 		return locator;


### PR DESCRIPTION
## Proposed Changes

`EditorSidebarBlockInserterComponent.selectBlockInserterResult` — drop the `hover()` and `focus()` calls that ran before the result click.

The inserter list remounts its option buttons while those two run (the button's React id changes mid-action), so `focus()` resolved a node that then detached and waited out the full 10s action timeout. `hover()` was already capped and swallowed for the same reason; `focus()` was not.

Deleting both beats capping both. They were added in 2022 as a speculative fix for a different flake, nothing downstream reads the resulting hover or focus state, the sibling `EditorInlineBlockInserterComponent` has never had them, and `click()` does its own scroll-into-view and actionability wait.

## Why are these changes being made?

`blocks__coblocks__extensions__replace-image.spec.ts` failed on the mobile viewport in the E2E Playwright Test Matrix (build 19137355), desktop passing in the same build, inside `addBlockFromSidebar`. Test history puts it at 2 failures in 97 recent runs (~2%), mobile-only, across unrelated branches — a pre-existing flake, not a regression.

The fix lives in a shared component, so every spec routing through the sidebar inserter benefits.

### Scope narrowed after review

An earlier revision of this PR also passed `noWaitAfter: true` to *every* insert click (not just pattern clicks) and retried the handle adoption in `EditorGutenbergComponent.getSelectedBlockElementHandle`. Both were dropped:

* `noWaitAfter` does more than skip the post-click navigation wait. In `playwright-core@1.57` it maps to `waitAfter: !noWaitAfter`, and the post-click hit-target result is only read when `waitAfter !== false`. Applying it to block clicks silently disables the check that the pointer landed on the intended element, so a click eaten by the list re-render is never retried. `FullSiteEditorPage.addBlockFromSidebar` cannot absorb that: it never resets the selection and then asserts on `.is-selected`, so a missed click can pass green against a pre-existing block. It cannot be given a selection reset either — `resetSelectedBlock()` clicks `.editor-post-title__input`, which does not exist in the site editor. Pattern clicks keep `noWaitAfter` as before, since those callers assert on a block-count delta.
* The handle retry was a no-op. `Locator.elementHandle()` is `waitForSelector({ state: 'attached' })`, which already polls and re-queries, so a detach between `waitFor()` and adoption is handled inside the first call. Re-entering after a timeout only doubled the dead wait on genuine failures.

CI call logs support the narrower scope: the insertion failures on the previous revision stall at `scrolling into view if needed` or `element is not stable`, never reaching the post-click phase that `noWaitAfter` skips.

## Testing Instructions

**Reproducing the mechanism.** The failure does not reproduce at full speed. Throttle the page CPU so the editor's re-render churn overlaps the waits. In a throwaway copy of the spec, add at the top of the test body:

```ts
const cdp = await page.context().newCDPSession( page );
await cdp.send( 'Emulation.setCPUThrottlingRate', { rate: 8 } );
```

and add `test.use( { actionTimeout: 4000 } );` above the `describe` to shrink the budget so the mechanism is visible at a measurable rate. Then, from `test/e2e`:

```bash
CALYPSO_BASE_URL=https://wpcalypso.wordpress.com yarn exec playwright test \
  specs/blocks/<copy>.spec.ts --project=mobile --repeat-each=30 --workers=8 --reporter=list
```

Measured on that harness (insert-step failures only; the publish-step failures it also produces are the artificially small budget breaking an unrelated step, and are constant across both arms):

| | Insert-step failures |
|---|---|
| Before | 6/30, every one at `focus()` |
| After | 0/30 at `focus()` |

**Local regression runs**, unthrottled against staging, both viewports:

* `blocks__coblocks__extensions__replace-image.spec.ts` and `editor__post-basic-flow.spec.ts`, 3 repeats each — 12/12 insertion runs passed. `editor__post-basic-flow` exercises `addBlockFromSidebar` and `addPatternFromSidebar`, covering both branches of the retained `noWaitAfter` conditional.
* One unrelated failure surfaced (`No category matching Uncategorized found.` in `EditorSettingsSidebarComponent.checkCategory`, downstream of insertion); it did not reproduce in 4 further runs.

**Full-suite CI comparison.** Because the only changed file lives under `packages/calypso-e2e/`, `bin/e2e-grep-flag.sh` clears `TEST_GROUP`, so the push-triggered E2E Playwright Test Matrix runs *every* spec on both the desktop and mobile legs rather than the `@calypso-pr` subset. Same suite, same branch, consecutive commits:

| | Passed | Failed | Ignored |
|---|---|---|---|
| Before (build 19141437) | 159 | 4 | 83 |
| After (build 19142793) | 163 | 0 | 83 |

All four of the previous run's failures were in the insertion path and are `SUCCESS` in the new run: `blocks__coblocks__extensions__gutter-control` (chrome, `locator.click` stalled at scroll-into-view), `editor__page-basic-flow` (chrome, pattern click "element is not stable"), `blocks__coblocks__extensions__cover-styles` (mobile, whole-test timeout), `editor__post-basic-flow` (mobile, `elementHandle.type` after insertion).

Two caveats worth stating plainly: this is a single full-suite sample on a suite that is genuinely flaky, and the last two of those four failures are downstream of insertion with no causal link to this change, so their flipping is at least partly luck. The signal is the two that do sit in the changed path.

`yarn typecheck-packages` and eslint on the changed file — clean.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
