### PR TITLE
Site logs: map Badge colors to @wordpress/ui intents

### DIFF
--- a/client/dashboard/app/_dark-theme.scss
+++ b/client/dashboard/app/_dark-theme.scss
@@ -444,40 +444,6 @@
 	}
 }
 
-/* Site Logs Badges */
-@mixin dashboard-dark-theme-site-logs-badges {
-	// Data table badges in the logs views don't declare a Badge intent, and
-	// override the colors locally, so we have to target them directly here.
-	:is( .site-logs-card, .site-logs-details-modal )
-		:is(
-			.badge--POST,
-			.badge--deprecated,
-			.badge--GET,
-			.badge--DELETE,
-			.badge--error,
-			.badge--fatal,
-			.badge--warning,
-			.badge--user
-		) {
-		background-color: color-mix(
-			in srgb,
-			var( --wp-components-color-background ) 90%,
-			var( --base-color )
-		);
-		color: color-mix( in srgb, var( --wp-components-color-foreground ) 50%, var( --base-color ) );
-
-		// `<Badge intent="default">` adds `.is-default`, which the Badge
-		// component pairs with an inset box-shadow in dark mode to stay
-		// visible against the card surface. The colored variants above
-		// already make the chip visible, so clear the shadow — except for
-		// `.badge--user`, whose gray-tinted bg is too close to the surface
-		// to stand on its own.
-		&:not( .badge--user ) {
-			box-shadow: none;
-		}
-	}
-}
-
 /* Modal */
 @mixin dashboard-dark-theme-modal {
 	.components-modal__frame {
@@ -527,6 +493,5 @@
 	@include dashboard-dark-theme-section-header;
 	@include color-scheme-dark-theme-site-icon;
 	@include dashboard-dark-theme-site-launch-modal;
-	@include dashboard-dark-theme-site-logs-badges;
 	@include color-scheme-dark-theme-summary-button;
 }

--- a/client/dashboard/sites/logs/components/details-modal-php.tsx
+++ b/client/dashboard/sites/logs/components/details-modal-php.tsx
@@ -1,10 +1,10 @@
-import { Badge } from '@automattic/ui';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { useLocale } from '../../../app/locale';
 import { getUtcOffsetDisplay } from '../../../utils/datetime';
-import { formatLogDateTimeForDisplay, toSeverityClass } from '../utils';
+import { formatLogDateTimeForDisplay, toSeverityIntent } from '../utils';
 import type { PHPLog, PHPData } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 import './style.scss';
@@ -65,9 +65,7 @@ export default function DetailsModalPHP( {
 			label: __( 'Severity' ),
 			type: 'text',
 			render: ( { item }: { item: PHPData } ) => (
-				<Badge intent="default" className={ `badge--${ toSeverityClass( item.severity ) }` }>
-					{ item.severity }
-				</Badge>
+				<Badge intent={ toSeverityIntent( item.severity ) }>{ item.severity }</Badge>
 			),
 			readOnly: true,
 		},

--- a/client/dashboard/sites/logs/components/details-modal-server.tsx
+++ b/client/dashboard/sites/logs/components/details-modal-server.tsx
@@ -1,10 +1,10 @@
-import { Badge } from '@automattic/ui';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { useLocale } from '../../../app/locale';
 import { getUtcOffsetDisplay } from '../../../utils/datetime';
-import { formatLogDateTimeForDisplay } from '../utils';
+import { formatLogDateTimeForDisplay, toRequestTypeIntent } from '../utils';
 import type { ServerLog, ServerData } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
 import './style.scss';
@@ -60,9 +60,7 @@ export default function DetailsModalServer( {
 			label: __( 'Request Type' ),
 			type: 'text',
 			render: ( { item }: { item: ServerData } ) => (
-				<Badge intent="default" className={ `badge--${ item.request_type }` }>
-					{ item.request_type }
-				</Badge>
+				<Badge intent={ toRequestTypeIntent( item.request_type ) }>{ item.request_type }</Badge>
 			),
 			readOnly: true,
 		},

--- a/client/dashboard/sites/logs/dataviews/fields.tsx
+++ b/client/dashboard/sites/logs/dataviews/fields.tsx
@@ -1,11 +1,16 @@
 import { LogType, PHPLog, ServerLog } from '@automattic/api-core';
 import { formatNumber } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { useLocale } from '../../../app/locale';
-import { formatDateCell, getDateTimeLabel } from '../../logs/utils';
+import {
+	formatDateCell,
+	getDateTimeLabel,
+	toRequestTypeIntent,
+	toSeverityIntent,
+} from '../../logs/utils';
 import {
 	VALUES_CACHED,
 	VALUES_RENDERER,
@@ -42,9 +47,6 @@ const getLabelRenderer = ( renderer: string ) => {
 	}
 };
 
-const toSeverityClass = ( severity: PHPLog[ 'severity' ] ) =>
-	severity.split( ' ' )[ 0 ].toLowerCase();
-
 export function useFields( {
 	logType,
 	timezoneString,
@@ -79,9 +81,7 @@ export function useFields( {
 					elements: VALUES_SEVERITY.map( ( severity ) => ( { value: severity, label: severity } ) ),
 					getValue: ( { item }: { item: PHPLog } ) => item.severity,
 					render: ( { item }: DataViewRenderFieldProps< PHPLog > ) => (
-						<Badge intent="default" className={ `badge--${ toSeverityClass( item.severity ) }` }>
-							{ item.severity }
-						</Badge>
+						<Badge intent={ toSeverityIntent( item.severity ) }>{ item.severity }</Badge>
 					),
 					filterBy: { operators: [ 'isAny' as Operator ] },
 				},
@@ -161,9 +161,7 @@ export function useFields( {
 				elements: VALUES_REQUEST_TYPE.map( ( t ) => ( { value: t, label: t } ) ),
 				getValue: ( { item }: { item: ServerLog } ) => item.request_type,
 				render: ( { item }: DataViewRenderFieldProps< ServerLog > ) => (
-					<Badge intent="default" className={ `badge--${ item.request_type }` }>
-						{ item.request_type }
-					</Badge>
+					<Badge intent={ toRequestTypeIntent( item.request_type ) }>{ item.request_type }</Badge>
 				),
 				filterBy: { operators: [ 'isAny' as Operator ] },
 			},

--- a/client/dashboard/sites/logs/dataviews/style.scss
+++ b/client/dashboard/sites/logs/dataviews/style.scss
@@ -12,48 +12,6 @@
 	text-overflow: ellipsis;
 }
 
-/* Badges */
-.site-logs-card,
-.site-logs-details-modal {
-	// Data tables always use the default intent, and override the colors.
-	.badge--POST,
-	.badge--deprecated {
-		--base-color: var(--color-deprecated-blue-50);
-		background-color: var(--color-deprecated-blue-5);
-		color: var(--color-deprecated-blue-80);
-	}
-
-	.badge--GET {
-		--base-color: var(--studio-green-50);
-		background-color: var(--studio-green-5);
-		color: var(--studio-green-80);
-	}
-
-	.badge--DELETE,
-	.badge--error,
-	.badge--fatal {
-		--base-color: var(--studio-red-50);
-		background-color: var(--studio-red-5);
-		color: var(--studio-red-80);
-	}
-
-	.badge--fatal {
-		white-space: nowrap;
-	}
-
-	.badge--warning {
-		--base-color: var(--studio-yellow-50);
-		background-color: var(--studio-yellow-5);
-		color: var(--studio-yellow-80);
-	}
-
-	.badge--user {
-		--base-color: var(--studio-gray-50);
-		background-color: var(--studio-gray-5);
-		color: var(--studio-gray-80);
-	}
-}
-
 /* Scroll to top button */
 .site-logs-card .site-logs-scroll-to-top {
 	position: absolute;

--- a/client/dashboard/sites/logs/utils.ts
+++ b/client/dashboard/sites/logs/utils.ts
@@ -3,6 +3,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import { startOfDay, endOfDay, fromUnixTime, isValid as isValidDate } from 'date-fns';
 import { formatDateWithOffset, getUtcOffsetDisplay } from '../../utils/datetime';
 import type { PHPLog, ServerLog } from '@automattic/api-core';
+import type { Badge } from '@wordpress/ui';
+import type { ComponentProps } from 'react';
+
+type BadgeIntent = NonNullable< ComponentProps< typeof Badge >[ 'intent' ] >;
 
 type DateRange = { start: Date; end: Date };
 
@@ -55,7 +59,7 @@ export function buildTimeRangeInSeconds(
 	return { startSec, endSec };
 }
 
-export const toSeverityIntent = ( severity: PHPLog[ 'severity' ] ) => {
+export const toSeverityIntent = ( severity: PHPLog[ 'severity' ] ): BadgeIntent => {
 	switch ( severity ) {
 		case 'Fatal error':
 			return 'high';
@@ -69,7 +73,7 @@ export const toSeverityIntent = ( severity: PHPLog[ 'severity' ] ) => {
 	}
 };
 
-export const toRequestTypeIntent = ( requestType: ServerLog[ 'request_type' ] ) => {
+export const toRequestTypeIntent = ( requestType: ServerLog[ 'request_type' ] ): BadgeIntent => {
 	switch ( requestType ) {
 		case 'DELETE':
 			return 'high';

--- a/client/dashboard/sites/logs/utils.ts
+++ b/client/dashboard/sites/logs/utils.ts
@@ -55,11 +55,32 @@ export function buildTimeRangeInSeconds(
 	return { startSec, endSec };
 }
 
-/**
- * Convert a PHP log severity string to lowercase (to be used in a CSS class name).
- */
-export const toSeverityClass = ( severity: PHPLog[ 'severity' ] ) =>
-	severity.split( ' ' )[ 0 ].toLowerCase();
+export const toSeverityIntent = ( severity: PHPLog[ 'severity' ] ) => {
+	switch ( severity ) {
+		case 'Fatal error':
+			return 'high';
+		case 'Warning':
+			return 'medium';
+		case 'Deprecated':
+			return 'informational';
+		case 'User':
+		default:
+			return 'none';
+	}
+};
+
+export const toRequestTypeIntent = ( requestType: ServerLog[ 'request_type' ] ) => {
+	switch ( requestType ) {
+		case 'DELETE':
+			return 'high';
+		case 'GET':
+			return 'stable';
+		case 'POST':
+			return 'informational';
+		default:
+			return 'none';
+	}
+};
 
 /**
  * Format a log date/time string for display.


### PR DESCRIPTION
Pre-requirement for removal of the Badge from `@automattic/ui` as we're now focusing on `@wordpress/ui` [Badge](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge-usage-guidelines--docs). 

Part of https://github.com/Automattic/wp-calypso/issues/113835



<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Replace `@automattic/ui` Badge component with `@wordpress/ui` [Badge](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge-usage-guidelines--docs).
* Replace class-based badge color overrides with Badge intent props so PHP severity and server request types use the design-system colors. This is also much more straightforward and less bug-prone.
* Remove custom overrides for dark mode. The generic WPDS token overrides should handle that now.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Badge is being removed from `@automattic/ui` as a way to consolidate into one design system badge instead. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See badges around site logs; do they still look good and logical.

### Before
<img width="532" height="315" alt="image" src="https://github.com/user-attachments/assets/3acb4be2-ed3e-4152-bf2b-d490ef6553d8" />

### After
<img width="514" height="227" alt="Screenshot 2026-08-25 at 19 01 45" src="https://github.com/user-attachments/assets/4e2d479d-cad7-4c56-b6e2-8482d2661584" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
