### PR TITLE
Hosting feature activation: map domain Badge colors to intent.

### DIFF
--- a/client/dashboard/sites/hosting-feature-activation-modal/style.scss
+++ b/client/dashboard/sites/hosting-feature-activation-modal/style.scss
@@ -12,40 +12,6 @@
 			@include ui-mixins.when-dark-theme {
 				background-color: var(--wp-components-color-gray-100);
 			}
-
-			// The design-system default badge sets its own padding, min-height,
-			// and (in dark mode) an inset outline; override them so both pills
-			// match the Figma spec.
-			.hosting-feature-activation-modal__domain-badge {
-				min-height: 20px;
-				padding-block: 0;
-				padding-inline: 10px;
-				font-weight: 500;
-				border-radius: 4px;
-				box-shadow: none;
-			}
-
-			// The badges use fixed studio palette values tuned for the light row,
-			// so flip them to the dark end of the same ramps in dark mode.
-			.hosting-feature-activation-modal__domain-badge-current {
-				background-color: var(--studio-gray-5);
-				color: var(--studio-gray-80);
-
-				@include ui-mixins.when-dark-theme {
-					background-color: var(--studio-gray-80);
-					color: var(--studio-gray-5);
-				}
-			}
-
-			.hosting-feature-activation-modal__domain-badge-new {
-				background-color: var(--studio-green-5);
-				color: var(--studio-green-80);
-
-				@include ui-mixins.when-dark-theme {
-					background-color: var(--studio-green-80);
-					color: var(--studio-green-5);
-				}
-			}
 		}
 	}
 }

--- a/client/dashboard/sites/hosting-feature-activation-modal/warning-content-info.tsx
+++ b/client/dashboard/sites/hosting-feature-activation-modal/warning-content-info.tsx
@@ -1,11 +1,10 @@
-import { Badge } from '@automattic/ui';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import clsx from 'clsx';
+import { Badge } from '@wordpress/ui';
 import InlineSupportLink from '../../components/inline-support-link';
 import { Text } from '../../components/text';
 import type {
@@ -25,12 +24,12 @@ function DomainNames( { names }: { names: AutomatedTransferEligibilityWarningDom
 		{
 			label: splitDomainName( names.current ),
 			badgeLabel: __( 'current' ),
-			isNew: false,
+			intent: 'none' as const,
 		},
 		{
 			label: splitDomainName( names.new ),
 			badgeLabel: __( 'new' ),
-			isNew: true,
+			intent: 'stable' as const,
 		},
 	];
 
@@ -53,14 +52,7 @@ function DomainNames( { names }: { names: AutomatedTransferEligibilityWarningDom
 							{ item.label.rest }
 						</Text>
 					</HStack>
-					<Badge
-						className={ clsx( 'hosting-feature-activation-modal__domain-badge', {
-							'hosting-feature-activation-modal__domain-badge-new': item.isNew,
-							'hosting-feature-activation-modal__domain-badge-current': ! item.isNew,
-						} ) }
-						intent="default"
-						style={ { flexShrink: 0 } }
-					>
+					<Badge intent={ item.intent } style={ { flexShrink: 0 } }>
 						{ item.badgeLabel }
 					</Badge>
 				</HStack>


### PR DESCRIPTION
Pre-requirement for removal of the Badge from `@automattic/ui` as we're now focusing on `@wordpress/ui` [Badge](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge-usage-guidelines--docs).

Part of https://github.com/Automattic/wp-calypso/issues/113835

<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes
* Replace `@automattic/ui` Badge component with `@wordpress/ui` [Badge](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge-usage-guidelines--docs).
* Replace class-based badge color overrides with Badge intent props so PHP severity and server request types use the design-system colors. This is also much more straightforward and less bug-prone.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Click on the feature at multi-site-dashboard for a simple site which would require a WoA transfer, e.g. "Monitoring" or "Logs".

### Before
<img width="634" height="469" alt="image" src="https://github.com/user-attachments/assets/4f3189b4-bc91-49d1-b4e1-3aa5f47c2fad" />

### After
<img width="598" height="459" alt="image" src="https://github.com/user-attachments/assets/28aecdad-2d8d-41f0-996a-ab55ae06bcc0" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
