### PR TITLE
Onboarding e2e: tolerate the post-transfer interface race

### DIFF
--- a/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__new-hosted-site.spec.ts
@@ -12,8 +12,43 @@ import {
 	cancelDashboardPurchaseFlow,
 	removeDashboardUpgradeFlow,
 } from '@automattic/calypso-e2e';
-import { skipIfNotTrunk, tags, test } from '../../lib/pw-base';
+import { expect, skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 import { apiCancelAtomicPlan, apiCloseAccount } from '../shared';
+
+// How long a user may be left on the Dashboard before the post-transfer job
+// switches their site to the wp-admin interface. Seconds of that go unnoticed;
+// longer is a product problem, not a test timing artifact.
+const wpAdminInterfaceSettleTimeout = 5 * 1000;
+
+/**
+ * Waits for the post-transfer job to switch the site to the wp-admin interface.
+ *
+ * Already true when the flow lands the user in WP Admin; a bounded wait when it
+ * sent them to the Dashboard instead because the job had not landed yet.
+ */
+async function expectWPAdminInterface( restAPIClient: RestAPIClient, siteSlug: string ) {
+	await expect
+		.poll(
+			async () => {
+				const site = await restAPIClient.sendRequest(
+					restAPIClient.getRequestURL( '1.2', `/sites/${ encodeURIComponent( siteSlug ) }` ),
+					{
+						method: 'get',
+						headers: {
+							Authorization: await restAPIClient.getAuthorizationHeader( 'bearer' ),
+						},
+					}
+				);
+
+				return site?.options?.wpcom_admin_interface;
+			},
+			{
+				timeout: wpAdminInterfaceSettleTimeout,
+				message: 'The post-transfer job did not switch the site to the wp-admin interface.',
+			}
+		)
+		.toBe( 'wp-admin' );
+}
 
 test.describe(
 	DataHelper.createSuiteTitle( 'New Hosted Site Flow: Purchase a hosted site and cancel it' ),
@@ -106,12 +141,24 @@ test.describe(
 
 			await test.step( 'Then I wait for the Atomic transfer to complete', async () => {
 				await page.waitForURL( /.*transferring-hosted-site.*/ );
-				await page.waitForURL( /wp-admin/, { timeout: 180 * 1000 } );
+
+				// The flow exits to WP Admin once the post-transfer job has switched the site
+				// to the wp-admin interface, and to the Dashboard site overview while that job
+				// is still in flight. WP Admin is served from the site itself, the Dashboard
+				// under /sites/<slug>; the slug is the same either way.
+				await page.waitForURL( /wp-admin|\/sites\/[^/?#]+/, { timeout: 180 * 1000 } );
+
+				const landingURL = new URL( page.url() );
+				siteSlug = landingURL.pathname.match( /\/sites\/([^/?#]+)/ )?.[ 1 ] ?? landingURL.hostname;
 			} );
 
-			await test.step( 'Then I am in WP Admin', async () => {
-				await page.waitForURL( /wp-admin/ );
-				siteSlug = new URL( page.url() ).hostname;
+			await test.step( 'Then I am using the WP Admin interface', async () => {
+				const restAPIClient = new RestAPIClient(
+					{ username: testUser.username, password: testUser.password },
+					newUserDetails!.body.bearer_token
+				);
+
+				await expectWPAdminInterface( restAPIClient, siteSlug );
 			} );
 
 			await test.step( 'When I navigate to Billing > Active upgrades to cancel add-on', async () => {


### PR DESCRIPTION
## Proposed Changes

* `onboarding__new-hosted-site.spec.ts` no longer assumes the `transferring-hosted-site` flow always exits to WP Admin. It accepts either exit, derives the site slug from whichever one it was, and then asserts the site settles on the wp-admin interface within 5s.

## Why are these changes being made?

The pre-release gate went red once in 59 trunk builds (build #38212, mobile only) and cleared on the next build. The spec timed out after 180s waiting for `/wp-admin/` while the browser sat on the Dashboard site overview.

Both endings are legitimate. `getRedirectTo()` in `transferring-hosted-site-flow.ts` sends the user to `options.admin_url` when the site reports the wp-admin interface, and to the Dashboard site overview otherwise. The interface is decided by the `wpcom_admin_interface` blog option, which is written by an async post-transfer job — the 8th of 22 queued after the transfer completes. `is_wpcom_atomic()`, which the flow polls on to decide the transfer is done, derives solely from the transfer record status, so it can flip before that job has run. When it does, the flow redirects to the Dashboard, once, via `window.location.assign()`. Nothing moves the page afterwards, hence the full 180s timeout.

The window is narrow: instrumented runs measured the gap at ~2s and 0s, which matches a roughly 1-in-59 failure rate — the spec was sampling a race, not hitting a broken destination.

So the spec now asserts what it actually cares about — the new site ends up on the wp-admin interface — and treats the destination as a consequence of that. The 5s budget is deliberate: that is a gap a user would not notice, and it keeps the test honest. A longer settle is a product problem, not a test timing artifact, and this spec should still fail on it.

Reverted along the way: a product-side fix in `useWaitForAtomic` that would have made `waitForLatestSiteData` block on the interface option. It moves the same wait into the flow, keeping every user on the loading screen for the job's duration, which is a worse experience than a Dashboard landing.

## Testing Instructions

* This is an E2E spec change. Run it against staging:
  ```
  cd test/e2e
  BRANCH_NAME=trunk yarn playwright test specs/onboarding/onboarding__new-hosted-site.spec.ts --project=mobile --reporter=list
  ```
  The spec is `skipIfNotTrunk()`, hence `BRANCH_NAME`. It needs `DASHBOARD_BASE_URL` set, or a local dev server for the billing steps. Note the run purchases a Business plan and a storage add-on, then cancels both.
* The race itself is not reproducible on demand; it depends on where the post-transfer job sits when the flow polls. Both endings were traced locally against a WPCOM checkout: creating a completed transfer record made the site report Atomic while `wpcom_admin_interface` did not yet exist, and running the post-transfer job flipped it to `wp-admin`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgGJeK4AcXzvyZ596sdqbp
