### PR TITLE
Odie: approve/decline cards for gated bot actions (HAL-1347 spike)

### DIFF
--- a/packages/odie-client/src/components/message/approval-request.tsx
+++ b/packages/odie-client/src/components/message/approval-request.tsx
@@ -21,6 +21,23 @@ export const ApprovalRequest = ( { message }: { message: Message } ) => {
 		return null;
 	}
 
+	// The server stops accepting a decision after expires_at. Past it, the card would only invite a
+	// click that fails, so say so instead of offering buttons.
+	const expiresAt = message.context?.approval?.expires_at;
+	const isExpired = typeof expiresAt === 'number' && Date.now() / 1000 >= expiresAt;
+	if ( isExpired ) {
+		return (
+			<div className="odie__transfer-chat">
+				<p className="odie__transfer-chat--note">
+					{ __(
+						'This request has expired and was not performed. Ask again if you still want it.',
+						__i18n_text_domain__
+					) }
+				</p>
+			</div>
+		);
+	}
+
 	const decide = ( decision: 'approve' | 'decline' ) => {
 		trackEvent( 'chat_write_approval_decision', { decision } );
 		approvalDecision.mutate( { token, decision } );

--- a/packages/odie-client/src/components/message/approval-request.tsx
+++ b/packages/odie-client/src/components/message/approval-request.tsx
@@ -5,19 +5,36 @@ import type { Message } from '../../types';
 
 import './get-support.scss';
 
+const DECIDED_LABELS: Record< string, string > = {
+	executed: __( 'You approved this action and it was completed.', __i18n_text_domain__ ),
+	declined: __( 'You declined this action. It was not performed.', __i18n_text_domain__ ),
+	failed: __( 'You approved this action, but it could not be completed.', __i18n_text_domain__ ),
+};
+
 /**
- * Approve / decline buttons for a pending action-approval message
- * (context.flags.wpcom_approval_required). The decision endpoints append the outcome to
- * the chat server-side; the hook's query invalidation refetches it, and because this
- * card only renders under the last bot message it disappears once the outcome message
- * arrives.
+ * The card under an action-approval message (context.flags.wpcom_approval_required).
+ *
+ * Once a decision is recorded the server marks the message's `approval.status` and drops the
+ * token, so a decided card shows a label on every later load. A pending card offers the
+ * buttons only while it is the live end of the conversation; a pending card that is no longer
+ * last was superseded (the user typed instead) and shows nothing.
  */
-export const ApprovalRequest = ( { message }: { message: Message } ) => {
-	const { trackEvent } = useOdieAssistantContext();
+export const ApprovalRequest = ( { message, isLive }: { message: Message; isLive: boolean } ) => {
+	const { trackEvent, chat } = useOdieAssistantContext();
+	const chatStatus = chat.status;
 	const approvalDecision = useSendApprovalDecision();
 
+	const status = message.context?.approval?.status;
+	if ( status && status in DECIDED_LABELS ) {
+		return (
+			<div className="odie__transfer-chat">
+				<p className="odie__transfer-chat--note">{ DECIDED_LABELS[ status ] }</p>
+			</div>
+		);
+	}
+
 	const token = message.context?.approval?.token;
-	if ( ! token ) {
+	if ( ! token || ! isLive ) {
 		return null;
 	}
 
@@ -44,30 +61,41 @@ export const ApprovalRequest = ( { message }: { message: Message } ) => {
 	};
 
 	// Once a decision succeeds the continuation replaces this card; keep the buttons locked
-	// meanwhile and say which decision is in flight. A request error means the decision itself
-	// could not be made (expired or already-decided token, signed out): say so under the buttons
-	// and re-enable them. A failure of the approved action is not an error here — the server
-	// reports it as the decision's outcome and the bot explains it in the continuation.
-	const isLocked = approvalDecision.isPending || approvalDecision.isSuccess;
+	// meanwhile and say which decision is in flight. On a request error the hook reloads the chat
+	// from the server, which replaces this card with its recorded state (decided label, outcome
+	// or continuation message). The buttons stay locked while that happens; they come back only
+	// if the reload still shows this card pending — i.e. the request genuinely never reached the
+	// server — with a note that says so. A failure of the approved action is not an error here —
+	// the server reports it as the decision's outcome and the bot explains it in the continuation.
+	const isReloading = approvalDecision.isError && chatStatus === 'loading';
+	const isLocked = approvalDecision.isPending || approvalDecision.isSuccess || isReloading;
 	const pendingDecision = isLocked ? approvalDecision.variables?.decision : undefined;
-	const errorMessage = approvalDecision.isError
-		? __(
-				'This approval could not be recorded — it may have expired. Ask again to get a new request.',
-				__i18n_text_domain__
-		  )
-		: null;
+	const errorMessage =
+		approvalDecision.isError && ! isReloading
+			? __( 'That didn’t go through. Check your connection and try again.', __i18n_text_domain__ )
+			: null;
+
+	const labelFor = ( decision: 'approve' | 'decline' ) => {
+		if ( decision !== pendingDecision ) {
+			return 'approve' === decision
+				? __( 'Approve and continue', __i18n_text_domain__ )
+				: __( 'Decline', __i18n_text_domain__ );
+		}
+		if ( isReloading ) {
+			return __( 'Checking…', __i18n_text_domain__ );
+		}
+		return 'approve' === decision
+			? __( 'Approving…', __i18n_text_domain__ )
+			: __( 'Declining…', __i18n_text_domain__ );
+	};
 
 	return (
 		<div className="odie__transfer-chat">
 			<button disabled={ isLocked } onClick={ () => decide( 'approve' ) }>
-				{ 'approve' === pendingDecision
-					? __( 'Approving…', __i18n_text_domain__ )
-					: __( 'Approve and continue', __i18n_text_domain__ ) }
+				{ labelFor( 'approve' ) }
 			</button>
 			<button disabled={ isLocked } onClick={ () => decide( 'decline' ) }>
-				{ 'decline' === pendingDecision
-					? __( 'Declining…', __i18n_text_domain__ )
-					: __( 'Decline', __i18n_text_domain__ ) }
+				{ labelFor( 'decline' ) }
 			</button>
 			{ errorMessage && <p className="odie__transfer-chat--error">{ errorMessage }</p> }
 		</div>

--- a/packages/odie-client/src/components/message/approval-request.tsx
+++ b/packages/odie-client/src/components/message/approval-request.tsx
@@ -6,7 +6,7 @@ import type { Message } from '../../types';
 import './get-support.scss';
 
 /**
- * Approve / decline buttons for a pending write-approval message
+ * Approve / decline buttons for a pending action-approval message
  * (context.flags.wpcom_approval_required). The decision endpoints append the outcome to
  * the chat server-side; the hook's query invalidation refetches it, and because this
  * card only renders under the last bot message it disappears once the outcome message

--- a/packages/odie-client/src/components/message/approval-request.tsx
+++ b/packages/odie-client/src/components/message/approval-request.tsx
@@ -26,17 +26,22 @@ export const ApprovalRequest = ( { message }: { message: Message } ) => {
 		approvalDecision.mutate( { token, decision } );
 	};
 
-	// Once a decision succeeds the refetch replaces this card; keep the buttons locked
-	// meanwhile. On error (e.g. an expired token) they re-enable.
+	// Once a decision succeeds the continuation replaces this card; keep the buttons locked
+	// meanwhile and say which decision is in flight. On error (e.g. an expired token) they re-enable.
 	const isLocked = approvalDecision.isPending || approvalDecision.isSuccess;
+	const pendingDecision = isLocked ? approvalDecision.variables?.decision : undefined;
 
 	return (
 		<div className="odie__transfer-chat">
 			<button disabled={ isLocked } onClick={ () => decide( 'approve' ) }>
-				{ __( 'Approve and continue', __i18n_text_domain__ ) }
+				{ 'approve' === pendingDecision
+					? __( 'Approving…', __i18n_text_domain__ )
+					: __( 'Approve and continue', __i18n_text_domain__ ) }
 			</button>
 			<button disabled={ isLocked } onClick={ () => decide( 'decline' ) }>
-				{ __( 'Decline', __i18n_text_domain__ ) }
+				{ 'decline' === pendingDecision
+					? __( 'Declining…', __i18n_text_domain__ )
+					: __( 'Decline', __i18n_text_domain__ ) }
 			</button>
 		</div>
 	);

--- a/packages/odie-client/src/components/message/approval-request.tsx
+++ b/packages/odie-client/src/components/message/approval-request.tsx
@@ -27,9 +27,18 @@ export const ApprovalRequest = ( { message }: { message: Message } ) => {
 	};
 
 	// Once a decision succeeds the continuation replaces this card; keep the buttons locked
-	// meanwhile and say which decision is in flight. On error (e.g. an expired token) they re-enable.
+	// meanwhile and say which decision is in flight. A request error means the decision itself
+	// could not be made (expired or already-decided token, signed out): say so under the buttons
+	// and re-enable them. A failure of the approved action is not an error here — the server
+	// reports it as the decision's outcome and the bot explains it in the continuation.
 	const isLocked = approvalDecision.isPending || approvalDecision.isSuccess;
 	const pendingDecision = isLocked ? approvalDecision.variables?.decision : undefined;
+	const errorMessage = approvalDecision.isError
+		? __(
+				'This approval could not be recorded — it may have expired. Ask again to get a new request.',
+				__i18n_text_domain__
+		  )
+		: null;
 
 	return (
 		<div className="odie__transfer-chat">
@@ -43,6 +52,7 @@ export const ApprovalRequest = ( { message }: { message: Message } ) => {
 					? __( 'Declining…', __i18n_text_domain__ )
 					: __( 'Decline', __i18n_text_domain__ ) }
 			</button>
+			{ errorMessage && <p className="odie__transfer-chat--error">{ errorMessage }</p> }
 		</div>
 	);
 };

--- a/packages/odie-client/src/components/message/approval-request.tsx
+++ b/packages/odie-client/src/components/message/approval-request.tsx
@@ -1,0 +1,43 @@
+import { __ } from '@wordpress/i18n';
+import { useOdieAssistantContext } from '../../context';
+import { useSendApprovalDecision } from '../../data/use-send-approval-decision';
+import type { Message } from '../../types';
+
+import './get-support.scss';
+
+/**
+ * Approve / decline buttons for a pending write-approval message
+ * (context.flags.wpcom_approval_required). The decision endpoints append the outcome to
+ * the chat server-side; the hook's query invalidation refetches it, and because this
+ * card only renders under the last bot message it disappears once the outcome message
+ * arrives.
+ */
+export const ApprovalRequest = ( { message }: { message: Message } ) => {
+	const { trackEvent } = useOdieAssistantContext();
+	const approvalDecision = useSendApprovalDecision();
+
+	const token = message.context?.approval?.token;
+	if ( ! token ) {
+		return null;
+	}
+
+	const decide = ( decision: 'approve' | 'decline' ) => {
+		trackEvent( 'chat_write_approval_decision', { decision } );
+		approvalDecision.mutate( { token, decision } );
+	};
+
+	// Once a decision succeeds the refetch replaces this card; keep the buttons locked
+	// meanwhile. On error (e.g. an expired token) they re-enable.
+	const isLocked = approvalDecision.isPending || approvalDecision.isSuccess;
+
+	return (
+		<div className="odie__transfer-chat">
+			<button disabled={ isLocked } onClick={ () => decide( 'approve' ) }>
+				{ __( 'Approve and continue', __i18n_text_domain__ ) }
+			</button>
+			<button disabled={ isLocked } onClick={ () => decide( 'decline' ) }>
+				{ __( 'Decline', __i18n_text_domain__ ) }
+			</button>
+		</div>
+	);
+};

--- a/packages/odie-client/src/components/message/get-support.scss
+++ b/packages/odie-client/src/components/message/get-support.scss
@@ -9,6 +9,13 @@
 		border-radius: 16px;
 		margin-top: 16px;
 
+		.odie__transfer-chat--error {
+			padding: 12px 16px;
+			margin: 0;
+			font-size: 0.75rem;
+			color: var( --studio-red-50 );
+		}
+
 		button {
 			display: flex;
 			justify-content: space-between;

--- a/packages/odie-client/src/components/message/get-support.scss
+++ b/packages/odie-client/src/components/message/get-support.scss
@@ -9,10 +9,15 @@
 		border-radius: 16px;
 		margin-top: 16px;
 
-		.odie__transfer-chat--error {
+		.odie__transfer-chat--error,
+		.odie__transfer-chat--note {
 			padding: 12px 16px;
 			margin: 0;
 			font-size: 0.75rem;
+			color: var( --studio-gray-50 );
+		}
+
+		.odie__transfer-chat--error {
 			color: var( --studio-red-50 );
 		}
 

--- a/packages/odie-client/src/components/message/get-support.scss
+++ b/packages/odie-client/src/components/message/get-support.scss
@@ -38,7 +38,12 @@
 				border-radius: 16px;
 			}
 
-			&:hover {
+			&:disabled {
+				color: var( --studio-gray-50 );
+				cursor: default;
+			}
+
+			&:hover:not( :disabled ) {
 				background: color-mix( in srgb, #fff 98%, var( --wp-admin-theme-color, #3858e9 ) );
 				color: var( --wp-components-color-accent, var( --wp-admin-theme-color, #3858e9 ) );
 				fill: var( --wp-components-color-accent, var( --wp-admin-theme-color, #3858e9 ) );

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -93,7 +93,7 @@ export const UserMessage = ( {
 	const showGetSupport =
 		isLastBotMessage && ( isRequestingHumanSupport || isErrorMessage ) && ! isStaleOdieChat( chat );
 
-	// A pending write-approval only renders its approve/decline card while it is the live
+	// A pending action-approval only renders its approve/decline card while it is the live
 	// end of the conversation — after a decision the server-appended outcome message becomes
 	// the last message and the card retires with the refetch.
 	const showApprovalRequest =

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -93,13 +93,10 @@ export const UserMessage = ( {
 	const showGetSupport =
 		isLastBotMessage && ( isRequestingHumanSupport || isErrorMessage ) && ! isStaleOdieChat( chat );
 
-	// A pending action-approval only renders its approve/decline card while it is the live
-	// end of the conversation — after a decision the server-appended outcome message becomes
-	// the last message and the card retires with the refetch.
-	const showApprovalRequest =
-		isLastBotMessage &&
-		!! message.context?.flags?.wpcom_approval_required &&
-		! isStaleOdieChat( chat );
+	// An action-approval card renders for every proposal message; ApprovalRequest decides
+	// between buttons (still pending and the live end of the conversation), a decided label
+	// (the server marked the card when it recorded the decision), or nothing.
+	const showApprovalRequest = !! message.context?.flags?.wpcom_approval_required;
 	const showActionButtons = ! isRequestingHumanSupport && ! isErrorMessage;
 
 	const messageContent = () => {
@@ -138,7 +135,12 @@ export const UserMessage = ( {
 			</div>
 			{ isMessageWithEscalationOption && (
 				<>
-					{ showApprovalRequest && <ApprovalRequest message={ message } /> }
+					{ showApprovalRequest && (
+						<ApprovalRequest
+							message={ message }
+							isLive={ isLastBotMessage && ! isStaleOdieChat( chat ) }
+						/>
+					) }
 					{ showGetSupport && (
 						<GetSupport
 							onClickAdditionalEvent={ ( destination, props ) => {

--- a/packages/odie-client/src/components/message/user-message.tsx
+++ b/packages/odie-client/src/components/message/user-message.tsx
@@ -18,6 +18,7 @@ import {
 	getIsErrorMessage,
 	isStaleOdieChat,
 } from '../../utils';
+import { ApprovalRequest } from './approval-request';
 import BotMessageActions from './bot-message-actions';
 import CustomALink from './custom-a-link';
 import { GetSupport } from './get-support';
@@ -91,6 +92,14 @@ export const UserMessage = ( {
 	// hanging off an abandoned interaction. The closed footer is the only way forward.
 	const showGetSupport =
 		isLastBotMessage && ( isRequestingHumanSupport || isErrorMessage ) && ! isStaleOdieChat( chat );
+
+	// A pending write-approval only renders its approve/decline card while it is the live
+	// end of the conversation — after a decision the server-appended outcome message becomes
+	// the last message and the card retires with the refetch.
+	const showApprovalRequest =
+		isLastBotMessage &&
+		!! message.context?.flags?.wpcom_approval_required &&
+		! isStaleOdieChat( chat );
 	const showActionButtons = ! isRequestingHumanSupport && ! isErrorMessage;
 
 	const messageContent = () => {
@@ -129,6 +138,7 @@ export const UserMessage = ( {
 			</div>
 			{ isMessageWithEscalationOption && (
 				<>
+					{ showApprovalRequest && <ApprovalRequest message={ message } /> }
 					{ showGetSupport && (
 						<GetSupport
 							onClickAdditionalEvent={ ( destination, props ) => {

--- a/packages/odie-client/src/components/send-message-input/index.tsx
+++ b/packages/odie-client/src/components/send-message-input/index.tsx
@@ -44,10 +44,14 @@ const AiDisclosure = ( { id }: { id: string } ) => (
 
 const getTextAreaPlaceholder = (
 	shouldDisableInputField: boolean,
-	cantTransferToZendesk: boolean
+	cantTransferToZendesk: boolean,
+	hasPendingApproval: boolean
 ) => {
 	if ( cantTransferToZendesk ) {
 		return __( 'Oops, something went wrong', __i18n_text_domain__ );
+	}
+	if ( hasPendingApproval ) {
+		return __( 'Approve or decline the request above to continue', __i18n_text_domain__ );
 	}
 	return shouldDisableInputField
 		? __( 'Just a moment…', __i18n_text_domain__ )
@@ -64,6 +68,17 @@ export const OdieSendMessageButton = () => {
 		false;
 	const { sendMessage } = useSendChatMessage();
 	const isChatBusy = chat.status === 'loading' || chat.status === 'sending';
+	// The turn is parked on an approval card: the buttons are the only valid input until it is
+	// answered (a typed "yes" would start a new turn and a second identical card).
+	const lastMessage = chat.messages?.[ chat.messages.length - 1 ];
+	const hasPendingApproval =
+		lastMessage?.role === 'bot' &&
+		!! lastMessage?.context?.flags?.wpcom_approval_required &&
+		!! lastMessage?.context?.approval?.token &&
+		! (
+			lastMessage?.context?.approval?.status &&
+			lastMessage.context.approval.status !== 'pending_approval'
+		);
 	const isInitialLoading = chat.status === 'loading';
 	const isLiveChat = chat.provider?.startsWith( 'zendesk' );
 	const [ searchParams ] = useSearchParams();
@@ -124,7 +139,7 @@ export const OdieSendMessageButton = () => {
 		inputValue,
 		setInputValue,
 		hasAttachments,
-		isChatBusy,
+		isChatBusy: isChatBusy || hasPendingApproval,
 		chat,
 		sendAttachments,
 		textareaRef,
@@ -156,7 +171,11 @@ export const OdieSendMessageButton = () => {
 		}
 	}, [ textareaRef, isLiveChat ] );
 
-	const textAreaPlaceholder = getTextAreaPlaceholder( isChatBusy, cantTransferToZendesk );
+	const textAreaPlaceholder = getTextAreaPlaceholder(
+		isChatBusy,
+		cantTransferToZendesk,
+		hasPendingApproval
+	);
 
 	const customActions = showAttachmentButton ? [ attachmentAction ] : undefined;
 
@@ -197,7 +216,9 @@ export const OdieSendMessageButton = () => {
 	// 2. Input is empty AND no attachments
 	const isDisabled = !! messageSizeNotice || ( isInputEmpty && ! hasAttachments );
 	// When there is a reason to disable the input, we should not convey a processing state.
-	const isProcessing = ( isChatBusy || isAttachingFile || cantTransferToZendesk ) && ! isDisabled;
+	const isProcessing =
+		( isChatBusy || isAttachingFile || cantTransferToZendesk || hasPendingApproval ) &&
+		! isDisabled;
 
 	useEffect( () => {
 		if ( initialQuery && ! isProcessing && chat.status !== 'loading' ) {

--- a/packages/odie-client/src/data/use-send-approval-decision.ts
+++ b/packages/odie-client/src/data/use-send-approval-decision.ts
@@ -35,7 +35,8 @@ type ApprovalDecisionResponse = {
 	 * The bot's next message: the server resumes the paused chat turn with the decision as the
 	 * tool call's result, and this is what the bot said next (possibly another approval request).
 	 * When the turn could not be resumed the server stores and returns a plain outcome message
-	 * instead, so this is null only when the proposal was not found in the chat.
+	 * instead, so this is null only when even that failed. (A token that is not pending in this
+	 * chat is a 404, checked before anything executes — not a null continuation.)
 	 */
 	continuation?: {
 		message_id?: number;
@@ -47,7 +48,8 @@ type ApprovalDecisionResponse = {
 /**
  * Approve or decline a pending action-approval proposal.
  *
- * The chat reference (chat_id + bot_id) rides on the request so the server resumes the paused
+ * The route is chat-scoped: the path names the bot, the chat, and the token, and the server
+ * verifies they belong together before anything executes. On success it resumes the paused
  * turn and returns the bot's continuation, already stored in the chat. The LIVE view deliberately
  * ignores refetches of an unchanged interaction (it protects optimistic local messages — see
  * useGetCombinedChat), so the continuation is appended locally via addMessage, the same way live
@@ -69,9 +71,8 @@ export const useSendApprovalDecision = () => {
 			return withTimeout(
 				wpcomRequest< ApprovalDecisionResponse >( {
 					method: 'POST',
-					path: `/ai/action-approvals/${ token }/${ decision }`,
+					path: `/ai/chat/${ botSlug }/${ chat.odieId }/approval/${ token }/${ decision }`,
 					apiNamespace: 'wpcom/v2',
-					body: { chat_id: chat.odieId, bot_id: botSlug },
 				} ),
 				DECISION_TIMEOUT_MS
 			);

--- a/packages/odie-client/src/data/use-send-approval-decision.ts
+++ b/packages/odie-client/src/data/use-send-approval-decision.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import { ODIE_DEFAULT_BOT_SLUG_LEGACY } from '../constants';
+import { useOdieAssistantContext } from '../context';
+import { useCurrentSupportInteraction } from './use-current-support-interaction';
+
+/**
+ * Approve or decline a pending write-approval proposal.
+ *
+ * The chat reference (chat_id + bot_id) rides on the request so the server appends the
+ * decided outcome to this chat as a bot message; on success the chat query is
+ * invalidated, the refetch renders that outcome message, and the pending approval card
+ * (which only shows on the last message) disappears with it.
+ * @returns useMutation return object.
+ */
+export const useSendApprovalDecision = () => {
+	const { chat } = useOdieAssistantContext();
+	const { data: supportInteraction } = useCurrentSupportInteraction();
+	const queryClient = useQueryClient();
+
+	const botSlug = supportInteraction?.bot_slug || ODIE_DEFAULT_BOT_SLUG_LEGACY;
+
+	return useMutation( {
+		mutationFn: ( { token, decision }: { token: string; decision: 'approve' | 'decline' } ) => {
+			return wpcomRequest( {
+				method: 'POST',
+				path: `/ai/write-approvals/${ token }/${ decision }`,
+				apiNamespace: 'wpcom/v2',
+				body: { chat_id: chat.odieId, bot_id: botSlug },
+			} );
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: [ 'odie-chat', botSlug, chat.odieId ] } );
+		},
+	} );
+};

--- a/packages/odie-client/src/data/use-send-approval-decision.ts
+++ b/packages/odie-client/src/data/use-send-approval-decision.ts
@@ -2,19 +2,31 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import { ODIE_DEFAULT_BOT_SLUG_LEGACY } from '../constants';
 import { useOdieAssistantContext } from '../context';
+import { generateUUID } from '../utils';
 import { useCurrentSupportInteraction } from './use-current-support-interaction';
+import type { Message } from '../types';
+
+type ApprovalDecisionResponse = {
+	status: 'executed' | 'declined';
+	action?: string;
+	description?: string;
+	reason?: string;
+};
 
 /**
  * Approve or decline a pending write-approval proposal.
  *
  * The chat reference (chat_id + bot_id) rides on the request so the server appends the
- * decided outcome to this chat as a bot message; on success the chat query is
- * invalidated, the refetch renders that outcome message, and the pending approval card
- * (which only shows on the last message) disappears with it.
+ * decided outcome to the stored chat as a bot message. The LIVE view deliberately ignores
+ * refetches of an unchanged interaction (it protects optimistic local messages — see
+ * useGetCombinedChat), so the outcome message is also appended locally via addMessage,
+ * the same way live bot replies land; the pending approval card (which only shows on the
+ * last message) retires with it. The query invalidation keeps the cache fresh for the
+ * next mount, where the server-stored copy is what loads.
  * @returns useMutation return object.
  */
 export const useSendApprovalDecision = () => {
-	const { chat } = useOdieAssistantContext();
+	const { chat, addMessage } = useOdieAssistantContext();
 	const { data: supportInteraction } = useCurrentSupportInteraction();
 	const queryClient = useQueryClient();
 
@@ -22,14 +34,34 @@ export const useSendApprovalDecision = () => {
 
 	return useMutation( {
 		mutationFn: ( { token, decision }: { token: string; decision: 'approve' | 'decline' } ) => {
-			return wpcomRequest( {
+			return wpcomRequest< ApprovalDecisionResponse >( {
 				method: 'POST',
 				path: `/ai/write-approvals/${ token }/${ decision }`,
 				apiNamespace: 'wpcom/v2',
 				body: { chat_id: chat.odieId, bot_id: botSlug },
 			} );
 		},
-		onSuccess: () => {
+		onSuccess: ( response, { decision } ) => {
+			const executed = 'approve' === decision;
+			const description = response?.description ?? '';
+			const outcome: Message = {
+				content: executed
+					? `Done — you approved this action and it has been completed: ${ description }`
+					: `You declined this action — it has not been performed: ${ description }`,
+				role: 'bot',
+				type: 'message',
+				internal_message_id: generateUUID(),
+				context: {
+					site_id: null,
+					flags: executed ? { wpcom_approval_executed: true } : { wpcom_approval_declined: true },
+					approval: {
+						status: executed ? 'executed' : 'declined',
+						action: response?.action,
+						description,
+					},
+				},
+			};
+			addMessage( outcome );
 			queryClient.invalidateQueries( { queryKey: [ 'odie-chat', botSlug, chat.odieId ] } );
 		},
 	} );

--- a/packages/odie-client/src/data/use-send-approval-decision.ts
+++ b/packages/odie-client/src/data/use-send-approval-decision.ts
@@ -9,6 +9,21 @@ import type { Message } from '../types';
 /** How long after a failed decision request to reload once more for a late continuation. */
 const CONTINUATION_RELOAD_DELAY_MS = 20000;
 
+/**
+ * Give up waiting for the decision response after this long. The request carries a whole bot turn
+ * (execute + model calls) so it is legitimately slow, but the error path (reload from the server)
+ * only works if the promise settles — wpcom-proxy-request has no timeout of its own.
+ */
+const DECISION_TIMEOUT_MS = 90000;
+
+const withTimeout = < T >( promise: Promise< T >, ms: number ): Promise< T > =>
+	Promise.race( [
+		promise,
+		new Promise< never >( ( _, reject ) =>
+			window.setTimeout( () => reject( new Error( 'approval-decision-timeout' ) ), ms )
+		),
+	] );
+
 type ApprovalDecisionResponse = {
 	/** `failed`: the approval was recorded but the action did not run (see `error`). */
 	status: 'executed' | 'declined' | 'failed';
@@ -51,12 +66,15 @@ export const useSendApprovalDecision = () => {
 
 	return useMutation( {
 		mutationFn: ( { token, decision }: { token: string; decision: 'approve' | 'decline' } ) => {
-			return wpcomRequest< ApprovalDecisionResponse >( {
-				method: 'POST',
-				path: `/ai/action-approvals/${ token }/${ decision }`,
-				apiNamespace: 'wpcom/v2',
-				body: { chat_id: chat.odieId, bot_id: botSlug },
-			} );
+			return withTimeout(
+				wpcomRequest< ApprovalDecisionResponse >( {
+					method: 'POST',
+					path: `/ai/action-approvals/${ token }/${ decision }`,
+					apiNamespace: 'wpcom/v2',
+					body: { chat_id: chat.odieId, bot_id: botSlug },
+				} ),
+				DECISION_TIMEOUT_MS
+			);
 		},
 		// The decision runs the bot's next turn server-side (execute, then a model call), so show
 		// the same "thinking" placeholder a live reply shows until the continuation arrives.

--- a/packages/odie-client/src/data/use-send-approval-decision.ts
+++ b/packages/odie-client/src/data/use-send-approval-decision.ts
@@ -37,7 +37,7 @@ type ApprovalDecisionResponse = {
  * @returns useMutation return object.
  */
 export const useSendApprovalDecision = () => {
-	const { chat, addMessage } = useOdieAssistantContext();
+	const { chat, addMessage, setChatStatus } = useOdieAssistantContext();
 	const { data: supportInteraction } = useCurrentSupportInteraction();
 	const queryClient = useQueryClient();
 
@@ -51,6 +51,14 @@ export const useSendApprovalDecision = () => {
 				apiNamespace: 'wpcom/v2',
 				body: { chat_id: chat.odieId, bot_id: botSlug },
 			} );
+		},
+		// The decision runs the bot's next turn server-side (execute, then a model call), so show
+		// the same "thinking" placeholder a live reply shows until the continuation arrives.
+		onMutate: () => {
+			setChatStatus( 'sending' );
+		},
+		onSettled: () => {
+			setChatStatus( 'loaded' );
 		},
 		onSuccess: ( response, { decision } ) => {
 			const executed = 'approve' === decision;

--- a/packages/odie-client/src/data/use-send-approval-decision.ts
+++ b/packages/odie-client/src/data/use-send-approval-decision.ts
@@ -14,7 +14,7 @@ type ApprovalDecisionResponse = {
 };
 
 /**
- * Approve or decline a pending write-approval proposal.
+ * Approve or decline a pending action-approval proposal.
  *
  * The chat reference (chat_id + bot_id) rides on the request so the server appends the
  * decided outcome to the stored chat as a bot message. The LIVE view deliberately ignores
@@ -36,7 +36,7 @@ export const useSendApprovalDecision = () => {
 		mutationFn: ( { token, decision }: { token: string; decision: 'approve' | 'decline' } ) => {
 			return wpcomRequest< ApprovalDecisionResponse >( {
 				method: 'POST',
-				path: `/ai/write-approvals/${ token }/${ decision }`,
+				path: `/ai/action-approvals/${ token }/${ decision }`,
 				apiNamespace: 'wpcom/v2',
 				body: { chat_id: chat.odieId, bot_id: botSlug },
 			} );

--- a/packages/odie-client/src/data/use-send-approval-decision.ts
+++ b/packages/odie-client/src/data/use-send-approval-decision.ts
@@ -6,6 +6,9 @@ import { generateUUID } from '../utils';
 import { useCurrentSupportInteraction } from './use-current-support-interaction';
 import type { Message } from '../types';
 
+/** How long after a failed decision request to reload once more for a late continuation. */
+const CONTINUATION_RELOAD_DELAY_MS = 20000;
+
 type ApprovalDecisionResponse = {
 	/** `failed`: the approval was recorded but the action did not run (see `error`). */
 	status: 'executed' | 'declined' | 'failed';
@@ -16,7 +19,8 @@ type ApprovalDecisionResponse = {
 	/**
 	 * The bot's next message: the server resumes the paused chat turn with the decision as the
 	 * tool call's result, and this is what the bot said next (possibly another approval request).
-	 * Null when the turn could not be resumed; the decision itself still stands.
+	 * When the turn could not be resumed the server stores and returns a plain outcome message
+	 * instead, so this is null only when the proposal was not found in the chat.
 	 */
 	continuation?: {
 		message_id?: number;
@@ -59,54 +63,36 @@ export const useSendApprovalDecision = () => {
 		onMutate: () => {
 			setChatStatus( 'sending' );
 		},
-		onSettled: () => {
-			setChatStatus( 'loaded' );
+		// A failed request does not mean a failed decision: the token is consumed before the action
+		// runs, and the request can die while the server is still generating the continuation. So
+		// never re-offer the buttons on our own judgement — reload the chat from the server, which
+		// now records the truth on the card itself (approval.status) and in the stored outcome or
+		// continuation message. Setting the chat to `loading` is what makes the LIVE view adopt the
+		// refetched chat (useGetCombinedChat ignores refetches otherwise).
+		onError: () => {
+			const reload = () => {
+				setChatStatus( 'loading' );
+				queryClient.invalidateQueries( { queryKey: [ 'odie-chat', botSlug, chat.odieId ] } );
+			};
+			reload();
+			// The usual reason for the error is a timeout while the server is still writing the bot's
+			// continuation; the first reload shows the decided card, this one picks up the reply.
+			window.setTimeout( reload, CONTINUATION_RELOAD_DELAY_MS );
 		},
-		onSuccess: ( response, { decision } ) => {
-			const failed = 'failed' === response?.status;
-			const executed = 'approve' === decision && ! failed;
-			const description = response?.description ?? '';
+		onSuccess: ( response ) => {
+			setChatStatus( 'loaded' );
 			const continuation = response?.continuation;
-
-			let fallbackStatus: 'executed' | 'declined' | 'failed' = 'declined';
-			let fallbackContent = `You declined this action — it has not been performed: ${ description }`;
-			if ( failed ) {
-				fallbackStatus = 'failed';
-				fallbackContent = `You approved this action, but it could not be completed: ${ description }`;
-			} else if ( executed ) {
-				fallbackStatus = 'executed';
-				fallbackContent = `Done — you approved this action and it has been completed: ${ description }`;
+			if ( continuation ) {
+				addMessage( {
+					message_id: continuation.message_id,
+					internal_message_id: generateUUID(),
+					content: continuation.content ?? '',
+					role: 'bot',
+					type: 'message',
+					context: continuation.context,
+				} );
 			}
-
-			const outcome: Message = continuation
-				? {
-						message_id: continuation.message_id,
-						internal_message_id: generateUUID(),
-						content: continuation.content ?? '',
-						role: 'bot',
-						type: 'message',
-						context: continuation.context,
-				  }
-				: {
-						// The server recorded the decision but could not resume the turn (pause
-						// expired, bot updated). Say what happened; the next message starts fresh.
-						content: fallbackContent,
-						role: 'bot',
-						type: 'message',
-						internal_message_id: generateUUID(),
-						context: {
-							site_id: null,
-							flags: executed
-								? { wpcom_approval_executed: true }
-								: { wpcom_approval_declined: true },
-							approval: {
-								status: fallbackStatus,
-								action: response?.action,
-								description,
-							},
-						},
-				  };
-			addMessage( outcome );
+			// The card's own message was marked decided server-side; the refetch picks that up.
 			queryClient.invalidateQueries( { queryKey: [ 'odie-chat', botSlug, chat.odieId ] } );
 		},
 	} );

--- a/packages/odie-client/src/data/use-send-approval-decision.ts
+++ b/packages/odie-client/src/data/use-send-approval-decision.ts
@@ -11,18 +11,29 @@ type ApprovalDecisionResponse = {
 	action?: string;
 	description?: string;
 	reason?: string;
+	/**
+	 * The bot's next message: the server resumes the paused chat turn with the decision as the
+	 * tool call's result, and this is what the bot said next (possibly another approval request).
+	 * Null when the turn could not be resumed; the decision itself still stands.
+	 */
+	continuation?: {
+		message_id?: number;
+		content?: string;
+		context?: Message[ 'context' ];
+	} | null;
 };
 
 /**
  * Approve or decline a pending action-approval proposal.
  *
- * The chat reference (chat_id + bot_id) rides on the request so the server appends the
- * decided outcome to the stored chat as a bot message. The LIVE view deliberately ignores
- * refetches of an unchanged interaction (it protects optimistic local messages — see
- * useGetCombinedChat), so the outcome message is also appended locally via addMessage,
- * the same way live bot replies land; the pending approval card (which only shows on the
- * last message) retires with it. The query invalidation keeps the cache fresh for the
- * next mount, where the server-stored copy is what loads.
+ * The chat reference (chat_id + bot_id) rides on the request so the server resumes the paused
+ * turn and returns the bot's continuation, already stored in the chat. The LIVE view deliberately
+ * ignores refetches of an unchanged interaction (it protects optimistic local messages — see
+ * useGetCombinedChat), so the continuation is appended locally via addMessage, the same way live
+ * bot replies land; the pending approval card (which only shows on the last message) retires with
+ * it, and a continuation that is itself a new approval request renders as the next card. The
+ * query invalidation keeps the cache fresh for the next mount, where the server-stored copy is
+ * what loads.
  * @returns useMutation return object.
  */
 export const useSendApprovalDecision = () => {
@@ -44,23 +55,38 @@ export const useSendApprovalDecision = () => {
 		onSuccess: ( response, { decision } ) => {
 			const executed = 'approve' === decision;
 			const description = response?.description ?? '';
-			const outcome: Message = {
-				content: executed
-					? `Done — you approved this action and it has been completed: ${ description }`
-					: `You declined this action — it has not been performed: ${ description }`,
-				role: 'bot',
-				type: 'message',
-				internal_message_id: generateUUID(),
-				context: {
-					site_id: null,
-					flags: executed ? { wpcom_approval_executed: true } : { wpcom_approval_declined: true },
-					approval: {
-						status: executed ? 'executed' : 'declined',
-						action: response?.action,
-						description,
-					},
-				},
-			};
+			const continuation = response?.continuation;
+
+			const outcome: Message = continuation
+				? {
+						message_id: continuation.message_id,
+						internal_message_id: generateUUID(),
+						content: continuation.content ?? '',
+						role: 'bot',
+						type: 'message',
+						context: continuation.context,
+				  }
+				: {
+						// The server recorded the decision but could not resume the turn (pause
+						// expired, bot updated). Say what happened; the next message starts fresh.
+						content: executed
+							? `Done — you approved this action and it has been completed: ${ description }`
+							: `You declined this action — it has not been performed: ${ description }`,
+						role: 'bot',
+						type: 'message',
+						internal_message_id: generateUUID(),
+						context: {
+							site_id: null,
+							flags: executed
+								? { wpcom_approval_executed: true }
+								: { wpcom_approval_declined: true },
+							approval: {
+								status: executed ? 'executed' : 'declined',
+								action: response?.action,
+								description,
+							},
+						},
+				  };
 			addMessage( outcome );
 			queryClient.invalidateQueries( { queryKey: [ 'odie-chat', botSlug, chat.odieId ] } );
 		},

--- a/packages/odie-client/src/data/use-send-approval-decision.ts
+++ b/packages/odie-client/src/data/use-send-approval-decision.ts
@@ -7,10 +7,12 @@ import { useCurrentSupportInteraction } from './use-current-support-interaction'
 import type { Message } from '../types';
 
 type ApprovalDecisionResponse = {
-	status: 'executed' | 'declined';
+	/** `failed`: the approval was recorded but the action did not run (see `error`). */
+	status: 'executed' | 'declined' | 'failed';
 	action?: string;
 	description?: string;
 	reason?: string;
+	error?: string;
 	/**
 	 * The bot's next message: the server resumes the paused chat turn with the decision as the
 	 * tool call's result, and this is what the bot said next (possibly another approval request).
@@ -61,9 +63,20 @@ export const useSendApprovalDecision = () => {
 			setChatStatus( 'loaded' );
 		},
 		onSuccess: ( response, { decision } ) => {
-			const executed = 'approve' === decision;
+			const failed = 'failed' === response?.status;
+			const executed = 'approve' === decision && ! failed;
 			const description = response?.description ?? '';
 			const continuation = response?.continuation;
+
+			let fallbackStatus: 'executed' | 'declined' | 'failed' = 'declined';
+			let fallbackContent = `You declined this action — it has not been performed: ${ description }`;
+			if ( failed ) {
+				fallbackStatus = 'failed';
+				fallbackContent = `You approved this action, but it could not be completed: ${ description }`;
+			} else if ( executed ) {
+				fallbackStatus = 'executed';
+				fallbackContent = `Done — you approved this action and it has been completed: ${ description }`;
+			}
 
 			const outcome: Message = continuation
 				? {
@@ -77,9 +90,7 @@ export const useSendApprovalDecision = () => {
 				: {
 						// The server recorded the decision but could not resume the turn (pause
 						// expired, bot updated). Say what happened; the next message starts fresh.
-						content: executed
-							? `Done — you approved this action and it has been completed: ${ description }`
-							: `You declined this action — it has not been performed: ${ description }`,
+						content: fallbackContent,
 						role: 'bot',
 						type: 'message',
 						internal_message_id: generateUUID(),
@@ -89,7 +100,7 @@ export const useSendApprovalDecision = () => {
 								? { wpcom_approval_executed: true }
 								: { wpcom_approval_declined: true },
 							approval: {
-								status: executed ? 'executed' : 'declined',
+								status: fallbackStatus,
 								action: response?.action,
 								description,
 							},

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -252,7 +252,15 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 
 			const currentScreen = { url };
 			const isAgentsManagerAvailable = getIsAgentsManagerAvailable();
-			const context = { selectedSiteId, currentScreen, pathname, isAgentsManagerAvailable };
+			// This client renders action-approval cards (ApprovalRequest), so the bot may pause on a
+			// proposal instead of hiding the actions that need one.
+			const context = {
+				selectedSiteId,
+				currentScreen,
+				pathname,
+				isAgentsManagerAvailable,
+				supports_action_approval: true,
+			};
 
 			if ( canAccessWpcomApis() ) {
 				if ( isLoggedOutSession ) {

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -140,7 +140,11 @@ export type Context = {
 		 * what the approval actually binds, for a "view exact parameters" affordance.
 		 */
 		details?: string;
-		declared_destructive?: boolean | null;
+		/**
+		 * The server's classification of the action when the proposal was minted
+		 * (e.g. 'needs_approval', 'always_confirm'); null when unclassified.
+		 */
+		tier?: string | null;
 		how_to_approve?: string;
 		reason?: string;
 	};

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -132,7 +132,10 @@ export type Context = {
 	 */
 	approval?: {
 		status?: 'pending_approval' | 'executed' | 'declined' | 'failed';
+		/** Present only while the proposal is still pending; removed once decided. */
 		token?: string;
+		/** Unix seconds of the decision, set on the card when the server records it. */
+		decided_at?: number;
 		action?: string;
 		description?: string;
 		/**

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -135,6 +135,11 @@ export type Context = {
 		token?: string;
 		action?: string;
 		description?: string;
+		/**
+		 * The generic argument dump when `description` is an ability-authored headline —
+		 * what the approval actually binds, for a "view exact parameters" affordance.
+		 */
+		details?: string;
 		declared_destructive?: boolean | null;
 		how_to_approve?: string;
 		reason?: string;

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -121,6 +121,23 @@ export type Context = {
 		hide_disclaimer_content?: boolean;
 		show_ai_avatar?: boolean;
 		is_error_message?: boolean;
+		wpcom_approval_required?: boolean;
+		wpcom_approval_executed?: boolean;
+		wpcom_approval_declined?: boolean;
+	};
+	/**
+	 * A write-approval outcome riding on the message (see flags.wpcom_approval_*): while
+	 * pending it carries the token the approve/decline endpoints consume; executed and
+	 * declined messages carry the decided outcome for rendering.
+	 */
+	approval?: {
+		status?: 'pending_approval' | 'executed' | 'declined';
+		token?: string;
+		action?: string;
+		description?: string;
+		declared_destructive?: boolean | null;
+		how_to_approve?: string;
+		reason?: string;
 	};
 };
 

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -145,7 +145,7 @@ export type Context = {
 		details?: string;
 		/**
 		 * The server's classification of the action when the proposal was minted
-		 * (e.g. 'needs_approval', 'always_confirm'); null when unclassified.
+		 * (e.g. 'require_approval', 'require_approval_if_supported'); opaque here.
 		 */
 		tier?: string | null;
 		/** Unix time (seconds) after which the server no longer accepts a decision on this token. */

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -145,6 +145,8 @@ export type Context = {
 		 * (e.g. 'needs_approval', 'always_confirm'); null when unclassified.
 		 */
 		tier?: string | null;
+		/** Unix time (seconds) after which the server no longer accepts a decision on this token. */
+		expires_at?: number;
 		how_to_approve?: string;
 		reason?: string;
 	};

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -131,7 +131,7 @@ export type Context = {
 	 * declined messages carry the decided outcome for rendering.
 	 */
 	approval?: {
-		status?: 'pending_approval' | 'executed' | 'declined';
+		status?: 'pending_approval' | 'executed' | 'declined' | 'failed';
 		token?: string;
 		action?: string;
 		description?: string;

--- a/packages/odie-client/src/types.ts
+++ b/packages/odie-client/src/types.ts
@@ -126,7 +126,7 @@ export type Context = {
 		wpcom_approval_declined?: boolean;
 	};
 	/**
-	 * A write-approval outcome riding on the message (see flags.wpcom_approval_*): while
+	 * An action-approval outcome riding on the message (see flags.wpcom_approval_*): while
 	 * pending it carries the token the approve/decline endpoints consume; executed and
 	 * declined messages carry the decided outcome for rendering.
 	 */


### PR DESCRIPTION
Part of HAL-1347. Server side: 235215-ghe-Automattic/wpcom.

**TLDR:** When the help-chat bot wants to change something on the user's site, it now pauses and shows an approve/decline card. The action only runs after the user clicks approve. This is the client half of the action-approval gate spike; the server half is in the wpcom PR above.

## Proposed Changes

* **Declare the approval surface.** `use-send-odie-message.ts` sends `supports_action_approval: true` in the message context. This tells the server this client can render approval cards, so the bot may propose gated actions instead of hiding them.
* **New `ApprovalRequest` card** (`components/message/approval-request.tsx`), rendered under any bot message flagged `wpcom_approval_required`. It shows one of:
  * **Approve and continue / Decline** buttons — only while the proposal is pending *and* the card is the live end of the conversation. A pending card that is no longer last was superseded (the user typed past it) and shows nothing.
  * A **decided label** ("You approved this action and it was completed." / declined / failed) once the server has recorded a decision on the message.
  * An **expired note** when the token is past `expires_at`, instead of buttons that could only fail.
* **New `useSendApprovalDecision` mutation** (`data/use-send-approval-decision.ts`). Posts to the chat-scoped route `POST /wpcom/v2/ai/chat/{bot}/{chat}/approval/{token}/{approve|decline}`:
  * Shows the normal "thinking" placeholder while the decision runs, because the server executes the action and resumes the bot's turn inside this request.
  * On success, appends the bot's continuation message locally via `addMessage` (the LIVE view ignores refetches of an unchanged interaction, so a refetch alone would not show it) and invalidates the chat query so the next mount loads the stored copy.
  * Wraps the request in an explicit 90s timeout — `wpcom-proxy-request` has none, and the error path only works if the promise settles.
  * **On error, never re-offers the buttons on its own judgement.** The token may already be consumed and the action may have run, even though the request died. Instead it reloads the chat from the server (which now records the truth on the card), and reloads once more after 20s to pick up a continuation that was still being written.
* **Composer lock.** While the last message is a pending approval card, the send input is disabled with the placeholder "Approve or decline the request above to continue". A typed "yes" would start a new turn and produce a second identical card, so the buttons are the only valid input.
* **Types** (`types.ts`): `context.approval` (status, token, description, details, tier, `expires_at`, decision metadata) and the `wpcom_approval_*` flags.

## Why are these changes being made?

The bots' write abilities can change a user's site (site settings, etc.). The action-approval gate (HAL-1347) makes the bot stop before any registered write and ask the human first. The server can only pause on a proposal if the client can show the question and send back the answer — a client that declares no approval surface gets gated tools hidden and blocked instead. This PR is the spike's proof that a real client (help chat) can declare the surface, render the pause, and resume the conversation with the decision.

Two design points worth recording:

* **The decision is a REST call, not a chat message.** The bot has no tool that approves; only this client's buttons can hit the approve route, and the route verifies the token belongs to this chat before anything executes.
* **Failure UX is server-truth-driven.** After a failed decision request the client deliberately does not guess. It reloads and renders whatever the server recorded: a decided label, an outcome message, or (if the request truly never arrived) the pending card again with a "try again" note.

## Testing Instructions

Needs the server branch: sandbox `public-api.wordpress.com` (and `wordpress.com`) with wpcom branch `try/hal-1347-aap-e2e-help-chat` checked out.

Happy path (10 minutes):

1. Check out this branch and start Calypso: `yarn start`.
2. Open Help Center on `http://calypso.localhost:3000` (logged in as your sandboxed user) and start a chat with the help bot.
3. Send: `Change my site title to "Approval Test"` (use one of **your own** test sites — the sandbox writes to production data).
4. Expect: the bot replies with a proposal and an **Approve and continue / Decline** card. The composer is locked with the placeholder "Approve or decline the request above to continue".
5. Click **Approve and continue**. Expect: buttons lock and show "Approving…", then the card collapses to "You approved this action and it was completed." and the bot posts a continuation message. Verify the site title actually changed.
6. Reload the page and reopen the chat. Expect: the decided card still shows its label (server-stored state), no buttons.

The full manual matrix (decline, superseding a card by typing, forced execution failure, expiry, reload mid-pause, transcript checks) is written up as flows 1–11 in the Testing Instructions of the wpcom PR (235215-ghe-Automattic/wpcom) — they were all run against this branch.

Verified manually on 2026-08-25/26: help-chat conversations against the sandboxed server branch, including approve, decline, a two-action fan-out (two cards in one turn), and a forced post-approval execution failure.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

**Spike caveats:** this is a proof-of-concept branch — no new automated tests yet, the card reuses `odie__transfer-chat` styling rather than its own design, and the new strings shouldn't enter String Freeze until the design settles. Server-composed card copy (description, outcome messages) is English-only for now; the client-side strings here are translatable.
