### PR TITLE
Site Launch Modals: keep i18n msgids literal so terser can't fold them

### DIFF
--- a/packages/site-launch-modals/package.json
+++ b/packages/site-launch-modals/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/site-launch-modals",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Presentational modals for the WordPress.com site-launch flow (pre-launch confirmation and post-launch celebration).",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/site-launch-modals/src/celebration-modal/index.tsx
+++ b/packages/site-launch-modals/src/celebration-modal/index.tsx
@@ -37,6 +37,8 @@ export default function CelebrationModal( {
 }: CelebrationModalProps ) {
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const isMobileViewport = useViewportMatch( 'small', '<' );
+	const copiedTitle = __( 'Copied!' );
+	const copyUrlTitle = __( 'Copy URL' );
 
 	const handleCopy = () => {
 		navigator.clipboard.writeText( siteDomain );
@@ -128,7 +130,7 @@ export default function CelebrationModal( {
 								icon={ copy }
 								label={ __( 'Copy URL' ) }
 								onClick={ handleCopy }
-								title={ clipboardCopied ? __( 'Copied!' ) : __( 'Copy URL' ) }
+								title={ clipboardCopied ? copiedTitle : copyUrlTitle }
 							/>
 						</HStack>
 						<Button icon={ globe } href={ siteUrl } target="_blank">

--- a/packages/site-launch-modals/src/pre-launch-modal/index.tsx
+++ b/packages/site-launch-modals/src/pre-launch-modal/index.tsx
@@ -32,10 +32,13 @@ export default function PreLaunchModal( {
 	onLaunch,
 	onClose,
 }: PreLaunchModalProps ) {
+	const launchingTitle = __( 'Launching site…' );
+	const readyTitle = __( 'Launching makes your site public' );
+
 	return (
 		<Modal
 			className="site-launch-pre-launch-modal"
-			title={ isLaunching ? __( 'Launching site…' ) : __( 'Launching makes your site public' ) }
+			title={ isLaunching ? launchingTitle : readyTitle }
 			size="medium"
 			onRequestClose={ onClose }
 		>


### PR DESCRIPTION
## Proposed Changes

* Extract each modal title string into its own unconditionally-evaluated `__()` call so the msgid stays a plain string literal:
  * `pre-launch-modal` — `launchingTitle` / `readyTitle`
  * `celebration-modal` — `copiedTitle` / `copyUrlTitle` (same anti-pattern on the Copy URL button `title`)
* Bump `@automattic/site-launch-modals` to `1.0.1`.

## Why are these changes being made?

`@automattic/site-launch-modals` (extracted and published as 1.0.0) is consumed by the Jetpack monorepo's `jetpack-mu-wpcom`. Jetpack's production webpack build runs `@automattic/i18n-check-webpack-plugin`, which failed on the modals.

The titles were written as `cond ? __( 'a' ) : __( 'b' )`. In production mode terser hoists the shared `__()` call and rewrites it to `__( cond ? 'a' : 'b' )`, making the msgid a ternary **expression** rather than a string literal. WordPress's string extractor and the i18n-check plugin require `__()`'s first argument to be a plain string literal, so the build errored:

```
ERROR: msgid argument is not a string literal
ERROR: Optimization seems to have broken the following translation strings:
 - "Launching makes your site public"
 - "Launching site…"
```

Assigning the whole ternary to one variable is not enough (terser still folds it). Both strings must be separate, unconditionally-evaluated `__()` calls. See: https://github.com/Automattic/i18n-check-webpack-plugin#known-problematic-code-patterns

A patch version bump is included so the fix can be published and picked up by Jetpack.

## Testing Instructions

* Build the package: `yarn build` in `packages/site-launch-modals`.
* Inspect `dist/esm/pre-launch-modal/index.js` and `dist/esm/celebration-modal/index.js` — each title string appears as its own literal `__()` call, with only variable references inside the JSX ternary. No `__( cond ? … : … )` remains.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?