### PR TITLE
Domains: don't break the overview page when the purchase is forbidden

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -189,8 +189,9 @@ export const domainOverviewRoute = createRoute( {
 		queryClient.prefetchQuery( siteByIdQuery( domain.blog_id ) );
 		queryClient.prefetchQuery( mailboxesQuery( domain.blog_id ) );
 
+		// The purchase can be forbidden as the domain owner may not be the current user.
 		if ( domain.subscription_id ) {
-			await queryClient.ensureQueryData( purchaseQuery( parseInt( domain.subscription_id, 10 ) ) );
+			queryClient.prefetchQuery( purchaseQuery( parseInt( domain.subscription_id, 10 ) ) );
 		}
 	},
 } ).lazy( () =>


### PR DESCRIPTION
## Proposed Changes

* The Domain Overview route loader no longer `await`s the purchase. `purchaseQuery` moves from `ensureQueryData` to `prefetchQuery`, matching the two prefetches directly above it.

## Why are these changes being made?

The Domain Overview loader treated the domain's purchase as a hard dependency of the route:

```ts
if ( domain.subscription_id ) {
    await queryClient.ensureQueryData( purchaseQuery( parseInt( domain.subscription_id, 10 ) ) );
}
```

If that request fails, `ensureQueryData` throws, the loader rejects, and the **entire Domain Overview screen** falls into the error boundary — not just a missing renewal card.

That failure is reachable in normal use, because the domain's owner may not be the current user. `/domain-details/<domain>` authorizes the caller against the blog the domain is attached to, so an admin of that site can read the domain and receive its `subscription_id`. `/upgrades/<id>` authorizes against the subscription's own owner instead, doesn't recognize that caller, and deliberately returns a generic "unable to find subscription" rather than a 403 so it doesn't confirm the subscription exists. The client sees a plain failure and takes the page down with it.

The page never needed the purchase to render. Every consumer already fetches it with a non-suspense `useQuery` guarded by `enabled: !! domain.subscription_id` and degrades cleanly:

* `domains/domain-overview/index.tsx` and `domains/domain-overview/actions.tsx` — `purchase` is optional throughout
* `domains/domain-overview/featured-card-renew.tsx` — doesn't read `purchase` at all; it renders from `domain.expiry`, `auto_renewing`, and `subscription_id`

So the `await` bought nothing beyond a slightly earlier cache warm, while turning a best-effort detail into a single point of failure for the screen. Prefetching keeps the warm cache and lets the page render without it — and also covers any other transient failure of `/upgrades`, not just the permissions case.

## Testing Instructions

* Open a domain's overview page (`/domains/<domain>`) and confirm it renders as before, including the renewal/expiry card.
* To reproduce the original breakage, block or fail the `/upgrades/<subscription_id>` request in devtools and reload:
  * **Before:** the whole Domain Overview screen fails to render.
  * **After:** the page renders normally; only purchase-derived details are absent.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
