### PR TITLE
Onboarding: WoW funnel pre-checkout Atomic builds (internal-only)

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -51,7 +51,6 @@ import {
 } from '../../../utils/build-wow';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import {
-	getWowFunnelArgs,
 	getWowFunnelDest,
 	getWowFunnelSlug,
 	getRememberedWowFunnelSite,
@@ -155,32 +154,6 @@ const onboarding: FlowV2< typeof initialize > = {
 						blog_id: siteId,
 					} );
 					return [ `${ siteUrl }/wp-admin/site-editor.php?canvas=edit&p=%2F`, null, null ];
-				}
-
-				// dest=site-spec: land on the AI site-spec. For the blueprint funnel, reuse the
-				// blueprint-archive site-spec URL, which polls the (already in-flight) import and
-				// then redirects to the Site Editor.
-				if ( wowFunnelDest === 'site-spec' ) {
-					const blueprintSlug = queryParams.get( 'blueprint' );
-					logWowFunnelEvent( 'post_checkout_site_spec', {
-						funnel: wowFunnelSlug,
-						blog_id: siteId,
-					} );
-					return [
-						blueprintSlug
-							? getBlueprintArchiveSiteSpecUrl( {
-									siteSlug,
-									siteId,
-									blueprintSlug,
-									ref: refParameter,
-							  } )
-							: addQueryArgs( withLocale( '/setup/ai-site-builder-spec/site-spec', locale ), {
-									siteSlug,
-									...( siteId && String( siteId ) !== '0' ? { siteId } : {} ),
-							  } ),
-						null,
-						null,
-					];
 				}
 
 				// dest=big-sky: hand off to the Big Sky AI builder.
@@ -551,7 +524,7 @@ const onboarding: FlowV2< typeof initialize > = {
 							// replace the location to delete processing step from history.
 							window.location.replace(
 								addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
-									// build_dest=wow and the WoW funnel (dest=site-spec/big-sky) go
+									// build_dest=wow and the WoW funnel (dest=editor/big-sky) go
 									// straight from checkout to their destination — no
 									// post-checkout-onboarding hop, no chooser.
 									redirect_to:
@@ -710,7 +683,6 @@ const onboarding: FlowV2< typeof initialize > = {
 			}
 			void startWowFunnelSite( {
 				funnelSlug,
-				funnelArgs: getWowFunnelArgs( queryParams ),
 				username,
 			} ).catch( () => {
 				// Errors are logged in the util; the create-site step retries as a fallback.

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -26,11 +26,7 @@ import {
 	clearSignupCompleteSiteID,
 } from 'calypso/signup/storageUtils';
 import { useSelector, useDispatch as useReduxDispatch } from 'calypso/state';
-import {
-	getCurrentUser,
-	getCurrentUserName,
-	isUserLoggedIn,
-} from 'calypso/state/current-user/selectors';
+import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { State } from '../../../../../../packages/data-stores/src/plans/reducer';
 import { isPlanProductFree } from '../../../../../../packages/data-stores/src/plans/selectors';
@@ -577,7 +573,6 @@ const onboarding: FlowV2< typeof initialize > = {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
 		const isLoggedIn = useSelector( isUserLoggedIn );
 		const user = useSelector( getCurrentUser );
-		const username = useSelector( getCurrentUserName );
 
 		/**
 		 * Clears every state we're persisting during the flow
@@ -627,7 +622,7 @@ const onboarding: FlowV2< typeof initialize > = {
 		// option it writes. For anyone else this creates the site the flow would create anyway,
 		// with the funnel option ignored.
 		useEffect( () => {
-			if ( ! currentStepSlug || ! isLoggedIn || ! username ) {
+			if ( ! currentStepSlug || ! isLoggedIn ) {
 				return;
 			}
 			const queryParams = new URLSearchParams( window.location.search );
@@ -635,13 +630,10 @@ const onboarding: FlowV2< typeof initialize > = {
 			if ( ! funnelSlug || getRememberedWowFunnelSite( funnelSlug ) ) {
 				return;
 			}
-			void startWowFunnelSite( {
-				funnelSlug,
-				username,
-			} ).catch( () => {
+			void startWowFunnelSite( { funnelSlug } ).catch( () => {
 				// Errors are logged in the util; the create-site step retries as a fallback.
 			} );
-		}, [ currentStepSlug, isLoggedIn, username ] );
+		}, [ currentStepSlug, isLoggedIn ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -1,9 +1,7 @@
-import { isAutomatticianQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import { clearStepPersistedState, ONBOARDING_FLOW, SITE_SETUP_FLOW } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import { useQuery as useReactQuery } from '@tanstack/react-query';
 import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
@@ -154,27 +152,6 @@ const onboarding: FlowV2< typeof initialize > = {
 						blog_id: siteId,
 					} );
 					return [ `${ siteUrl }/wp-admin/site-editor.php?canvas=edit&p=%2F`, null, null ];
-				}
-
-				// dest=big-sky: hand off to the Big Sky AI builder.
-				if ( wowFunnelDest === 'big-sky' ) {
-					logWowFunnelEvent( 'post_checkout_big_sky', {
-						funnel: wowFunnelSlug,
-						blog_id: siteId,
-					} );
-					return [
-						addQueryArgs(
-							withLocale( `/setup/${ SITE_SETUP_FLOW }/${ STEPS.LAUNCH_BIG_SKY.slug }`, locale ),
-							{
-								siteSlug,
-								...( siteId && String( siteId ) !== '0' ? { siteId } : {} ),
-								fromPostCheckoutSetupSite: '1',
-								...( refParameter ? { ref: refParameter } : {} ),
-							}
-						),
-						null,
-						null,
-					];
 				}
 			}
 
@@ -524,7 +501,7 @@ const onboarding: FlowV2< typeof initialize > = {
 							// replace the location to delete processing step from history.
 							window.location.replace(
 								addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
-									// build_dest=wow and the WoW funnel (dest=editor/big-sky) go
+									// build_dest=wow and the WoW funnel (dest=editor) go
 									// straight from checkout to their destination — no
 									// post-checkout-onboarding hop, no chooser.
 									redirect_to:
@@ -645,40 +622,17 @@ const onboarding: FlowV2< typeof initialize > = {
 		// second one. Only fires once the funnel step is known (currentStepSlug set) and the
 		// user is logged in.
 		//
-		// Internal-only: the funnel is an Automattician experiment (the server enforces the same
-		// boundary). For anyone else the params are stripped so the flow — domains, plans,
-		// post-checkout — degrades to ordinary onboarding.
-		const hasWowFunnelParam = !! getWowFunnelSlug( new URLSearchParams( window.location.search ) );
-		const { data: isAutomattician } = useReactQuery( {
-			...isAutomatticianQuery(),
-			enabled: hasWowFunnelParam && isLoggedIn,
-		} );
+		// The funnel is an internal-only experiment, but the gate lives server-side: /sites/new
+		// only honours the option for Automatticians and the plan-gate skip is bound to the
+		// option it writes. For anyone else this creates the site the flow would create anyway,
+		// with the funnel option ignored.
 		useEffect( () => {
 			if ( ! currentStepSlug || ! isLoggedIn || ! username ) {
 				return;
 			}
 			const queryParams = new URLSearchParams( window.location.search );
 			const funnelSlug = getWowFunnelSlug( queryParams );
-			if ( ! funnelSlug ) {
-				return;
-			}
-			if ( isAutomattician === undefined ) {
-				// Still resolving; the effect re-runs when the answer lands.
-				return;
-			}
-			if ( ! isAutomattician ) {
-				logWowFunnelEvent( 'denied_not_automattician', { funnel: funnelSlug } );
-				queryParams.delete( 'wow_funnel' );
-				queryParams.delete( 'dest' );
-				const search = queryParams.toString();
-				window.history.replaceState(
-					{},
-					'',
-					window.location.pathname + ( search ? `?${ search }` : '' )
-				);
-				return;
-			}
-			if ( getRememberedWowFunnelSite( funnelSlug ) ) {
+			if ( ! funnelSlug || getRememberedWowFunnelSite( funnelSlug ) ) {
 				return;
 			}
 			void startWowFunnelSite( {
@@ -687,7 +641,7 @@ const onboarding: FlowV2< typeof initialize > = {
 			} ).catch( () => {
 				// Errors are logged in the util; the create-site step retries as a fallback.
 			} );
-		}, [ currentStepSlug, isLoggedIn, username, isAutomattician ] );
+		}, [ currentStepSlug, isLoggedIn, username ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -1,7 +1,9 @@
+import { isAutomatticianQuery } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import { OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import { clearStepPersistedState, ONBOARDING_FLOW, SITE_SETUP_FLOW } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import { useQuery as useReactQuery } from '@tanstack/react-query';
 import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
@@ -38,14 +40,6 @@ import { useFlowLocale } from '../../../hooks/use-flow-locale';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE, SITE_STORE } from '../../../stores';
 import {
-	getAtomicFunnelArgs,
-	getAtomicFunnelDest,
-	getAtomicFunnelSlug,
-	getRememberedAtomicFunnelSite,
-	startAtomicFunnelSite,
-	logAtomicFunnelEvent,
-} from '../../../utils/atomic-funnel';
-import {
 	getBlueprintArchiveSiteSpecUrl,
 	getStandaloneBlueprintArchiveSlug,
 } from '../../../utils/blueprint-archive-import';
@@ -56,6 +50,14 @@ import {
 	requestBuildWowSite,
 } from '../../../utils/build-wow';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
+import {
+	getWowFunnelArgs,
+	getWowFunnelDest,
+	getWowFunnelSlug,
+	getRememberedWowFunnelSite,
+	startWowFunnelSite,
+	logWowFunnelEvent,
+} from '../../../utils/wow-funnel';
 import { getOnboardingPostCheckoutDestination } from '../../helpers/get-onboarding-post-checkout-destination';
 import { withLocale } from '../../helpers/with-locale';
 import { usePurchasePlanNotification } from '../../internals/hooks/use-purchase-plan-notification';
@@ -126,8 +128,8 @@ const onboarding: FlowV2< typeof initialize > = {
 			playgroundId,
 			buildDest
 		);
-		const atomicFunnelSlug = getAtomicFunnelSlug( queryParams );
-		const atomicFunnelDest = getAtomicFunnelDest( queryParams );
+		const wowFunnelSlug = getWowFunnelSlug( queryParams );
+		const wowFunnelDest = getWowFunnelDest( queryParams );
 
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
@@ -137,17 +139,17 @@ const onboarding: FlowV2< typeof initialize > = {
 			planCartItem: MinimalRequestCartProduct | null,
 			launchpadPersonalizationVariation: LaunchpadPersonalizationVariation
 		): Promise< [ string, string | null, string | null ] > => {
-			if ( atomicFunnelSlug && atomicFunnelDest !== 'manual' ) {
+			if ( wowFunnelSlug && wowFunnelDest !== 'manual' ) {
 				const siteSlug = providedDependencies.siteSlug as string;
 				const siteId = providedDependencies.siteId as number;
 
 				// dest=site-spec: land on the AI site-spec. For the blueprint funnel, reuse the
 				// blueprint-archive site-spec URL, which polls the (already in-flight) import and
 				// then redirects to the Site Editor.
-				if ( atomicFunnelDest === 'site-spec' ) {
+				if ( wowFunnelDest === 'site-spec' ) {
 					const blueprintSlug = queryParams.get( 'blueprint' );
-					logAtomicFunnelEvent( 'post_checkout_site_spec', {
-						funnel: atomicFunnelSlug,
+					logWowFunnelEvent( 'post_checkout_site_spec', {
+						funnel: wowFunnelSlug,
 						blog_id: siteId,
 					} );
 					return [
@@ -168,9 +170,9 @@ const onboarding: FlowV2< typeof initialize > = {
 				}
 
 				// dest=big-sky: hand off to the Big Sky AI builder.
-				if ( atomicFunnelDest === 'big-sky' ) {
-					logAtomicFunnelEvent( 'post_checkout_big_sky', {
-						funnel: atomicFunnelSlug,
+				if ( wowFunnelDest === 'big-sky' ) {
+					logWowFunnelEvent( 'post_checkout_big_sky', {
+						funnel: wowFunnelSlug,
 						blog_id: siteId,
 					} );
 					return [
@@ -535,11 +537,11 @@ const onboarding: FlowV2< typeof initialize > = {
 							// replace the location to delete processing step from history.
 							window.location.replace(
 								addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
-									// build_dest=wow and the atomic funnel (dest=site-spec/big-sky) go
+									// build_dest=wow and the WoW funnel (dest=site-spec/big-sky) go
 									// straight from checkout to their destination — no
 									// post-checkout-onboarding hop, no chooser.
 									redirect_to:
-										blueprintArchiveSlug || ( atomicFunnelSlug && atomicFunnelDest !== 'manual' )
+										blueprintArchiveSlug || ( wowFunnelSlug && wowFunnelDest !== 'manual' )
 											? destination
 											: redirectTo,
 									signup: 1,
@@ -553,11 +555,8 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if (
-							blueprintArchiveSlug ||
-							( atomicFunnelSlug && atomicFunnelDest !== 'manual' )
-						) {
-							// build_dest=wow and the atomic funnel never show the
+						} else if ( blueprintArchiveSlug || ( wowFunnelSlug && wowFunnelDest !== 'manual' ) ) {
+							// build_dest=wow and the WoW funnel never show the
 							// setup-your-site-ai chooser; go straight to their destination.
 							window.location.replace( destination );
 						} else if (
@@ -653,28 +652,56 @@ const onboarding: FlowV2< typeof initialize > = {
 			loadExperimentAssignment( 'calypso_plans_page_visual_separation_2025_09_v2' );
 		}, [] );
 
-		// Atomic funnel: create the Simple site as soon as the customer is in the flow, so its
-		// Atomic host builds (and any follow-up, e.g. a blueprint import) while they pick a domain
-		// and check out. Single-flight — the create-site step consumes the same site rather than
-		// creating a second one. Only fires once the funnel step is known (currentStepSlug set) and
-		// the user is logged in.
+		// WoW funnel: create the Simple site as soon as the customer is in the flow, so its
+		// Atomic host builds (and any follow-up work) while they pick a domain and check out.
+		// Single-flight — the create-site step consumes the same site rather than creating a
+		// second one. Only fires once the funnel step is known (currentStepSlug set) and the
+		// user is logged in.
+		//
+		// Internal-only: the funnel is an Automattician experiment (the server enforces the same
+		// boundary). For anyone else the params are stripped so the flow — domains, plans,
+		// post-checkout — degrades to ordinary onboarding.
+		const hasWowFunnelParam = !! getWowFunnelSlug( new URLSearchParams( window.location.search ) );
+		const { data: isAutomattician } = useReactQuery( {
+			...isAutomatticianQuery(),
+			enabled: hasWowFunnelParam && isLoggedIn,
+		} );
 		useEffect( () => {
 			if ( ! currentStepSlug || ! isLoggedIn || ! username ) {
 				return;
 			}
 			const queryParams = new URLSearchParams( window.location.search );
-			const funnelSlug = getAtomicFunnelSlug( queryParams );
-			if ( ! funnelSlug || getRememberedAtomicFunnelSite( funnelSlug ) ) {
+			const funnelSlug = getWowFunnelSlug( queryParams );
+			if ( ! funnelSlug ) {
 				return;
 			}
-			void startAtomicFunnelSite( {
+			if ( isAutomattician === undefined ) {
+				// Still resolving; the effect re-runs when the answer lands.
+				return;
+			}
+			if ( ! isAutomattician ) {
+				logWowFunnelEvent( 'denied_not_automattician', { funnel: funnelSlug } );
+				queryParams.delete( 'wow_funnel' );
+				queryParams.delete( 'dest' );
+				const search = queryParams.toString();
+				window.history.replaceState(
+					{},
+					'',
+					window.location.pathname + ( search ? `?${ search }` : '' )
+				);
+				return;
+			}
+			if ( getRememberedWowFunnelSite( funnelSlug ) ) {
+				return;
+			}
+			void startWowFunnelSite( {
 				funnelSlug,
-				funnelArgs: getAtomicFunnelArgs( queryParams ),
+				funnelArgs: getWowFunnelArgs( queryParams ),
 				username,
 			} ).catch( () => {
 				// Errors are logged in the util; the create-site step retries as a fallback.
 			} );
-		}, [ currentStepSlug, isLoggedIn, username ] );
+		}, [ currentStepSlug, isLoggedIn, username, isAutomattician ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -132,12 +132,12 @@ const onboarding: FlowV2< typeof initialize > = {
 			planCartItem: MinimalRequestCartProduct | null,
 			launchpadPersonalizationVariation: LaunchpadPersonalizationVariation
 		): Promise< [ string, string | null, string | null ] > => {
-			// dest=editor: straight into the Site Editor on the built Atomic site. The build ran
-			// during domain selection and checkout, so the transfer is normally complete; the URL
-			// goes through the site's own domain, which follows the Simple->Atomic switch. Same
-			// shape as the ai-site-builder editor hand-off. `manual` falls through to the
-			// ordinary post-checkout destinations below.
-			if ( wowFunnelSlug && wowFunnelDest === 'editor' ) {
+			// A funnel CTA can ask for a specific post-checkout destination; today that means the
+			// Site Editor on the built Atomic site. The build ran during domain selection and
+			// checkout, so the transfer is normally complete; the URL goes through the site's own
+			// domain, which follows the Simple->Atomic switch (same shape as the ai-site-builder
+			// hand-off). With no dest, the ordinary destinations below apply.
+			if ( wowFunnelSlug && wowFunnelDest ) {
 				const siteSlug = providedDependencies.siteSlug as string;
 				const siteId = providedDependencies.siteId as number;
 				const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
@@ -496,7 +496,7 @@ const onboarding: FlowV2< typeof initialize > = {
 									// straight from checkout to their destination — no
 									// post-checkout-onboarding hop, no chooser.
 									redirect_to:
-										blueprintArchiveSlug || ( wowFunnelSlug && wowFunnelDest === 'editor' )
+										blueprintArchiveSlug || ( wowFunnelSlug && wowFunnelDest )
 											? destination
 											: redirectTo,
 									signup: 1,
@@ -510,7 +510,7 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if ( blueprintArchiveSlug || ( wowFunnelSlug && wowFunnelDest === 'editor' ) ) {
+						} else if ( blueprintArchiveSlug || ( wowFunnelSlug && wowFunnelDest ) ) {
 							// build_dest=wow and the WoW funnel never show the
 							// setup-your-site-ai chooser; go straight to their destination.
 							window.location.replace( destination );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -143,6 +143,20 @@ const onboarding: FlowV2< typeof initialize > = {
 				const siteSlug = providedDependencies.siteSlug as string;
 				const siteId = providedDependencies.siteId as number;
 
+				// dest=editor: straight into the Site Editor on the built Atomic site. The build
+				// ran during domain selection and checkout, so the transfer is normally complete;
+				// the URL goes through the site's own domain, which follows the Simple->Atomic
+				// switch. Same shape as the ai-site-builder editor hand-off.
+				if ( wowFunnelDest === 'editor' ) {
+					const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
+					const siteUrl = site?.URL ?? `https://${ siteSlug }`;
+					logWowFunnelEvent( 'post_checkout_editor', {
+						funnel: wowFunnelSlug,
+						blog_id: siteId,
+					} );
+					return [ `${ siteUrl }/wp-admin/site-editor.php?canvas=edit&p=%2F`, null, null ];
+				}
+
 				// dest=site-spec: land on the AI site-spec. For the blueprint funnel, reuse the
 				// blueprint-archive site-spec URL, which polls the (already in-flight) import and
 				// then redirects to the Site Editor.

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -132,23 +132,18 @@ const onboarding: FlowV2< typeof initialize > = {
 			planCartItem: MinimalRequestCartProduct | null,
 			launchpadPersonalizationVariation: LaunchpadPersonalizationVariation
 		): Promise< [ string, string | null, string | null ] > => {
-			if ( wowFunnelSlug && wowFunnelDest !== 'manual' ) {
+			// dest=editor: straight into the Site Editor on the built Atomic site. The build ran
+			// during domain selection and checkout, so the transfer is normally complete; the URL
+			// goes through the site's own domain, which follows the Simple->Atomic switch. Same
+			// shape as the ai-site-builder editor hand-off. `manual` falls through to the
+			// ordinary post-checkout destinations below.
+			if ( wowFunnelSlug && wowFunnelDest === 'editor' ) {
 				const siteSlug = providedDependencies.siteSlug as string;
 				const siteId = providedDependencies.siteId as number;
-
-				// dest=editor: straight into the Site Editor on the built Atomic site. The build
-				// ran during domain selection and checkout, so the transfer is normally complete;
-				// the URL goes through the site's own domain, which follows the Simple->Atomic
-				// switch. Same shape as the ai-site-builder editor hand-off.
-				if ( wowFunnelDest === 'editor' ) {
-					const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
-					const siteUrl = site?.URL ?? `https://${ siteSlug }`;
-					logWowFunnelEvent( 'post_checkout_editor', {
-						funnel: wowFunnelSlug,
-						blog_id: siteId,
-					} );
-					return [ `${ siteUrl }/wp-admin/site-editor.php?canvas=edit&p=%2F`, null, null ];
-				}
+				const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
+				const siteUrl = site?.URL ?? `https://${ siteSlug }`;
+				logWowFunnelEvent( 'post_checkout_editor', { funnel: wowFunnelSlug, blog_id: siteId } );
+				return [ `${ siteUrl }/wp-admin/site-editor.php?canvas=edit&p=%2F`, null, null ];
 			}
 
 			if ( ! providedDependencies.hasExternalTheme && providedDependencies.hasPluginByGoal ) {
@@ -501,7 +496,7 @@ const onboarding: FlowV2< typeof initialize > = {
 									// straight from checkout to their destination — no
 									// post-checkout-onboarding hop, no chooser.
 									redirect_to:
-										blueprintArchiveSlug || ( wowFunnelSlug && wowFunnelDest !== 'manual' )
+										blueprintArchiveSlug || ( wowFunnelSlug && wowFunnelDest === 'editor' )
 											? destination
 											: redirectTo,
 									signup: 1,
@@ -515,7 +510,7 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if ( blueprintArchiveSlug || ( wowFunnelSlug && wowFunnelDest !== 'manual' ) ) {
+						} else if ( blueprintArchiveSlug || ( wowFunnelSlug && wowFunnelDest === 'editor' ) ) {
 							// build_dest=wow and the WoW funnel never show the
 							// setup-your-site-ai chooser; go straight to their destination.
 							window.location.replace( destination );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -26,13 +26,25 @@ import {
 	clearSignupCompleteSiteID,
 } from 'calypso/signup/storageUtils';
 import { useSelector, useDispatch as useReduxDispatch } from 'calypso/state';
-import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import {
+	getCurrentUser,
+	getCurrentUserName,
+	isUserLoggedIn,
+} from 'calypso/state/current-user/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { State } from '../../../../../../packages/data-stores/src/plans/reducer';
 import { isPlanProductFree } from '../../../../../../packages/data-stores/src/plans/selectors';
 import { useFlowLocale } from '../../../hooks/use-flow-locale';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE, SITE_STORE } from '../../../stores';
+import {
+	getAtomicFunnelArgs,
+	getAtomicFunnelDest,
+	getAtomicFunnelSlug,
+	getRememberedAtomicFunnelSite,
+	startAtomicFunnelSite,
+	logAtomicFunnelEvent,
+} from '../../../utils/atomic-funnel';
 import {
 	getBlueprintArchiveSiteSpecUrl,
 	getStandaloneBlueprintArchiveSlug,
@@ -114,6 +126,8 @@ const onboarding: FlowV2< typeof initialize > = {
 			playgroundId,
 			buildDest
 		);
+		const atomicFunnelSlug = getAtomicFunnelSlug( queryParams );
+		const atomicFunnelDest = getAtomicFunnelDest( queryParams );
 
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
@@ -123,6 +137,58 @@ const onboarding: FlowV2< typeof initialize > = {
 			planCartItem: MinimalRequestCartProduct | null,
 			launchpadPersonalizationVariation: LaunchpadPersonalizationVariation
 		): Promise< [ string, string | null, string | null ] > => {
+			if ( atomicFunnelSlug && atomicFunnelDest !== 'manual' ) {
+				const siteSlug = providedDependencies.siteSlug as string;
+				const siteId = providedDependencies.siteId as number;
+
+				// dest=site-spec: land on the AI site-spec. For the blueprint funnel, reuse the
+				// blueprint-archive site-spec URL, which polls the (already in-flight) import and
+				// then redirects to the Site Editor.
+				if ( atomicFunnelDest === 'site-spec' ) {
+					const blueprintSlug = queryParams.get( 'blueprint' );
+					logAtomicFunnelEvent( 'post_checkout_site_spec', {
+						funnel: atomicFunnelSlug,
+						blog_id: siteId,
+					} );
+					return [
+						blueprintSlug
+							? getBlueprintArchiveSiteSpecUrl( {
+									siteSlug,
+									siteId,
+									blueprintSlug,
+									ref: refParameter,
+							  } )
+							: addQueryArgs( withLocale( '/setup/ai-site-builder-spec/site-spec', locale ), {
+									siteSlug,
+									...( siteId && String( siteId ) !== '0' ? { siteId } : {} ),
+							  } ),
+						null,
+						null,
+					];
+				}
+
+				// dest=big-sky: hand off to the Big Sky AI builder.
+				if ( atomicFunnelDest === 'big-sky' ) {
+					logAtomicFunnelEvent( 'post_checkout_big_sky', {
+						funnel: atomicFunnelSlug,
+						blog_id: siteId,
+					} );
+					return [
+						addQueryArgs(
+							withLocale( `/setup/${ SITE_SETUP_FLOW }/${ STEPS.LAUNCH_BIG_SKY.slug }`, locale ),
+							{
+								siteSlug,
+								...( siteId && String( siteId ) !== '0' ? { siteId } : {} ),
+								fromPostCheckoutSetupSite: '1',
+								...( refParameter ? { ref: refParameter } : {} ),
+							}
+						),
+						null,
+						null,
+					];
+				}
+			}
+
 			if ( ! providedDependencies.hasExternalTheme && providedDependencies.hasPluginByGoal ) {
 				return [ `/home/${ providedDependencies.siteSlug }`, null, null ];
 			}
@@ -469,9 +535,13 @@ const onboarding: FlowV2< typeof initialize > = {
 							// replace the location to delete processing step from history.
 							window.location.replace(
 								addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
-									// build_dest=wow goes straight from checkout to the AI site-spec
-									// (no post-checkout-onboarding hop, no chooser).
-									redirect_to: blueprintArchiveSlug ? destination : redirectTo,
+									// build_dest=wow and the atomic funnel (dest=site-spec/big-sky) go
+									// straight from checkout to their destination — no
+									// post-checkout-onboarding hop, no chooser.
+									redirect_to:
+										blueprintArchiveSlug || ( atomicFunnelSlug && atomicFunnelDest !== 'manual' )
+											? destination
+											: redirectTo,
 									signup: 1,
 									flow: ONBOARDING_FLOW,
 									checkoutBackUrl: pathToUrl( backDestination ?? '' ),
@@ -483,9 +553,12 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if ( blueprintArchiveSlug ) {
-							// build_dest=wow never shows the setup-your-site-ai chooser; go
-							// straight to the AI site-spec destination.
+						} else if (
+							blueprintArchiveSlug ||
+							( atomicFunnelSlug && atomicFunnelDest !== 'manual' )
+						) {
+							// build_dest=wow and the atomic funnel never show the
+							// setup-your-site-ai chooser; go straight to their destination.
 							window.location.replace( destination );
 						} else if (
 							refParameter === WOO_HOSTING_SOLUTIONS_REF &&
@@ -541,6 +614,7 @@ const onboarding: FlowV2< typeof initialize > = {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
 		const isLoggedIn = useSelector( isUserLoggedIn );
 		const user = useSelector( getCurrentUser );
+		const username = useSelector( getCurrentUserName );
 
 		/**
 		 * Clears every state we're persisting during the flow
@@ -578,6 +652,29 @@ const onboarding: FlowV2< typeof initialize > = {
 		useEffect( () => {
 			loadExperimentAssignment( 'calypso_plans_page_visual_separation_2025_09_v2' );
 		}, [] );
+
+		// Atomic funnel: create the Simple site as soon as the customer is in the flow, so its
+		// Atomic host builds (and any follow-up, e.g. a blueprint import) while they pick a domain
+		// and check out. Single-flight — the create-site step consumes the same site rather than
+		// creating a second one. Only fires once the funnel step is known (currentStepSlug set) and
+		// the user is logged in.
+		useEffect( () => {
+			if ( ! currentStepSlug || ! isLoggedIn || ! username ) {
+				return;
+			}
+			const queryParams = new URLSearchParams( window.location.search );
+			const funnelSlug = getAtomicFunnelSlug( queryParams );
+			if ( ! funnelSlug || getRememberedAtomicFunnelSite( funnelSlug ) ) {
+				return;
+			}
+			void startAtomicFunnelSite( {
+				funnelSlug,
+				funnelArgs: getAtomicFunnelArgs( queryParams ),
+				username,
+			} ).catch( () => {
+				// Errors are logged in the util; the create-site step retries as a fallback.
+			} );
+		}, [ currentStepSlug, isLoggedIn, username ] );
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -27,11 +27,7 @@ import Loading from 'calypso/components/loading';
 import useAddEcommerceTrialMutation from 'calypso/data/ecommerce/use-add-ecommerce-trial-mutation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import {
-	getWowFunnelArgs,
-	getWowFunnelSlug,
-	startWowFunnelSite,
-} from 'calypso/landing/stepper/utils/wow-funnel';
+import { getWowFunnelSlug, startWowFunnelSite } from 'calypso/landing/stepper/utils/wow-funnel';
 import { resolveLaunchpadPersonalizationVariation } from 'calypso/lib/ai-launchpad';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
@@ -230,7 +226,6 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		if ( wowFunnelSlug ) {
 			const funnelSite = await startWowFunnelSite( {
 				funnelSlug: wowFunnelSlug,
-				funnelArgs: getWowFunnelArgs( urlQueryParams ),
 				siteTitle: selectedSiteTitle,
 				username,
 			} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -227,7 +227,6 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			const funnelSite = await startWowFunnelSite( {
 				funnelSlug: wowFunnelSlug,
 				siteTitle: selectedSiteTitle,
-				username,
 			} );
 
 			const funnelCartItems = [

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -27,6 +27,11 @@ import Loading from 'calypso/components/loading';
 import useAddEcommerceTrialMutation from 'calypso/data/ecommerce/use-add-ecommerce-trial-mutation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import {
+	getAtomicFunnelArgs,
+	getAtomicFunnelSlug,
+	startAtomicFunnelSite,
+} from 'calypso/landing/stepper/utils/atomic-funnel';
 import { resolveLaunchpadPersonalizationVariation } from 'calypso/lib/ai-launchpad';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
@@ -212,6 +217,36 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 
 			return {
 				siteSlug: getSignupCompleteSlug(),
+				goToCheckout: shouldGoToCheckout,
+				siteCreated: true,
+			};
+		}
+
+		// Atomic funnel: the Simple site was already created at flow entry (its Atomic host is
+		// building in the background). Consume that site instead of creating a second one; if the
+		// background request has not finished — or failed — fall back to creating it here, sharing
+		// the same single-flight request.
+		const atomicFunnelSlug = getAtomicFunnelSlug( urlQueryParams );
+		if ( atomicFunnelSlug ) {
+			const funnelSite = await startAtomicFunnelSite( {
+				funnelSlug: atomicFunnelSlug,
+				funnelArgs: getAtomicFunnelArgs( urlQueryParams ),
+				siteTitle: selectedSiteTitle,
+				username,
+			} );
+
+			const funnelCartItems = [
+				...( planCartItem ? [ planCartItem ] : [] ),
+				...( productCartItems ?? [] ),
+				...mergedDomainCartItems,
+			];
+			if ( funnelCartItems.length > 0 ) {
+				await addProductsToCart( funnelSite.siteSlug, flow, funnelCartItems );
+			}
+
+			return {
+				siteId: funnelSite.blogId,
+				siteSlug: funnelSite.siteSlug,
 				goToCheckout: shouldGoToCheckout,
 				siteCreated: true,
 			};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -28,10 +28,10 @@ import useAddEcommerceTrialMutation from 'calypso/data/ecommerce/use-add-ecommer
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import {
-	getAtomicFunnelArgs,
-	getAtomicFunnelSlug,
-	startAtomicFunnelSite,
-} from 'calypso/landing/stepper/utils/atomic-funnel';
+	getWowFunnelArgs,
+	getWowFunnelSlug,
+	startWowFunnelSite,
+} from 'calypso/landing/stepper/utils/wow-funnel';
 import { resolveLaunchpadPersonalizationVariation } from 'calypso/lib/ai-launchpad';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
@@ -222,15 +222,15 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			};
 		}
 
-		// Atomic funnel: the Simple site was already created at flow entry (its Atomic host is
+		// WoW funnel: the Simple site was already created at flow entry (its Atomic host is
 		// building in the background). Consume that site instead of creating a second one; if the
 		// background request has not finished — or failed — fall back to creating it here, sharing
 		// the same single-flight request.
-		const atomicFunnelSlug = getAtomicFunnelSlug( urlQueryParams );
-		if ( atomicFunnelSlug ) {
-			const funnelSite = await startAtomicFunnelSite( {
-				funnelSlug: atomicFunnelSlug,
-				funnelArgs: getAtomicFunnelArgs( urlQueryParams ),
+		const wowFunnelSlug = getWowFunnelSlug( urlQueryParams );
+		if ( wowFunnelSlug ) {
+			const funnelSite = await startWowFunnelSite( {
+				funnelSlug: wowFunnelSlug,
+				funnelArgs: getWowFunnelArgs( urlQueryParams ),
 				siteTitle: selectedSiteTitle,
 				username,
 			} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -139,6 +139,9 @@ const DomainSearchStep: StepType< {
 	const isCiab = dashboard === 'ciab';
 	const isWooHostingSolutions = queryParams.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF;
 	const showProgress = useShowOnboardingProgress( isOnboardingFlow( flow ) );
+	// Atomic funnel: the site is always transferred to Atomic, so there is no free-subdomain
+	// option to offer — show only a "Set up a domain later" skip control.
+	const isAtomicFunnel = !! queryParams.get( 'atomic_funnel' );
 	const stepCounter = useOnboardingStepCounter( flow, 'domains' );
 
 	const storedSiteTitle = useSelect(
@@ -199,7 +202,12 @@ const DomainSearchStep: StepType< {
 				! isDomainAndPlanFlow( flow ),
 			// AI Website Builder onboarding requires a paid plan, so skipping the
 			// domain doesn't start a free site — drop the "start free" framing.
-			skipSuggestionCopy: getSkipSuggestionCopy( flow, __ ),
+			skipSuggestionCopy: isAtomicFunnel
+				? { title: __( 'Set up a domain later' ), buttonText: __( 'Set up a domain later' ) }
+				: getSkipSuggestionCopy( flow, __ ),
+			// Atomic funnel: hide the free *.wordpress.com subdomain card entirely and offer only
+			// the skip control.
+			hideFreeSubdomainSuggestion: isAtomicFunnel,
 			includeDotBlogSubdomain:
 				! isHundredYearPlanFlow( flow ) &&
 				! isHundredYearDomainFlow( flow ) &&
@@ -214,7 +222,16 @@ const DomainSearchStep: StepType< {
 				! isHundredYearPlanFlow( flow ) &&
 				( isHundredYearDomainFlow( flow ) ? !! query : true ),
 		};
-	}, [ __, flow, isCiab, isWooHostingSolutions, tldQuery, query, allowedTldsProp ] );
+	}, [
+		__,
+		flow,
+		isCiab,
+		isWooHostingSolutions,
+		isAtomicFunnel,
+		tldQuery,
+		query,
+		allowedTldsProp,
+	] );
 
 	const { submit } = navigation;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -139,9 +139,9 @@ const DomainSearchStep: StepType< {
 	const isCiab = dashboard === 'ciab';
 	const isWooHostingSolutions = queryParams.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF;
 	const showProgress = useShowOnboardingProgress( isOnboardingFlow( flow ) );
-	// Atomic funnel: the site is always transferred to Atomic, so there is no free-subdomain
+	// WoW funnel: the site is always transferred to Atomic, so there is no free-subdomain
 	// option to offer — show only a "Set up a domain later" skip control.
-	const isAtomicFunnel = !! queryParams.get( 'atomic_funnel' );
+	const isWowFunnel = !! queryParams.get( 'wow_funnel' );
 	const stepCounter = useOnboardingStepCounter( flow, 'domains' );
 
 	const storedSiteTitle = useSelect(
@@ -202,12 +202,12 @@ const DomainSearchStep: StepType< {
 				! isDomainAndPlanFlow( flow ),
 			// AI Website Builder onboarding requires a paid plan, so skipping the
 			// domain doesn't start a free site — drop the "start free" framing.
-			skipSuggestionCopy: isAtomicFunnel
+			skipSuggestionCopy: isWowFunnel
 				? { title: __( 'Set up a domain later' ), buttonText: __( 'Set up a domain later' ) }
 				: getSkipSuggestionCopy( flow, __ ),
-			// Atomic funnel: hide the free *.wordpress.com subdomain card entirely and offer only
+			// WoW funnel: hide the free *.wordpress.com subdomain card entirely and offer only
 			// the skip control.
-			hideFreeSubdomainSuggestion: isAtomicFunnel,
+			hideFreeSubdomainSuggestion: isWowFunnel,
 			includeDotBlogSubdomain:
 				! isHundredYearPlanFlow( flow ) &&
 				! isHundredYearDomainFlow( flow ) &&
@@ -222,16 +222,7 @@ const DomainSearchStep: StepType< {
 				! isHundredYearPlanFlow( flow ) &&
 				( isHundredYearDomainFlow( flow ) ? !! query : true ),
 		};
-	}, [
-		__,
-		flow,
-		isCiab,
-		isWooHostingSolutions,
-		isAtomicFunnel,
-		tldQuery,
-		query,
-		allowedTldsProp,
-	] );
+	}, [ __, flow, isCiab, isWooHostingSolutions, isWowFunnel, tldQuery, query, allowedTldsProp ] );
 
 	const { submit } = navigation;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
@@ -42,14 +42,14 @@ describe( 'getPlansIntent', () => {
 		} );
 	} );
 
-	describe( 'onboarding flow atomic_funnel param', () => {
-		it( 'hides the free plan for any atomic_funnel value', () => {
-			window.history.replaceState( {}, '', '/?atomic_funnel=blueprint' );
+	describe( 'onboarding flow wow_funnel param', () => {
+		it( 'hides the free plan for any wow_funnel value', () => {
+			window.history.replaceState( {}, '', '/?wow_funnel=blueprint' );
 			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-ai-assembler-paid-only' );
 		} );
 
-		it( 'keeps playground precedence over atomic_funnel', () => {
-			window.history.replaceState( {}, '', '/?atomic_funnel=blueprint&playground=abc' );
+		it( 'keeps playground precedence over wow_funnel', () => {
+			window.history.replaceState( {}, '', '/?wow_funnel=blueprint&playground=abc' );
 			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-playground' );
 		} );
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
@@ -42,6 +42,18 @@ describe( 'getPlansIntent', () => {
 		} );
 	} );
 
+	describe( 'onboarding flow atomic_funnel param', () => {
+		it( 'hides the free plan for any atomic_funnel value', () => {
+			window.history.replaceState( {}, '', '/?atomic_funnel=blueprint' );
+			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-ai-assembler-paid-only' );
+		} );
+
+		it( 'keeps playground precedence over atomic_funnel', () => {
+			window.history.replaceState( {}, '', '/?atomic_funnel=blueprint&playground=abc' );
+			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-playground' );
+		} );
+	} );
+
 	describe( 'plan-upgrade flow (dashboard "Change plan" downgrade entry point)', () => {
 		it( 'maps to the upgrade-or-downgrade intent when allow_downgrade=true', () => {
 			window.history.replaceState( {}, '', '/?allow_downgrade=true' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
@@ -41,10 +41,10 @@ export function getPlansIntent( flowName: string | null ): PlansIntent | null {
 			if ( search.has( 'playground' ) ) {
 				return playgroundPlansIntent( search.get( 'playground' )! );
 			}
-			// Atomic funnel: the site is always transferred to Atomic, so only plans that grant
+			// WoW funnel: the site is always transferred to Atomic, so only plans that grant
 			// the transfer make sense. Hide the free plan. Kept after the playground check so a
 			// playground entry keeps its own intent.
-			if ( search.has( 'atomic_funnel' ) ) {
+			if ( search.has( 'wow_funnel' ) ) {
 				return 'plans-ai-assembler-paid-only';
 			}
 			// Blueprint imports targeting Atomic (build_dest=wow) need a plan that

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
@@ -41,6 +41,12 @@ export function getPlansIntent( flowName: string | null ): PlansIntent | null {
 			if ( search.has( 'playground' ) ) {
 				return playgroundPlansIntent( search.get( 'playground' )! );
 			}
+			// Atomic funnel: the site is always transferred to Atomic, so only plans that grant
+			// the transfer make sense. Hide the free plan. Kept after the playground check so a
+			// playground entry keeps its own intent.
+			if ( search.has( 'atomic_funnel' ) ) {
+				return 'plans-ai-assembler-paid-only';
+			}
 			// Blueprint imports targeting Atomic (build_dest=wow) need a plan that
 			// supports the transfer, so hide the free plan. Plain blueprint imports
 			// build on a Simple site and keep the default grid.

--- a/client/landing/stepper/utils/atomic-funnel.ts
+++ b/client/landing/stepper/utils/atomic-funnel.ts
@@ -1,0 +1,211 @@
+import { Site } from '@automattic/data-stores';
+import { ONBOARDING_FLOW, createSite } from '@automattic/onboarding';
+import { logToLogstash } from 'calypso/lib/logstash';
+
+/**
+ * An atomic funnel is a CTA-selected onboarding path whose end state is always an Atomic site,
+ * with the Atomic build started before the customer picks a domain or pays. The funnel slug is
+ * validated server-side against the registry in wp-content/lib/atomic/funnels.php; the client only
+ * passes it through.
+ *
+ * Entry URL shape: /setup/onboarding?atomic_funnel=<slug>&dest=<dest>[&blueprint=<id>]
+ */
+
+/**
+ * Where the customer lands after checkout, chosen by the CTA.
+ *
+ * - `site-spec` — the AI site-spec step (used by the blueprint funnel).
+ * - `big-sky`   — the Big Sky / AI setup chooser.
+ * - `manual`    — the default post-checkout onboarding (Launchpad / My Home).
+ */
+export type AtomicFunnelDest = 'site-spec' | 'big-sky' | 'manual';
+
+const ATOMIC_FUNNEL_DESTS: AtomicFunnelDest[] = [ 'site-spec', 'big-sky', 'manual' ];
+
+/**
+ * A funnel site created for this flow, remembered so the create-site step can consume it rather
+ * than creating a second site. Persisted in sessionStorage so it survives a refresh mid-flow.
+ */
+export type RememberedAtomicFunnelSite = {
+	funnelSlug: string;
+	blogId: number;
+	siteSlug: string;
+};
+
+const SESSION_KEY = 'atomic-funnel-created-site';
+
+/**
+ * In-flight background-creation promises, keyed by funnel slug. Lets the create-site step await the
+ * same request the flow-entry side effect started, so we never create two sites for one funnel.
+ */
+const inFlight: Record< string, Promise< RememberedAtomicFunnelSite > | undefined > = {};
+
+export function getAtomicFunnelSlug( queryParams: URLSearchParams ): string | null {
+	const raw = queryParams.get( 'atomic_funnel' );
+	if ( ! raw ) {
+		return null;
+	}
+	// Mirror sanitize_key(): lowercase, [a-z0-9_-] only.
+	const slug = raw.toLowerCase().replace( /[^a-z0-9_-]/g, '' );
+	return slug || null;
+}
+
+export function getAtomicFunnelDest( queryParams: URLSearchParams ): AtomicFunnelDest {
+	const dest = queryParams.get( 'dest' );
+	return ATOMIC_FUNNEL_DESTS.find( ( d ) => d === dest ) ?? 'manual';
+}
+
+/**
+ * Funnel-specific args pulled from the entry URL, forwarded to the server as atomic_funnel_args.
+ * Currently just the blueprint slug for the blueprint funnel.
+ */
+export function getAtomicFunnelArgs( queryParams: URLSearchParams ): Record< string, string > {
+	const args: Record< string, string > = {};
+	const blueprint = queryParams.get( 'blueprint' );
+	if ( blueprint ) {
+		args.blueprint_slug = blueprint;
+	}
+	return args;
+}
+
+export function logAtomicFunnelEvent(
+	type: string,
+	properties: Record< string, unknown > = {}
+): void {
+	void logToLogstash( {
+		feature: 'calypso_client',
+		message: 'Atomic funnel onboarding',
+		severity: 'debug',
+		properties: {
+			type: `atomic_funnel_${ type }`,
+			...properties,
+		},
+	} ).catch( () => {} );
+}
+
+function readRemembered(): RememberedAtomicFunnelSite | null {
+	try {
+		const raw = window.sessionStorage.getItem( SESSION_KEY );
+		if ( ! raw ) {
+			return null;
+		}
+		const parsed = JSON.parse( raw ) as RememberedAtomicFunnelSite;
+		if ( parsed && parsed.funnelSlug && parsed.blogId && parsed.siteSlug ) {
+			return parsed;
+		}
+	} catch {
+		// Corrupt value — treat as absent.
+	}
+	return null;
+}
+
+export function getRememberedAtomicFunnelSite(
+	funnelSlug: string
+): RememberedAtomicFunnelSite | null {
+	const remembered = readRemembered();
+	return remembered && remembered.funnelSlug === funnelSlug ? remembered : null;
+}
+
+function rememberAtomicFunnelSite( site: RememberedAtomicFunnelSite ): void {
+	try {
+		window.sessionStorage.setItem( SESSION_KEY, JSON.stringify( site ) );
+	} catch {
+		// sessionStorage unavailable — the module-level in-flight cache still de-dupes within the
+		// session, and create-site falls back to creating the site itself.
+	}
+}
+
+export function clearAtomicFunnelSite(): void {
+	try {
+		window.sessionStorage.removeItem( SESSION_KEY );
+	} catch {
+		// Ignore.
+	}
+}
+
+/**
+ * Create the funnel's Simple site (which the server immediately fast-provisions to Atomic), once.
+ *
+ * Single-flight: concurrent callers for the same funnel share one request, and a site already
+ * remembered from this session is returned without a second create. The server generates an
+ * arbitrary subdomain (empty blog_name + find_available_url on the onboarding flow), so no
+ * siteUrl/title is needed here.
+ */
+export function startAtomicFunnelSite( {
+	funnelSlug,
+	funnelArgs,
+	siteTitle,
+	username,
+}: {
+	funnelSlug: string;
+	funnelArgs: Record< string, string >;
+	siteTitle?: string;
+	username: string;
+} ): Promise< RememberedAtomicFunnelSite > {
+	const remembered = getRememberedAtomicFunnelSite( funnelSlug );
+	if ( remembered ) {
+		return Promise.resolve( remembered );
+	}
+
+	const existing = inFlight[ funnelSlug ];
+	if ( existing ) {
+		return existing;
+	}
+
+	const request = ( async () => {
+		logAtomicFunnelEvent( 'start_site_creation', { funnel: funnelSlug } );
+
+		const site = await createSite(
+			ONBOARDING_FLOW,
+			'', // themeSlugWithRepo — default theme.
+			Site.Visibility.PublicNotIndexed, // coming soon.
+			siteTitle ?? '',
+			'#113AF5', // accent — backend requires a value.
+			false, // useThemeHeadstart.
+			username,
+			null, // partnerBundle.
+			undefined, // storedSiteUrl — empty so the server generates an arbitrary subdomain.
+			undefined, // domainItem.
+			undefined, // sourceSlug.
+			undefined, // siteIntent.
+			undefined, // siteGoals.
+			null, // gardenName.
+			null, // gardenPartnerName.
+			undefined, // specId.
+			undefined, // ref.
+			undefined, // provisionTarget.
+			undefined, // aiLaunchpadEnabled.
+			funnelSlug,
+			funnelArgs
+		);
+
+		if ( ! site ) {
+			throw new Error( 'Failed to create atomic funnel site' );
+		}
+
+		const result: RememberedAtomicFunnelSite = {
+			funnelSlug,
+			blogId: site.siteId,
+			siteSlug: site.siteSlug,
+		};
+		rememberAtomicFunnelSite( result );
+		logAtomicFunnelEvent( 'start_site_created', {
+			funnel: funnelSlug,
+			blog_id: result.blogId,
+			site_slug: result.siteSlug,
+		} );
+		return result;
+	} )();
+
+	inFlight[ funnelSlug ] = request;
+	request.catch( ( error ) => {
+		logAtomicFunnelEvent( 'start_site_error', {
+			funnel: funnelSlug,
+			error: error instanceof Error ? error.message : String( error ),
+		} );
+		// Clear so a later attempt (e.g. the create-site fallback) can retry.
+		inFlight[ funnelSlug ] = undefined;
+	} );
+
+	return request;
+}

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -14,16 +14,15 @@ import { logToLogstash } from 'calypso/lib/logstash';
 /**
  * Where the customer lands after checkout, chosen by the CTA.
  *
- * - `editor`  — straight into the Site Editor on the built Atomic site.
- * - `big-sky` — the Big Sky / AI setup chooser.
- * - `manual`  — the default post-checkout onboarding (Launchpad / My Home).
+ * - `editor` — straight into the Site Editor on the built Atomic site.
+ * - `manual` — the default post-checkout onboarding (Launchpad / My Home).
  *
- * Funnels with follow-up work add their own destinations alongside their server-side funnel
- * (e.g. the blueprint funnel's site-spec hand-off).
+ * Other funnels add their own destinations alongside their server-side funnel (e.g. the
+ * blueprint funnel's site-spec hand-off).
  */
-export type WowFunnelDest = 'editor' | 'big-sky' | 'manual';
+export type WowFunnelDest = 'editor' | 'manual';
 
-const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'editor', 'big-sky', 'manual' ];
+const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'editor', 'manual' ];
 
 /**
  * A funnel site created for this flow, remembered so the create-site step can consume it rather

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -12,17 +12,17 @@ import { logToLogstash } from 'calypso/lib/logstash';
  */
 
 /**
- * Where the customer lands after checkout, chosen by the CTA.
+ * Where the customer lands after checkout, when the CTA asks for somewhere specific.
  *
  * - `editor` — straight into the Site Editor on the built Atomic site.
- * - `manual` — the default post-checkout onboarding (Launchpad / My Home).
  *
- * Other funnels add their own destinations alongside their server-side funnel (e.g. the
+ * No (or unrecognized) `dest` means no override: the flow's ordinary post-checkout destination
+ * applies. Other funnels add their own values alongside their server-side funnel (e.g. the
  * blueprint funnel's site-spec hand-off).
  */
-export type WowFunnelDest = 'editor' | 'manual';
+export type WowFunnelDest = 'editor';
 
-const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'editor', 'manual' ];
+const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'editor' ];
 
 /**
  * A funnel site created for this flow, remembered so the create-site step can consume it rather
@@ -52,9 +52,9 @@ export function getWowFunnelSlug( queryParams: URLSearchParams ): string | null 
 	return slug || null;
 }
 
-export function getWowFunnelDest( queryParams: URLSearchParams ): WowFunnelDest {
+export function getWowFunnelDest( queryParams: URLSearchParams ): WowFunnelDest | null {
 	const dest = queryParams.get( 'dest' );
-	return WOW_FUNNEL_DESTS.find( ( d ) => d === dest ) ?? 'manual';
+	return WOW_FUNNEL_DESTS.find( ( d ) => d === dest ) ?? null;
 }
 
 export function logWowFunnelEvent(

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -14,14 +14,16 @@ import { logToLogstash } from 'calypso/lib/logstash';
 /**
  * Where the customer lands after checkout, chosen by the CTA.
  *
- * - `editor`    — straight into the Site Editor on the built Atomic site.
- * - `site-spec` — the AI site-spec step (used by the blueprint funnel).
- * - `big-sky`   — the Big Sky / AI setup chooser.
- * - `manual`    — the default post-checkout onboarding (Launchpad / My Home).
+ * - `editor`  — straight into the Site Editor on the built Atomic site.
+ * - `big-sky` — the Big Sky / AI setup chooser.
+ * - `manual`  — the default post-checkout onboarding (Launchpad / My Home).
+ *
+ * Funnels with follow-up work add their own destinations alongside their server-side funnel
+ * (e.g. the blueprint funnel's site-spec hand-off).
  */
-export type WowFunnelDest = 'editor' | 'site-spec' | 'big-sky' | 'manual';
+export type WowFunnelDest = 'editor' | 'big-sky' | 'manual';
 
-const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'editor', 'site-spec', 'big-sky', 'manual' ];
+const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'editor', 'big-sky', 'manual' ];
 
 /**
  * A funnel site created for this flow, remembered so the create-site step can consume it rather
@@ -54,19 +56,6 @@ export function getWowFunnelSlug( queryParams: URLSearchParams ): string | null 
 export function getWowFunnelDest( queryParams: URLSearchParams ): WowFunnelDest {
 	const dest = queryParams.get( 'dest' );
 	return WOW_FUNNEL_DESTS.find( ( d ) => d === dest ) ?? 'manual';
-}
-
-/**
- * Funnel-specific args pulled from the entry URL, forwarded to the server as wow_funnel_args.
- * Currently just the blueprint slug for the blueprint funnel.
- */
-export function getWowFunnelArgs( queryParams: URLSearchParams ): Record< string, string > {
-	const args: Record< string, string > = {};
-	const blueprint = queryParams.get( 'blueprint' );
-	if ( blueprint ) {
-		args.blueprint_slug = blueprint;
-	}
-	return args;
 }
 
 export function logWowFunnelEvent(
@@ -132,12 +121,10 @@ export function clearWowFunnelSite(): void {
  */
 export function startWowFunnelSite( {
 	funnelSlug,
-	funnelArgs,
 	siteTitle,
 	username,
 }: {
 	funnelSlug: string;
-	funnelArgs: Record< string, string >;
 	siteTitle?: string;
 	username: string;
 } ): Promise< RememberedWowFunnelSite > {
@@ -174,8 +161,7 @@ export function startWowFunnelSite( {
 			undefined, // ref.
 			undefined, // provisionTarget.
 			undefined, // aiLaunchpadEnabled.
-			funnelSlug,
-			funnelArgs
+			funnelSlug
 		);
 
 		if ( ! site ) {

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -14,13 +14,14 @@ import { logToLogstash } from 'calypso/lib/logstash';
 /**
  * Where the customer lands after checkout, chosen by the CTA.
  *
+ * - `editor`    — straight into the Site Editor on the built Atomic site.
  * - `site-spec` — the AI site-spec step (used by the blueprint funnel).
  * - `big-sky`   — the Big Sky / AI setup chooser.
  * - `manual`    — the default post-checkout onboarding (Launchpad / My Home).
  */
-export type WowFunnelDest = 'site-spec' | 'big-sky' | 'manual';
+export type WowFunnelDest = 'editor' | 'site-spec' | 'big-sky' | 'manual';
 
-const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'site-spec', 'big-sky', 'manual' ];
+const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'editor', 'site-spec', 'big-sky', 'manual' ];
 
 /**
  * A funnel site created for this flow, remembered so the create-site step can consume it rather

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -3,12 +3,12 @@ import { ONBOARDING_FLOW, createSite } from '@automattic/onboarding';
 import { logToLogstash } from 'calypso/lib/logstash';
 
 /**
- * An atomic funnel is a CTA-selected onboarding path whose end state is always an Atomic site,
+ * A WoW funnel is a CTA-selected onboarding path whose end state is always an Atomic site,
  * with the Atomic build started before the customer picks a domain or pays. The funnel slug is
  * validated server-side against the registry in wp-content/lib/atomic/funnels.php; the client only
  * passes it through.
  *
- * Entry URL shape: /setup/onboarding?atomic_funnel=<slug>&dest=<dest>[&blueprint=<id>]
+ * Entry URL shape: /setup/onboarding?wow_funnel=<slug>&dest=<dest>[&blueprint=<id>]
  */
 
 /**
@@ -18,30 +18,30 @@ import { logToLogstash } from 'calypso/lib/logstash';
  * - `big-sky`   — the Big Sky / AI setup chooser.
  * - `manual`    — the default post-checkout onboarding (Launchpad / My Home).
  */
-export type AtomicFunnelDest = 'site-spec' | 'big-sky' | 'manual';
+export type WowFunnelDest = 'site-spec' | 'big-sky' | 'manual';
 
-const ATOMIC_FUNNEL_DESTS: AtomicFunnelDest[] = [ 'site-spec', 'big-sky', 'manual' ];
+const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'site-spec', 'big-sky', 'manual' ];
 
 /**
  * A funnel site created for this flow, remembered so the create-site step can consume it rather
  * than creating a second site. Persisted in sessionStorage so it survives a refresh mid-flow.
  */
-export type RememberedAtomicFunnelSite = {
+export type RememberedWowFunnelSite = {
 	funnelSlug: string;
 	blogId: number;
 	siteSlug: string;
 };
 
-const SESSION_KEY = 'atomic-funnel-created-site';
+const SESSION_KEY = 'wow-funnel-created-site';
 
 /**
  * In-flight background-creation promises, keyed by funnel slug. Lets the create-site step await the
  * same request the flow-entry side effect started, so we never create two sites for one funnel.
  */
-const inFlight: Record< string, Promise< RememberedAtomicFunnelSite > | undefined > = {};
+const inFlight: Record< string, Promise< RememberedWowFunnelSite > | undefined > = {};
 
-export function getAtomicFunnelSlug( queryParams: URLSearchParams ): string | null {
-	const raw = queryParams.get( 'atomic_funnel' );
+export function getWowFunnelSlug( queryParams: URLSearchParams ): string | null {
+	const raw = queryParams.get( 'wow_funnel' );
 	if ( ! raw ) {
 		return null;
 	}
@@ -50,16 +50,16 @@ export function getAtomicFunnelSlug( queryParams: URLSearchParams ): string | nu
 	return slug || null;
 }
 
-export function getAtomicFunnelDest( queryParams: URLSearchParams ): AtomicFunnelDest {
+export function getWowFunnelDest( queryParams: URLSearchParams ): WowFunnelDest {
 	const dest = queryParams.get( 'dest' );
-	return ATOMIC_FUNNEL_DESTS.find( ( d ) => d === dest ) ?? 'manual';
+	return WOW_FUNNEL_DESTS.find( ( d ) => d === dest ) ?? 'manual';
 }
 
 /**
- * Funnel-specific args pulled from the entry URL, forwarded to the server as atomic_funnel_args.
+ * Funnel-specific args pulled from the entry URL, forwarded to the server as wow_funnel_args.
  * Currently just the blueprint slug for the blueprint funnel.
  */
-export function getAtomicFunnelArgs( queryParams: URLSearchParams ): Record< string, string > {
+export function getWowFunnelArgs( queryParams: URLSearchParams ): Record< string, string > {
 	const args: Record< string, string > = {};
 	const blueprint = queryParams.get( 'blueprint' );
 	if ( blueprint ) {
@@ -68,28 +68,28 @@ export function getAtomicFunnelArgs( queryParams: URLSearchParams ): Record< str
 	return args;
 }
 
-export function logAtomicFunnelEvent(
+export function logWowFunnelEvent(
 	type: string,
 	properties: Record< string, unknown > = {}
 ): void {
 	void logToLogstash( {
 		feature: 'calypso_client',
-		message: 'Atomic funnel onboarding',
+		message: 'WoW funnel onboarding',
 		severity: 'debug',
 		properties: {
-			type: `atomic_funnel_${ type }`,
+			type: `wow_funnel_${ type }`,
 			...properties,
 		},
 	} ).catch( () => {} );
 }
 
-function readRemembered(): RememberedAtomicFunnelSite | null {
+function readRemembered(): RememberedWowFunnelSite | null {
 	try {
 		const raw = window.sessionStorage.getItem( SESSION_KEY );
 		if ( ! raw ) {
 			return null;
 		}
-		const parsed = JSON.parse( raw ) as RememberedAtomicFunnelSite;
+		const parsed = JSON.parse( raw ) as RememberedWowFunnelSite;
 		if ( parsed && parsed.funnelSlug && parsed.blogId && parsed.siteSlug ) {
 			return parsed;
 		}
@@ -99,14 +99,12 @@ function readRemembered(): RememberedAtomicFunnelSite | null {
 	return null;
 }
 
-export function getRememberedAtomicFunnelSite(
-	funnelSlug: string
-): RememberedAtomicFunnelSite | null {
+export function getRememberedWowFunnelSite( funnelSlug: string ): RememberedWowFunnelSite | null {
 	const remembered = readRemembered();
 	return remembered && remembered.funnelSlug === funnelSlug ? remembered : null;
 }
 
-function rememberAtomicFunnelSite( site: RememberedAtomicFunnelSite ): void {
+function rememberWowFunnelSite( site: RememberedWowFunnelSite ): void {
 	try {
 		window.sessionStorage.setItem( SESSION_KEY, JSON.stringify( site ) );
 	} catch {
@@ -115,7 +113,7 @@ function rememberAtomicFunnelSite( site: RememberedAtomicFunnelSite ): void {
 	}
 }
 
-export function clearAtomicFunnelSite(): void {
+export function clearWowFunnelSite(): void {
 	try {
 		window.sessionStorage.removeItem( SESSION_KEY );
 	} catch {
@@ -131,7 +129,7 @@ export function clearAtomicFunnelSite(): void {
  * arbitrary subdomain (empty blog_name + find_available_url on the onboarding flow), so no
  * siteUrl/title is needed here.
  */
-export function startAtomicFunnelSite( {
+export function startWowFunnelSite( {
 	funnelSlug,
 	funnelArgs,
 	siteTitle,
@@ -141,8 +139,8 @@ export function startAtomicFunnelSite( {
 	funnelArgs: Record< string, string >;
 	siteTitle?: string;
 	username: string;
-} ): Promise< RememberedAtomicFunnelSite > {
-	const remembered = getRememberedAtomicFunnelSite( funnelSlug );
+} ): Promise< RememberedWowFunnelSite > {
+	const remembered = getRememberedWowFunnelSite( funnelSlug );
 	if ( remembered ) {
 		return Promise.resolve( remembered );
 	}
@@ -153,7 +151,7 @@ export function startAtomicFunnelSite( {
 	}
 
 	const request = ( async () => {
-		logAtomicFunnelEvent( 'start_site_creation', { funnel: funnelSlug } );
+		logWowFunnelEvent( 'start_site_creation', { funnel: funnelSlug } );
 
 		const site = await createSite(
 			ONBOARDING_FLOW,
@@ -180,16 +178,16 @@ export function startAtomicFunnelSite( {
 		);
 
 		if ( ! site ) {
-			throw new Error( 'Failed to create atomic funnel site' );
+			throw new Error( 'Failed to create WoW funnel site' );
 		}
 
-		const result: RememberedAtomicFunnelSite = {
+		const result: RememberedWowFunnelSite = {
 			funnelSlug,
 			blogId: site.siteId,
 			siteSlug: site.siteSlug,
 		};
-		rememberAtomicFunnelSite( result );
-		logAtomicFunnelEvent( 'start_site_created', {
+		rememberWowFunnelSite( result );
+		logWowFunnelEvent( 'start_site_created', {
 			funnel: funnelSlug,
 			blog_id: result.blogId,
 			site_slug: result.siteSlug,
@@ -199,7 +197,7 @@ export function startAtomicFunnelSite( {
 
 	inFlight[ funnelSlug ] = request;
 	request.catch( ( error ) => {
-		logAtomicFunnelEvent( 'start_site_error', {
+		logWowFunnelEvent( 'start_site_error', {
 			funnel: funnelSlug,
 			error: error instanceof Error ? error.message : String( error ),
 		} );

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -121,11 +121,9 @@ export function clearWowFunnelSite(): void {
 export function startWowFunnelSite( {
 	funnelSlug,
 	siteTitle,
-	username,
 }: {
 	funnelSlug: string;
 	siteTitle?: string;
-	username: string;
 } ): Promise< RememberedWowFunnelSite > {
 	const remembered = getRememberedWowFunnelSite( funnelSlug );
 	if ( remembered ) {
@@ -147,7 +145,9 @@ export function startWowFunnelSite( {
 			siteTitle ?? '',
 			'#113AF5', // accent — backend requires a value.
 			false, // useThemeHeadstart.
-			username,
+			// username: only ever a last-resort blog_name seed, and the server generates the
+			// funnel's arbitrary subdomain regardless — see /sites/new's wow-funnel block.
+			'',
 			null, // partnerBundle.
 			undefined, // storedSiteUrl — empty so the server generates an arbitrary subdomain.
 			undefined, // domainItem.

--- a/packages/domain-search/src/components/skip-suggestion/index.tsx
+++ b/packages/domain-search/src/components/skip-suggestion/index.tsx
@@ -17,10 +17,15 @@ const SkipSuggestion = () => {
 		? stripWpcomSubdomainSuffix( query )
 		: query;
 
-	const { data: suggestion } = useQuery( {
-		...queries.freeSuggestion( normalizedQuery ),
-		enabled: ! config.hideFreeSubdomainSuggestion,
-	} );
+	// When the free-subdomain card is hidden there is nothing to fetch; otherwise pass the
+	// query options through untouched so this observer keeps trunk's exact fetch semantics
+	// alongside useSuggestionsList's gated observer on the same key.
+	const freeSuggestionOptions = queries.freeSuggestion( normalizedQuery );
+	const { data: suggestion } = useQuery(
+		config.hideFreeSubdomainSuggestion
+			? { ...freeSuggestionOptions, enabled: false }
+			: freeSuggestionOptions
+	);
 
 	// Flows that never keep a free subdomain (e.g. the atomic funnel) show only a skip control,
 	// no *.wordpress.com domain. Skipping with no suggestion records a "choose later" origin.

--- a/packages/domain-search/src/components/skip-suggestion/index.tsx
+++ b/packages/domain-search/src/components/skip-suggestion/index.tsx
@@ -17,7 +17,24 @@ const SkipSuggestion = () => {
 		? stripWpcomSubdomainSuffix( query )
 		: query;
 
-	const { data: suggestion } = useQuery( queries.freeSuggestion( normalizedQuery ) );
+	const { data: suggestion } = useQuery( {
+		...queries.freeSuggestion( normalizedQuery ),
+		enabled: ! config.hideFreeSubdomainSuggestion,
+	} );
+
+	// Flows that never keep a free subdomain (e.g. the atomic funnel) show only a skip control,
+	// no *.wordpress.com domain. Skipping with no suggestion records a "choose later" origin.
+	if ( config.hideFreeSubdomainSuggestion ) {
+		return (
+			<DomainSearchSkipSuggestion
+				chooseLaterOnly
+				title={ config.skipSuggestionCopy?.title }
+				buttonText={ config.skipSuggestionCopy?.buttonText }
+				onSkip={ () => events.onSkip() }
+				disabled={ !! isMutating }
+			/>
+		);
+	}
 
 	if ( currentSiteUrl ) {
 		return (

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -69,6 +69,7 @@ export const DEFAULT_CONTEXT_VALUE: DomainSearchContextType = {
 	config: {
 		vendor: 'variation2_front',
 		skippable: false,
+		hideFreeSubdomainSuggestion: false,
 		deemphasizedTlds: [],
 		includeDotBlogSubdomain: false,
 		allowsUsingOwnDomain: false,

--- a/packages/domain-search/src/page/types.ts
+++ b/packages/domain-search/src/page/types.ts
@@ -136,6 +136,12 @@ export interface DomainSearchConfig {
 		title?: string;
 		buttonText?: string;
 	};
+	/**
+	 * Hide the free *.wordpress.com subdomain skip card and offer only a plain "skip / set up a
+	 * domain later" control. Used by flows whose site never keeps a free subdomain (e.g. the
+	 * atomic funnel, which always transfers to Atomic).
+	 */
+	hideFreeSubdomainSuggestion?: boolean;
 	deemphasizedTlds: string[];
 	priceRules: PriceRulesConfig;
 	includeDotBlogSubdomain: boolean;

--- a/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
+++ b/packages/domain-search/src/ui/domain-search-skip-suggestion/index.tsx
@@ -23,6 +23,11 @@ interface Props {
 	title?: string;
 	/** Overrides the default "Start Free" CTA of the free-subdomain card. */
 	buttonText?: string;
+	/**
+	 * Render a plain "set up a domain later" control with no domain shown, for flows that never
+	 * keep a free subdomain. `title`/`buttonText` still override the defaults.
+	 */
+	chooseLaterOnly?: boolean;
 	onSkip: () => void;
 	onSuggestionClick?: () => void;
 	disabled?: boolean;
@@ -35,6 +40,7 @@ const DomainSearchSkipSuggestion = ( {
 	existingSiteUrl,
 	title: titleOverride,
 	buttonText: buttonTextOverride,
+	chooseLaterOnly,
 	onSkip,
 	onSuggestionClick,
 	disabled,
@@ -49,7 +55,11 @@ const DomainSearchSkipSuggestion = ( {
 	let showButton = true;
 	let chevronOnMobile = false;
 
-	if ( existingSiteUrl ) {
+	if ( chooseLaterOnly ) {
+		title = titleOverride ?? __( 'Set up a domain later' );
+		subtitle = __( 'You can add a custom domain after your site is set up.' );
+		buttonText = buttonTextOverride ?? __( 'Set up a domain later' );
+	} else if ( existingSiteUrl ) {
 		const [ domain, ...tld ] = existingSiteUrl.split( '.' );
 
 		title = __( 'Current address' );
@@ -103,11 +113,13 @@ const DomainSearchSkipSuggestion = ( {
 
 	const domain = existingSiteUrl ?? freeSuggestion;
 	const showChevron = chevronOnMobile && isSmall;
-	const skipLabel = sprintf(
-		// translators: %(domain)s is the domain name
-		__( 'Skip purchase and continue with %(domain)s' ),
-		{ domain: domain ?? '' }
-	);
+	const skipLabel = chooseLaterOnly
+		? buttonText
+		: sprintf(
+				// translators: %(domain)s is the domain name
+				__( 'Skip purchase and continue with %(domain)s' ),
+				{ domain: domain ?? '' }
+		  );
 
 	const renderRight = () => {
 		if ( ! showButton ) {

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -33,8 +33,8 @@ interface GetNewSiteParams {
 	sourceSlug?: string;
 	siteIntent?: string;
 	provisionTarget?: string | null;
-	atomicFunnel?: string;
-	atomicFunnelArgs?: Record< string, string >;
+	wowFunnel?: string;
+	wowFunnelArgs?: Record< string, string >;
 }
 
 type NewSiteParams = {
@@ -57,8 +57,8 @@ type NewSiteParams = {
 		site_accent_color?: string;
 		site_intent?: string;
 		early_provision_target?: string;
-		atomic_funnel?: string;
-		atomic_funnel_args?: Record< string, string >;
+		wow_funnel?: string;
+		wow_funnel_args?: Record< string, string >;
 	};
 	validate: boolean;
 };
@@ -112,8 +112,8 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 		siteIntent,
 		partnerBundle,
 		provisionTarget,
-		atomicFunnel,
-		atomicFunnelArgs,
+		wowFunnel,
+		wowFunnelArgs,
 	} = params;
 
 	// We will use the default annotation instead of theme annotation as fallback,
@@ -139,11 +139,11 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 			...( siteIntent && { site_intent: siteIntent } ),
 			...( partnerBundle && { site_partner_bundle: partnerBundle } ),
 			...( provisionTarget && { early_provision_target: provisionTarget } ),
-			// Atomic funnel: build the site's Atomic host before checkout. The slug names a
+			// WoW funnel: build the site's Atomic host before checkout. The slug names a
 			// registered funnel server-side (see wp-content/lib/atomic/funnels.php).
-			...( atomicFunnel && { atomic_funnel: atomicFunnel } ),
-			...( atomicFunnelArgs &&
-				Object.keys( atomicFunnelArgs ).length > 0 && { atomic_funnel_args: atomicFunnelArgs } ),
+			...( wowFunnel && { wow_funnel: wowFunnel } ),
+			...( wowFunnelArgs &&
+				Object.keys( wowFunnelArgs ).length > 0 && { wow_funnel_args: wowFunnelArgs } ),
 		},
 		validate: false,
 	};
@@ -171,8 +171,8 @@ export const createSite = async (
 	ref?: string,
 	provisionTarget?: string | null,
 	aiLaunchpadEnabled?: boolean,
-	atomicFunnel?: string,
-	atomicFunnelArgs?: Record< string, string >
+	wowFunnel?: string,
+	wowFunnelArgs?: Record< string, string >
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
 
@@ -189,8 +189,8 @@ export const createSite = async (
 		siteIntent,
 		partnerBundle,
 		provisionTarget,
-		atomicFunnel,
-		atomicFunnelArgs,
+		wowFunnel,
+		wowFunnelArgs,
 	} );
 
 	// if ( isEmpty( bearerToken ) && 'onboarding-registrationless' === flowToCheck ) {

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -34,7 +34,6 @@ interface GetNewSiteParams {
 	siteIntent?: string;
 	provisionTarget?: string | null;
 	wowFunnel?: string;
-	wowFunnelArgs?: Record< string, string >;
 }
 
 type NewSiteParams = {
@@ -58,7 +57,6 @@ type NewSiteParams = {
 		site_intent?: string;
 		early_provision_target?: string;
 		wow_funnel?: string;
-		wow_funnel_args?: Record< string, string >;
 	};
 	validate: boolean;
 };
@@ -113,7 +111,6 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 		partnerBundle,
 		provisionTarget,
 		wowFunnel,
-		wowFunnelArgs,
 	} = params;
 
 	// We will use the default annotation instead of theme annotation as fallback,
@@ -142,8 +139,6 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 			// WoW funnel: build the site's Atomic host before checkout. The slug names a
 			// registered funnel server-side (see wp-content/lib/atomic/funnels.php).
 			...( wowFunnel && { wow_funnel: wowFunnel } ),
-			...( wowFunnelArgs &&
-				Object.keys( wowFunnelArgs ).length > 0 && { wow_funnel_args: wowFunnelArgs } ),
 		},
 		validate: false,
 	};
@@ -171,8 +166,7 @@ export const createSite = async (
 	ref?: string,
 	provisionTarget?: string | null,
 	aiLaunchpadEnabled?: boolean,
-	wowFunnel?: string,
-	wowFunnelArgs?: Record< string, string >
+	wowFunnel?: string
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
 
@@ -190,7 +184,6 @@ export const createSite = async (
 		partnerBundle,
 		provisionTarget,
 		wowFunnel,
-		wowFunnelArgs,
 	} );
 
 	// if ( isEmpty( bearerToken ) && 'onboarding-registrationless' === flowToCheck ) {

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -33,6 +33,8 @@ interface GetNewSiteParams {
 	sourceSlug?: string;
 	siteIntent?: string;
 	provisionTarget?: string | null;
+	atomicFunnel?: string;
+	atomicFunnelArgs?: Record< string, string >;
 }
 
 type NewSiteParams = {
@@ -55,6 +57,8 @@ type NewSiteParams = {
 		site_accent_color?: string;
 		site_intent?: string;
 		early_provision_target?: string;
+		atomic_funnel?: string;
+		atomic_funnel_args?: Record< string, string >;
 	};
 	validate: boolean;
 };
@@ -108,6 +112,8 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 		siteIntent,
 		partnerBundle,
 		provisionTarget,
+		atomicFunnel,
+		atomicFunnelArgs,
 	} = params;
 
 	// We will use the default annotation instead of theme annotation as fallback,
@@ -133,6 +139,11 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 			...( siteIntent && { site_intent: siteIntent } ),
 			...( partnerBundle && { site_partner_bundle: partnerBundle } ),
 			...( provisionTarget && { early_provision_target: provisionTarget } ),
+			// Atomic funnel: build the site's Atomic host before checkout. The slug names a
+			// registered funnel server-side (see wp-content/lib/atomic/funnels.php).
+			...( atomicFunnel && { atomic_funnel: atomicFunnel } ),
+			...( atomicFunnelArgs &&
+				Object.keys( atomicFunnelArgs ).length > 0 && { atomic_funnel_args: atomicFunnelArgs } ),
 		},
 		validate: false,
 	};
@@ -159,7 +170,9 @@ export const createSite = async (
 	specId?: string | null,
 	ref?: string,
 	provisionTarget?: string | null,
-	aiLaunchpadEnabled?: boolean
+	aiLaunchpadEnabled?: boolean,
+	atomicFunnel?: string,
+	atomicFunnelArgs?: Record< string, string >
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
 
@@ -176,6 +189,8 @@ export const createSite = async (
 		siteIntent,
 		partnerBundle,
 		provisionTarget,
+		atomicFunnel,
+		atomicFunnelArgs,
 	} );
 
 	// if ( isEmpty( bearerToken ) && 'onboarding-registrationless' === flowToCheck ) {


### PR DESCRIPTION
## Proposed Changes

Adds a **WoW funnel** variant to the onboarding flow: a CTA-selected path whose end state is always an Atomic site, with the build started before the customer picks a domain or pays. **Internal-only for now, enforced server-side**: `/sites/new` honours the funnel option only for Automatticians and the plan-gate skip is bound to the option it writes, so for anyone else this flow behaves like ordinary onboarding (the funnel option is simply ignored). The client carries no gate of its own.

Entry URL: `/setup/onboarding?wow_funnel=<slug>[&dest=editor]`

* **Background site creation at flow entry** — new `client/landing/stepper/utils/wow-funnel.ts`. Right after login, the flow fires `/sites/new` in the background with `options.wow_funnel` (+ args); the server generates an arbitrary subdomain and starts the Atomic build while the customer browses domains/plans. Single-flight with sessionStorage memory, so the create-site step consumes the same site instead of creating a second one (with a create-here fallback if the background call failed).
* **Domains step** — with `wow_funnel` set, the free `*.wordpress.com` subdomain card is hidden and only a "Set up a domain later" control is offered (submits the existing choose-later origin). New `@automattic/domain-search` config `hideFreeSubdomainSuggestion` + `chooseLaterOnly` mode on the skip-suggestion UI.
* **Plans step** — `wow_funnel` maps to the `plans-ai-assembler-paid-only` intent (all Atomic-granting tiers, Free hidden), kept after the existing playground precedence.
* **Post-checkout destination** — a CTA can request one with `dest`; today the only value is `editor` (straight into the Site Editor on the built Atomic site), baked into the checkout `redirect_to` the same way `build_dest=wow` is. Without `dest` the flow's ordinary post-checkout destination applies. Other funnels (e.g. the blueprint funnel's site-spec hand-off) add their values in their own PRs.
* `createSite()` (`packages/onboarding/src/cart`) threads `wowFunnel` through to `/sites/new`.

Server side is `236636-ghe-Automattic/wpcom` — the funnel registry, the Automattician-gated plan-check skip for funnel transfers, the fast-provision prepare job, and the purchase-release / 6h-abandonment-revert lifecycle. The server PR ships the follow-up-less `default` funnel; the blueprint funnel (archive import as follow-up) lands in a separate pair of PRs. Until the server side ships, the funnel param is ignored server-side and this flow degrades to ordinary onboarding.

## Why are these changes being made?

So funnels (blueprint CTAs, custom-theme builds, vertical landing pages) can hand the customer a finished Atomic site the moment they pay, instead of making them wait through a transfer after checkout. The domain is decoupled from site identity (arbitrary staging subdomain, chosen domain attaches later), which also removes the free-subdomain framing from a flow that never keeps one.

## Testing Instructions

1. Run against a sandbox with the server-side branch synced, logged in as an Automattician.
2. Visit `/setup/onboarding?wow_funnel=default&dest=editor`.
3. Domains step shows no free-subdomain card — only "Set up a domain later"; plans grid shows paid tiers only.
4. Pick a plan → checkout → land on the `dest` destination with the built `*.wpcomstaging.com` site (full pipeline verified end-to-end 2026-08-24 with the blueprint follow-up layered on).
5. As a non-Automattician (or logged out → new account): the same URL degrades to ordinary onboarding (the server ignores the funnel option).
6. Jest: `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts` (11/11).

Pre-merge checklist:

* [x] Tests pass locally
* [ ] E2E happy path re-verified against production API

🤖 Generated with [Claude Code](https://claude.com/claude-code)
