### PR TITLE
Checkout: protect userless signup with Blackbox

### DIFF
--- a/client/blocks/login/utils/test/use-blackbox.jsx
+++ b/client/blocks/login/utils/test/use-blackbox.jsx
@@ -120,7 +120,39 @@ describe( 'useBlackbox', () => {
 		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
 	} );
 
-	test( 'tracks the rendered challenge widget by measuring the container', async () => {
+	test( 'stops blocking when the SDK cannot present a challenge it announced', async () => {
+		let callbacks;
+		window.Blackbox.configure.mockImplementationOnce( ( config ) => {
+			callbacks = config;
+		} );
+
+		render( <TestComponent /> );
+
+		await act( async () => {} );
+		act( () => callbacks.onChallengeStart() );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/active/empty' );
+
+		act( () => callbacks.onError( { method: 'challenge' } ) );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+	} );
+
+	test( 'keeps blocking on errors unrelated to presenting the challenge', async () => {
+		let callbacks;
+		window.Blackbox.configure.mockImplementationOnce( ( config ) => {
+			callbacks = config;
+		} );
+
+		render( <TestComponent /> );
+
+		await act( async () => {} );
+		act( () => callbacks.onChallengeStart() );
+		act( () => callbacks.onError( { method: 'collect' } ) );
+
+		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/active/empty' );
+	} );
+
 		render( <TestComponent /> );
 
 		await act( async () => {} );

--- a/client/blocks/login/utils/test/use-blackbox.jsx
+++ b/client/blocks/login/utils/test/use-blackbox.jsx
@@ -153,6 +153,7 @@ describe( 'useBlackbox', () => {
 		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/active/empty' );
 	} );
 
+	test( 'tracks the rendered challenge widget by measuring the container', async () => {
 		render( <TestComponent /> );
 
 		await act( async () => {} );

--- a/client/blocks/login/utils/use-blackbox.js
+++ b/client/blocks/login/utils/use-blackbox.js
@@ -97,6 +97,17 @@ export function useBlackbox( { containerRef, enabled } ) {
 					// Fill the login form column so the challenge lines up with the
 					// input above and the full-width Continue button below.
 					challengeMaxWidth: '100%',
+					// The SDK reports a challenge it cannot present (bundle blocked
+					// or failed to load) through onError rather than
+					// onChallengeFailure, and only after onChallengeStart has already
+					// blocked the form. Without this the form stays blocked forever
+					// with no widget to solve.
+					onError: ( error ) => {
+						if ( ! cancelled && error?.method === 'challenge' ) {
+							stopLoading();
+							setIsChallengeActive( false );
+						}
+					},
 					onChallengeStart: () => {
 						if ( ! cancelled ) {
 							hasStartedChallenge = true;

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -476,7 +476,7 @@ export default function CheckoutMainContent( {
 
 	const leaveModalProps = useCheckoutLeaveModal( { siteUrl: siteUrl ?? '' } );
 	const blackbox = useBlackboxProtection( {
-		feature: 'blackbox-signup',
+		feature: 'blackbox-userless-checkout',
 		suspended: ! isLoggedOutCart,
 	} );
 

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -50,6 +50,7 @@ import {
 	type ReactNode,
 } from 'react';
 import { createPortal } from 'react-dom';
+import { useBlackboxProtection } from 'calypso/blocks/login/use-blackbox-protection';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Loading from 'calypso/components/loading';
 import { ONBOARDING_STEPPER_TOTAL } from 'calypso/landing/stepper/declarative-flow/flows/onboarding/step-counter-config';
@@ -392,9 +393,11 @@ function CheckoutSidebarNudge( {
 function PortaledCheckoutFormSubmit( {
 	validateForm,
 	submitButtonHeader,
+	disableSubmitButton,
 }: {
 	validateForm?: () => Promise< boolean >;
 	submitButtonHeader?: ReactNode;
+	disableSubmitButton?: boolean;
 } ) {
 	const { slotEl } = useSubmitButtonSlot();
 	if ( ! slotEl ) {
@@ -405,6 +408,7 @@ function PortaledCheckoutFormSubmit( {
 			validateForm={ validateForm }
 			continueToNextIncompleteStep
 			submitButtonHeader={ submitButtonHeader }
+			disableSubmitButton={ disableSubmitButton }
 		/>,
 		slotEl
 	);
@@ -471,6 +475,10 @@ export default function CheckoutMainContent( {
 	} = useShoppingCart( cartKey );
 
 	const leaveModalProps = useCheckoutLeaveModal( { siteUrl: siteUrl ?? '' } );
+	const blackbox = useBlackboxProtection( {
+		feature: 'blackbox-signup',
+		suspended: ! isLoggedOutCart,
+	} );
 
 	// Shared sidebar slot for the active payment-method submit button. We render
 	// <CheckoutFormSubmit> inside <CheckoutStepGroup> so it keeps full step-state
@@ -858,7 +866,22 @@ export default function CheckoutMainContent( {
 	// money-back guarantee is surfaced up in the payment step instead (see
 	// paymentStepRefundCopy) — reassurance at the moment of entering card
 	// details — so the footer slot below the CTA stays empty.
-	const portaledSubmitButtonHeader = isLargeViewport ? undefined : <SubmitButtonHeader />;
+	const blackboxChallengeHeader =
+		isLoggedOutCart && blackbox.challenge ? (
+			<BlackboxChallengeWrapper>{ blackbox.challenge }</BlackboxChallengeWrapper>
+		) : null;
+	const portaledSubmitButtonHeader = (
+		<>
+			{ isLargeViewport ? null : <SubmitButtonHeader /> }
+			{ blackboxChallengeHeader }
+		</>
+	);
+	const mobileSubmitButtonHeader = (
+		<>
+			<SubmitButtonHeader />
+			{ blackboxChallengeHeader }
+		</>
+	);
 	// Refund copy, no icon, that continues the secure-encryption notice at payment
 	// entry. getRefundWindowCopy is null when no refund window applies; mirror
 	// CheckoutMoneyBackGuarantee's all-domains guard.
@@ -1119,12 +1142,14 @@ export default function CheckoutMainContent( {
 						<PortaledCheckoutFormSubmit
 							validateForm={ validateForm }
 							submitButtonHeader={ portaledSubmitButtonHeader }
+							disableSubmitButton={ blackbox.isSubmitBlocked }
 						/>
 					) : (
 						<CheckoutFormSubmit
 							validateForm={ validateForm }
-							submitButtonHeader={ <SubmitButtonHeader /> }
+							submitButtonHeader={ mobileSubmitButtonHeader }
 							submitButtonFooter={ mobileSubmitButtonFooter }
+							disableSubmitButton={ blackbox.isSubmitBlocked }
 						/>
 					) }
 				</CheckoutStepGroup>
@@ -2415,6 +2440,12 @@ function CheckoutTermsAndCheckboxes( {
 		</CheckoutTermsAndCheckboxesWrapper>
 	);
 }
+
+const BlackboxChallengeWrapper = styled.div`
+	.login__form-blackbox-challenge.has-visible-challenge {
+		margin-block-end: 8px;
+	}
+`;
 
 function SubmitButtonHeader() {
 	const translate = useTranslate();

--- a/client/my-sites/checkout/src/payment-method-helpers.ts
+++ b/client/my-sites/checkout/src/payment-method-helpers.ts
@@ -7,11 +7,11 @@ import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import wp from 'calypso/lib/wp';
 import { stringifyBody } from 'calypso/state/login/utils';
 
-function isBlackboxSignupEnabled() {
+function isBlackboxUserlessCheckoutEnabled() {
 	return (
 		!! config( 'blackbox_api_key' ) &&
 		config.isEnabled( 'blackbox' ) &&
-		config.isEnabled( 'blackbox-signup' )
+		config.isEnabled( 'blackbox-userless-checkout' )
 	);
 }
 
@@ -98,7 +98,9 @@ export async function createAccount( {
 	}
 
 	const blogName = newSiteParams?.blog_name;
-	const blackboxSessionId = isBlackboxSignupEnabled() ? await getBlackboxSessionId() : undefined;
+	const blackboxSessionId = isBlackboxUserlessCheckoutEnabled()
+		? await getBlackboxSessionId()
+		: undefined;
 
 	try {
 		const response = await wp.req.post( '/users/new', {
@@ -125,7 +127,7 @@ export async function createAccount( {
 		createAccountCallback( response );
 		return response;
 	} catch ( error ) {
-		if ( isBlackboxSignupEnabled() ) {
+		if ( isBlackboxUserlessCheckoutEnabled() ) {
 			resetBlackbox();
 		}
 		const errorMessage = ( error as Error )?.message

--- a/client/my-sites/checkout/src/payment-method-helpers.ts
+++ b/client/my-sites/checkout/src/payment-method-helpers.ts
@@ -1,10 +1,27 @@
 import config from '@automattic/calypso-config';
 import i18n from 'i18n-calypso';
+import { getBlackboxSessionId } from 'calypso/blocks/login/utils/get-blackbox-session-id';
 import { recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
 import { getLocaleSlug } from 'calypso/lib/i18n-utils';
 import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import wp from 'calypso/lib/wp';
 import { stringifyBody } from 'calypso/state/login/utils';
+
+function isBlackboxSignupEnabled() {
+	return (
+		!! config( 'blackbox_api_key' ) &&
+		config.isEnabled( 'blackbox' ) &&
+		config.isEnabled( 'blackbox-signup' )
+	);
+}
+
+function resetBlackbox() {
+	try {
+		window.Blackbox?.reset?.();
+	} catch {
+		// Blackbox must never block checkout.
+	}
+}
 
 interface CreateAccountResponse {
 	success: boolean;
@@ -81,6 +98,7 @@ export async function createAccount( {
 	}
 
 	const blogName = newSiteParams?.blog_name;
+	const blackboxSessionId = isBlackboxSignupEnabled() ? await getBlackboxSessionId() : undefined;
 
 	try {
 		const response = await wp.req.post( '/users/new', {
@@ -97,6 +115,7 @@ export async function createAccount( {
 			client_id: config( 'wpcom_signup_id' ),
 			client_secret: config( 'wpcom_signup_key' ),
 			tos: getToSAcceptancePayload(),
+			...( blackboxSessionId && { blackbox_session_id: blackboxSessionId } ),
 		} );
 
 		if ( ! isCreateAccountResponse( response ) || ! response.success ) {
@@ -106,6 +125,9 @@ export async function createAccount( {
 		createAccountCallback( response );
 		return response;
 	} catch ( error ) {
+		if ( isBlackboxSignupEnabled() ) {
+			resetBlackbox();
+		}
 		const errorMessage = ( error as Error )?.message
 			? getErrorMessage( error as Error )
 			: ( error as string );

--- a/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal-js.tsx
@@ -1,5 +1,6 @@
 import { PayPalConfigurationApiResponse, PayPalProvider } from '@automattic/calypso-paypal';
 import {
+	PaymentProcessorResponseType,
 	useTogglePaymentMethod,
 	type PaymentMethod,
 	type ProcessPayment,
@@ -190,8 +191,24 @@ function PayPalSubmitButton( {
 		// handler) to call the transactions endpoint and then eventually
 		// return here to trigger the PayPal popup which happens when this
 		// Promise resolves with the PayPal order ID.
-		const { promise: orderPromise, resolve: resolvePayPalOrderPromise } = deferred< string >();
-		onClick( { resolvePayPalOrderPromise, payPalApprovalPromise } );
+		const {
+			promise: orderPromise,
+			resolve: resolvePayPalOrderPromise,
+			reject: rejectPayPalOrderPromise,
+		} = deferred< string >();
+		onClick( { resolvePayPalOrderPromise, payPalApprovalPromise } )
+			.then( ( response ) => {
+				if ( response.type === PaymentProcessorResponseType.ERROR ) {
+					// PayPal already opened its checkout UI; rejecting createOrder
+					// is how we ask it to close when we never minted an order.
+					rejectPayPalOrderPromise( new Error( response.payload ) );
+					setForceReRender( ( val ) => val + 1 );
+				}
+			} )
+			.catch( ( error ) => {
+				rejectPayPalOrderPromise( error );
+				setForceReRender( ( val ) => val + 1 );
+			} );
 		return orderPromise;
 	};
 

--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -42,6 +42,13 @@ jest.mock( 'calypso/lib/analytics/utils/refresh-country-code-cookie-gdpr' );
 jest.mock( 'calypso/state/products-list/selectors/is-marketplace-product' );
 jest.mock( 'calypso/lib/navigate' );
 jest.mock( 'calypso/state/notices/actions' );
+jest.mock( 'calypso/blocks/login/blackbox-challenge', () => {
+	const { useEffect } = jest.requireActual( 'react' );
+	return ( { onSubmitBlockedChange } ) => {
+		useEffect( () => onSubmitBlockedChange?.( false ), [ onSubmitBlockedChange ] );
+		return null;
+	};
+} );
 
 describe( 'CheckoutMain', () => {
 	const initialCart = getBasicCart();

--- a/client/my-sites/checkout/src/test/multi-partner-card-processor.tsx
+++ b/client/my-sites/checkout/src/test/multi-partner-card-processor.tsx
@@ -31,6 +31,10 @@ jest.mock( '../lib/create-ebanx-token-vgs', () => ( {
 	createEbanxTokenVgs: jest.fn(),
 } ) );
 
+jest.mock( 'calypso/blocks/login/utils/get-blackbox-session-id', () => ( {
+	getBlackboxSessionId: jest.fn().mockResolvedValue( undefined ),
+} ) );
+
 async function createMockStripeToken( {
 	type,
 	card,

--- a/client/my-sites/checkout/src/test/payment-method-helpers.ts
+++ b/client/my-sites/checkout/src/test/payment-method-helpers.ts
@@ -68,10 +68,16 @@ describe( 'createAccount', () => {
 	} );
 
 	it( 'resets Blackbox when account creation fails', async () => {
-		window.Blackbox = { reset: jest.fn() };
+		const reset = jest.fn();
+		window.Blackbox = {
+			configure: jest.fn(),
+			collect: jest.fn(),
+			getSessionId: jest.fn(),
+			reset,
+		};
 		interceptUsersNew( 500, { error: 'internal_server_error', message: 'fail' } );
 
 		await expect( createAccount( createAccountArgs ) ).rejects.toThrow();
-		expect( window.Blackbox.reset ).toHaveBeenCalledTimes( 1 );
+		expect( reset ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/client/my-sites/checkout/src/test/payment-method-helpers.ts
+++ b/client/my-sites/checkout/src/test/payment-method-helpers.ts
@@ -32,7 +32,7 @@ const createAccountArgs = {
 describe( 'createAccount', () => {
 	beforeEach( () => {
 		config.enable( 'blackbox' );
-		config.enable( 'blackbox-signup' );
+		config.enable( 'blackbox-userless-checkout' );
 		( getBlackboxSessionId as jest.Mock ).mockReset();
 		( getBlackboxSessionId as jest.Mock ).mockResolvedValue( undefined );
 		delete window.Blackbox;
@@ -48,8 +48,8 @@ describe( 'createAccount', () => {
 		expect( getRequestBody()?.blackbox_session_id ).toBe( 'ABCDEFGHIJKLMNOPQRSTuv' );
 	} );
 
-	it( 'omits blackbox_session_id when the signup feature flag is off', async () => {
-		config.disable( 'blackbox-signup' );
+	it( 'omits blackbox_session_id when the userless checkout feature flag is off', async () => {
+		config.disable( 'blackbox-userless-checkout' );
 		( getBlackboxSessionId as jest.Mock ).mockResolvedValue( 'ABCDEFGHIJKLMNOPQRSTuv' );
 		const getRequestBody = interceptUsersNew();
 

--- a/client/my-sites/checkout/src/test/payment-method-helpers.ts
+++ b/client/my-sites/checkout/src/test/payment-method-helpers.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import config from '@automattic/calypso-config';
+import nock from 'nock';
+import { getBlackboxSessionId } from 'calypso/blocks/login/utils/get-blackbox-session-id';
+import { createAccount } from '../payment-method-helpers';
+
+jest.mock( 'calypso/blocks/login/utils/get-blackbox-session-id', () => ( {
+	getBlackboxSessionId: jest.fn().mockResolvedValue( undefined ),
+} ) );
+
+function interceptUsersNew( status = 200, responseBody: object = { success: true } ) {
+	let requestBody: Record< string, unknown > | undefined;
+	nock( 'https://public-api.wordpress.com' )
+		.post( '/rest/v1.1/users/new', ( body ) => {
+			requestBody = body;
+			return true;
+		} )
+		.reply( status, responseBody );
+	return () => requestBody;
+}
+
+const createAccountArgs = {
+	signupFlowName: 'akismet-userless-checkout',
+	email: 'test@example.com',
+	siteId: undefined,
+	recaptchaClientId: undefined,
+};
+
+describe( 'createAccount', () => {
+	beforeEach( () => {
+		config.enable( 'blackbox' );
+		config.enable( 'blackbox-signup' );
+		( getBlackboxSessionId as jest.Mock ).mockReset();
+		( getBlackboxSessionId as jest.Mock ).mockResolvedValue( undefined );
+		delete window.Blackbox;
+		nock.cleanAll();
+	} );
+
+	it( 'attaches blackbox_session_id when available', async () => {
+		( getBlackboxSessionId as jest.Mock ).mockResolvedValue( 'ABCDEFGHIJKLMNOPQRSTuv' );
+		const getRequestBody = interceptUsersNew();
+
+		await createAccount( createAccountArgs );
+
+		expect( getRequestBody()?.blackbox_session_id ).toBe( 'ABCDEFGHIJKLMNOPQRSTuv' );
+	} );
+
+	it( 'omits blackbox_session_id when the signup feature flag is off', async () => {
+		config.disable( 'blackbox-signup' );
+		( getBlackboxSessionId as jest.Mock ).mockResolvedValue( 'ABCDEFGHIJKLMNOPQRSTuv' );
+		const getRequestBody = interceptUsersNew();
+
+		await createAccount( createAccountArgs );
+
+		expect( getRequestBody() ).not.toHaveProperty( 'blackbox_session_id' );
+		expect( getBlackboxSessionId ).not.toHaveBeenCalled();
+	} );
+
+	it( 'omits blackbox_session_id when no session is available', async () => {
+		const getRequestBody = interceptUsersNew();
+
+		await createAccount( createAccountArgs );
+
+		expect( getRequestBody() ).not.toHaveProperty( 'blackbox_session_id' );
+	} );
+
+	it( 'resets Blackbox when account creation fails', async () => {
+		window.Blackbox = { reset: jest.fn() };
+		interceptUsersNew( 500, { error: 'internal_server_error', message: 'fail' } );
+
+		await expect( createAccount( createAccountArgs ) ).rejects.toThrow();
+		expect( window.Blackbox.reset ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/client/my-sites/checkout/src/test/paypal-express-processor.ts
+++ b/client/my-sites/checkout/src/test/paypal-express-processor.ts
@@ -21,6 +21,10 @@ import {
 	setMockLocation,
 } from './util';
 
+jest.mock( 'calypso/blocks/login/utils/get-blackbox-session-id', () => ( {
+	getBlackboxSessionId: jest.fn().mockResolvedValue( undefined ),
+} ) );
+
 describe( 'payPalExpressProcessor', () => {
 	const product = getEmptyResponseCartProduct();
 	const domainProduct = {

--- a/config/development.json
+++ b/config/development.json
@@ -55,6 +55,7 @@
 		"blackbox-login": true,
 		"blackbox-lost-password": true,
 		"blackbox-signup": true,
+		"blackbox-userless-checkout": true,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/ai-site-builder-build-wow": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -17,6 +17,7 @@
 		"blackbox-login": true,
 		"blackbox-lost-password": true,
 		"blackbox-signup": true,
+		"blackbox-userless-checkout": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/all-domain-management": false,
 		"calypso/big-sky": true,

--- a/config/production.json
+++ b/config/production.json
@@ -29,6 +29,7 @@
 		"blackbox-login": true,
 		"blackbox-lost-password": true,
 		"blackbox-signup": true,
+		"blackbox-userless-checkout": false,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/ai-site-builder-build-wow": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -26,6 +26,7 @@
 		"blackbox-login": true,
 		"blackbox-lost-password": true,
 		"blackbox-signup": true,
+		"blackbox-userless-checkout": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/ai-site-builder-build-wow": true,

--- a/config/test.json
+++ b/config/test.json
@@ -29,6 +29,7 @@
 		"blackbox-login": true,
 		"blackbox-lost-password": true,
 		"blackbox-signup": true,
+		"blackbox-userless-checkout": true,
 		"calypso/all-domain-management": true,
 		"calypso/domains-dataviews": true,
 		"catch-js-errors": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -25,6 +25,7 @@
 		"blackbox-login": true,
 		"blackbox-lost-password": true,
 		"blackbox-signup": true,
+		"blackbox-userless-checkout": true,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/ai-site-builder-flow": true,
 		"calypso/ai-site-builder-build-wow": false,

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -946,11 +946,10 @@ export function CheckoutFormSubmit( {
 	// actually an incomplete step to go to. The latter guard matters for returning
 	// purchasers whose steps are all auto-completed while the active step is still
 	// an earlier step: there is nothing to continue to, so show the Pay button.
+	// `disableSubmitButton` only disables Pay. Continue validates the current
+	// step rather than paying, so it stays available while a later step exists.
 	const showContinueToNextIncompleteStep =
-		!! continueToNextIncompleteStep &&
-		! disableSubmitButton &&
-		isThereAnotherNumberedStep &&
-		!! nextIncompleteStepId;
+		!! continueToNextIncompleteStep && isThereAnotherNumberedStep && !! nextIncompleteStepId;
 
 	const goToNextIncompleteStep = async () => {
 		// Prefer the next incomplete step; otherwise just advance one step so the

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -872,7 +872,10 @@ describe( 'Checkout', () => {
 							{ stepObjectsWithoutStepNumber.map( createStepFromStepObject ) }
 							{ stepObjectsWithStepNumber.map( createStepFromStepObject ) }
 							{ props.withProp ? (
-								<CheckoutFormSubmit continueToNextIncompleteStep />
+								<CheckoutFormSubmit
+									continueToNextIncompleteStep
+									disableSubmitButton={ props.disableSubmitButton }
+								/>
 							) : (
 								<CheckoutFormSubmit />
 							) }
@@ -931,6 +934,20 @@ describe( 'Checkout', () => {
 				'aria-label',
 				'Continue to the next step'
 			);
+			expect( queryByTextInNode( submitArea, 'Pay Please' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'still renders Continue when disableSubmitButton is set', () => {
+			const { container } = render(
+				<ContinueCheckout
+					withProp
+					disableSubmitButton
+					steps={ [ steps[ 0 ], steps[ 1 ], steps[ 3 ] ] }
+				/>
+			);
+			const submitArea = getSubmitArea( container );
+			expect( getByTextInNode( submitArea, 'Continue' ) ).toBeInTheDocument();
+			expect( getByTextInNode( submitArea, 'Continue' ) ).not.toBeDisabled();
 			expect( queryByTextInNode( submitArea, 'Pay Please' ) ).not.toBeInTheDocument();
 		} );
 

--- a/test/e2e/lib/blackbox-test-key.ts
+++ b/test/e2e/lib/blackbox-test-key.ts
@@ -1,3 +1,5 @@
+import { DataHelper } from '@automattic/calypso-e2e';
+import type { NewTestUserDetails } from '@automattic/calypso-e2e';
 import type { Page } from '@playwright/test';
 
 const BLACKBOX_COLLECT_ROUTE = 'https://blackbox-api.wp.com/v1/collect**';
@@ -63,4 +65,13 @@ export async function useBlackboxTestKeyForCollect(
 			},
 		} );
 	} );
+}
+
+/**
+ * Siteless / passwordless signup generates the username from the email.
+ * A Mailosaur address is `e2eflowtestingblackbox<id>@inbox.mailosaur.net`,
+ * which sanitizes to a test-loop username and passes close-account email checks.
+ */
+export function getBlackboxTestLoopUser(): NewTestUserDetails {
+	return DataHelper.getNewTestUser( { usernamePrefix: 'blackbox', useMailosaur: true } );
 }

--- a/test/e2e/specs/checkout/checkout__blackbox-userless.spec.ts
+++ b/test/e2e/specs/checkout/checkout__blackbox-userless.spec.ts
@@ -1,0 +1,343 @@
+import { BrowserManager, DataHelper, RestAPIClient } from '@automattic/calypso-e2e';
+import {
+	getBlackboxTestLoopUser,
+	useBlackboxTestKeyForCollect,
+	waitForCollectData,
+	type BlackboxTestCollectOutcome,
+} from '../../lib/blackbox-test-key';
+import { expect, tags, test } from '../../lib/pw-base';
+import { apiCloseAccount } from '../shared';
+import type { CartCheckoutPage, NewUserResponse } from '@automattic/calypso-e2e';
+import type { Page, Request } from '@playwright/test';
+
+const waitForUsersNewRequest = ( page: Page ): Promise< Request > =>
+	page.waitForRequest(
+		( request ) => request.method() === 'POST' && /\/users\/new/.test( request.url() ),
+		{ timeout: 60 * 1000 }
+	);
+
+/**
+ * Blackbox verdicts on logged-out Jetpack siteless checkout
+ * (`/checkout/jetpack/:product`). Account creation happens on Pay via
+ * `/users/new`. A block must reject that signup before a transaction starts;
+ * createAccount() then resets Blackbox so a new session is collected.
+ */
+test.describe( 'Checkout: Blackbox userless Jetpack', { tag: [ tags.CALYPSO_RELEASE ] }, () => {
+	const productSlug = 'jetpack_backup_t1_yearly';
+	const cartItemName = 'VaultPress Backup';
+
+	const accountsToCleanup: { user: NewUserResponse[ 'body' ]; password: string; email: string }[] =
+		[];
+
+	test.afterAll( async function () {
+		for ( const account of accountsToCleanup ) {
+			console.log(
+				`[blackbox-userless] user_id=${ account.user.user_id } username=${ account.user.username } email=${ account.email }`
+			);
+			const restAPIClient = new RestAPIClient(
+				{ username: account.user.username, password: account.password },
+				account.user.bearer_token
+			);
+			await cancelAccountPurchases( restAPIClient, account.user.user_id );
+			await apiCloseAccount( restAPIClient, {
+				userID: account.user.user_id,
+				username: account.user.username,
+				email: account.email,
+			} );
+		}
+	} );
+
+	test( 'As a logged-out user, I see a challenge and cannot pay while it is active', async ( {
+		helperData,
+		page,
+		pageCartCheckout,
+	} ) => {
+		const testUser = getBlackboxTestLoopUser();
+
+		await test.step( 'Given Blackbox collect uses the public challenge test key', async function () {
+			await useBlackboxTestKeyForCollect( page, 'challenge' );
+		} );
+
+		await test.step( 'And store cookies are set for purchases', async function () {
+			await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+		} );
+
+		const collectData = waitForCollectData( page );
+
+		await test.step( 'When I visit Jetpack siteless checkout', async function () {
+			await openUserlessCheckout( page, pageCartCheckout, helperData.getCalypsoURL );
+
+			const collectBody = await collectData;
+			expect( collectBody?.data?.session_id ).toBe( 'bbtest_challenge______' );
+			expect( collectBody?.data?.challenge ).toBeTruthy();
+		} );
+
+		await test.step( 'And I complete the contact step', async function () {
+			await completeContactStep( page, testUser.email );
+		} );
+
+		await test.step( 'Then the challenge widget is shown and Pay is blocked', async function () {
+			await expect(
+				page.locator( '.login__form-blackbox-challenge.has-visible-challenge' )
+			).toBeVisible();
+			await expect( page.getByRole( 'button', { name: /Pay (now|with)/ } ) ).toBeDisabled();
+		} );
+	} );
+
+	test( 'As a logged-out user, I can complete purchase when Blackbox returns allow', async ( {
+		helperData,
+		page,
+		pageCartCheckout,
+	} ) => {
+		test.setTimeout( 180 * 1000 );
+		const expectedSessionId = 'bbtest_allow__________';
+		const testUser = await startCheckoutThroughPaymentDetails( {
+			page,
+			pageCartCheckout,
+			getCalypsoURL: helperData.getCalypsoURL,
+			outcome: 'allow',
+			expectedSessionId,
+		} );
+
+		await test.step( 'When I complete the purchase', async function () {
+			const usersNewRequest = waitForUsersNewRequest( page );
+			const usersNewResponse = page.waitForResponse(
+				( response ) =>
+					response.request().method() === 'POST' && /\/users\/new/.test( response.url() ),
+				{ timeout: 60 * 1000 }
+			);
+
+			await pageCartCheckout.purchase( { timeout: 90 * 1000 } );
+
+			const request = await usersNewRequest;
+			expect( request.postDataJSON()?.blackbox_session_id ).toBe( expectedSessionId );
+
+			const createdUser = parseCreatedUser( await ( await usersNewResponse ).json() );
+			// Queue teardown before asserting so a created account never leaks.
+			if ( createdUser ) {
+				accountsToCleanup.push( {
+					user: createdUser,
+					password: testUser.password,
+					email: testUser.email,
+				} );
+			}
+			expect( createdUser?.user_id ).toBeTruthy();
+			expect( createdUser?.bearer_token ).toBeTruthy();
+		} );
+
+		await test.step( 'Then I land on the Jetpack siteless thank-you page', async function () {
+			await page.waitForURL( /\/checkout\/jetpack\/thank-you\/licensing-auto-activate\//, {
+				timeout: 60 * 1000,
+			} );
+		} );
+	} );
+
+	test( 'As a logged-out user, I cannot complete purchase when Blackbox returns block', async ( {
+		helperData,
+		page,
+		pageCartCheckout,
+	} ) => {
+		test.setTimeout( 180 * 1000 );
+		const expectedSessionId = 'bbtest_block__________';
+		const testUser = await startCheckoutThroughPaymentDetails( {
+			page,
+			pageCartCheckout,
+			getCalypsoURL: helperData.getCalypsoURL,
+			outcome: 'block',
+			expectedSessionId,
+		} );
+
+		await test.step( 'When I try to pay', async function () {
+			const nextCollect = waitForCollectData( page );
+			const usersNewRequest = waitForUsersNewRequest( page );
+			const usersNewResponse = page.waitForResponse(
+				( response ) =>
+					response.request().method() === 'POST' && /\/users\/new/.test( response.url() ),
+				{ timeout: 60 * 1000 }
+			);
+
+			const transactionUrls: string[] = [];
+			const trackTransactions = ( request: Request ) => {
+				if ( request.method() === 'POST' && /me\/transactions/.test( request.url() ) ) {
+					transactionUrls.push( request.url() );
+				}
+			};
+			page.on( 'request', trackTransactions );
+
+			try {
+				const payButton = page.getByRole( 'button', { name: /Pay (now|with)/ } );
+				await expect( payButton ).toBeEnabled( { timeout: 30 * 1000 } );
+				await payButton.click();
+
+				const request = await usersNewRequest;
+				expect( request.postDataJSON()?.blackbox_session_id ).toBe( expectedSessionId );
+
+				const body = await ( await usersNewResponse ).json();
+				const createdUser = parseCreatedUser( body );
+				// Queue teardown before asserting so a created account never leaks.
+				if ( createdUser ) {
+					accountsToCleanup.push( {
+						user: createdUser,
+						password: testUser.password,
+						email: testUser.email,
+					} );
+				}
+
+				expect( createdUser ).toBeNull();
+				expect( usersNewErrorCode( body ) ).toBe( 'throttled' );
+
+				const collectBody = await nextCollect;
+				expect( collectBody?.data?.session_id ).toBeTruthy();
+				expect( transactionUrls ).toEqual( [] );
+			} finally {
+				page.off( 'request', trackTransactions );
+			}
+		} );
+
+		await test.step( 'Then I remain on checkout with an error', async function () {
+			await expect( page ).toHaveURL( /\/checkout\/jetpack\// );
+			expect( page.url() ).not.toMatch( /thank-you/ );
+			await expect( page.locator( '.calypso-notice.is-error' ) ).toBeVisible();
+		} );
+	} );
+
+	async function openUserlessCheckout(
+		page: Page,
+		pageCartCheckout: CartCheckoutPage,
+		getCalypsoURL: ( path: string ) => string
+	) {
+		await page.goto( getCalypsoURL( `/checkout/jetpack/${ productSlug }` ) );
+		await pageCartCheckout.validateCartItem( cartItemName );
+	}
+
+	async function completeContactStep( page: Page, email: string ) {
+		const paymentDetails = DataHelper.getTestPaymentDetails();
+		await page.locator( '#email' ).fill( email );
+		// Postal is hidden until a country is chosen on siteless checkout.
+		await page
+			.locator( 'select[aria-labelledby="country-selector-label"]' )
+			.selectOption( paymentDetails.countryCode );
+		const postalCode = page.locator( 'input[id="contact-postal-code"]' );
+		if ( await postalCode.isVisible() ) {
+			await postalCode.fill( paymentDetails.postalCode );
+		}
+		await page
+			.locator( '[data-testid="contact-form--visible"] button.checkout-button.is-status-primary' )
+			.click();
+	}
+
+	async function startCheckoutThroughPaymentDetails( {
+		page,
+		pageCartCheckout,
+		getCalypsoURL,
+		outcome,
+		expectedSessionId,
+	}: {
+		page: Page;
+		pageCartCheckout: CartCheckoutPage;
+		getCalypsoURL: ( path: string ) => string;
+		outcome: BlackboxTestCollectOutcome;
+		expectedSessionId: string;
+	} ) {
+		const testUser = getBlackboxTestLoopUser();
+		const paymentDetails = DataHelper.getTestPaymentDetails();
+
+		await test.step( `Given Blackbox collect uses the public ${ outcome } test key`, async function () {
+			await useBlackboxTestKeyForCollect( page, outcome );
+		} );
+
+		await test.step( 'And store cookies are set for purchases', async function () {
+			await BrowserManager.setStoreCookie( page, { currency: 'USD' } );
+		} );
+
+		const collectData = waitForCollectData( page );
+
+		await test.step( 'When I visit Jetpack siteless checkout', async function () {
+			await openUserlessCheckout( page, pageCartCheckout, getCalypsoURL );
+
+			const collectBody = await collectData;
+			expect( collectBody?.data?.session_id ).toBe( expectedSessionId );
+		} );
+
+		await test.step( 'And I complete the contact step', async function () {
+			await completeContactStep( page, testUser.email );
+		} );
+
+		await test.step( 'And I enter payment details', async function () {
+			await pageCartCheckout.enterPaymentDetails( paymentDetails );
+		} );
+
+		return testUser;
+	}
+} );
+
+function usersNewBody( json: unknown ): Record< string, unknown > | null {
+	if ( ! json || typeof json !== 'object' ) {
+		return null;
+	}
+	const record = json as Record< string, unknown >;
+	return ( record.body && typeof record.body === 'object' ? record.body : record ) as Record<
+		string,
+		unknown
+	>;
+}
+
+function usersNewErrorCode( json: unknown ): string | undefined {
+	const error = usersNewBody( json )?.error;
+	return typeof error === 'string' ? error : undefined;
+}
+
+function parseCreatedUser( json: unknown ): NewUserResponse[ 'body' ] | null {
+	const body = usersNewBody( json );
+	if ( ! body ) {
+		return null;
+	}
+	const rawUserID = body.user_id;
+	const userID =
+		typeof rawUserID === 'number' || typeof rawUserID === 'string' ? Number( rawUserID ) : NaN;
+	if (
+		body.success !== true ||
+		! Number.isInteger( userID ) ||
+		userID <= 0 ||
+		typeof body.username !== 'string' ||
+		typeof body.bearer_token !== 'string'
+	) {
+		return null;
+	}
+	return {
+		success: true,
+		user_id: userID,
+		username: body.username,
+		bearer_token: body.bearer_token,
+	};
+}
+
+async function cancelAccountPurchases( client: RestAPIClient, userId: number ): Promise< void > {
+	try {
+		const purchases = await client.getAllPurchases();
+		console.log(
+			`[blackbox-userless] user_id=${ userId } purchases=${ purchases.length }`,
+			purchases.map( ( purchase ) => ( {
+				id: purchase.ID,
+				product_id: purchase.product_id,
+				product_slug: purchase.product_slug,
+				blog_id: purchase.blog_id,
+			} ) )
+		);
+		for ( const purchase of purchases ) {
+			console.log(
+				`[blackbox-userless] cancelling purchase id=${ purchase.ID } slug=${ purchase.product_slug }`
+			);
+			const result = await client.cancelPurchase( purchase.ID, {
+				product_id: purchase.product_id,
+				cancel_bundled_domain: 0,
+				email_variant: 'control',
+			} );
+			console.log( `[blackbox-userless] cancel result for purchase id=${ purchase.ID }`, result );
+		}
+	} catch ( error ) {
+		console.warn(
+			`[blackbox-userless] Error cancelling purchases for user_id=${ userId } (continuing to account close): ${ error }`
+		);
+	}
+}

--- a/test/e2e/specs/checkout/checkout__blackbox-userless.spec.ts
+++ b/test/e2e/specs/checkout/checkout__blackbox-userless.spec.ts
@@ -80,7 +80,7 @@ test.describe( 'Checkout: Blackbox userless Jetpack', { tag: [ tags.CALYPSO_RELE
 			await expect(
 				page.locator( '.login__form-blackbox-challenge.has-visible-challenge' )
 			).toBeVisible();
-			await expect( page.getByRole( 'button', { name: /Pay (now|with)/ } ) ).toBeDisabled();
+			await expect( page.locator( '.checkout-submit-button--active button' ) ).toBeDisabled();
 		} );
 	} );
 


### PR DESCRIPTION
Related to BBOX-310.

`createAccount()` for `*-userless-checkout` now sends `blackbox_session_id` so those just-in-time signups get a session like the other signup forms.

The challenge is mounted next to the sidebar/mobile submit button, not the email field (within the contact section). Putting it in the contact section hides it once that step collapses: a problem if we `reset()` after a failed signup or the session expires and we need to show another one. The final "Pay" button stays disabled while the challenge is unsolved. If the SDK cannot present a challenge (`onError` with `method === 'challenge'`), we fail open.

Also, this PR rejects PayPal's `createOrder` when signup fails so the popup closes. That's an old bug; Blackbox just makes it more likely to fail at the signup part of the payment.

## Rollout

Enabled everywhere but production. Will open a separate PR for production.

## Testing

I added E2E tests for each of these cases (minus PayPal). These are mainly aimed at the Blackbox part of the userless checkout, but they also happen to be the first E2E tests for _userless_ checkouts.

---

Go to any of the userless checkouts, e.g.

- http://calypso.localhost:3000/checkout/akismet/ak_plus_yearly_1
- http://calypso.localhost:3000/checkout/jetpack/jetpack_backup_t1_yearly

#### Logged in

1. Make sure you are logged in
2. Visit a checkout page
3. **Expected**: Blackbox does not load
4. Complete checkout
5. **Expected**: Nothing is disabled or blocked by the missing Blackbox load

#### Logged out

Each of these should be done for both a PayPal checkout and a CC checkout. Use the "Store Sandbox" dev helper.

##### Allow

1. Visit a checkout page
2. Complete the checkout
3. **Expected**: request body to `https://public-api.wordpress.com/rest/v1.1/users/new` contains session id

##### Block

1. Visit a checkout page
2. Complete the checkout using an e2eflowtesting... account name
3. **Expected**: Signup fails (session is sent) and new Blackbox session is minted
4. **BONUS expected**: If PayPal is used the payment window should close automatically

#### Challenge

1. Visit a checkout page
2. Complete the checkout
3. **Expected**: Payment button is disabled until challenge is solved
4. Click pay
5. **Expected**: request body contains session id