### PR TITLE
Agents Manager: merge the Ask AI click events into one with a surface per entry point

### DIFF
--- a/client/dashboard/app/omnibar/plugin-ai-chat.tsx
+++ b/client/dashboard/app/omnibar/plugin-ai-chat.tsx
@@ -38,7 +38,8 @@ export function useAiChatPlugin( {
 	const handleClick = () => {
 		const isChatVisible = isAgentsManagerChatVisible();
 
-		recordAgentsManagerTracksEvent( 'calypso_masterbar_agents_manager_ai_chat_clicked', {
+		recordAgentsManagerTracksEvent( 'calypso_agents_manager_ai_chat_clicked', {
+			surface: 'masterbar',
 			section: sectionName || 'unknown',
 			action: isChatVisible ? 'close' : 'open',
 		} );

--- a/client/dashboard/app/omnibar/test/plugin-ai-chat.test.tsx
+++ b/client/dashboard/app/omnibar/test/plugin-ai-chat.test.tsx
@@ -46,8 +46,8 @@ describe( 'useAiChatPlugin', () => {
 		result.current?.onClick?.( {} as React.MouseEvent );
 
 		expect( recordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
-			'calypso_masterbar_agents_manager_ai_chat_clicked',
-			{ section: 'sites', action: 'open' }
+			'calypso_agents_manager_ai_chat_clicked',
+			{ surface: 'masterbar', section: 'sites', action: 'open' }
 		);
 		expect( openAgentsManagerChat ).toHaveBeenCalled();
 		expect( closeAgentsManagerChat ).not.toHaveBeenCalled();
@@ -60,8 +60,8 @@ describe( 'useAiChatPlugin', () => {
 		result.current?.onClick?.( {} as React.MouseEvent );
 
 		expect( recordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
-			'calypso_masterbar_agents_manager_ai_chat_clicked',
-			{ section: 'unknown', action: 'close' }
+			'calypso_agents_manager_ai_chat_clicked',
+			{ surface: 'masterbar', section: 'unknown', action: 'close' }
 		);
 		expect( closeAgentsManagerChat ).toHaveBeenCalled();
 		expect( openAgentsManagerChat ).not.toHaveBeenCalled();

--- a/client/layout/masterbar/masterbar-agents-manager/ai-chat-button.tsx
+++ b/client/layout/masterbar/masterbar-agents-manager/ai-chat-button.tsx
@@ -26,7 +26,8 @@ const MasterbarAiChatButton = () => {
 	// Toggle: close the chat if it's already showing, otherwise resume the active
 	// conversation and open it.
 	const handleClick = () => {
-		recordAgentsManagerTracksEvent( 'calypso_masterbar_agents_manager_ai_chat_clicked', {
+		recordAgentsManagerTracksEvent( 'calypso_agents_manager_ai_chat_clicked', {
+			surface: 'masterbar',
 			section: sectionName || 'unknown',
 			action: isChatVisible ? 'close' : 'open',
 		} );

--- a/client/layout/masterbar/masterbar-agents-manager/test/ai-chat-button.tsx
+++ b/client/layout/masterbar/masterbar-agents-manager/test/ai-chat-button.tsx
@@ -76,8 +76,8 @@ describe( 'MasterbarAiChatButton', () => {
 		expect( closeAgentsManagerChat ).toHaveBeenCalled();
 		expect( openAgentsManagerChat ).not.toHaveBeenCalled();
 		expect( recordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
-			'calypso_masterbar_agents_manager_ai_chat_clicked',
-			{ section: 'test-section', action: 'close' }
+			'calypso_agents_manager_ai_chat_clicked',
+			{ surface: 'masterbar', section: 'test-section', action: 'close' }
 		);
 	} );
 
@@ -90,8 +90,8 @@ describe( 'MasterbarAiChatButton', () => {
 		expect( openAgentsManagerChat ).toHaveBeenCalled();
 		expect( closeAgentsManagerChat ).not.toHaveBeenCalled();
 		expect( recordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
-			'calypso_masterbar_agents_manager_ai_chat_clicked',
-			{ section: 'test-section', action: 'open' }
+			'calypso_agents_manager_ai_chat_clicked',
+			{ surface: 'masterbar', section: 'test-section', action: 'open' }
 		);
 	} );
 
@@ -104,8 +104,8 @@ describe( 'MasterbarAiChatButton', () => {
 		await userEvent.click( screen.getByRole( 'button' ) );
 
 		expect( recordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
-			'calypso_masterbar_agents_manager_ai_chat_clicked',
-			{ section: 'unknown', action: 'open' }
+			'calypso_agents_manager_ai_chat_clicked',
+			{ surface: 'masterbar', section: 'unknown', action: 'open' }
 		);
 	} );
 } );

--- a/packages/agents-manager/src/components/editor-ai-chat-button/index.tsx
+++ b/packages/agents-manager/src/components/editor-ai-chat-button/index.tsx
@@ -36,7 +36,8 @@ export default function EditorAiChatButton( { onClose, onOpenChat }: Props ) {
 
 	// Mirrors the admin-bar button: close if showing, else resume the tab's conversation and open.
 	const handleToggle = () => {
-		recordAgentsManagerTracksEvent( 'calypso_editor_agents_manager_ai_chat_clicked', {
+		recordAgentsManagerTracksEvent( 'calypso_agents_manager_ai_chat_clicked', {
+			surface: 'editor_toolbar',
 			section: sectionName || 'gutenberg',
 			action: isChatVisible ? 'close' : 'open',
 		} );

--- a/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
+++ b/packages/agents-manager/src/hooks/use-admin-bar-integration/index.tsx
@@ -139,7 +139,8 @@ export default function useAdminBarIntegration( {
 		}
 
 		const handleClick = () => {
-			recordAgentsManagerTracksEvent( 'calypso_admin_bar_agents_manager_ai_chat_clicked', {
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_ai_chat_clicked', {
+				surface: 'admin_bar',
 				section: sectionName || 'wp-admin',
 				action: isChatVisibleRef.current ? 'close' : 'open',
 			} );

--- a/packages/agents-manager/src/utils/__tests__/tracks.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/tracks.test.ts
@@ -257,22 +257,23 @@ describe( 'tracks wrappers', () => {
 		} );
 	} );
 
-	describe( 'entry-point event names', () => {
-		it( 'records a host-prefixed name verbatim with the unified base-prop set', () => {
-			recordAgentsManagerTracksEvent( 'calypso_editor_agents_manager_ai_chat_clicked', {
+	describe( 'entry-point events', () => {
+		it( 'lets a caller-supplied surface override the base value', () => {
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_ai_chat_clicked', {
+				surface: 'editor_toolbar',
 				section: 'gutenberg',
 				action: 'open',
 			} );
 
 			const [ eventName ] = mockRecordTracksEvent.mock.calls[ 0 ];
-			expect( eventName ).toBe( 'calypso_editor_agents_manager_ai_chat_clicked' );
+			expect( eventName ).toBe( 'calypso_agents_manager_ai_chat_clicked' );
 
 			expect( lastEventProps() ).toMatchObject( {
 				section: 'gutenberg',
 				action: 'open',
 				ai_session_id: 'session-xyz',
 				agent_name: 'dolly',
-				surface: 'editor',
+				surface: 'editor_toolbar',
 				is_test: true,
 			} );
 		} );

--- a/packages/agents-manager/src/utils/tracks.ts
+++ b/packages/agents-manager/src/utils/tracks.ts
@@ -161,11 +161,9 @@ function getUnifiedBaseProps(): TracksProps {
 
 /**
  * Records an Agents Manager event using the shared unified property names.
- * Most events live under `calypso_agents_manager_`; the entry-point events
- * carry a host prefix instead (e.g. `calypso_editor_agents_manager_ai_chat_clicked`).
  */
 export function recordAgentsManagerTracksEvent(
-	eventName: `calypso_${ string }`,
+	eventName: `calypso_agents_manager_${ string }`,
 	props: TracksProps = {}
 ): void {
 	recordTracksEvent( eventName, { ...getUnifiedBaseProps(), ...props } );


### PR DESCRIPTION
Part of AI-1120

## Proposed Changes

* Merge the three "Ask AI" entry-point click events into a single `calypso_agents_manager_ai_chat_clicked`, distinguished by a new `surface` property carrying the entry point:
  * block editor toolbar button → `surface: 'editor_toolbar'`
  * wp-admin admin-bar button → `surface: 'admin_bar'`
  * Calypso masterbar button and the Dashboard omnibar plugin → `surface: 'masterbar'`
* The old names (`calypso_editor_agents_manager_ai_chat_clicked`, `calypso_admin_bar_agents_manager_ai_chat_clicked`, `calypso_masterbar_agents_manager_ai_chat_clicked`) stop firing. The data science owner confirmed on the audit P2 that renaming is fine — these events are not in any funnels, dashboards, or metrics yet — and approved the specific `surface` values.
* Tighten the recorder's event-name type from `` `calypso_${ string }` `` to `` `calypso_agents_manager_${ string }` `` — with the rename, every unified event lives under the product prefix, so the compiler now enforces it.
* `surface` values use underscores per the Tracks standard's value convention (lowercase with underscores).

Notes for reviewers:
* The Dashboard omnibar reuses `masterbar` since it occupies the masterbar position; if a distinct `omnibar` value is preferred, it is a one-line change.
* The chat-surface events keep the wrapper's default `surface` (`editor` / `reader-chat`) — aligning those values with the standard is left for the event-registration work (AI-1117).
* `calypso_editor_agents_manager_help_menu_clicked` still fires outside the wrapper and is unaffected here.

## Why are these changes being made?

* `surface` could not answer where the user was when they opened the chat — it read `editor` on virtually every fire, and the entry point was encoded in three separate event names instead of a property. One event with a `surface` property matches the AI product Tracks standard, makes entry-point comparison a group-by instead of a name join, and completes the shape changes sequenced before event registration (AI-1117).

## Testing Instructions

* Sync the agents-manager app with your WordPress.com sandbox (`cd apps/agents-manager && yarn dev --sync`).
* Open the browser DevTools, switch to the **Network** tab, and filter requests by `t.gif`.
* Trigger each entry point and confirm a `calypso_agents_manager_ai_chat_clicked` fire with the expected `surface`:
  * Site editor via wp-admin → AI button in the admin bar → `surface: admin_bar`.
  * A wp-admin page → AI button in the admin bar → `surface: admin_bar`; on an editor without the admin bar, the toolbar Ask AI button → `surface: editor_toolbar`.
* With Calypso running locally (`yarn start`): open http://my.localhost:3000/me/account and click the masterbar AI button → `surface: masterbar`.
* Confirm none of the three old event names fire anywhere.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
