### PR TITLE
Auth: recover from a missing wordpress_sec cookie instead of stranding the user

### DIFF
--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -1,18 +1,19 @@
 import { isWpError } from '@automattic/api-core';
 import { Button, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { reauthRequiredLink, wpcomLink } from '../../utils/link';
 import { AuthContext } from '../auth';
 
-function isAuthorizationError( error: Error ) {
-	return (
-		error.name === 'AuthorizationRequiredError' ||
-		( isWpError( error ) && error.error === 'authorization_required' )
-	);
+function ReauthRedirect() {
+	useEffect( () => {
+		window.location.href = reauthRequiredLink();
+	}, [] );
+
+	return null;
 }
 
 function SessionError() {
@@ -61,16 +62,7 @@ function SessionError() {
 	);
 }
 
-function UnknownError( { error }: { error: Error } ) {
-	if ( isWpError( error ) && error.error === 'reauthorization_required' ) {
-		window.location.href = reauthRequiredLink();
-		return null;
-	}
-
-	if ( isAuthorizationError( error ) ) {
-		return <SessionError />;
-	}
-
+function GenericError( { error }: { error: Error } ) {
 	return (
 		<PageLayout
 			header={
@@ -79,6 +71,31 @@ function UnknownError( { error }: { error: Error } ) {
 			notices={ <Notice variant="error">{ error.message }</Notice> }
 		></PageLayout>
 	);
+}
+
+/**
+ * The dashboard's last-resort error screen.
+ *
+ * Route error boundaries fall back to this, and the area-specific error
+ * components (site, domain) delegate to it for anything they do not recognise.
+ * Only add a branch here for a failure that can happen anywhere in the app;
+ * anything scoped to one area belongs in that area's error component.
+ */
+function UnknownError( { error }: { error: Error } ) {
+	if ( isWpError( error ) ) {
+		if ( error.error === 'reauthorization_required' ) {
+			return <ReauthRedirect />;
+		}
+
+		// The API marks a request that carried no usable credential with this
+		// reason. An authorization failure without it is a genuine permission
+		// error, where signing in again would not help.
+		if ( error.reason === 'no_identity' ) {
+			return <SessionError />;
+		}
+	}
+
+	return <GenericError error={ error } />;
 }
 
 export default UnknownError;

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -65,7 +65,7 @@ function RefusedRequestError() {
 					}
 				>
 					{ __(
-						'We’re having trouble accessing data from your account at the moment. Please log out and log back in to try again. We apologize for the error.'
+						'We’re having trouble accessing data from your account at the moment. Please log out and log back in to try again.'
 					) }
 				</Notice>
 			}

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -1,5 +1,4 @@
-import { fetchUser, isWpError } from '@automattic/api-core';
-import { useQuery } from '@tanstack/react-query';
+import { isWpError } from '@automattic/api-core';
 import { Button, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useContext, useEffect } from 'react';
@@ -8,7 +7,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { reauthRequiredLink, wpcomLink } from '../../utils/link';
 import { bumpStat } from '../analytics';
-import { AuthContext } from '../auth';
+import { AuthContext, useSessionStateQuery } from '../auth';
 
 function ReauthRedirect() {
 	useEffect( () => {
@@ -35,38 +34,17 @@ function isAuthorizationError( error: Error ) {
 	return code === 'authorization_required' || code === 'rest_forbidden';
 }
 
-/**
- * Whether the session behind this screen still works.
- *
- * Asking for the current user is the only way to tell the two causes apart: it
- * succeeds for an account that is merely missing a permission, and fails the same
- * way as everything else once the session is gone.
- */
-function useHasWorkingSession() {
-	const { data, isPending } = useQuery( {
-		queryKey: [ 'auth', 'session-probe' ],
-		queryFn: () =>
-			fetchUser().then(
-				() => true,
-				() => false
-			),
-		retry: false,
-		gcTime: 0,
-		meta: { persist: false },
-	} );
-
-	return { hasWorkingSession: data ?? false, isPending };
-}
-
 function RefusedRequestError() {
-	const { hasWorkingSession, isPending } = useHasWorkingSession();
+	const { data: sessionState, isPending } = useSessionStateQuery();
 
 	// Better a moment of nothing than a moment of the wrong advice.
 	if ( isPending ) {
 		return null;
 	}
 
-	return hasWorkingSession ? <PermissionError /> : <SessionError />;
+	// A session we could not reach is treated as gone: wrong advice the user can
+	// act on beats correct advice they cannot.
+	return sessionState === 'alive' ? <PermissionError /> : <SessionError />;
 }
 
 function PermissionError() {

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -6,6 +6,7 @@ import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { reauthRequiredLink, wpcomLink } from '../../utils/link';
+import { bumpStat } from '../analytics';
 import { AuthContext } from '../auth';
 
 function ReauthRedirect() {
@@ -31,6 +32,12 @@ function RefusedRequestError() {
 	// `useAuth` throws when there is no provider, and this component is the last
 	// thing standing between the user and a blank screen.
 	const auth = useContext( AuthContext );
+
+	// Counts the users we failed to send to log in and left to recover by hand,
+	// which is the half of DOTCOM-14911 nothing measures today.
+	useEffect( () => {
+		bumpStat( 'dashboard-error', 'refused-request' );
+	}, [] );
 
 	// Logging out loads a chunk and clears stored state, either of which can fail
 	// in the very state that got the user here. Send them to log in regardless, so
@@ -79,7 +86,16 @@ function GenericError( { error }: { error: Error } ) {
 			header={
 				<PageHeader title={ __( '500 Error' ) } description={ __( 'Something wrong happened.' ) } />
 			}
-			notices={ <Notice variant="error">{ error.message }</Notice> }
+			notices={
+				<Notice
+					variant="error"
+					actions={
+						<ExternalLink href={ wpcomLink( '/help' ) }>{ __( 'Contact support' ) }</ExternalLink>
+					}
+				>
+					{ error.message }
+				</Notice>
+			}
 		></PageLayout>
 	);
 }

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -1,4 +1,5 @@
-import { isWpError } from '@automattic/api-core';
+import { fetchUser, isWpError } from '@automattic/api-core';
+import { useQuery } from '@tanstack/react-query';
 import { Button, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useContext, useEffect } from 'react';
@@ -17,26 +18,86 @@ function ReauthRedirect() {
 	return null;
 }
 
-// `authorization_required` covers both a session that can no longer authenticate
-// and an account that is authenticated but not allowed to see something, and the
-// API gives us no way to tell them apart. So suggest the fix for the first rather
-// than diagnosing either, and offer support for when it does not help.
+// A refused request means either that the session can no longer authenticate or
+// that the account simply is not allowed to see this, and the error says the same
+// thing in both cases. The v1 endpoints report the code as `error` and the ones
+// registered through the WP REST infrastructure report it as `code`.
 function isAuthorizationError( error: Error ) {
-	return (
-		error.name === 'AuthorizationRequiredError' ||
-		( isWpError( error ) && error.error === 'authorization_required' )
-	);
+	if ( error.name === 'AuthorizationRequiredError' ) {
+		return true;
+	}
+
+	if ( ! isWpError( error ) ) {
+		return false;
+	}
+
+	const code = typeof error.error === 'string' ? error.error : error.code;
+	return code === 'authorization_required' || code === 'rest_forbidden';
+}
+
+/**
+ * Whether the session behind this screen still works.
+ *
+ * Asking for the current user is the only way to tell the two causes apart: it
+ * succeeds for an account that is merely missing a permission, and fails the same
+ * way as everything else once the session is gone.
+ */
+function useHasWorkingSession() {
+	const { data, isPending } = useQuery( {
+		queryKey: [ 'auth', 'session-probe' ],
+		queryFn: () =>
+			fetchUser().then(
+				() => true,
+				() => false
+			),
+		retry: false,
+		gcTime: 0,
+		meta: { persist: false },
+	} );
+
+	return { hasWorkingSession: data ?? false, isPending };
 }
 
 function RefusedRequestError() {
+	const { hasWorkingSession, isPending } = useHasWorkingSession();
+
+	// Better a moment of nothing than a moment of the wrong advice.
+	if ( isPending ) {
+		return null;
+	}
+
+	return hasWorkingSession ? <PermissionError /> : <SessionError />;
+}
+
+function PermissionError() {
+	return (
+		<PageLayout
+			header={ <PageHeader title={ __( 'You don’t have access to this' ) } /> }
+			notices={
+				<Notice
+					variant="error"
+					actions={
+						<ExternalLink href={ wpcomLink( '/help' ) }>{ __( 'Contact support' ) }</ExternalLink>
+					}
+				>
+					{ __( 'Your account doesn’t have permission to view this page.' ) }
+				</Notice>
+			}
+		></PageLayout>
+	);
+}
+
+function SessionError() {
 	// `useAuth` throws when there is no provider, and this component is the last
 	// thing standing between the user and a blank screen.
 	const auth = useContext( AuthContext );
 
 	// Counts the users we failed to send to log in and left to recover by hand,
-	// which is the half of DOTCOM-14911 nothing measures today.
+	// which is the half of DOTCOM-14911 nothing measures today. The probe has
+	// confirmed the session by this point, so this is not diluted by people who
+	// merely lack a permission.
 	useEffect( () => {
-		bumpStat( 'dashboard-error', 'refused-request' );
+		bumpStat( 'dashboard-error', 'dead-session' );
 	}, [] );
 
 	// Logging out loads a chunk and clears stored state, either of which can fail

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -16,7 +16,18 @@ function ReauthRedirect() {
 	return null;
 }
 
-function SessionError() {
+// `authorization_required` covers both a session that can no longer authenticate
+// and an account that is authenticated but not allowed to see something, and the
+// API gives us no way to tell them apart. So suggest the fix for the first rather
+// than diagnosing either, and offer support for when it does not help.
+function isAuthorizationError( error: Error ) {
+	return (
+		error.name === 'AuthorizationRequiredError' ||
+		( isWpError( error ) && error.error === 'authorization_required' )
+	);
+}
+
+function RefusedRequestError() {
 	// `useAuth` throws when there is no provider, and this component is the last
 	// thing standing between the user and a blank screen.
 	const auth = useContext( AuthContext );
@@ -34,7 +45,7 @@ function SessionError() {
 
 	return (
 		<PageLayout
-			header={ <PageHeader title={ __( 'There’s a problem with your session' ) } /> }
+			header={ <PageHeader title={ __( 'Something went wrong' ) } /> }
 			notices={
 				<Notice
 					variant="error"
@@ -82,17 +93,12 @@ function GenericError( { error }: { error: Error } ) {
  * anything scoped to one area belongs in that area's error component.
  */
 function UnknownError( { error }: { error: Error } ) {
-	if ( isWpError( error ) ) {
-		if ( error.error === 'reauthorization_required' ) {
-			return <ReauthRedirect />;
-		}
+	if ( isWpError( error ) && error.error === 'reauthorization_required' ) {
+		return <ReauthRedirect />;
+	}
 
-		// The API marks a request that carried no usable credential with this
-		// reason. An authorization failure without it is a genuine permission
-		// error, where signing in again would not help.
-		if ( error.reason === 'no_identity' ) {
-			return <SessionError />;
-		}
+	if ( isAuthorizationError( error ) ) {
+		return <RefusedRequestError />;
 	}
 
 	return <GenericError error={ error } />;

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -1,14 +1,74 @@
 import { isWpError } from '@automattic/api-core';
+import { Button, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useContext } from 'react';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { reauthRequiredLink } from '../../utils/link';
+import { reauthRequiredLink, wpcomLink } from '../../utils/link';
+import { AuthContext } from '../auth';
+
+function isAuthorizationError( error: Error ) {
+	return (
+		error.name === 'AuthorizationRequiredError' ||
+		( isWpError( error ) && error.error === 'authorization_required' )
+	);
+}
+
+function SessionError() {
+	// `useAuth` throws when there is no provider, and this component is the last
+	// thing standing between the user and a blank screen.
+	const auth = useContext( AuthContext );
+
+	// Logging out loads a chunk and clears stored state, either of which can fail
+	// in the very state that got the user here. Send them to log in regardless, so
+	// the button is never a dead end.
+	const handleLogout = async () => {
+		try {
+			await auth?.logout();
+		} catch {
+			window.location.href = wpcomLink( '/log-in' );
+		}
+	};
+
+	return (
+		<PageLayout
+			header={ <PageHeader title={ __( 'There’s a problem with your session' ) } /> }
+			notices={
+				<Notice
+					variant="error"
+					actions={
+						<>
+							{ auth ? (
+								<Button variant="primary" onClick={ handleLogout }>
+									{ __( 'Log out' ) }
+								</Button>
+							) : (
+								<Button variant="primary" href={ wpcomLink( '/log-in' ) }>
+									{ __( 'Log in again' ) }
+								</Button>
+							) }
+							<ExternalLink href={ wpcomLink( '/help' ) }>{ __( 'Contact support' ) }</ExternalLink>
+						</>
+					}
+				>
+					{ __(
+						'We’re having trouble accessing data from your account at the moment. Please log out and log back in to try again. We apologize for the error.'
+					) }
+				</Notice>
+			}
+		></PageLayout>
+	);
+}
 
 function UnknownError( { error }: { error: Error } ) {
 	if ( isWpError( error ) && error.error === 'reauthorization_required' ) {
 		window.location.href = reauthRequiredLink();
 		return null;
+	}
+
+	if ( isAuthorizationError( error ) ) {
+		return <SessionError />;
 	}
 
 	return (

--- a/client/dashboard/app/500/test/index.test.tsx
+++ b/client/dashboard/app/500/test/index.test.tsx
@@ -20,12 +20,11 @@ function wpError( fields: Record< string, unknown >, message = RAW_API_MESSAGE )
 	} );
 }
 
-/** No credential was accepted, so signing in again is the fix. */
-function noIdentityError() {
-	return wpError( { error: 'authorization_required', reason: 'no_identity' } );
+function authorizationError() {
+	return wpError( { error: 'authorization_required' } );
 }
 
-/** Authenticated, but not allowed to see this. Signing in again changes nothing. */
+/** Authenticated, but not allowed to see this. Indistinguishable from the above. */
 function forbiddenError() {
 	return wpError(
 		{ error: 'authorization_required' },
@@ -63,13 +62,13 @@ describe( 'UnknownError', () => {
 			);
 
 			expect( window.location.href ).toContain( '/me/reauth-required' );
-			expect( container ).not.toHaveTextContent( /problem with your session/i );
+			expect( container ).not.toHaveTextContent( /trouble accessing data/i );
 		} );
 	} );
 
-	describe( 'when the request carried no usable credential', () => {
+	describe( 'when a request is refused', () => {
 		it( 'explains the problem instead of showing the raw API message', async () => {
-			renderWithLogout( noIdentityError(), jest.fn() );
+			renderWithLogout( authorizationError(), jest.fn() );
 
 			expect(
 				await screen.findByText( /trouble accessing data from your account/i )
@@ -79,7 +78,7 @@ describe( 'UnknownError', () => {
 
 		it( 'offers a way to log out and back in', async () => {
 			const logout = jest.fn();
-			renderWithLogout( noIdentityError(), logout );
+			renderWithLogout( authorizationError(), logout );
 
 			await userEvent.click( await screen.findByRole( 'button', { name: /log out/i } ) );
 
@@ -87,20 +86,21 @@ describe( 'UnknownError', () => {
 		} );
 
 		it( 'links to support', async () => {
-			renderWithLogout( noIdentityError(), jest.fn() );
+			renderWithLogout( authorizationError(), jest.fn() );
 
 			expect( await screen.findByRole( 'link', { name: /support/i } ) ).toBeVisible();
 		} );
 	} );
 
 	describe( 'when the account simply lacks access', () => {
-		it( 'does not tell the user to log in again', async () => {
+		// The API reports this identically to an unusable session, so the same
+		// screen is shown. The copy suggests logging back in rather than claiming
+		// it is the cause, and support is offered for when it does not help.
+		it( 'still offers a recovery path', async () => {
 			renderWithLogout( forbiddenError(), jest.fn() );
 
-			expect(
-				await screen.findByText( 'User or Token does not have access to specified site.' )
-			).toBeVisible();
-			expect( screen.queryByRole( 'button', { name: /log out/i } ) ).not.toBeInTheDocument();
+			expect( await screen.findByRole( 'button', { name: /log out/i } ) ).toBeVisible();
+			expect( screen.getByRole( 'link', { name: /support/i } ) ).toBeVisible();
 		} );
 	} );
 

--- a/client/dashboard/app/500/test/index.test.tsx
+++ b/client/dashboard/app/500/test/index.test.tsx
@@ -11,13 +11,26 @@ import type { User } from '@automattic/api-core';
 const RAW_API_MESSAGE =
 	'An active access token must be used to query information about the current user.';
 
-function authorizationError() {
-	return Object.assign( new Error( RAW_API_MESSAGE ), {
+function wpError( fields: Record< string, unknown >, message = RAW_API_MESSAGE ) {
+	return Object.assign( new Error( message ), {
 		name: 'AuthorizationRequiredError',
 		status: 403,
 		statusCode: 403,
-		error: 'authorization_required',
+		...fields,
 	} );
+}
+
+/** No credential was accepted, so signing in again is the fix. */
+function noIdentityError() {
+	return wpError( { error: 'authorization_required', reason: 'no_identity' } );
+}
+
+/** Authenticated, but not allowed to see this. Signing in again changes nothing. */
+function forbiddenError() {
+	return wpError(
+		{ error: 'authorization_required' },
+		'User or Token does not have access to specified site.'
+	);
 }
 
 function renderWithLogout( error: Error, logout: () => Promise< void > ) {
@@ -30,9 +43,33 @@ function renderWithLogout( error: Error, logout: () => Promise< void > ) {
 }
 
 describe( 'UnknownError', () => {
-	describe( 'when the session cannot authenticate', () => {
+	describe( 'when re-authentication is required', () => {
+		const originalLocation = window.location;
+
+		beforeEach( () => {
+			Object.defineProperty( window, 'location', {
+				writable: true,
+				value: { href: '', origin: 'http://localhost', pathname: '/sites' },
+			} );
+		} );
+
+		afterEach( () => {
+			Object.defineProperty( window, 'location', { writable: true, value: originalLocation } );
+		} );
+
+		it( 'sends the user to re-authenticate instead of rendering', () => {
+			const { container } = render(
+				<UnknownError error={ wpError( { error: 'reauthorization_required' } ) } />
+			);
+
+			expect( window.location.href ).toContain( '/me/reauth-required' );
+			expect( container ).not.toHaveTextContent( /problem with your session/i );
+		} );
+	} );
+
+	describe( 'when the request carried no usable credential', () => {
 		it( 'explains the problem instead of showing the raw API message', async () => {
-			renderWithLogout( authorizationError(), jest.fn() );
+			renderWithLogout( noIdentityError(), jest.fn() );
 
 			expect(
 				await screen.findByText( /trouble accessing data from your account/i )
@@ -42,18 +79,28 @@ describe( 'UnknownError', () => {
 
 		it( 'offers a way to log out and back in', async () => {
 			const logout = jest.fn();
-			renderWithLogout( authorizationError(), logout );
+			renderWithLogout( noIdentityError(), logout );
 
-			const button = await screen.findByRole( 'button', { name: /log out/i } );
-			await userEvent.click( button );
+			await userEvent.click( await screen.findByRole( 'button', { name: /log out/i } ) );
 
 			expect( logout ).toHaveBeenCalled();
 		} );
 
 		it( 'links to support', async () => {
-			renderWithLogout( authorizationError(), jest.fn() );
+			renderWithLogout( noIdentityError(), jest.fn() );
 
 			expect( await screen.findByRole( 'link', { name: /support/i } ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'when the account simply lacks access', () => {
+		it( 'does not tell the user to log in again', async () => {
+			renderWithLogout( forbiddenError(), jest.fn() );
+
+			expect(
+				await screen.findByText( 'User or Token does not have access to specified site.' )
+			).toBeVisible();
+			expect( screen.queryByRole( 'button', { name: /log out/i } ) ).not.toBeInTheDocument();
 		} );
 	} );
 

--- a/client/dashboard/app/500/test/index.test.tsx
+++ b/client/dashboard/app/500/test/index.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../test-utils';
+import { AuthContext } from '../../auth';
+import UnknownError from '../index';
+import type { User } from '@automattic/api-core';
+
+const RAW_API_MESSAGE =
+	'An active access token must be used to query information about the current user.';
+
+function authorizationError() {
+	return Object.assign( new Error( RAW_API_MESSAGE ), {
+		name: 'AuthorizationRequiredError',
+		status: 403,
+		statusCode: 403,
+		error: 'authorization_required',
+	} );
+}
+
+function renderWithLogout( error: Error, logout: () => Promise< void > ) {
+	const user = { ID: 1, username: 'testuser', language: 'en' } as User;
+	return render(
+		<AuthContext.Provider value={ { user, logout } }>
+			<UnknownError error={ error } />
+		</AuthContext.Provider>
+	);
+}
+
+describe( 'UnknownError', () => {
+	describe( 'when the session cannot authenticate', () => {
+		it( 'explains the problem instead of showing the raw API message', async () => {
+			renderWithLogout( authorizationError(), jest.fn() );
+
+			expect(
+				await screen.findByText( /trouble accessing data from your account/i )
+			).toBeVisible();
+			expect( screen.queryByText( RAW_API_MESSAGE ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'offers a way to log out and back in', async () => {
+			const logout = jest.fn();
+			renderWithLogout( authorizationError(), logout );
+
+			const button = await screen.findByRole( 'button', { name: /log out/i } );
+			await userEvent.click( button );
+
+			expect( logout ).toHaveBeenCalled();
+		} );
+
+		it( 'links to support', async () => {
+			renderWithLogout( authorizationError(), jest.fn() );
+
+			expect( await screen.findByRole( 'link', { name: /support/i } ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'for any other failure', () => {
+		it( 'keeps showing the underlying message', async () => {
+			render( <UnknownError error={ new Error( 'Something specific broke' ) } /> );
+
+			expect( await screen.findByText( 'Something specific broke' ) ).toBeVisible();
+			expect( screen.queryByRole( 'button', { name: /log out/i } ) ).not.toBeInTheDocument();
+		} );
+	} );
+} );

--- a/client/dashboard/app/500/test/index.test.tsx
+++ b/client/dashboard/app/500/test/index.test.tsx
@@ -4,9 +4,17 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '../../../test-utils';
+import { bumpStat } from '../../analytics';
 import { AuthContext } from '../../auth';
 import UnknownError from '../index';
 import type { User } from '@automattic/api-core';
+
+jest.mock( '../../analytics', () => ( {
+	...jest.requireActual( '../../analytics' ),
+	bumpStat: jest.fn(),
+} ) );
+
+const mockedBumpStat = jest.mocked( bumpStat );
 
 const RAW_API_MESSAGE =
 	'An active access token must be used to query information about the current user.';
@@ -90,6 +98,13 @@ describe( 'UnknownError', () => {
 
 			expect( await screen.findByRole( 'link', { name: /support/i } ) ).toBeVisible();
 		} );
+
+		it( 'counts the user as stranded', async () => {
+			renderWithLogout( authorizationError(), jest.fn() );
+
+			await screen.findByRole( 'button', { name: /log out/i } );
+			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-error', 'refused-request' );
+		} );
 	} );
 
 	describe( 'when the account simply lacks access', () => {
@@ -110,6 +125,19 @@ describe( 'UnknownError', () => {
 
 			expect( await screen.findByText( 'Something specific broke' ) ).toBeVisible();
 			expect( screen.queryByRole( 'button', { name: /log out/i } ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'still offers support, since the message alone is no help', async () => {
+			render( <UnknownError error={ new Error( 'Something specific broke' ) } /> );
+
+			expect( await screen.findByRole( 'link', { name: /support/i } ) ).toBeVisible();
+		} );
+
+		it( 'is not counted as a refused request', async () => {
+			render( <UnknownError error={ new Error( 'Something specific broke' ) } /> );
+
+			await screen.findByText( 'Something specific broke' );
+			expect( mockedBumpStat ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/client/dashboard/app/500/test/index.test.tsx
+++ b/client/dashboard/app/500/test/index.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 import { render } from '../../../test-utils';
 import { bumpStat } from '../../analytics';
 import { AuthContext } from '../../auth';
@@ -40,6 +41,22 @@ function forbiddenError() {
 	);
 }
 
+/** The session is gone: asking who we are fails like everything else. */
+function mockDeadSession() {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me' )
+		.query( true )
+		.reply( 403, { error: 'authorization_required', message: 'No active access token' } );
+}
+
+/** The session works; this account just cannot see this particular thing. */
+function mockWorkingSession() {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me' )
+		.query( true )
+		.reply( 200, { ID: 1, username: 'testuser', language: 'en' } );
+}
+
 function renderWithLogout( error: Error, logout: () => Promise< void > ) {
 	const user = { ID: 1, username: 'testuser', language: 'en' } as User;
 	return render(
@@ -74,7 +91,9 @@ describe( 'UnknownError', () => {
 		} );
 	} );
 
-	describe( 'when a request is refused', () => {
+	describe( 'when a request is refused and the session is gone', () => {
+		beforeEach( mockDeadSession );
+
 		it( 'explains the problem instead of showing the raw API message', async () => {
 			renderWithLogout( authorizationError(), jest.fn() );
 
@@ -103,19 +122,46 @@ describe( 'UnknownError', () => {
 			renderWithLogout( authorizationError(), jest.fn() );
 
 			await screen.findByRole( 'button', { name: /log out/i } );
-			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-error', 'refused-request' );
+			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-error', 'dead-session' );
 		} );
 	} );
 
 	describe( 'when the account simply lacks access', () => {
-		// The API reports this identically to an unusable session, so the same
-		// screen is shown. The copy suggests logging back in rather than claiming
-		// it is the cause, and support is offered for when it does not help.
-		it( 'still offers a recovery path', async () => {
+		beforeEach( mockWorkingSession );
+
+		it( 'says so instead of blaming the session', async () => {
 			renderWithLogout( forbiddenError(), jest.fn() );
 
-			expect( await screen.findByRole( 'button', { name: /log out/i } ) ).toBeVisible();
-			expect( screen.getByRole( 'link', { name: /support/i } ) ).toBeVisible();
+			expect( await screen.findByText( /doesn’t have permission/i ) ).toBeVisible();
+			expect( screen.queryByRole( 'button', { name: /log out/i } ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'still offers support', async () => {
+			renderWithLogout( forbiddenError(), jest.fn() );
+
+			expect( await screen.findByRole( 'link', { name: /support/i } ) ).toBeVisible();
+		} );
+
+		it( 'is not counted as a dead session', async () => {
+			renderWithLogout( forbiddenError(), jest.fn() );
+
+			await screen.findByText( /doesn’t have permission/i );
+			expect( mockedBumpStat ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'when the session cannot be checked at all', () => {
+		it( 'falls back to suggesting a fresh log in', async () => {
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/rest/v1.1/me' )
+				.query( true )
+				.replyWithError( 'offline' );
+			renderWithLogout( authorizationError(), jest.fn() );
+
+			// Wrong advice a user can act on beats correct advice they cannot.
+			await waitFor( async () =>
+				expect( await screen.findByRole( 'button', { name: /log out/i } ) ).toBeVisible()
+			);
 		} );
 	} );
 
@@ -133,7 +179,7 @@ describe( 'UnknownError', () => {
 			expect( await screen.findByRole( 'link', { name: /support/i } ) ).toBeVisible();
 		} );
 
-		it( 'is not counted as a refused request', async () => {
+		it( 'is not counted as a dead session either', async () => {
 			render( <UnknownError error={ new Error( 'Something specific broke' ) } /> );
 
 			await screen.findByText( 'Something specific broke' );

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -76,6 +76,46 @@ function isAuthBounceRecord( value: unknown ): value is AuthBounceRecord {
 	);
 }
 
+/**
+ * Whether the session behind the current page can still authenticate.
+ *
+ * `unknown` is kept apart from `dead` because callers disagree about what to do
+ * with a probe that never got an answer: nobody should be bounced on a guess,
+ * but a user already looking at an error screen is better off being told to log
+ * in again than being told nothing.
+ */
+export type SessionState = 'alive' | 'dead' | 'unknown';
+
+export const SESSION_STATE_QUERY_KEY = [ 'auth', 'session-state' ];
+
+/**
+ * Asks the API who we are, which is the only way to tell a session that can no
+ * longer authenticate from an account that is merely missing a permission: the
+ * two are reported identically on the request that failed.
+ *
+ * Shared so that one incident costs one request. A dead session fails every
+ * request alike, so the answer holds for the rest of the page.
+ */
+export const sessionStateQuery = () => ( {
+	queryKey: SESSION_STATE_QUERY_KEY,
+	queryFn: (): Promise< SessionState > =>
+		fetchUser().then(
+			() => 'alive' as const,
+			( error: unknown ) =>
+				isWpError( error ) &&
+				( error.statusCode === 401 || error.error === 'authorization_required' )
+					? ( 'dead' as const )
+					: ( 'unknown' as const )
+		),
+	retry: false,
+	staleTime: Infinity,
+	meta: { persist: false },
+} );
+
+export function useSessionStateQuery() {
+	return useQuery( sessionStateQuery() );
+}
+
 function getOAuthAuthorizeUrl( {
 	state,
 	next = '',

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -2,7 +2,7 @@ import { fetchUser, isWpError, User } from '@automattic/api-core';
 import { clearQueryClient, disablePersistQueryClient } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { setUser } from '@automattic/calypso-sentry';
-import { isSupportUserSession } from '@automattic/calypso-support-session';
+import { isSupportSession, isSupportUserSession } from '@automattic/calypso-support-session';
 import { magnificentNonEnLocales } from '@automattic/i18n-utils';
 import {
 	hashKey,
@@ -12,6 +12,7 @@ import {
 	type MutationCacheNotifyEvent,
 } from '@tanstack/react-query';
 import { createContext, useContext, useMemo, useEffect, useRef, useCallback } from 'react';
+import { isCookieAuthMissing } from 'wpcom-proxy-request';
 import { wpcomLink } from '../../utils/link';
 import { bumpStat } from '../analytics';
 import { useAppContext } from '../context';
@@ -124,6 +125,39 @@ export function useSessionStateQuery() {
 	return useQuery( sessionStateQuery() );
 }
 
+/**
+ * How confident we are that a failed request means the session itself is gone,
+ * and the stat suffix reported when it turns out to be right.
+ *
+ * `expired` is conclusive. The others also occur for reasons that have nothing
+ * to do with the session, so they are confirmed against `/me` before anyone is
+ * bounced.
+ */
+type AuthFailure = 'expired' | 'forbidden' | 'cookie-auth-missing';
+
+function classifyAuthFailure( { statusCode, error = '' }: WPError ): AuthFailure | null {
+	if ( statusCode === 401 && [ 'authorization_required', 'rest_forbidden' ].includes( error ) ) {
+		return 'expired';
+	}
+
+	// `wp_api_sec` is derived from `wordpress_sec`, so once that goes missing the
+	// API answers 403. The same code covers ordinary per-resource permission
+	// errors, which is why this one needs confirming.
+	if ( statusCode === 403 && error === 'authorization_required' ) {
+		return 'forbidden';
+	}
+
+	// The rest-proxy iframe reports the missing cookie itself, which catches the
+	// state even when the failing request does not look like an auth error. It is
+	// a sticky flag and also fires when third-party cookies are blocked, so on its
+	// own it never means more than "worth checking".
+	if ( isCookieAuthMissing() ) {
+		return 'cookie-auth-missing';
+	}
+
+	return null;
+}
+
 function getOAuthAuthorizeUrl( {
 	state,
 	next = '',
@@ -233,9 +267,14 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 	// A dead session fails every request alike, so one probe settles it for all of
 	// them.
 	const sessionProbe = useRef< Promise< boolean > | null >( null );
-	const confirmSessionExpired = useCallback( () => {
+	const confirmSessionExpired = useCallback( ( failure: AuthFailure ) => {
 		sessionProbe.current ??= fetchUser().then(
-			() => false,
+			() => {
+				// How often each signal turns out to be a false alarm is the thing we
+				// most need to know before acting on any of them more aggressively.
+				bumpStat( 'dashboard-auth', `probe-ok:${ failure }` );
+				return false;
+			},
 			( error: unknown ) =>
 				isWpError( error ) &&
 				( error.statusCode === 401 || error.error === 'authorization_required' )
@@ -285,17 +324,6 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 	// Subscribe to network errors and when errors occur due to being logged
 	// out, redirect the user to the log in screen.
 	useEffect( () => {
-		const isAuthError = ( { statusCode, error = '' }: WPError ) => {
-			return statusCode === 401 && [ 'authorization_required', 'rest_forbidden' ].includes( error );
-		};
-
-		// A missing or expired `wordpress_sec` invalidates `wp_api_sec` and the API
-		// answers 403 rather than 401. The same code covers per-resource permission
-		// errors, so confirm the whole session is gone before bouncing.
-		const isMaybeAuthError = ( { statusCode, error = '' }: WPError ) => {
-			return statusCode === 403 && error === 'authorization_required';
-		};
-
 		const handleEvent = ( event: MutationCacheNotifyEvent | QueryCacheNotifyEvent ) => {
 			// Errors fetching the user object itself are handled (and classified) below.
 			if ( 'query' in event && event.query.queryHash === hashKey( AUTH_QUERY_KEY ) ) {
@@ -303,22 +331,34 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 			}
 
 			if (
-				event.type === 'updated' &&
-				event.action.type === 'error' &&
-				isWpError( event.action.error )
+				event.type !== 'updated' ||
+				event.action.type !== 'error' ||
+				! isWpError( event.action.error )
 			) {
-				const error = event.action.error;
-
-				if ( isAuthError( error ) ) {
-					handleAuthError( 'expired' );
-				} else if ( isMaybeAuthError( error ) ) {
-					confirmSessionExpired().then( ( expired ) => {
-						if ( expired ) {
-							handleAuthError( 'expired' );
-						}
-					} );
-				}
+				return;
 			}
+
+			const failure = classifyAuthFailure( event.action.error );
+
+			if ( failure === null ) {
+				return;
+			}
+
+			if ( failure === 'expired' ) {
+				handleAuthError( failure );
+				return;
+			}
+
+			// Support sessions run on their own cookies and read as broken here.
+			if ( isSupportSession() ) {
+				return;
+			}
+
+			confirmSessionExpired( failure ).then( ( expired ) => {
+				if ( expired ) {
+					handleAuthError( failure );
+				}
+			} );
 		};
 		const unsubMutationCache = queryClient.getMutationCache().subscribe( handleEvent );
 		const unsubQueryCache = queryClient.getQueryCache().subscribe( handleEvent );

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -147,10 +147,12 @@ function classifyAuthFailure( { statusCode, error = '' }: WPError ): AuthFailure
 		return 'forbidden';
 	}
 
-	// The rest-proxy iframe reports the missing cookie itself, which catches the
-	// state even when the failing request does not look like an auth error. It is
-	// a sticky flag and also fires when third-party cookies are blocked, so on its
-	// own it never means more than "worth checking".
+	// The rest-proxy iframe reports at handshake whether it had anything to
+	// authenticate with, which catches the state even when the failing request
+	// does not look like an auth error. It is only ever a hint: it also fires for
+	// blocked third-party cookies, it tests the token for presence rather than
+	// validity, and being a one-off handshake it never reports a session that dies
+	// later.
 	if ( isCookieAuthMissing() ) {
 		return 'cookie-auth-missing';
 	}

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -133,18 +133,37 @@ export function useSessionStateQuery() {
  * to do with the session, so they are confirmed against `/me` before anyone is
  * bounced.
  */
-type AuthFailure = 'expired' | 'forbidden' | 'cookie-auth-missing';
+type AuthFailure = 'expired' | 'refused' | 'cookie-auth-missing';
 
-function classifyAuthFailure( { statusCode, error = '' }: WPError ): AuthFailure | null {
-	if ( statusCode === 401 && [ 'authorization_required', 'rest_forbidden' ].includes( error ) ) {
+// The two REST surfaces the dashboard talks to disagree about where the machine
+// readable code goes: `/rest/v1.x` answers `{ error }`, everything registered
+// through the WP REST infrastructure answers `{ code }`. Most of the dashboard is
+// on the latter, so reading only one of them misses most of the app. The slug
+// alone does not say which to expect — `authorization_required` arrives under
+// both — so read whichever is populated. Keep the string check: the proxy also
+// puts the HTTP status on `code` as a number.
+function getErrorCode( error: WPError ): string {
+	if ( typeof error.error === 'string' ) {
+		return error.error;
+	}
+	return typeof error.code === 'string' ? error.code : '';
+}
+
+function classifyAuthFailure( error: WPError ): AuthFailure | null {
+	const { statusCode } = error;
+
+	if (
+		statusCode === 401 &&
+		[ 'authorization_required', 'rest_forbidden' ].includes( getErrorCode( error ) )
+	) {
 		return 'expired';
 	}
 
-	// `wp_api_sec` is derived from `wordpress_sec`, so once that goes missing the
-	// API answers 403. The same code covers ordinary per-resource permission
-	// errors, which is why this one needs confirming.
-	if ( statusCode === 403 && error === 'authorization_required' ) {
-		return 'forbidden';
+	// The codes for a refused request vary by surface and are not worth matching
+	// individually. Anything refused is treated as suspicion only, and the check
+	// against `/me` is what decides, so being generous here costs one request.
+	if ( statusCode === 401 || statusCode === 403 ) {
+		return 'refused';
 	}
 
 	// The rest-proxy iframe reports at handshake whether it had anything to

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -24,6 +24,14 @@ const BOOTSTRAP_ERROR_MESSAGE = 'Failed to bootstrap user object';
 
 const AUTH_BOUNCE_COUNT_KEY = 'wpcom_auth_bounce_count';
 
+// Whether a redirect to log in has been started. Consumers use this to tell a
+// recoverable auth failure from one that leaves the user stranded in the app.
+let authRedirectInFlight = false;
+
+export function isAuthRedirectInFlight(): boolean {
+	return authRedirectInFlight;
+}
+
 const AUTH_LOOP_WINDOW_MS = 30 * 1000;
 
 // Cap the reported loop count (reported as "10+") so a runaway loop can't
@@ -222,6 +230,19 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		};
 	}, [ user ] );
 
+	// A dead session fails every request alike, so one probe settles it for all of
+	// them.
+	const sessionProbe = useRef< Promise< boolean > | null >( null );
+	const confirmSessionExpired = useCallback( () => {
+		sessionProbe.current ??= fetchUser().then(
+			() => false,
+			( error: unknown ) =>
+				isWpError( error ) &&
+				( error.statusCode === 401 || error.error === 'authorization_required' )
+		);
+		return sessionProbe.current;
+	}, [] );
+
 	const handleAuthError = useCallback(
 		( reason: string ) => {
 			// Prevents repeated calls to redirect
@@ -230,6 +251,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 			}
 
 			authErrorHandled.current = true;
+			authRedirectInFlight = true;
 
 			bumpStat( 'dashboard-auth', `bounce:${ reason }` );
 			trackAuthBounceLoop();
@@ -267,6 +289,13 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 			return statusCode === 401 && [ 'authorization_required', 'rest_forbidden' ].includes( error );
 		};
 
+		// A missing or expired `wordpress_sec` invalidates `wp_api_sec` and the API
+		// answers 403 rather than 401. The same code covers per-resource permission
+		// errors, so confirm the whole session is gone before bouncing.
+		const isMaybeAuthError = ( { statusCode, error = '' }: WPError ) => {
+			return statusCode === 403 && error === 'authorization_required';
+		};
+
 		const handleEvent = ( event: MutationCacheNotifyEvent | QueryCacheNotifyEvent ) => {
 			// Errors fetching the user object itself are handled (and classified) below.
 			if ( 'query' in event && event.query.queryHash === hashKey( AUTH_QUERY_KEY ) ) {
@@ -276,10 +305,19 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 			if (
 				event.type === 'updated' &&
 				event.action.type === 'error' &&
-				isWpError( event.action.error ) &&
-				isAuthError( event.action.error )
+				isWpError( event.action.error )
 			) {
-				handleAuthError( 'expired' );
+				const error = event.action.error;
+
+				if ( isAuthError( error ) ) {
+					handleAuthError( 'expired' );
+				} else if ( isMaybeAuthError( error ) ) {
+					confirmSessionExpired().then( ( expired ) => {
+						if ( expired ) {
+							handleAuthError( 'expired' );
+						}
+					} );
+				}
 			}
 		};
 		const unsubMutationCache = queryClient.getMutationCache().subscribe( handleEvent );
@@ -288,7 +326,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 			unsubMutationCache();
 			unsubQueryCache();
 		};
-	}, [ queryClient, handleAuthError ] );
+	}, [ queryClient, handleAuthError, confirmSessionExpired ] );
 
 	const successStatBumped = useRef( false );
 	useEffect( () => {

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -285,23 +285,21 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 		};
 	}, [ user ] );
 
-	// A dead session fails every request alike, so one probe settles it for all of
-	// them.
-	const sessionProbe = useRef< Promise< boolean > | null >( null );
-	const confirmSessionExpired = useCallback( ( failure: AuthFailure ) => {
-		sessionProbe.current ??= fetchUser().then(
-			() => {
-				// How often each signal turns out to be a false alarm is the thing we
-				// most need to know before acting on any of them more aggressively.
-				bumpStat( 'dashboard-auth', `probe-ok:${ failure }` );
-				return false;
-			},
-			( error: unknown ) =>
-				isWpError( error ) &&
-				( error.statusCode === 401 || error.error === 'authorization_required' )
-		);
-		return sessionProbe.current;
-	}, [] );
+	const confirmSessionExpired = useCallback(
+		( failure: AuthFailure ) =>
+			queryClient.fetchQuery( sessionStateQuery() ).then( ( state ) => {
+				if ( state === 'alive' ) {
+					// How often each signal turns out to be a false alarm is the thing we
+					// most need to know before acting on any of them more aggressively.
+					bumpStat( 'dashboard-auth', `probe-ok:${ failure }` );
+				}
+
+				// Nobody is bounced on a guess: an unanswered probe leaves the user where
+				// they are.
+				return state === 'dead';
+			} ),
+		[ queryClient ]
+	);
 
 	const handleAuthError = useCallback(
 		( reason: string ) => {

--- a/client/dashboard/app/auth/test/index.test.tsx
+++ b/client/dashboard/app/auth/test/index.test.tsx
@@ -275,6 +275,68 @@ describe( '<AuthProvider> stats', () => {
 				expect.stringContaining( 'bounce:' )
 			);
 		} );
+
+		test( 'leaves the user alone when the probe never answers', async () => {
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/rest/v1.1/me' )
+				.query( true )
+				.replyWithError( 'offline' );
+
+			await renderSignedInAndFail( forbidden() );
+
+			await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+			expect( mockedBumpStat ).not.toHaveBeenCalledWith(
+				'dashboard-auth',
+				expect.stringContaining( 'bounce:' )
+			);
+		} );
+
+		test( 'probes once even for a refusal arriving after the first answer', async () => {
+			// A second probe would find a dead session and bounce, so leaving the reply
+			// queued makes an extra request visible rather than merely uncounted.
+			const scope = nock( 'https://public-api.wordpress.com' )
+				.get( '/rest/v1.1/me' )
+				.query( true )
+				.reply( 200, testUser );
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/rest/v1.1/me' )
+				.query( true )
+				.reply( 403, { error: 'authorization_required', message: 'User cannot access this' } );
+
+			config.enable( 'wpcom-user-bootstrap' );
+			window.currentUser = testUser;
+
+			const { queryClient } = renderAuth();
+			expect( await screen.findByText( 'signed in' ) ).toBeVisible();
+
+			const failOnce = ( key: string ) =>
+				expect(
+					queryClient.fetchQuery( {
+						queryKey: [ key ],
+						queryFn: () => Promise.reject( forbidden() ),
+						retry: false,
+					} )
+				).rejects.toThrow();
+
+			// Errors trickle in rather than arriving together, so the probe has already
+			// settled by the time the second one is classified. Deduplicating requests
+			// in flight is not enough to cover this.
+			await failOnce( 'a' );
+			await waitFor( () =>
+				expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'probe-ok:refused' )
+			);
+
+			await failOnce( 'b' );
+
+			await expect(
+				waitFor( () => expect( nock.isDone() ).toBe( true ), { timeout: 250 } )
+			).rejects.toThrow();
+			expect( scope.isDone() ).toBe( true );
+			expect( mockedBumpStat ).not.toHaveBeenCalledWith(
+				'dashboard-auth',
+				expect.stringContaining( 'bounce:' )
+			);
+		} );
 	} );
 
 	test( 'bumps a bounce stat when the session expires mid-app', async () => {

--- a/client/dashboard/app/auth/test/index.test.tsx
+++ b/client/dashboard/app/auth/test/index.test.tsx
@@ -2,9 +2,11 @@
  * @jest-environment jsdom
  */
 import config from '@automattic/calypso-config';
+import { isSupportSession } from '@automattic/calypso-support-session';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import nock from 'nock';
+import { isCookieAuthMissing } from 'wpcom-proxy-request';
 import { bumpStat } from '../../analytics';
 import { AppProvider, APP_CONTEXT_DEFAULT_CONFIG } from '../../context';
 import { AuthProvider, sessionStateQuery, useSessionStateQuery } from '../index';
@@ -15,7 +17,19 @@ jest.mock( '../../analytics', () => ( {
 	bumpStat: jest.fn(),
 } ) );
 
+jest.mock( 'wpcom-proxy-request', () => ( {
+	...jest.requireActual( 'wpcom-proxy-request' ),
+	isCookieAuthMissing: jest.fn( () => false ),
+} ) );
+
+jest.mock( '@automattic/calypso-support-session', () => ( {
+	...jest.requireActual( '@automattic/calypso-support-session' ),
+	isSupportSession: jest.fn( () => false ),
+} ) );
+
 const mockedBumpStat = jest.mocked( bumpStat );
+const mockedIsCookieAuthMissing = jest.mocked( isCookieAuthMissing );
+const mockedIsSupportSession = jest.mocked( isSupportSession );
 
 const testUser = { ID: 1, username: 'testuser', language: 'en' } as User;
 
@@ -51,6 +65,9 @@ describe( '<AuthProvider> stats', () => {
 		config.disable( 'wpcom-user-bootstrap' );
 		delete window.currentUser;
 		window.sessionStorage.clear();
+		mockedIsCookieAuthMissing.mockReturnValue( false );
+		mockedIsSupportSession.mockReturnValue( false );
+		nock.cleanAll();
 	} );
 
 	test( 'bumps a success stat when the bootstrapped user is available', async () => {
@@ -153,6 +170,94 @@ describe( '<AuthProvider> stats', () => {
 			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'bounce:bootstrap' )
 		);
 		expect( mockedBumpStat ).not.toHaveBeenCalledWith( 'dashboard-auth-loop', expect.anything() );
+	} );
+
+	describe( 'when a request is refused but the code is ambiguous', () => {
+		async function renderSignedInAndFail( error: Error ) {
+			config.enable( 'wpcom-user-bootstrap' );
+			window.currentUser = testUser;
+
+			const { queryClient } = renderAuth();
+			expect( await screen.findByText( 'signed in' ) ).toBeVisible();
+
+			await expect(
+				queryClient.fetchQuery( {
+					queryKey: [ 'some-data' ],
+					queryFn: () => Promise.reject( error ),
+					retry: false,
+				} )
+			).rejects.toBe( error );
+		}
+
+		const forbidden = () =>
+			wpError( { status: 403, statusCode: 403, error: 'authorization_required' } );
+
+		test( 'bounces when the session turns out to be gone', async () => {
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/rest/v1.1/me' )
+				.query( true )
+				.reply( 403, { error: 'authorization_required', message: 'User cannot access this' } );
+
+			await renderSignedInAndFail( forbidden() );
+
+			await waitFor( () =>
+				expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'bounce:forbidden' )
+			);
+		} );
+
+		test( 'leaves the user alone when the session is still good', async () => {
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/rest/v1.1/me' )
+				.query( true )
+				.reply( 200, testUser );
+
+			await renderSignedInAndFail( forbidden() );
+
+			await waitFor( () =>
+				expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'probe-ok:forbidden' )
+			);
+			expect( mockedBumpStat ).not.toHaveBeenCalledWith(
+				'dashboard-auth',
+				expect.stringContaining( 'bounce:' )
+			);
+		} );
+
+		test( 'bounces on any failure once the proxy reports the auth cookie missing', async () => {
+			mockedIsCookieAuthMissing.mockReturnValue( true );
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/rest/v1.1/me' )
+				.query( true )
+				.reply( 403, { error: 'authorization_required', message: 'User cannot access this' } );
+
+			await renderSignedInAndFail( wpError( { status: 500, statusCode: 500 } ) );
+
+			await waitFor( () =>
+				expect( mockedBumpStat ).toHaveBeenCalledWith(
+					'dashboard-auth',
+					'bounce:cookie-auth-missing'
+				)
+			);
+		} );
+
+		test( 'never bounces a support session', async () => {
+			mockedIsSupportSession.mockReturnValue( true );
+			mockedIsCookieAuthMissing.mockReturnValue( true );
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/rest/v1.1/me' )
+				.query( true )
+				.reply( 403, { error: 'authorization_required', message: 'User cannot access this' } );
+
+			await renderSignedInAndFail( forbidden() );
+
+			// The session is never even probed, so nothing can bounce it.
+			await expect(
+				waitFor( () => expect( nock.isDone() ).toBe( true ), { timeout: 250 } )
+			).rejects.toThrow();
+			expect( mockedBumpStat ).not.toHaveBeenCalledWith(
+				'dashboard-auth',
+				expect.stringContaining( 'bounce:' )
+			);
+		} );
 	} );
 
 	test( 'bumps a bounce stat when the session expires mid-app', async () => {

--- a/client/dashboard/app/auth/test/index.test.tsx
+++ b/client/dashboard/app/auth/test/index.test.tsx
@@ -192,6 +192,10 @@ describe( '<AuthProvider> stats', () => {
 		const forbidden = () =>
 			wpError( { status: 403, statusCode: 403, error: 'authorization_required' } );
 
+		// What every endpoint registered through the WP REST infrastructure returns.
+		const forbiddenRestShape = () =>
+			Object.assign( wpError( { status: 403, statusCode: 403 } ), { code: 'unauthorized' } );
+
 		test( 'bounces when the session turns out to be gone', async () => {
 			nock( 'https://public-api.wordpress.com' )
 				.get( '/rest/v1.1/me' )
@@ -201,7 +205,7 @@ describe( '<AuthProvider> stats', () => {
 			await renderSignedInAndFail( forbidden() );
 
 			await waitFor( () =>
-				expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'bounce:forbidden' )
+				expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'bounce:refused' )
 			);
 		} );
 
@@ -214,7 +218,7 @@ describe( '<AuthProvider> stats', () => {
 			await renderSignedInAndFail( forbidden() );
 
 			await waitFor( () =>
-				expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'probe-ok:forbidden' )
+				expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'probe-ok:refused' )
 			);
 			expect( mockedBumpStat ).not.toHaveBeenCalledWith(
 				'dashboard-auth',
@@ -236,6 +240,19 @@ describe( '<AuthProvider> stats', () => {
 					'dashboard-auth',
 					'bounce:cookie-auth-missing'
 				)
+			);
+		} );
+
+		test( 'bounces on the WP REST error shape too', async () => {
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/rest/v1.1/me' )
+				.query( true )
+				.reply( 403, { error: 'authorization_required', message: 'User cannot access this' } );
+
+			await renderSignedInAndFail( forbiddenRestShape() );
+
+			await waitFor( () =>
+				expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'bounce:refused' )
 			);
 		} );
 

--- a/client/dashboard/app/auth/test/index.test.tsx
+++ b/client/dashboard/app/auth/test/index.test.tsx
@@ -3,11 +3,11 @@
  */
 import config from '@automattic/calypso-config';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { bumpStat } from '../../analytics';
 import { AppProvider, APP_CONTEXT_DEFAULT_CONFIG } from '../../context';
-import { AuthProvider } from '../index';
+import { AuthProvider, sessionStateQuery, useSessionStateQuery } from '../index';
 import type { User } from '@automattic/api-core';
 
 jest.mock( '../../analytics', () => ( {
@@ -174,5 +174,73 @@ describe( '<AuthProvider> stats', () => {
 		await waitFor( () =>
 			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'bounce:expired' )
 		);
+	} );
+} );
+
+describe( 'useSessionStateQuery', () => {
+	function renderSessionState( queryClient = new QueryClient() ) {
+		return renderHook( () => useSessionStateQuery(), {
+			wrapper: ( { children } ) => (
+				<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+			),
+		} );
+	}
+
+	test( 'reports a session that can no longer authenticate as dead', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me' )
+			.query( true )
+			.reply( 403, { error: 'authorization_required', message: 'User cannot access this' } );
+
+		const { result } = renderSessionState();
+
+		await waitFor( () => expect( result.current.data ).toBe( 'dead' ) );
+	} );
+
+	test( 'reports an account that merely lacks a permission as alive', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me' )
+			.query( true )
+			.reply( 200, testUser );
+
+		const { result } = renderSessionState();
+
+		await waitFor( () => expect( result.current.data ).toBe( 'alive' ) );
+	} );
+
+	test( 'separates a probe that never answered from a dead session', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me' )
+			.query( true )
+			.replyWithError( 'offline' );
+
+		const { result } = renderSessionState();
+
+		await waitFor( () => expect( result.current.data ).toBe( 'unknown' ) );
+	} );
+
+	test( 'reuses an answer already in the cache', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me' )
+			.query( true )
+			.reply( 200, testUser );
+		// Queued for a refetch to consume. Serving stale data while revalidating would
+		// still read as 'alive' at first, so flipping the answer is what makes an
+		// extra request visible.
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me' )
+			.query( true )
+			.reply( 403, { error: 'authorization_required', message: 'User cannot access this' } );
+
+		const queryClient = new QueryClient();
+		await queryClient.fetchQuery( sessionStateQuery() );
+
+		const { result } = renderSessionState( queryClient );
+
+		await waitFor( () => expect( result.current.data ).toBe( 'alive' ) );
+		await expect(
+			waitFor( () => expect( nock.isDone() ).toBe( true ), { timeout: 250 } )
+		).rejects.toThrow();
+		expect( result.current.data ).toBe( 'alive' );
 	} );
 } );

--- a/client/dashboard/app/logger/index.tsx
+++ b/client/dashboard/app/logger/index.tsx
@@ -3,6 +3,7 @@ import calypsoConfig from '@automattic/calypso-config';
 import { captureException } from '@automattic/calypso-sentry';
 import { camelToSnakeCase } from '@automattic/js-utils';
 import { logToLogstash } from 'calypso/lib/logstash';
+import { isAuthRedirectInFlight } from '../auth';
 import { maybeReloadForChunkError } from '../chunk-load-recovery';
 import type { AnyRouter } from '@tanstack/react-router';
 import type { ErrorInfo } from 'react';
@@ -21,11 +22,15 @@ export function initLogger( router: AnyRouter ) {
 }
 
 function isBenignError( error: Error ) {
-	// Ignore errors related to missing auth tokens.
-	// The user will get redirected to the login page / second auth factor.
 	switch ( error.name ) {
+		// Only benign while we are actually bouncing the user to log in. With no
+		// redirect in flight the session is dead but the app stays up, and that is
+		// the state worth reporting.
 		case 'AuthorizationRequiredError':
 		case 'ReauthorizationRequiredError':
+			return isAuthRedirectInFlight();
+
+		// The user is expected to sort out their own domain permissions.
 		case 'DomainPermissionError':
 			return true;
 	}

--- a/client/server/boot/index.js
+++ b/client/server/boot/index.js
@@ -66,6 +66,11 @@ export default function setup() {
 					if ( ! req.cookies.wordpress_logged_in ) {
 						req.cookies.wordpress_logged_in = config( 'wordpress_logged_in_cookie' );
 					}
+					// The logged-in check also requires a `wordpress_sec` cookie, which is
+					// Secure and so never reaches a plain-http dev server.
+					if ( ! req.cookies.wordpress_sec ) {
+						req.cookies.wordpress_sec = 'development';
+					}
 					next();
 				} );
 			} else {

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -111,10 +111,20 @@ function getCurrentCommitShortChecksum() {
  * accordingly. The handler is called very early (immediately after parsing the cookies) and
  * all following handlers (including the locale and redirect ones) can rely on the context values.
  */
+function hasSecureAuthCookie( cookies ) {
+	return Object.keys( cookies ).some( ( name ) => name.startsWith( 'wordpress_sec' ) );
+}
+
 function setupLoggedInContext( req, res, next ) {
 	const isSupportSession = !! req.get( 'x-support-session' ) || !! req.cookies.support_session_id;
 	const isSSP = !! req.cookies.ssp;
-	const isLoggedIn = !! req.cookies.wordpress_logged_in;
+	// `wordpress_logged_in` on its own is not enough to call the API: `wp_api_sec`
+	// is derived from `wordpress_sec`, so once that expires every request 403s
+	// while the app still renders as logged in. Treat it as logged out instead, so
+	// the user is sent to log in and gets a complete set of cookies back.
+	const isLoggedIn =
+		!! req.cookies.wordpress_logged_in &&
+		( hasSecureAuthCookie( req.cookies ) || isSupportSession );
 
 	req.context = {
 		...req.context,

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -179,7 +179,11 @@ const buildApp = ( environment ) => {
 		},
 		withAuthenticatedUser() {
 			defaultCookies.wordpress_logged_in = true;
-			tearDown.push( () => delete defaultCookies.wordpress_logged_in );
+			defaultCookies.wordpress_sec = true;
+			tearDown.push( () => {
+				delete defaultCookies.wordpress_logged_in;
+				delete defaultCookies.wordpress_sec;
+			} );
 		},
 		withAnonymousUser() {
 			defaultCookies.wordpress_logged_in = false;
@@ -963,7 +967,28 @@ describe( 'main app', () => {
 		} );
 
 		it( 'detects if it is logged in based on a cookie', async () => {
+			const { request } = await app.run( {
+				request: { cookies: { wordpress_logged_in: true, wordpress_sec: true } },
+			} );
+			expect( request.context.isLoggedIn ).toBe( true );
+		} );
+
+		it( 'accepts a hashed secure auth cookie', async () => {
+			const { request } = await app.run( {
+				request: { cookies: { wordpress_logged_in: true, wordpress_sec_0ff1ce: true } },
+			} );
+			expect( request.context.isLoggedIn ).toBe( true );
+		} );
+
+		it( 'is not logged in when the secure auth cookie is missing', async () => {
 			const { request } = await app.run( { request: { cookies: { wordpress_logged_in: true } } } );
+			expect( request.context.isLoggedIn ).toBe( false );
+		} );
+
+		it( 'is logged in without a secure auth cookie during a support session', async () => {
+			const { request } = await app.run( {
+				request: { cookies: { wordpress_logged_in: true, support_session_id: true } },
+			} );
 			expect( request.context.isLoggedIn ).toBe( true );
 		} );
 	} );
@@ -1245,7 +1270,7 @@ describe( 'main app', () => {
 				const { response } = await app.run( {
 					request: {
 						url: '/',
-						cookies: { wordpress_logged_in: true },
+						cookies: { wordpress_logged_in: true, wordpress_sec: true },
 						query: { s: 'my search' },
 					},
 				} );
@@ -1260,7 +1285,7 @@ describe( 'main app', () => {
 				const { response } = await app.run( {
 					request: {
 						url: '/',
-						cookies: { wordpress_logged_in: true },
+						cookies: { wordpress_logged_in: true, wordpress_sec: true },
 						query: { q: 'my search' },
 					},
 				} );
@@ -1275,7 +1300,7 @@ describe( 'main app', () => {
 				const { response } = await app.run( {
 					request: {
 						url: '/',
-						cookies: { wordpress_logged_in: true },
+						cookies: { wordpress_logged_in: true, wordpress_sec: true },
 						query: { newuseremail: 'any value' },
 					},
 				} );
@@ -1290,7 +1315,7 @@ describe( 'main app', () => {
 				const { response } = await app.run( {
 					request: {
 						url: '/',
-						cookies: { wordpress_logged_in: true },
+						cookies: { wordpress_logged_in: true, wordpress_sec: true },
 						query: { action: 'wpcom-invite-users' },
 					},
 				} );


### PR DESCRIPTION
Based on #113887, and targets that branch so the diff stays to the auth guard. Merge that one first.

## Proposed Changes

* Treat a request carrying a logged-in cookie but no secure auth cookie as logged out.
* Redirect the dashboard to log in on a 403 auth failure, not only a 401.
* Act on the rest proxy's own report that the auth cookie is missing, which the dashboard was ignoring.
* Confirm a suspected dead session against the API before redirecting anyone, reusing the shared query added in #113887 so one incident costs one request.
* Stop discarding authorization errors in the dashboard logger when no redirect to log in is actually happening.

## Why are these changes being made?

API requests from the browser are authenticated with a token derived from the secure auth cookie. The logged-in cookie is deliberately not accepted for API authentication. The two cookies can fall out of sync, since the secure one is given a much shorter lifetime in some cases.

When that happens, the session breaks in a way that hides itself:

* The server-side user bootstrap still succeeds, because it authenticates with the logged-in cookie and a privileged key. The app renders as a normal signed-in session.
* Every API call the app then makes fails with a 403.

So the user gets a dashboard that looks signed in and loads nothing. The dashboard did not send them to log in, because it only recognised a 401 as an auth failure. The only real fix is to log out and back in, and nothing on screen suggests it.

Ref: DOTCOM-14911. A mitigation for this already shipped, but only for the classic dashboard, where the router middleware re-checks the user and logs out. The new dashboard has none of it. The note on that issue that the new dashboard is unaffected because it always fetches the user over the API is no longer true: the user is bootstrapped there too now, so it lands in exactly the same broken-but-signed-in state.

The same errors were also classified as benign and skipped for logging, on the assumption that a redirect to log in was about to happen. In this state no redirect happens, so the failure never reached Logstash or Sentry and the whole scenario is invisible in our metrics.

## Testing Instructions

1. Log in to WordPress.com and open the dashboard.
2. In devtools, delete the `wordpress_sec` cookie. Leave `wordpress_logged_in` in place.
3. Reload.

Before: the page shows a 500 error reading "An active access token must be used to query information about the current user", and nothing on the page offers a way out.

After: you are redirected to log in with `redirect_to` pointing back at the page you were on, and signing in restores a working session.

Note that reproducing this locally needs `wpcom-user-bootstrap` enabled, since with it off the client fetches the user itself, sees the failure and logs out cleanly.

## Considerations

Two separate signals suggest a session might be dead, and neither is conclusive on its own:

* A 403 with `authorization_required`. The API returns this both when the session is unusable and when the account simply lacks access to one particular resource. Treating every such 403 as a dead session would sign people out over a single inaccessible site.
* The rest proxy reporting that it had nothing to authenticate with. This catches the state even when the failing request does not look like an auth error, but it is a weak signal in both directions. It fires for anyone who blocks third-party cookies. It also misses: the proxy reports this once, during its handshake, and tests its token for presence rather than validity, so an expired token reads as fine and a session that dies later is never reported at all.

There is also no single error code to match on. The two REST surfaces the dashboard talks to report a refused request differently: the v1 endpoints answer `{ error }`, and everything registered through the WP REST infrastructure answers `{ code }`, with a different vocabulary of slugs and the same slug sometimes appearing in either field. The dashboard is overwhelmingly on the latter, so matching a code string against one field would have missed most of the app.

Rather than trying to make any of this precise, a refused request is treated as suspicion only, whatever it looks like: it triggers a single check against the user endpoint, and nobody is redirected unless that fails too. The cost is one extra request per session for anyone who hits an ordinary permission error, which seems a fair price for not having to track two error vocabularies. Support sessions are skipped, since they run on their own cookie arrangement and read as broken here. A 401 keeps redirecting immediately, as before.

Which signal fired is recorded in the bounce stat, and a check that comes back healthy is recorded too. How often each signal is a false alarm is the thing the linked issue still needs to know, and there is currently no way to measure it.

Worth noting for anyone coming from that issue: the server-side change reads cookies on the first-party request to the Calypso server, so it is unaffected by third-party cookie blocking.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)



