### PR TITLE
Onboarding: start the wow funnel from the theme-sheet blueprint CTA

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -46,6 +46,7 @@ import {
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import {
 	getWowFunnelDest,
+	getWowFunnelArgs,
 	getWowFunnelSlug,
 	getRememberedWowFunnelSite,
 	startWowFunnelSite,
@@ -140,6 +141,28 @@ const onboarding: FlowV2< typeof initialize > = {
 			if ( wowFunnelSlug && wowFunnelDest ) {
 				const siteSlug = providedDependencies.siteSlug as string;
 				const siteId = providedDependencies.siteId as number;
+
+				// dest=site-spec: the funnel's follow-up (e.g. the blueprint import) is already
+				// running server-side, so site-spec only waits on it and hands over. It must not
+				// start one — see the funnel guard on its kickoff effect.
+				if ( 'site-spec' === wowFunnelDest ) {
+					const blueprintSlug = queryParams.get( 'blueprint' ) ?? '';
+					logWowFunnelEvent( 'post_checkout_site_spec', {
+						funnel: wowFunnelSlug,
+						blog_id: siteId,
+					} );
+					return [
+						getBlueprintArchiveSiteSpecUrl( {
+							siteSlug,
+							siteId,
+							blueprintSlug,
+							ref: refParameter,
+						} ),
+						null,
+						null,
+					];
+				}
+
 				const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
 				const siteUrl = site?.URL ?? `https://${ siteSlug }`;
 				logWowFunnelEvent( 'post_checkout_editor', { funnel: wowFunnelSlug, blog_id: siteId } );
@@ -625,7 +648,10 @@ const onboarding: FlowV2< typeof initialize > = {
 			if ( ! funnelSlug || getRememberedWowFunnelSite( funnelSlug ) ) {
 				return;
 			}
-			void startWowFunnelSite( { funnelSlug } ).catch( () => {
+			void startWowFunnelSite( {
+				funnelSlug,
+				funnelArgs: getWowFunnelArgs( queryParams ),
+			} ).catch( () => {
 				// Errors are logged in the util; the create-site step retries as a fallback.
 			} );
 		}, [ currentStepSlug, isLoggedIn ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/index.tsx
@@ -23,6 +23,8 @@ export const BlueprintStep: StepType = ( { navigation } ) => {
 
 	const blueprintParam = query.get( 'blueprint' ) ?? '';
 	const buildDestParam = query.get( 'build_dest' ) ?? '';
+	// The wow funnel builds the Atomic site from the same archive, before checkout.
+	const wowFunnelParam = query.get( 'wow_funnel' ) ?? '';
 
 	useEffect( () => {
 		const fetchBlueprint = async () => {
@@ -38,11 +40,11 @@ export const BlueprintStep: StepType = ( { navigation } ) => {
 				return;
 			}
 
-			// build_dest=wow restores the blueprint's pre-built archive onto an
-			// Atomic site, so it needs that archive to exist on the library post.
-			// Verify up front; when missing, fall back to the legacy Simple-site
-			// import by stripping the param (tracked, so missing archives surface).
-			if ( 'wow' === buildDestParam ) {
+			// Both Atomic paths restore the blueprint's pre-built archive, so both need that
+			// archive to exist on the library post: build_dest=wow imports after checkout, the
+			// wow funnel before it. Verify up front; when missing, fall back to the legacy
+			// Simple-site import by stripping the params (tracked, so missing archives surface).
+			if ( 'wow' === buildDestParam || 'blueprint' === wowFunnelParam ) {
 				const hasArchive = await checkBlueprintExists( id );
 
 				if ( ! hasArchive ) {
@@ -54,11 +56,17 @@ export const BlueprintStep: StepType = ( { navigation } ) => {
 					// Strip through the router rather than window.history: navigation to
 					// a logged-out user's auth step builds its path from the router's
 					// search params, which a plain history.replaceState would leave
-					// holding build_dest=wow. Submitting is deferred to the re-run of
+					// holding the Atomic params. Submitting is deferred to the re-run of
 					// this effect, once the sanitized query is what navigation will
 					// carry forward.
+					//
+					// wow_funnel and dest go together: leaving the funnel on would build an
+					// Atomic site with nothing to import onto it, and leaving dest on would
+					// send the customer to a site-spec waiting for an import that never runs.
 					const sanitized = new URLSearchParams( query );
 					sanitized.delete( 'build_dest' );
+					sanitized.delete( 'wow_funnel' );
+					sanitized.delete( 'dest' );
 					setQuery( sanitized, { replace: true } );
 					return;
 				}
@@ -72,7 +80,7 @@ export const BlueprintStep: StepType = ( { navigation } ) => {
 
 		fetchBlueprint();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ blueprintParam, buildDestParam ] );
+	}, [ blueprintParam, buildDestParam, wowFunnelParam ] );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/test/index.tsx
@@ -77,6 +77,37 @@ describe( 'BlueprintStep', () => {
 		} );
 	} );
 
+	it( 'keeps the wow funnel when the blueprint has an archive', async () => {
+		( checkBlueprintExists as jest.Mock ).mockResolvedValue( true );
+		let searchAtSubmit = '';
+		const submit = jest.fn( () => {
+			searchAtSubmit = currentSearch;
+		} );
+
+		render( '/blueprint?blueprint=961&wow_funnel=blueprint&dest=site-spec', submit );
+
+		await waitFor( () => expect( submit ).toHaveBeenCalled() );
+		expect( checkBlueprintExists ).toHaveBeenCalledWith( '961' );
+		expect( searchAtSubmit ).toContain( 'wow_funnel=blueprint' );
+		expect( searchAtSubmit ).toContain( 'dest=site-spec' );
+	} );
+
+	it( 'strips the wow funnel and dest when the archive is missing', async () => {
+		( checkBlueprintExists as jest.Mock ).mockResolvedValue( false );
+		let searchAtSubmit = '';
+		const submit = jest.fn( () => {
+			searchAtSubmit = currentSearch;
+		} );
+
+		render( '/blueprint?blueprint=961&wow_funnel=blueprint&dest=site-spec', submit );
+
+		await waitFor( () => expect( submit ).toHaveBeenCalled() );
+		// Leaving the funnel on would build an Atomic site with nothing to import onto it, and
+		// leaving dest on would hand over to a site-spec waiting for an import that never runs.
+		expect( searchAtSubmit ).not.toContain( 'wow_funnel' );
+		expect( searchAtSubmit ).not.toContain( 'dest' );
+	} );
+
 	it( 'does not look up an archive without build_dest=wow', async () => {
 		const submit = jest.fn();
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -27,7 +27,11 @@ import Loading from 'calypso/components/loading';
 import useAddEcommerceTrialMutation from 'calypso/data/ecommerce/use-add-ecommerce-trial-mutation';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import { getWowFunnelSlug, startWowFunnelSite } from 'calypso/landing/stepper/utils/wow-funnel';
+import {
+	getWowFunnelArgs,
+	getWowFunnelSlug,
+	startWowFunnelSite,
+} from 'calypso/landing/stepper/utils/wow-funnel';
 import { resolveLaunchpadPersonalizationVariation } from 'calypso/lib/ai-launchpad';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';
@@ -226,6 +230,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 		if ( wowFunnelSlug ) {
 			const funnelSite = await startWowFunnelSite( {
 				funnelSlug: wowFunnelSlug,
+				funnelArgs: getWowFunnelArgs( urlQueryParams ),
 				siteTitle: selectedSiteTitle,
 			} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -142,6 +142,9 @@ const SiteSpec: StepType = function SiteSpec() {
 
 	const ciabSiteCreationPromiseRef = useRef< Promise< number | null > | null >( null );
 	const shouldImportBlueprint = queryParams.get( 'blueprint_archive_import' ) === '1';
+	// A wow-funnel run already started the import server-side, before checkout. This page still
+	// waits on it and hands over, but must not start a second one.
+	const isWowFunnelRun = !! queryParams.get( 'wow_funnel' );
 	const blueprintArchiveSlug = queryParams.get( 'blueprint_slug' ) ?? '';
 	const blueprintArchiveSiteIdentifier = getBlueprintArchiveSiteIdentifier( {
 		siteSlug: queryParams.get( 'siteSlug' ),
@@ -428,10 +431,13 @@ const SiteSpec: StepType = function SiteSpec() {
 	);
 
 	// Kick off the background transfer + blueprint-archive import as soon as the
-	// spec page mounts, so it runs while the user reviews the spec.
+	// spec page mounts, so it runs while the user reviews the spec. A funnel run skips this:
+	// its build started before checkout and is likely finished by now, so the waits below are
+	// all this page needs to do.
 	useEffect( () => {
 		if (
 			! shouldImportBlueprint ||
+			isWowFunnelRun ||
 			! blueprintArchiveSlug ||
 			! blueprintArchiveSiteIdentifier ||
 			blueprintImportStartedRef.current
@@ -457,7 +463,12 @@ const SiteSpec: StepType = function SiteSpec() {
 					error: error instanceof Error ? error.message : String( error ),
 				} );
 			} );
-	}, [ shouldImportBlueprint, blueprintArchiveSlug, blueprintArchiveSiteIdentifier ] );
+	}, [
+		shouldImportBlueprint,
+		isWowFunnelRun,
+		blueprintArchiveSlug,
+		blueprintArchiveSiteIdentifier,
+	] );
 
 	if ( buildWowRequested && isLoadingAutomattician ) {
 		return <DocumentHead title={ translate( 'Build Your Site with AI' ) } />;

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -14,15 +14,15 @@ import { logToLogstash } from 'calypso/lib/logstash';
 /**
  * Where the customer lands after checkout, when the CTA asks for somewhere specific.
  *
- * - `editor` — straight into the Site Editor on the built Atomic site.
+ * - `editor`    — straight into the Site Editor on the built Atomic site.
+ * - `site-spec` — the AI site-spec, which polls the funnel's build and hands over when it lands.
  *
  * No (or unrecognized) `dest` means no override: the flow's ordinary post-checkout destination
- * applies. Other funnels add their own values alongside their server-side funnel (e.g. the
- * blueprint funnel's site-spec hand-off).
+ * applies.
  */
-export type WowFunnelDest = 'editor';
+export type WowFunnelDest = 'editor' | 'site-spec';
 
-const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'editor' ];
+const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'editor', 'site-spec' ];
 
 /**
  * A funnel site created for this flow, remembered so the create-site step can consume it rather
@@ -50,6 +50,24 @@ export function getWowFunnelSlug( queryParams: URLSearchParams ): string | null 
 	// Mirror sanitize_key(): lowercase, [a-z0-9_-] only.
 	const slug = raw.toLowerCase().replace( /[^a-z0-9_-]/g, '' );
 	return slug || null;
+}
+
+/**
+ * Input the funnel's server-side follow-up needs, read off the entry URL.
+ *
+ * Sent as `wow_funnel_args` to /sites/new, where the registered funnel's follow-up consumes it —
+ * the blueprint funnel, for instance, seeds its archive import from `blueprint_slug`. Empty for
+ * funnels that do no follow-up work.
+ */
+export function getWowFunnelArgs( queryParams: URLSearchParams ): Record< string, string > {
+	const args: Record< string, string > = {};
+
+	const blueprint = queryParams.get( 'blueprint' );
+	if ( blueprint ) {
+		args.blueprint_slug = blueprint;
+	}
+
+	return args;
 }
 
 export function getWowFunnelDest( queryParams: URLSearchParams ): WowFunnelDest | null {
@@ -120,9 +138,11 @@ export function clearWowFunnelSite(): void {
  */
 export function startWowFunnelSite( {
 	funnelSlug,
+	funnelArgs,
 	siteTitle,
 }: {
 	funnelSlug: string;
+	funnelArgs?: Record< string, string >;
 	siteTitle?: string;
 } ): Promise< RememberedWowFunnelSite > {
 	const remembered = getRememberedWowFunnelSite( funnelSlug );
@@ -160,7 +180,8 @@ export function startWowFunnelSite( {
 			undefined, // ref.
 			undefined, // provisionTarget.
 			undefined, // aiLaunchpadEnabled.
-			funnelSlug
+			funnelSlug,
+			funnelArgs
 		);
 
 		if ( ! site ) {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -184,14 +184,15 @@ function BlueprintCtaButton( {
 		return null;
 	}
 
-	// The onboarding blueprint step accepts a blueprint-library post id or slug
-	// via ?blueprint=. build_dest=wow asks for the theme demo to be restored onto
-	// an Atomic site from the blueprint's archive, which keeps the plugins the
-	// Simple-site blueprint runner would drop; the step falls back to that runner
-	// when the blueprint has no archive.
+	// The onboarding blueprint step accepts a blueprint-library post id or slug via ?blueprint=.
+	// wow_funnel=blueprint builds the Atomic site from the blueprint's archive *before* checkout,
+	// so the finished site is waiting the moment the customer pays; dest=site-spec hands them to
+	// the AI site-spec afterwards. The step falls back to the legacy Simple-site runner when the
+	// blueprint has no archive.
 	const href = addQueryArgs( '/setup/onboarding/blueprint', {
 		blueprint: blueprintId,
-		build_dest: 'wow',
+		wow_funnel: 'blueprint',
+		dest: 'site-spec',
 		ref: `theme-${ themeId }`,
 	} );
 

--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -34,6 +34,7 @@ interface GetNewSiteParams {
 	siteIntent?: string;
 	provisionTarget?: string | null;
 	wowFunnel?: string;
+	wowFunnelArgs?: Record< string, string >;
 }
 
 type NewSiteParams = {
@@ -57,6 +58,7 @@ type NewSiteParams = {
 		site_intent?: string;
 		early_provision_target?: string;
 		wow_funnel?: string;
+		wow_funnel_args?: Record< string, string >;
 	};
 	validate: boolean;
 };
@@ -111,6 +113,7 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 		partnerBundle,
 		provisionTarget,
 		wowFunnel,
+		wowFunnelArgs,
 	} = params;
 
 	// We will use the default annotation instead of theme annotation as fallback,
@@ -139,6 +142,9 @@ export const getNewSiteParams = ( params: GetNewSiteParams ) => {
 			// WoW funnel: build the site's Atomic host before checkout. The slug names a
 			// registered funnel server-side (see wp-content/lib/atomic/funnels.php).
 			...( wowFunnel && { wow_funnel: wowFunnel } ),
+			// Input for the funnel's server-side follow-up (e.g. the blueprint archive to import).
+			...( wowFunnelArgs &&
+				Object.keys( wowFunnelArgs ).length > 0 && { wow_funnel_args: wowFunnelArgs } ),
 		},
 		validate: false,
 	};
@@ -166,7 +172,8 @@ export const createSite = async (
 	ref?: string,
 	provisionTarget?: string | null,
 	aiLaunchpadEnabled?: boolean,
-	wowFunnel?: string
+	wowFunnel?: string,
+	wowFunnelArgs?: Record< string, string >
 ) => {
 	const siteUrl = storedSiteUrl || domainItem?.domain_name;
 
@@ -184,6 +191,7 @@ export const createSite = async (
 		partnerBundle,
 		provisionTarget,
 		wowFunnel,
+		wowFunnelArgs,
 	} );
 
 	// if ( isEmpty( bearerToken ) && 'onboarding-registrationless' === flowToCheck ) {


### PR DESCRIPTION
## Proposed Changes

Points the theme-sheet blueprint CTA at the **WoW funnel**, so the blueprint's Atomic site is built *before* checkout instead of after it.

Today the CTA sends `build_dest=wow`: the customer picks a domain, pays, and only then waits through a Simple→Atomic transfer and an archive import. The funnel starts that build the moment they enter the flow, so the finished site is waiting when they pay.

* **CTA href** — `build_dest=wow` → `wow_funnel=blueprint&dest=site-spec` (`client/my-sites/theme/main.jsx`). The CTA is already Automattician-gated behind `themes/blueprint-cta`, which is the same audience the funnel serves, so this adds no new exposure.
* **Funnel args** — `getWowFunnelArgs()` reads `?blueprint=` off the entry URL and `createSite()` sends it as `wow_funnel_args`. This is load-bearing: the server-side funnel's follow-up consumes `blueprint_slug`, and without it the funnel builds an empty Atomic site and silently skips the import.
* **`dest=site-spec`** returns as a funnel destination, reusing `getBlueprintArchiveSiteSpecUrl()`.
* **site-spec no longer starts the import on a funnel run** — it already happened server-side. Only the kickoff is skipped; the transfer/import waits and the confirm branch still run, since the build may not have landed yet. (That's why this is a new condition rather than deleting the block — the same flag gates all three.)
* **Archive-missing fallback** strips `wow_funnel` and `dest` alongside `build_dest`, so a blueprint with no archive degrades to the legacy Simple-site import rather than building an Atomic site with nothing to put on it.

`build_dest=wow` handling is deliberately left in place, now unused, so anyone mid-flow on an old URL still completes. It has no other producer, so it can be retired in a follow-up.

Server side: `236646-ghe-Automattic/wpcom` registers the `blueprint` funnel and its follow-up (already green, targeting trunk). Until it ships, an unknown funnel slug is ignored server-side and this degrades to ordinary onboarding.

## Why are these changes being made?

So a blueprint CTA hands over a finished site at the moment of payment rather than starting the work then. It also removes the free-plan option from the path, which is consistent with the funnel always producing an Atomic site.

## Testing Instructions

1. Sandboxed API with the server branch, logged in as an Automattician, `themes/blueprint-cta` enabled.
2. Open a theme sheet for a theme with a blueprint archive and click **Build a site with this blueprint**.
3. The site is created in the background at flow entry; domains offers only "Set up a domain later"; plans shows paid tiers only.
4. Complete checkout → you land on the site-spec, which waits on the already-running build and hands over to the editor.
5. Confirm in Logstash that only **one** import ran for the site (`feature:wow_funnel AND blog_id:<id>`, plus the import record on `GET /sites/{id}/imports`) — site-spec should not have started a second.
6. Regression: a blueprint **without** an archive falls back to the legacy Simple-site import, with `wow_funnel`/`dest` stripped from the URL.

Jest: `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/blueprint` and `.../flows/onboarding` — 30 passing, including two new cases covering the funnel keep/strip behaviour.

Pre-merge checklist:

* [x] Tests pass locally
* [ ] E2E verified against a sandboxed API once the server PR lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
