### PR TITLE
E2E: retry the assertions that read the page once

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/feedback-inbox-page.ts
@@ -56,6 +56,15 @@ export class FeedbackInboxPage {
 	}
 
 	/**
+	 * Waits for the response row matching the given text to render.
+	 *
+	 * @param {string} text The text to match in the row.
+	 */
+	async waitForResponseRow( text: string ): Promise< void > {
+		await this.getResponseRow( text ).waitFor( { state: 'visible' } );
+	}
+
+	/**
 	 * View a response row that has the provided text.
 	 * Doesn't verify the row is selected, it just makes sure the response
 	 * is visible (inspector on desktop, modal on mobile)

--- a/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
+++ b/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
@@ -5,6 +5,7 @@ import {
 	apiCloseAccount,
 	apiWaitForBearerTokenAcceptance,
 	apiWaitForEmailVerification,
+	isVisibleWithin,
 } from '../shared';
 import type { LoginPage } from '@automattic/calypso-e2e';
 import type { CDPSession, Page } from 'playwright';
@@ -89,7 +90,9 @@ async function continueWithSecurityKey( page: Page ): Promise< void > {
 	const switchToSecurityKey = page.getByRole( 'button', {
 		name: /Continue with your security.key/,
 	} );
-	const canSwitchToSecurityKey = await switchToSecurityKey.isVisible();
+	// Which second factor the flow offers first is decided as the form renders, so give
+	// the switch a moment to appear rather than reading for it the instant we arrive.
+	const canSwitchToSecurityKey = await isVisibleWithin( switchToSecurityKey, 5_000 );
 	if ( canSwitchToSecurityKey ) {
 		await switchToSecurityKey.click();
 	}

--- a/test/e2e/specs/dashboard/dashboard__basic-and-routing.spec.ts
+++ b/test/e2e/specs/dashboard/dashboard__basic-and-routing.spec.ts
@@ -21,8 +21,8 @@ test.describe(
 			} );
 
 			await test.step( 'Then I see the WordPress.com Multi-site Dashboard page (list of sites)', async function () {
-				expect( await pageDashboard.isLoaded() ).toBe( true );
-				expect( await pageDashboard.getHeadingText() ).toEqual( 'Sites' );
+				await expect.poll( () => pageDashboard.isLoaded() ).toBe( true );
+				await expect.poll( () => pageDashboard.getHeadingText() ).toEqual( 'Sites' );
 			} );
 		} );
 

--- a/test/e2e/specs/dashboard/settings__site-visibility.spec.ts
+++ b/test/e2e/specs/dashboard/settings__site-visibility.spec.ts
@@ -27,8 +27,17 @@ test.describe( 'Dashboard: Site Visibility Settings', { tag: [ tags.DASHBOARD_PR
 		} );
 
 		await test.step( 'Then I can not see my site if I check as an external visitor', async function () {
-			await pageIncognito.goto( sitePublic.blog_details.url );
-			expect( await pageIncognito.getPageText() ).toContain( 'Private Site' );
+			// The visibility change propagates asynchronously, so reload until it lands
+			// instead of reading the page once.
+			await expect
+				.poll(
+					async () => {
+						await pageIncognito.goto( sitePublic.blog_details.url );
+						return pageIncognito.getPageText();
+					},
+					{ timeout: 30 * 1000 }
+				)
+				.toContain( 'Private Site' );
 		} );
 	} );
 
@@ -55,8 +64,15 @@ test.describe( 'Dashboard: Site Visibility Settings', { tag: [ tags.DASHBOARD_PR
 		} );
 
 		await test.step( 'Then I can see the coming soon message if I visit as an external visitor', async function () {
-			await pageIncognito.goto( sitePublic.blog_details.url );
-			expect( await pageIncognito.getPageText() ).toContain( 'coming soon' );
+			await expect
+				.poll(
+					async () => {
+						await pageIncognito.goto( sitePublic.blog_details.url );
+						return pageIncognito.getPageText();
+					},
+					{ timeout: 30 * 1000 }
+				)
+				.toContain( 'coming soon' );
 		} );
 	} );
 
@@ -84,15 +100,23 @@ test.describe( 'Dashboard: Site Visibility Settings', { tag: [ tags.DASHBOARD_PR
 
 		await test.step( 'Then I can still my public site if I visit as an external visitor', async function () {
 			await pageIncognito.goto( sitePublic.blog_details.url );
+			const pageText = await pageIncognito.getPageText();
 			// Soft assert to allow for the possibility that the site is still private
 			// or coming soon, and to test the robots.txt test step even if these checks fail.
-			expect.soft( await pageIncognito.getPageText() ).not.toContain( 'Private Site' );
-			expect.soft( await pageIncognito.getPageText() ).not.toContain( 'coming soon' );
+			expect.soft( pageText ).not.toContain( 'Private Site' );
+			expect.soft( pageText ).not.toContain( 'coming soon' );
 		} );
 
 		await test.step( 'But search engine robots will see a disallow instruction', async function () {
-			await pageIncognito.goto( `${ sitePublic.blog_details.url }robots.txt` );
-			expect( await pageIncognito.getPageText() ).toContain( 'User-agent: *\nDisallow: /' );
+			await expect
+				.poll(
+					async () => {
+						await pageIncognito.goto( `${ sitePublic.blog_details.url }robots.txt` );
+						return pageIncognito.getPageText();
+					},
+					{ timeout: 30 * 1000 }
+				)
+				.toContain( 'User-agent: *\nDisallow: /' );
 		} );
 	} );
 } );

--- a/test/e2e/specs/editor/editor__navbar.spec.ts
+++ b/test/e2e/specs/editor/editor__navbar.spec.ts
@@ -7,6 +7,7 @@ import {
 	getTestAccountByFeature,
 } from '@automattic/calypso-e2e';
 import { tags, test } from '../../lib/pw-base';
+import { isVisibleWithin } from '../shared';
 
 test.describe(
 	DataHelper.createSuiteTitle( 'Editor: Navbar' ),
@@ -44,7 +45,8 @@ test.describe(
 			await test.step( 'Return to Calypso dashboard', async () => {
 				const WPAdminBarLocator = page.locator( '#wpadminbar' );
 				const isMobileClassicView =
-					envVariables.VIEWPORT_NAME === 'mobile' && ( await WPAdminBarLocator.isVisible() );
+					envVariables.VIEWPORT_NAME === 'mobile' &&
+					( await isVisibleWithin( WPAdminBarLocator, 5 * 1000 ) );
 
 				// The classic WP Admin Bar on mobile viewport doesn't have the
 				// "return" button, so let's not fail this test if it's the case.

--- a/test/e2e/specs/editor/editor__page-basic-flow.spec.ts
+++ b/test/e2e/specs/editor/editor__page-basic-flow.spec.ts
@@ -73,7 +73,9 @@ test.describe(
 
 			await test.step( 'Then template content loads into editor', async () => {
 				const editorCanvas = await pageEditor.getEditorCanvas();
-				expect( await editorCanvas.textContent() ).toContain( pageTemplateFirstTextContent! );
+				await expect
+					.poll( () => editorCanvas.textContent() )
+					.toContain( pageTemplateFirstTextContent! );
 			} );
 
 			await test.step( 'When I open settings sidebar', async () => {

--- a/test/e2e/specs/flows/setup-onboarding__flows.spec.ts
+++ b/test/e2e/specs/flows/setup-onboarding__flows.spec.ts
@@ -143,7 +143,7 @@ test.describe(
 			} );
 
 			await test.step( 'And I fill the "Use a domain I own" input', async function () {
-				expect( await pageUseADomainIAlreadyOwn.getDomainInputValue() ).toBe( blogName );
+				await expect.poll( () => pageUseADomainIAlreadyOwn.getDomainInputValue() ).toBe( blogName );
 				await pageUseADomainIAlreadyOwn.fillUseDomainIOwnInput( domain );
 			} );
 

--- a/test/e2e/specs/help-center/help-center__calypso.spec.ts
+++ b/test/e2e/specs/help-center/help-center__calypso.spec.ts
@@ -44,56 +44,56 @@ test.describe( 'Help Center in Calypso', { tag: [ tags.CALYPSO_PR ] }, () => {
 		} );
 
 		await test.step( 'Help Center is showing on the screen', async () => {
-			expect( await helpCenterComponent.isPopoverShown() ).toBeTruthy();
+			await expect.poll( () => helpCenterComponent.isPopoverShown() ).toBeTruthy();
 		} );
 
 		await test.step( 'Help Center can be minimized', async () => {
 			await helpCenterComponent.minimizePopover();
-			await page.waitForTimeout( 200 );
-			const containerHeight = await helpCenterLocator.evaluate(
-				( el: HTMLElement ) => el.offsetHeight
-			);
-			expect( containerHeight ).toBe( 56 );
+			await expect
+				.poll( () => helpCenterLocator.evaluate( ( el: HTMLElement ) => el.offsetHeight ) )
+				.toBe( 56 );
 		} );
 
 		await test.step( 'Help Center can be maximized', async () => {
 			await helpCenterComponent.maximizePopover();
-			expect( await helpCenterComponent.isPopoverShown() ).toBeTruthy();
+			await expect.poll( () => helpCenterComponent.isPopoverShown() ).toBeTruthy();
 		} );
 
 		// Articles
 
 		await test.step( 'Initial articles are shown', async () => {
 			const articles = helpCenterComponent.getArticles();
-			expect( await articles.count() ).toBeGreaterThanOrEqual( 1 );
+			await expect.poll( () => articles.count() ).toBeGreaterThanOrEqual( 1 );
 		} );
 
 		await test.step( 'Search returns proper results', async () => {
 			await helpCenterComponent.search( 'Change a domain name address' );
-			const resultTitles = await helpCenterComponent.getArticles().allTextContents();
-			expect(
-				resultTitles.some(
-					( title ) => normalizeString( title )?.includes( 'Change a domain name address' )
-				)
-			).toBeTruthy();
+			await expect
+				.poll( async () => {
+					const resultTitles = await helpCenterComponent.getArticles().allTextContents();
+					return resultTitles.some(
+						( title ) => normalizeString( title )?.includes( 'Change a domain name address' )
+					);
+				} )
+				.toBeTruthy();
 		} );
 
 		await test.step( 'Post loads correctly', async () => {
 			const article = helpCenterComponent.getArticles().first();
 			const articleTitle = await article.textContent();
-			await article.click();
 
-			await page.waitForResponse(
+			const articleResponsePromise = page.waitForResponse(
 				( response ) =>
 					response.url().includes( '/wpcom/v2/help/article' ) && response.status() === 200
 			);
+			await article.click();
+			await articleResponsePromise;
 
 			const articleHeader = helpCenterLocator.getByRole( 'article' ).getByRole( 'heading' ).first();
-			await articleHeader.waitFor( { state: 'visible' } );
 
-			expect( normalizeString( await articleHeader.textContent() ) ).toBe(
-				normalizeString( articleTitle )
-			);
+			await expect
+				.poll( async () => normalizeString( await articleHeader.textContent() ) )
+				.toBe( normalizeString( articleTitle ) );
 
 			await helpCenterComponent.goBack();
 		} );
@@ -113,7 +113,7 @@ test.describe( 'Help Center in Calypso', { tag: [ tags.CALYPSO_PR ] }, () => {
 			);
 
 			await helpCenterLocator.waitFor( { state: 'visible' } );
-			expect( await helpCenterComponent.isPopoverShown() ).toBeTruthy();
+			await expect.poll( () => helpCenterComponent.isPopoverShown() ).toBeTruthy();
 		} );
 
 		await test.step( 'Open help center to Wapuu on page load', async () => {
@@ -124,8 +124,8 @@ test.describe( 'Help Center in Calypso', { tag: [ tags.CALYPSO_PR ] }, () => {
 			);
 
 			await helpCenterLocator.waitFor( { state: 'visible' } );
-			expect( await helpCenterComponent.isPopoverShown() ).toBeTruthy();
-			expect( await helpCenterComponent.getOdieChat().count() ).toBeTruthy();
+			await expect.poll( () => helpCenterComponent.isPopoverShown() ).toBeTruthy();
+			await expect( helpCenterComponent.getOdieChat() ).toBeVisible();
 		} );
 	} );
 
@@ -146,7 +146,7 @@ test.describe( 'Help Center in Calypso', { tag: [ tags.CALYPSO_PR ] }, () => {
 			await stillNeedHelpButton.waitFor( { state: 'visible' } );
 			await stillNeedHelpButton.click();
 
-			expect( await helpCenterLocator.locator( '#odie-messages-container' ).count() ).toBeTruthy();
+			await expect( helpCenterLocator.locator( '#odie-messages-container' ) ).toBeVisible();
 		} );
 
 		// It's rare that chat is disabled so I'm opting to add a message to the test
@@ -160,9 +160,8 @@ test.describe( 'Help Center in Calypso', { tag: [ tags.CALYPSO_PR ] }, () => {
 			await helpCenterComponent.startAIChat( 'talk to human' );
 
 			const contactSupportButton = helpCenterComponent.getContactSupportButton();
-			await contactSupportButton.waitFor( { state: 'visible', timeout: 30000 } );
 
-			expect( await contactSupportButton.count() ).toBeTruthy();
+			await expect( contactSupportButton ).toBeVisible( { timeout: 30000 } );
 		} );
 
 		test( 'start talking with a human', async ( { page } ) => {
@@ -172,9 +171,8 @@ test.describe( 'Help Center in Calypso', { tag: [ tags.CALYPSO_PR ] }, () => {
 			await contactSupportButton.click();
 
 			const zendeskMessaging = page.locator( 'iframe[title="Messaging window"]' );
-			await zendeskMessaging.waitFor( { state: 'visible' } );
 
-			expect( await zendeskMessaging.count() ).toBeTruthy();
+			await expect( zendeskMessaging ).toBeVisible();
 		} );
 	} );
 } );

--- a/test/e2e/specs/help-center/help-center__wp-admin.spec.ts
+++ b/test/e2e/specs/help-center/help-center__wp-admin.spec.ts
@@ -42,15 +42,14 @@ test.describe( 'Help Center in WP Admin', { tag: [ tags.JETPACK_WPCOM_INTEGRATIO
 		} );
 
 		await test.step( 'Is showing on the screen', async () => {
-			expect( await helpCenterComponent.isPopoverShown() ).toBeTruthy();
+			await expect.poll( () => helpCenterComponent.isPopoverShown() ).toBeTruthy();
 		} );
 
 		await test.step( 'Can be minimized', async () => {
 			await helpCenterComponent.minimizePopover();
-			const containerHeight = await helpCenterLocator.evaluate(
-				( el: HTMLElement ) => el.offsetHeight
-			);
-			expect( containerHeight ).toBe( 50 );
+			await expect
+				.poll( () => helpCenterLocator.evaluate( ( el: HTMLElement ) => el.offsetHeight ) )
+				.toBe( 50 );
 		} );
 
 		await test.step( 'The popover can be closed', async () => {
@@ -63,38 +62,37 @@ test.describe( 'Help Center in WP Admin', { tag: [ tags.JETPACK_WPCOM_INTEGRATIO
 		await test.step( 'Initial articles are shown', async () => {
 			await helpCenterComponent.openPopover();
 			const articles = helpCenterComponent.getArticles();
-			expect( await articles.count() ).toBeGreaterThanOrEqual( 1 );
+			await expect.poll( () => articles.count() ).toBeGreaterThanOrEqual( 1 );
 		} );
 
 		await test.step( 'Search returns proper results', async () => {
 			await helpCenterComponent.search( 'Change a Domain Name Address' );
-			const resultTitles = await helpCenterComponent.getArticles().allTextContents();
-			expect(
-				resultTitles.some(
-					( title ) => normalizeString( title )?.includes( 'Change a Domain Name Address' )
-				)
-			).toBeTruthy();
+			await expect
+				.poll( async () => {
+					const resultTitles = await helpCenterComponent.getArticles().allTextContents();
+					return resultTitles.some(
+						( title ) => normalizeString( title )?.includes( 'Change a Domain Name Address' )
+					);
+				} )
+				.toBeTruthy();
 		} );
 
 		await test.step( 'Post loads correctly', async () => {
-			const article = await helpCenterComponent.getArticles().first();
+			const article = helpCenterComponent.getArticles().first();
 			const articleTitle = await article.textContent();
-			await article.click();
 
-			await page.waitForResponse(
+			const articleResponsePromise = page.waitForResponse(
 				( response ) =>
 					response.url().includes( '/wpcom/v2/help/article' ) && response.status() === 200
 			);
+			await article.click();
+			await articleResponsePromise;
 
-			const articleHeader = await helpCenterLocator
-				.getByRole( 'article' )
-				.getByRole( 'heading' )
-				.first();
-			await articleHeader.waitFor( { state: 'visible' } );
+			const articleHeader = helpCenterLocator.getByRole( 'article' ).getByRole( 'heading' ).first();
 
-			expect( normalizeString( await articleHeader.textContent() ) ).toBe(
-				normalizeString( articleTitle )
-			);
+			await expect
+				.poll( async () => normalizeString( await articleHeader.textContent() ) )
+				.toBe( normalizeString( articleTitle ) );
 
 			await helpCenterComponent.goBack();
 		} );
@@ -106,9 +104,8 @@ test.describe( 'Help Center in WP Admin', { tag: [ tags.JETPACK_WPCOM_INTEGRATIO
 			const stillNeedHelpButton = helpCenterLocator.getByRole( 'link', {
 				name: 'Still need help?',
 			} );
-			await stillNeedHelpButton.waitFor( { state: 'visible' } );
 			await stillNeedHelpButton.click();
-			expect( await helpCenterComponent.getOdieChat().count() ).toBeTruthy();
+			await expect( helpCenterComponent.getOdieChat() ).toBeVisible();
 		} );
 
 		// Skipped: get forwarded to a human
@@ -131,7 +128,7 @@ test.describe( 'Help Center in WP Admin', { tag: [ tags.JETPACK_WPCOM_INTEGRATIO
 		await test.step( 'Open help center on page load', async () => {
 			await page.goto( pageUrl + '?help-center=home' );
 			await helpCenterLocator.waitFor( { state: 'visible' } );
-			expect( await helpCenterComponent.isPopoverShown() ).toBeTruthy();
+			await expect.poll( () => helpCenterComponent.isPopoverShown() ).toBeTruthy();
 		} );
 	} );
 } );

--- a/test/e2e/specs/jetpack/social__editor-features.spec.ts
+++ b/test/e2e/specs/jetpack/social__editor-features.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@automattic/calypso-e2e';
 import { Page } from 'playwright';
 import { expect, tags, test } from '../../lib/pw-base';
+import { isVisibleWithin } from '../shared';
 
 const features4SimpleSites = {
 	resharing: false,
@@ -228,7 +229,9 @@ test.describe(
 
 						// Look for the Share button within the modal dialog
 						reshareButton = reshareModal.getByRole( 'button', { name: 'Share', exact: true } );
-						isReshareButtonVisible = await reshareButton.isVisible();
+						// The modal renders before its buttons do, so a point-in-time check here
+						// reads as "not visible" and fails the assertion below.
+						isReshareButtonVisible = await isVisibleWithin( reshareButton );
 
 						// Close the share post modal by clicking the Close button within the modal
 						closeButton = reshareModal.getByRole( 'button', { name: 'Close' } ).first();
@@ -243,12 +246,12 @@ test.describe(
 						await upgradeButton.waitFor();
 					}
 
-					const content = await section.textContent();
-
 					const message =
 						'To re-share a post, you need to upgrade to the WordPress.com Premium plan';
 
-					expect( content?.includes( message ) ).toBe( ! features.resharing );
+					await expect
+						.poll( async () => ( await section.textContent() )?.includes( message ) )
+						.toBe( ! features.resharing );
 				} );
 
 				test( `Should verify that manual sharing ${

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.spec.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.spec.ts
@@ -20,7 +20,7 @@ import {
 	cancelDashboardPurchaseFlow,
 } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
-import { apiCloseAccount } from '../shared';
+import { apiCloseAccount, isVisibleWithin } from '../shared';
 
 /**
  * Checks the entire user lifecycle, from signup, onboarding, launch and plan cancellation.
@@ -147,11 +147,13 @@ test.describe(
 				const startSiteFlow = new StartSiteFlow( page );
 				const themeName = 'Attar';
 				const showThemesButton = page.getByRole( 'button', { name: 'Show all Blog themes' } );
-				if ( await showThemesButton.isVisible() ) {
+				// `isVisible` is point-in-time, so a screen that is still rendering reads as
+				// "not shown" and silently skips the step. Wait it out before deciding.
+				if ( await isVisibleWithin( showThemesButton ) ) {
 					await showThemesButton.click();
 				}
 				const themeLocator = page.getByRole( 'link', { name: themeName } );
-				if ( ! ( await themeLocator.isVisible() ) ) {
+				if ( ! ( await isVisibleWithin( themeLocator ) ) ) {
 					return;
 				}
 				await startSiteFlow.selectTheme( themeName );
@@ -160,10 +162,8 @@ test.describe(
 
 			await test.step( 'Then Launchpad is shown (if applicable)', async () => {
 				const title = page.getByText( "Let's get started!" );
-				if ( ! ( await title.isVisible() ) ) {
-					return;
-				}
-				await title.waitFor( { timeout: 30 * 1000 } );
+				// Launchpad only follows some flows, so its absence is not a failure.
+				await isVisibleWithin( title, 30 * 1000 );
 			} );
 
 			await test.step( 'Then site slug exists', async () => {

--- a/test/e2e/specs/onboarding/onboarding__write.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__write.spec.ts
@@ -10,7 +10,7 @@ import {
 	UserSignupPage,
 } from '@automattic/calypso-e2e';
 import { expect, tags, test } from '../../lib/pw-base';
-import { apiCloseAccount, fixme_retry } from '../shared';
+import { apiCloseAccount, fixme_retry, isVisibleWithin } from '../shared';
 
 test.describe(
 	DataHelper.createSuiteTitle( 'Onboarding: Write Focus' ),
@@ -75,13 +75,17 @@ test.describe(
 
 			await test.step( 'Then I enter the onboarding flow for the selected domain', async () => {
 				await page.waitForURL( /home\/.*ref=onboarding/, { timeout: 60 * 1000 } );
-				expect( page.url() ).toContain( selectedFreeDomain );
+				// The wait above matches any site's Home, so give the redirect chain a chance
+				// to settle on the site that was just created.
+				await expect.poll( () => page.url() ).toContain( selectedFreeDomain );
 			} );
 
 			await test.step( 'When I select theme', async () => {
 				const startSiteFlow = new StartSiteFlow( page );
 				const showThemesButton = page.getByRole( 'button', { name: 'Show all Blog themes' } );
-				if ( ! ( await showThemesButton.isVisible() ) ) {
+				// `isVisible` is point-in-time, so a screen that is still rendering reads as
+				// "not shown" and silently skips the step. Wait it out before deciding.
+				if ( ! ( await isVisibleWithin( showThemesButton ) ) ) {
 					return;
 				}
 				await showThemesButton.click();
@@ -95,7 +99,7 @@ test.describe(
 
 			await test.step( 'When I write first post', async () => {
 				const writeFirstPostLink = page.getByRole( 'link', { name: 'Write your first post' } );
-				if ( ! ( await writeFirstPostLink.isVisible() ) ) {
+				if ( ! ( await isVisibleWithin( writeFirstPostLink ) ) ) {
 					return;
 				}
 				editorOpened = true;
@@ -135,10 +139,8 @@ test.describe(
 
 			await test.step( 'Then Launchpad is shown (if applicable)', async () => {
 				const title = page.getByText( "Let's get started!" );
-				if ( ! ( await title.isVisible() ) ) {
-					return;
-				}
-				await title.waitFor( { timeout: 30 * 1000 } );
+				// Launchpad only follows some flows, so its absence is not a failure.
+				await isVisibleWithin( title, 30 * 1000 );
 			} );
 		} );
 	}

--- a/test/e2e/specs/plans/plans__signup-business.spec.ts
+++ b/test/e2e/specs/plans/plans__signup-business.spec.ts
@@ -75,8 +75,9 @@ test.describe(
 				await page.goto(
 					helperData.getCalypsoURL( `home/${ newSiteDetails?.blog_details.site_slug as string }` )
 				);
-				const currentPlan = await componentSidebar.getCurrentPlanName();
-				expect( currentPlan ).toBe( planName );
+				// The sidebar renders the previous plan until the purchase lands in the
+				// site's plan data, so poll rather than reading it once.
+				await expect.poll( () => componentSidebar.getCurrentPlanName() ).toBe( planName );
 			} );
 		} );
 

--- a/test/e2e/specs/published-content/forms__submissions.spec.ts
+++ b/test/e2e/specs/published-content/forms__submissions.spec.ts
@@ -319,7 +319,9 @@ test.describe(
 			await test.step( 'Clear search to show both responses', async () => {
 				feedbackInboxPage = new FeedbackInboxPage( page );
 				await feedbackInboxPage.clearSearch( true );
-				await page.waitForTimeout( 1000 );
+				// Both responses coming back is what says the cleared list has rendered.
+				await feedbackInboxPage.waitForResponseRow( formData1.email );
+				await feedbackInboxPage.waitForResponseRow( formData2.email );
 			} );
 
 			await test.step( 'Click on first response', async () => {

--- a/test/e2e/specs/search/search__jetpack-instant.spec.ts
+++ b/test/e2e/specs/search/search__jetpack-instant.spec.ts
@@ -90,8 +90,9 @@ test.describe(
 
 			await test.step( 'The search term pulls into the modal', async () => {
 				// See: https://github.com/Automattic/jetpack/issues/32753
-				const termInModal = ( await searchModalComponent.getSearchTerm() ).replace( /\+/g, ' ' );
-				expect( termInModal ).toEqual( searchString );
+				await expect
+					.poll( async () => ( await searchModalComponent.getSearchTerm() ).replace( /\+/g, ' ' ) )
+					.toEqual( searchString );
 			} );
 
 			await test.step( 'Clear the search term', async () => {
@@ -99,7 +100,7 @@ test.describe(
 					searchModalComponent.expectAndWaitForSearch( '' ),
 					searchModalComponent.clearSearchTerm(),
 				] );
-				expect( await searchModalComponent.getSearchTerm() ).toEqual( '' );
+				await expect.poll( () => searchModalComponent.getSearchTerm() ).toEqual( '' );
 			} );
 
 			await test.step( 'Close the modal', async () => {

--- a/test/e2e/specs/shared/index.ts
+++ b/test/e2e/specs/shared/index.ts
@@ -1,9 +1,31 @@
+import type { Locator } from 'playwright';
+
 export * from './api-cancel-atomic-plan';
 export * from './api-close-account';
 export * from './api-create-free-site';
 export * from './api-delete-site';
 export * from './api-wait-for-account-propagation';
 export * from './swap-base-url';
+
+/**
+ * Waits for a locator to become visible, and reports whether it did.
+ *
+ * `Locator.isVisible` answers for the current moment, so a screen that is still
+ * rendering reads as "not visible" and a step conditional on it is silently
+ * skipped. Use this wherever the app may simply not have painted yet.
+ *
+ * @param locator The locator to wait on.
+ * @param timeout How long to wait, in milliseconds.
+ */
+export async function isVisibleWithin(
+	locator: Locator,
+	timeout: number = 15 * 1000
+): Promise< boolean > {
+	return locator.waitFor( { state: 'visible', timeout } ).then(
+		() => true,
+		() => false
+	);
+}
 
 /**
  * This is a fix for e2e test that was deployed on Christmas eve as an emergency fix. Please remove and fix the root cause.


### PR DESCRIPTION
A sweep of the suite for assertions and branches that read the page at a single instant, which is the main source of flakes and timeouts we keep re-fixing one spec at a time.

## Proposed Changes

* Poll the assertions that read live page state — element counts, text, measured heights, the sidebar's plan name, a site's public visibility.
* Arm the Help Center's article `waitForResponse` before the click that triggers it.
* Give conditional steps a bounded wait instead of an instantaneous visibility check, via a shared `isVisibleWithin` helper.
* Replace a fixed sleep in the Jetpack Forms spec with a wait for the rows it was sleeping for.

## Why are these changes being made?

* `isVisible`, `count`, `textContent` and friends answer for the moment they are called. Wrapped in a plain `expect`, they fail whenever the app is a beat behind — the exact pattern our own reliability doc warns about, still present across a dozen specs.
* Two of these were worse than a flake. The Help Center registered its wait for the article response *after* clicking the article, so a fast response was missed and the spec ran to its timeout. And two onboarding specs branched on an instantaneous check right after a navigation: a screen still painting read as absent, the step was skipped, and the run passed having tested less than it claimed — in the Write flow, that quietly dropped the whole editor half of the test.
* Site visibility changes propagate asynchronously, so checking the public site once after saving is a race against the backend rather than a test of it. Those checks now reload until the change lands.
* The sleeps that remain are deliberate — retry backoff, and the 30s TOTP window that the login endpoint enforces.

## Testing Instructions

* CI: the Calypso PR and Dashboard PR E2E jobs cover most of the touched specs.
* Locally, against a dev instance, the specs most worth re-running are the Help Center, the Dashboard basics and site visibility, and Jetpack Forms submissions. `--repeat-each` is the useful signal here, per our reliability doc.
* No product code changes, so nothing to check in the app itself.

## Considerations

* Bounded waits cost time when the thing genuinely is absent — the conditional branches use 5–15s, chosen to stay well inside each spec's budget.
* Left alone: assertions of absence, where polling only makes a real failure slower, and the SSR hydration spec, where reading the heading immediately is the point of the test.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
