### PR TITLE
Login: forward the Blackbox session id on security-key requests

### DIFF
--- a/client/state/login/actions/login-user-with-security-key.js
+++ b/client/state/login/actions/login-user-with-security-key.js
@@ -9,7 +9,11 @@ import {
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { remoteLoginUser } from 'calypso/state/login/actions/remote-login-user';
 import { updateNonce } from 'calypso/state/login/actions/update-nonce';
-import { getTwoFactorAuthNonce, getTwoFactorUserId } from 'calypso/state/login/selectors';
+import {
+	getConsumedBlackboxSessionId,
+	getTwoFactorAuthNonce,
+	getTwoFactorUserId,
+} from 'calypso/state/login/selectors';
 import { getErrorFromHTTPError, postLoginRequest } from 'calypso/state/login/utils';
 
 import 'calypso/state/login/init';
@@ -17,11 +21,13 @@ import 'calypso/state/login/init';
 export const loginUserWithSecurityKey = () => ( dispatch, getState ) => {
 	const twoFactorAuthType = 'webauthn';
 	dispatch( { type: TWO_FACTOR_AUTHENTICATION_LOGIN_REQUEST } );
+	const blackboxSessionId = getConsumedBlackboxSessionId( getState() );
 	const loginParams = {
 		user_id: getTwoFactorUserId( getState() ),
 		client_id: config( 'wpcom_signup_id' ),
 		client_secret: config( 'wpcom_signup_key' ),
 		auth_type: twoFactorAuthType,
+		...( blackboxSessionId && { blackbox_session_id: blackboxSessionId } ),
 	};
 	return postLoginRequest( 'webauthn-challenge-endpoint', {
 		...loginParams,

--- a/client/state/login/actions/test/login-user-with-security-key.js
+++ b/client/state/login/actions/test/login-user-with-security-key.js
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+import configureStore from 'redux-mock-store';
+import { thunk } from 'redux-thunk';
+import { postLoginRequest } from 'calypso/state/login/utils';
+import { loginUserWithSecurityKey } from '../login-user-with-security-key';
+
+jest.mock( 'calypso/state/login/utils', () => ( {
+	postLoginRequest: jest.fn(),
+	getErrorFromHTTPError: jest.fn( () => ( { code: 'error', message: 'error' } ) ),
+} ) );
+
+jest.mock( 'calypso/state/login/actions/remote-login-user', () => ( {
+	remoteLoginUser: jest.fn( () => Promise.resolve() ),
+} ) );
+
+jest.mock( '@github/webauthn-json', () => ( {
+	get: jest.fn( () => Promise.resolve( { response: {} } ) ),
+} ) );
+
+const mockStore = configureStore( [ thunk ] );
+
+const loginState = ( consumedBlackboxSessionId ) => ( {
+	login: {
+		twoFactorAuth: {
+			user_id: 123456,
+			two_step_nonce_webauthn: 'a-webauthn-nonce',
+		},
+		consumedBlackboxSessionId,
+	},
+} );
+
+const dispatchSecurityKey = ( consumedBlackboxSessionId ) =>
+	mockStore( loginState( consumedBlackboxSessionId ) ).dispatch( loginUserWithSecurityKey() );
+
+describe( 'loginUserWithSecurityKey', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		postLoginRequest.mockResolvedValue( { body: { data: { token_links: [] } } } );
+	} );
+
+	test( 'forwards the session id the password step spent on both requests', async () => {
+		await dispatchSecurityKey( 'ABCDEFGHIJKLMNOPQRSTuv' );
+
+		const [ challengeAction, challengeBody ] = postLoginRequest.mock.calls[ 0 ];
+		const [ authAction, authBody ] = postLoginRequest.mock.calls[ 1 ];
+
+		expect( challengeAction ).toBe( 'webauthn-challenge-endpoint' );
+		expect( challengeBody.blackbox_session_id ).toBe( 'ABCDEFGHIJKLMNOPQRSTuv' );
+
+		// The authentication request is the one that announces an outcome on the
+		// wpcom side, so it is the one that has to carry the id.
+		expect( authAction ).toBe( 'webauthn-authentication-endpoint' );
+		expect( authBody.blackbox_session_id ).toBe( 'ABCDEFGHIJKLMNOPQRSTuv' );
+	} );
+
+	test( 'omits the field when the password step spent no session', async () => {
+		await dispatchSecurityKey( null );
+
+		for ( const [ , body ] of postLoginRequest.mock.calls ) {
+			expect( body ).not.toHaveProperty( 'blackbox_session_id' );
+		}
+	} );
+
+	test( 'leaves the rest of the webauthn payload intact', async () => {
+		await dispatchSecurityKey( 'ABCDEFGHIJKLMNOPQRSTuv' );
+
+		const [ , authBody ] = postLoginRequest.mock.calls[ 1 ];
+		expect( authBody ).toMatchObject( {
+			user_id: 123456,
+			auth_type: 'webauthn',
+			two_step_nonce: 'a-webauthn-nonce',
+			remember_me: true,
+		} );
+		expect( authBody.client_data ).toEqual( expect.any( String ) );
+	} );
+} );


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/BBOX-343/report-security-key-webauthn-two-step-outcomes-to-blackbox

Part of BBOX-162. Pairs with the wpcom side, Automattic/wpcom#236673. Follows #113807, which covered the code-based factors and push.

## Proposed Changes

* `login-user-with-security-key.js`: read the consumed Blackbox session id and add it to `loginParams`, which both `webauthn-challenge-endpoint` and `webauthn-authentication-endpoint` already spread.
* Tests over both request bodies: the id is forwarded, omitted when the password step produced none, and the rest of the webauthn payload is untouched.

## Why are these changes being made?

`loginUserWithSecurityKey` posts to its own endpoints rather than going through `loginUserWithTwoFactorVerificationCode`, so it was never carrying the session id the password step spent. The authentication request is the one the wpcom side announces an outcome from, so it is the one that has to carry the id. The challenge request gets it too because both spread the same `loginParams`, and an extra field there is ignored.

Without this, a security-key login records `two_step_required=true` in the original `/verify` context and then produces no completion event, which the offline pass reads as a second factor that was never completed. That puts legitimate security-key users in the same bucket as the attacker case the signal exists to catch, and it cannot be corrected downstream because `/verify` records `two_step_enabled` but not the method.

This is inert on its own. `Login_Webauthn_Authentication_Endpoint` fires `twostep_login_success` rather than `wpcom_two_step_login_outcome`, so nothing reads the field until Automattic/wpcom#236673 lands. Either side can deploy first.

## Testing Instructions

```
yarn test-client client/state/login
```

(122 tests across 5 suites.)

Manually, against an account with a security key:

1. Log in with a correct password and open the Network tab.
2. On the `wp-login.php?action=login-endpoint` request, note the `blackbox_session_id` form field.
3. Complete the security-key prompt. Both `webauthn-challenge-endpoint` and `webauthn-authentication-endpoint` should carry a `blackbox_session_id` field with the same value.
4. Confirm an account without a security key is unaffected.

Once both sides deploy, `wpcom-blackbox-two-step-report` should gain volume attributable to webauthn, with `calypso_logins_webauthn` as the denominator.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
