### PR TITLE
Update preview chip when text is selected

### DIFF
--- a/packages/agents-manager/src/components/selected-block/__tests__/get-selected-text.test.ts
+++ b/packages/agents-manager/src/components/selected-block/__tests__/get-selected-text.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getAttributePlainText, getSelectedTextContext } from '../get-selected-text';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	store: 'core/block-editor',
+} ) );
+
+const mockGetSelectionStart = jest.fn();
+const mockGetSelectionEnd = jest.fn();
+const mockGetBlockAttributes = jest.fn();
+
+const select = () => ( {
+	getSelectionStart: () => mockGetSelectionStart(),
+	getSelectionEnd: () => mockGetSelectionEnd(),
+	getBlockAttributes: ( clientId: string ) => mockGetBlockAttributes( clientId ),
+} );
+
+describe( 'getAttributePlainText', () => {
+	it( 'returns the text of a rich-text object', () => {
+		expect( getAttributePlainText( { text: 'Hello world' } ) ).toBe( 'Hello world' );
+	} );
+
+	it( 'strips markup from an HTML string and keeps <br> as newline', () => {
+		expect( getAttributePlainText( 'Hello <strong>bold</strong><br>world' ) ).toBe(
+			'Hello bold\nworld'
+		);
+	} );
+
+	it( 'returns null for non-text values', () => {
+		expect( getAttributePlainText( 42 ) ).toBeNull();
+		expect( getAttributePlainText( { url: 'x' } ) ).toBeNull();
+		expect( getAttributePlainText( undefined ) ).toBeNull();
+	} );
+} );
+
+describe( 'getSelectedTextContext', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockGetBlockAttributes.mockReturnValue( {
+			content: { text: 'Welcome to our new product page' },
+		} );
+	} );
+
+	const point = ( offset: number ) => ( {
+		clientId: 'block-1',
+		attributeKey: 'content',
+		offset,
+	} );
+
+	it( 'returns the selected range', () => {
+		mockGetSelectionStart.mockReturnValue( point( 15 ) );
+		mockGetSelectionEnd.mockReturnValue( point( 26 ) );
+
+		expect( getSelectedTextContext( select ) ).toEqual( {
+			text: 'new product',
+			attributeKey: 'content',
+			start: 15,
+			end: 26,
+		} );
+	} );
+
+	it( 'normalizes a backwards selection', () => {
+		mockGetSelectionStart.mockReturnValue( point( 26 ) );
+		mockGetSelectionEnd.mockReturnValue( point( 15 ) );
+
+		expect( getSelectedTextContext( select ) ).toMatchObject( {
+			text: 'new product',
+			start: 15,
+			end: 26,
+		} );
+	} );
+
+	it( 'returns null for a caret (equal offsets)', () => {
+		mockGetSelectionStart.mockReturnValue( point( 5 ) );
+		mockGetSelectionEnd.mockReturnValue( point( 5 ) );
+
+		expect( getSelectedTextContext( select ) ).toBeNull();
+	} );
+
+	it( 'returns null when the selection spans two blocks', () => {
+		mockGetSelectionStart.mockReturnValue( point( 2 ) );
+		mockGetSelectionEnd.mockReturnValue( {
+			...point( 8 ),
+			clientId: 'block-2',
+		} );
+
+		expect( getSelectedTextContext( select ) ).toBeNull();
+	} );
+
+	it( 'returns null when the selection spans two attributes of one block', () => {
+		mockGetSelectionStart.mockReturnValue( point( 2 ) );
+		mockGetSelectionEnd.mockReturnValue( {
+			...point( 8 ),
+			attributeKey: 'citation',
+		} );
+
+		expect( getSelectedTextContext( select ) ).toBeNull();
+	} );
+
+	it( 'returns null for a block-level selection (no attributeKey)', () => {
+		mockGetSelectionStart.mockReturnValue( { clientId: 'block-1' } );
+		mockGetSelectionEnd.mockReturnValue( { clientId: 'block-1' } );
+
+		expect( getSelectedTextContext( select ) ).toBeNull();
+	} );
+
+	it( 'reads HTML string attributes', () => {
+		mockGetBlockAttributes.mockReturnValue( {
+			content: 'Welcome to <em>our new product</em> page',
+		} );
+		mockGetSelectionStart.mockReturnValue( point( 11 ) );
+		mockGetSelectionEnd.mockReturnValue( point( 26 ) );
+
+		expect( getSelectedTextContext( select ) ).toMatchObject( {
+			text: 'our new product',
+		} );
+	} );
+
+	it( 'returns null when the attribute is not text-like', () => {
+		mockGetBlockAttributes.mockReturnValue( { content: undefined } );
+		mockGetSelectionStart.mockReturnValue( point( 0 ) );
+		mockGetSelectionEnd.mockReturnValue( point( 4 ) );
+
+		expect( getSelectedTextContext( select ) ).toBeNull();
+	} );
+} );

--- a/packages/agents-manager/src/components/selected-block/__tests__/get-selected-text.test.ts
+++ b/packages/agents-manager/src/components/selected-block/__tests__/get-selected-text.test.ts
@@ -118,6 +118,32 @@ describe( 'getSelectedTextContext', () => {
 		} );
 	} );
 
+	it( 'drops inline-object placeholders from the text but keeps their offsets', () => {
+		// "\ufffc" is what rich-text stores for an inline image / footnote.
+		mockGetBlockAttributes.mockReturnValue( {
+			content: { text: 'Welcome \ufffcto our new product page' },
+		} );
+		mockGetSelectionStart.mockReturnValue( point( 0 ) );
+		mockGetSelectionEnd.mockReturnValue( point( 16 ) );
+
+		expect( getSelectedTextContext( select ) ).toEqual( {
+			text: 'Welcome to our ',
+			attributeKey: 'content',
+			start: 0,
+			end: 16,
+		} );
+	} );
+
+	it( 'returns null when only an inline object is selected', () => {
+		mockGetBlockAttributes.mockReturnValue( {
+			content: { text: 'Welcome \ufffcto our new product page' },
+		} );
+		mockGetSelectionStart.mockReturnValue( point( 8 ) );
+		mockGetSelectionEnd.mockReturnValue( point( 9 ) );
+
+		expect( getSelectedTextContext( select ) ).toBeNull();
+	} );
+
 	it( 'returns null when the attribute is not text-like', () => {
 		mockGetBlockAttributes.mockReturnValue( { content: undefined } );
 		mockGetSelectionStart.mockReturnValue( point( 0 ) );

--- a/packages/agents-manager/src/components/selected-block/get-selected-text.ts
+++ b/packages/agents-manager/src/components/selected-block/get-selected-text.ts
@@ -1,0 +1,87 @@
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+export interface SelectedTextContext {
+	text: string;
+	attributeKey: string;
+	start: number;
+	end: number;
+}
+
+/**
+ * Get the plain text of a block attribute value.
+ *
+ * Rich-text attributes (RichTextData) expose a `text` property whose indices
+ * match the selection offsets from the block-editor store. HTML string
+ * attributes are converted to an equivalent plain-text shape.
+ */
+export function getAttributePlainText( value: unknown ): string | null {
+	if ( value && typeof value === 'object' ) {
+		const text = ( value as { text?: unknown } ).text;
+		return typeof text === 'string' ? text : null;
+	}
+
+	if ( typeof value === 'string' ) {
+		// Approximate the rich-text plain-text shape: <br> becomes a newline,
+		// other markup is stripped.
+		const html = value.replace( /<br\s*\/?>/gi, '\n' );
+		const doc = new window.DOMParser().parseFromString( html, 'text/html' );
+		return doc.body.textContent || '';
+	}
+
+	return null;
+}
+
+/**
+ * Read the current inline text selection from the block editor.
+ *
+ * A selection is valid when the selection start and end are inside the same
+ * block, point at the same text attribute, and have different offsets.
+ *
+ * Mirror of big-sky-plugin's `src/ai/utils/text-selection.ts` — keep in sync.
+ */
+export function getSelectedTextContext(
+	// Accepts both the registry `select` and the one given to `useSelect`.
+	select: ( store: unknown ) => unknown
+): SelectedTextContext | null {
+	const { getSelectionStart, getSelectionEnd, getBlockAttributes } = select(
+		blockEditorStore
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	) as any;
+
+	const selectionStart = getSelectionStart?.();
+	const selectionEnd = getSelectionEnd?.();
+
+	if (
+		! selectionStart?.clientId ||
+		selectionStart.clientId !== selectionEnd?.clientId ||
+		! selectionStart.attributeKey ||
+		selectionStart.attributeKey !== selectionEnd.attributeKey ||
+		typeof selectionStart.offset !== 'number' ||
+		typeof selectionEnd.offset !== 'number' ||
+		selectionStart.offset === selectionEnd.offset
+	) {
+		return null;
+	}
+
+	const attributes = getBlockAttributes?.( selectionStart.clientId );
+	const plainText = getAttributePlainText( attributes?.[ selectionStart.attributeKey ] );
+
+	if ( typeof plainText !== 'string' ) {
+		return null;
+	}
+
+	const start = Math.min( selectionStart.offset, selectionEnd.offset );
+	const end = Math.max( selectionStart.offset, selectionEnd.offset );
+	const text = plainText.slice( start, end );
+
+	if ( ! text ) {
+		return null;
+	}
+
+	return {
+		text,
+		attributeKey: selectionStart.attributeKey,
+		start,
+		end,
+	};
+}

--- a/packages/agents-manager/src/components/selected-block/get-selected-text.ts
+++ b/packages/agents-manager/src/components/selected-block/get-selected-text.ts
@@ -8,6 +8,14 @@ export interface SelectedTextContext {
 }
 
 /**
+ * Characters `@wordpress/rich-text` reserves inside a value's `text`: the
+ * object replacement character standing in for inline objects (images,
+ * footnotes) and the zero-width no-break space used as padding. They occupy
+ * a selection index but are not text the user selected.
+ */
+const RESERVED_CHARACTERS = /[\ufffc\ufeff]/gu;
+
+/**
  * Get the plain text of a block attribute value.
  *
  * Rich-text attributes (RichTextData) expose a `text` property whose indices
@@ -72,7 +80,8 @@ export function getSelectedTextContext(
 
 	const start = Math.min( selectionStart.offset, selectionEnd.offset );
 	const end = Math.max( selectionStart.offset, selectionEnd.offset );
-	const text = plainText.slice( start, end );
+	// Strip only after slicing so `start`/`end` stay in the editor's index space.
+	const text = plainText.slice( start, end ).replace( RESERVED_CHARACTERS, '' );
 
 	if ( ! text ) {
 		return null;

--- a/packages/agents-manager/src/components/selected-block/index.tsx
+++ b/packages/agents-manager/src/components/selected-block/index.tsx
@@ -37,8 +37,6 @@ export default function SelectedBlock() {
 
 		const blockType = getBlockType( selectedBlock.name );
 
-		// When the user selects text inside the block, show that text so the
-		// chip communicates the precise target of the request.
 		const selectedText = getSelectedTextContext( select );
 
 		return {

--- a/packages/agents-manager/src/components/selected-block/index.tsx
+++ b/packages/agents-manager/src/components/selected-block/index.tsx
@@ -5,6 +5,7 @@ import { Button, __unstableMotion as motion } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
+import { getSelectedTextContext } from './get-selected-text';
 import './style.scss';
 
 const animations = {
@@ -36,9 +37,15 @@ export default function SelectedBlock() {
 
 		const blockType = getBlockType( selectedBlock.name );
 
+		// When the user selects text inside the block, show that text so the
+		// chip communicates the precise target of the request.
+		const selectedText = getSelectedTextContext( select );
+
 		return {
 			block: selectedBlock,
-			name: selectedBlock.attributes?.content?.text || blockType?.title,
+			name: selectedText
+				? `“${ selectedText.text }”`
+				: selectedBlock.attributes?.content?.text || blockType?.title,
 			icon: blockType?.icon,
 		};
 	}, [] );


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes BSKY-2074

### Proposed Changes

When the user has a text range selected inside a block, the chip above the chat
input now shows that text quoted (`¶ “Edit”`) instead of the block title, so
it's clear the request targets the selection, not the whole block.

- New `selected-block/get-selected-text.ts`: reads `getSelectionStart/End` from
  `core/block-editor`, validates the range (same block, same text attribute,
  different offsets), slices the attribute's plain text. Mirror of
  big-sky-plugin's `src/ai/utils/text-selection.ts` — keep in sync.
- `selected-block/index.tsx`: quoted-selection label with the existing fallback.

UI-only: the selection context itself is sent by the big-sky provider, not AM.
Standalone-safe, but merge after the backend + plugin PRs are live so the chip
never advertises precision the model doesn't have yet.
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Testing instructions here: https://github.com/Automattic/big-sky-plugin/pull/6338
