### PR TITLE
Agents Manager: fix Big Sky event name type error

### DIFF
--- a/packages/agents-manager/src/hooks/__tests__/custom-actions.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/custom-actions.test.ts
@@ -7,6 +7,7 @@ import { recordBigSkyTracksEvent } from '../../utils/tracks';
 import { useRegisterCustomActions, useSetupCustomActions } from '../custom-actions';
 
 jest.mock( '../../utils/tracks', () => ( {
+	BIG_SKY_EVENT_PREFIX: jest.requireActual( '../../utils/tracks' ).BIG_SKY_EVENT_PREFIX,
 	recordBigSkyTracksEvent: jest.fn(),
 } ) );
 
@@ -134,9 +135,12 @@ describe( 'useSetupCustomActions', () => {
 		window.__agentsManagerActions?.recordBigSkyTracksEvent?.( 'split_screen_guide_click', {
 			component_type: 'proofread',
 		} );
-		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith( 'split_screen_guide_click', {
-			component_type: 'proofread',
-		} );
+		expect( mockRecordBigSkyTracksEvent ).toHaveBeenCalledWith(
+			'jetpack_big_sky_split_screen_guide_click',
+			{
+				component_type: 'proofread',
+			}
+		);
 
 		mockRecordBigSkyTracksEvent.mockClear();
 		window.__agentsManagerActions?.recordBigSkyTracksEvent?.( '' );

--- a/packages/agents-manager/src/hooks/custom-actions/index.ts
+++ b/packages/agents-manager/src/hooks/custom-actions/index.ts
@@ -19,11 +19,12 @@ function recordGuardedBigSkyTracksEvent(
 	eventName: string,
 	props?: Record< string, unknown >
 ): void {
-	if ( typeof eventName !== 'string' || eventName === '' ) {
+	if ( typeof eventName !== 'string' || ! eventName.startsWith( 'jetpack_big_sky_' ) ) {
 		return;
 	}
 
-	recordBigSkyTracksEvent( eventName, props );
+	// `startsWith` doesn't narrow to the template-literal type; the guard above proves it.
+	recordBigSkyTracksEvent( eventName as `jetpack_big_sky_${ string }`, props );
 }
 
 /**

--- a/packages/agents-manager/src/hooks/custom-actions/index.ts
+++ b/packages/agents-manager/src/hooks/custom-actions/index.ts
@@ -12,7 +12,6 @@ import {
 import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
 import { setSiteEditorAction } from '../../utils/site-editor-context';
 import { BIG_SKY_EVENT_PREFIX, recordBigSkyTracksEvent } from '../../utils/tracks';
-import type { BigSkyEventName } from '../../utils/tracks';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
 
 /** Bridge-facing recorder: drops malformed calls instead of emitting `jetpack_big_sky_undefined`. */
@@ -20,12 +19,12 @@ function recordGuardedBigSkyTracksEvent(
 	eventName: string,
 	props?: Record< string, unknown >
 ): void {
-	if ( typeof eventName !== 'string' || ! eventName.startsWith( BIG_SKY_EVENT_PREFIX ) ) {
+	if ( typeof eventName !== 'string' || eventName === '' ) {
 		return;
 	}
 
-	// `startsWith` doesn't narrow to the template-literal type; the guard above proves it.
-	recordBigSkyTracksEvent( eventName as BigSkyEventName, props );
+	// Bridge callers pass the suffix only — see `recordBigSkyTracksEvent` in `global.d.ts`.
+	recordBigSkyTracksEvent( `${ BIG_SKY_EVENT_PREFIX }${ eventName }`, props );
 }
 
 /**

--- a/packages/agents-manager/src/hooks/custom-actions/index.ts
+++ b/packages/agents-manager/src/hooks/custom-actions/index.ts
@@ -11,7 +11,8 @@ import {
 } from '../../utils/external-context';
 import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
 import { setSiteEditorAction } from '../../utils/site-editor-context';
-import { recordBigSkyTracksEvent } from '../../utils/tracks';
+import { BIG_SKY_EVENT_PREFIX, recordBigSkyTracksEvent } from '../../utils/tracks';
+import type { BigSkyEventName } from '../../utils/tracks';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
 
 /** Bridge-facing recorder: drops malformed calls instead of emitting `jetpack_big_sky_undefined`. */
@@ -19,12 +20,12 @@ function recordGuardedBigSkyTracksEvent(
 	eventName: string,
 	props?: Record< string, unknown >
 ): void {
-	if ( typeof eventName !== 'string' || ! eventName.startsWith( 'jetpack_big_sky_' ) ) {
+	if ( typeof eventName !== 'string' || ! eventName.startsWith( BIG_SKY_EVENT_PREFIX ) ) {
 		return;
 	}
 
 	// `startsWith` doesn't narrow to the template-literal type; the guard above proves it.
-	recordBigSkyTracksEvent( eventName as `jetpack_big_sky_${ string }`, props );
+	recordBigSkyTracksEvent( eventName as BigSkyEventName, props );
 }
 
 /**

--- a/packages/agents-manager/src/utils/tracks.ts
+++ b/packages/agents-manager/src/utils/tracks.ts
@@ -20,6 +20,9 @@ import { getResolvedAgentId } from './resolved-agent-id';
 
 type TracksProps = Record< string, unknown >;
 
+export const BIG_SKY_EVENT_PREFIX = 'jetpack_big_sky_';
+export type BigSkyEventName = `${ typeof BIG_SKY_EVENT_PREFIX }${ string }`;
+
 type EditorSelectStore =
 	| {
 			getCurrentPostType?: () => string | undefined;
@@ -108,7 +111,7 @@ function getBigSkyPageProps(): TracksProps {
  * dashboards keep working.
  */
 export function recordBigSkyTracksEvent(
-	eventName: `jetpack_big_sky_${ string }`,
+	eventName: BigSkyEventName,
 	props: TracksProps = {}
 ): void {
 	if ( isReaderChatAgent( getResolvedAgentId() ) ) {


### PR DESCRIPTION
## Proposed Changes

* Fix the TS2345 error in `packages/agents-manager/src/hooks/custom-actions/index.ts` that breaks `type_check_packages` on trunk: tighten `recordGuardedBigSkyTracksEvent`'s runtime guard to check the `jetpack_big_sky_` prefix (matching what its doc comment already claims) and assert the narrowed template-literal type at the call. `startsWith` does not narrow template-literal types, so the assertion is required.

## Why are these changes being made?

* Trunk is currently broken for all PRs: the "Unit tests (Web app)" build fails on `type_check_packages` with:
  ```
  packages/agents-manager/src/hooks/custom-actions/index.ts:26:27 - error TS2345:
  Argument of type 'string' is not assignable to parameter of type '`jetpack_big_sky_${string}`'.
  ```
* Root cause is a semantic merge conflict between two PRs that each passed CI alone: #113786 narrowed `recordBigSkyTracksEvent`'s `eventName` parameter to `` `jetpack_big_sky_${string}` ``, and #113742 added the caller `recordGuardedBigSkyTracksEvent(eventName: string, ...)` passing a plain string.
* TeamCity evidence: build 19164658 (`fbd8a7dbcd3`, parent of the second PR's merge) is green; 19164914 (`c590e1b309f`) and 19165757 (trunk head `1a6c7d37c35`) both fail with the identical error.

## Testing Instructions

* Run `yarn typecheck-packages` on trunk — it fails with the error above.
* Run it on this branch — it passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?