### PR TITLE
Landing page: bump an MC stat per logged-in destination

### DIFF
--- a/client/lib/landing-page/index.js
+++ b/client/lib/landing-page/index.js
@@ -47,6 +47,8 @@ const waitForPrefs = () => async ( dispatch, getState ) => {
 };
 
 const getSitesLink = ( isDashboardOptIn ) => {
+	bumpStat( 'landing-page', 'sites' );
+
 	if ( isDashboardOptIn ) {
 		bumpStat( 'dashboard-redirect', 'landing-page' );
 		return dashboardLink( '/sites' );
@@ -68,6 +70,7 @@ export async function getLoggedInLandingPage( { dispatch, getState } ) {
 	const useReaderAsLandingPage = hasReadersAsLandingPage( getState() );
 
 	if ( useReaderAsLandingPage ) {
+		bumpStat( 'landing-page', 'reader' );
 		return '/reader';
 	}
 
@@ -79,6 +82,7 @@ export async function getLoggedInLandingPage( { dispatch, getState } ) {
 
 	if ( ! primarySiteSlug ) {
 		if ( getIsSubscriptionOnly( getState() ) ) {
+			bumpStat( 'landing-page', 'reader' );
 			return '/reader';
 		}
 
@@ -90,11 +94,14 @@ export async function getLoggedInLandingPage( { dispatch, getState } ) {
 
 	if ( isCustomerHomeEnabled ) {
 		if ( isAdminInterfaceWPAdmin( getState(), primarySiteId ) ) {
+			bumpStat( 'landing-page', 'wp-admin' );
 			return getSiteAdminUrl( getState(), primarySiteId );
 		}
+		bumpStat( 'landing-page', 'customer-home' );
 		return `/home/${ primarySiteSlug }`;
 	}
 
+	bumpStat( 'landing-page', 'stats' );
 	return `/stats/day/${ primarySiteSlug }`;
 }
 


### PR DESCRIPTION
Fixes READ-700

## Proposed Changes

* `getLoggedInLandingPage()` sends every logged-in visitor to one of five places (Reader, the sites dashboard, customer home, wp-admin, or stats), but the only MC stat lived in the sites branch and fired just for people opted into the multi-site dashboard. The Reader branches counted nothing.
* Bump the `landing-page` MC group with a bin per branch: `reader`, `sites`, `customer-home`, `wp-admin`, and `stats`. The existing `dashboard-redirect` stat is left as-is.

## Why are these changes being made?

* We made Reader the default landing page and had no way to watch its share move. This gives us the split per destination. Part of the Dumb Stats ask.
* Two limits worth stating: the stat fires on the redirect decision, so someone typing a Reader URL directly is not counted, and it counts events rather than people.

## Testing Instructions

* Load Calypso as a logged-in user and trigger the logged-in landing redirect (for example, visit `/`).
* Watch the network requests and confirm a call to `pixel.wp.com/g.gif` fires with `x_landing-page=<bin>` matching where you land: Reader → `reader`, sites dashboard → `sites`, customer home → `customer-home`, wp-admin interface → `wp-admin`, stats → `stats`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
