### PR TITLE
Domains: show Cancel transfer option on the inbound transfer view

### DIFF
--- a/client/dashboard/domains/domain-transfer/inbound-transfer/transfer-step.tsx
+++ b/client/dashboard/domains/domain-transfer/inbound-transfer/transfer-step.tsx
@@ -5,12 +5,15 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { purchaseSettingsRoute } from '../../../app/router/me';
+import { purchaseSettingsRoute, cancelPurchaseRoute } from '../../../app/router/me';
 import { Card, CardBody } from '../../../components/card';
 import InlineSupportLink from '../../../components/inline-support-link';
 import SegmentedBar, { type SegmentedBarSegment } from '../../../components/segmented-bar';
 import { Text } from '../../../components/text';
-import { shouldShowRemoveAction } from '../../domain-overview/actions.utils';
+import {
+	shouldShowRemoveAction,
+	shouldShowCancelAction,
+} from '../../domain-overview/actions.utils';
 import type { ReactNode } from 'react';
 
 interface InboundTransferStepProps {
@@ -84,6 +87,11 @@ export const InboundTransferStep = ( {
 							</InlineSupportLink>
 							{ purchase && shouldShowRemoveAction( domain, purchase ) && (
 								<Link to={ purchaseSettingsRoute.fullPath } params={ { purchaseId: purchase.ID } }>
+									{ __( 'Cancel transfer' ) }
+								</Link>
+							) }
+							{ purchase && shouldShowCancelAction( domain, purchase ) && (
+								<Link to={ cancelPurchaseRoute.fullPath } params={ { purchaseId: purchase.ID } }>
 									{ __( 'Cancel transfer' ) }
 								</Link>
 							) }


### PR DESCRIPTION
Part of DOMENG-1003

## Proposed Changes

* On the Dashboard inbound-transfer view (`/domains/<domain>/transfer`), show the **Cancel transfer** link for the refundable ("cancel") purchase state, not just the non-refundable ("remove") state.

<img width="1287" height="1092" alt="Screenshot 2026-08-27 at 16 16 16" src="https://github.com/user-attachments/assets/eccf5503-9367-43d4-a04d-7d34240185da" />

## Why are these changes being made?

The transfer view's "Need help?" footer only checked `shouldShowRemoveAction`, so refundable transfers (handled by `shouldShowCancelAction`) had no cancel option there, even though the Overview did. This adds the missing branch so both views stay consistent.

## Note on the two Cancel transfer links

There are now two `Cancel transfer` entries in the footer, but they render from two mutually-exclusive conditions, so a user never sees both at once. Exactly one (or neither) shows, depending on the purchase state:

* **`shouldShowRemoveAction` → `purchaseSettingsRoute`** (`/me/billing/purchases/$purchaseId`): non-refundable transfers (auto-renew cannot be turned off). Opens the purchase settings page to remove it.
* **`shouldShowCancelAction` → `cancelPurchaseRoute`** (`/me/billing/purchases/$purchaseId/cancel`): refundable transfers (`is_refundable && refund_amount > 0`). Opens the cancel/refund flow.

Both split on `canAutoRenewBeTurnedOff( purchase )` (one requires it `false`, the other `true`), so they can never both be true for the same purchase. Same label to the user, correct underlying action per state, matching the Overview.

## Testing Instructions

* Open `/domains/<domain>/transfer` for a refundable inbound transfer and confirm a **Cancel transfer** link appears in "Need help?", pointing to the cancel-purchase flow.
* Confirm a non-refundable transfer still links to purchase settings, and the Overview behaves the same.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
