### PR TITLE
Marketplace: give the stalled install wait an honest line and a way out

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -22,6 +22,7 @@ const MarketplaceProductInstall = ( {
 } ) => {
 	const {
 		siteId,
+		selectedSiteSlug,
 		currentStep,
 		steps,
 		additionalSteps,
@@ -77,6 +78,8 @@ const MarketplaceProductInstall = ( {
 						transferStatus={ transferStatus }
 						currentStep={ currentStep }
 						startedAt={ transferStartedAt }
+						siteSlug={ selectedSiteSlug }
+						productSlug={ pluginSlug || themeSlug }
 					/>
 				) }
 				{ ! error && ! isTransferWait && (

--- a/client/my-sites/marketplace/pages/marketplace-product-install/install-progress/card.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/install-progress/card.tsx
@@ -1,10 +1,18 @@
 import './style.scss';
 
 import { Step } from '@automattic/onboarding';
-import { ProgressBar } from '@wordpress/components';
+import { Button, ProgressBar } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect, useRef } from 'react';
 import ExpectationChecklist from 'calypso/components/expectation-checklist';
-import { useOverrunCopy, useStageSentences, useStageTitles } from './copy';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import {
+	useOverrunCopy,
+	useStageSentences,
+	useStageTitles,
+	useStalledActionLabel,
+	useStalledCopy,
+} from './copy';
 import { INSTALL_STAGES } from './get-install-stage';
 import { useInstallProgress } from './use-install-progress';
 
@@ -17,13 +25,17 @@ export default function InstallProgressCard( {
 	transferStatus,
 	currentStep,
 	startedAt,
+	siteSlug,
+	productSlug,
 }: {
 	transferStatus: string | null;
 	currentStep: number;
 	startedAt?: number | null;
+	siteSlug?: string | null;
+	productSlug?: string;
 } ) {
 	const translate = useTranslate();
-	const { stage, isOverrun, overallProgress } = useInstallProgress( {
+	const { stage, stageElapsed, isOverrun, isStalled, overallProgress } = useInstallProgress( {
 		transferStatus,
 		currentStep,
 		startedAt,
@@ -32,6 +44,22 @@ export default function InstallProgressCard( {
 	const stageTitles = useStageTitles();
 	const sentences = useStageSentences();
 	const overrunCopy = useOverrunCopy();
+	const stalledCopy = useStalledCopy();
+	const stalledActionLabel = useStalledActionLabel();
+
+	// The bar re-renders twice a second; keep the elapsed figure out of the effect's deps.
+	const stageElapsedRef = useRef( stageElapsed );
+	stageElapsedRef.current = stageElapsed;
+	const reportedStalledRef = useRef( false );
+	useEffect( () => {
+		if ( ! isStalled || reportedStalledRef.current ) {
+			return;
+		}
+		reportedStalledRef.current = true;
+		recordTracksEvent( 'calypso_marketplace_install_wait_stalled', { product_slug: productSlug } );
+	}, [ isStalled, productSlug ] );
+
+	const showEscape = isStalled && !! siteSlug;
 
 	return (
 		<div className="marketplace-install-progress">
@@ -40,9 +68,9 @@ export default function InstallProgressCard( {
 				<p className="marketplace-install-progress__stage" role="status">
 					{ sentences[ stageKey ] }
 				</p>
-				{ isOverrun && (
+				{ ( isStalled || isOverrun ) && (
 					<p className="marketplace-install-progress__overrun" role="status">
-						{ overrunCopy }
+						{ isStalled ? stalledCopy : overrunCopy }
 					</p>
 				) }
 			</div>
@@ -52,6 +80,21 @@ export default function InstallProgressCard( {
 					value={ overallProgress }
 					aria-label={ String( stageTitles[ stageKey ] ) }
 				/>
+				{ showEscape && (
+					<Button
+						className="marketplace-install-progress__escape"
+						variant="link"
+						href={ `/plugins/${ siteSlug }` }
+						onClick={ () =>
+							recordTracksEvent( 'calypso_marketplace_install_wait_stalled_click', {
+								product_slug: productSlug,
+								stage_seconds: Math.round( stageElapsedRef.current ),
+							} )
+						}
+					>
+						{ stalledActionLabel }
+					</Button>
+				) }
 			</div>
 			<ExpectationChecklist
 				title={ translate( "Here's what to expect" ) }

--- a/client/my-sites/marketplace/pages/marketplace-product-install/install-progress/copy.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/install-progress/copy.tsx
@@ -41,6 +41,22 @@ export function useStageSentences(): Record< InstallStageKey, ReactNode > {
 	};
 }
 
+/**
+ * Once the wait is long enough that reassurance stops being honest: the transfer is done and the
+ * site is usable, so say that and point at the door rather than repeat that nothing is wrong.
+ */
+export function useStalledCopy() {
+	const translate = useTranslate();
+	return translate(
+		'This is taking longer than it should. Your site is ready — your plugin may still finish installing on its own.'
+	);
+}
+
+export function useStalledActionLabel() {
+	const translate = useTranslate();
+	return translate( 'Go to your plugins' );
+}
+
 export function useOverrunCopy() {
 	const translate = useTranslate();
 	return translate(

--- a/client/my-sites/marketplace/pages/marketplace-product-install/install-progress/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/install-progress/style.scss
@@ -50,3 +50,11 @@
 		background: var( --color-accent );
 	}
 }
+
+.marketplace-install-progress__escape {
+	display: flex;
+	margin-block-start: 16px;
+	margin-inline: auto;
+	font-size: 0.875rem;
+	line-height: 1.5;
+}

--- a/client/my-sites/marketplace/pages/marketplace-product-install/install-progress/test/card.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/install-progress/test/card.tsx
@@ -2,11 +2,15 @@
  * @jest-environment jsdom
  */
 import { render, screen, act } from '@testing-library/react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import InstallProgressCard from '../card';
 
+jest.mock( 'calypso/lib/analytics/tracks', () => ( { recordTracksEvent: jest.fn() } ) );
+
 describe( 'InstallProgressCard', () => {
 	beforeEach( () => {
+		jest.clearAllMocks();
 		jest.useFakeTimers();
 		jest.setSystemTime( new Date( '2026-08-17T10:00:00Z' ) );
 	} );
@@ -51,5 +55,80 @@ describe( 'InstallProgressCard', () => {
 		render( <InstallProgressCard transferStatus={ transferStates.ACTIVE } currentStep={ 1 } /> );
 		act( () => jest.advanceTimersByTime( 45_000 ) );
 		expect( screen.getByText( /taking longer than usual/ ) ).toBeVisible();
+	} );
+
+	it( 'still reassures while a finishing stage is merely slow', () => {
+		render(
+			<InstallProgressCard
+				transferStatus={ transferStates.COMPLETE }
+				currentStep={ 1 }
+				siteSlug="example.wordpress.com"
+			/>
+		);
+		act( () => jest.advanceTimersByTime( 45_000 ) );
+		expect( screen.getByText( /nothing is wrong/ ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: 'Go to your plugins' } ) ).not.toBeInTheDocument();
+	} );
+
+	// Past this point the promise is one we cannot keep: the plugin may never activate.
+	it( 'stops promising nothing is wrong once the finishing stage stalls', () => {
+		render(
+			<InstallProgressCard
+				transferStatus={ transferStates.COMPLETE }
+				currentStep={ 1 }
+				siteSlug="example.wordpress.com"
+			/>
+		);
+		act( () => jest.advanceTimersByTime( 95_000 ) );
+		expect( screen.getByText( /taking longer than it should/ ) ).toBeVisible();
+		expect( screen.queryByText( /nothing is wrong/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'offers a way out to the site plugins once stalled', () => {
+		render(
+			<InstallProgressCard
+				transferStatus={ transferStates.COMPLETE }
+				currentStep={ 1 }
+				siteSlug="example.wordpress.com"
+			/>
+		);
+		act( () => jest.advanceTimersByTime( 95_000 ) );
+		expect( screen.getByRole( 'link', { name: 'Go to your plugins' } ) ).toHaveAttribute(
+			'href',
+			'/plugins/example.wordpress.com'
+		);
+	} );
+
+	it( 'offers no way out while the transfer itself is unfinished', () => {
+		render(
+			<InstallProgressCard
+				transferStatus={ transferStates.ACTIVE }
+				currentStep={ 1 }
+				siteSlug="example.wordpress.com"
+			/>
+		);
+		act( () => jest.advanceTimersByTime( 300_000 ) );
+		expect( screen.queryByRole( 'link', { name: 'Go to your plugins' } ) ).not.toBeInTheDocument();
+		expect( screen.getByText( /nothing is wrong/ ) ).toBeVisible();
+	} );
+
+	it( 'records the stall once, not on every tick', () => {
+		render(
+			<InstallProgressCard
+				transferStatus={ transferStates.COMPLETE }
+				currentStep={ 1 }
+				siteSlug="example.wordpress.com"
+				productSlug="sensei-pro"
+			/>
+		);
+		act( () => jest.advanceTimersByTime( 45_000 ) );
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+
+		act( () => jest.advanceTimersByTime( 50_000 ) );
+		act( () => jest.advanceTimersByTime( 30_000 ) );
+		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_marketplace_install_wait_stalled', {
+			product_slug: 'sensei-pro',
+		} );
 	} );
 } );

--- a/client/my-sites/marketplace/pages/marketplace-product-install/install-progress/test/use-install-progress.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/install-progress/test/use-install-progress.ts
@@ -24,6 +24,32 @@ describe( 'useInstallProgress', () => {
 		expect( result.current.elapsed ).toBeCloseTo( 15, 0 );
 	} );
 
+	it( 'does not call a finishing stage stalled while it is merely slow', () => {
+		const { result } = renderHook( () =>
+			useInstallProgress( { transferStatus: transferStates.COMPLETE, currentStep: 1 } )
+		);
+		advance( 89_000 );
+		expect( result.current.isOverrun ).toBe( true );
+		expect( result.current.isStalled ).toBe( false );
+	} );
+
+	it( 'calls a finishing stage stalled once it runs past 90s', () => {
+		const { result } = renderHook( () =>
+			useInstallProgress( { transferStatus: transferStates.COMPLETE, currentStep: 1 } )
+		);
+		advance( 91_000 );
+		expect( result.current.isStalled ).toBe( true );
+	} );
+
+	// Earlier stages have nowhere to send anyone: the transfer itself is still unfinished.
+	it( 'never calls an earlier stage stalled, however long it runs', () => {
+		const { result } = renderHook( () =>
+			useInstallProgress( { transferStatus: transferStates.ACTIVE, currentStep: 1 } )
+		);
+		advance( 300_000 );
+		expect( result.current.isStalled ).toBe( false );
+	} );
+
 	it( 'never claims more than 92% of a stage until the server confirms it', () => {
 		const { result } = renderHook( () =>
 			useInstallProgress( { transferStatus: transferStates.ACTIVE, currentStep: 1 } )

--- a/client/my-sites/marketplace/pages/marketplace-product-install/install-progress/use-install-progress.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/install-progress/use-install-progress.ts
@@ -11,6 +11,13 @@ const MAX_UNCONFIRMED_PROGRESS = 92;
 // How far past a stage's typical duration we wait before saying it's running long.
 const OVERRUN_FACTOR = 1.6;
 
+// Once finishing has run this long the wait stops reassuring and offers a way out: 90s clears the
+// p95 of a healthy finishing stage while still catching every install that never activates.
+const STALLED_SECONDS = 90;
+
+// The only stage with somewhere to send people — before it the transfer itself is unfinished.
+const FINISHING_STAGE = INSTALL_STAGES.length - 1;
+
 /**
  * When this UI first learns the transfer is already past `preparing` — a refresh mid-transfer —
  * the real stage boundary was never observed. Estimate it from the transfer's start plus the
@@ -90,6 +97,7 @@ export function useInstallProgress( {
 		stage === 0 ? elapsed : Math.max( 0, ( now - stageStartedAt.current ) / 1000 );
 
 	const isOverrun = stageElapsed > INSTALL_STAGES[ stage ].expectedSeconds * OVERRUN_FACTOR;
+	const isStalled = stage === FINISHING_STAGE && stageElapsed > STALLED_SECONDS;
 
 	const getStageProgress = ( index: number ): number => {
 		if ( index < stage ) {
@@ -113,5 +121,5 @@ export function useInstallProgress( {
 			0
 		) / totalExpected;
 
-	return { stage, elapsed, stageElapsed, isOverrun, getStageProgress, overallProgress };
+	return { stage, elapsed, stageElapsed, isOverrun, isStalled, getStageProgress, overallProgress };
 }

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -798,6 +798,7 @@ export function useProductInstall( {
 
 	return {
 		siteId,
+		selectedSiteSlug,
 		currentStep,
 		steps,
 		additionalSteps,


### PR DESCRIPTION
Part of DOTCOM-18312

## Proposed Changes

**When someone buys a plugin, we make them wait on a screen. If the plugin never turns on, that screen tells them "nothing is wrong" for four and a half minutes. This adds a second, honest message at 90 seconds — plus a button so they can leave.**

Today the wait screen escalates exactly once, at 32 seconds:

> This step is taking longer than usual. We're still working on it — nothing is wrong.

Then nothing changes until the 5-minute deadline shows an error. Meanwhile the progress bar is frozen at 92%, because it is not allowed to claim we're done when we can't confirm it.

At 90 seconds the screen now says instead:

> This is taking longer than it should. Your site is ready — your plugin may still finish installing on its own.

…and offers a "Go to your plugins" link.

* `use-install-progress.ts` — new `isStalled` flag: finishing stage, past 90s
* `copy.tsx` — the escalated line and the link label
* `card.tsx` — renders the new tier and the link; two Tracks events
* `index.tsx` / `use-product-install.tsx` — pass the site slug and product slug down
* `style.scss` — the link needs its own rule (its container sets `line-height: 0`)

## Why are these changes being made?

The key thing: **by this point the site is already finished.** The transfer is done. Only the plugin activation is outstanding, and it may still land on its own. There is no reason to hold someone on a loading screen — but today the only exit is an error screen five minutes in.

For 48 users a week the plugin never activates at all (see DOTCOM-18182 — the backend reports the transfer complete when the install job is only *queued*, and nothing reports back when it runs). Those people currently sit and stare while we tell them everything is fine.

**Why 90 seconds.** Measured on a week of transfer installs (19–25 Aug), by how long the finishing stage had been running:

| Threshold | Healthy installs that would see it | Timeout cohort caught | Abandoners caught |
|---|---|---|---|
| 45s | 12.5% | 100% | 68% |
| 60s | 7.4% | 100% | 59% |
| **90s** | **2.7%** | **100%** | **59%** |
| 120s | 1.5% | 100% | 55% |

p95 of a healthy finishing stage is 68s. 90s catches every stuck install while interrupting under 3% of good ones — and those 3% are genuinely slow, so the message is true for them too. 60s is too noisy. 120s starts losing abandoners.

Abandoners have a p95 of 884 seconds — they sit far past 90s before giving up. A door at 90s gives them ~3.5 minutes back.

**Gated to the finishing stage on purpose.** During the earlier stages the transfer really is unfinished and there is nowhere useful to send anyone, so nothing changes there.

**The 92% cap is left alone.** It is correct not to claim completion we cannot confirm. The problem was never the frozen bar — it was pairing a frozen bar with words saying everything is fine.

## Testing Instructions

Automated: `yarn test-client client/my-sites/marketplace/pages/marketplace-product-install` — 154 pass. Stubbing `isStalled` to `false` fails exactly the 4 tests that assert the new behavior.

By hand, without waiting 90 seconds: in `use-install-progress.ts` temporarily set `STALLED_SECONDS = 5`, then buy any plugin on a Simple site and watch the wait screen after the transfer completes.

* Before 5s (normally 90s): "Finishing up", no extra line
* After ~8s (normally 32s): the "nothing is wrong" line appears
* After 5s (normally 90s): that line is replaced by the new one, and "Go to your plugins" appears below the bar
* During the earlier stages, however long you wait, no link appears and the old line stays

Two new Tracks events: `calypso_marketplace_install_wait_stalled` (once per install) and `calypso_marketplace_install_wait_stalled_click` with `stage_seconds`, so we can see how long people waited before leaving.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
