### PR TITLE
Plans: let the plan-upgrade flow offer a longer billing term on the current tier

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
@@ -34,6 +34,8 @@ import {
 	PLAN_FREE,
 	PLAN_HOSTING_TRIAL_MONTHLY,
 	PLAN_PERSONAL,
+	PLAN_PERSONAL_MONTHLY,
+	PLAN_PREMIUM_MONTHLY,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
 import { renderHook } from '@testing-library/react';
@@ -469,5 +471,69 @@ describe( 'useGenerateActionHook', () => {
 
 		expect( action.primary.text ).toBe( 'Downgrade' );
 		expect( action.primary.variant ).toBe( 'secondary' );
+	} );
+	it( 'should offer a term upgrade on the current plan tier in the plans-upgrade intent', () => {
+		( Plans.useCurrentPlan as jest.Mock ).mockReturnValue( {
+			planSlug: PLAN_PERSONAL_MONTHLY,
+		} );
+
+		const { result } = renderHook( () =>
+			useGenerateActionHook( {
+				isInSignup: false,
+				isLaunchPage: false,
+				plansIntent: 'plans-upgrade',
+			} )
+		);
+
+		const action = result.current( {
+			planSlug: PLAN_PERSONAL,
+			availableForPurchase: true,
+		} );
+
+		expect( action.primary.text ).toBe( 'Upgrade to Yearly' );
+		expect( action.primary.status ).toBe( 'enabled' );
+	} );
+
+	it( 'should show the current plan as owned in the plans-upgrade intent when the term matches', () => {
+		( Plans.useCurrentPlan as jest.Mock ).mockReturnValue( {
+			planSlug: PLAN_PERSONAL_MONTHLY,
+		} );
+
+		const { result } = renderHook( () =>
+			useGenerateActionHook( {
+				isInSignup: false,
+				isLaunchPage: false,
+				plansIntent: 'plans-upgrade',
+			} )
+		);
+
+		const action = result.current( { planSlug: PLAN_PERSONAL_MONTHLY } );
+
+		expect( action.primary.text ).toBe( 'Your plan' );
+		expect( action.primary.status ).toBe( 'disabled' );
+	} );
+
+	it( 'should offer a higher tier at the same term in the plans-upgrade intent', () => {
+		( Plans.useCurrentPlan as jest.Mock ).mockReturnValue( {
+			planSlug: PLAN_PERSONAL_MONTHLY,
+		} );
+		( useSelector as jest.Mock ).mockImplementation( currentPlanIsOwnerMockSelector );
+
+		const { result } = renderHook( () =>
+			useGenerateActionHook( {
+				isInSignup: false,
+				isLaunchPage: false,
+				siteId: mockSiteId,
+				plansIntent: 'plans-upgrade',
+			} )
+		);
+
+		const action = result.current( {
+			planSlug: PLAN_PREMIUM_MONTHLY,
+			availableForPurchase: true,
+		} );
+
+		expect( action.primary.text ).toBe( 'Upgrade' );
+		expect( action.primary.status ).toBe( 'enabled' );
 	} );
 } );

--- a/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
+++ b/client/my-sites/plans-features-main/hooks/use-generate-action-hook.tsx
@@ -461,15 +461,12 @@ function getLoggedInPlansAction( {
 	delayedDowngradeToProductSlug?: string | null;
 	onRenewCurrentPlan?: () => void;
 } & UseActionHookProps ): GridAction {
-	// Use plan type matching instead of exact slug matching for the 'plans-upgrade' intent.
-	// This allows monthly/yearly versions of the same plan to be considered "current"
 	const isUpgradeFlow =
 		plansIntent &&
 		[ 'plans-upgrade', 'plans-upgrade-or-downgrade', 'plans-woo-hosted' ].includes( plansIntent );
-	const current =
-		isUpgradeFlow && sitePlanSlug
-			? getPlanClass( sitePlanSlug ) === getPlanClass( planSlug )
-			: sitePlanSlug === planSlug;
+	// Term matters: a longer-term card of the tier the user already owns is a term upgrade, not
+	// the plan they're on, so it has to stay purchasable.
+	const current = sitePlanSlug === planSlug;
 	const isTrialPlan =
 		sitePlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY ||
 		sitePlanSlug === PLAN_MIGRATION_TRIAL_MONTHLY ||


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-536/

## Proposed Changes

Customers on a monthly plan could not switch to annual billing on their current tier in `/setup/plan-upgrade/plans`: their own tier rendered a disabled "Your plan" button at every billing term. This makes the current-plan comparison in `useGenerateActionHook` term-aware, so a longer-term card of the tier you already own stays purchasable.

* Compare the owned plan to each grid card by plan slug rather than by plan class, so the billing term is part of the comparison.
* Add tests covering the `plans-upgrade` intent: a longer term on the current tier offers "Upgrade to Yearly", the same term still shows a disabled "Your plan", and a higher tier at the same term still offers "Upgrade".

## Why are these changes being made?

`getLoggedInPlansAction` special-cased the `plans-upgrade`, `plans-upgrade-or-downgrade`, and `plans-woo-hosted` intents to compare `getPlanClass( sitePlanSlug ) === getPlanClass( planSlug )`. `getPlanClass` collapses every term of a tier onto one value — `personal-bundle-monthly` and `personal-bundle` are both `is-personal-plan` — so with a monthly plan the yearly card of that same tier matched as the current plan and returned early with a disabled "Your plan" button.

That early return shadowed the branch ~130 lines below it, which already handles exactly this case and renders "Upgrade to Yearly" / "Upgrade to Biennial" / "Upgrade to Triennial". Since the class comparison only applied to those intents, the legacy `/plans` page kept working while the plan-upgrade stepper flow did not — which is why this surfaced when the entry point moved. The grid agreed with the legacy behaviour too: both `useGridPlans` and the "Your plan" badge in `useHighlightLabels` already use `isSamePlan`, an exact slug match, so the card rendered as purchasable and only its button claimed otherwise.

Matching on the slug restores the intended fall-through and keeps the grid and the button consistent. Lower terms than the current plan are already filtered out of the interval selector by `useFilteredDisplayedIntervals`, so no shorter-term card reaches the removed branch. One deliberate behaviour change: a user with a pending delayed downgrade viewing a longer term now sees "Upgrade to Yearly" on their own tier instead of "Renew {plan}".

## Testing Instructions

TC:
```
yarn test-client client/my-sites/plans-features-main/hooks/test/use-generate-action-hook.ts
```

Manual testing:
* Use a site on a monthly paid plan (e.g. Personal Monthly) that you own.
* Go to Purchases, open the monthly plan, and choose the option that takes you to `/setup/plan-upgrade/plans`.
* With the billing term set to Yearly, confirm your own tier now shows "Upgrade to Yearly" rather than a disabled "Your plan", and that clicking it lands on checkout for the yearly plan.
* Switch the term to 2 years / 3 years and confirm "Upgrade to Biennial" / "Upgrade to Triennial".
* Switch the term back to Monthly and confirm your own tier still shows a disabled "Your plan", and that higher tiers still show "Upgrade".
* On a site already on a yearly plan, confirm the yearly card still shows "Your plan" and that the Monthly term is still absent from the term selector.
