### PR TITLE
Site Spec: pin v1.16.0 and ask build-wow for social links only

### DIFF
--- a/client/lib/site-spec/test/utils.ts
+++ b/client/lib/site-spec/test/utils.ts
@@ -227,6 +227,14 @@ describe( 'SiteSpec Utils', () => {
 			expect( result.features?.siteBrief ).toBe( 'next' );
 		} );
 
+		it( 'should offer social links only', () => {
+			// `links` is a sub-feature of the next brief, so it only means
+			// anything alongside the siteBrief assertion above.
+			const result = getBuildWowSiteSpecConfig( { siteSlug: 'example.wordpress.com' } );
+
+			expect( result.features?.links ).toBe( 'social' );
+		} );
+
 		it( 'should leave the other flows on the default spec preview', () => {
 			// The widget gates the brief on a truthy features.siteBrief, so any
 			// flow that grows one starts rendering the brief. Pin that this one

--- a/client/lib/site-spec/utils.ts
+++ b/client/lib/site-spec/utils.ts
@@ -120,6 +120,11 @@ export interface SiteSpecConfig {
 		// `true` shows the site brief dialog in place of the basic spec preview;
 		// `'next'` also shows its socials/attachments sections.
 		siteBrief?: boolean | 'next';
+		// Which link types the brief offers. `'social'` (the widget's default)
+		// is social networks only; `'all'` adds a website link, its preview
+		// card and remove button. Sub-feature of `siteBrief: 'next'` — the
+		// widget ignores it otherwise.
+		links?: 'social' | 'all';
 	};
 	tosConfig?: ToSConfig;
 	placeholder?: string | string[];
@@ -398,6 +403,10 @@ export function getBuildWowSiteSpecConfig( {
 		features: {
 			...defaultConfig.features,
 			siteBrief: 'next',
+			// Social networks only. `'social'` is the widget's default, but pin
+			// it so this flow keeps offering social links and nothing else if
+			// that default ever moves.
+			links: 'social',
 		},
 	};
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -226,7 +226,7 @@
 	"blackbox_url": "https://blackbox-api.wp.com/v1/dist/v.js",
 	"blackbox_api_key": "1b4f123e7dae4d83bbd18170c4358f8e",
 	"site_spec": {
-		"script_url": "https://widgets.wp.com/site-spec/v1.15.0/index.js",
-		"css_url": "https://widgets.wp.com/site-spec/v1.15.0/style.css"
+		"script_url": "https://widgets.wp.com/site-spec/v1.16.0/index.js",
+		"css_url": "https://widgets.wp.com/site-spec/v1.16.0/style.css"
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Bump the Site Spec widget pin in `config/_shared.json` from `v1.15.0` to `v1.16.0`.
* `SiteSpecConfig`'s `features` mirror gains `links?: 'social' | 'all'`.
* `getBuildWowSiteSpecConfig()` sets `features: { siteBrief: 'next', links: 'social' }`.
* No other config builder is touched.

**Draft — do not merge yet.** `https://widgets.wp.com/site-spec/v1.16.0/index.js` currently 404s; v1.15.0 is what is live. `config/_shared.json` is the global pin, so merging before the bundle is synced would break the widget for every flow, not just build-wow. This comes out of draft once v1.16.0 is on the CDN.

## Why are these changes being made?

* v1.16.0 introduces `features.links`, a sub-feature of `siteBrief: 'next'`, controlling whether the brief offers a **website** link alongside social networks. `'social'` is social networks only; `'all'` also adds the website option, its mShots preview card and remove button.
* `'social'` is the widget's own default, so this pin is behaviour-preserving today. It is here so the flow keeps offering social links and nothing else if that default ever moves — the same reasoning as the "only this flow asks for the brief" test added in #113630.
* Calypso hand-mirrors the widget's config interface, so `features.links` has to be added there before it can be passed. That is the type hunk.
* Follows the shape of #113630, which set `siteBrief: 'next'` for this same flow.

Widget-side change: 330-ghe-Automattic/site-spec

## Testing Instructions

Until v1.16.0 is on the CDN, the widget assets will 404 locally. The config assertions are covered by unit tests in the meantime:

```
yarn test-client client/lib/site-spec
```

Once v1.16.0 is live:

1. Load `/setup/ai-site-builder-spec/site-spec?build_wow=1&siteSlug=<site>&siteId=<id>`.
2. This path needs an Automattician account — without one `shouldBuildWow` is false and you are testing the default config instead.
3. Talk to the agent until it confirms; the brief renders at `spec_confirm`, not on the landing screen.
4. In the brief, open the socials editor. Expect Instagram / Facebook / X / LinkedIn and **no** Website option.
5. Load the same step without `build_wow=1` and confirm it is unchanged (basic spec preview, no brief).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Unchecked items do not apply: no new strings, no new UI in this repo, no selectors, no Jetpack data collection. The dialog is drawn by the widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8suRQP3j2dnowyqkxwF7W
