### PR TITLE
Notifications: show a Loading… state while the panel chunk loads

### DIFF
--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -5,6 +5,7 @@ import { bellUnread, bell } from '@wordpress/icons';
 import clsx from 'clsx';
 import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import wpcom from 'calypso/lib/wp';
+import { Text } from '../../components/text';
 import { dashboardLink } from '../../utils/link';
 import { useAuth } from '../auth';
 import { useHelpCenter } from '../help-center';
@@ -184,7 +185,13 @@ export default function Notifications( {
 				)
 			}
 			renderContent={ () => (
-				<Suspense fallback={ null }>
+				<Suspense
+					fallback={
+						<Text variant="muted" className="dashboard-notifications__loading">
+							{ __( 'Loading…' ) }
+						</Text>
+					}
+				>
 					<AsyncNotificationApp
 						locale={ locale }
 						isDismissible={ isMobileViewport }

--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -187,7 +187,7 @@ export default function Notifications( {
 			renderContent={ () => (
 				<Suspense
 					fallback={
-						<Text variant="muted" className="dashboard-notifications__loading">
+						<Text variant="muted" style={ { display: 'block', padding: '8px 12px' } }>
 							{ __( 'Loading…' ) }
 						</Text>
 					}

--- a/client/dashboard/app/notifications/style.scss
+++ b/client/dashboard/app/notifications/style.scss
@@ -1,14 +1,7 @@
-@import '@wordpress/base-styles/variables';
-
 .dashboard-notifications__icon {
 	svg {
 		circle {
 			fill: var( --wp-admin-theme-color );
 		}
 	}
-}
-
-.dashboard-notifications__loading {
-	display: block;
-	padding: $grid-unit-10 $grid-unit-15;
 }

--- a/client/dashboard/app/notifications/style.scss
+++ b/client/dashboard/app/notifications/style.scss
@@ -1,7 +1,14 @@
+@import '@wordpress/base-styles/variables';
+
 .dashboard-notifications__icon {
 	svg {
 		circle {
 			fill: var( --wp-admin-theme-color );
 		}
 	}
+}
+
+.dashboard-notifications__loading {
+	display: block;
+	padding: $grid-unit-10 $grid-unit-15;
 }


### PR DESCRIPTION
Fixes DOTMSD-1354

## Proposed Changes

* Show a muted “Loading…” message in the notifications panel while its code chunk is still downloading, matching what the site switcher already does.

## Why are these changes being made?

The notifications panel is code-split and loaded on demand, but it had no loading state. Clicking the bell before the chunk arrived showed an empty popover — a small blank square, with no indication that anything was happening. On a slow connection that can sit there for a couple of seconds.

The site switcher hit the same problem and settled on a plain “Loading…” line, so this follows that precedent rather than introducing a second loading treatment for the same kind of popover.

## Testing Instructions

* Open the dashboard and throttle the network in DevTools (Slow 3G is enough to make it obvious).
* Do a hard reload so the notifications chunk isn't cached, then click the notifications bell.
* The panel should show “Loading…” instead of an empty square, then swap to the notifications list once the chunk arrives.
* Compare against the site switcher (the chevron next to the site name) — the loading text should look the same.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
