### PR TITLE
Agents Manager: broadcast the agent's turn and ability completions

### DIFF
--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -10,6 +10,7 @@ import type { ComponentProps } from 'react';
 const mockUseAgentChat = jest.fn();
 const mockUpdateSessionId = jest.fn();
 let mockManagerHasAgent = true;
+let mockManagerTurnInFlight = false;
 let mockAgentChatConfig: { onTaskUpdate?: ( update: TaskUpdate ) => Promise< void > } | undefined;
 let mockConversationConfig:
 	| {
@@ -292,6 +293,7 @@ jest.mock(
 		getAgentManager: () => ( {
 			updateSessionId: mockUpdateSessionId,
 			hasAgent: () => mockManagerHasAgent,
+			isTurnInFlight: () => mockManagerTurnInFlight,
 		} ),
 		useAgentChat: ( config: typeof mockAgentChatConfig ) => {
 			mockAgentChatConfig = config;
@@ -649,6 +651,7 @@ describe( 'OrchestratorChat', () => {
 		mockBlockEditorStoreThrows = false;
 		sessionStorage.clear();
 		mockManagerHasAgent = true;
+		mockManagerTurnInFlight = false;
 		mockHasEditorRedo = false;
 		mockOpenPost = null;
 		mockEditorBlocks = [];

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -1714,7 +1714,7 @@ export default function OrchestratorChat( {
 
 	// Broadcast the turn's edges so a host editing surface can tell the agent's
 	// writes from a block settling itself on mount.
-	useBroadcastTurnActivity( isProcessing );
+	useBroadcastTurnActivity( agentConfig?.agentId, isProcessing );
 
 	const latestDisplayedMessage = displayedMessages[ displayedMessages.length - 1 ];
 	const shouldSuppressTransientThinking = Boolean(

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -25,6 +25,7 @@ import { useRegisterCustomActions } from '../../hooks/custom-actions';
 import useAbilitiesRegistration from '../../hooks/use-abilities-registration';
 import useAgentTraceIds from '../../hooks/use-agent-trace-ids';
 import { useBroadcastConversationActivity } from '../../hooks/use-broadcast-conversation-activity';
+import { useBroadcastTurnActivity } from '../../hooks/use-broadcast-turn-activity';
 import useCheckpointAction, {
 	getCheckpointIdForMessage,
 	invalidateCheckpointAction,
@@ -1710,6 +1711,10 @@ export default function OrchestratorChat( {
 
 	// Broadcast conversation activity so other bundles can re-sync transcript cards.
 	useBroadcastConversationActivity( messageCount );
+
+	// Broadcast the turn's edges so a host editing surface can tell the agent's
+	// writes from a block settling itself on mount.
+	useBroadcastTurnActivity( isProcessing );
 
 	const latestDisplayedMessage = displayedMessages[ displayedMessages.length - 1 ];
 	const shouldSuppressTransientThinking = Boolean(

--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -137,6 +137,15 @@ interface AgentsManagerActions {
 	 * instead of waiting for the `agents-manager-ready` event.
 	 */
 	isReady?: boolean;
+	/**
+	 * Set to `true` by builds that broadcast the agent's activity as window
+	 * events — `agents-manager-turn-started`, `agents-manager-turn-ended` and
+	 * `agents-manager-ability-completed`; see `utils/agent-activity-events.ts`.
+	 * A host that acts on the agent's silence (Big Sky's easy mode writes over
+	 * edits it can attribute to nobody) must check this first: against a build
+	 * without it, the agent is always silent.
+	 */
+	broadcastsAgentActivity?: boolean;
 }
 
 /**

--- a/packages/agents-manager/src/hooks/__tests__/use-broadcast-turn-activity.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-broadcast-turn-activity.test.ts
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import {
+	AGENT_TURN_ENDED_EVENT,
+	AGENT_TURN_STARTED_EVENT,
+} from '../../utils/agent-activity-events';
+import { useBroadcastTurnActivity } from '../use-broadcast-turn-activity';
+
+function renderWithProcessing( initial: boolean ) {
+	const started = jest.fn();
+	const ended = jest.fn();
+	window.addEventListener( AGENT_TURN_STARTED_EVENT, started );
+	window.addEventListener( AGENT_TURN_ENDED_EVENT, ended );
+
+	const view = renderHook( ( { isProcessing } ) => useBroadcastTurnActivity( isProcessing ), {
+		initialProps: { isProcessing: initial },
+	} );
+
+	return {
+		started,
+		ended,
+		setProcessing: ( isProcessing: boolean ) => view.rerender( { isProcessing } ),
+		cleanup: () => {
+			window.removeEventListener( AGENT_TURN_STARTED_EVENT, started );
+			window.removeEventListener( AGENT_TURN_ENDED_EVENT, ended );
+		},
+	};
+}
+
+describe( 'useBroadcastTurnActivity', () => {
+	it( 'broadcasts nothing while idle', () => {
+		const { started, ended, cleanup } = renderWithProcessing( false );
+
+		expect( started ).not.toHaveBeenCalled();
+		expect( ended ).not.toHaveBeenCalled();
+		cleanup();
+	} );
+
+	it( 'broadcasts a start when a turn begins', () => {
+		const { started, ended, setProcessing, cleanup } = renderWithProcessing( false );
+
+		setProcessing( true );
+
+		expect( started ).toHaveBeenCalledTimes( 1 );
+		expect( ended ).not.toHaveBeenCalled();
+		cleanup();
+	} );
+
+	it( 'broadcasts an end when the turn finishes', () => {
+		const { started, ended, setProcessing, cleanup } = renderWithProcessing( false );
+
+		setProcessing( true );
+		setProcessing( false );
+
+		expect( started ).toHaveBeenCalledTimes( 1 );
+		expect( ended ).toHaveBeenCalledTimes( 1 );
+		cleanup();
+	} );
+
+	it( 'treats mounting mid-turn as a start', () => {
+		// A listener that attaches after the turn began still needs to know one
+		// is in flight, or it will read the turn's writes as nobody's.
+		const { started, cleanup } = renderWithProcessing( true );
+
+		expect( started ).toHaveBeenCalledTimes( 1 );
+		cleanup();
+	} );
+
+	it( 'does not repeat a broadcast for an unchanged state', () => {
+		const { started, ended, setProcessing, cleanup } = renderWithProcessing( false );
+
+		setProcessing( true );
+		setProcessing( true );
+		setProcessing( false );
+		setProcessing( false );
+
+		expect( started ).toHaveBeenCalledTimes( 1 );
+		expect( ended ).toHaveBeenCalledTimes( 1 );
+		cleanup();
+	} );
+
+	it( 'reports a turn still open on unmount as ended', () => {
+		// The chat unmounting mid-turn (dock closed, page navigated) takes the
+		// turn with it; a listener left waiting for the end would wait forever.
+		const { ended, cleanup } = renderWithProcessing( true );
+		const view = renderHook( () => useBroadcastTurnActivity( true ) );
+
+		view.unmount();
+
+		expect( ended ).toHaveBeenCalledTimes( 1 );
+		cleanup();
+	} );
+} );

--- a/packages/agents-manager/src/hooks/__tests__/use-broadcast-turn-activity.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-broadcast-turn-activity.test.ts
@@ -8,20 +8,43 @@ import {
 } from '../../utils/agent-activity-events';
 import { useBroadcastTurnActivity } from '../use-broadcast-turn-activity';
 
-function renderWithProcessing( initial: boolean ) {
+const mockIsTurnInFlight = jest.fn();
+
+jest.mock(
+	'@automattic/agenttic-client',
+	() => ( { getAgentManager: () => ( { isTurnInFlight: mockIsTurnInFlight } ) } ),
+	{ virtual: true }
+);
+
+const AGENT_ID = 'wpcom-orchestrator';
+
+beforeEach( () => {
+	mockIsTurnInFlight.mockReturnValue( false );
+
+	// The hook remembers what it last announced at module scope, deliberately,
+	// so that the chat unmounting does not reset it. Reloading the module would
+	// hand it a second copy of React, so it is driven back to quiet instead —
+	// before any listener is attached, so the tests never see this.
+	renderHook( () => useBroadcastTurnActivity( AGENT_ID, false ) ).unmount();
+} );
+
+function render( isProcessing = false ) {
 	const started = jest.fn();
 	const ended = jest.fn();
 	window.addEventListener( AGENT_TURN_STARTED_EVENT, started );
 	window.addEventListener( AGENT_TURN_ENDED_EVENT, ended );
 
-	const view = renderHook( ( { isProcessing } ) => useBroadcastTurnActivity( isProcessing ), {
-		initialProps: { isProcessing: initial },
-	} );
+	const view = renderHook(
+		( props: { isProcessing: boolean } ) =>
+			useBroadcastTurnActivity( AGENT_ID, props.isProcessing ),
+		{ initialProps: { isProcessing } }
+	);
 
 	return {
 		started,
 		ended,
-		setProcessing: ( isProcessing: boolean ) => view.rerender( { isProcessing } ),
+		setProcessing: ( next: boolean ) => view.rerender( { isProcessing: next } ),
+		unmount: () => view.unmount(),
 		cleanup: () => {
 			window.removeEventListener( AGENT_TURN_STARTED_EVENT, started );
 			window.removeEventListener( AGENT_TURN_ENDED_EVENT, ended );
@@ -31,7 +54,7 @@ function renderWithProcessing( initial: boolean ) {
 
 describe( 'useBroadcastTurnActivity', () => {
 	it( 'broadcasts nothing while idle', () => {
-		const { started, ended, cleanup } = renderWithProcessing( false );
+		const { started, ended, cleanup } = render();
 
 		expect( started ).not.toHaveBeenCalled();
 		expect( ended ).not.toHaveBeenCalled();
@@ -39,7 +62,7 @@ describe( 'useBroadcastTurnActivity', () => {
 	} );
 
 	it( 'broadcasts a start when a turn begins', () => {
-		const { started, ended, setProcessing, cleanup } = renderWithProcessing( false );
+		const { started, ended, setProcessing, cleanup } = render();
 
 		setProcessing( true );
 
@@ -49,27 +72,18 @@ describe( 'useBroadcastTurnActivity', () => {
 	} );
 
 	it( 'broadcasts an end when the turn finishes', () => {
-		const { started, ended, setProcessing, cleanup } = renderWithProcessing( false );
+		const { started, ended, setProcessing, cleanup } = render();
 
 		setProcessing( true );
 		setProcessing( false );
 
 		expect( started ).toHaveBeenCalledTimes( 1 );
 		expect( ended ).toHaveBeenCalledTimes( 1 );
-		cleanup();
-	} );
-
-	it( 'treats mounting mid-turn as a start', () => {
-		// A listener that attaches after the turn began still needs to know one
-		// is in flight, or it will read the turn's writes as nobody's.
-		const { started, cleanup } = renderWithProcessing( true );
-
-		expect( started ).toHaveBeenCalledTimes( 1 );
 		cleanup();
 	} );
 
 	it( 'does not repeat a broadcast for an unchanged state', () => {
-		const { started, ended, setProcessing, cleanup } = renderWithProcessing( false );
+		const { started, ended, setProcessing, cleanup } = render();
 
 		setProcessing( true );
 		setProcessing( true );
@@ -81,15 +95,57 @@ describe( 'useBroadcastTurnActivity', () => {
 		cleanup();
 	} );
 
-	it( 'reports a turn still open on unmount as ended', () => {
-		// The chat unmounting mid-turn (dock closed, page navigated) takes the
-		// turn with it; a listener left waiting for the end would wait forever.
-		const { ended, cleanup } = renderWithProcessing( true );
-		const view = renderHook( () => useBroadcastTurnActivity( true ) );
+	it( 'treats mounting onto a turn the manager is still running as a start', () => {
+		// The remount case: `useAgentChat` starts a fresh instance at
+		// `isProcessing: false` and never re-attaches to the running stream, so
+		// the manager is the only thing that knows a turn is in flight.
+		mockIsTurnInFlight.mockReturnValue( true );
 
-		view.unmount();
+		const { started, cleanup } = render( false );
+
+		expect( started ).toHaveBeenCalledTimes( 1 );
+		cleanup();
+	} );
+
+	it( 'does not report a turn as ended when the manager is still running it', () => {
+		// The chat is one route among several: opening conversation history
+		// mid-turn unmounts it while the agent carries on writing.
+		mockIsTurnInFlight.mockReturnValue( true );
+
+		const { ended, unmount, cleanup } = render( true );
+
+		unmount();
+
+		expect( ended ).not.toHaveBeenCalled();
+		cleanup();
+	} );
+
+	it( 'reports the end on unmount once the manager says the turn is over', () => {
+		const { ended, unmount, cleanup } = render( true );
+
+		unmount();
 
 		expect( ended ).toHaveBeenCalledTimes( 1 );
 		cleanup();
+	} );
+
+	it( 'announces the end on the next mount when the turn finished while unmounted', () => {
+		// Nothing is listening between the two, so the end is owed until the
+		// chat comes back. A listener is told the agent is still working until
+		// then, which is the safe way round.
+		mockIsTurnInFlight.mockReturnValue( true );
+
+		const first = render( true );
+		first.unmount();
+		expect( first.ended ).not.toHaveBeenCalled();
+		first.cleanup();
+
+		mockIsTurnInFlight.mockReturnValue( false );
+
+		const second = render( false );
+
+		expect( second.ended ).toHaveBeenCalledTimes( 1 );
+		expect( second.started ).not.toHaveBeenCalled();
+		second.cleanup();
 	} );
 } );

--- a/packages/agents-manager/src/hooks/custom-actions/README.md
+++ b/packages/agents-manager/src/hooks/custom-actions/README.md
@@ -34,6 +34,7 @@ Consuming the API? See [Public API](#public-api). Adding a new action? See [Addi
 | `chatNavigate`             | `NavigateFunction`                                      | The `react-router-dom` navigate function (path with options, or delta).   |
 | `resumeChat`               | `() => void`                                            | Reopen the chat, resuming this tab's conversation (not a new one).        |
 | `isReady`                  | `boolean`                                               | `true` once the API is fully populated and safe to call.                  |
+| `broadcastsAgentActivity`  | `boolean`                                               | Whether this build fires the [agent activity](#agent-activity) events.    |
 
 \* Available only while the chat panel is mounted. Always optional-chain these calls — they can be `undefined` even after `isReady` is `true`.
 
@@ -66,6 +67,33 @@ window.addEventListener( 'agents-manager-conversation-changed', resync );
 ```
 
 Dispatched by `OrchestratorChat` as the transcript grows. Prefer this over the provider contract for chat interactions — providers are reserved for agent setup.
+
+## Agent activity
+
+Three more window events say what the agent is _doing_, for hosts that render their own editing surface around the chat and have to tell the agent's writes apart from the user's. Nothing else on the page can see that difference: an editor's own dirty state also changes on mount, so a page opening reads the same as an agent editing it.
+
+| Event                              | `detail`                        | Fires when                                                                                                                                            |
+| ---------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `agents-manager-turn-started`      | —                               | A turn began — a message was sent and the agent is working on it.                                                                                     |
+| `agents-manager-turn-ended`        | —                               | The turn finished or was aborted.                                                                                                                     |
+| `agents-manager-ability-completed` | `{ name: string, ok: boolean }` | An ability ran to completion, after it resolved or threw so anything it wrote has landed. `ok` is `false` when it threw or answered `success: false`. |
+
+The turn events are edges, not state: they fire on the change, so a listener that arrives mid-turn hears nothing until that turn ends. The turn is taken from the agent manager rather than from the chat, which is one route in the dock and can unmount while the stream carries on — a turn that ends while the chat is away has its end announced when the chat comes back, and until then a listener is told the agent is still working.
+
+Check `broadcastsAgentActivity` before relying on any of this. Against a build without it no events arrive, and the agent looks permanently silent:
+
+```js
+if ( window.__agentsManagerActions?.broadcastsAgentActivity ) {
+	window.addEventListener( 'agents-manager-turn-started', () => {
+		// the agent is working — attribute what changes next to it
+	} );
+	window.addEventListener( 'agents-manager-ability-completed', ( event ) => {
+		const { name, ok } = event.detail;
+	} );
+}
+```
+
+Defined in `utils/agent-activity-events.ts`.
 
 ## Initial values
 

--- a/packages/agents-manager/src/hooks/custom-actions/index.ts
+++ b/packages/agents-manager/src/hooks/custom-actions/index.ts
@@ -223,6 +223,9 @@ export function useSetupCustomActions( {
 		chatNavigate: navigate,
 		resumeChat,
 		isReady: true,
+		// See the field's doc in global.d.ts. Advertised here, where the API
+		// is assembled, so a host reading it can trust the events are wired.
+		broadcastsAgentActivity: true,
 	} );
 
 	// Hosts (e.g. CIAB) listen for `agents-manager-ready` to invoke actions without polling.

--- a/packages/agents-manager/src/hooks/use-broadcast-turn-activity.ts
+++ b/packages/agents-manager/src/hooks/use-broadcast-turn-activity.ts
@@ -1,4 +1,5 @@
-import { useEffect, useRef } from '@wordpress/element';
+import { getAgentManager } from '@automattic/agenttic-client';
+import { useEffect } from '@wordpress/element';
 import {
 	AGENT_TURN_ENDED_EVENT,
 	AGENT_TURN_STARTED_EVENT,
@@ -6,33 +7,76 @@ import {
 } from '../utils/agent-activity-events';
 
 /**
+ * What was last announced, at module scope so it survives the chat unmounting.
+ *
+ * The turn does not belong to the component: the stream runs on the agent
+ * manager singleton, and this chat can unmount and remount around it. A ref
+ * would be reset by that remount and the next announcement would repeat or
+ * contradict the last one.
+ */
+let announcedActive = false;
+
+/**
+ * Whether a turn is still running, according to the singleton that runs it.
+ * @param agentId The chat's agent, absent until its config has loaded.
+ * @returns Whether a turn is in flight.
+ */
+function hasTurnInFlight( agentId: string | undefined ): boolean {
+	return Boolean( agentId ) && getAgentManager().isTurnInFlight( agentId as string );
+}
+
+/**
+ * Announce a change in whether the agent is working.
+ * @param isActive Whether a turn is running.
+ */
+function announce( isActive: boolean ): void {
+	if ( isActive === announcedActive ) {
+		return;
+	}
+
+	announcedActive = isActive;
+	broadcastTurnEvent( isActive ? AGENT_TURN_STARTED_EVENT : AGENT_TURN_ENDED_EVENT );
+}
+
+/**
  * Broadcast the edges of the agent's turn to code outside the React tree.
  *
  * Edges only, not the state: a listener wants to know when the agent started
- * and stopped acting, and repeating "still processing" on every render would say
- * nothing new. Mounting mid-turn counts as a start — a listener attaching after
- * the turn began would otherwise read the turn's writes as nobody's — and
- * unmounting mid-turn counts as an end, since the turn goes with the chat.
- * @param isProcessing Whether a turn is in flight.
+ * and stopped acting, and repeating "still processing" on every render would
+ * say nothing new.
+ *
+ * `isProcessing` alone would be wrong at both edges, because it belongs to this
+ * component and the turn does not. The chat is one route among several
+ * (`agent-dock` renders it under `/chat`), so opening conversation history
+ * mid-turn unmounts it while the stream carries on running on the agent manager
+ * singleton — and `useAgentChat` neither aborts on unmount nor re-attaches to a
+ * running stream on mount, so a remount reports `isProcessing: false` for the
+ * rest of the turn. Announcing the end there would tell a host the agent had
+ * stopped while it was still writing, which is the one thing this API exists to
+ * prevent.
+ *
+ * So the manager is asked at every edge, and it has the last word: the turn is
+ * over only when it says so. What that cannot cover is a turn finishing while
+ * the chat is unmounted — nothing is listening to notice. The end is announced
+ * when the chat comes back instead, and until then a listener is told the agent
+ * is still working. Deliberately that way round: a host that wrongly believes
+ * the agent is busy holds off, while one that wrongly believes it is idle acts
+ * over the agent's work.
+ * @param agentId      The chat's agent, absent until its config has loaded.
+ * @param isProcessing Whether this chat has a turn in flight.
  */
-export function useBroadcastTurnActivity( isProcessing: boolean ): void {
-	const wasProcessingRef = useRef( false );
-
+export function useBroadcastTurnActivity(
+	agentId: string | undefined,
+	isProcessing: boolean
+): void {
 	useEffect( () => {
-		if ( isProcessing === wasProcessingRef.current ) {
-			return;
-		}
-		wasProcessingRef.current = isProcessing;
-		broadcastTurnEvent( isProcessing ? AGENT_TURN_STARTED_EVENT : AGENT_TURN_ENDED_EVENT );
-	}, [ isProcessing ] );
+		announce( isProcessing || hasTurnInFlight( agentId ) );
+	}, [ agentId, isProcessing ] );
 
 	useEffect(
 		() => () => {
-			if ( wasProcessingRef.current ) {
-				wasProcessingRef.current = false;
-				broadcastTurnEvent( AGENT_TURN_ENDED_EVENT );
-			}
+			announce( hasTurnInFlight( agentId ) );
 		},
-		[]
+		[ agentId ]
 	);
 }

--- a/packages/agents-manager/src/hooks/use-broadcast-turn-activity.ts
+++ b/packages/agents-manager/src/hooks/use-broadcast-turn-activity.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef } from '@wordpress/element';
+import {
+	AGENT_TURN_ENDED_EVENT,
+	AGENT_TURN_STARTED_EVENT,
+	broadcastTurnEvent,
+} from '../utils/agent-activity-events';
+
+/**
+ * Broadcast the edges of the agent's turn to code outside the React tree.
+ *
+ * Edges only, not the state: a listener wants to know when the agent started
+ * and stopped acting, and repeating "still processing" on every render would say
+ * nothing new. Mounting mid-turn counts as a start — a listener attaching after
+ * the turn began would otherwise read the turn's writes as nobody's — and
+ * unmounting mid-turn counts as an end, since the turn goes with the chat.
+ * @param isProcessing Whether a turn is in flight.
+ */
+export function useBroadcastTurnActivity( isProcessing: boolean ): void {
+	const wasProcessingRef = useRef( false );
+
+	useEffect( () => {
+		if ( isProcessing === wasProcessingRef.current ) {
+			return;
+		}
+		wasProcessingRef.current = isProcessing;
+		broadcastTurnEvent( isProcessing ? AGENT_TURN_STARTED_EVENT : AGENT_TURN_ENDED_EVENT );
+	}, [ isProcessing ] );
+
+	useEffect(
+		() => () => {
+			if ( wasProcessingRef.current ) {
+				wasProcessingRef.current = false;
+				broadcastTurnEvent( AGENT_TURN_ENDED_EVENT );
+			}
+		},
+		[]
+	);
+}

--- a/packages/agents-manager/src/utils/__tests__/ability-completion-broadcast.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/ability-completion-broadcast.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment jsdom
+ */
+import { withAbilityCompletionBroadcast } from '../ability-completion-broadcast';
+import { ABILITY_COMPLETED_EVENT, type AbilityCompletedDetail } from '../agent-activity-events';
+import type { Ability, ToolProvider } from '../../types';
+
+function listen() {
+	const events: AbilityCompletedDetail[] = [];
+	const listener = ( event: Event ) => {
+		events.push( ( event as CustomEvent< AbilityCompletedDetail > ).detail );
+	};
+	window.addEventListener( ABILITY_COMPLETED_EVENT, listener );
+
+	return {
+		events,
+		cleanup: () => window.removeEventListener( ABILITY_COMPLETED_EVENT, listener ),
+	};
+}
+
+function createToolProvider(
+	abilities: Ability[] = [],
+	executeAbility: jest.Mock = jest.fn( () => Promise.resolve( { success: true } ) )
+): ToolProvider {
+	return {
+		getAbilities: jest.fn( () => Promise.resolve( abilities ) ),
+		executeAbility,
+	} as unknown as ToolProvider;
+}
+
+describe( 'withAbilityCompletionBroadcast', () => {
+	it( 'hands back nothing when there is no provider to wrap', () => {
+		expect( withAbilityCompletionBroadcast( undefined ) ).toBeUndefined();
+	} );
+
+	describe( 'the executeAbility path', () => {
+		it( 'broadcasts after the ability resolves', async () => {
+			const { events, cleanup } = listen();
+			const wrapped = withAbilityCompletionBroadcast( createToolProvider() )!;
+
+			await wrapped.executeAbility( 'big-sky/apply-block-edits', {} );
+
+			expect( events ).toEqual( [ { name: 'big-sky/apply-block-edits', ok: true } ] );
+			cleanup();
+		} );
+
+		it( 'returns whatever the ability answered', async () => {
+			const { cleanup } = listen();
+			const wrapped = withAbilityCompletionBroadcast(
+				createToolProvider(
+					[],
+					jest.fn( () => Promise.resolve( { success: true, data: 42 } ) )
+				)
+			)!;
+
+			await expect( wrapped.executeAbility( 'x', {} ) ).resolves.toEqual( {
+				success: true,
+				data: 42,
+			} );
+			cleanup();
+		} );
+
+		it( 'does not broadcast before the ability has finished', async () => {
+			// The whole point of the event is that the ability's writes have
+			// landed by the time it fires.
+			const { events, cleanup } = listen();
+			let finish!: () => void;
+			const wrapped = withAbilityCompletionBroadcast(
+				createToolProvider(
+					[],
+					jest.fn( () => new Promise( ( resolve ) => ( finish = () => resolve( {} ) ) ) )
+				)
+			)!;
+
+			const pending = wrapped.executeAbility( 'x', {} );
+			expect( events ).toEqual( [] );
+
+			finish();
+			await pending;
+
+			expect( events ).toHaveLength( 1 );
+			cleanup();
+		} );
+
+		it( 'reports an ability that answered failure as not ok', async () => {
+			const { events, cleanup } = listen();
+			const wrapped = withAbilityCompletionBroadcast(
+				createToolProvider(
+					[],
+					jest.fn( () => Promise.resolve( { success: false } ) )
+				)
+			)!;
+
+			await wrapped.executeAbility( 'x', {} );
+
+			expect( events ).toEqual( [ { name: 'x', ok: false } ] );
+			cleanup();
+		} );
+
+		it( 'reports an ability that threw as not ok, and still throws', async () => {
+			const { events, cleanup } = listen();
+			const wrapped = withAbilityCompletionBroadcast(
+				createToolProvider(
+					[],
+					jest.fn( () => Promise.reject( new Error( 'boom' ) ) )
+				)
+			)!;
+
+			await expect( wrapped.executeAbility( 'x', {} ) ).rejects.toThrow( 'boom' );
+
+			expect( events ).toEqual( [ { name: 'x', ok: false } ] );
+			cleanup();
+		} );
+	} );
+
+	describe( 'the callback path', () => {
+		it( 'broadcasts after an ability with its own callback resolves', async () => {
+			// agenttic-client calls an ability's callback when it has one and
+			// never reaches executeAbility for it, so wrapping that path alone
+			// would miss every Big Sky ability.
+			const { events, cleanup } = listen();
+			const callback = jest.fn( () => Promise.resolve( { success: true } ) );
+			const wrapped = withAbilityCompletionBroadcast(
+				createToolProvider( [ { name: 'big-sky/add-pages', callback } as unknown as Ability ] )
+			)!;
+
+			const [ ability ] = await wrapped.getAbilities();
+			await ability.callback!( { foo: 'bar' } );
+
+			expect( callback ).toHaveBeenCalledWith( { foo: 'bar' } );
+			expect( events ).toEqual( [ { name: 'big-sky/add-pages', ok: true } ] );
+			cleanup();
+		} );
+
+		it( 'leaves an ability without a callback untouched', async () => {
+			const { cleanup } = listen();
+			const ability = { name: 'no-callback' } as unknown as Ability;
+			const wrapped = withAbilityCompletionBroadcast( createToolProvider( [ ability ] ) )!;
+
+			const [ result ] = await wrapped.getAbilities();
+
+			expect( result ).toBe( ability );
+			cleanup();
+		} );
+	} );
+} );

--- a/packages/agents-manager/src/utils/ability-completion-broadcast.ts
+++ b/packages/agents-manager/src/utils/ability-completion-broadcast.ts
@@ -1,0 +1,93 @@
+/**
+ * Announces every ability's completion on the merged provider.
+ *
+ * Installed on both dispatch paths, for the reason `canvas-guard` gives:
+ * agenttic-client calls an ability's own `callback` when it has one and only
+ * falls back to the provider's `executeAbility` when it does not, so a wrapper
+ * on one path alone is inert for every ability that takes the other.
+ *
+ * Every ability, deliberately, rather than a curated list of the ones that
+ * write. A listener that needs to know whether anything changed can ask the
+ * editor once the event arrives; a list here would have to be kept in step with
+ * abilities in two codebases as they migrate, and a missed entry would fail
+ * silently.
+ */
+import { broadcastAbilityCompleted } from './agent-activity-events';
+import type { Ability } from '../abilities/types';
+import type { ToolProvider } from '../types';
+
+/**
+ * Whether an ability answered that it did not do what it was asked.
+ *
+ * Reads both the `AbilityResult` envelope and the bare form, as `canvas-guard`
+ * does, since the provider contract types both paths as `Promise< any >`.
+ * @param result Whatever the ability answered.
+ * @returns Whether it reported failure.
+ */
+function reportsFailure( result: unknown ): boolean {
+	const answer = result as { success?: unknown; result?: { success?: unknown } } | undefined;
+
+	return false === ( answer?.result?.success ?? answer?.success );
+}
+
+/**
+ * Run one ability and announce its completion, however it ends.
+ * @param name     The ability name, in either form.
+ * @param dispatch Runs the ability itself.
+ * @returns Whatever the ability answered.
+ */
+async function dispatchAndBroadcast(
+	name: string,
+	dispatch: () => Promise< unknown >
+): Promise< unknown > {
+	let result: unknown;
+
+	try {
+		result = await dispatch();
+	} catch ( error ) {
+		// Announced, not swallowed: the caller still sees the failure.
+		broadcastAbilityCompleted( { name, ok: false } );
+		throw error;
+	}
+
+	broadcastAbilityCompleted( { name, ok: ! reportsFailure( result ) } );
+
+	return result;
+}
+
+/**
+ * Put the announcement on an ability's own callback.
+ * @param ability The ability as its provider registered it.
+ * @returns The ability, with an announcing callback when it has one.
+ */
+function announceAbilityCallback( ability: Ability ): Ability {
+	const { callback } = ability;
+
+	if ( ! callback ) {
+		return ability;
+	}
+
+	return {
+		...ability,
+		callback: ( input ) => dispatchAndBroadcast( ability.name, async () => callback( input ) ),
+	};
+}
+
+/**
+ * Announce every ability's completion, whichever path dispatches it.
+ * @param toolProvider The merged tool provider, if any.
+ * @returns The wrapped provider, or undefined when there is nothing to wrap.
+ */
+export function withAbilityCompletionBroadcast(
+	toolProvider: ToolProvider | undefined
+): ToolProvider | undefined {
+	if ( ! toolProvider ) {
+		return undefined;
+	}
+
+	return {
+		getAbilities: async () => ( await toolProvider.getAbilities() ).map( announceAbilityCallback ),
+		executeAbility: ( name: string, args: unknown ) =>
+			dispatchAndBroadcast( name, async () => toolProvider.executeAbility( name, args ) ),
+	};
+}

--- a/packages/agents-manager/src/utils/agent-activity-events.ts
+++ b/packages/agents-manager/src/utils/agent-activity-events.ts
@@ -1,0 +1,50 @@
+/**
+ * Window events that tell code outside the React tree what the agent is doing.
+ *
+ * Hosts that render their own editing surface around the chat (Big Sky's easy
+ * mode) need two things they cannot see from outside: whether a turn is in
+ * flight, and when an ability has finished writing. Without them, the only
+ * signal left is the editor's own dirty state, which blocks also change on
+ * mount — so a page opening reads the same as an agent editing it.
+ *
+ * Same channel as `agents-manager-ready` and `agents-manager-conversation-changed`:
+ * a window event, because the listeners are other bundles.
+ */
+
+/** A turn began: the user sent a message and the agent is working on it. */
+export const AGENT_TURN_STARTED_EVENT = 'agents-manager-turn-started';
+
+/** The turn finished, was aborted, or the chat unmounted with it open. */
+export const AGENT_TURN_ENDED_EVENT = 'agents-manager-turn-ended';
+
+/**
+ * An ability ran to completion. Fired after it resolved (or threw), so anything
+ * it wrote has landed by the time a listener hears about it.
+ */
+export const ABILITY_COMPLETED_EVENT = 'agents-manager-ability-completed';
+
+/** What `ABILITY_COMPLETED_EVENT` carries in `detail`. */
+export type AbilityCompletedDetail = {
+	/** The ability name as it was invoked, in either form. */
+	name: string;
+	/** False when the ability answered `success: false` or threw. */
+	ok: boolean;
+};
+
+/**
+ * Broadcast one of the turn events.
+ * @param eventName Which one.
+ */
+export function broadcastTurnEvent(
+	eventName: typeof AGENT_TURN_STARTED_EVENT | typeof AGENT_TURN_ENDED_EVENT
+): void {
+	window.dispatchEvent( new CustomEvent( eventName ) );
+}
+
+/**
+ * Broadcast that an ability has finished.
+ * @param detail What finished, and how.
+ */
+export function broadcastAbilityCompleted( detail: AbilityCompletedDetail ): void {
+	window.dispatchEvent( new CustomEvent( ABILITY_COMPLETED_EVENT, { detail } ) );
+}

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -14,6 +14,7 @@
 import { getAgentManager, UIMessage } from '@automattic/agenttic-client';
 import { amToolProvider, getAmCheckpointContext } from '../abilities';
 import { findAbilityByName } from '../abilities/ability-name';
+import { withAbilityCompletionBroadcast } from './ability-completion-broadcast';
 import { withCanvasBinding, withCanvasGuard } from './canvas-guard';
 import { getAgentsManagerInlineData } from './get-agents-manager-inline-data';
 import { isReaderChatAgent } from './is-reader-chat-agent';
@@ -793,7 +794,10 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	// After the branch, deliberately: the single-provider path above assigns
 	// `allToolProviders[ 0 ]` straight through, so a guard applied inside the
 	// multi-provider closure would silently not exist on those surfaces.
-	mergedToolProvider = withCanvasGuard( mergedToolProvider );
+	//
+	// Announcement inside the guard: an ability the guard refuses never ran,
+	// so there is no completion to announce for it.
+	mergedToolProvider = withCanvasGuard( withAbilityCompletionBroadcast( mergedToolProvider ) );
 
 	// Merge transformMessages: compose in registration order, so each provider
 	// rewrites what the previous one produced. Unlike the singleton exports this

--- a/packages/agenttic-client/src/react/agentManager.test.ts
+++ b/packages/agenttic-client/src/react/agentManager.test.ts
@@ -535,6 +535,88 @@ describe( 'agentManager', () => {
 		} );
 	} );
 
+	describe( 'isTurnInFlight', () => {
+		beforeEach( async () => {
+			await agentManager.createAgent( 'test-key', testConfig );
+		} );
+
+		/**
+		 * Run a turn to completion against a scripted stream.
+		 * @param updates What the client yields.
+		 */
+		async function runTurn( updates: TaskUpdate[] ) {
+			mockClient.sendMessageStream.mockImplementation( async function* () {
+				for ( const update of updates ) {
+					yield update;
+				}
+			} );
+
+			for await ( const update of agentManager.sendMessageStream( 'test-key', 'Hello' ) ) {
+				void update;
+			}
+		}
+
+		it( 'is false before any turn has run', () => {
+			expect( agentManager.isTurnInFlight( 'test-key' ) ).toBe( false );
+		} );
+
+		it( 'is false for an agent that does not exist', () => {
+			// Asked to decide whether to say anything at all, so an absent agent
+			// is a normal answer rather than the throw the mutators use.
+			expect( agentManager.isTurnInFlight( 'no-such-key' ) ).toBe( false );
+		} );
+
+		it( 'is false once the turn completes', async () => {
+			await runTurn( [
+				{
+					id: 'task-123',
+					status: { state: 'completed', message: mockAgentMessage },
+					final: true,
+					text: 'Done',
+				},
+			] );
+
+			expect( agentManager.isTurnInFlight( 'test-key' ) ).toBe( false );
+		} );
+
+		it( 'stays true while the turn is paused on a tool call', async () => {
+			// The stream ends here and the turn carries on in `sendToolResult`.
+			// A signal that dropped in this gap would flicker once per tool call.
+			await runTurn( [
+				{
+					id: 'task-123',
+					status: { state: 'input-required', message: mockAgentMessage },
+					final: true,
+					text: 'Working',
+				},
+			] );
+
+			expect( agentManager.isTurnInFlight( 'test-key' ) ).toBe( true );
+		} );
+
+		it( 'is false after the stream throws', async () => {
+			// Nothing further will arrive to resolve the turn, so a flag left set
+			// would report it as running for the life of the page.
+			mockClient.sendMessageStream.mockImplementation( async function* () {
+				yield {
+					id: 'task-123',
+					status: { state: 'working', message: mockAgentMessage },
+					final: false,
+					text: 'Working',
+				} as TaskUpdate;
+				throw new Error( 'network died' );
+			} );
+
+			await expect( async () => {
+				for await ( const update of agentManager.sendMessageStream( 'test-key', 'Hello' ) ) {
+					void update;
+				}
+			} ).rejects.toThrow( 'network died' );
+
+			expect( agentManager.isTurnInFlight( 'test-key' ) ).toBe( false );
+		} );
+	} );
+
 	describe( 'resetConversation', () => {
 		it( 'should reset conversation history', async () => {
 			await agentManager.createAgent( 'test-key', testConfig );

--- a/packages/agenttic-client/src/react/agentManager.ts
+++ b/packages/agenttic-client/src/react/agentManager.ts
@@ -566,6 +566,10 @@ function createAgentManager(): AgentManager {
 
 			const outboundSessionId = toOutboundSessionId( sessionId || managedAgent.sessionId );
 
+			// Whether the stream ever said how the turn ends: a final update, or
+			// the `input-required` pause that hands the turn to `sendToolResult`.
+			let sawTurnTerminus = false;
+
 			try {
 				for await ( const update of client.sendMessageStream( {
 					message: messageObj,
@@ -688,6 +692,10 @@ function createAgentManager(): AgentManager {
 						}
 					}
 
+					if ( update.final || update.status?.state === 'input-required' ) {
+						sawTurnTerminus = true;
+					}
+
 					if ( update.final && update.status?.state !== 'input-required' ) {
 						// Clear tool call tracking for next batch
 						currentToolCallIds = [];
@@ -731,6 +739,15 @@ function createAgentManager(): AgentManager {
 
 					yield update;
 				}
+
+				// A stream can run out without a word about the turn: an SSE reader
+				// that hits EOF mid-turn reads as a clean finish. Nothing further
+				// will arrive to resolve the opener, so the turn is over whether or
+				// not the server said so — left set, it would report the agent as
+				// working for the life of the page.
+				if ( ! sawTurnTerminus ) {
+					managedAgent.inFlightUserMessageId = null;
+				}
 			} catch ( error ) {
 				// A turn that threw is over, and nothing further will arrive to
 				// resolve its in-flight message. Left set, it would report the turn
@@ -740,7 +757,12 @@ function createAgentManager(): AgentManager {
 				managedAgent.inFlightUserMessageId = null;
 				throw error;
 			} finally {
-				managedAgent.currentAbortController = null;
+				// Only when the slot is still this stream's: one that outlived its
+				// chat can finish after a remount has started a newer stream, and
+				// clearing it then would leave `abortCurrentRequest` nothing to cancel.
+				if ( managedAgent.currentAbortController === abortController ) {
+					managedAgent.currentAbortController = null;
+				}
 			}
 		},
 

--- a/packages/agenttic-client/src/react/agentManager.ts
+++ b/packages/agenttic-client/src/react/agentManager.ts
@@ -215,6 +215,13 @@ export interface AgentManager {
 	getConversationHistory: ( key: string ) => Message[];
 	updateSessionId: ( key: string, sessionId: string ) => void;
 	abortCurrentRequest: ( key: string ) => void;
+	/**
+	 * Whether a user turn is still in flight, tool follow-ups included.
+	 *
+	 * Asked of the manager rather than of whatever renders the chat: the stream
+	 * runs here, on the singleton, and outlives the React tree that started it.
+	 */
+	isTurnInFlight: ( key: string ) => boolean;
 	clear: () => void;
 }
 
@@ -559,101 +566,70 @@ function createAgentManager(): AgentManager {
 
 			const outboundSessionId = toOutboundSessionId( sessionId || managedAgent.sessionId );
 
-			for await ( const update of client.sendMessageStream( {
-				message: messageObj,
-				withHistory,
-				sessionId: outboundSessionId,
-				abortSignal: abortController.signal,
-				...otherOptions,
-				...( messageMetadata &&
-					Object.keys( messageMetadata ).length > 0 && {
-						metadata: messageMetadata,
-					} ),
-			} ) ) {
-				// Capture sessionId from server response (always trust the server)
-				if ( update.sessionId ) {
-					const oldSessionId = managedAgent.sessionId;
-					// Always update the sessionId for consistency, even if unchanged
-					// (this is a simple assignment and keeps code straightforward)
-					managedAgent.sessionId = update.sessionId;
+			try {
+				for await ( const update of client.sendMessageStream( {
+					message: messageObj,
+					withHistory,
+					sessionId: outboundSessionId,
+					abortSignal: abortController.signal,
+					...otherOptions,
+					...( messageMetadata &&
+						Object.keys( messageMetadata ).length > 0 && {
+							metadata: messageMetadata,
+						} ),
+				} ) ) {
+					// Capture sessionId from server response (always trust the server)
+					if ( update.sessionId ) {
+						const oldSessionId = managedAgent.sessionId;
+						// Always update the sessionId for consistency, even if unchanged
+						// (this is a simple assignment and keeps code straightforward)
+						managedAgent.sessionId = update.sessionId;
 
-					if ( oldSessionId !== update.sessionId ) {
-						notifySessionIdChange( managedAgent.onSessionIdChange, update.sessionId );
-					}
-
-					// Update localStorage only when sessionId actually changes
-					// This handles two scenarios:
-					// 1. Initial session creation (oldSessionId is null/undefined)
-					// 2. Temporary -> stable session ID transitions
-					// Note: We intentionally skip updating storage when IDs are equal
-					if (
-						update.sessionId &&
-						oldSessionId !== update.sessionId &&
-						managedAgent.sessionIdStorageKey
-					) {
-						log(
-							'Session ID %s, updating localStorage',
-							oldSessionId
-								? `changed from ${ oldSessionId } to ${ update.sessionId }`
-								: `received: ${ update.sessionId }`
-						);
-						updateSessionIdInLocalStorage( managedAgent.sessionIdStorageKey, update.sessionId );
-					}
-
-					// Persist under the server id and drop the temp local-* key
-					// (skip when conversationStorageKey owns the slot name).
-					if (
-						oldSessionId?.startsWith( 'local-' ) &&
-						oldSessionId !== update.sessionId &&
-						! managedAgent.conversationStorageKey
-					) {
-						if ( withHistory ) {
-							await persistConversationHistory( key, currentConversationHistory );
+						if ( oldSessionId !== update.sessionId ) {
+							notifySessionIdChange( managedAgent.onSessionIdChange, update.sessionId );
 						}
-						await clearConversation( oldSessionId );
+
+						// Update localStorage only when sessionId actually changes
+						// This handles two scenarios:
+						// 1. Initial session creation (oldSessionId is null/undefined)
+						// 2. Temporary -> stable session ID transitions
+						// Note: We intentionally skip updating storage when IDs are equal
+						if (
+							update.sessionId &&
+							oldSessionId !== update.sessionId &&
+							managedAgent.sessionIdStorageKey
+						) {
+							log(
+								'Session ID %s, updating localStorage',
+								oldSessionId
+									? `changed from ${ oldSessionId } to ${ update.sessionId }`
+									: `received: ${ update.sessionId }`
+							);
+							updateSessionIdInLocalStorage( managedAgent.sessionIdStorageKey, update.sessionId );
+						}
+
+						// Persist under the server id and drop the temp local-* key
+						// (skip when conversationStorageKey owns the slot name).
+						if (
+							oldSessionId?.startsWith( 'local-' ) &&
+							oldSessionId !== update.sessionId &&
+							! managedAgent.conversationStorageKey
+						) {
+							if ( withHistory ) {
+								await persistConversationHistory( key, currentConversationHistory );
+							}
+							await clearConversation( oldSessionId );
+						}
 					}
-				}
 
-				// Save tool interactions when input is required (this saves the agent message with tool calls)
-				if ( update.status?.state === 'input-required' && update.status?.message ) {
-					// Capture the tool call IDs for this batch
-					const toolCalls = extractToolCallsFromMessage( update.status.message );
-					currentToolCallIds = toolCalls.map( ( call ) => call.data.toolCallId as string );
+					// Save tool interactions when input is required (this saves the agent message with tool calls)
+					if ( update.status?.state === 'input-required' && update.status?.message ) {
+						// Capture the tool call IDs for this batch
+						const toolCalls = extractToolCallsFromMessage( update.status.message );
+						currentToolCallIds = toolCalls.map( ( call ) => call.data.toolCallId as string );
 
-					const toolMessage = extractNewContentFromMessage( update.status.message );
-					currentConversationHistory = [ ...currentConversationHistory, toolMessage ];
-
-					// Update agent's conversation history immediately
-					managedAgent.conversationHistory = currentConversationHistory;
-					// Persist only if withHistory is true
-					if ( withHistory ) {
-						await persistConversationHistory( key, currentConversationHistory );
-					}
-				}
-
-				// Capture tool results when tools are executed (state becomes 'working' after tool execution)
-				if ( update.status?.state === 'working' && update.status?.message && ! update.final ) {
-					// Extract ALL tool results first
-					const allToolResults = extractToolResultsFromMessage( update.status.message );
-
-					// Filter to only include results that match current tool call IDs
-					const currentToolResults = allToolResults.filter( ( result ) =>
-						currentToolCallIds.includes( result.data.toolCallId as string )
-					);
-
-					if ( currentToolResults.length > 0 ) {
-						// Create a message containing just the matching tool results
-						const toolResultMessage: Message = {
-							role: 'agent',
-							kind: 'message',
-							parts: currentToolResults,
-							messageId: generateMessageId(),
-						};
-
-						currentConversationHistory = [
-							...currentConversationHistory,
-							extractNewContentFromMessage( toolResultMessage ),
-						];
+						const toolMessage = extractNewContentFromMessage( update.status.message );
+						currentConversationHistory = [ ...currentConversationHistory, toolMessage ];
 
 						// Update agent's conversation history immediately
 						managedAgent.conversationHistory = currentConversationHistory;
@@ -661,71 +637,111 @@ function createAgentManager(): AgentManager {
 						if ( withHistory ) {
 							await persistConversationHistory( key, currentConversationHistory );
 						}
-					} else if ( messageCarriesToolPayload( update.status.message ) ) {
-						// A tool produced a renderable agent message (e.g. a
-						// picker) and the turn is still continuing to the agent.
-						// Append it so it renders live, but deliberately leave
-						// `currentToolCallIds` untouched: the agent continuation
-						// may still echo tool results that must match the
-						// in-flight tool calls.
-						currentConversationHistory = [
-							...currentConversationHistory,
-							extractNewContentFromMessage( update.status.message ),
-						];
+					}
+
+					// Capture tool results when tools are executed (state becomes 'working' after tool execution)
+					if ( update.status?.state === 'working' && update.status?.message && ! update.final ) {
+						// Extract ALL tool results first
+						const allToolResults = extractToolResultsFromMessage( update.status.message );
+
+						// Filter to only include results that match current tool call IDs
+						const currentToolResults = allToolResults.filter( ( result ) =>
+							currentToolCallIds.includes( result.data.toolCallId as string )
+						);
+
+						if ( currentToolResults.length > 0 ) {
+							// Create a message containing just the matching tool results
+							const toolResultMessage: Message = {
+								role: 'agent',
+								kind: 'message',
+								parts: currentToolResults,
+								messageId: generateMessageId(),
+							};
+
+							currentConversationHistory = [
+								...currentConversationHistory,
+								extractNewContentFromMessage( toolResultMessage ),
+							];
+
+							// Update agent's conversation history immediately
+							managedAgent.conversationHistory = currentConversationHistory;
+							// Persist only if withHistory is true
+							if ( withHistory ) {
+								await persistConversationHistory( key, currentConversationHistory );
+							}
+						} else if ( messageCarriesToolPayload( update.status.message ) ) {
+							// A tool produced a renderable agent message (e.g. a
+							// picker) and the turn is still continuing to the agent.
+							// Append it so it renders live, but deliberately leave
+							// `currentToolCallIds` untouched: the agent continuation
+							// may still echo tool results that must match the
+							// in-flight tool calls.
+							currentConversationHistory = [
+								...currentConversationHistory,
+								extractNewContentFromMessage( update.status.message ),
+							];
+
+							managedAgent.conversationHistory = currentConversationHistory;
+							if ( withHistory ) {
+								await persistConversationHistory( key, currentConversationHistory );
+							}
+						}
+					}
+
+					if ( update.final && update.status?.state !== 'input-required' ) {
+						// Clear tool call tracking for next batch
+						currentToolCallIds = [];
+
+						// Resolve only the in-flight opener; older pending stay.
+						const inFlightId = managedAgent.inFlightUserMessageId;
+						const nextStatus =
+							update.status?.state === 'failed' || update.status?.state === 'canceled'
+								? 'failed'
+								: 'complete';
+						if ( inFlightId ) {
+							currentConversationHistory = currentConversationHistory.map( ( m ) => {
+								if ( m.messageId !== inFlightId ) {
+									return m;
+								}
+								const status = m.metadata?.deliveryStatus;
+								if ( status === 'pending' || status === 'streaming' ) {
+									return {
+										...m,
+										metadata: {
+											...( m.metadata || {} ),
+											deliveryStatus: nextStatus,
+										},
+									};
+								}
+								return m;
+							} );
+							managedAgent.inFlightUserMessageId = null;
+						}
+
+						if ( update.status?.message ) {
+							const finalAgentMessage = extractNewContentFromMessage( update.status.message );
+							currentConversationHistory = [ ...currentConversationHistory, finalAgentMessage ];
+						}
 
 						managedAgent.conversationHistory = currentConversationHistory;
 						if ( withHistory ) {
 							await persistConversationHistory( key, currentConversationHistory );
 						}
 					}
+
+					yield update;
 				}
-
-				if ( update.final && update.status?.state !== 'input-required' ) {
-					// Clear tool call tracking for next batch
-					currentToolCallIds = [];
-
-					// Resolve only the in-flight opener; older pending stay.
-					const inFlightId = managedAgent.inFlightUserMessageId;
-					const nextStatus =
-						update.status?.state === 'failed' || update.status?.state === 'canceled'
-							? 'failed'
-							: 'complete';
-					if ( inFlightId ) {
-						currentConversationHistory = currentConversationHistory.map( ( m ) => {
-							if ( m.messageId !== inFlightId ) {
-								return m;
-							}
-							const status = m.metadata?.deliveryStatus;
-							if ( status === 'pending' || status === 'streaming' ) {
-								return {
-									...m,
-									metadata: {
-										...( m.metadata || {} ),
-										deliveryStatus: nextStatus,
-									},
-								};
-							}
-							return m;
-						} );
-						managedAgent.inFlightUserMessageId = null;
-					}
-
-					if ( update.status?.message ) {
-						const finalAgentMessage = extractNewContentFromMessage( update.status.message );
-						currentConversationHistory = [ ...currentConversationHistory, finalAgentMessage ];
-					}
-
-					managedAgent.conversationHistory = currentConversationHistory;
-					if ( withHistory ) {
-						await persistConversationHistory( key, currentConversationHistory );
-					}
-				}
-
-				yield update;
+			} catch ( error ) {
+				// A turn that threw is over, and nothing further will arrive to
+				// resolve its in-flight message. Left set, it would report the turn
+				// as still running for the life of the page. Not cleared when the
+				// generator is merely closed early: a turn pausing on a tool call
+				// ends this stream and continues in `sendToolResult`.
+				managedAgent.inFlightUserMessageId = null;
+				throw error;
+			} finally {
+				managedAgent.currentAbortController = null;
 			}
-
-			// Clear abort controller when stream completes
-			managedAgent.currentAbortController = null;
 		},
 
 		/**
@@ -839,6 +855,14 @@ function createAgentManager(): AgentManager {
 				managedAgent.currentAbortController.abort();
 				managedAgent.currentAbortController = null;
 			}
+		},
+
+		isTurnInFlight( key: string ): boolean {
+			// An agent that does not exist has no turn. Deliberately not the
+			// `not found` throw the mutating methods use: callers ask this to
+			// decide whether to say anything at all, and a chat that has not
+			// created its agent yet is a normal answer, not an error.
+			return Boolean( agents.get( key )?.inFlightUserMessageId );
 		},
 
 		clear(): void {


### PR DESCRIPTION
## Proposed Changes

* Three window events, in `utils/agent-activity-events.ts`: `agents-manager-turn-started`, `agents-manager-turn-ended`, `agents-manager-ability-completed` (detail `{ name, ok }`).
* `useBroadcastTurnActivity` broadcasts the turn edges from `orchestrator-chat`, taking the turn from the agent manager rather than the chat's own lifecycle. The chat is one route in the dock, so it can unmount mid-turn while the stream carries on. Mounting onto a running turn announces a start; unmounting announces an end only when the manager says the turn is over; a turn that ends while the chat is away has its end announced on the next mount.
* `agenttic-client` gains `agentManager.isTurnInFlight( key )`, backed by `inFlightUserMessageId` so it spans tool follow-ups and does not flicker between an ability's call and its result. `sendMessageStream` now clears its abort controller however the stream ends, and clears the in-flight message when the stream throws.
* `withAbilityCompletionBroadcast` wraps the merged tool provider on both dispatch paths (`callback` and `executeAbility`), inside the canvas guard, so every ability announces its completion whichever provider owns it, and a refused ability never does.
* `broadcastsAgentActivity: true` on `window.__agentsManagerActions`, so a host can check the events are wired before relying on them.

## Why are these changes being made?

Currently the new Easy mode in site editor often flips into edit mode when a user is browsing a site in preview mode as Gutenberg often flags editor as dirty on initial page load.

This PR changes the mechanism from switching to Edit from a simple dirty canvas check, to only changes linked to an active agent session.

## Testing Instructions

- Sync this PR along with https://github.com/Automattic/big-sky-plugin/pull/6328 to sandbox
- Check that the AI agent still works as expected in the site and post editors and also in the help centre
- Turn on Easy mode in the site editor by adding `easy-mode=true` to the site editor url when you have a page loaded in the editor
- Browse the site in preview mode and make sure it never changes to edit while browsing
- Ask the agent to make a change to the page, including asking for new colors or new fonts so that the color and font pickers show - in each case make sure the page toggles from Preview to Edit when changes are applied.
- You can turn off easy mode by adding `easy-mode=false` to url

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
