### PR TITLE
Pre-launch: gate the direct-launch surfaces behind the confirmation modal

### DIFF
--- a/client/components/pre-launch-site-modal/index.tsx
+++ b/client/components/pre-launch-site-modal/index.tsx
@@ -16,23 +16,32 @@ interface PreLaunchSiteModalProps {
 	siteId: number;
 	isOpen: boolean;
 	onClose: () => void;
-	// Where launch is handed off to. The caller owns this so the destination
-	// (and the `/start/launch-site` path) stays explicit at each call site.
-	launchUrl: string;
+	// Redirect destination for the default surfaces. Optional: surfaces that
+	// launch in place pass `onConfirm`/`onSkip` instead of a URL.
+	launchUrl?: string;
+	// Run on confirm instead of redirecting to `launchUrl`, letting a caller
+	// launch in place (e.g. dispatch `launchSite`).
+	onConfirm?: () => void;
+	// Run for a non-qualifying site instead of redirecting to `launchUrl`, so the
+	// caller keeps ownership of that path (e.g. its own launch thunk).
+	onSkip?: () => void;
 }
 
 /**
  * Gates the classic "launch site" surfaces behind the pre-launch modal.
  *
  * A paid plan + custom domain makes the launch flow auto-skip its steps and
- * launch immediately, so those sites get a confirmation modal first (on confirm
- * we redirect to `launchUrl`). Every other site goes straight to `launchUrl`.
+ * launch immediately, so those sites get a confirmation modal first. Confirming
+ * (and every non-qualifying site) either redirects to `launchUrl` or, for
+ * in-place surfaces, runs the caller's `onConfirm`/`onSkip`.
  */
 function PreLaunchSiteModalContent( {
 	siteId,
 	isOpen,
 	onClose,
 	launchUrl,
+	onConfirm,
+	onSkip,
 }: PreLaunchSiteModalProps ) {
 	const [ isRedirecting, setIsRedirecting ] = useState( false );
 	const [ previewResizeListener, { width: previewWidth, height: previewHeight } ] =
@@ -77,14 +86,17 @@ function PreLaunchSiteModalContent( {
 		if ( decision !== 'pending' || ! isOpen || ! isSettled ) {
 			return;
 		}
-		setDecision( qualifiesForPreLaunch ? 'modal' : 'redirect' );
-	}, [ decision, isOpen, isSettled, qualifiesForPreLaunch ] );
-
-	useEffect( () => {
-		if ( decision === 'redirect' && launchUrl ) {
+		if ( qualifiesForPreLaunch ) {
+			setDecision( 'modal' );
+			return;
+		}
+		setDecision( 'redirect' );
+		if ( onSkip ) {
+			onSkip();
+		} else if ( launchUrl ) {
 			window.location.assign( launchUrl );
 		}
-	}, [ decision, launchUrl ] );
+	}, [ decision, isOpen, isSettled, qualifiesForPreLaunch, onSkip, launchUrl ] );
 
 	if ( decision !== 'modal' || ! isOpen || ! site ) {
 		return null;
@@ -102,7 +114,11 @@ function PreLaunchSiteModalContent( {
 			onClose={ onClose }
 			onLaunch={ () => {
 				setIsRedirecting( true );
-				window.location.assign( launchUrl );
+				if ( onConfirm ) {
+					onConfirm();
+				} else if ( launchUrl ) {
+					window.location.assign( launchUrl );
+				}
 			} }
 			preview={
 				site.URL ? (

--- a/client/components/pre-launch-site-modal/test/index.test.tsx
+++ b/client/components/pre-launch-site-modal/test/index.test.tsx
@@ -180,6 +180,29 @@ describe( 'PreLaunchSiteModal', () => {
 		expect( assign ).not.toHaveBeenCalled();
 	} );
 
+	it( 'runs onConfirm instead of redirecting when the site qualifies', async () => {
+		const user = userEvent.setup();
+		const onConfirm = jest.fn();
+		renderBridge( { onConfirm } );
+
+		await screen.findByTestId( 'pre-launch-modal' );
+		await user.click( screen.getByRole( 'button', { name: 'Yes, launch site!' } ) );
+
+		expect( onConfirm ).toHaveBeenCalledTimes( 1 );
+		expect( assign ).not.toHaveBeenCalled();
+		expect( screen.getByTestId( 'pre-launch-modal' ) ).toHaveAttribute( 'data-launching', 'true' );
+	} );
+
+	it( 'runs onSkip instead of redirecting when the site does not qualify', async () => {
+		mockIsPaid = false;
+		const onSkip = jest.fn();
+		renderBridge( { onSkip } );
+
+		await waitFor( () => expect( onSkip ).toHaveBeenCalledTimes( 1 ) );
+		expect( assign ).not.toHaveBeenCalled();
+		expect( screen.queryByTestId( 'pre-launch-modal' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'redirects straight to the launch flow when the plan is not paid', async () => {
 		mockIsPaid = false;
 

--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx
@@ -8,6 +8,7 @@ import { useEffect, useState } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import QuerySiteChecklist from 'calypso/components/data/query-site-checklist';
+import PreLaunchSiteModal from 'calypso/components/pre-launch-site-modal';
 import useSkipCurrentViewMutation from 'calypso/data/home/use-skip-current-view-mutation';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
 import { getTaskList } from 'calypso/lib/checklist';
@@ -23,7 +24,13 @@ import getSiteChecklist from 'calypso/state/selectors/get-site-checklist';
 import getSites from 'calypso/state/selectors/get-sites';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { useSiteOption } from 'calypso/state/sites/hooks';
-import { getSiteOption, getSiteSlug, getCustomizerUrl } from 'calypso/state/sites/selectors';
+import { launchSite } from 'calypso/state/sites/launch/actions';
+import {
+	getSiteOption,
+	getSiteSlug,
+	getCustomizerUrl,
+	isCurrentPlanPaid,
+} from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CurrentTaskItem from './current-task-item';
 import { getTask } from './get-task';
@@ -33,7 +40,14 @@ import NavItem from './nav-item';
  */
 import './style.scss';
 
-const startTask = ( dispatch, task, siteId, advanceToNextIncompleteTask, isPodcastingSite ) => {
+const startTask = (
+	dispatch,
+	task,
+	siteId,
+	advanceToNextIncompleteTask,
+	isPodcastingSite,
+	openPreLaunch
+) => {
 	dispatch(
 		recordTracksEvent( 'calypso_checklist_task_start', {
 			checklist_name: 'new_blog',
@@ -54,7 +68,14 @@ const startTask = ( dispatch, task, siteId, advanceToNextIncompleteTask, isPodca
 	}
 
 	if ( task.actionDispatch ) {
-		dispatch( task.actionDispatch( ...task.actionDispatchArgs ) );
+		// Paid sites launching from here get the pre-launch confirmation first; the
+		// bridge decides and, if the site doesn't qualify, hands back to the task's
+		// own dispatch via onSkip.
+		if ( task.id === CHECKLIST_KNOWN_TASKS.SITE_LAUNCHED && openPreLaunch ) {
+			openPreLaunch( task );
+		} else {
+			dispatch( task.actionDispatch( ...task.actionDispatchArgs ) );
+		}
 	}
 
 	if ( task.actionAdvanceToNext ) {
@@ -116,6 +137,7 @@ const SiteSetupList = ( {
 	isEmailUnverified,
 	isPodcastingSite,
 	isFSEActive,
+	isPaidPlan,
 	menusUrl,
 	siteId,
 	siteSlug,
@@ -130,9 +152,20 @@ const SiteSetupList = ( {
 	const [ useAccordionLayout, setUseAccordionLayout ] = useState( false );
 	const [ showAccordionSelectedTask, setShowAccordionSelectedTask ] = useState( false );
 	const [ isLoading, setIsLoading ] = useState( false );
+	const [ isPreLaunchModalOpen, setIsPreLaunchModalOpen ] = useState( false );
+	const [ preLaunchTask, setPreLaunchTask ] = useState( null );
 
 	const dispatch = useDispatch();
 	const { skipCurrentView } = useSkipCurrentViewMutation( siteId );
+
+	// Paid sites route the launch task through the pre-launch confirmation; free
+	// sites keep dispatching the task directly (openPreLaunch stays undefined).
+	const openPreLaunch = isPaidPlan
+		? ( task ) => {
+				setPreLaunchTask( task );
+				setIsPreLaunchModalOpen( true );
+		  }
+		: undefined;
 
 	const isDomainUnverified =
 		tasks.filter(
@@ -265,7 +298,8 @@ const SiteSetupList = ( {
 							currentTask,
 							siteId,
 							advanceToNextIncompleteTask,
-							isPodcastingSite
+							isPodcastingSite,
+							openPreLaunch
 						)
 					}
 				/>
@@ -335,7 +369,8 @@ const SiteSetupList = ( {
 												currentTask,
 												siteId,
 												advanceToNextIncompleteTask,
-												isPodcastingSite
+												isPodcastingSite,
+												openPreLaunch
 											)
 										}
 										useAccordionLayout={ useAccordionLayout }
@@ -346,6 +381,21 @@ const SiteSetupList = ( {
 					} ) }
 				</ul>
 			</div>
+			{ isPaidPlan && (
+				<PreLaunchSiteModal
+					siteId={ siteId }
+					isOpen={ isPreLaunchModalOpen }
+					onClose={ () => setIsPreLaunchModalOpen( false ) }
+					onConfirm={ () => {
+						dispatch( launchSite( siteId ) );
+						setIsPreLaunchModalOpen( false );
+					} }
+					onSkip={ () =>
+						preLaunchTask &&
+						dispatch( preLaunchTask.actionDispatch( ...preLaunchTask.actionDispatchArgs ) )
+					}
+				/>
+			) }
 		</Card>
 	);
 };
@@ -375,6 +425,7 @@ const ConnectedSiteSetupList = connect( ( state, props ) => {
 		firstIncompleteTask: taskList.getFirstIncompleteTask(),
 		isEmailUnverified,
 		isFSEActive,
+		isPaidPlan: isCurrentPlanPaid( state, siteId ),
 		isPodcastingSite: !! getSiteOption( state, siteId, 'anchor_podcast' ),
 		menusUrl: getCustomizerUrl( state, siteId, null, null, 'add-menu' ),
 		siteId,

--- a/client/sites/settings/site/visibility/index.jsx
+++ b/client/sites/settings/site/visibility/index.jsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import useFetchAgencyFromBlog from 'calypso/a8c-for-agencies/data/agencies/use-fetch-agency-from-blog';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import { PanelCard, PanelCardHeading } from 'calypso/components/panel';
+import PreLaunchSiteModal from 'calypso/components/pre-launch-site-modal';
 import SitePreviewLinks from 'calypso/components/site-preview-links';
 import { a4aLink } from 'calypso/dashboard/utils/link';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -107,6 +108,7 @@ const LaunchSite = () => {
 	const [ isLaunchConfirmationModalOpen, setLaunchConfirmationModalOpen ] = useState( false );
 	const openLaunchConfirmationModal = () => setLaunchConfirmationModalOpen( true );
 	const closeLaunchConfirmationModal = () => setLaunchConfirmationModalOpen( false );
+	const [ isPreLaunchModalOpen, setIsPreLaunchModalOpen ] = useState( false );
 
 	const dispatch = useDispatch();
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
@@ -161,10 +163,14 @@ const LaunchSite = () => {
 			} else {
 				openLaunchConfirmationModal();
 			}
-		} else {
+		} else if ( ! isPaidPlan ) {
 			dispatch(
 				launchSiteOrRedirectToLaunchSignupFlow( siteId, 'general-settings', site.title, 'yes' )
 			);
+		} else {
+			// Paid sites may qualify for the pre-launch confirmation; the bridge
+			// decides and, if not, hands back to the flow via onSkip.
+			setIsPreLaunchModalOpen( true );
 		}
 	};
 
@@ -259,6 +265,27 @@ const LaunchSite = () => {
 	return (
 		<>
 			{ renderConfirmationModal() }
+			{ isPaidPlan && (
+				<PreLaunchSiteModal
+					siteId={ siteId }
+					isOpen={ isPreLaunchModalOpen }
+					onClose={ () => setIsPreLaunchModalOpen( false ) }
+					onConfirm={ () => {
+						dispatch( launchSite( site.ID ) );
+						setIsPreLaunchModalOpen( false );
+					} }
+					onSkip={ () =>
+						dispatch(
+							launchSiteOrRedirectToLaunchSignupFlow(
+								siteId,
+								'general-settings',
+								site.title,
+								'yes'
+							)
+						)
+					}
+				/>
+			) }
 			<PanelCard>
 				<PanelCardHeading>{ translate( 'Launch site' ) }</PanelCardHeading>
 				{ renderContent() }


### PR DESCRIPTION
Part of the pre-launch confirmation work. Stacked on #113773.

Follow-up to a review note on #113773: two surfaces outside that PR can make a paid + custom-domain site public **without** the pre-launch confirmation.

## Proposed Changes

* Extend the `PreLaunchSiteModal` bridge with an **in-place launch mode**: `launchUrl` is now optional, and two new callbacks — `onConfirm` (run on confirm instead of redirecting) and `onSkip` (run for a non-qualifying site instead of redirecting) — let a caller launch in place rather than hand off to `/start/launch-site`.
* Route the **site-visibility settings page** (`client/sites/settings/site/visibility/index.jsx`) launch click for paid sites through the bridge: on confirm we `dispatch( launchSite() )`; non-qualifying sites fall back to the existing `launchSiteOrRedirectToLaunchSignupFlow` thunk. Free sites keep the instant thunk path.
* Route the **customer-home setup-list “Launch site” task** (`client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx`) through the bridge by intercepting the `site_launched` task in the shared `startTask` choke point (gated on `isPaidPlan`). On confirm we `dispatch( launchSite() )`; non-qualifying sites replay the task’s own dispatch via `onSkip`.
* Add bridge unit tests for the `onConfirm`/`onSkip` modes.

## Why are these changes being made?

Both surfaces dispatch `launchSiteOrRedirectToLaunchSignupFlow`, which for paid + custom-domain sites fires `dispatch( launchSite( siteId ) )` **directly** — the site goes public with no confirmation. That is exactly the case the pre-launch modal exists to gate. This brings the two remaining classic entry points in line with the masterbar and Launchpad surfaces.

## Testing Instructions

Prerequisite: a paid-plan site with a **custom domain** that is still unlaunched (private / coming soon).

* **Settings → Privacy** (`/settings/general/<site>#site-privacy-settings`, or the newer site settings visibility panel): click **Launch site** → the pre-launch confirmation modal appears. Confirm → the site launches in place. Cancel → nothing happens.
* **Customer Home → Site setup checklist**: click the **Launch site** task → the same modal appears; confirm launches the site.
* Repeat both with a **free** site and with a **paid site that has no custom domain** → no modal, behavior is unchanged (redirects to `/start/launch-site`).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the “[Status] String Freeze” label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the “[Status] Needs Privacy Updates” label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
