### PR TITLE
Stats post detail: show email tabs based on actual email stats

### DIFF
--- a/client/my-sites/stats/hooks/test/use-post-email-stats-availability-query.test.ts
+++ b/client/my-sites/stats/hooks/test/use-post-email-stats-availability-query.test.ts
@@ -1,0 +1,21 @@
+import { hasEmailStats } from '../use-post-email-stats-availability-query';
+
+describe( 'hasEmailStats', () => {
+	it( 'returns false when there is no data', () => {
+		expect( hasEmailStats( undefined ) ).toBe( false );
+		expect( hasEmailStats( {} ) ).toBe( false );
+	} );
+
+	it( 'returns false when the counters are null or zero', () => {
+		expect( hasEmailStats( { total_sends: null, total_opens: null } ) ).toBe( false );
+		expect( hasEmailStats( { total_sends: 0, total_opens: 0 } ) ).toBe( false );
+	} );
+
+	it( 'returns true when the post has sends', () => {
+		expect( hasEmailStats( { total_sends: 68036, total_opens: 0 } ) ).toBe( true );
+	} );
+
+	it( 'returns true when the post has opens even if sends are not reported', () => {
+		expect( hasEmailStats( { total_sends: 0, total_opens: 9109 } ) ).toBe( true );
+	} );
+} );

--- a/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
+++ b/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import getDefaultQueryParams from './default-query-params';
+
+interface EmailRateResponse {
+	total_sends?: number;
+	total_opens?: number;
+}
+
+function queryEmailRate( siteId: number, postId: number ): Promise< EmailRateResponse > {
+	return wpcom.req.get( `/sites/${ siteId }/stats/opens/emails/${ postId }/rate` );
+}
+
+/**
+ * Whether a post was ever sent as a newsletter email, based on the email stats themselves
+ * rather than post metadata, which does not always reflect what was actually sent.
+ */
+export default function usePostEmailStatsAvailabilityQuery(
+	siteId: number | null,
+	postId: number,
+	enabled = true
+) {
+	return useQuery( {
+		...getDefaultQueryParams(),
+		queryKey: [ 'stats', 'emails', 'rate', siteId, postId ],
+		queryFn: () => queryEmailRate( siteId as number, postId ),
+		enabled: enabled && !! siteId && postId > 0,
+		staleTime: 1000 * 60 * 5,
+		select: ( data ) => ( data?.total_sends ?? 0 ) > 0 || ( data?.total_opens ?? 0 ) > 0,
+	} );
+}

--- a/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
+++ b/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
@@ -7,6 +7,10 @@ interface EmailRateResponse {
 	total_opens?: number;
 }
 
+function hasEmailStats( data?: EmailRateResponse ) {
+	return ( data?.total_sends ?? 0 ) > 0 || ( data?.total_opens ?? 0 ) > 0;
+}
+
 function queryEmailRate( siteId: number, postId: number ): Promise< EmailRateResponse > {
 	return wpcom.req.get( `/sites/${ siteId }/stats/opens/emails/${ postId }/rate` );
 }
@@ -25,7 +29,9 @@ export default function usePostEmailStatsAvailabilityQuery(
 		queryKey: [ 'stats', 'emails', 'rate', siteId, postId ],
 		queryFn: () => queryEmailRate( siteId as number, postId ),
 		enabled: enabled && !! siteId && postId > 0,
-		staleTime: 1000 * 60 * 5,
-		select: ( data ) => ( data?.total_sends ?? 0 ) > 0 || ( data?.total_opens ?? 0 ) > 0,
+		// A "no email stats" answer can be transient while a newsletter is still being sent,
+		// so only a positive result is kept for a while.
+		staleTime: ( query ) => ( hasEmailStats( query.state.data ) ? 1000 * 60 * 5 : 0 ),
+		select: hasEmailStats,
 	} );
 }

--- a/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
+++ b/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
@@ -26,12 +26,16 @@ export default function usePostEmailStatsAvailabilityQuery(
 ) {
 	return useQuery( {
 		...getDefaultQueryParams(),
-		queryKey: [ 'stats', 'emails', 'rate', siteId, postId ],
+		queryKey: [ 'stats', 'emails', 'opens', 'rate', siteId, postId ],
 		queryFn: () => queryEmailRate( siteId as number, postId ),
 		enabled: enabled && !! siteId && postId > 0,
 		// A "no email stats" answer can be transient while a newsletter is still being sent,
 		// so only a positive result is kept for a while.
 		staleTime: ( query ) => ( hasEmailStats( query.state.data ) ? 1000 * 60 * 5 : 0 ),
+		// A failed request reads the same as "no email stats" and hides the tabs, so
+		// let a remount retry instead of pinning the error until a full reload
+		// (the shared defaults set retryOnMount: false).
+		retryOnMount: true,
 		select: hasEmailStats,
 	} );
 }

--- a/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
+++ b/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
@@ -3,11 +3,11 @@ import wpcom from 'calypso/lib/wp';
 import getDefaultQueryParams from './default-query-params';
 
 interface EmailRateResponse {
-	total_sends?: number;
-	total_opens?: number;
+	total_sends?: number | null;
+	total_opens?: number | null;
 }
 
-function hasEmailStats( data?: EmailRateResponse ) {
+export function hasEmailStats( data?: EmailRateResponse ) {
 	return ( data?.total_sends ?? 0 ) > 0 || ( data?.total_opens ?? 0 ) > 0;
 }
 
@@ -28,10 +28,10 @@ export default function usePostEmailStatsAvailabilityQuery(
 		...getDefaultQueryParams(),
 		queryKey: [ 'stats', 'emails', 'opens', 'rate', siteId, postId ],
 		queryFn: () => queryEmailRate( siteId as number, postId ),
-		enabled: enabled && !! siteId && postId > 0,
+		enabled: !! enabled && !! siteId && postId > 0,
 		// A "no email stats" answer can be transient while a newsletter is still being sent,
 		// so only a positive result is kept for a while.
-		staleTime: ( query ) => ( hasEmailStats( query.state.data ) ? 1000 * 60 * 5 : 0 ),
+		staleTime: ( query ) => ( hasEmailStats( query.state.data ) ? 1000 * 60 * 5 : 1000 * 30 ),
 		// A failed request reads the same as "no email stats" and hides the tabs, so
 		// let a remount retry instead of pinning the error until a full reload
 		// (the shared defaults set retryOnMount: false).

--- a/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
+++ b/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
@@ -11,7 +11,7 @@ export function hasEmailStats( data?: EmailRateResponse ) {
 	return ( data?.total_sends ?? 0 ) > 0 || ( data?.total_opens ?? 0 ) > 0;
 }
 
-function queryEmailRate( siteId: number, postId: number ): Promise< EmailRateResponse > {
+function queryEmailRate( siteId: number | null, postId: number ): Promise< EmailRateResponse > {
 	return wpcom.req.get( `/sites/${ siteId }/stats/opens/emails/${ postId }/rate` );
 }
 
@@ -27,7 +27,7 @@ export default function usePostEmailStatsAvailabilityQuery(
 	return useQuery( {
 		...getDefaultQueryParams(),
 		queryKey: [ 'stats', 'emails', 'opens', 'rate', siteId, postId ],
-		queryFn: () => queryEmailRate( siteId as number, postId ),
+		queryFn: () => queryEmailRate( siteId, postId ),
 		enabled: !! enabled && !! siteId && postId > 0,
 		// A "no email stats" answer can be transient while a newsletter is still being sent,
 		// so only a positive result is kept for a while.
@@ -36,6 +36,7 @@ export default function usePostEmailStatsAvailabilityQuery(
 		// let a remount retry instead of pinning the error until a full reload
 		// (the shared defaults set retryOnMount: false).
 		retryOnMount: true,
+		meta: { persist: false },
 		select: hasEmailStats,
 	} );
 }

--- a/client/my-sites/stats/post-detail-highlights-section/index.tsx
+++ b/client/my-sites/stats/post-detail-highlights-section/index.tsx
@@ -17,7 +17,6 @@ type PostThumbnail = {
 
 type Post = {
 	date: string | null;
-	dont_email_post_to_subs: boolean | null;
 	title: string;
 	type: string | null;
 	like_count: number | null;

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -65,7 +65,7 @@ class StatsPostDetail extends Component {
 		} ),
 		editUrl: PropTypes.string,
 		openSupportDoc: PropTypes.func,
-		hasEmailStats: PropTypes.bool,
+		isEmailTabsAvailable: PropTypes.bool,
 	};
 
 	state = {
@@ -201,10 +201,7 @@ class StatsPostDetail extends Component {
 			showViewLink,
 			previewUrl,
 			supportsUTMStats,
-			isSubscriptionsModuleActive,
-			supportsEmailStats,
-			hasEmailStats,
-			isSimple,
+			isEmailTabsAvailable,
 			breadcrumbTrail,
 		} = this.props;
 
@@ -233,11 +230,6 @@ class StatsPostDetail extends Component {
 
 		// TODO: Refactor navigationItems to a single object with backLink and title attributes.
 		const navigationItems = this.getNavigationItemsWithTitle( this.getTitle() );
-
-		const subscriptionsEnabled = isSimple || isSubscriptionsModuleActive;
-		// postId > 0: Show the tabs for posts except for the Home Page (postId = 0).
-		const isEmailTabsAvailable =
-			subscriptionsEnabled && postId > 0 && supportsEmailStats && hasEmailStats;
 
 		return (
 			<Main
@@ -337,19 +329,19 @@ const StatsPostDetailWrapper = ( props ) => {
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
 
-	const canHaveEmailStats = useSelector( ( state ) => {
-		const { supportsEmailStats } = getEnvStatsFeatureSupportChecks( state, siteId );
-		const subscriptionsEnabled =
-			isSimpleSite( state, siteId ) ||
-			isJetpackModuleActive( state, siteId, 'subscriptions', true );
-		return supportsEmailStats && subscriptionsEnabled;
-	} );
+	// `connect` wraps this component, so the environment checks arrive as props;
+	// the whole email-tabs rule lives here rather than being re-derived in render.
+	const { supportsEmailStats, isSimple, isSubscriptionsModuleActive, postId } = props;
+	const canHaveEmailStats = supportsEmailStats && ( isSimple || isSubscriptionsModuleActive );
 
 	const { data: hasEmailStats = false } = usePostEmailStatsAvailabilityQuery(
 		siteId,
-		props.postId,
+		postId,
 		canHaveEmailStats
 	);
+
+	// postId > 0: show the tabs for posts except for the Home Page (postId = 0).
+	const isEmailTabsAvailable = canHaveEmailStats && postId > 0 && hasEmailStats;
 
 	const openDoc = () => {
 		if ( isJetpack ) {
@@ -365,7 +357,7 @@ const StatsPostDetailWrapper = ( props ) => {
 			siteId={ siteId }
 			breadcrumbTrail={ breadcrumbTrail }
 			openSupportDoc={ openDoc }
-			hasEmailStats={ hasEmailStats }
+			isEmailTabsAvailable={ isEmailTabsAvailable }
 		/>
 	);
 };

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -39,6 +39,7 @@ import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-e
 import getSiteAdminUrlFromState from 'calypso/state/sites/selectors/get-site-admin-url';
 import { getPostStat, isRequestingPostStats } from 'calypso/state/stats/posts/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import usePostEmailStatsAvailabilityQuery from '../hooks/use-post-email-stats-availability-query';
 import PostDetailHighlightsSection from '../post-detail-highlights-section';
 import PostDetailTableSection from '../post-detail-table-section';
 import StatsPlaceholder from '../stats-module/placeholder';
@@ -64,6 +65,7 @@ class StatsPostDetail extends Component {
 		} ),
 		editUrl: PropTypes.string,
 		openSupportDoc: PropTypes.func,
+		hasEmailStats: PropTypes.bool,
 	};
 
 	state = {
@@ -153,12 +155,6 @@ class StatsPostDetail extends Component {
 		return null;
 	}
 
-	hasDontSendEmailPostToSubs( metadata ) {
-		return metadata?.some(
-			( { key, value } ) => key === '_jetpack_dont_email_post_to_subs' && !! value
-		);
-	}
-
 	getPost() {
 		const { isPostHomepage, post, postFallback, countLikes } = this.props;
 
@@ -173,7 +169,6 @@ class StatsPostDetail extends Component {
 			return {
 				...postBase,
 				date: post?.date,
-				dont_email_post_to_subs: this.hasDontSendEmailPostToSubs( post?.metadata ),
 				post_thumbnail: post?.post_thumbnail,
 				comment_count: post?.discussion?.comment_count,
 				type: post?.type,
@@ -185,7 +180,6 @@ class StatsPostDetail extends Component {
 			return {
 				...postBase,
 				date: postFallback?.post_date_gmt,
-				dont_email_post_to_subs: this.hasDontSendEmailPostToSubs( post?.metadata ),
 				post_thumbnail: null,
 				comment_count: parseInt( postFallback?.comment_count, 10 ),
 				type: postFallback?.post_type,
@@ -209,6 +203,7 @@ class StatsPostDetail extends Component {
 			supportsUTMStats,
 			isSubscriptionsModuleActive,
 			supportsEmailStats,
+			hasEmailStats,
 			isSimple,
 			breadcrumbTrail,
 		} = this.props;
@@ -242,13 +237,7 @@ class StatsPostDetail extends Component {
 		const subscriptionsEnabled = isSimple || isSubscriptionsModuleActive;
 		// postId > 0: Show the tabs for posts except for the Home Page (postId = 0).
 		const isEmailTabsAvailable =
-			subscriptionsEnabled &&
-			postId > 0 &&
-			! passedPost?.dont_email_post_to_subs &&
-			passedPost?.date &&
-			// The Newsletter Stats data was never backfilled (internal ref pdDOJh-1Uy-p2).
-			new Date( passedPost?.date ) >= new Date( '2023-05-30' ) &&
-			supportsEmailStats;
+			subscriptionsEnabled && postId > 0 && supportsEmailStats && hasEmailStats;
 
 		return (
 			<Main
@@ -348,6 +337,11 @@ const StatsPostDetailWrapper = ( props ) => {
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
 
+	const { data: hasEmailStats = false } = usePostEmailStatsAvailabilityQuery(
+		siteId,
+		props.postId
+	);
+
 	const openDoc = () => {
 		if ( isJetpack ) {
 			setTimeout( () => window.open( supportLink, '_blank' ), 250 );
@@ -362,6 +356,7 @@ const StatsPostDetailWrapper = ( props ) => {
 			siteId={ siteId }
 			breadcrumbTrail={ breadcrumbTrail }
 			openSupportDoc={ openDoc }
+			hasEmailStats={ hasEmailStats }
 		/>
 	);
 };

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -334,11 +334,9 @@ const StatsPostDetailWrapper = ( props ) => {
 	const { supportsEmailStats, isSimple, isSubscriptionsModuleActive, postId } = props;
 	const canHaveEmailStats = !! supportsEmailStats && !! ( isSimple || isSubscriptionsModuleActive );
 
-	const { data: hasEmailStats = false } = usePostEmailStatsAvailabilityQuery(
-		siteId,
-		postId,
-		canHaveEmailStats
-	);
+	const { data, isError } = usePostEmailStatsAvailabilityQuery( siteId, postId, canHaveEmailStats );
+	// A failed request would otherwise read as "never emailed"; fail open instead.
+	const hasEmailStats = data ?? isError;
 
 	// postId > 0: show the tabs for posts except for the Home Page (postId = 0).
 	const isEmailTabsAvailable = canHaveEmailStats && postId > 0 && hasEmailStats;

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -332,7 +332,7 @@ const StatsPostDetailWrapper = ( props ) => {
 	// `connect` wraps this component, so the environment checks arrive as props;
 	// the whole email-tabs rule lives here rather than being re-derived in render.
 	const { supportsEmailStats, isSimple, isSubscriptionsModuleActive, postId } = props;
-	const canHaveEmailStats = supportsEmailStats && ( isSimple || isSubscriptionsModuleActive );
+	const canHaveEmailStats = !! supportsEmailStats && !! ( isSimple || isSubscriptionsModuleActive );
 
 	const { data: hasEmailStats = false } = usePostEmailStatsAvailabilityQuery(
 		siteId,

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -337,9 +337,18 @@ const StatsPostDetailWrapper = ( props ) => {
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
 
+	const canHaveEmailStats = useSelector( ( state ) => {
+		const { supportsEmailStats } = getEnvStatsFeatureSupportChecks( state, siteId );
+		const subscriptionsEnabled =
+			isSimpleSite( state, siteId ) ||
+			isJetpackModuleActive( state, siteId, 'subscriptions', true );
+		return supportsEmailStats && subscriptionsEnabled;
+	} );
+
 	const { data: hasEmailStats = false } = usePostEmailStatsAvailabilityQuery(
 		siteId,
-		props.postId
+		props.postId,
+		canHaveEmailStats
 	);
 
 	const openDoc = () => {


### PR DESCRIPTION
Fixes STATS-456

## Proposed Changes

* Add `usePostEmailStatsAvailabilityQuery`, a small react-query hook that reads `/sites/:site/stats/opens/emails/:post/rate` and reports whether the post has any email sends or opens.
* The post detail page now shows the **Post traffic / Email opens / Email clicks** tabs when that query says the post has email stats, instead of guessing from the `_jetpack_dont_email_post_to_subs` post meta and a 2023-05-30 publish-date cutoff.
* Remove the now-unused `dont_email_post_to_subs` plumbing from `getPost()` and the highlights section type.

## Why are these changes being made?

The post detail page and the email detail page share the same tab strip but decided differently whether to render it: the email page always did, while the post page relied on post metadata. A post that carries `_jetpack_dont_email_post_to_subs` but still has email stats (the case in STATS-456) showed all three tabs on the email page and none on the post page, so clicking **Post traffic** made the tabs disappear.

Basing the decision on the email stats themselves keeps both pages consistent and also covers the old publish-date cutoff: posts from before newsletter stats existed simply have no sends and get no tabs. This supersedes the metadata check from #97739, which had the same intent (no tabs for posts that were never sent as an email) but relied on a flag that does not always match what was actually sent. In the reported case the email went out at publish time and the meta was only flipped to true by a later edit, so the flag reflects the editor's last-saved state rather than what was sent.

## Testing Instructions

**Finding a post that reproduces the bug.** The tabs only went missing for posts that have email stats *and* carry the `_jetpack_dont_email_post_to_subs` meta. A newsletter sent through the normal flow does not carry it, so either:

* use the post from STATS-456 (an Automattic-owned Simple site, so a11ns can open its Stats), or
* build one on a self-hosted test site with newsletters enabled and at least one subscriber: publish a post with "Post and email", wait for it to show up under **Emails** on the Traffic page, then set the meta with WP-CLI (it is protected meta, so the Custom Fields panel cannot add it): `wp post meta update <post_id> _jetpack_dont_email_post_to_subs 1`.

**Steps:**

1. Open the Traffic page and click the post above in **Posts & Pages**.
2. Before: no email tabs. After: **Post traffic / Email opens / Email clicks** tabs are shown.
3. Open the same post from the **Emails** module and click **Post traffic**: the tabs are shown again once the post detail page has loaded (the strip briefly disappears while the page switches; that also happens on trunk and is not addressed here).
4. Regression checks, unchanged before and after:
   * a normal newsletter post (no custom field): tabs shown;
   * a post that was never sent as an email, e.g. one published before 2023-05-30 or with "Post only": no email tabs;
   * the site's home page entry (post ID 0): no tabs.

Also worth checking on a self-hosted Jetpack site with newsletters enabled, since the rate endpoint goes through the Jetpack API there.

### Screenshots

|Before|After|
|-|-|
|<img width="1312" height="471" alt="截圖 2026-08-27 下午1 03 17" src="https://github.com/user-attachments/assets/01f8b07e-bd52-4bdc-bcea-b60b712120c8" />|<img width="1313" height="515" alt="截圖 2026-08-27 下午1 03 23" src="https://github.com/user-attachments/assets/2eee3391-e2e4-46cd-bbea-aeca8573e044" />|

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)





