### PR TITLE
Notifications: keep the panel still while the page scrolls

### DIFF
--- a/client/dashboard/app/notifications/index.tsx
+++ b/client/dashboard/app/notifications/index.tsx
@@ -146,7 +146,7 @@ export default function Notifications( {
 		};
 	}, [ handleOmnibarToggle ] );
 
-	return (
+	const dropdown = (
 		<Dropdown
 			popoverProps={ {
 				placement: 'bottom-start',
@@ -154,6 +154,11 @@ export default function Notifications( {
 				focusOnMount: true,
 				flip: false,
 				shift: true,
+				// Render in place so the popover is positioned against the fixed
+				// container below. Portalled to the body, its coordinates are
+				// document-relative and have to be recomputed on every scroll
+				// frame, which visibly lags behind the fixed masterbar.
+				...( anchor && { inline: true } ),
 				...( anchor ? { anchor: popoverAnchor } : anchorEl && { anchor: anchorEl } ),
 				onFocusOutside: () => {
 					// When focus moves to the omnibar (e.g. clicking the
@@ -202,4 +207,10 @@ export default function Notifications( {
 			) }
 		/>
 	);
+
+	if ( ! anchor ) {
+		return dropdown;
+	}
+
+	return <div className="dashboard-notifications__popover-container">{ dropdown }</div>;
 }

--- a/client/dashboard/app/notifications/style.scss
+++ b/client/dashboard/app/notifications/style.scss
@@ -5,3 +5,10 @@
 		}
 	}
 }
+
+.dashboard-notifications__popover-container {
+	position: fixed;
+	top: 0;
+	inset-inline-start: 0;
+	z-index: 1000;
+}


### PR DESCRIPTION
Fixes DOTMSD-1336

## Proposed Changes

* Anchor the notifications panel to a fixed positioning context so it stays put while the page scrolls behind it.

## Why are these changes being made?

Scrolling with the notifications panel open is janky — the panel jitters as if it's chasing the bell icon.

The panel is a `Dropdown`/`Popover` from `@wordpress/components`. By default the popover is rendered into a container on `document.body` and positioned in *document* coordinates. Its anchor is the bell in the omnibar, which is fixed to the viewport — so the anchor never moves on screen, but its document coordinates change on every scroll frame, and the popover has to be re-translated to keep up. That repositioning runs in JS on an animation-frame loop, so it always lands a frame behind the compositor-driven scroll. The result is the visible stutter.

Popover doesn't expose floating-ui's fixed positioning strategy, so instead the popover is rendered in place inside a fixed container. Its coordinates then become viewport-relative and constant while scrolling: there's nothing to recompute, and nothing to lag.

## Testing Instructions

1. Open the dashboard on a page long enough to scroll.
2. Open the notifications panel from the omnibar bell.
3. Scroll the page. The panel should stay perfectly still — no jitter, no drift.
4. Repeat at a mobile viewport width, where the panel expands to full screen, and confirm it still fills the screen and closes correctly.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
