### PR TITLE
Agents Manager: scope Woo admin chat history to the current store (DO NOT MERGE — proposal)

### DIFF
--- a/packages/agents-manager/src/hooks/use-conversation-list.ts
+++ b/packages/agents-manager/src/hooks/use-conversation-list.ts
@@ -15,12 +15,17 @@ import { normalizeZendeskConversations } from '../utils/zendesk';
 import { useShouldUseUnifiedAgent } from './use-should-use-unified-agent';
 
 export default function useConversationList() {
-	const { agentConfig, site, zendeskSmoochIntegrationKey } = useAgentsManagerContext();
+	const { agentConfig, site, sectionName, zendeskSmoochIntegrationKey } = useAgentsManagerContext();
 	const { agentId, authProvider } = agentConfig!;
 	const urlSearchParams = new URLSearchParams( window.location.search );
 	const hasAgentParam = urlSearchParams.has( 'agent' );
 	const botId = getConversationBotId( agentId, hasAgentParam );
 	const isReaderChat = isReaderChatAgent( agentId );
+	// Woo admin host only: scope history to the current store (chats are tagged server-side).
+	const wooStoreFilter =
+		sectionName === 'wooai-admin' && site?.ID
+			? { externalIdProvider: 'woo-merchant', externalId: String( site.ID ) }
+			: undefined;
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 
 	// Only fetch Zendesk conversations if the unified agent flag is enabled
@@ -37,8 +42,8 @@ export default function useConversationList() {
 		isError: isOrchestratorError,
 		error: orchestratorError,
 	} = useQuery< ServerConversationListItem[] >( {
-		// eslint-disable-next-line @tanstack/query/exhaustive-deps -- we only want to refetch when `botId` changes
-		queryKey: [ 'agents-manager-conversation-list', botId ],
+		// eslint-disable-next-line @tanstack/query/exhaustive-deps -- we only want to refetch when `botId` or the store scope changes
+		queryKey: [ 'agents-manager-conversation-list', botId, wooStoreFilter?.externalId ],
 		queryFn: async () => {
 			const result = await listConversationsFromServer(
 				botId,
@@ -46,7 +51,8 @@ export default function useConversationList() {
 					apiBaseUrl: API_BASE_URL,
 					authProvider,
 				},
-				true
+				true,
+				wooStoreFilter
 			);
 			return result;
 		},

--- a/packages/agenttic-client/src/react/odieService.ts
+++ b/packages/agenttic-client/src/react/odieService.ts
@@ -132,7 +132,8 @@ export async function loadChatFromServer(
 export async function listConversationsFromServer(
 	botId: string,
 	config: Omit< OdieServiceConfig, 'botId' >,
-	useFirstMessage = false
+	useFirstMessage = false,
+	channelFilter?: { externalIdProvider: string; externalId: string }
 ): Promise< ServerConversationListItem[] > {
 	const { apiBaseUrl = DEFAULT_API_BASE_URL, authProvider } = config;
 
@@ -142,6 +143,12 @@ export async function listConversationsFromServer(
 	);
 
 	url.searchParams.set( 'truncation_method', useFirstMessage ? 'first_message' : 'last_message' );
+
+	// Optional server-side channel filter (narrowing-only; user scoping always applies first).
+	if ( channelFilter ) {
+		url.searchParams.set( 'external_id_provider', channelFilter.externalIdProvider );
+		url.searchParams.set( 'external_id', channelFilter.externalId );
+	}
 
 	logger( 'Listing conversations from server for bot: %s', botId );
 


### PR DESCRIPTION
**Proposal for the assistants call — do not merge without AM owners' sign-off.** Companion to 236876-ghe-Automattic/wpcom

Context: the Woo AI admin assistant lists one merged chat history across every store a user manages (applied_ai_bot_chats keyed on wpcom_user_id + bot_slug only). The wpcom side stamps each Woo chat with the store's blog id as channel identity; this PR opts the listing into the server's existing channel filter:

- **agenttic-client**: `listConversationsFromServer()` accepts an optional `channelFilter` → `external_id_provider`/`external_id` query params. Inert unless passed — no other host changes.
- **agents-manager**: `useConversationList` passes the filter ONLY on the `wooai-admin` host, keyed to the current site (query key includes the store, so switching stores refetches).

Legacy: untagged chats drop out of the filtered listing by design (soft reset, nothing deleted). Every non-Woo host: byte-identical behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)