### PR TITLE
E2E: publish the post after a multi-entity save

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -134,6 +134,46 @@ function getResponseDiagnostic( response: Response | null, action: string ): Res
 	return diagnostic;
 }
 
+const ENTITIES_PANEL_SAVE_TIMEOUT = 30 * 1000;
+// Publishing through the multi-entity save panel takes ~16s: a 5s wait on the publish panel that
+// never opens, the entity save, then the publish itself. The 10s `actionTimeout` from
+// playwright.config.ts, which is what an omitted timeout falls back to, cuts that short.
+const PUBLISH_TIMEOUT = 30 * 1000;
+
+// The first pattern matches Atomic requests, the second Simple ones.
+const atomicPublishURL = /v2\/(posts|pages)\/[\d]+/;
+const simplePublishURL = /v2\/sites\/[\d]+\/(posts|pages)\/[\d]+/;
+const draftStatuses = [ 'draft', 'auto-draft' ];
+
+/**
+ * Whether a response is the one that published the article.
+ *
+ * Saving a draft hits the same endpoint with the same verb as publishing, so the status in the
+ * body is what tells them apart. Without that check a multi-entity save resolves the publish
+ * wait and the test goes on to validate an unpublished article.
+ */
+async function isPublishResponse( response: Response ): Promise< boolean > {
+	const url = response.url();
+	const method = response.request().method();
+	const isPublishRequest =
+		( atomicPublishURL.test( url ) && method === 'POST' ) ||
+		( simplePublishURL.test( url ) && method === 'PUT' );
+
+	if ( ! isPublishRequest || /\/autosaves/.test( url ) ) {
+		return false;
+	}
+
+	try {
+		const json = ( await response.json() ) as PublishResponseBody;
+		const status = ( json.body ?? json ).status;
+
+		return ! status || ! draftStatuses.includes( status );
+	} catch {
+		// A body that cannot be read tells nothing either way; keep the URL/verb match.
+		return true;
+	}
+}
+
 /**
  * Extracts the publish response fields needed to debug public 404s after publish.
  */
@@ -1100,10 +1140,22 @@ export class EditorPage {
 	 */
 	async publish( {
 		visit = false,
-		timeout,
+		timeout = PUBLISH_TIMEOUT,
 	}: { visit?: boolean; timeout?: number } = {} ): Promise< URL > {
 		const actionsArray = [];
 		await this.editorToolbarComponent.waitForPublishButton();
+
+		let publishedAtMs: number | undefined;
+		let published = false;
+		const publishResponsePromise = this.page
+			.waitForResponse( isPublishResponse, { timeout: timeout } )
+			.then( ( publishResponse ) => {
+				// Captured the moment the publish response arrives, before the remaining
+				// publish-panel actions settle, so the probe measures the full window.
+				publishedAtMs = Date.now();
+				published = true;
+				return publishResponse;
+			} );
 
 		// Every publish action requires at least one click on the EditorToolbarComponent.
 		actionsArray.push( this.editorToolbarComponent.clickPublish() );
@@ -1122,39 +1174,29 @@ export class EditorPage {
 				const saveButton = editorParent.locator(
 					'.entities-saved-states__panel button:has-text("Save")'
 				);
-				if ( await saveButton.isVisible( { timeout: 2000 } ).catch( () => false ) ) {
-					await saveButton.click();
+				if ( ! ( await saveButton.isVisible( { timeout: 2000 } ).catch( () => false ) ) ) {
+					return;
 				}
+
+				await saveButton.click();
+				await saveButton.waitFor( { state: 'hidden', timeout: ENTITIES_PANEL_SAVE_TIMEOUT } );
+
+				// That panel only saves; it leaves the post a draft. Whether it lists the post at
+				// all depends on an autosave having flushed the post's edits first, so neither the
+				// draft save nor its absence means the article got published: run the publish now.
+				if ( published ) {
+					return;
+				}
+
+				if ( ! ( await this.editorPublishPanelComponent.panelIsOpen() ) ) {
+					await this.editorToolbarComponent.clickPublish();
+				}
+				await this.editorPublishPanelComponent.publish();
 			} )()
 		);
 
 		// Resolve the promises.
-		let publishedAtMs: number | undefined;
-		const [ response ] = await Promise.all( [
-			// First URL matches Atomic requests while the second matches Simple requests.
-			Promise.race( [
-				this.page.waitForResponse(
-					async ( response ) =>
-						/v2\/(posts|pages)\/[\d]+/.test( response.url() ) &&
-						! /v2\/(posts|pages)\/[\d]+\/autosaves/.test( response.url() ) &&
-						response.request().method() === 'POST',
-					{ timeout: timeout }
-				),
-				this.page.waitForResponse(
-					async ( response ) =>
-						/v2\/sites\/[\d]+\/(posts|pages)\/[\d]+/.test( response.url() ) &&
-						! /v2\/sites\/[\d]+\/(posts|pages)\/[\d]+\/autosaves/.test( response.url() ) &&
-						response.request().method() === 'PUT',
-					{ timeout: timeout }
-				),
-			] ).then( ( publishResponse ) => {
-				// Captured the moment the publish response arrives, before the remaining
-				// publish-panel actions settle, so the probe measures the full window.
-				publishedAtMs = Date.now();
-				return publishResponse;
-			} ),
-			...actionsArray,
-		] );
+		const [ response ] = await Promise.all( [ publishResponsePromise, ...actionsArray ] );
 
 		const json = ( await response.json() ) as PublishResponseBody;
 		// AT and Simple sites have slightly differing response from the API.

--- a/test/e2e/specs/blocks/shared/block-smoke-testing.ts
+++ b/test/e2e/specs/blocks/shared/block-smoke-testing.ts
@@ -12,12 +12,15 @@ import { expect, tags as allTags, test } from '../../../lib/pw-base';
 
 // Publishing a post carrying a synced form saves two entities. On Atomic the second save
 // regularly outruns the cap that predates it, so only Atomic gets the longer one; Simple keeps
-// the tighter bound, where it still catches a regression. Omitting the argument would not lift
-// the cap either way: `waitForResponse` falls back to `actionTimeout` from playwright.config.ts.
+// the tighter bound, where it still catches a regression.
 //
 // 60s was not enough: the Jetpack Forms flows overran it on the private variation, where four
 // workers share one site. Both values stay well inside the per-test budget set below.
-const PUBLISH_TIMEOUT = 15 * 1000;
+//
+// The tighter bound is 30s because publishing through the multi-entity save panel costs ~16s
+// locally and ~19s on CI: two 5s waits on panels that never open, either side of the entity save
+// and the publish itself.
+const PUBLISH_TIMEOUT = 30 * 1000;
 const ATOMIC_PUBLISH_TIMEOUT = 120 * 1000;
 
 /**


### PR DESCRIPTION
## Proposed Changes

* Publish the post after the multi-entity save panel closes, instead of treating that panel's save as the publish.
* Match the publish response on the status in its body, so a draft save no longer resolves the wait.
* Give `publish()` a 30s default timeout and drop the 15s override the block smoke suite passed.

## Why are these changes being made?

The Jetpack Forms block smoke test failed on `page.waitForResponse` at the publish step 7 times. Six were `Jetpack Atomic Build Smoke E2E Tests (desktop)` (`19119777`, `19116025`, `19113622`, `19102980`, `19102673`, `19093320`) and one was `Gutenberg E2E Tests` on Simple (`19134808`).

A publish click is answered with the multi-entity save panel whenever a synced entity is dirty, which a Jetpack Forms post always has. That panel only saves — it leaves the post a draft — and the flow ended there, never publishing.

How that surfaced depended on the post's own edits:

* **Post edits still pending.** The panel saved the post as a draft. A draft save hits the same endpoint with the same verb as a publish, so the wait matched it, resolved, and the suite went on to validate an article it had never published. A silent false pass, not a failure.
* **Post edits already flushed** by the 60s autosave timer. The post was absent from the panel altogether, so no request the wait could match was ever sent, and the step failed on the timeout. This is the reported failure; the timer landing inside the ~5s window between the last block edit and the panel's save is what made it intermittent.

The trace from `19134808` shows the second case directly: after the panel's save, the only requests are two `PUT …/jetpack-forms/{id}` — no post request in the remaining 10s of the trace, and the post is still a draft at teardown.

The timeout the suite passed was covering for this rather than causing it. An omitted timeout falls back to the 10s `actionTimeout` from `playwright.config.ts` — tighter than the 15s the suite asked for, and far tighter than the ~16s that publishing through the panel takes. Deleting the override on its own would have made the failure more likely, so `publish()` carries a 30s default now and every caller gets a budget that fits the flow.

## Testing Instructions

The failure needs the post's edits flushed while a synced form is still dirty. To force it instead of waiting on the 60s timer, in the editor console after inserting a Form block:

```js
wp.data.dispatch( 'core/editor' ).updateEditorSettings( { autosaveInterval: 2 } );
// once an /autosaves request lands:
wp.data.select( 'core' ).__experimentalGetDirtyEntityRecords();
// => only jetpack_form entries, no postType/post entry
```

Then publish. Before this change the publish request is never sent and the post stays a draft; after it, the post publishes.

Suite run on Simple:

```bash
CALYPSO_BASE_URL=https://wpcalypso.wordpress.com \
  yarn workspace wp-e2e-tests exec playwright test specs/blocks/blocks__jetpack-forms.spec.ts \
  --project=chrome --project=mobile --repeat-each=3 --reporter=list
```

Suite run on Atomic, mirroring the build smoke config. The base URL matters: pointed at staging the run dies at the editor-load step on the wp-admin SSO wall, well before publish.

```bash
TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment ATOMIC_VARIATION=php-new \
  CALYPSO_BASE_URL=https://wordpress.com VIEWPORT_NAME=desktop \
  yarn workspace wp-e2e-tests exec playwright test specs/blocks/blocks__jetpack-forms.spec.ts \
  --project=chrome --repeat-each=3 --reporter=list
```

Verified locally on both site types, using the same environment variables CI uses.

Simple: 13/14 on chrome, 6/6 across chrome and mobile.

Atomic, with the Atomic build smoke config's own environment (`TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment CALYPSO_BASE_URL=https://wordpress.com`): 3/3 on `php-new` desktop, 2/2 on `php-new` mobile, and one run each on the `default`, `php-old` and `wp-beta` variations that `ATOMIC_VARIATION=mixed` can select.

A scripted reproduction of the state described above — post entity clean, synced form dirty — was run on both site types, against the code before and after this change:

| | before | after |
|---|---|---|
| Simple | timeout, post left `draft` | publishes, 3/3 |
| Atomic | timeout, post left `draft` | publishes |

Regression runs on the other `publish()` callers all pass, including `editor__post-advanced-flow` (publish, revert to draft, trash) 2/2, plus `editor__post-basic-flow`, `editor__page-basic-flow`, `editor__schedule` and `blocks__core`.

One thing a reviewer should know:

* One Jetpack Forms run failed in the first batch after the change and its artifacts were overwritten before they could be read. The following 14 runs were green, so whether it was a pre-existing flake is unresolved.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? <!-- the reproduction was a scratch spec, not committed; the change is itself test infrastructure -->

- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? <!-- Simple and Atomic; not self-hosted Jetpack -->
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015zLegvYsNKZGVZPPSYYTKP
