### PR TITLE
Agents Manager: WebMCP for isDevMode

### DIFF
--- a/packages/agents-manager/WEBMCP.md
+++ b/packages/agents-manager/WEBMCP.md
@@ -5,8 +5,9 @@ WebMCP API. The browser agent supplies the model and all reasoning. This adapter
 Agenttic agent, open Agents Manager chat, or call the WordPress.com AI orchestrator.
 
 This is a staff-testing proof of concept, not a production-supported integration. It is disabled by
-default. Enable it on a supported post, page, or site editor URL with `?webmcp=1` in a browser that
-implements `document.modelContext.registerTool` (or the older `navigator.modelContext` location).
+default. It is enabled only when the Agents Manager inline data reports `isDevMode: true`, on a
+supported post, page, or site editor URL in a browser that implements
+`document.modelContext.registerTool` (or the older `navigator.modelContext` location).
 
 ## Execution and exposure
 
@@ -27,8 +28,9 @@ The allowlist contains:
 - `big-sky/apply-block-edits`: a client-registered ability that deterministically changes the
   current block-editor canvas. It does not save or publish the edit, so the result remains visible
   and reviewable. Its WebMCP contract supplies item-level schemas for updates, insertions, and
-  deletions, strips internal-only arguments, and injects an identity mapping for IDs from the most
-  recent block-tree read. On current trunk it is owned by the Big Sky fallback provider; the
+  deletions, accepts serialized Gutenberg pattern markup as an insertion, strips internal-only
+  arguments, and injects an identity mapping for IDs from the most recent block-tree read. On
+  current trunk it is owned by the Big Sky fallback provider; the
   merged-provider seam continues to work when ownership migrates to Agents Manager.
 
 - `big-sky/show-template`: an Agents Manager-owned, client-only ability that turns on the editor's
@@ -38,7 +40,8 @@ The allowlist contains:
   to `agents_manager__get_block_tree`.
 
 - `wpcom/get-block-schemas`, `wpcom/get-content-guidelines`, `wpcom/get-posts`,
-  `wpcom/get-site-stats`, and `core/get-site-info`: read-only server abilities registered by
+  `wpcom/get-site-stats`, `wpcom/patterns-list`, `wpcom/patterns-get`, and `core/get-site-info`:
+  read-only server abilities registered by
   Gutenberg from the current site's Abilities REST API. Their existing input schemas, permission
   checks, and authenticated site-specific execution path are preserved. The adapter also includes
   each ability's server-provided instructions in the WebMCP description when present.
@@ -55,33 +58,38 @@ neither allowlist grants eligibility to a lookalike from the other provenance.
    account in that browser profile.
 2. Sandbox `widgets.wp.com` to wpdev and run `WPCOM_SANDBOX=wpdev yarn dev --sync` from
    `apps/agents-manager`.
-3. Open a post, page, or site editor with `?webmcp=1` using GPT-5.6 Sol or Terra.
-4. Ask Codex to inspect the current page's Site tools. Confirm it discovers all eight tools:
+3. Open a post, page, or site editor where the inline Agents Manager data has `isDevMode: true`
+   using GPT-5.6 Sol or Terra.
+4. Ask Codex to inspect the current page's Site tools. Confirm it discovers all ten tools:
    `agents_manager__get_block_tree`, `big_sky__show_template`, and
    `big_sky__apply_block_edits`, plus `wpcom__get_block_schemas`,
    `wpcom__get_content_guidelines`, `wpcom__get_posts`, `wpcom__get_site_stats`, and
-   `core__get_site_info`. Do not use DevTools or call `document.modelContext` directly for this
-   path.
+   `wpcom__patterns_list`, `wpcom__patterns_get`, and `core__get_site_info`. Do not use DevTools or
+   call `document.modelContext` directly for this path.
 5. Call `agents_manager__get_block_tree`. If a requested template part is absent, call
    `big_sky__show_template`, then read the tree again.
 6. Call `big_sky__apply_block_edits` with a client ID from the latest tree, or insert a small test
    block on an empty page. Read the tree one final time and confirm the expected block and
    attributes are present.
-7. Do not publish the page. Discard the test changes or remove any auto-draft the editor created.
+7. Call `wpcom__patterns_list`, choose a pattern, and fetch it with `wpcom__patterns_get`. Pass its
+   `content` to `big_sky__apply_block_edits` as `inserts[0].blockMarkup`, then confirm the pattern's
+   blocks appear on the canvas in order.
+8. Do not publish the page. Discard the test changes or remove any auto-draft the editor created.
 
 ### Direct browser API fallback
 
-1. Open a post, page, or site editor with `?webmcp=1` and the browser's WebMCP testing feature on.
+1. Open a post, page, or site editor with `isDevMode: true` and the browser's WebMCP testing feature
+   on.
 2. Without opening Agents Manager chat, enumerate the page's tools through
    `document.modelContext.getTools()`.
-3. Confirm the same eight tools are present and that the five server tools expose input schemas.
+3. Confirm the same ten tools are present and that the seven server tools expose input schemas.
 4. Call `agents_manager__get_block_tree`, choose a returned client ID, then call
    `big_sky__apply_block_edits` with that ID and a small reversible edit. Confirm the canvas changes
    without publishing the page.
 5. Confirm the Network panel shows no Agenttic/orchestrator/model request.
 6. Navigate to another editor/site and confirm the tool now targets only the current canvas.
-7. Remove `webmcp=1` and reload; confirm the tool is absent.
-8. Use `?webmcp=1&am_abilities=0` to exercise the external-provider ownership path during migration.
+7. Force `isDevMode: false` in the inline data and reload; confirm the tools are absent.
+8. Use `?am_abilities=0` to exercise the external-provider ownership path during migration.
 
 The adapter reconciles the provider every two seconds only while the experiment is eligible. This
 covers abilities registered by later React effects. Changing scope or unmounting Agents Manager

--- a/packages/agents-manager/WEBMCP.md
+++ b/packages/agents-manager/WEBMCP.md
@@ -17,12 +17,19 @@ the original slash-based ability name through `toolProvider.executeAbility()`. W
 is eligible, the external provider's ability-setup hook also mounts at the stable Agents Manager
 lifecycle so hook-dependent abilities can register without opening the chat route.
 
-The initial allowlist contains only:
+The initial allowlist contains:
+
+- `agents-manager/get-block-tree`: an Agents Manager-owned, client-only ability that reads the live
+  Gutenberg tree. It returns real client IDs, block names, serializable attributes, nesting, the
+  current selection, and a block count. The WebMCP adapter remembers these IDs for the matching
+  edit call. It is annotated as read-only and idempotent.
 
 - `big-sky/apply-block-edits`: a client-registered ability that deterministically changes the
   current block-editor canvas. It does not save or publish the edit, so the result remains visible
-  and reviewable. On current trunk it is owned by the Big Sky fallback provider; the merged-provider
-  seam continues to work when ownership migrates to Agents Manager.
+  and reviewable. Its WebMCP contract supplies item-level schemas for updates, insertions, and
+  deletions, strips internal-only arguments, and injects an identity mapping for IDs from the most
+  recent block-tree read. On current trunk it is owned by the Big Sky fallback provider; the
+  merged-provider seam continues to work when ownership migrates to Agents Manager.
 
 An allowlisted ability is still rejected if it is marked server-registered. It must be marked
 client-registered or carry a client callback, which supports both registry-returned provider
@@ -32,8 +39,11 @@ abilities and direct Agents Manager-owned definitions.
 
 1. Open a post, page, or site editor with `?webmcp=1` and the browser's WebMCP testing feature on.
 2. Without opening Agents Manager chat, ask the browser agent to enumerate the page's tools.
-3. Confirm `big_sky__apply_block_edits` is the only tool from this adapter.
-4. Apply a small reversible edit and confirm the canvas changes without being saved or published.
+3. Confirm `agents_manager__get_block_tree` and `big_sky__apply_block_edits` are the only tools from
+   this adapter.
+4. Call `agents_manager__get_block_tree`, choose a returned client ID, then call
+   `big_sky__apply_block_edits` with that ID and a small reversible edit. Confirm the canvas changes
+   without being saved or published.
 5. Confirm the Network panel shows no Agenttic/orchestrator/model request.
 6. Navigate to another editor/site and confirm the tool now targets only the current canvas.
 7. Remove `webmcp=1` and reload; confirm the tool is absent.
@@ -43,6 +53,9 @@ The adapter reconciles the provider every two seconds only while the experiment 
 covers abilities registered by later React effects. Changing scope or unmounting Agents Manager
 aborts all registrations. An already-aborted tool execution is rejected, but an in-flight provider
 execution cannot currently be cancelled because `ToolProvider.executeAbility()` has no signal.
+
+The edit tool should be preceded by a fresh block-tree read. This keeps its targets aligned with the
+current editor and refreshes the identity map used by the Big Sky callback.
 
 To add another tool, verify its complete implementation and execution path are client-only,
 editor-scoped, deterministic, reviewable, non-administrative, and free of model/orchestrator calls.

--- a/packages/agents-manager/WEBMCP.md
+++ b/packages/agents-manager/WEBMCP.md
@@ -17,7 +17,7 @@ the original slash-based ability name through `toolProvider.executeAbility()`. W
 is eligible, the external provider's ability-setup hook also mounts at the stable Agents Manager
 lifecycle so hook-dependent abilities can register without opening the chat route.
 
-The initial allowlist contains:
+The allowlist contains:
 
 - `agents-manager/get-block-tree`: an Agents Manager-owned, client-only ability that reads the live
   Gutenberg tree. It returns real client IDs, block names, serializable attributes, nesting, the
@@ -31,19 +31,45 @@ The initial allowlist contains:
   recent block-tree read. On current trunk it is owned by the Big Sky fallback provider; the
   merged-provider seam continues to work when ownership migrates to Agents Manager.
 
+- `big-sky/show-template`: an Agents Manager-owned, client-only ability that turns on the editor's
+  Show template mode. Use it when the block-tree result does not contain the requested header or
+  footer, then read the tree again before editing. Repeated calls are safe, and it does not save or
+  publish content. The WebMCP adapter translates the ability's Big Sky-specific next-step reference
+  to `agents_manager__get_block_tree`.
+
 An allowlisted ability is still rejected if it is marked server-registered. It must be marked
 client-registered or carry a client callback, which supports both registry-returned provider
 abilities and direct Agents Manager-owned definitions.
 
 ## Testing
 
+### Codex built-in browser
+
+1. In the ChatGPT desktop app, open the built-in browser and sign in to the test WordPress.com
+   account in that browser profile.
+2. Sandbox `widgets.wp.com` to wpdev and run `WPCOM_SANDBOX=wpdev yarn dev --sync` from
+   `apps/agents-manager`.
+3. Open a post, page, or site editor with `?webmcp=1` using GPT-5.6 Sol or Terra.
+4. Ask Codex to inspect the current page's Site tools. Confirm it discovers
+   `agents_manager__get_block_tree`, `big_sky__show_template`, and
+   `big_sky__apply_block_edits` natively; do not use DevTools or call `document.modelContext`
+   directly for this path.
+5. Call `agents_manager__get_block_tree`. If a requested template part is absent, call
+   `big_sky__show_template`, then read the tree again.
+6. Call `big_sky__apply_block_edits` with a client ID from the latest tree, or insert a small test
+   block on an empty page. Read the tree one final time and confirm the expected block and
+   attributes are present.
+7. Do not publish the page. Discard the test changes or remove any auto-draft the editor created.
+
+### Direct browser API fallback
+
 1. Open a post, page, or site editor with `?webmcp=1` and the browser's WebMCP testing feature on.
-2. Without opening Agents Manager chat, ask the browser agent to enumerate the page's tools.
-3. Confirm `agents_manager__get_block_tree` and `big_sky__apply_block_edits` are the only tools from
-   this adapter.
+2. Without opening Agents Manager chat, enumerate the page's tools through
+   `document.modelContext.getTools()`.
+3. Confirm the same three tools are present.
 4. Call `agents_manager__get_block_tree`, choose a returned client ID, then call
    `big_sky__apply_block_edits` with that ID and a small reversible edit. Confirm the canvas changes
-   without being saved or published.
+   without publishing the page.
 5. Confirm the Network panel shows no Agenttic/orchestrator/model request.
 6. Navigate to another editor/site and confirm the tool now targets only the current canvas.
 7. Remove `webmcp=1` and reload; confirm the tool is absent.

--- a/packages/agents-manager/WEBMCP.md
+++ b/packages/agents-manager/WEBMCP.md
@@ -1,0 +1,50 @@
+# Experimental WebMCP editor tools
+
+Agents Manager can expose a small set of editor abilities to browser agents through the draft
+WebMCP API. The browser agent supplies the model and all reasoning. This adapter does not create an
+Agenttic agent, open Agents Manager chat, or call the WordPress.com AI orchestrator.
+
+This is a staff-testing proof of concept, not a production-supported integration. It is disabled by
+default. Enable it on a supported post, page, or site editor URL with `?webmcp=1` in a browser that
+implements `document.modelContext.registerTool` (or the older `navigator.modelContext` location).
+
+## Execution and exposure
+
+The adapter uses the live merged `ToolProvider` returned by `loadExternalProviders()`. That provider
+combines Agents Manager-owned abilities with external fallback providers, resolves duplicate names
+using the established precedence, and applies the existing canvas guard. WebMCP calls execute with
+the original slash-based ability name through `toolProvider.executeAbility()`. While the experiment
+is eligible, the external provider's ability-setup hook also mounts at the stable Agents Manager
+lifecycle so hook-dependent abilities can register without opening the chat route.
+
+The initial allowlist contains only:
+
+- `big-sky/apply-block-edits`: a client-registered ability that deterministically changes the
+  current block-editor canvas. It does not save or publish the edit, so the result remains visible
+  and reviewable. On current trunk it is owned by the Big Sky fallback provider; the merged-provider
+  seam continues to work when ownership migrates to Agents Manager.
+
+An allowlisted ability is still rejected if it is marked server-registered. It must be marked
+client-registered or carry a client callback, which supports both registry-returned provider
+abilities and direct Agents Manager-owned definitions.
+
+## Testing
+
+1. Open a post, page, or site editor with `?webmcp=1` and the browser's WebMCP testing feature on.
+2. Without opening Agents Manager chat, ask the browser agent to enumerate the page's tools.
+3. Confirm `big_sky__apply_block_edits` is the only tool from this adapter.
+4. Apply a small reversible edit and confirm the canvas changes without being saved or published.
+5. Confirm the Network panel shows no Agenttic/orchestrator/model request.
+6. Navigate to another editor/site and confirm the tool now targets only the current canvas.
+7. Remove `webmcp=1` and reload; confirm the tool is absent.
+8. Use `?webmcp=1&am_abilities=0` to exercise the external-provider ownership path during migration.
+
+The adapter reconciles the provider every two seconds only while the experiment is eligible. This
+covers abilities registered by later React effects. Changing scope or unmounting Agents Manager
+aborts all registrations. An already-aborted tool execution is rejected, but an in-flight provider
+execution cannot currently be cancelled because `ToolProvider.executeAbility()` has no signal.
+
+To add another tool, verify its complete implementation and execution path are client-only,
+editor-scoped, deterministic, reviewable, non-administrative, and free of model/orchestrator calls.
+Then add its original ability name to `WEBMCP_EDITOR_ABILITY_ALLOWLIST` with a concise safety
+rationale and tests proving server lookalikes remain excluded.

--- a/packages/agents-manager/WEBMCP.md
+++ b/packages/agents-manager/WEBMCP.md
@@ -46,6 +46,10 @@ The allowlist contains:
   checks, and authenticated site-specific execution path are preserved. The adapter also includes
   each ability's server-provided instructions in the WebMCP description when present.
 
+- `wpcom/media-create`: an explicitly allowlisted mutating server ability that uploads base64-encoded
+  files to the site's media library after user confirmation. WebMCP sends its input as a JSON POST
+  body and preserves its existing authentication, site capability, MIME validation, and size checks.
+
 Client abilities must be in the editor allowlist and be client-registered or carry a client
 callback. Server abilities must be in the separate server allowlist and marked server-registered;
 neither allowlist grants eligibility to a lookalike from the other provenance.
@@ -60,10 +64,11 @@ neither allowlist grants eligibility to a lookalike from the other provenance.
    `apps/agents-manager`.
 3. Open a post, page, or site editor where the inline Agents Manager data has `isDevMode: true`
    using GPT-5.6 Sol or Terra.
-4. Ask Codex to inspect the current page's Site tools. Confirm it discovers all ten tools:
+4. Ask Codex to inspect the current page's Site tools. Confirm it discovers all eleven tools:
    `agents_manager__get_block_tree`, `big_sky__show_template`, and
    `big_sky__apply_block_edits`, plus `wpcom__get_block_schemas`,
-   `wpcom__get_content_guidelines`, `wpcom__get_posts`, `wpcom__get_site_stats`, and
+   `wpcom__get_content_guidelines`, `wpcom__get_posts`, `wpcom__get_site_stats`,
+   `wpcom__media_create`, and
    `wpcom__patterns_list`, `wpcom__patterns_get`, and `core__get_site_info`. Do not use DevTools or
    call `document.modelContext` directly for this path.
 5. Call `agents_manager__get_block_tree`. If a requested template part is absent, call
@@ -74,7 +79,10 @@ neither allowlist grants eligibility to a lookalike from the other provenance.
 7. Call `wpcom__patterns_list`, choose a pattern, and fetch it with `wpcom__patterns_get`. Pass its
    `content` to `big_sky__apply_block_edits` as `inserts[0].blockMarkup`, then confirm the pattern's
    blocks appear on the canvas in order.
-8. Do not publish the page. Discard the test changes or remove any auto-draft the editor created.
+8. After confirming the upload with the user, call `wpcom__media_create` with a small test image and
+   confirm its returned attachment ID and URL exist in the site's media library. Delete the test
+   attachment afterward.
+9. Do not publish the page. Discard the test changes or remove any auto-draft the editor created.
 
 ### Direct browser API fallback
 
@@ -82,7 +90,7 @@ neither allowlist grants eligibility to a lookalike from the other provenance.
    on.
 2. Without opening Agents Manager chat, enumerate the page's tools through
    `document.modelContext.getTools()`.
-3. Confirm the same ten tools are present and that the seven server tools expose input schemas.
+3. Confirm the same eleven tools are present and that the eight server tools expose input schemas.
 4. Call `agents_manager__get_block_tree`, choose a returned client ID, then call
    `big_sky__apply_block_edits` with that ID and a small reversible edit. Confirm the canvas changes
    without publishing the page.

--- a/packages/agents-manager/WEBMCP.md
+++ b/packages/agents-manager/WEBMCP.md
@@ -37,9 +37,15 @@ The allowlist contains:
   publish content. The WebMCP adapter translates the ability's Big Sky-specific next-step reference
   to `agents_manager__get_block_tree`.
 
-An allowlisted ability is still rejected if it is marked server-registered. It must be marked
-client-registered or carry a client callback, which supports both registry-returned provider
-abilities and direct Agents Manager-owned definitions.
+- `wpcom/get-block-schemas`, `wpcom/get-content-guidelines`, `wpcom/get-posts`,
+  `wpcom/get-site-stats`, and `core/get-site-info`: read-only server abilities registered by
+  Gutenberg from the current site's Abilities REST API. Their existing input schemas, permission
+  checks, and authenticated site-specific execution path are preserved. The adapter also includes
+  each ability's server-provided instructions in the WebMCP description when present.
+
+Client abilities must be in the editor allowlist and be client-registered or carry a client
+callback. Server abilities must be in the separate server allowlist and marked server-registered;
+neither allowlist grants eligibility to a lookalike from the other provenance.
 
 ## Testing
 
@@ -50,10 +56,12 @@ abilities and direct Agents Manager-owned definitions.
 2. Sandbox `widgets.wp.com` to wpdev and run `WPCOM_SANDBOX=wpdev yarn dev --sync` from
    `apps/agents-manager`.
 3. Open a post, page, or site editor with `?webmcp=1` using GPT-5.6 Sol or Terra.
-4. Ask Codex to inspect the current page's Site tools. Confirm it discovers
+4. Ask Codex to inspect the current page's Site tools. Confirm it discovers all eight tools:
    `agents_manager__get_block_tree`, `big_sky__show_template`, and
-   `big_sky__apply_block_edits` natively; do not use DevTools or call `document.modelContext`
-   directly for this path.
+   `big_sky__apply_block_edits`, plus `wpcom__get_block_schemas`,
+   `wpcom__get_content_guidelines`, `wpcom__get_posts`, `wpcom__get_site_stats`, and
+   `core__get_site_info`. Do not use DevTools or call `document.modelContext` directly for this
+   path.
 5. Call `agents_manager__get_block_tree`. If a requested template part is absent, call
    `big_sky__show_template`, then read the tree again.
 6. Call `big_sky__apply_block_edits` with a client ID from the latest tree, or insert a small test
@@ -66,7 +74,7 @@ abilities and direct Agents Manager-owned definitions.
 1. Open a post, page, or site editor with `?webmcp=1` and the browser's WebMCP testing feature on.
 2. Without opening Agents Manager chat, enumerate the page's tools through
    `document.modelContext.getTools()`.
-3. Confirm the same three tools are present.
+3. Confirm the same eight tools are present and that the five server tools expose input schemas.
 4. Call `agents_manager__get_block_tree`, choose a returned client ID, then call
    `big_sky__apply_block_edits` with that ID and a small reversible edit. Confirm the canvas changes
    without publishing the page.
@@ -83,7 +91,7 @@ execution cannot currently be cancelled because `ToolProvider.executeAbility()` 
 The edit tool should be preceded by a fresh block-tree read. This keeps its targets aligned with the
 current editor and refreshes the identity map used by the Big Sky callback.
 
-To add another tool, verify its complete implementation and execution path are client-only,
-editor-scoped, deterministic, reviewable, non-administrative, and free of model/orchestrator calls.
-Then add its original ability name to `WEBMCP_EDITOR_ABILITY_ALLOWLIST` with a concise safety
-rationale and tests proving server lookalikes remain excluded.
+To add another tool, verify its complete implementation, permissions, annotations, and execution
+path. Add client tools to `WEBMCP_EDITOR_ABILITY_ALLOWLIST` or REST-backed tools to
+`WEBMCP_SERVER_ABILITY_NAMES`, with tests proving the opposite provenance and unlisted abilities
+remain excluded.

--- a/packages/agents-manager/src/abilities/__tests__/index.test.ts
+++ b/packages/agents-manager/src/abilities/__tests__/index.test.ts
@@ -328,6 +328,9 @@ describe( 'registerEditorAbilities', () => {
 
 		expect( registerAbility ).toHaveBeenCalledTimes( editorAbilities.getEditorAbilities().length );
 		expect( registerAbility ).toHaveBeenCalledWith(
+			expect.objectContaining( { name: 'agents-manager/get-block-tree' } )
+		);
+		expect( registerAbility ).toHaveBeenCalledWith(
 			expect.objectContaining( { name: 'big-sky/restore-checkpoint' } )
 		);
 		expect( registerAbility ).toHaveBeenCalledWith(
@@ -348,13 +351,13 @@ describe( 'registerEditorAbilities', () => {
 	it( 'replaces a provider copy when the name is already registered', async () => {
 		const { editorAbilities, getAbility, registerAbility, unregisterAbility } = await load();
 		registerAbility.mockRejectedValueOnce(
-			new Error( 'Ability "big-sky/restore-checkpoint" is already registered' )
+			new Error( 'Ability "agents-manager/get-block-tree" is already registered' )
 		);
-		getAbility.mockReturnValue( { name: 'big-sky/restore-checkpoint' } );
+		getAbility.mockReturnValue( { name: 'agents-manager/get-block-tree' } );
 
 		await editorAbilities.registerEditorAbilities();
 
-		expect( unregisterAbility ).toHaveBeenCalledWith( 'big-sky/restore-checkpoint' );
+		expect( unregisterAbility ).toHaveBeenCalledWith( 'agents-manager/get-block-tree' );
 		// One extra call: the collision is retried after unregistering.
 		expect( registerAbility ).toHaveBeenCalledTimes(
 			editorAbilities.getEditorAbilities().length + 1

--- a/packages/agents-manager/src/abilities/editor-abilities.ts
+++ b/packages/agents-manager/src/abilities/editor-abilities.ts
@@ -12,6 +12,7 @@ import {
 	unregisterAbility,
 } from '@wordpress/abilities';
 import { BIG_SKY_ABILITY_CATEGORY } from './constants';
+import { getBlockTreeAbility } from './get-block-tree';
 import { restoreCheckpointAbility } from './restore-checkpoint';
 import { setSiteLogoAbility } from './set-site-logo';
 import { showComponentAbility } from './show-component';
@@ -21,6 +22,7 @@ import type { Ability } from './types';
 // Editor abilities. Migrating an editor ability from Big Sky = add its folder
 // under `abilities/` and list it here.
 const EDITOR_ABILITIES: Ability[] = [
+	getBlockTreeAbility,
 	restoreCheckpointAbility,
 	setSiteLogoAbility,
 	showComponentAbility,

--- a/packages/agents-manager/src/abilities/get-block-tree/__tests__/callback.test.ts
+++ b/packages/agents-manager/src/abilities/get-block-tree/__tests__/callback.test.ts
@@ -1,0 +1,93 @@
+import { select } from '@wordpress/data';
+import { getBlockTreeCallback } from '../callback';
+
+jest.mock( '@wordpress/data', () => ( { select: jest.fn() } ) );
+
+const mockedSelect = select as jest.Mock;
+
+describe( 'getBlockTreeCallback', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'returns a serializable recursive tree and the current selection', async () => {
+		const paragraph = {
+			clientId: 'paragraph-1',
+			name: 'core/paragraph',
+			attributes: { content: 'Hello' },
+			innerBlocks: [],
+		};
+		const group = {
+			clientId: 'group-1',
+			name: 'core/group',
+			attributes: { layout: { type: 'constrained' } },
+			innerBlocks: [],
+		};
+		mockedSelect.mockReturnValue( {
+			getSelectedBlockClientId: () => 'paragraph-1',
+			getBlocks: ( clientId?: string ) => ( clientId === 'group-1' ? [ paragraph ] : [ group ] ),
+		} );
+
+		await expect( getBlockTreeCallback() ).resolves.toMatchObject( {
+			result: {
+				success: true,
+				details: {
+					selectedBlockClientId: 'paragraph-1',
+					blockCount: 2,
+					blocks: [
+						{
+							clientId: 'group-1',
+							name: 'core/group',
+							innerBlocks: [
+								{
+									clientId: 'paragraph-1',
+									name: 'core/paragraph',
+									attributes: { content: 'Hello' },
+								},
+							],
+						},
+					],
+				},
+			},
+			returnToAgent: true,
+		} );
+	} );
+
+	it( 'falls back to block-owned children and avoids cycles', async () => {
+		const child = {
+			clientId: 'child-1',
+			name: 'core/paragraph',
+			attributes: {},
+			innerBlocks: [],
+		};
+		const parent = {
+			clientId: 'parent-1',
+			name: 'core/group',
+			attributes: {},
+			innerBlocks: [ child ],
+		};
+		child.innerBlocks = [ parent ] as never[];
+		mockedSelect.mockReturnValue( {
+			getSelectedBlockClientId: () => null,
+			getBlocks: ( clientId?: string ) => ( clientId ? [] : [ parent ] ),
+		} );
+
+		const result = await getBlockTreeCallback();
+		expect( result.result.details ).toMatchObject( {
+			selectedBlockClientId: null,
+			blockCount: 2,
+		} );
+	} );
+
+	it( 'returns a structured error outside the block editor', async () => {
+		mockedSelect.mockReturnValue( undefined );
+
+		await expect( getBlockTreeCallback() ).resolves.toMatchObject( {
+			result: {
+				success: false,
+				error: 'The block editor data store is unavailable.',
+			},
+			returnToAgent: true,
+		} );
+	} );
+} );

--- a/packages/agents-manager/src/abilities/get-block-tree/callback.ts
+++ b/packages/agents-manager/src/abilities/get-block-tree/callback.ts
@@ -1,0 +1,95 @@
+import { select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import type { AbilityResult } from '../types';
+
+type EditorBlock = {
+	clientId: string;
+	name: string;
+	attributes?: Record< string, unknown >;
+	innerBlocks?: EditorBlock[];
+};
+
+type BlockTreeNode = {
+	clientId: string;
+	name: string;
+	attributes: Record< string, unknown >;
+	innerBlocks: BlockTreeNode[];
+};
+
+type BlockEditorSelectors = {
+	getBlocks: ( clientId?: string ) => EditorBlock[];
+	getSelectedBlockClientId: () => string | null;
+};
+
+function cloneAttributes( attributes: Record< string, unknown > | undefined ) {
+	if ( ! attributes ) {
+		return {};
+	}
+
+	return JSON.parse( JSON.stringify( attributes ) ) as Record< string, unknown >;
+}
+
+function readBlockTree(
+	blocks: EditorBlock[],
+	selectors: BlockEditorSelectors,
+	visited: Set< string >
+): { blocks: BlockTreeNode[]; count: number } {
+	let count = 0;
+	const result: BlockTreeNode[] = [];
+
+	for ( const block of blocks ) {
+		if ( ! block?.clientId || visited.has( block.clientId ) ) {
+			continue;
+		}
+
+		visited.add( block.clientId );
+		const children = selectors.getBlocks( block.clientId );
+		const childTree = readBlockTree(
+			children.length ? children : block.innerBlocks || [],
+			selectors,
+			visited
+		);
+
+		result.push( {
+			clientId: block.clientId,
+			name: block.name,
+			attributes: cloneAttributes( block.attributes ),
+			innerBlocks: childTree.blocks,
+		} );
+		count += childTree.count + 1;
+	}
+
+	return { blocks: result, count };
+}
+
+export async function getBlockTreeCallback(): Promise< AbilityResult > {
+	try {
+		const selectors = select( 'core/block-editor' ) as unknown as BlockEditorSelectors | undefined;
+		if ( ! selectors?.getBlocks || ! selectors.getSelectedBlockClientId ) {
+			throw new Error( 'The block editor data store is unavailable.' );
+		}
+
+		const tree = readBlockTree( selectors.getBlocks(), selectors, new Set() );
+		return {
+			result: {
+				success: true,
+				message: __( 'Read the current editor block tree.', __i18n_text_domain__ ),
+				details: {
+					selectedBlockClientId: selectors.getSelectedBlockClientId(),
+					blockCount: tree.count,
+					blocks: tree.blocks,
+				},
+			},
+			returnToAgent: true,
+		};
+	} catch ( error ) {
+		return {
+			result: {
+				success: false,
+				message: __( 'Unable to read the current editor block tree.', __i18n_text_domain__ ),
+				error: error instanceof Error ? error.message : String( error ),
+			},
+			returnToAgent: true,
+		};
+	}
+}

--- a/packages/agents-manager/src/abilities/get-block-tree/index.ts
+++ b/packages/agents-manager/src/abilities/get-block-tree/index.ts
@@ -1,0 +1,68 @@
+import { __ } from '@wordpress/i18n';
+import { BIG_SKY_ABILITY_CATEGORY } from '../constants';
+import { getBlockTreeCallback } from './callback';
+import type { Ability } from '../types';
+
+const BLOCK_TREE_NODE_SCHEMA = {
+	type: 'object',
+	properties: {
+		clientId: { type: 'string' },
+		name: { type: 'string' },
+		attributes: { type: 'object' },
+		innerBlocks: {
+			type: 'array',
+			items: { $ref: '#/$defs/block' },
+		},
+	},
+	required: [ 'clientId', 'name', 'attributes', 'innerBlocks' ],
+} as const;
+
+export const getBlockTreeAbility: Ability = {
+	name: 'agents-manager/get-block-tree',
+	label: __( 'Get Block Tree', __i18n_text_domain__ ),
+	category: BIG_SKY_ABILITY_CATEGORY,
+	description: __(
+		'Reads the current editor block tree, including real client IDs, block names, attributes, nesting, and the selected block. Call this immediately before applying block edits and use the returned client IDs unchanged.',
+		__i18n_text_domain__
+	),
+	input_schema: {
+		type: 'object',
+		properties: {},
+		additionalProperties: false,
+	},
+	output_schema: {
+		type: 'object',
+		properties: {
+			result: {
+				type: 'object',
+				properties: {
+					success: { type: 'boolean' },
+					message: { type: 'string' },
+					details: {
+						type: 'object',
+						properties: {
+							selectedBlockClientId: { type: [ 'string', 'null' ] },
+							blockCount: { type: 'number' },
+							blocks: {
+								type: 'array',
+								items: { $ref: '#/$defs/block' },
+							},
+						},
+						required: [ 'selectedBlockClientId', 'blockCount', 'blocks' ],
+					},
+				},
+				required: [ 'success', 'message', 'details' ],
+			},
+			returnToAgent: { type: 'boolean' },
+		},
+		required: [ 'result', 'returnToAgent' ],
+		$defs: { block: BLOCK_TREE_NODE_SCHEMA },
+	},
+	callback: getBlockTreeCallback,
+	meta: {
+		annotations: {
+			readonly: true,
+			idempotent: true,
+		},
+	},
+};

--- a/packages/agents-manager/src/abilities/show-template/index.ts
+++ b/packages/agents-manager/src/abilities/show-template/index.ts
@@ -61,5 +61,12 @@ export const showTemplateAbility: Ability = {
 		},
 		required: [ 'result', 'returnToAgent' ],
 	},
+	meta: {
+		annotations: {
+			clientRegistered: true,
+			readonly: false,
+			idempotent: true,
+		},
+	},
 	callback: showTemplateCallback,
 };

--- a/packages/agents-manager/src/components/__tests__/agent-setup.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-setup.test.tsx
@@ -46,10 +46,6 @@ jest.mock( '../../utils/create-agent-config', () => ( {
 jest.mock( '../../hooks/use-agent-config', () => ( {
 	useAgentConfig: () => ( { agentId: 'wp-orchestrator', isLoading: false } ),
 } ) );
-jest.mock( '../../hooks/use-abilities-registration', () => ( {
-	__esModule: true,
-	default: jest.fn(),
-} ) );
 jest.mock( '../../hooks/use-open-chat-url-param', () => ( {
 	useOpenChatUrlParam: () => true,
 } ) );
@@ -130,6 +126,19 @@ describe( 'AgentSetup', () => {
 		render( manager( 111 ) );
 
 		await waitFor( () => expect( mockUseAbilitiesSetup ).toHaveBeenCalled() );
+	} );
+
+	it( 'does not mount provider ability setup without WebMCP opt-in', async () => {
+		document.body.className = 'site-editor-php';
+		Object.defineProperty( document, 'modelContext', {
+			configurable: true,
+			value: { registerTool: jest.fn() },
+		} );
+
+		render( manager( 111 ) );
+
+		await waitFor( () => expect( mockCreateAgentConfig ).toHaveBeenCalled() );
+		expect( mockUseAbilitiesSetup ).not.toHaveBeenCalled();
 	} );
 
 	it( 'does not re-initialize while the chat view stays shown', async () => {

--- a/packages/agents-manager/src/components/__tests__/agent-setup.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-setup.test.tsx
@@ -108,6 +108,7 @@ describe( 'AgentSetup', () => {
 		sessionStorage.clear();
 		document.body.className = '';
 		window.history.replaceState( {}, '', '/' );
+		delete ( globalThis as { agentsManagerData?: unknown } ).agentsManagerData;
 		Object.defineProperty( document, 'modelContext', { configurable: true, value: undefined } );
 		setSessionSiteKey( 'no-site' );
 		setSessionUserId( undefined );
@@ -117,7 +118,9 @@ describe( 'AgentSetup', () => {
 		mockIsOpen = false;
 		mockHasAiChatEntry = true;
 		document.body.className = 'site-editor-php';
-		window.history.replaceState( {}, '', '/?webmcp=1' );
+		( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+			isDevMode: true,
+		};
 		Object.defineProperty( document, 'modelContext', {
 			configurable: true,
 			value: { registerTool: jest.fn() },
@@ -128,7 +131,7 @@ describe( 'AgentSetup', () => {
 		await waitFor( () => expect( mockUseAbilitiesSetup ).toHaveBeenCalled() );
 	} );
 
-	it( 'does not mount provider ability setup without WebMCP opt-in', async () => {
+	it( 'does not mount provider ability setup outside development mode', async () => {
 		document.body.className = 'site-editor-php';
 		Object.defineProperty( document, 'modelContext', {
 			configurable: true,

--- a/packages/agents-manager/src/components/__tests__/agent-setup.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-setup.test.tsx
@@ -11,6 +11,7 @@ const mockAgentManager = {
 };
 let mockIsOpen = true;
 let mockHasAiChatEntry = false;
+const mockUseAbilitiesSetup = jest.fn();
 const mockCreateAgentConfig = jest.fn(
 	async ( { sessionId, agentId }: { sessionId: string; agentId: string } ) => ( {
 		agentId,
@@ -45,11 +46,18 @@ jest.mock( '../../utils/create-agent-config', () => ( {
 jest.mock( '../../hooks/use-agent-config', () => ( {
 	useAgentConfig: () => ( { agentId: 'wp-orchestrator', isLoading: false } ),
 } ) );
+jest.mock( '../../hooks/use-abilities-registration', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
 jest.mock( '../../hooks/use-open-chat-url-param', () => ( {
 	useOpenChatUrlParam: () => true,
 } ) );
 jest.mock( '../../utils/load-external-providers', () => ( {
-	loadExternalProviders: async () => ( { providerIds: [] } ),
+	loadExternalProviders: async () => ( {
+		providerIds: [],
+		useAbilitiesSetup: mockUseAbilitiesSetup,
+	} ),
 } ) );
 jest.mock( '../../hooks/use-empty-view-suggestions', () => ( {
 	useEmptyViewSuggestions: () => [],
@@ -102,8 +110,26 @@ describe( 'AgentSetup', () => {
 		mockIsOpen = true;
 		mockHasAiChatEntry = false;
 		sessionStorage.clear();
+		document.body.className = '';
+		window.history.replaceState( {}, '', '/' );
+		Object.defineProperty( document, 'modelContext', { configurable: true, value: undefined } );
 		setSessionSiteKey( 'no-site' );
 		setSessionUserId( undefined );
+	} );
+
+	it( 'mounts provider ability setup for eligible WebMCP without opening chat', async () => {
+		mockIsOpen = false;
+		mockHasAiChatEntry = true;
+		document.body.className = 'site-editor-php';
+		window.history.replaceState( {}, '', '/?webmcp=1' );
+		Object.defineProperty( document, 'modelContext', {
+			configurable: true,
+			value: { registerTool: jest.fn() },
+		} );
+
+		render( manager( 111 ) );
+
+		await waitFor( () => expect( mockUseAbilitiesSetup ).toHaveBeenCalled() );
 	} );
 
 	it( 'does not re-initialize while the chat view stays shown', async () => {

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -9,15 +9,22 @@ import { useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { AgentsManagerContextProvider, useAgentsManagerContext } from '../contexts';
+import useAbilitiesRegistration from '../hooks/use-abilities-registration';
 import { useAgentConfig } from '../hooks/use-agent-config';
 import { useEmptyViewSuggestions } from '../hooks/use-empty-view-suggestions';
 import useHasAiChatEntryButton from '../hooks/use-has-ai-chat-entry-button';
 import { useOpenChatUrlParam } from '../hooks/use-open-chat-url-param';
+import useWebMcpTools from '../hooks/use-webmcp-tools';
 import { AGENTS_MANAGER_STORE } from '../stores';
 import { clearSessionId, getOrCreateSessionId, getSessionId } from '../utils/agent-session';
 import { createAgentConfig } from '../utils/create-agent-config';
 import { isReaderChatAgent } from '../utils/is-reader-chat-agent';
-import { loadExternalProviders, type LoadedProviders } from '../utils/load-external-providers';
+import {
+	loadExternalProviders,
+	type AbilitiesSetupHook,
+	type LoadedProviders,
+} from '../utils/load-external-providers';
+import { canExposeWebMcpTools } from '../webmcp/eligibility';
 import AgentDock from './agent-dock';
 import { PersistentRouter } from './persistent-router';
 import type { JSX } from 'react';
@@ -53,6 +60,30 @@ const EMPTY_ARRAY: string[] = [];
 // manager itself, so a host that unmounts and remounts this tree (Calypso does
 // on some routes) still discards when the remount lands on a different scope.
 let lastInitializedScope: string | undefined;
+
+// External editor abilities currently register from a chat-owned hook. These
+// inert chat actions let that hook mount for WebMCP without starting a chat run.
+const WEBMCP_PROVIDER_SETUP_ACTIONS = {
+	addMessage: () => {},
+	clearMessages: () => {},
+	clearSuggestions: () => {},
+	getAgentManager,
+	isProcessing: false,
+	setIsThinking: () => {},
+	deleteMarkedMessages: () => {},
+	getSessionId: () => undefined,
+	setIsBuildingSite: () => {},
+	setThinkingMessage: () => {},
+} satisfies Parameters< AbilitiesSetupHook >[ 0 ];
+
+function WebMcpProviderAbilitiesSetup( {
+	useProviderAbilitiesSetup,
+}: {
+	useProviderAbilitiesSetup: AbilitiesSetupHook;
+} ): null {
+	useProviderAbilitiesSetup( WEBMCP_PROVIDER_SETUP_ACTIONS );
+	return null;
+}
 
 export default function AgentsManager( {
 	sectionName,
@@ -159,6 +190,14 @@ function AgentSetup( { agentId: hostAgentId }: { agentId?: string } ): JSX.Eleme
 	const { agentId, version, isLoading: isAgentConfigLoading } = useAgentConfig( hostAgentId );
 
 	const sessionId = resolveTabSessionId( isNewChat, agentId, siteKey, userId );
+
+	useAbilitiesRegistration();
+	useWebMcpTools( {
+		toolProvider: loadedProvidersRef.current?.toolProvider,
+		scope: `${ siteKey }:${ currentRoute ?? '' }:${ window.location.pathname }${
+			window.location.search
+		}`,
+	} );
 
 	useEffect( () => {
 		// Wait for the agent config to stabilize before initializing.
@@ -302,17 +341,24 @@ function AgentSetup( { agentId: hostAgentId }: { agentId?: string } ): JSX.Eleme
 	}
 
 	return (
-		<AgentDock
-			emptyViewSuggestions={ emptyViewSuggestions }
-			markdownComponents={ loadedProviders.markdownComponents || {} }
-			markdownExtensions={ loadedProviders.markdownExtensions || {} }
-			useProviderAbilitiesSetup={ loadedProviders.useAbilitiesSetup }
-			useSuggestions={ loadedProviders.useSuggestions }
-			getChatComponent={ loadedProviders.getChatComponent }
-			siteBuildUtils={ loadedProviders.siteBuildUtils }
-			transformMessages={ loadedProviders.transformMessages }
-			useCheckpoint={ loadedProviders.useCheckpoint }
-			capabilities={ loadedProviders.capabilities }
-		/>
+		<>
+			{ loadedProviders.useAbilitiesSetup && canExposeWebMcpTools() && (
+				<WebMcpProviderAbilitiesSetup
+					useProviderAbilitiesSetup={ loadedProviders.useAbilitiesSetup }
+				/>
+			) }
+			<AgentDock
+				emptyViewSuggestions={ emptyViewSuggestions }
+				markdownComponents={ loadedProviders.markdownComponents || {} }
+				markdownExtensions={ loadedProviders.markdownExtensions || {} }
+				useProviderAbilitiesSetup={ loadedProviders.useAbilitiesSetup }
+				useSuggestions={ loadedProviders.useSuggestions }
+				getChatComponent={ loadedProviders.getChatComponent }
+				siteBuildUtils={ loadedProviders.siteBuildUtils }
+				transformMessages={ loadedProviders.transformMessages }
+				useCheckpoint={ loadedProviders.useCheckpoint }
+				capabilities={ loadedProviders.capabilities }
+			/>
+		</>
 	);
 }

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -9,7 +9,6 @@ import { useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { AgentsManagerContextProvider, useAgentsManagerContext } from '../contexts';
-import useAbilitiesRegistration from '../hooks/use-abilities-registration';
 import { useAgentConfig } from '../hooks/use-agent-config';
 import { useEmptyViewSuggestions } from '../hooks/use-empty-view-suggestions';
 import useHasAiChatEntryButton from '../hooks/use-has-ai-chat-entry-button';
@@ -191,7 +190,6 @@ function AgentSetup( { agentId: hostAgentId }: { agentId?: string } ): JSX.Eleme
 
 	const sessionId = resolveTabSessionId( isNewChat, agentId, siteKey, userId );
 
-	useAbilitiesRegistration();
 	useWebMcpTools( {
 		toolProvider: loadedProvidersRef.current?.toolProvider,
 		scope: `${ siteKey }:${ currentRoute ?? '' }:${ window.location.pathname }${

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -22,6 +22,7 @@ import { __ } from '@wordpress/i18n';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
 import { useAgentsManagerContext } from '../../contexts';
 import { useRegisterCustomActions } from '../../hooks/custom-actions';
+import useAbilitiesRegistration from '../../hooks/use-abilities-registration';
 import useAgentTraceIds from '../../hooks/use-agent-trace-ids';
 import { useBroadcastConversationActivity } from '../../hooks/use-broadcast-conversation-activity';
 import { useBroadcastTurnActivity } from '../../hooks/use-broadcast-turn-activity';
@@ -1539,6 +1540,8 @@ export default function OrchestratorChat( {
 		setIsBuildingSite,
 		setThinkingMessage,
 	} );
+
+	useAbilitiesRegistration();
 
 	const displayedMessages = useMemo< AgentsManagerUIMessage[] >( () => {
 		// The stable checkpoint getter reads these values through refs.

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -22,7 +22,6 @@ import { __ } from '@wordpress/i18n';
 import { LOCAL_TOOL_RUNNING_MESSAGE } from '../../constants';
 import { useAgentsManagerContext } from '../../contexts';
 import { useRegisterCustomActions } from '../../hooks/custom-actions';
-import useAbilitiesRegistration from '../../hooks/use-abilities-registration';
 import useAgentTraceIds from '../../hooks/use-agent-trace-ids';
 import { useBroadcastConversationActivity } from '../../hooks/use-broadcast-conversation-activity';
 import { useBroadcastTurnActivity } from '../../hooks/use-broadcast-turn-activity';
@@ -1540,8 +1539,6 @@ export default function OrchestratorChat( {
 		setIsBuildingSite,
 		setThinkingMessage,
 	} );
-
-	useAbilitiesRegistration();
 
 	const displayedMessages = useMemo< AgentsManagerUIMessage[] >( () => {
 		// The stable checkpoint getter reads these values through refs.

--- a/packages/agents-manager/src/hooks/__tests__/use-webmcp-tools.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-webmcp-tools.test.ts
@@ -1,8 +1,11 @@
 import { renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
 import useWebMcpTools from '../use-webmcp-tools';
 import type { Ability } from '../../abilities/types';
 import type { ToolProvider } from '../../extension-types';
 import type { WebMcpTool } from '../../webmcp/types';
+
+jest.mock( '@wordpress/api-fetch' );
 
 const ability: Ability = {
 	name: 'big-sky/apply-block-edits',
@@ -15,6 +18,7 @@ const ability: Ability = {
 
 describe( 'useWebMcpTools', () => {
 	beforeEach( () => {
+		jest.mocked( apiFetch ).mockReset().mockResolvedValue( [] );
 		document.body.className = 'site-editor-php';
 		window.history.replaceState( {}, '', '/?webmcp=1' );
 		Object.defineProperty( navigator, 'modelContext', { configurable: true, value: undefined } );

--- a/packages/agents-manager/src/hooks/__tests__/use-webmcp-tools.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-webmcp-tools.test.ts
@@ -1,0 +1,77 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import useWebMcpTools from '../use-webmcp-tools';
+import type { Ability } from '../../abilities/types';
+import type { ToolProvider } from '../../extension-types';
+import type { WebMcpTool } from '../../webmcp/types';
+
+const ability: Ability = {
+	name: 'big-sky/apply-block-edits',
+	label: 'Apply block edits',
+	description: 'Apply edits to the current block canvas.',
+	category: 'big-sky',
+	input_schema: { type: 'object', properties: {} },
+	meta: { annotations: { clientRegistered: true } },
+};
+
+describe( 'useWebMcpTools', () => {
+	beforeEach( () => {
+		document.body.className = 'site-editor-php';
+		window.history.replaceState( {}, '', '/?webmcp=1' );
+		Object.defineProperty( navigator, 'modelContext', { configurable: true, value: undefined } );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( document, 'modelContext', { configurable: true, value: undefined } );
+	} );
+
+	it( 'registers on mount and clears stale scope registrations', async () => {
+		const registrations: Array< { signal?: AbortSignal; tool: WebMcpTool } > = [];
+		Object.defineProperty( document, 'modelContext', {
+			configurable: true,
+			value: {
+				registerTool: jest.fn( async ( tool: WebMcpTool, options?: { signal?: AbortSignal } ) => {
+					registrations.push( { signal: options?.signal, tool } );
+				} ),
+			},
+		} );
+		const toolProvider: ToolProvider = {
+			getAbilities: jest.fn( async () => [ ability ] ),
+			executeAbility: jest.fn(),
+		};
+
+		const { rerender, unmount } = renderHook(
+			( { scope } ) => useWebMcpTools( { toolProvider, scope } ),
+			{ initialProps: { scope: 'site-1' } }
+		);
+
+		await waitFor( () => expect( registrations ).toHaveLength( 1 ) );
+		expect( registrations[ 0 ].tool.name ).toBe( 'big_sky__apply_block_edits' );
+
+		rerender( { scope: 'site-2' } );
+		await waitFor( () => {
+			expect( registrations[ 0 ].signal?.aborted ).toBe( true );
+			expect( registrations ).toHaveLength( 2 );
+		} );
+
+		unmount();
+		expect( registrations[ 1 ].signal?.aborted ).toBe( true );
+	} );
+
+	it( 'does not load tools while the experiment is disabled', async () => {
+		window.history.replaceState( {}, '', '/' );
+		const registerTool = jest.fn();
+		Object.defineProperty( document, 'modelContext', {
+			configurable: true,
+			value: { registerTool },
+		} );
+		const toolProvider: ToolProvider = {
+			getAbilities: jest.fn( async () => [ ability ] ),
+			executeAbility: jest.fn(),
+		};
+
+		const { unmount } = renderHook( () => useWebMcpTools( { toolProvider, scope: 'site-1' } ) );
+		await Promise.resolve();
+		expect( registerTool ).not.toHaveBeenCalled();
+		unmount();
+	} );
+} );

--- a/packages/agents-manager/src/hooks/__tests__/use-webmcp-tools.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-webmcp-tools.test.ts
@@ -20,11 +20,15 @@ describe( 'useWebMcpTools', () => {
 	beforeEach( () => {
 		jest.mocked( apiFetch ).mockReset().mockResolvedValue( [] );
 		document.body.className = 'site-editor-php';
-		window.history.replaceState( {}, '', '/?webmcp=1' );
+		window.history.replaceState( {}, '', '/' );
+		( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+			isDevMode: true,
+		};
 		Object.defineProperty( navigator, 'modelContext', { configurable: true, value: undefined } );
 	} );
 
 	afterEach( () => {
+		delete ( globalThis as { agentsManagerData?: unknown } ).agentsManagerData;
 		Object.defineProperty( document, 'modelContext', { configurable: true, value: undefined } );
 	} );
 
@@ -61,8 +65,10 @@ describe( 'useWebMcpTools', () => {
 		expect( registrations[ 1 ].signal?.aborted ).toBe( true );
 	} );
 
-	it( 'does not load tools while the experiment is disabled', async () => {
-		window.history.replaceState( {}, '', '/' );
+	it( 'does not load tools outside development mode', async () => {
+		( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+			isDevMode: false,
+		};
 		const registerTool = jest.fn();
 		Object.defineProperty( document, 'modelContext', {
 			configurable: true,

--- a/packages/agents-manager/src/hooks/use-webmcp-tools.ts
+++ b/packages/agents-manager/src/hooks/use-webmcp-tools.ts
@@ -1,0 +1,60 @@
+import { useEffect } from '@wordpress/element';
+import { canExposeWebMcpTools, getWebMcpModelContext } from '../webmcp/eligibility';
+import type { ToolProvider } from '../extension-types';
+
+const RECONCILIATION_INTERVAL_MS = 2000;
+
+export default function useWebMcpTools( {
+	toolProvider,
+	scope,
+}: {
+	toolProvider?: ToolProvider;
+	scope: string;
+} ): void {
+	useEffect( () => {
+		if ( ! toolProvider || ! canExposeWebMcpTools() ) {
+			return;
+		}
+
+		const modelContext = getWebMcpModelContext();
+		if ( ! modelContext ) {
+			return;
+		}
+
+		let disposed = false;
+		let interval: ReturnType< typeof setInterval > | undefined;
+		let adapter: import('../webmcp/types').WebMcpAdapter | undefined;
+
+		import( /* webpackChunkName: "am-webmcp" */ '../webmcp/adapter' )
+			.then( ( { createWebMcpAdapter } ) => {
+				if ( disposed ) {
+					return;
+				}
+
+				adapter = createWebMcpAdapter( { toolProvider, modelContext } );
+				adapter.sync().catch( ( error ) => {
+					// eslint-disable-next-line no-console
+					console.warn( '[AgentsManager] Failed to synchronize WebMCP tools:', error );
+				} );
+
+				interval = setInterval( () => {
+					adapter?.sync().catch( ( error ) => {
+						// eslint-disable-next-line no-console
+						console.warn( '[AgentsManager] Failed to synchronize WebMCP tools:', error );
+					} );
+				}, RECONCILIATION_INTERVAL_MS );
+			} )
+			.catch( ( error ) => {
+				// eslint-disable-next-line no-console
+				console.warn( '[AgentsManager] Failed to load the WebMCP experiment:', error );
+			} );
+
+		return () => {
+			disposed = true;
+			if ( interval ) {
+				clearInterval( interval );
+			}
+			adapter?.dispose();
+		};
+	}, [ scope, toolProvider ] );
+}

--- a/packages/agents-manager/src/hooks/use-webmcp-tools.ts
+++ b/packages/agents-manager/src/hooks/use-webmcp-tools.ts
@@ -26,12 +26,15 @@ export default function useWebMcpTools( {
 		let adapter: import('../webmcp/types').WebMcpAdapter | undefined;
 
 		import( /* webpackChunkName: "am-webmcp" */ '../webmcp/adapter' )
-			.then( ( { createWebMcpAdapter } ) => {
+			.then( ( { createWebMcpAdapter, createWebMcpToolProvider } ) => {
 				if ( disposed ) {
 					return;
 				}
 
-				adapter = createWebMcpAdapter( { toolProvider, modelContext } );
+				adapter = createWebMcpAdapter( {
+					toolProvider: createWebMcpToolProvider( toolProvider ),
+					modelContext,
+				} );
 				adapter.sync().catch( ( error ) => {
 					// eslint-disable-next-line no-console
 					console.warn( '[AgentsManager] Failed to synchronize WebMCP tools:', error );

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { amToolProvider } from '../../abilities';
+import { getBlockTreeAbility } from '../../abilities/get-block-tree';
 import { restoreCheckpointAbility } from '../../abilities/restore-checkpoint';
 import { setSiteLogoAbility } from '../../abilities/set-site-logo';
 import { showComponentAbility } from '../../abilities/show-component';
@@ -218,6 +219,7 @@ describe( 'loadExternalProviders', () => {
 		expect( abilityShapes( await providers.toolProvider?.getAbilities() ) ).toEqual(
 			abilityShapes( [
 				wpAdminNavigateAbility,
+				getBlockTreeAbility,
 				restoreCheckpointAbility,
 				setSiteLogoAbility,
 				showComponentAbility,
@@ -253,6 +255,7 @@ describe( 'loadExternalProviders', () => {
 		expect( abilityShapes( await providers.toolProvider?.getAbilities() ) ).toEqual(
 			abilityShapes( [
 				wpAdminNavigateAbility,
+				getBlockTreeAbility,
 				restoreCheckpointAbility,
 				setSiteLogoAbility,
 				showComponentAbility,
@@ -344,6 +347,7 @@ describe( 'loadExternalProviders', () => {
 		expect( abilityShapes( await providers.toolProvider?.getAbilities() ) ).toEqual(
 			abilityShapes( [
 				wpAdminNavigateAbility,
+				getBlockTreeAbility,
 				restoreCheckpointAbility,
 				setSiteLogoAbility,
 				showComponentAbility,
@@ -820,6 +824,7 @@ describe( 'loadExternalProviders', () => {
 		expect( abilityShapes( await providers.toolProvider?.getAbilities() ) ).toEqual(
 			abilityShapes( [
 				wpAdminNavigateAbility,
+				getBlockTreeAbility,
 				restoreCheckpointAbility,
 				setSiteLogoAbility,
 				showComponentAbility,

--- a/packages/agents-manager/src/webmcp/__tests__/adapter.test.ts
+++ b/packages/agents-manager/src/webmcp/__tests__/adapter.test.ts
@@ -134,6 +134,13 @@ describe( 'WebMCP adapter', () => {
 		).toBe( false );
 		expect(
 			shouldExposeWebMcpAbility(
+				createServerAbility( 'wpcom/get-posts', {
+					meta: { annotations: { serverRegistered: true, readonly: false } },
+				} )
+			)
+		).toBe( false );
+		expect(
+			shouldExposeWebMcpAbility(
 				createAbility( { meta: { annotations: {} }, callback: undefined } )
 			)
 		).toBe( false );

--- a/packages/agents-manager/src/webmcp/__tests__/adapter.test.ts
+++ b/packages/agents-manager/src/webmcp/__tests__/adapter.test.ts
@@ -151,6 +151,13 @@ describe( 'WebMCP adapter', () => {
 		).toBe( false );
 		expect(
 			shouldExposeWebMcpAbility(
+				createServerAbility( 'wpcom/media-create', {
+					meta: { annotations: { serverRegistered: true, readonly: false } },
+				} )
+			)
+		).toBe( true );
+		expect(
+			shouldExposeWebMcpAbility(
 				createAbility( { meta: { annotations: {} }, callback: undefined } )
 			)
 		).toBe( false );

--- a/packages/agents-manager/src/webmcp/__tests__/adapter.test.ts
+++ b/packages/agents-manager/src/webmcp/__tests__/adapter.test.ts
@@ -30,6 +30,17 @@ const createBlockTreeAbility = (): Ability => ( {
 	meta: { annotations: { clientRegistered: true, readonly: true, idempotent: true } },
 } );
 
+const createShowTemplateAbility = (): Ability => ( {
+	name: 'big-sky/show-template',
+	label: 'Show the page template',
+	description: 'Show the page template, then call big_sky__get_page_structure again.',
+	category: 'big-sky',
+	input_schema: { type: 'object', properties: {}, additionalProperties: false },
+	meta: {
+		annotations: { clientRegistered: true, readonly: false, idempotent: true },
+	},
+} );
+
 function createHarness( initialAbilities: Ability[] = [ createAbility() ] ) {
 	let abilities = initialAbilities;
 	const tools = new Map< string, WebMcpTool >();
@@ -78,6 +89,7 @@ describe( 'WebMCP adapter', () => {
 	it( 'requires both the explicit allowlist and client provenance', () => {
 		expect( shouldExposeWebMcpAbility( createAbility() ) ).toBe( true );
 		expect( shouldExposeWebMcpAbility( createBlockTreeAbility() ) ).toBe( true );
+		expect( shouldExposeWebMcpAbility( createShowTemplateAbility() ) ).toBe( true );
 		expect(
 			shouldExposeWebMcpAbility( createAbility( { meta: undefined, callback: jest.fn() } ) )
 		).toBe( true );
@@ -96,6 +108,42 @@ describe( 'WebMCP adapter', () => {
 				createAbility( { meta: { annotations: {} }, callback: undefined } )
 			)
 		).toBe( false );
+	} );
+
+	it( 'maps show-template guidance to the WebMCP block reader', async () => {
+		const harness = createHarness( [ createShowTemplateAbility() ] );
+		( harness.toolProvider.executeAbility as jest.Mock ).mockResolvedValue( {
+			result: {
+				success: true,
+				message: 'The template is showing.',
+				details: {
+					nextStep: 'Call big_sky__get_page_structure again before editing.',
+				},
+			},
+			returnToAgent: true,
+		} );
+		await harness.adapter.sync();
+
+		const tool = harness.tools.get( 'big_sky__show_template' );
+		expect( tool ).toMatchObject( {
+			description: expect.stringContaining( 'agents_manager__get_block_tree' ),
+			inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+			annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+		} );
+		await expect( tool?.execute( {} ) ).resolves.toEqual( {
+			result: {
+				success: true,
+				message: 'The template is showing.',
+				details: {
+					nextStep: 'Call agents_manager__get_block_tree again before editing.',
+				},
+			},
+			returnToAgent: true,
+		} );
+		expect( harness.toolProvider.executeAbility ).toHaveBeenCalledWith(
+			'big-sky/show-template',
+			{}
+		);
 	} );
 
 	it( 'registers mapped metadata and executes through the provider with the original name', async () => {

--- a/packages/agents-manager/src/webmcp/__tests__/adapter.test.ts
+++ b/packages/agents-manager/src/webmcp/__tests__/adapter.test.ts
@@ -1,0 +1,216 @@
+import { createWebMcpAdapter, normalizeInputSchema, shouldExposeWebMcpAbility } from '../adapter';
+import type { Ability } from '../../abilities/types';
+import type { ToolProvider } from '../../extension-types';
+import type { WebMcpModelContext, WebMcpTool } from '../types';
+
+const createAbility = ( overrides: Partial< Ability > = {} ): Ability => ( {
+	name: 'big-sky/apply-block-edits',
+	label: 'Apply block edits',
+	description: 'Apply deterministic edits to the current block canvas.',
+	category: 'big-sky',
+	input_schema: {
+		type: 'object',
+		properties: { edits: { type: 'array' } },
+	},
+	meta: {
+		annotations: {
+			clientRegistered: true,
+			readonly: false,
+		},
+	},
+	...overrides,
+} );
+
+function createHarness( initialAbilities: Ability[] = [ createAbility() ] ) {
+	let abilities = initialAbilities;
+	const tools = new Map< string, WebMcpTool >();
+	const signals = new Map< string, AbortSignal | undefined >();
+	const toolProvider: ToolProvider = {
+		getAbilities: jest.fn( async () => abilities ),
+		executeAbility: jest.fn( async ( _name, input ) => ( { input } ) ),
+	};
+	const modelContext: WebMcpModelContext = {
+		registerTool: jest.fn( async ( tool, options ) => {
+			tools.set( tool.name, tool );
+			signals.set( tool.name, options?.signal );
+		} ),
+	};
+	const adapter = createWebMcpAdapter( { toolProvider, modelContext } );
+
+	return {
+		adapter,
+		modelContext,
+		setAbilities: ( next: Ability[] ) => {
+			abilities = next;
+		},
+		signals,
+		toolProvider,
+		tools,
+	};
+}
+
+describe( 'WebMCP adapter', () => {
+	it( 'normalizes missing and malformed input schemas', () => {
+		expect( normalizeInputSchema( undefined ) ).toEqual( { type: 'object', properties: {} } );
+		expect( normalizeInputSchema( 'invalid' ) ).toEqual( { type: 'object', properties: {} } );
+		expect( normalizeInputSchema( [] ) ).toEqual( { type: 'object', properties: {} } );
+		expect( normalizeInputSchema( { properties: { value: { type: 'string' } } } ) ).toEqual( {
+			properties: { value: { type: 'string' } },
+			type: 'object',
+		} );
+		expect( normalizeInputSchema( { anyOf: [ { type: 'string' } ] } ) ).toEqual( {
+			anyOf: [ { type: 'string' } ],
+		} );
+		expect( normalizeInputSchema( { oneOf: [ { type: 'number' } ] } ) ).toEqual( {
+			oneOf: [ { type: 'number' } ],
+		} );
+	} );
+
+	it( 'requires both the explicit allowlist and client provenance', () => {
+		expect( shouldExposeWebMcpAbility( createAbility() ) ).toBe( true );
+		expect(
+			shouldExposeWebMcpAbility( createAbility( { meta: undefined, callback: jest.fn() } ) )
+		).toBe( true );
+		expect( shouldExposeWebMcpAbility( createAbility( { name: 'big-sky/save-post' } ) ) ).toBe(
+			false
+		);
+		expect(
+			shouldExposeWebMcpAbility(
+				createAbility( {
+					meta: { annotations: { serverRegistered: true, clientRegistered: true } },
+				} )
+			)
+		).toBe( false );
+		expect(
+			shouldExposeWebMcpAbility(
+				createAbility( { meta: { annotations: {} }, callback: undefined } )
+			)
+		).toBe( false );
+	} );
+
+	it( 'registers mapped metadata and executes through the provider with the original name', async () => {
+		const harness = createHarness();
+		await harness.adapter.sync();
+
+		expect( harness.modelContext.registerTool ).toHaveBeenCalledTimes( 1 );
+		const tool = harness.tools.get( 'big_sky__apply_block_edits' );
+		expect( tool ).toMatchObject( {
+			name: 'big_sky__apply_block_edits',
+			title: 'Apply block edits',
+			description: 'Apply deterministic edits to the current block canvas.',
+			inputSchema: {
+				type: 'object',
+				properties: { edits: { type: 'array' } },
+			},
+			annotations: { readOnlyHint: false },
+		} );
+
+		const input = { edits: [ { clientId: 'block-1' } ] };
+		await expect( tool?.execute( input ) ).resolves.toEqual( { input } );
+		expect( harness.toolProvider.executeAbility ).toHaveBeenCalledWith(
+			'big-sky/apply-block-edits',
+			input
+		);
+	} );
+
+	it( 'returns structured provider results without double encoding', async () => {
+		const harness = createHarness();
+		const result = { result: { success: true }, returnToAgent: true };
+		( harness.toolProvider.executeAbility as jest.Mock ).mockResolvedValue( result );
+		await harness.adapter.sync();
+
+		await expect( harness.tools.get( 'big_sky__apply_block_edits' )?.execute( {} ) ).resolves.toBe(
+			result
+		);
+	} );
+
+	it( 'preserves provider execution rejections', async () => {
+		const harness = createHarness();
+		const error = new Error( 'Canvas rejected the edit' );
+		( harness.toolProvider.executeAbility as jest.Mock ).mockRejectedValue( error );
+		await harness.adapter.sync();
+
+		await expect( harness.tools.get( 'big_sky__apply_block_edits' )?.execute( {} ) ).rejects.toBe(
+			error
+		);
+	} );
+
+	it( 'does not dispatch an already-aborted execution', async () => {
+		const harness = createHarness();
+		await harness.adapter.sync();
+		const controller = new AbortController();
+		controller.abort();
+
+		await expect(
+			harness.tools
+				.get( 'big_sky__apply_block_edits' )
+				?.execute( {}, { signal: controller.signal } )
+		).rejects.toMatchObject( { name: 'AbortError' } );
+		expect( harness.toolProvider.executeAbility ).not.toHaveBeenCalled();
+	} );
+
+	it( 'reconciles late, removed, and changed abilities without duplicates', async () => {
+		const harness = createHarness( [] );
+		await harness.adapter.sync();
+		expect( harness.modelContext.registerTool ).not.toHaveBeenCalled();
+
+		harness.setAbilities( [ createAbility() ] );
+		await harness.adapter.sync();
+		await harness.adapter.sync();
+		expect( harness.modelContext.registerTool ).toHaveBeenCalledTimes( 1 );
+
+		const firstSignal = harness.signals.get( 'big_sky__apply_block_edits' );
+		harness.setAbilities( [ createAbility( { description: 'Updated description' } ) ] );
+		await harness.adapter.sync();
+		expect( firstSignal?.aborted ).toBe( true );
+		expect( harness.modelContext.registerTool ).toHaveBeenCalledTimes( 2 );
+
+		const secondSignal = harness.signals.get( 'big_sky__apply_block_edits' );
+		harness.setAbilities( [] );
+		await harness.adapter.sync();
+		expect( secondSignal?.aborted ).toBe( true );
+	} );
+
+	it( 'serializes overlapping synchronization', async () => {
+		const harness = createHarness();
+		let releaseFirst: () => void = () => {};
+		( harness.toolProvider.getAbilities as jest.Mock )
+			.mockImplementationOnce(
+				() =>
+					new Promise< Ability[] >(
+						( resolve ) => ( releaseFirst = () => resolve( [ createAbility() ] ) )
+					)
+			)
+			.mockResolvedValue( [ createAbility() ] );
+
+		const first = harness.adapter.sync();
+		await Promise.resolve();
+		const second = harness.adapter.sync();
+		releaseFirst();
+		await Promise.all( [ first, second ] );
+
+		expect( harness.modelContext.registerTool ).toHaveBeenCalledTimes( 1 );
+		expect( harness.toolProvider.getAbilities ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'disposal unregisters every owned tool', async () => {
+		const harness = createHarness();
+		await harness.adapter.sync();
+		const signal = harness.signals.get( 'big_sky__apply_block_edits' );
+
+		harness.adapter.dispose();
+		expect( signal?.aborted ).toBe( true );
+		await expect( harness.adapter.sync() ).resolves.toBeUndefined();
+	} );
+
+	it( 'surfaces registration failures and can retry them', async () => {
+		const harness = createHarness();
+		( harness.modelContext.registerTool as jest.Mock )
+			.mockRejectedValueOnce( new Error( 'Invalid WebMCP schema' ) )
+			.mockResolvedValueOnce( undefined );
+
+		await expect( harness.adapter.sync() ).rejects.toThrow( 'Invalid WebMCP schema' );
+		await expect( harness.adapter.sync() ).resolves.toBeUndefined();
+		expect( harness.modelContext.registerTool ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/packages/agents-manager/src/webmcp/__tests__/adapter.test.ts
+++ b/packages/agents-manager/src/webmcp/__tests__/adapter.test.ts
@@ -1,4 +1,5 @@
 import { createWebMcpAdapter, normalizeInputSchema, shouldExposeWebMcpAbility } from '../adapter';
+import { WEBMCP_SERVER_ABILITY_NAMES } from '../contracts';
 import type { Ability } from '../../abilities/types';
 import type { ToolProvider } from '../../extension-types';
 import type { WebMcpModelContext, WebMcpTool } from '../types';
@@ -39,6 +40,23 @@ const createShowTemplateAbility = (): Ability => ( {
 	meta: {
 		annotations: { clientRegistered: true, readonly: false, idempotent: true },
 	},
+} );
+
+const createServerAbility = ( name: string, overrides: Partial< Ability > = {} ): Ability => ( {
+	name,
+	label: name,
+	description: `Description for ${ name }`,
+	category: 'wpcom',
+	input_schema: { type: 'object', properties: {} },
+	meta: {
+		annotations: {
+			serverRegistered: true,
+			readonly: true,
+			idempotent: true,
+		},
+		instructions: `Instructions for ${ name }`,
+	},
+	...overrides,
 } );
 
 function createHarness( initialAbilities: Ability[] = [ createAbility() ] ) {
@@ -86,10 +104,13 @@ describe( 'WebMCP adapter', () => {
 		} );
 	} );
 
-	it( 'requires both the explicit allowlist and client provenance', () => {
+	it( 'requires the explicit allowlist and matching client or server provenance', () => {
 		expect( shouldExposeWebMcpAbility( createAbility() ) ).toBe( true );
 		expect( shouldExposeWebMcpAbility( createBlockTreeAbility() ) ).toBe( true );
 		expect( shouldExposeWebMcpAbility( createShowTemplateAbility() ) ).toBe( true );
+		for ( const name of WEBMCP_SERVER_ABILITY_NAMES ) {
+			expect( shouldExposeWebMcpAbility( createServerAbility( name ) ) ).toBe( true );
+		}
 		expect(
 			shouldExposeWebMcpAbility( createAbility( { meta: undefined, callback: jest.fn() } ) )
 		).toBe( true );
@@ -103,11 +124,41 @@ describe( 'WebMCP adapter', () => {
 				} )
 			)
 		).toBe( false );
+		expect( shouldExposeWebMcpAbility( createServerAbility( 'wpcom/delete-site' ) ) ).toBe( false );
+		expect(
+			shouldExposeWebMcpAbility(
+				createServerAbility( 'wpcom/get-posts', {
+					meta: { annotations: { clientRegistered: true } },
+				} )
+			)
+		).toBe( false );
 		expect(
 			shouldExposeWebMcpAbility(
 				createAbility( { meta: { annotations: {} }, callback: undefined } )
 			)
 		).toBe( false );
+	} );
+
+	it( 'registers a server ability with its schema and executes through the provider', async () => {
+		const ability = createServerAbility( 'wpcom/get-posts', {
+			input_schema: {
+				type: 'object',
+				properties: { fields: { type: 'string', enum: [ 'summary', 'full' ] } },
+			},
+		} );
+		const harness = createHarness( [ ability ] );
+		await harness.adapter.sync();
+
+		const tool = harness.tools.get( 'wpcom__get_posts' );
+		expect( tool ).toMatchObject( {
+			description: expect.stringContaining( 'Instructions for wpcom/get-posts' ),
+			inputSchema: ability.input_schema,
+			annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+		} );
+		await tool?.execute( { fields: 'summary' } );
+		expect( harness.toolProvider.executeAbility ).toHaveBeenCalledWith( 'wpcom/get-posts', {
+			fields: 'summary',
+		} );
 	} );
 
 	it( 'maps show-template guidance to the WebMCP block reader', async () => {

--- a/packages/agents-manager/src/webmcp/__tests__/adapter.test.ts
+++ b/packages/agents-manager/src/webmcp/__tests__/adapter.test.ts
@@ -1,8 +1,14 @@
+import * as blocks from '@wordpress/blocks';
 import { createWebMcpAdapter, normalizeInputSchema, shouldExposeWebMcpAbility } from '../adapter';
 import { WEBMCP_SERVER_ABILITY_NAMES } from '../contracts';
 import type { Ability } from '../../abilities/types';
 import type { ToolProvider } from '../../extension-types';
 import type { WebMcpModelContext, WebMcpTool } from '../types';
+
+jest.mock( '@wordpress/blocks', () => ( {
+	...jest.requireActual( '@wordpress/blocks' ),
+	parse: jest.fn(),
+} ) );
 
 const createAbility = ( overrides: Partial< Ability > = {} ): Ability => ( {
 	name: 'big-sky/apply-block-edits',
@@ -88,6 +94,10 @@ function createHarness( initialAbilities: Ability[] = [ createAbility() ] ) {
 }
 
 describe( 'WebMCP adapter', () => {
+	beforeEach( () => {
+		jest.mocked( blocks.parse ).mockReset().mockReturnValue( [] );
+	} );
+
 	it( 'normalizes missing and malformed input schemas', () => {
 		expect( normalizeInputSchema( undefined ) ).toEqual( { type: 'object', properties: {} } );
 		expect( normalizeInputSchema( 'invalid' ) ).toEqual( { type: 'object', properties: {} } );
@@ -301,6 +311,79 @@ describe( 'WebMCP adapter', () => {
 				suppressAssistantMessage: true,
 			}
 		);
+	} );
+
+	it( 'turns pattern markup into ordered block insertions', async () => {
+		jest.mocked( blocks.parse ).mockReturnValue( [
+			{
+				clientId: 'parsed-heading',
+				name: 'core/heading',
+				isValid: true,
+				attributes: { content: 'Pattern heading' },
+				innerBlocks: [],
+			},
+			{
+				clientId: 'parsed-paragraph',
+				name: 'core/paragraph',
+				isValid: true,
+				attributes: { content: 'Pattern copy' },
+				innerBlocks: [],
+			},
+		] );
+		const harness = createHarness();
+		await harness.adapter.sync();
+
+		await harness.tools.get( 'big_sky__apply_block_edits' )?.execute( {
+			inserts: [
+				{
+					parentClientId: 'group-1',
+					index: 2,
+					blockMarkup:
+						'<!-- wp:heading --><h2 class="wp-block-heading">Pattern heading</h2><!-- /wp:heading --><!-- wp:paragraph --><p>Pattern copy</p><!-- /wp:paragraph -->',
+				},
+			],
+			summary: 'Inserted a pattern.',
+		} );
+
+		expect( harness.toolProvider.executeAbility ).toHaveBeenCalledWith(
+			'big-sky/apply-block-edits',
+			{
+				inserts: [
+					{
+						parentClientId: 'group-1',
+						index: 2,
+						block: {
+							name: 'core/heading',
+							attributes: { content: 'Pattern heading' },
+						},
+					},
+					{
+						parentClientId: 'group-1',
+						index: 3,
+						block: {
+							name: 'core/paragraph',
+							attributes: { content: 'Pattern copy' },
+						},
+					},
+				],
+				summary: 'Inserted a pattern.',
+				reverseMap: {},
+				suppressAssistantMessage: true,
+			}
+		);
+		expect( blocks.parse ).toHaveBeenCalledWith( expect.stringContaining( 'Pattern heading' ) );
+	} );
+
+	it( 'rejects empty pattern markup before dispatching the edit', async () => {
+		const harness = createHarness();
+		await harness.adapter.sync();
+
+		await expect(
+			harness.tools.get( 'big_sky__apply_block_edits' )?.execute( {
+				inserts: [ { blockMarkup: '' } ],
+			} )
+		).rejects.toThrow( 'did not contain any Gutenberg blocks' );
+		expect( harness.toolProvider.executeAbility ).not.toHaveBeenCalled();
 	} );
 
 	it( 'returns structured provider results without double encoding', async () => {

--- a/packages/agents-manager/src/webmcp/__tests__/adapter.test.ts
+++ b/packages/agents-manager/src/webmcp/__tests__/adapter.test.ts
@@ -21,6 +21,15 @@ const createAbility = ( overrides: Partial< Ability > = {} ): Ability => ( {
 	...overrides,
 } );
 
+const createBlockTreeAbility = (): Ability => ( {
+	name: 'agents-manager/get-block-tree',
+	label: 'Get block tree',
+	description: 'Read the current editor block tree.',
+	category: 'big-sky',
+	input_schema: { type: 'object', properties: {} },
+	meta: { annotations: { clientRegistered: true, readonly: true, idempotent: true } },
+} );
+
 function createHarness( initialAbilities: Ability[] = [ createAbility() ] ) {
 	let abilities = initialAbilities;
 	const tools = new Map< string, WebMcpTool >();
@@ -68,6 +77,7 @@ describe( 'WebMCP adapter', () => {
 
 	it( 'requires both the explicit allowlist and client provenance', () => {
 		expect( shouldExposeWebMcpAbility( createAbility() ) ).toBe( true );
+		expect( shouldExposeWebMcpAbility( createBlockTreeAbility() ) ).toBe( true );
 		expect(
 			shouldExposeWebMcpAbility( createAbility( { meta: undefined, callback: jest.fn() } ) )
 		).toBe( true );
@@ -97,19 +107,93 @@ describe( 'WebMCP adapter', () => {
 		expect( tool ).toMatchObject( {
 			name: 'big_sky__apply_block_edits',
 			title: 'Apply block edits',
-			description: 'Apply deterministic edits to the current block canvas.',
+			description: expect.stringContaining( 'agents_manager__get_block_tree' ),
 			inputSchema: {
 				type: 'object',
-				properties: { edits: { type: 'array' } },
+				properties: {
+					updates: expect.objectContaining( { type: 'array' } ),
+					inserts: expect.objectContaining( { type: 'array' } ),
+					deletes: expect.objectContaining( {
+						type: 'array',
+						items: { type: 'string' },
+					} ),
+				},
+				additionalProperties: false,
 			},
-			annotations: { readOnlyHint: false },
+			annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: false },
 		} );
 
-		const input = { edits: [ { clientId: 'block-1' } ] };
-		await expect( tool?.execute( input ) ).resolves.toEqual( { input } );
+		const input = {
+			updates: [ { clientId: 'block-1', name: 'core/paragraph', attributes: {} } ],
+			customCSS: 'body { display: none }',
+		};
+		await expect( tool?.execute( input ) ).resolves.toEqual( {
+			input: {
+				updates: input.updates,
+				reverseMap: {},
+				suppressAssistantMessage: true,
+			},
+		} );
 		expect( harness.toolProvider.executeAbility ).toHaveBeenCalledWith(
 			'big-sky/apply-block-edits',
-			input
+			{
+				updates: input.updates,
+				reverseMap: {},
+				suppressAssistantMessage: true,
+			}
+		);
+	} );
+
+	it( 'pairs the block-tree IDs with the edit bridge', async () => {
+		const harness = createHarness( [ createBlockTreeAbility(), createAbility() ] );
+		( harness.toolProvider.executeAbility as jest.Mock ).mockImplementation(
+			async ( name: string, input: unknown ) => {
+				if ( name === 'agents-manager/get-block-tree' ) {
+					return {
+						result: {
+							success: true,
+							details: {
+								blocks: [
+									{
+										clientId: 'group-1',
+										innerBlocks: [ { clientId: 'paragraph-1', innerBlocks: [] } ],
+									},
+								],
+							},
+						},
+						returnToAgent: true,
+					};
+				}
+
+				return { input };
+			}
+		);
+		await harness.adapter.sync();
+
+		const readTool = harness.tools.get( 'agents_manager__get_block_tree' );
+		expect( readTool ).toMatchObject( {
+			annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+		} );
+		await readTool?.execute( {} );
+
+		const editInput = {
+			updates: [
+				{ clientId: 'paragraph-1', name: 'core/paragraph', attributes: { content: 'Updated' } },
+			],
+			summary: 'Updated the paragraph.',
+		};
+		await harness.tools.get( 'big_sky__apply_block_edits' )?.execute( editInput );
+
+		expect( harness.toolProvider.executeAbility ).toHaveBeenLastCalledWith(
+			'big-sky/apply-block-edits',
+			{
+				...editInput,
+				reverseMap: {
+					'group-1': 'group-1',
+					'paragraph-1': 'paragraph-1',
+				},
+				suppressAssistantMessage: true,
+			}
 		);
 	} );
 
@@ -160,7 +244,7 @@ describe( 'WebMCP adapter', () => {
 		expect( harness.modelContext.registerTool ).toHaveBeenCalledTimes( 1 );
 
 		const firstSignal = harness.signals.get( 'big_sky__apply_block_edits' );
-		harness.setAbilities( [ createAbility( { description: 'Updated description' } ) ] );
+		harness.setAbilities( [ createAbility( { label: 'Updated label' } ) ] );
 		await harness.adapter.sync();
 		expect( firstSignal?.aborted ).toBe( true );
 		expect( harness.modelContext.registerTool ).toHaveBeenCalledTimes( 2 );

--- a/packages/agents-manager/src/webmcp/__tests__/eligibility.test.ts
+++ b/packages/agents-manager/src/webmcp/__tests__/eligibility.test.ts
@@ -8,14 +8,25 @@ describe( 'WebMCP eligibility', () => {
 	beforeEach( () => {
 		document.body.className = 'site-editor-php';
 		window.history.replaceState( {}, '', '/' );
+		delete ( globalThis as { agentsManagerData?: unknown } ).agentsManagerData;
 		Object.defineProperty( document, 'modelContext', { configurable: true, value: undefined } );
 		Object.defineProperty( navigator, 'modelContext', { configurable: true, value: undefined } );
 	} );
 
-	it( 'is default-off and requires the exact query opt-in', () => {
-		expect( isWebMcpExperimentEnabled( '' ) ).toBe( false );
-		expect( isWebMcpExperimentEnabled( '?webmcp=0' ) ).toBe( false );
-		expect( isWebMcpExperimentEnabled( '?webmcp=1' ) ).toBe( true );
+	it( 'is default-off and uses the server-provided development mode', () => {
+		expect( isWebMcpExperimentEnabled() ).toBe( false );
+
+		window.history.replaceState( {}, '', '/?webmcp=1' );
+		( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+			isDevMode: false,
+		};
+		expect( isWebMcpExperimentEnabled() ).toBe( false );
+
+		window.history.replaceState( {}, '', '/' );
+		( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+			isDevMode: true,
+		};
+		expect( isWebMcpExperimentEnabled() ).toBe( true );
 	} );
 
 	it( 'prefers document.modelContext and falls back to navigator.modelContext', () => {
@@ -32,12 +43,16 @@ describe( 'WebMCP eligibility', () => {
 	} );
 
 	it( 'is a no-op in unsupported browsers', () => {
-		window.history.replaceState( {}, '', '/?webmcp=1' );
+		( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+			isDevMode: true,
+		};
 		expect( canExposeWebMcpTools() ).toBe( false );
 	} );
 
 	it( 'is a no-op on non-editor routes', () => {
-		window.history.replaceState( {}, '', '/?webmcp=1' );
+		( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+			isDevMode: true,
+		};
 		document.body.className = 'wp-admin';
 		Object.defineProperty( document, 'modelContext', {
 			configurable: true,
@@ -47,7 +62,9 @@ describe( 'WebMCP eligibility', () => {
 	} );
 
 	it( 'qualifies only when enabled in a supported editor and browser', () => {
-		window.history.replaceState( {}, '', '/?webmcp=1' );
+		( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+			isDevMode: true,
+		};
 		Object.defineProperty( document, 'modelContext', {
 			configurable: true,
 			value: { registerTool: jest.fn() },

--- a/packages/agents-manager/src/webmcp/__tests__/eligibility.test.ts
+++ b/packages/agents-manager/src/webmcp/__tests__/eligibility.test.ts
@@ -1,0 +1,57 @@
+import {
+	canExposeWebMcpTools,
+	getWebMcpModelContext,
+	isWebMcpExperimentEnabled,
+} from '../eligibility';
+
+describe( 'WebMCP eligibility', () => {
+	beforeEach( () => {
+		document.body.className = 'site-editor-php';
+		window.history.replaceState( {}, '', '/' );
+		Object.defineProperty( document, 'modelContext', { configurable: true, value: undefined } );
+		Object.defineProperty( navigator, 'modelContext', { configurable: true, value: undefined } );
+	} );
+
+	it( 'is default-off and requires the exact query opt-in', () => {
+		expect( isWebMcpExperimentEnabled( '' ) ).toBe( false );
+		expect( isWebMcpExperimentEnabled( '?webmcp=0' ) ).toBe( false );
+		expect( isWebMcpExperimentEnabled( '?webmcp=1' ) ).toBe( true );
+	} );
+
+	it( 'prefers document.modelContext and falls back to navigator.modelContext', () => {
+		const documentContext = { registerTool: jest.fn() };
+		const navigatorContext = { registerTool: jest.fn() };
+
+		expect(
+			getWebMcpModelContext( { modelContext: documentContext }, { modelContext: navigatorContext } )
+		).toBe( documentContext );
+		expect(
+			getWebMcpModelContext( { modelContext: undefined }, { modelContext: navigatorContext } )
+		).toBe( navigatorContext );
+		expect( getWebMcpModelContext( {}, {} ) ).toBeUndefined();
+	} );
+
+	it( 'is a no-op in unsupported browsers', () => {
+		window.history.replaceState( {}, '', '/?webmcp=1' );
+		expect( canExposeWebMcpTools() ).toBe( false );
+	} );
+
+	it( 'is a no-op on non-editor routes', () => {
+		window.history.replaceState( {}, '', '/?webmcp=1' );
+		document.body.className = 'wp-admin';
+		Object.defineProperty( document, 'modelContext', {
+			configurable: true,
+			value: { registerTool: jest.fn() },
+		} );
+		expect( canExposeWebMcpTools() ).toBe( false );
+	} );
+
+	it( 'qualifies only when enabled in a supported editor and browser', () => {
+		window.history.replaceState( {}, '', '/?webmcp=1' );
+		Object.defineProperty( document, 'modelContext', {
+			configurable: true,
+			value: { registerTool: jest.fn() },
+		} );
+		expect( canExposeWebMcpTools() ).toBe( true );
+	} );
+} );

--- a/packages/agents-manager/src/webmcp/__tests__/server-ability-provider.test.ts
+++ b/packages/agents-manager/src/webmcp/__tests__/server-ability-provider.test.ts
@@ -23,6 +23,15 @@ const serverAbility: Ability = {
 	meta: { annotations: { readonly: true, idempotent: true } },
 };
 
+const mutatingServerAbility: Ability = {
+	name: 'wpcom/media-create',
+	label: 'Upload media',
+	description: 'Upload media to this site.',
+	category: 'wpcom',
+	input_schema: { type: 'object', properties: {} },
+	meta: { annotations: { readonly: false, destructive: false, idempotent: false } },
+};
+
 describe( 'WebMCP server ability provider', () => {
 	beforeEach( () => {
 		jest.mocked( apiFetch ).mockReset();
@@ -98,6 +107,36 @@ describe( 'WebMCP server ability provider', () => {
 		expect( apiFetch ).toHaveBeenLastCalledWith( {
 			method: 'GET',
 			path: expect.stringMatching( /wp-abilities\/v1\/abilities\/wpcom\/get-posts\/run/ ),
+		} );
+		expect( toolProvider.executeAbility ).not.toHaveBeenCalled();
+	} );
+
+	it( 'executes mutating server abilities through POST with a JSON body', async () => {
+		jest
+			.mocked( apiFetch )
+			.mockResolvedValueOnce( [ mutatingServerAbility ] )
+			.mockResolvedValueOnce( { data: { id: 123, source_url: 'https://example.com/image.jpg' } } );
+		const toolProvider: ToolProvider = {
+			getAbilities: jest.fn( async () => [ clientAbility ] ),
+			executeAbility: jest.fn(),
+		};
+		const provider = createWebMcpToolProvider( toolProvider );
+		const input = {
+			wpcom_site: 'example.wordpress.com',
+			file_content_base64: 'aW1hZ2U=',
+			filename: 'image.jpg',
+			mime_type: 'image/jpeg',
+			user_confirmed: true,
+		};
+
+		await provider.executeAbility( 'wpcom/media-create', input );
+
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			method: 'POST',
+			path: expect.stringMatching(
+				/wp-abilities\/v1\/abilities\/wpcom\/media-create\/run.*webmcp=1/
+			),
+			data: { input },
 		} );
 		expect( toolProvider.executeAbility ).not.toHaveBeenCalled();
 	} );

--- a/packages/agents-manager/src/webmcp/__tests__/server-ability-provider.test.ts
+++ b/packages/agents-manager/src/webmcp/__tests__/server-ability-provider.test.ts
@@ -1,0 +1,136 @@
+import apiFetch from '@wordpress/api-fetch';
+import { createWebMcpToolProvider } from '../server-ability-provider';
+import type { Ability } from '../../abilities/types';
+import type { ToolProvider } from '../../extension-types';
+
+jest.mock( '@wordpress/api-fetch' );
+
+const clientAbility: Ability = {
+	name: 'agents-manager/get-block-tree',
+	label: 'Get block tree',
+	description: 'Read the editor block tree.',
+	category: 'big-sky',
+	input_schema: { type: 'object', properties: {} },
+	meta: { annotations: { clientRegistered: true } },
+};
+
+const serverAbility: Ability = {
+	name: 'wpcom/get-posts',
+	label: 'Get posts',
+	description: 'Get posts from this site.',
+	category: 'wpcom',
+	input_schema: { type: 'object', properties: {} },
+	meta: { annotations: { readonly: true, idempotent: true } },
+};
+
+describe( 'WebMCP server ability provider', () => {
+	beforeEach( () => {
+		jest.mocked( apiFetch ).mockReset();
+	} );
+
+	it( 'adds only allowlisted REST abilities and marks their provenance', async () => {
+		jest
+			.mocked( apiFetch )
+			.mockResolvedValueOnce( [ serverAbility, { ...serverAbility, name: 'wpcom/delete-site' } ] );
+		const toolProvider: ToolProvider = {
+			getAbilities: jest.fn( async () => [ clientAbility ] ),
+			executeAbility: jest.fn(),
+		};
+
+		const provider = createWebMcpToolProvider( toolProvider );
+		await expect( provider.getAbilities() ).resolves.toEqual( [
+			clientAbility,
+			{
+				...serverAbility,
+				meta: {
+					...serverAbility.meta,
+					annotations: {
+						...serverAbility.meta?.annotations,
+						serverRegistered: true,
+					},
+				},
+			},
+		] );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: expect.stringContaining( 'webmcp=1' ),
+		} );
+	} );
+
+	it( 'prefers the REST definition when the provider already advertises the ability', async () => {
+		jest.mocked( apiFetch ).mockResolvedValueOnce( [ serverAbility ] );
+		const toolProvider: ToolProvider = {
+			getAbilities: jest.fn( async () => [
+				clientAbility,
+				{
+					...serverAbility,
+					meta: { annotations: { readonly: true } },
+				},
+			] ),
+			executeAbility: jest.fn(),
+		};
+
+		const abilities = await createWebMcpToolProvider( toolProvider ).getAbilities();
+
+		expect( abilities ).toHaveLength( 2 );
+		expect( abilities.find( ( ability ) => ability.name === serverAbility.name ) ).toEqual(
+			expect.objectContaining( {
+				meta: expect.objectContaining( {
+					annotations: expect.objectContaining( { serverRegistered: true } ),
+				} ),
+			} )
+		);
+	} );
+
+	it( 'executes server abilities through the read-only REST route', async () => {
+		jest
+			.mocked( apiFetch )
+			.mockResolvedValueOnce( [ serverAbility ] )
+			.mockResolvedValueOnce( { posts: [] } );
+		const toolProvider: ToolProvider = {
+			getAbilities: jest.fn( async () => [ clientAbility ] ),
+			executeAbility: jest.fn(),
+		};
+		const provider = createWebMcpToolProvider( toolProvider );
+
+		await expect(
+			provider.executeAbility( 'wpcom/get-posts', { fields: 'summary' } )
+		).resolves.toEqual( { posts: [] } );
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			method: 'GET',
+			path: expect.stringMatching( /wp-abilities\/v1\/abilities\/wpcom\/get-posts\/run/ ),
+		} );
+		expect( toolProvider.executeAbility ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps client ability execution on the existing provider', async () => {
+		jest.mocked( apiFetch ).mockResolvedValueOnce( [ serverAbility ] );
+		const toolProvider: ToolProvider = {
+			getAbilities: jest.fn( async () => [ clientAbility ] ),
+			executeAbility: jest.fn( async () => ( { ok: true } ) ),
+		};
+		const provider = createWebMcpToolProvider( toolProvider );
+
+		await expect( provider.executeAbility( clientAbility.name, {} ) ).resolves.toEqual( {
+			ok: true,
+		} );
+		expect( toolProvider.executeAbility ).toHaveBeenCalledWith( clientAbility.name, {} );
+	} );
+
+	it( 'keeps client abilities available when the REST request fails', async () => {
+		jest.mocked( apiFetch ).mockRejectedValueOnce( new Error( 'Request failed' ) );
+		// eslint-disable-next-line no-console
+		const warn = jest.spyOn( console, 'warn' ).mockImplementation();
+		const toolProvider: ToolProvider = {
+			getAbilities: jest.fn( async () => [ clientAbility ] ),
+			executeAbility: jest.fn(),
+		};
+
+		await expect( createWebMcpToolProvider( toolProvider ).getAbilities() ).resolves.toEqual( [
+			clientAbility,
+		] );
+		expect( warn ).toHaveBeenCalledWith(
+			'[AgentsManager] Failed to load WebMCP server abilities:',
+			expect.any( Error )
+		);
+	} );
+} );

--- a/packages/agents-manager/src/webmcp/adapter.ts
+++ b/packages/agents-manager/src/webmcp/adapter.ts
@@ -2,6 +2,7 @@ import { normalizeAbilityName } from '../abilities/ability-name';
 import {
 	APPLY_BLOCK_EDITS_ABILITY_NAME,
 	GET_BLOCK_TREE_ABILITY_NAME,
+	SHOW_TEMPLATE_ABILITY_NAME,
 	getWebMcpDescription,
 	getWebMcpInputSchema,
 } from './contracts';
@@ -22,13 +23,13 @@ type CreateWebMcpAdapterOptions = {
 };
 
 /**
- * The experiment exposes one read-only editor snapshot and one client-side
- * mutation. Execution remains behind the merged provider's permission checks
- * and canvas guard.
+ * Execution remains behind the merged provider's permission checks and canvas
+ * guard.
  */
 export const WEBMCP_EDITOR_ABILITY_ALLOWLIST = new Set( [
 	APPLY_BLOCK_EDITS_ABILITY_NAME,
 	GET_BLOCK_TREE_ABILITY_NAME,
+	SHOW_TEMPLATE_ABILITY_NAME,
 ] );
 
 export function shouldExposeWebMcpAbility( ability: Ability ): boolean {
@@ -119,6 +120,31 @@ function prepareApplyBlockEditsInput(
 	};
 }
 
+function adaptResultForWebMcp( abilityName: string, value: unknown ): unknown {
+	if ( abilityName !== SHOW_TEMPLATE_ABILITY_NAME ) {
+		return value;
+	}
+
+	if ( typeof value === 'string' ) {
+		return value.replaceAll( 'big_sky__get_page_structure', 'agents_manager__get_block_tree' );
+	}
+
+	if ( Array.isArray( value ) ) {
+		return value.map( ( item ) => adaptResultForWebMcp( abilityName, item ) );
+	}
+
+	if ( isRecord( value ) ) {
+		return Object.fromEntries(
+			Object.entries( value ).map( ( [ key, item ] ) => [
+				key,
+				adaptResultForWebMcp( abilityName, item ),
+			] )
+		);
+	}
+
+	return value;
+}
+
 function createTool(
 	ability: Ability,
 	toolProvider: ToolProvider,
@@ -151,7 +177,7 @@ function createTool(
 				rememberBlockClientIds( result, executionContext );
 			}
 
-			return result;
+			return adaptResultForWebMcp( ability.name, result );
 		},
 	};
 }

--- a/packages/agents-manager/src/webmcp/adapter.ts
+++ b/packages/agents-manager/src/webmcp/adapter.ts
@@ -1,3 +1,4 @@
+import { parse } from '@wordpress/blocks';
 import { normalizeAbilityName } from '../abilities/ability-name';
 import {
 	APPLY_BLOCK_EDITS_ABILITY_NAME,
@@ -10,6 +11,7 @@ import {
 import type { Ability } from '../abilities/types';
 import type { ToolProvider } from '../extension-types';
 import type { WebMcpAdapter, WebMcpModelContext, WebMcpTool } from './types';
+import type { Block } from '@wordpress/blocks';
 
 export { createWebMcpToolProvider } from './server-ability-provider';
 
@@ -116,13 +118,37 @@ function prepareApplyBlockEditsInput(
 	input: Record< string, unknown >,
 	context: ExecutionContext
 ): Record< string, unknown > {
+	const toBlockData = ( block: Block ): Record< string, unknown > => ( {
+		name: block.name,
+		attributes: block.attributes,
+		...( block.innerBlocks.length ? { innerBlocks: block.innerBlocks.map( toBlockData ) } : {} ),
+	} );
+	const inserts = Array.isArray( input.inserts )
+		? input.inserts.flatMap( ( insert ) => {
+				if ( ! isRecord( insert ) || typeof insert.blockMarkup !== 'string' ) {
+					return [ insert ];
+				}
+
+				const blocks = parse( insert.blockMarkup );
+				if ( blocks.length === 0 ) {
+					throw new Error( 'The supplied blockMarkup did not contain any Gutenberg blocks.' );
+				}
+
+				const { blockMarkup: _blockMarkup, block: _block, ...placement } = insert;
+				return blocks.map( ( block, offset ) => ( {
+					...placement,
+					...( typeof placement.index === 'number' ? { index: placement.index + offset } : {} ),
+					block: toBlockData( block ),
+				} ) );
+		  } )
+		: undefined;
 	const reverseMap = Object.fromEntries(
 		Array.from( context.knownBlockClientIds, ( clientId ) => [ clientId, clientId ] )
 	);
 
 	return {
 		...( Array.isArray( input.updates ) ? { updates: input.updates } : {} ),
-		...( Array.isArray( input.inserts ) ? { inserts: input.inserts } : {} ),
+		...( inserts ? { inserts } : {} ),
 		...( Array.isArray( input.deletes ) ? { deletes: input.deletes } : {} ),
 		...( typeof input.summary === 'string' ? { summary: input.summary } : {} ),
 		reverseMap,

--- a/packages/agents-manager/src/webmcp/adapter.ts
+++ b/packages/agents-manager/src/webmcp/adapter.ts
@@ -1,0 +1,201 @@
+import { normalizeAbilityName } from '../abilities/ability-name';
+import type { Ability } from '../abilities/types';
+import type { ToolProvider } from '../extension-types';
+import type { WebMcpAdapter, WebMcpModelContext, WebMcpTool } from './types';
+
+type Registration = {
+	abortController: AbortController;
+	fingerprint: string;
+	toolName: string;
+};
+
+type CreateWebMcpAdapterOptions = {
+	toolProvider: ToolProvider;
+	modelContext: WebMcpModelContext;
+	shouldExposeAbility?: ( ability: Ability ) => boolean;
+};
+
+/**
+ * The initial experiment exposes only this client-side editor mutation. It edits
+ * the current canvas without saving or publishing, and execution remains behind
+ * the merged provider's permission checks and canvas guard.
+ */
+export const WEBMCP_EDITOR_ABILITY_ALLOWLIST = new Set( [ 'big-sky/apply-block-edits' ] );
+
+export function shouldExposeWebMcpAbility( ability: Ability ): boolean {
+	if ( ! WEBMCP_EDITOR_ABILITY_ALLOWLIST.has( ability.name ) ) {
+		return false;
+	}
+
+	const annotations = ability.meta?.annotations;
+	if ( annotations?.serverRegistered === true ) {
+		return false;
+	}
+
+	return annotations?.clientRegistered === true || typeof ability.callback === 'function';
+}
+
+export function normalizeInputSchema( schema: unknown ): Record< string, unknown > {
+	if ( ! schema || typeof schema !== 'object' || Array.isArray( schema ) ) {
+		return { type: 'object', properties: {} };
+	}
+
+	const normalized = schema as Record< string, unknown >;
+	if ( ! ( 'type' in normalized ) && ! ( 'anyOf' in normalized ) && ! ( 'oneOf' in normalized ) ) {
+		return { ...normalized, type: 'object' };
+	}
+
+	return normalized;
+}
+
+function createAbortError(): Error {
+	const error = new Error( 'WebMCP tool execution was aborted.' );
+	error.name = 'AbortError';
+	return error;
+}
+
+function createTool( ability: Ability, toolProvider: ToolProvider ): WebMcpTool {
+	return {
+		name: normalizeAbilityName( ability.name ),
+		title: ability.label || ability.name,
+		description: ability.description || ability.label || ability.name,
+		inputSchema: normalizeInputSchema( ability.input_schema ),
+		annotations: {
+			readOnlyHint: ability.meta?.annotations?.readonly === true,
+		},
+		execute: async ( input, options ) => {
+			if ( options?.signal?.aborted ) {
+				throw createAbortError();
+			}
+
+			return toolProvider.executeAbility( ability.name, input ?? {} );
+		},
+	};
+}
+
+function fingerprintTool( tool: WebMcpTool ): string {
+	return JSON.stringify( {
+		name: tool.name,
+		title: tool.title,
+		description: tool.description,
+		inputSchema: tool.inputSchema,
+		annotations: tool.annotations,
+	} );
+}
+
+export function createWebMcpAdapter( {
+	toolProvider,
+	modelContext,
+	shouldExposeAbility = shouldExposeWebMcpAbility,
+}: CreateWebMcpAdapterOptions ): WebMcpAdapter {
+	const registrations = new Map< string, Registration >();
+	const pendingControllers = new Set< AbortController >();
+	let disposed = false;
+	let syncRequested = false;
+	let syncQueue = Promise.resolve();
+
+	const unregister = async ( registration: Registration ): Promise< void > => {
+		registration.abortController.abort();
+
+		if ( modelContext.unregisterTool ) {
+			try {
+				await modelContext.unregisterTool( registration.toolName );
+			} catch {
+				// Aborting the registration signal may already have removed the tool.
+			}
+		}
+	};
+
+	const reconcile = async () => {
+		const abilities = await toolProvider.getAbilities();
+		if ( disposed ) {
+			return;
+		}
+
+		const eligible = new Map(
+			abilities
+				.filter( shouldExposeAbility )
+				.map( ( ability ) => [ ability.name, ability ] as const )
+		);
+
+		for ( const [ abilityName, registration ] of registrations ) {
+			if ( ! eligible.has( abilityName ) ) {
+				await unregister( registration );
+				registrations.delete( abilityName );
+			}
+		}
+
+		for ( const [ abilityName, ability ] of eligible ) {
+			const tool = createTool( ability, toolProvider );
+			const fingerprint = fingerprintTool( tool );
+			const current = registrations.get( abilityName );
+
+			if ( current?.fingerprint === fingerprint ) {
+				continue;
+			}
+
+			if ( current ) {
+				await unregister( current );
+				registrations.delete( abilityName );
+			}
+
+			const abortController = new AbortController();
+			pendingControllers.add( abortController );
+
+			try {
+				await modelContext.registerTool( tool, { signal: abortController.signal } );
+			} catch ( error ) {
+				abortController.abort();
+				throw error;
+			} finally {
+				pendingControllers.delete( abortController );
+			}
+
+			if ( disposed ) {
+				abortController.abort();
+				continue;
+			}
+
+			registrations.set( abilityName, {
+				abortController,
+				fingerprint,
+				toolName: tool.name,
+			} );
+		}
+	};
+
+	const sync = (): Promise< void > => {
+		if ( disposed ) {
+			return Promise.resolve();
+		}
+
+		syncRequested = true;
+		const result = syncQueue.then( async () => {
+			while ( syncRequested && ! disposed ) {
+				syncRequested = false;
+				await reconcile();
+			}
+		} );
+
+		syncQueue = result.catch( () => {} );
+		return result;
+	};
+
+	return {
+		sync,
+		dispose: () => {
+			disposed = true;
+			syncRequested = false;
+
+			for ( const controller of pendingControllers ) {
+				controller.abort();
+			}
+			pendingControllers.clear();
+
+			for ( const registration of registrations.values() ) {
+				void unregister( registration );
+			}
+			registrations.clear();
+		},
+	};
+}

--- a/packages/agents-manager/src/webmcp/adapter.ts
+++ b/packages/agents-manager/src/webmcp/adapter.ts
@@ -3,6 +3,7 @@ import {
 	APPLY_BLOCK_EDITS_ABILITY_NAME,
 	GET_BLOCK_TREE_ABILITY_NAME,
 	SHOW_TEMPLATE_ABILITY_NAME,
+	WEBMCP_SERVER_ABILITY_NAMES,
 	getWebMcpDescription,
 	getWebMcpInputSchema,
 } from './contracts';
@@ -32,12 +33,19 @@ export const WEBMCP_EDITOR_ABILITY_ALLOWLIST = new Set( [
 	SHOW_TEMPLATE_ABILITY_NAME,
 ] );
 
+export const WEBMCP_SERVER_ABILITY_ALLOWLIST = new Set< string >( WEBMCP_SERVER_ABILITY_NAMES );
+
 export function shouldExposeWebMcpAbility( ability: Ability ): boolean {
+	const annotations = ability.meta?.annotations;
+
+	if ( WEBMCP_SERVER_ABILITY_ALLOWLIST.has( ability.name ) ) {
+		return annotations?.serverRegistered === true;
+	}
+
 	if ( ! WEBMCP_EDITOR_ABILITY_ALLOWLIST.has( ability.name ) ) {
 		return false;
 	}
 
-	const annotations = ability.meta?.annotations;
 	if ( annotations?.serverRegistered === true ) {
 		return false;
 	}

--- a/packages/agents-manager/src/webmcp/adapter.ts
+++ b/packages/agents-manager/src/webmcp/adapter.ts
@@ -7,6 +7,7 @@ import {
 	WEBMCP_SERVER_ABILITY_NAMES,
 	getWebMcpDescription,
 	getWebMcpInputSchema,
+	isWebMcpMutatingServerAbilityName,
 } from './contracts';
 import type { Ability } from '../abilities/types';
 import type { ToolProvider } from '../extension-types';
@@ -43,7 +44,10 @@ export function shouldExposeWebMcpAbility( ability: Ability ): boolean {
 	const annotations = ability.meta?.annotations;
 
 	if ( WEBMCP_SERVER_ABILITY_ALLOWLIST.has( ability.name ) ) {
-		return annotations?.serverRegistered === true && annotations.readonly === true;
+		return (
+			annotations?.serverRegistered === true &&
+			( annotations.readonly === true || isWebMcpMutatingServerAbilityName( ability.name ) )
+		);
 	}
 
 	if ( ! WEBMCP_EDITOR_ABILITY_ALLOWLIST.has( ability.name ) ) {

--- a/packages/agents-manager/src/webmcp/adapter.ts
+++ b/packages/agents-manager/src/webmcp/adapter.ts
@@ -11,6 +11,8 @@ import type { Ability } from '../abilities/types';
 import type { ToolProvider } from '../extension-types';
 import type { WebMcpAdapter, WebMcpModelContext, WebMcpTool } from './types';
 
+export { createWebMcpToolProvider } from './server-ability-provider';
+
 type Registration = {
 	abortController: AbortController;
 	fingerprint: string;
@@ -39,7 +41,7 @@ export function shouldExposeWebMcpAbility( ability: Ability ): boolean {
 	const annotations = ability.meta?.annotations;
 
 	if ( WEBMCP_SERVER_ABILITY_ALLOWLIST.has( ability.name ) ) {
-		return annotations?.serverRegistered === true;
+		return annotations?.serverRegistered === true && annotations.readonly === true;
 	}
 
 	if ( ! WEBMCP_EDITOR_ABILITY_ALLOWLIST.has( ability.name ) ) {

--- a/packages/agents-manager/src/webmcp/adapter.ts
+++ b/packages/agents-manager/src/webmcp/adapter.ts
@@ -1,4 +1,10 @@
 import { normalizeAbilityName } from '../abilities/ability-name';
+import {
+	APPLY_BLOCK_EDITS_ABILITY_NAME,
+	GET_BLOCK_TREE_ABILITY_NAME,
+	getWebMcpDescription,
+	getWebMcpInputSchema,
+} from './contracts';
 import type { Ability } from '../abilities/types';
 import type { ToolProvider } from '../extension-types';
 import type { WebMcpAdapter, WebMcpModelContext, WebMcpTool } from './types';
@@ -16,11 +22,14 @@ type CreateWebMcpAdapterOptions = {
 };
 
 /**
- * The initial experiment exposes only this client-side editor mutation. It edits
- * the current canvas without saving or publishing, and execution remains behind
- * the merged provider's permission checks and canvas guard.
+ * The experiment exposes one read-only editor snapshot and one client-side
+ * mutation. Execution remains behind the merged provider's permission checks
+ * and canvas guard.
  */
-export const WEBMCP_EDITOR_ABILITY_ALLOWLIST = new Set( [ 'big-sky/apply-block-edits' ] );
+export const WEBMCP_EDITOR_ABILITY_ALLOWLIST = new Set( [
+	APPLY_BLOCK_EDITS_ABILITY_NAME,
+	GET_BLOCK_TREE_ABILITY_NAME,
+] );
 
 export function shouldExposeWebMcpAbility( ability: Ability ): boolean {
 	if ( ! WEBMCP_EDITOR_ABILITY_ALLOWLIST.has( ability.name ) ) {
@@ -54,21 +63,95 @@ function createAbortError(): Error {
 	return error;
 }
 
-function createTool( ability: Ability, toolProvider: ToolProvider ): WebMcpTool {
+type ExecutionContext = {
+	knownBlockClientIds: Set< string >;
+};
+
+function isRecord( value: unknown ): value is Record< string, unknown > {
+	return !! value && typeof value === 'object' && ! Array.isArray( value );
+}
+
+function rememberBlockClientIds( result: unknown, context: ExecutionContext ): void {
+	if (
+		! isRecord( result ) ||
+		! isRecord( result.result ) ||
+		! isRecord( result.result.details )
+	) {
+		return;
+	}
+
+	const visit = ( blocks: unknown ) => {
+		if ( ! Array.isArray( blocks ) ) {
+			return;
+		}
+
+		for ( const block of blocks ) {
+			if ( ! isRecord( block ) ) {
+				continue;
+			}
+
+			if ( typeof block.clientId === 'string' ) {
+				context.knownBlockClientIds.add( block.clientId );
+			}
+			visit( block.innerBlocks );
+		}
+	};
+
+	context.knownBlockClientIds.clear();
+	visit( result.result.details.blocks );
+}
+
+function prepareApplyBlockEditsInput(
+	input: Record< string, unknown >,
+	context: ExecutionContext
+): Record< string, unknown > {
+	const reverseMap = Object.fromEntries(
+		Array.from( context.knownBlockClientIds, ( clientId ) => [ clientId, clientId ] )
+	);
+
+	return {
+		...( Array.isArray( input.updates ) ? { updates: input.updates } : {} ),
+		...( Array.isArray( input.inserts ) ? { inserts: input.inserts } : {} ),
+		...( Array.isArray( input.deletes ) ? { deletes: input.deletes } : {} ),
+		...( typeof input.summary === 'string' ? { summary: input.summary } : {} ),
+		reverseMap,
+		suppressAssistantMessage: true,
+	};
+}
+
+function createTool(
+	ability: Ability,
+	toolProvider: ToolProvider,
+	executionContext: ExecutionContext
+): WebMcpTool {
 	return {
 		name: normalizeAbilityName( ability.name ),
 		title: ability.label || ability.name,
-		description: ability.description || ability.label || ability.name,
-		inputSchema: normalizeInputSchema( ability.input_schema ),
+		description: getWebMcpDescription( ability ),
+		inputSchema: normalizeInputSchema( getWebMcpInputSchema( ability ) ),
 		annotations: {
 			readOnlyHint: ability.meta?.annotations?.readonly === true,
+			destructiveHint:
+				ability.name === APPLY_BLOCK_EDITS_ABILITY_NAME ||
+				ability.meta?.annotations?.destructive === true,
+			idempotentHint: ability.meta?.annotations?.idempotent === true,
 		},
 		execute: async ( input, options ) => {
 			if ( options?.signal?.aborted ) {
 				throw createAbortError();
 			}
 
-			return toolProvider.executeAbility( ability.name, input ?? {} );
+			const preparedInput =
+				ability.name === APPLY_BLOCK_EDITS_ABILITY_NAME
+					? prepareApplyBlockEditsInput( input ?? {}, executionContext )
+					: input ?? {};
+			const result = await toolProvider.executeAbility( ability.name, preparedInput );
+
+			if ( ability.name === GET_BLOCK_TREE_ABILITY_NAME ) {
+				rememberBlockClientIds( result, executionContext );
+			}
+
+			return result;
 		},
 	};
 }
@@ -90,6 +173,7 @@ export function createWebMcpAdapter( {
 }: CreateWebMcpAdapterOptions ): WebMcpAdapter {
 	const registrations = new Map< string, Registration >();
 	const pendingControllers = new Set< AbortController >();
+	const executionContext: ExecutionContext = { knownBlockClientIds: new Set() };
 	let disposed = false;
 	let syncRequested = false;
 	let syncQueue = Promise.resolve();
@@ -126,7 +210,7 @@ export function createWebMcpAdapter( {
 		}
 
 		for ( const [ abilityName, ability ] of eligible ) {
-			const tool = createTool( ability, toolProvider );
+			const tool = createTool( ability, toolProvider, executionContext );
 			const fingerprint = fingerprintTool( tool );
 			const current = registrations.get( abilityName );
 
@@ -196,6 +280,7 @@ export function createWebMcpAdapter( {
 				void unregister( registration );
 			}
 			registrations.clear();
+			executionContext.knownBlockClientIds.clear();
 		},
 	};
 }

--- a/packages/agents-manager/src/webmcp/contracts.ts
+++ b/packages/agents-manager/src/webmcp/contracts.ts
@@ -1,0 +1,96 @@
+import type { Ability } from '../abilities/types';
+
+export const GET_BLOCK_TREE_ABILITY_NAME = 'agents-manager/get-block-tree';
+export const APPLY_BLOCK_EDITS_ABILITY_NAME = 'big-sky/apply-block-edits';
+
+const BLOCK_DATA_SCHEMA = {
+	type: 'object',
+	properties: {
+		clientId: {
+			type: 'string',
+			description:
+				'Existing block ID returned by agents_manager__get_block_tree. Omit for a new block.',
+		},
+		name: {
+			type: 'string',
+			description: 'Registered block name, for example core/paragraph.',
+		},
+		attributes: {
+			type: 'object',
+			description: 'Complete or partial block attributes to apply.',
+		},
+		innerBlocks: {
+			type: 'array',
+			items: { $ref: '#/$defs/blockData' },
+		},
+	},
+	required: [ 'name' ],
+	additionalProperties: false,
+} as const;
+
+export const APPLY_BLOCK_EDITS_WEBMCP_INPUT_SCHEMA: Record< string, unknown > = {
+	type: 'object',
+	description:
+		'Call agents_manager__get_block_tree immediately before this tool. Use its clientId values unchanged.',
+	properties: {
+		updates: {
+			type: 'array',
+			description: 'Existing blocks to update.',
+			items: {
+				allOf: [
+					{ $ref: '#/$defs/blockData' },
+					{ type: 'object', required: [ 'clientId', 'name' ] },
+				],
+			},
+		},
+		inserts: {
+			type: 'array',
+			description: 'New blocks to insert.',
+			items: {
+				type: 'object',
+				properties: {
+					parentClientId: {
+						type: 'string',
+						description:
+							'Parent ID returned by agents_manager__get_block_tree. Omit for a root insertion.',
+					},
+					index: {
+						type: 'integer',
+						minimum: 0,
+						description: 'Zero-based insertion position.',
+					},
+					block: { $ref: '#/$defs/blockData' },
+				},
+				required: [ 'block' ],
+				additionalProperties: false,
+			},
+		},
+		deletes: {
+			type: 'array',
+			description: 'Block IDs returned by agents_manager__get_block_tree to delete.',
+			items: { type: 'string' },
+		},
+		summary: {
+			type: 'string',
+			description: 'Short description of the changes made.',
+		},
+	},
+	additionalProperties: false,
+	$defs: { blockData: BLOCK_DATA_SCHEMA },
+};
+
+export function getWebMcpInputSchema( ability: Ability ): Record< string, unknown > | undefined {
+	if ( ability.name === APPLY_BLOCK_EDITS_ABILITY_NAME ) {
+		return APPLY_BLOCK_EDITS_WEBMCP_INPUT_SCHEMA;
+	}
+
+	return ability.input_schema;
+}
+
+export function getWebMcpDescription( ability: Ability ): string {
+	if ( ability.name === APPLY_BLOCK_EDITS_ABILITY_NAME ) {
+		return 'Applies deterministic edits to the current block-editor canvas. Call agents_manager__get_block_tree immediately before every edit and use the returned clientId values unchanged. The change remains unsaved and reviewable in the editor.';
+	}
+
+	return ability.description || ability.label || ability.name;
+}

--- a/packages/agents-manager/src/webmcp/contracts.ts
+++ b/packages/agents-manager/src/webmcp/contracts.ts
@@ -8,6 +8,8 @@ export const WEBMCP_SERVER_ABILITY_NAMES = [
 	'wpcom/get-content-guidelines',
 	'wpcom/get-posts',
 	'wpcom/get-site-stats',
+	'wpcom/patterns-list',
+	'wpcom/patterns-get',
 	'core/get-site-info',
 ] as const;
 
@@ -59,7 +61,8 @@ export const APPLY_BLOCK_EDITS_WEBMCP_INPUT_SCHEMA: Record< string, unknown > = 
 		},
 		inserts: {
 			type: 'array',
-			description: 'New blocks to insert.',
+			description:
+				'New blocks to insert. Use blockMarkup with content returned by wpcom__patterns_get to insert a pattern.',
 			items: {
 				type: 'object',
 				properties: {
@@ -74,8 +77,13 @@ export const APPLY_BLOCK_EDITS_WEBMCP_INPUT_SCHEMA: Record< string, unknown > = 
 						description: 'Zero-based insertion position.',
 					},
 					block: { $ref: '#/$defs/blockData' },
+					blockMarkup: {
+						type: 'string',
+						description:
+							'Serialized Gutenberg block markup returned in the content field by wpcom__patterns_get. All top-level blocks are inserted in order.',
+					},
 				},
-				required: [ 'block' ],
+				oneOf: [ { required: [ 'block' ] }, { required: [ 'blockMarkup' ] } ],
 				additionalProperties: false,
 			},
 		},
@@ -103,7 +111,7 @@ export function getWebMcpInputSchema( ability: Ability ): Record< string, unknow
 
 export function getWebMcpDescription( ability: Ability ): string {
 	if ( ability.name === APPLY_BLOCK_EDITS_ABILITY_NAME ) {
-		return 'Applies deterministic edits to the current block-editor canvas. Call agents_manager__get_block_tree immediately before every edit and use the returned clientId values unchanged. The change remains unsaved and reviewable in the editor.';
+		return 'Applies deterministic edits to the current block-editor canvas. Call agents_manager__get_block_tree immediately before every edit and use the returned clientId values unchanged. To insert a block pattern, call wpcom__patterns_list, fetch one with wpcom__patterns_get, then pass its content as an insert blockMarkup value. The change remains unsaved and reviewable in the editor.';
 	}
 
 	if ( ability.name === SHOW_TEMPLATE_ABILITY_NAME ) {

--- a/packages/agents-manager/src/webmcp/contracts.ts
+++ b/packages/agents-manager/src/webmcp/contracts.ts
@@ -3,6 +3,19 @@ import type { Ability } from '../abilities/types';
 export const GET_BLOCK_TREE_ABILITY_NAME = 'agents-manager/get-block-tree';
 export const APPLY_BLOCK_EDITS_ABILITY_NAME = 'big-sky/apply-block-edits';
 export const SHOW_TEMPLATE_ABILITY_NAME = 'big-sky/show-template';
+export const WEBMCP_SERVER_ABILITY_NAMES = [
+	'wpcom/get-block-schemas',
+	'wpcom/get-content-guidelines',
+	'wpcom/get-posts',
+	'wpcom/get-site-stats',
+	'core/get-site-info',
+] as const;
+
+export type WebMcpServerAbilityName = ( typeof WEBMCP_SERVER_ABILITY_NAMES )[ number ];
+
+export function isWebMcpServerAbilityName( name: string ): name is WebMcpServerAbilityName {
+	return ( WEBMCP_SERVER_ABILITY_NAMES as readonly string[] ).includes( name );
+}
 
 const BLOCK_DATA_SCHEMA = {
 	type: 'object',
@@ -97,5 +110,12 @@ export function getWebMcpDescription( ability: Ability ): string {
 		return "Turns on the editor's Show template mode so headers and footers become available to agents_manager__get_block_tree. Use this when the requested header or footer is absent from the block tree, then read the block tree again before editing. This does not unlock a template part that is already visible but locked.";
 	}
 
-	return ability.description || ability.label || ability.name;
+	const description = ability.description || ability.label || ability.name;
+	const instructions = ability.meta?.instructions;
+
+	if ( isWebMcpServerAbilityName( ability.name ) && typeof instructions === 'string' ) {
+		return `${ description }\n\n${ instructions }`;
+	}
+
+	return description;
 }

--- a/packages/agents-manager/src/webmcp/contracts.ts
+++ b/packages/agents-manager/src/webmcp/contracts.ts
@@ -2,6 +2,7 @@ import type { Ability } from '../abilities/types';
 
 export const GET_BLOCK_TREE_ABILITY_NAME = 'agents-manager/get-block-tree';
 export const APPLY_BLOCK_EDITS_ABILITY_NAME = 'big-sky/apply-block-edits';
+export const SHOW_TEMPLATE_ABILITY_NAME = 'big-sky/show-template';
 
 const BLOCK_DATA_SCHEMA = {
 	type: 'object',
@@ -90,6 +91,10 @@ export function getWebMcpInputSchema( ability: Ability ): Record< string, unknow
 export function getWebMcpDescription( ability: Ability ): string {
 	if ( ability.name === APPLY_BLOCK_EDITS_ABILITY_NAME ) {
 		return 'Applies deterministic edits to the current block-editor canvas. Call agents_manager__get_block_tree immediately before every edit and use the returned clientId values unchanged. The change remains unsaved and reviewable in the editor.';
+	}
+
+	if ( ability.name === SHOW_TEMPLATE_ABILITY_NAME ) {
+		return "Turns on the editor's Show template mode so headers and footers become available to agents_manager__get_block_tree. Use this when the requested header or footer is absent from the block tree, then read the block tree again before editing. This does not unlock a template part that is already visible but locked.";
 	}
 
 	return ability.description || ability.label || ability.name;

--- a/packages/agents-manager/src/webmcp/contracts.ts
+++ b/packages/agents-manager/src/webmcp/contracts.ts
@@ -8,15 +8,22 @@ export const WEBMCP_SERVER_ABILITY_NAMES = [
 	'wpcom/get-content-guidelines',
 	'wpcom/get-posts',
 	'wpcom/get-site-stats',
+	'wpcom/media-create',
 	'wpcom/patterns-list',
 	'wpcom/patterns-get',
 	'core/get-site-info',
 ] as const;
 
+export const WEBMCP_MUTATING_SERVER_ABILITY_NAMES = [ 'wpcom/media-create' ] as const;
+
 export type WebMcpServerAbilityName = ( typeof WEBMCP_SERVER_ABILITY_NAMES )[ number ];
 
 export function isWebMcpServerAbilityName( name: string ): name is WebMcpServerAbilityName {
 	return ( WEBMCP_SERVER_ABILITY_NAMES as readonly string[] ).includes( name );
+}
+
+export function isWebMcpMutatingServerAbilityName( name: string ): boolean {
+	return ( WEBMCP_MUTATING_SERVER_ABILITY_NAMES as readonly string[] ).includes( name );
 }
 
 const BLOCK_DATA_SCHEMA = {

--- a/packages/agents-manager/src/webmcp/eligibility.ts
+++ b/packages/agents-manager/src/webmcp/eligibility.ts
@@ -1,3 +1,4 @@
+import { getAgentsManagerInlineData } from '../utils/get-agents-manager-inline-data';
 import { isEditorPage } from '../utils/is-editor-page';
 import type { WebMcpModelContext } from './types';
 
@@ -13,8 +14,8 @@ function isModelContext( value: unknown ): value is WebMcpModelContext {
 	);
 }
 
-export function isWebMcpExperimentEnabled( search = window.location.search ): boolean {
-	return new URLSearchParams( search ).get( 'webmcp' ) === '1';
+export function isWebMcpExperimentEnabled(): boolean {
+	return getAgentsManagerInlineData()?.isDevMode === true;
 }
 
 export function getWebMcpModelContext(

--- a/packages/agents-manager/src/webmcp/eligibility.ts
+++ b/packages/agents-manager/src/webmcp/eligibility.ts
@@ -1,0 +1,41 @@
+import { isEditorPage } from '../utils/is-editor-page';
+import type { WebMcpModelContext } from './types';
+
+type ModelContextHost = {
+	modelContext?: unknown;
+};
+
+function isModelContext( value: unknown ): value is WebMcpModelContext {
+	return (
+		value !== null &&
+		typeof value === 'object' &&
+		typeof ( value as WebMcpModelContext ).registerTool === 'function'
+	);
+}
+
+export function isWebMcpExperimentEnabled( search = window.location.search ): boolean {
+	return new URLSearchParams( search ).get( 'webmcp' ) === '1';
+}
+
+export function getWebMcpModelContext(
+	documentHost: ModelContextHost | undefined = typeof document === 'undefined'
+		? undefined
+		: ( document as unknown as ModelContextHost ),
+	navigatorHost: ModelContextHost | undefined = typeof navigator === 'undefined'
+		? undefined
+		: ( navigator as unknown as ModelContextHost )
+): WebMcpModelContext | undefined {
+	if ( isModelContext( documentHost?.modelContext ) ) {
+		return documentHost.modelContext;
+	}
+
+	if ( isModelContext( navigatorHost?.modelContext ) ) {
+		return navigatorHost.modelContext;
+	}
+
+	return undefined;
+}
+
+export function canExposeWebMcpTools(): boolean {
+	return isWebMcpExperimentEnabled() && isEditorPage() && !! getWebMcpModelContext();
+}

--- a/packages/agents-manager/src/webmcp/server-ability-provider.ts
+++ b/packages/agents-manager/src/webmcp/server-ability-provider.ts
@@ -1,0 +1,91 @@
+import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
+import { WEBMCP_SERVER_ABILITY_NAMES } from './contracts';
+import type { Ability } from '../abilities/types';
+import type { ToolProvider } from '../extension-types';
+
+const SERVER_ABILITY_NAMES = new Set< string >( WEBMCP_SERVER_ABILITY_NAMES );
+
+function markServerRegistered( ability: Ability ): Ability {
+	return {
+		...ability,
+		meta: {
+			...ability.meta,
+			annotations: {
+				...ability.meta?.annotations,
+				serverRegistered: true,
+			},
+		},
+	};
+}
+
+export function createWebMcpToolProvider( toolProvider: ToolProvider ): ToolProvider {
+	let serverAbilitiesPromise: Promise< Ability[] > | undefined;
+	let didWarnAboutServerAbilities = false;
+
+	const getServerAbilities = (): Promise< Ability[] > => {
+		if ( ! serverAbilitiesPromise ) {
+			serverAbilitiesPromise = apiFetch< Ability[] >( {
+				path: addQueryArgs( '/wp-abilities/v1/abilities', {
+					context: 'edit',
+					per_page: -1,
+					webmcp: 1,
+				} ),
+			} )
+				.then( ( abilities ) =>
+					abilities
+						.filter( ( ability ) => SERVER_ABILITY_NAMES.has( ability.name ) )
+						.map( markServerRegistered )
+				)
+				.catch( ( error ) => {
+					serverAbilitiesPromise = undefined;
+					throw error;
+				} );
+		}
+
+		return serverAbilitiesPromise;
+	};
+
+	return {
+		getAbilities: async () => {
+			const abilities = await toolProvider.getAbilities();
+			let serverAbilities: Ability[] = [];
+
+			try {
+				serverAbilities = await getServerAbilities();
+				didWarnAboutServerAbilities = false;
+			} catch ( error ) {
+				if ( ! didWarnAboutServerAbilities ) {
+					// eslint-disable-next-line no-console
+					console.warn( '[AgentsManager] Failed to load WebMCP server abilities:', error );
+					didWarnAboutServerAbilities = true;
+				}
+			}
+
+			const serverNames = new Set( serverAbilities.map( ( ability ) => ability.name ) );
+
+			return [
+				...abilities.filter( ( ability ) => ! serverNames.has( ability.name ) ),
+				...serverAbilities,
+			];
+		},
+		executeAbility: async ( name, input ) => {
+			if ( ! SERVER_ABILITY_NAMES.has( name ) ) {
+				return toolProvider.executeAbility( name, input );
+			}
+
+			const ability = ( await getServerAbilities() ).find( ( item ) => item.name === name );
+			if ( ! ability ) {
+				throw new Error( `WebMCP server ability is unavailable: ${ name }` );
+			}
+
+			return apiFetch( {
+				method: 'GET',
+				path: addQueryArgs( `/wp-abilities/v1/abilities/${ name }/run`, {
+					input,
+					webmcp: 1,
+				} ),
+			} );
+		},
+	};
+}

--- a/packages/agents-manager/src/webmcp/server-ability-provider.ts
+++ b/packages/agents-manager/src/webmcp/server-ability-provider.ts
@@ -79,6 +79,16 @@ export function createWebMcpToolProvider( toolProvider: ToolProvider ): ToolProv
 				throw new Error( `WebMCP server ability is unavailable: ${ name }` );
 			}
 
+			if ( ability.meta?.annotations?.readonly !== true ) {
+				return apiFetch( {
+					method: 'POST',
+					path: addQueryArgs( `/wp-abilities/v1/abilities/${ name }/run`, {
+						webmcp: 1,
+					} ),
+					data: { input },
+				} );
+			}
+
 			return apiFetch( {
 				method: 'GET',
 				path: addQueryArgs( `/wp-abilities/v1/abilities/${ name }/run`, {

--- a/packages/agents-manager/src/webmcp/types.ts
+++ b/packages/agents-manager/src/webmcp/types.ts
@@ -5,6 +5,8 @@ export type WebMcpTool = {
 	inputSchema: Record< string, unknown >;
 	annotations: {
 		readOnlyHint: boolean;
+		destructiveHint?: boolean;
+		idempotentHint?: boolean;
 	};
 	execute: (
 		input: Record< string, unknown >,

--- a/packages/agents-manager/src/webmcp/types.ts
+++ b/packages/agents-manager/src/webmcp/types.ts
@@ -1,0 +1,23 @@
+export type WebMcpTool = {
+	name: string;
+	title?: string;
+	description: string;
+	inputSchema: Record< string, unknown >;
+	annotations: {
+		readOnlyHint: boolean;
+	};
+	execute: (
+		input: Record< string, unknown >,
+		options?: { signal?: AbortSignal }
+	) => Promise< unknown >;
+};
+
+export type WebMcpModelContext = {
+	registerTool: ( tool: WebMcpTool, options?: { signal?: AbortSignal } ) => void | Promise< void >;
+	unregisterTool?: ( name: string ) => void | Promise< void >;
+};
+
+export type WebMcpAdapter = {
+	sync: () => Promise< void >;
+	dispose: () => void;
+};


### PR DESCRIPTION
Part of BSKY-2070

This exposes a deliberately small set of abilities through WebMCP on Gutenberg canvases while Agents Manager reports `isDevMode`. The browser supplies the model and reasoning; the adapter does not start an Agenttic agent or open Agents Manager chat.

<img width="1502" height="950" alt="WebMCP tools running in the editor" src="https://github.com/user-attachments/assets/2ea7a24a-6717-47b1-af33-9a6acfd239bc" />

## Proposed Changes

* Add an editor-only WebMCP adapter behind the existing `isDevMode` check.
* Preserve the existing chat-owned ability-registration lifecycle unless WebMCP is eligible.
* Expose the client-side editor loop through `agents_manager__get_block_tree`, `big_sky__show_template`, and `big_sky__apply_block_edits`.
* Expose seven explicitly allowlisted, read-only server abilities: `wpcom__get_block_schemas`, `wpcom__get_content_guidelines`, `wpcom__get_posts`, `wpcom__get_site_stats`, `wpcom__patterns_list`, `wpcom__patterns_get`, and `core__get_site_info`.
* Expose `wpcom__media_create` as the sole explicitly allowlisted mutating server ability. Mutating calls use POST with a JSON body, while read-only calls remain GET.
* Preserve the media ability's existing confirmation, authentication, site capability, MIME validation, integrity, and size checks.
* Let the WebMCP-only edit schema accept serialized Gutenberg markup returned by `wpcom__patterns_get`, parse it in the browser, and stage all top-level blocks in order.
* Keep the WebMCP tools out of ordinary Agents Manager agent routes and tool configuration. The companion dotcom change is Automattic/wpcom#237669.

### What's next?

1. Keep iterating under the development flag.
2. Validate the flow across Simple, Atomic, and self-hosted Jetpack editors.
3. Decompose more Big Sky use cases into narrow, reusable abilities before broadening exposure.

## Testing Instructions

### Automated

* `yarn jest -c test/packages/jest.config.js --runInBand --testPathPattern=agents-manager`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`
* `yarn eslint packages/agents-manager/src/webmcp/contracts.ts packages/agents-manager/src/webmcp/adapter.ts packages/agents-manager/src/webmcp/server-ability-provider.ts packages/agents-manager/src/webmcp/__tests__/server-ability-provider.test.ts packages/agents-manager/src/webmcp/__tests__/adapter.test.ts`

### Codex built-in browser

1. Sync Automattic/wpcom#237669 to wpdev, including `public-api.wordpress.com` in the sandbox routing.
2. Sandbox `widgets.wp.com` and run `NODE_OPTIONS=--max-old-space-size=8192 WPCOM_SANDBOX=wpdev yarn dev --sync` from `apps/agents-manager`.
3. Sign in to a test site in the Codex built-in browser and open an existing post, page, or site editor while `isDevMode` is true.
4. Ask Codex to inspect the page's Site tools. Confirm it discovers all eleven WebMCP tools, including `wpcom__media_create`, `wpcom__patterns_list`, and `wpcom__patterns_get`.
5. Call `wpcom__patterns_list`, fetch a suitable pattern with `wpcom__patterns_get`, and pass its returned `content` to `big_sky__apply_block_edits` as `inserts[0].blockMarkup`.
6. Read the block tree again and confirm the pattern's top-level blocks were staged in order. Do not publish; remove the test insertion or discard the editor changes.
7. After explicit user confirmation, call `wpcom__media_create` with a small base64-encoded image. Confirm the response includes a valid attachment ID and URL, then delete the test attachment from the media library.
8. Force `isDevMode` false and confirm the editor exposes no WebMCP tools and the base Agents Manager UI still opens, sends a message, and handles history normally.

### Verified

* All 83 Agents Manager suites pass: 1,068 tests.
* The focused WebMCP adapter/provider suites pass: 21 tests.
* `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client` passes.
* Focused ESLint passes.
* On wpdev, the Codex built-in browser discovered the original ten tools on an existing sandboxed page.
* `wpcom__patterns_list` returned the live pattern library and `wpcom__patterns_get` returned the serialized content for `a8c/page-title-1`.
* Passing that exact content to `big_sky__apply_block_edits` staged the complete seven-block pattern (`4 → 11` blocks), then cleanup returned the tree to four blocks without publishing.
* The built-in browser discovered all eleven tools and `wpcom__media_create` successfully uploaded a 68-byte PNG as attachment 617 with the expected ID, URL, MIME, dimensions, alt text, and edit link. The test attachment was deleted and wpdev was restored to read-only mode.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

