### PR TITLE
Omnibar: gate the free domain chip on an ExPlat experiment

### DIFF
--- a/client/dashboard/app/free-domain-upsell/index.ts
+++ b/client/dashboard/app/free-domain-upsell/index.ts
@@ -1,10 +1,16 @@
-import { isEnabled } from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
+import { isSupportSession } from '@automattic/calypso-support-session';
 import { addQueryArgs } from '@wordpress/url';
+import { useExperiment } from 'calypso/lib/explat';
 import { wpcomLink } from '../../utils/link';
 import { isSimple } from '../../utils/site-types';
 import type { Site } from '@automattic/api-core';
 
 export const FREE_DOMAIN_UPSELL_ID = 'omnibar-free-domain';
+
+export const FREE_DOMAIN_UPSELL_EXPERIMENT = 'calypso_omnibar_free_domain_upsell_20260825';
+
+const QUERY_PARAM = 'omnibar_free_domain';
 
 export type FreeDomainUpsellSurface = 'msd' | 'calypso';
 
@@ -54,4 +60,55 @@ export function isFreeDomainUpsellEligible( site?: Site ): site is Site {
 
 export function getFreeDomainUpsellHref( site: Site ) {
 	return wpcomLink( addQueryArgs( '/setup/domain-and-plan', { siteSlug: site.slug } ) );
+}
+
+/**
+ * ExPlat gate for the omnibar free-domain chip. The treatment shows the chip
+ * on every omnibar surface and (server-side, via jetpack-mu-wpcom) hides the
+ * `free_to_paid_plan` and `monthly_to_annual_plan` sidebar banners in
+ * wp-admin; control keeps the banners.
+ *
+ * Eligibility is deliberately reactive, not frozen at mount: the omnibar
+ * mounts before the selected site resolves, so eligibility flips false -> true
+ * once site data arrives (and again when switching sites in the dashboard).
+ * `useExperiment` only requests an assignment while eligible, which keeps
+ * enrollment scoped to users who could actually see the chip.
+ *
+ * Teardown: everything belonging to this experiment falls out of
+ * `grep -rEi 'free[-_]?domain[-_]?(upsell|chip)'` — identifiers
+ * (`FreeDomainUpsell`), CSS classes and file names (`free-domain-chip`,
+ * `omnibar__free-domain`), the feature flag
+ * (`dashboard/omnibar-free-domain-chip`), the experiment name, and the
+ * `omnibar_free_domain` query param.
+ */
+export function useFreeDomainUpsellExperiment( site?: Site ): {
+	isLoading: boolean;
+	showChip: boolean;
+} {
+	const isEligible = isFreeDomainUpsellEligible( site );
+	const [ isLoading, assignment ] = useExperiment( FREE_DOMAIN_UPSELL_EXPERIMENT, {
+		isEligible,
+	} );
+
+	if ( ! isEligible ) {
+		return { isLoading: false, showChip: false };
+	}
+
+	// QA override. Dead on production builds (except inside a support session)
+	// so regular users can't force treatment UI — and its treatment-only Tracks
+	// events — outside a real assignment.
+	const canUseQaOverride =
+		! String( config( 'env_id' ) ?? '' ).endsWith( 'production' ) || isSupportSession();
+	if ( canUseQaOverride && typeof window !== 'undefined' ) {
+		const searchParams = new URLSearchParams( window.location.search );
+		if ( searchParams.get( QUERY_PARAM ) === '1' ) {
+			return { isLoading: false, showChip: true };
+		}
+	}
+
+	if ( isLoading ) {
+		return { isLoading: true, showChip: false };
+	}
+
+	return { isLoading: false, showChip: assignment?.variationName === 'treatment' };
 }

--- a/client/dashboard/app/free-domain-upsell/index.ts
+++ b/client/dashboard/app/free-domain-upsell/index.ts
@@ -84,6 +84,7 @@ export function getFreeDomainUpsellHref( site: Site ) {
 export function useFreeDomainUpsellExperiment( site?: Site ): {
 	isLoading: boolean;
 	showChip: boolean;
+	isQaOverride: boolean;
 } {
 	const isEligible = isFreeDomainUpsellEligible( site );
 	const [ isLoading, assignment ] = useExperiment( FREE_DOMAIN_UPSELL_EXPERIMENT, {
@@ -91,24 +92,29 @@ export function useFreeDomainUpsellExperiment( site?: Site ): {
 	} );
 
 	if ( ! isEligible ) {
-		return { isLoading: false, showChip: false };
+		return { isLoading: false, showChip: false, isQaOverride: false };
 	}
 
 	// QA override. Dead on production builds (except inside a support session)
-	// so regular users can't force treatment UI — and its treatment-only Tracks
-	// events — outside a real assignment.
+	// so regular users can't force treatment UI outside a real assignment.
+	// `isQaOverride` marks the resulting Tracks events so QA sessions can be
+	// filtered out of the experiment analysis.
 	const canUseQaOverride =
 		! String( config( 'env_id' ) ?? '' ).endsWith( 'production' ) || isSupportSession();
 	if ( canUseQaOverride && typeof window !== 'undefined' ) {
 		const searchParams = new URLSearchParams( window.location.search );
 		if ( searchParams.get( QUERY_PARAM ) === '1' ) {
-			return { isLoading: false, showChip: true };
+			return { isLoading: false, showChip: true, isQaOverride: true };
 		}
 	}
 
 	if ( isLoading ) {
-		return { isLoading: true, showChip: false };
+		return { isLoading: true, showChip: false, isQaOverride: false };
 	}
 
-	return { isLoading: false, showChip: assignment?.variationName === 'treatment' };
+	return {
+		isLoading: false,
+		showChip: assignment?.variationName === 'treatment',
+		isQaOverride: false,
+	};
 }

--- a/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.tsx
@@ -15,7 +15,7 @@ import type { Site } from '@automattic/api-core';
 import './omnibar-free-domain-chip.scss';
 
 export function OmnibarFreeDomainChip( { site }: { site: Site } ) {
-	const { showChip } = useFreeDomainUpsellExperiment( site );
+	const { showChip, isQaOverride } = useFreeDomainUpsellExperiment( site );
 	const upsellSource = getFreeDomainUpsellSource( site );
 	const siteId = site.ID;
 
@@ -30,8 +30,9 @@ export function OmnibarFreeDomainChip( { site }: { site: Site } ) {
 			upsell_id: FREE_DOMAIN_UPSELL_ID,
 			surface: 'msd',
 			upsell_source: upsellSource,
+			...( isQaOverride && { qa_override: true } ),
 		} );
-	}, [ showChip, upsellSource, siteId ] );
+	}, [ showChip, isQaOverride, upsellSource, siteId ] );
 
 	if ( ! showChip ) {
 		return null;
@@ -47,6 +48,7 @@ export function OmnibarFreeDomainChip( { site }: { site: Site } ) {
 						upsell_id: FREE_DOMAIN_UPSELL_ID,
 						surface: 'msd',
 						upsell_source: upsellSource,
+						...( isQaOverride && { qa_override: true } ),
 					} )
 				}
 			>

--- a/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-free-domain-chip.tsx
@@ -8,19 +8,21 @@ import {
 	FREE_DOMAIN_UPSELL_ID,
 	getFreeDomainUpsellHref,
 	getFreeDomainUpsellSource,
+	useFreeDomainUpsellExperiment,
 } from '../free-domain-upsell';
 import type { Site } from '@automattic/api-core';
 
 import './omnibar-free-domain-chip.scss';
 
 export function OmnibarFreeDomainChip( { site }: { site: Site } ) {
+	const { showChip } = useFreeDomainUpsellExperiment( site );
 	const upsellSource = getFreeDomainUpsellSource( site );
 	const siteId = site.ID;
 
 	// One impression per site: switching sites in the same mount re-fires.
 	const impressionSiteIds = useRef( new Set< number >() );
 	useEffect( () => {
-		if ( ! upsellSource || impressionSiteIds.current.has( siteId ) ) {
+		if ( ! showChip || impressionSiteIds.current.has( siteId ) ) {
 			return;
 		}
 		impressionSiteIds.current.add( siteId );
@@ -29,9 +31,9 @@ export function OmnibarFreeDomainChip( { site }: { site: Site } ) {
 			surface: 'msd',
 			upsell_source: upsellSource,
 		} );
-	}, [ upsellSource, siteId ] );
+	}, [ showChip, upsellSource, siteId ] );
 
-	if ( ! upsellSource ) {
+	if ( ! showChip ) {
 		return null;
 	}
 

--- a/client/dashboard/app/interim-omnibar/test/omnibar-free-domain-chip.test.tsx
+++ b/client/dashboard/app/interim-omnibar/test/omnibar-free-domain-chip.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ * @jest-environment-options { "url": "https://my.localhost/" }
+ */
+
+import { disable, enable } from '@automattic/calypso-config';
+import { screen, waitFor } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import { FREE_DOMAIN_UPSELL_EXPERIMENT } from '../../free-domain-upsell';
+import { OmnibarFreeDomainChip } from '../omnibar-free-domain-chip';
+import type { Site } from '@automattic/api-core';
+
+const FREE_SIMPLE_SITE = {
+	ID: 123,
+	slug: 'test-site.wordpress.com',
+	plan: { is_free: true },
+	jetpack: false,
+	is_wpcom_atomic: false,
+	is_garden: false,
+	is_wpcom_staging_site: false,
+} as Site;
+
+const PAID_SITE = {
+	...FREE_SIMPLE_SITE,
+	plan: { is_free: false },
+} as Site;
+
+// Seed a live assignment into the storage ExPlat reads from, so the real
+// `useExperiment` hook resolves to the given variation through its normal code
+// path — no network call, no mocking.
+function assignExperiment( variationName: string | null = null ) {
+	window.localStorage.setItem(
+		`explat-experiment--${ FREE_DOMAIN_UPSELL_EXPERIMENT }`,
+		JSON.stringify( {
+			experimentName: FREE_DOMAIN_UPSELL_EXPERIMENT,
+			variationName,
+			retrievedTimestamp: Date.now(),
+			ttl: 3600,
+		} )
+	);
+}
+
+describe( '<OmnibarFreeDomainChip>', () => {
+	beforeEach( () => {
+		enable( 'dashboard/omnibar-free-domain-chip' );
+	} );
+
+	afterEach( () => {
+		window.localStorage.clear();
+		window.history.replaceState( {}, '', '/' );
+		disable( 'dashboard/omnibar-free-domain-chip' );
+	} );
+
+	test( 'shows the chip for an eligible site in the treatment group', async () => {
+		assignExperiment( 'treatment' );
+
+		render( <OmnibarFreeDomainChip site={ FREE_SIMPLE_SITE } /> );
+
+		const link = await screen.findByRole( 'link', { name: 'Free domain' } );
+		expect( link ).toBeVisible();
+		expect( link ).toHaveAttribute(
+			'href',
+			expect.stringContaining( '/setup/domain-and-plan?siteSlug=test-site.wordpress.com' )
+		);
+	} );
+
+	test( 'does not show the chip for an eligible site in the control group', async () => {
+		assignExperiment( null );
+
+		render( <OmnibarFreeDomainChip site={ FREE_SIMPLE_SITE } /> );
+
+		await waitFor( () => {
+			expect( screen.queryByRole( 'link', { name: 'Free domain' } ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	test( 'does not show the chip for a paid site, even in the treatment group', async () => {
+		assignExperiment( 'treatment' );
+
+		render( <OmnibarFreeDomainChip site={ PAID_SITE } /> );
+
+		await waitFor( () => {
+			expect( screen.queryByRole( 'link', { name: 'Free domain' } ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	test( 'does not show the chip when the feature flag is off, even in the treatment group', async () => {
+		disable( 'dashboard/omnibar-free-domain-chip' );
+		assignExperiment( 'treatment' );
+
+		render( <OmnibarFreeDomainChip site={ FREE_SIMPLE_SITE } /> );
+
+		await waitFor( () => {
+			expect( screen.queryByRole( 'link', { name: 'Free domain' } ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	test( 'the omnibar_free_domain query param forces the chip on, overriding the assignment', async () => {
+		assignExperiment( null );
+		window.history.replaceState( {}, '', '/?omnibar_free_domain=1' );
+
+		render( <OmnibarFreeDomainChip site={ FREE_SIMPLE_SITE } /> );
+
+		expect( await screen.findByRole( 'link', { name: 'Free domain' } ) ).toBeVisible();
+	} );
+} );

--- a/client/dashboard/app/interim-omnibar/test/omnibar-free-domain-chip.test.tsx
+++ b/client/dashboard/app/interim-omnibar/test/omnibar-free-domain-chip.test.tsx
@@ -14,21 +14,38 @@ const FREE_SIMPLE_SITE = {
 	ID: 123,
 	slug: 'test-site.wordpress.com',
 	plan: { is_free: true },
+	capabilities: { manage_options: true },
+	options: {},
 	jetpack: false,
 	is_wpcom_atomic: false,
 	is_garden: false,
 	is_wpcom_staging_site: false,
 } as Site;
 
-const PAID_SITE = {
+const MONTHLY_PLAN_SITE = {
 	...FREE_SIMPLE_SITE,
-	plan: { is_free: false },
+	plan: { is_free: false, billing_period: 'Monthly' },
+} as Site;
+
+const YEARLY_PAID_SITE = {
+	...FREE_SIMPLE_SITE,
+	plan: { is_free: false, billing_period: 'Yearly' },
+} as Site;
+
+const NON_ADMIN_SITE = {
+	...FREE_SIMPLE_SITE,
+	capabilities: { manage_options: false },
+} as Site;
+
+const MAPPED_DOMAIN_SITE = {
+	...FREE_SIMPLE_SITE,
+	slug: 'example.com',
 } as Site;
 
 // Seed a live assignment into the storage ExPlat reads from, so the real
 // `useExperiment` hook resolves to the given variation through its normal code
 // path — no network call, no mocking.
-function assignExperiment( variationName: string | null = null ) {
+function assignExperiment( variationName: string | null ) {
 	window.localStorage.setItem(
 		`explat-experiment--${ FREE_DOMAIN_UPSELL_EXPERIMENT }`,
 		JSON.stringify( {
@@ -51,7 +68,7 @@ describe( '<OmnibarFreeDomainChip>', () => {
 		disable( 'dashboard/omnibar-free-domain-chip' );
 	} );
 
-	test( 'shows the chip for an eligible site in the treatment group', async () => {
+	test( 'shows the chip for an eligible free site in the treatment group', async () => {
 		assignExperiment( 'treatment' );
 
 		render( <OmnibarFreeDomainChip site={ FREE_SIMPLE_SITE } /> );
@@ -64,7 +81,25 @@ describe( '<OmnibarFreeDomainChip>', () => {
 		);
 	} );
 
+	test( 'shows the chip for an eligible monthly-plan site in the treatment group', async () => {
+		assignExperiment( 'treatment' );
+
+		render( <OmnibarFreeDomainChip site={ MONTHLY_PLAN_SITE } /> );
+
+		expect( await screen.findByRole( 'link', { name: 'Free domain' } ) ).toBeVisible();
+	} );
+
 	test( 'does not show the chip for an eligible site in the control group', async () => {
+		assignExperiment( 'control' );
+
+		render( <OmnibarFreeDomainChip site={ FREE_SIMPLE_SITE } /> );
+
+		await waitFor( () => {
+			expect( screen.queryByRole( 'link', { name: 'Free domain' } ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	test( 'does not show the chip while unassigned (null variation): safe default experience', async () => {
 		assignExperiment( null );
 
 		render( <OmnibarFreeDomainChip site={ FREE_SIMPLE_SITE } /> );
@@ -74,10 +109,30 @@ describe( '<OmnibarFreeDomainChip>', () => {
 		} );
 	} );
 
-	test( 'does not show the chip for a paid site, even in the treatment group', async () => {
+	test( 'does not show the chip for a yearly paid site, even in the treatment group', async () => {
 		assignExperiment( 'treatment' );
 
-		render( <OmnibarFreeDomainChip site={ PAID_SITE } /> );
+		render( <OmnibarFreeDomainChip site={ YEARLY_PAID_SITE } /> );
+
+		await waitFor( () => {
+			expect( screen.queryByRole( 'link', { name: 'Free domain' } ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	test( 'does not show the chip for a non-admin, even in the treatment group', async () => {
+		assignExperiment( 'treatment' );
+
+		render( <OmnibarFreeDomainChip site={ NON_ADMIN_SITE } /> );
+
+		await waitFor( () => {
+			expect( screen.queryByRole( 'link', { name: 'Free domain' } ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	test( 'does not show the chip for a site with a mapped primary domain, even in the treatment group', async () => {
+		assignExperiment( 'treatment' );
+
+		render( <OmnibarFreeDomainChip site={ MAPPED_DOMAIN_SITE } /> );
 
 		await waitFor( () => {
 			expect( screen.queryByRole( 'link', { name: 'Free domain' } ) ).not.toBeInTheDocument();
@@ -95,8 +150,8 @@ describe( '<OmnibarFreeDomainChip>', () => {
 		} );
 	} );
 
-	test( 'the omnibar_free_domain query param forces the chip on, overriding the assignment', async () => {
-		assignExperiment( null );
+	test( 'the omnibar_free_domain query param forces the chip on outside production, overriding the assignment', async () => {
+		assignExperiment( 'control' );
 		window.history.replaceState( {}, '', '/?omnibar_free_domain=1' );
 
 		render( <OmnibarFreeDomainChip site={ FREE_SIMPLE_SITE } /> );

--- a/client/dashboard/app/interim-omnibar/test/omnibar-free-domain-chip.test.tsx
+++ b/client/dashboard/app/interim-omnibar/test/omnibar-free-domain-chip.test.tsx
@@ -10,6 +10,15 @@ import { FREE_DOMAIN_UPSELL_EXPERIMENT } from '../../free-domain-upsell';
 import { OmnibarFreeDomainChip } from '../omnibar-free-domain-chip';
 import type { Site } from '@automattic/api-core';
 
+// Lets a test fake a production build; everything else delegates to the real config.
+let mockEnvId: string | undefined;
+jest.mock( '@automattic/calypso-config', () => {
+	const actual = jest.requireActual( '@automattic/calypso-config' );
+	const configFn = ( key: string ) =>
+		key === 'env_id' && mockEnvId !== undefined ? mockEnvId : actual( key );
+	return Object.assign( configFn, actual, { __esModule: true, default: configFn } );
+} );
+
 const FREE_SIMPLE_SITE = {
 	ID: 123,
 	slug: 'test-site.wordpress.com',
@@ -66,6 +75,7 @@ describe( '<OmnibarFreeDomainChip>', () => {
 		window.localStorage.clear();
 		window.history.replaceState( {}, '', '/' );
 		disable( 'dashboard/omnibar-free-domain-chip' );
+		mockEnvId = undefined;
 	} );
 
 	test( 'shows the chip for an eligible free site in the treatment group', async () => {
@@ -157,5 +167,17 @@ describe( '<OmnibarFreeDomainChip>', () => {
 		render( <OmnibarFreeDomainChip site={ FREE_SIMPLE_SITE } /> );
 
 		expect( await screen.findByRole( 'link', { name: 'Free domain' } ) ).toBeVisible();
+	} );
+
+	test( 'the omnibar_free_domain query param is inert on production builds', async () => {
+		mockEnvId = 'dashboard-production';
+		assignExperiment( 'control' );
+		window.history.replaceState( {}, '', '/?omnibar_free_domain=1' );
+
+		render( <OmnibarFreeDomainChip site={ FREE_SIMPLE_SITE } /> );
+
+		await waitFor( () => {
+			expect( screen.queryByRole( 'link', { name: 'Free domain' } ) ).not.toBeInTheDocument();
+		} );
 	} );
 } );

--- a/client/dashboard/app/omnibar/plugin-free-domain.tsx
+++ b/client/dashboard/app/omnibar/plugin-free-domain.tsx
@@ -7,6 +7,7 @@ import {
 	FREE_DOMAIN_UPSELL_ID,
 	getFreeDomainUpsellHref,
 	getFreeDomainUpsellSource,
+	useFreeDomainUpsellExperiment,
 } from '../free-domain-upsell';
 import type { FreeDomainUpsellSurface } from '../free-domain-upsell';
 import type { Site } from '@automattic/api-core';
@@ -22,13 +23,14 @@ export function useFreeDomainPlugin( {
 	surface: FreeDomainUpsellSurface;
 } ): OmnibarNode | undefined {
 	const { recordTracksEvent } = useAnalytics();
+	const { showChip } = useFreeDomainUpsellExperiment( site );
 	const upsellSource = getFreeDomainUpsellSource( site );
 	const siteId = site?.ID;
 
 	// One impression per site: switching sites in the same mount re-fires.
 	const impressionSiteIds = useRef( new Set< number >() );
 	useEffect( () => {
-		if ( ! upsellSource || ! siteId || impressionSiteIds.current.has( siteId ) ) {
+		if ( ! showChip || ! siteId || impressionSiteIds.current.has( siteId ) ) {
 			return;
 		}
 		impressionSiteIds.current.add( siteId );
@@ -37,9 +39,9 @@ export function useFreeDomainPlugin( {
 			surface,
 			upsell_source: upsellSource,
 		} );
-	}, [ upsellSource, siteId, surface, recordTracksEvent ] );
+	}, [ showChip, upsellSource, siteId, surface, recordTracksEvent ] );
 
-	if ( ! site || ! upsellSource ) {
+	if ( ! site || ! showChip ) {
 		return undefined;
 	}
 

--- a/client/dashboard/app/omnibar/plugin-free-domain.tsx
+++ b/client/dashboard/app/omnibar/plugin-free-domain.tsx
@@ -23,7 +23,7 @@ export function useFreeDomainPlugin( {
 	surface: FreeDomainUpsellSurface;
 } ): OmnibarNode | undefined {
 	const { recordTracksEvent } = useAnalytics();
-	const { showChip } = useFreeDomainUpsellExperiment( site );
+	const { showChip, isQaOverride } = useFreeDomainUpsellExperiment( site );
 	const upsellSource = getFreeDomainUpsellSource( site );
 	const siteId = site?.ID;
 
@@ -38,8 +38,9 @@ export function useFreeDomainPlugin( {
 			upsell_id: FREE_DOMAIN_UPSELL_ID,
 			surface,
 			upsell_source: upsellSource,
+			...( isQaOverride && { qa_override: true } ),
 		} );
-	}, [ showChip, upsellSource, siteId, surface, recordTracksEvent ] );
+	}, [ showChip, isQaOverride, upsellSource, siteId, surface, recordTracksEvent ] );
 
 	if ( ! site || ! showChip ) {
 		return undefined;
@@ -55,6 +56,7 @@ export function useFreeDomainPlugin( {
 				upsell_id: FREE_DOMAIN_UPSELL_ID,
 				surface,
 				upsell_source: upsellSource,
+				...( isQaOverride && { qa_override: true } ),
 			} ),
 		render: () => (
 			<span className="omnibar__free-domain-chip">

--- a/config/dashboard-horizon.json
+++ b/config/dashboard-horizon.json
@@ -28,7 +28,7 @@
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": true,
-		"dashboard/omnibar-free-domain-chip": false,
+		"dashboard/omnibar-free-domain-chip": true,
 		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,

--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -35,7 +35,7 @@
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": false,
 		"dashboard/enable-percentage-rollout": true,
-		"dashboard/omnibar-free-domain-chip": false,
+		"dashboard/omnibar-free-domain-chip": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,

--- a/config/dashboard-stage.json
+++ b/config/dashboard-stage.json
@@ -33,7 +33,7 @@
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": true,
 		"dashboard/enable-percentage-rollout": true,
-		"dashboard/omnibar-free-domain-chip": false,
+		"dashboard/omnibar-free-domain-chip": true,
 		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/simulate-full-rollout": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -34,7 +34,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
-		"dashboard/omnibar-free-domain-chip": false,
+		"dashboard/omnibar-free-domain-chip": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,
 		"dashboard/rollout-advance-notice": true,

--- a/config/production.json
+++ b/config/production.json
@@ -46,7 +46,7 @@
 		"current-site/notice": true,
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
-		"dashboard/omnibar-free-domain-chip": false,
+		"dashboard/omnibar-free-domain-chip": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -44,7 +44,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
-		"dashboard/omnibar-free-domain-chip": false,
+		"dashboard/omnibar-free-domain-chip": true,
 		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/rollout-advance-notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -43,7 +43,7 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
-		"dashboard/omnibar-free-domain-chip": false,
+		"dashboard/omnibar-free-domain-chip": true,
 		"dashboard/omnibar-radical": true,
 		"dashboard/opt-in-welcome-modal": true,
 		"dashboard/plans": true,


### PR DESCRIPTION
Part of DOTMSD-1529. Stacked on #113748.

## Proposed Changes

* Add `useFreeDomainUpsellExperiment()` to `client/dashboard/app/free-domain-upsell`: wraps `useExperiment( 'calypso_omnibar_free_domain_upsell_20260825', { isEligible } )` so only users who could actually see the chip are enrolled. The chip renders only for the `treatment` variation.
* Eligibility mirrors the two sidebar JITMs the chip replaces (same copy and CTA): `free_to_paid_plan` (Free plan, not domain-only) and `monthly_to_annual_plan` (any monthly plan); both require Simple, admin (`manage_options`), not staging, and no mapped primary domain.
* Both chips consume the hook: the interim omnibar chip and the new omnibar `plugin-free-domain` plugin.
* QA override: `?omnibar_free_domain=1` forces the chip (eligibility still required). It is dead on production builds unless in a support session, so regular users cannot force treatment UI outside a real assignment. When the override is active, impression/click events carry `qa_override: true` so QA sessions (including support-session QA on production) can be filtered out of the experiment analysis.
* Flip `dashboard/omnibar-free-domain-chip` to `true` outside development.
* Unit tests seed the ExPlat localStorage store so the real `useExperiment` path runs without mocking: treatment (free + monthly), explicit control, unassigned (null), non-admin, mapped domain, yearly paid, flag off, the QA override, and the override being inert on production `env_id`s.

## Operational notes for the experiment

* **Kill switch:** stopping the experiment in ExPlat is the global kill — Calypso (localStorage TTL 3600s) and wp-admin (per-user transient, 1h) both revert to control within about an hour. Do NOT flip the `dashboard/omnibar-free-domain-chip` flag alone mid-test: it only removes the Calypso chips and would leave the wp-admin chip and sidebar suppression active.
* **Impression definition:** an impression means the chip rendered in the bar, once per site per mount — the same render-based basis as the sidebar banner's JITM impressions.
* **Engagement metric:** combine both event families — `calypso_omnibar_upsell_*` (surfaces `msd`, `calypso`) and `wpcom_omnibar_upsell_*` (surfaces `wp_admin`, `post_editor`, `site_editor`, `site_frontend`) — sharing `upsell_id: omnibar-free-domain`.
* **Cohorts:** impression/click events carry `upsell_source` (`free_to_paid_plan` | `monthly_to_annual_plan`) on every surface, so the Free and monthly cohorts can be read separately — the combined result is dominated by Free volume.
* **JITM queue caveat (by design):** chip eligibility reconstructs the two target JITMs' conditions instead of reading the JITM queue winner. The two banners have low queue priority, so a higher-priority sidebar JITM (domain-to-plan credit, ML flash sales/promos) can win for the same audience: those treatment users see that banner AND the chip. This holds in both arms symmetrically (only the two target banners are ever suppressed, and only when the chip shows), so it does not bias the comparison — but the experiment write-up should state it.
* **Assignment consistency:** Calypso assigns via `/experiments/0.1.0/assignments/calypso`; wp-admin uses the wpcom-native ExPlat calls. The ExPlat model review must confirm both resolve one user-level assignment.

## Why are these changes being made?

* This is the Calypso half of the DOTMSD-1529 AB test: moving the "Free domain with an annual plan" upsell from the wp-admin sidebar banner to a persistent omnibar chip. Assignment is by wpcom user id server-side, which keeps the variation consistent across Calypso and wp-admin surfaces.
* The wp-admin half (admin-bar chip + sidebar banner suppression for treatment users) is Automattic/jetpack#51565.
* Eligibility is deliberately reactive rather than frozen at mount: the omnibar mounts before the selected site resolves, so eligibility flips once site data arrives. `useExperiment` only requests an assignment while eligible.

## Testing Instructions

* `yarn start-dashboard`, select a Free Simple site (or a monthly-plan Simple site).
* In development ExPlat resolves to no variation, so the chip stays hidden by default; append `?omnibar_free_domain=1` to force it on (works because dev is not a production build).
* To exercise a real variation, seed localStorage: `explat-experiment--calypso_omnibar_free_domain_upsell_20260825` with `{"experimentName":"calypso_omnibar_free_domain_upsell_20260825","variationName":"treatment","retrievedTimestamp":<Date.now()>,"ttl":3600}` and reload.
* Repeat with the `dashboard/omnibar-radical` flag enabled to check the new omnibar plugin. Switch between eligible sites and confirm one impression per site.
* `yarn test-client client/dashboard/app/interim-omnibar/test/omnibar-free-domain-chip.test.tsx`

Note: the experiment must be created in ExPlat with the exact name above before this can launch, and the implementation needs an experiment code review before the experiment starts.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

