### PR TITLE
Marketplace: activate the transferred plugin as soon as the site allows it

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-post-transfer-plugin-recovery.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-post-transfer-plugin-recovery.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { usePostTransferPluginRecovery } from '../use-post-transfer-plugin-recovery';
 
 const mockDispatch = jest.fn();
@@ -45,78 +45,105 @@ const render = ( props?: Partial< Props > ) =>
 	renderHook( ( p: Props ) => usePostTransferPluginRecovery( p ), {
 		initialProps: { ...defaults, ...props },
 	} );
-const tick = () => mockIntervalCallback?.();
+const tick = () => act( () => mockIntervalCallback?.() );
 // The in-flight guard clears in the dispatched thunk's `.finally`, a microtask; let it settle.
-const settle = () => Promise.resolve();
+const settle = () => act( () => Promise.resolve() );
+// Backoff is measured on the wall clock, which modern fake timers move with them.
+const elapse = ( ms: number ) => act( () => jest.advanceTimersByTime( ms ) );
 
 describe( 'usePostTransferPluginRecovery', () => {
 	beforeEach( () => {
+		jest.useFakeTimers();
 		jest.clearAllMocks();
 		mockIntervalCallback = null;
 		mockIntervalDelay = null;
 	} );
+	afterEach( () => jest.useRealTimers() );
 
-	it( 'polls the site plugins on an interval while enabled', () => {
+	it( 'lists the site plugins as soon as it is enabled, then on an interval', () => {
 		render( { installedPlugin: null } );
+		expect( fetchSitePlugins ).toHaveBeenCalledTimes( 1 );
+		expect( fetchSitePlugins ).toHaveBeenCalledWith( 1 );
 		expect( mockIntervalDelay ).toBe( 3000 );
 		tick();
-		expect( fetchSitePlugins ).toHaveBeenCalledWith( 1 );
+		expect( fetchSitePlugins ).toHaveBeenCalledTimes( 2 );
 	} );
 
-	it( 'does not poll while disabled', () => {
+	it( 'does nothing while disabled', () => {
 		render( { enabled: false } );
+		expect( fetchSitePlugins ).not.toHaveBeenCalled();
 		expect( mockIntervalDelay ).toBeNull();
 	} );
 
-	it( 'nudges an installed-but-inactive plugin active on a tick', () => {
+	it( 'nudges an installed-but-inactive plugin active without waiting for a tick', () => {
 		render();
-		tick();
 		expect( activatePlugin ).toHaveBeenCalledWith( 1, {
 			slug: 'sensei-pro',
 			id: 'sensei-pro/sensei-pro',
 		} );
 	} );
 
-	it( 'does not consume the retry budget while it cannot yet activate', async () => {
+	it( 'activates the moment the capability gap closes', () => {
 		const { rerender } = render( { canActivate: false } );
 		tick();
 		tick();
 		expect( activatePlugin ).not.toHaveBeenCalled();
 
-		// Once ready, all attempts remain available.
 		rerender( defaults );
-		tick();
-		await settle();
-		tick();
-		await settle();
-		tick();
-		expect( activatePlugin ).toHaveBeenCalledTimes( 3 );
+		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'does not start a new attempt while the previous one is still in flight', () => {
 		render();
-		tick();
+		elapse( 60000 );
 		tick();
 		tick();
 		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'retries a bounded number of times once attempts settle, not forever', async () => {
+	// The backend activates the plugin itself once its job runs, so a retry here is a fallback that
+	// should not hammer a site still coming up — but it must not stop either, since that job can fail.
+	it( 'backs off between attempts instead of giving up', async () => {
 		render();
-		for ( let i = 0; i < 6; i++ ) {
-			tick();
-			await settle();
-		}
+		await settle();
+		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
+
+		elapse( 1000 );
+		tick();
+		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
+
+		elapse( 2000 );
+		tick();
+		await settle();
+		expect( activatePlugin ).toHaveBeenCalledTimes( 2 );
+
+		elapse( 3000 );
+		tick();
+		expect( activatePlugin ).toHaveBeenCalledTimes( 2 );
+
+		elapse( 3000 );
+		tick();
+		await settle();
 		expect( activatePlugin ).toHaveBeenCalledTimes( 3 );
+
+		elapse( 12000 );
+		tick();
+		await settle();
+		elapse( 24000 );
+		tick();
+		await settle();
+		elapse( 30000 );
+		tick();
+		await settle();
+		expect( activatePlugin ).toHaveBeenCalledTimes( 6 );
 	} );
 
 	it( 'refreshes the plugin list right after activating, without waiting for the next poll', async () => {
 		render();
-		tick();
 		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
-		const pollFetches = fetchSitePlugins.mock.calls.length;
+		const fetchesBeforeSettle = fetchSitePlugins.mock.calls.length;
 		await settle();
-		expect( fetchSitePlugins.mock.calls.length ).toBeGreaterThan( pollFetches );
+		expect( fetchSitePlugins.mock.calls.length ).toBeGreaterThan( fetchesBeforeSettle );
 		expect( fetchSitePlugins ).toHaveBeenLastCalledWith( 1 );
 	} );
 
@@ -126,13 +153,12 @@ describe( 'usePostTransferPluginRecovery', () => {
 		expect( activatePlugin ).not.toHaveBeenCalled();
 	} );
 
-	it( 'waits to activate until the plugin appears in the refreshed list', () => {
+	it( 'activates as soon as the plugin appears in the refreshed list', () => {
 		const { rerender } = render( { installedPlugin: null } );
 		tick();
 		expect( activatePlugin ).not.toHaveBeenCalled();
 
 		rerender( defaults );
-		tick();
 		expect( activatePlugin ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-post-transfer-plugin-recovery.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-post-transfer-plugin-recovery.ts
@@ -1,15 +1,17 @@
-import { useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useInterval } from 'calypso/lib/interval';
 import { useDispatch } from 'calypso/state';
 import { activatePlugin, fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 
 const POLL_INTERVAL_MS = 3000;
-const MAX_ACTIVATION_ATTEMPTS = 3;
+// Activation retries back off from the poll cadence up to this ceiling; the caller's activation
+// deadline is what ends them.
+const ACTIVATION_RETRY_MAX_MS = 30000;
 
-// The Atomic transfer can report complete before the checkout-installed plugin is activated, leaving it
-// installed but inactive. Poll the plugin list and nudge it active; that flips `pluginActive`, which the
-// caller's redirect watches for and which disables this hook. If activation never lands the poll keeps
-// running, so a late backend activation is still caught.
+// The Atomic transfer reports complete once the plugin's install+activate job is queued on the new
+// host, not once it has run, and the site's plugin list stays unreachable until Jetpack has synced.
+// Poll the list until the plugin shows up active; nudge it active ourselves as a fallback for a job
+// that never lands. Both the listing and the nudge happen as soon as they can, not on the next tick.
 export function usePostTransferPluginRecovery( {
 	siteId,
 	enabled,
@@ -26,33 +28,54 @@ export function usePostTransferPluginRecovery( {
 	const dispatch = useDispatch();
 	const attemptsRef = useRef( 0 );
 	const inFlightRef = useRef( false );
+	const retryAfterRef = useRef( 0 );
+	const pluginId = installedPlugin?.id;
+	const pluginSlug = installedPlugin?.slug;
+
+	const activateIfReady = useCallback( () => {
+		// Gate activation on: the transfer being usable (capability gap); this hook owning activation
+		// (the step-driven flow owns it otherwise); one settled attempt at a time; the backoff.
+		if (
+			! canActivate ||
+			! ownsActivation ||
+			! pluginId ||
+			inFlightRef.current ||
+			Date.now() < retryAfterRef.current
+		) {
+			return;
+		}
+
+		const attempt = attemptsRef.current;
+		attemptsRef.current += 1;
+		retryAfterRef.current =
+			Date.now() + Math.min( POLL_INTERVAL_MS * 2 ** attempt, ACTIVATION_RETRY_MAX_MS );
+		inFlightRef.current = true;
+		Promise.resolve(
+			dispatch( activatePlugin( siteId, { slug: pluginSlug, id: pluginId } ) )
+		).finally( () => {
+			inFlightRef.current = false;
+			// Refresh right away so the now-active plugin is observed immediately, rather than waiting
+			// for the next poll — the caller's redirect is gated on that active state.
+			dispatch( fetchSitePlugins( siteId ) );
+		} );
+	}, [ canActivate, ownsActivation, pluginId, pluginSlug, siteId, dispatch ] );
+
+	useEffect( () => {
+		if ( enabled ) {
+			dispatch( fetchSitePlugins( siteId ) );
+		}
+	}, [ enabled, siteId, dispatch ] );
+
+	useEffect( () => {
+		if ( enabled ) {
+			activateIfReady();
+		}
+	}, [ enabled, activateIfReady ] );
 
 	useInterval(
 		() => {
 			dispatch( fetchSitePlugins( siteId ) );
-
-			// Gate activation on: the transfer being usable (capability gap); this hook owning activation
-			// (the step-driven flow owns it otherwise); one settled attempt at a time; a bounded budget.
-			if (
-				! canActivate ||
-				! ownsActivation ||
-				! installedPlugin?.id ||
-				inFlightRef.current ||
-				attemptsRef.current >= MAX_ACTIVATION_ATTEMPTS
-			) {
-				return;
-			}
-
-			attemptsRef.current += 1;
-			inFlightRef.current = true;
-			Promise.resolve(
-				dispatch( activatePlugin( siteId, { slug: installedPlugin.slug, id: installedPlugin.id } ) )
-			).finally( () => {
-				inFlightRef.current = false;
-				// Refresh right away so the now-active plugin is observed immediately, rather than waiting
-				// for the next poll — the caller's redirect is gated on that active state.
-				dispatch( fetchSitePlugins( siteId ) );
-			} );
+			activateIfReady();
 		},
 		enabled ? POLL_INTERVAL_MS : null
 	);


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18182/plugin-activation-stalls-45s-after-a-marketplace-transfer-likely-the

## Proposed Changes

**After a marketplace transfer, the install screen now checks for the plugin and switches it on as soon as the site allows it, and keeps trying instead of giving up after three attempts.**

The last phase of a marketplace install is a small loop that asks the new Atomic site “is the plugin there and on yet?” and nudges it on if not. Three changes to that loop, all in `use-post-transfer-plugin-recovery.ts`:

- It asks immediately when it starts, instead of waiting a full 3-second tick first.
- It activates the moment the plugin appears and permissions are ready, instead of on the next tick.
- Retries back off (3 s → 6 s → 12 s → 24 s → 30 s) and continue until the activation deadline, instead of stopping after three tries.

## Why are these changes being made?

Installing a marketplace plugin on a Simple site ends with a stretch on “Activating plugin” ([DOTCOM-18182](https://linear.app/a8c/issue/DOTCOM-18182)). Over the last week, on 600 successful installs, that phase took 9–29 s at the median and over 30 s for one install in five.

Two things explain it. Most of the long tail is the backend: the transfer reports “completed” the moment the plugin's install job is *queued* on the new server, not when it has run, so the screen is waiting on a background job with no signal for when it finishes. That needs a backend change and is out of scope here. But at the median, the client's own lazy polling was most of the wait — a full 3 s before the first check, and activation deferred to the next tick. This PR removes that.

The retry change closes a trap. The loop gave up after ~9 s of failed activation attempts; with the failure itself unreported, the user was left hanging. Last week ~35 users hit repeated activation errors after a transfer: 13 hung with no outcome, 12 sat out the full five-minute timeout, only 8 eventually succeeded. The loop now keeps trying (with backoff) until the activation deadline ends the wait with a real error.

## Testing Instructions

1. Run `yarn start`.
2. On a Simple site with a Business plan, install a marketplace plugin so the install screen at `/marketplace/plugin/<slug>/install/<site>` runs an Atomic transfer.
3. With DevTools open on the Network tab, watch the requests after the staged wait reaches the finishing stage: the `plugins` list request should fire right away when the site reads as Atomic, and the activate request right after the plugin first appears in the list.
4. The install should complete and redirect to wp-admin's plugins page as before.
