### PR TITLE
Dashboard: put the activity actor avatar on the row's first line

### DIFF
--- a/client/dashboard/components/logs-activity/activity-actor.tsx
+++ b/client/dashboard/components/logs-activity/activity-actor.tsx
@@ -113,7 +113,7 @@ export function ActivityActor( { actor }: { actor?: ActivityActorDetails } ) {
 	const mcpIndicator = getMcpIndicator( actor );
 
 	return (
-		<HStack spacing="2" alignment="left" className="site-activity-logs__actor">
+		<HStack spacing="2" alignment="topLeft" className="site-activity-logs__actor">
 			{ icon }
 			<span>
 				{ label }


### PR DESCRIPTION
Follows up on #113800, which top-aligned the activity log event icon. The avatar in the column beside it has the same problem.

## Proposed Changes

* Top-align the activity log's User column, so the avatar sits on the first line of a name that wraps.

## Why are these changes being made?

* This is what a reviewer pointed out on #113800: with a name long enough to wrap, the 24px avatar centered itself between the two lines instead of sitting beside the first.
* The event icon next to it needed a small upward pull because its box is taller than a line. The avatar is exactly one line tall, so alignment alone does it.

## Testing Instructions

* Open a site's Activity log at a width where a user's name wraps to two lines — the avatar should sit beside the first line, matching the event icon in the column to its left.
* Check in light and dark mode.

## Considerations

* This started out also putting line-clamped table text back on the 24px line grid, for the Deployments list's three-line commit message. That went in as a table-wide rule forcing a line height onto the text component, which would have made every multi-line clamp in the table airier and reached inside a components package's own typography to do it. DataViews already centers cell contents; the gap is in the description slot beside the title field, so the fix belongs on that container rather than on the text. Dropped from this PR to be done properly on its own.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
