### PR TITLE
Enable WordPress Agent for Slack in production

### DIFF
--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -59,7 +59,7 @@
 		"site-spec": true,
 		"two-factor/enhanced-security": true,
 		"webauthn/related-origin-requests": true,
-		"wordpress-agent-slack": false,
+		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
 		"wordpress-labs": false,
 		"wpcom-user-bootstrap": true

--- a/config/production.json
+++ b/config/production.json
@@ -180,7 +180,7 @@
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"use-translation-chunks": true,
-		"wordpress-agent-slack": false,
+		"wordpress-agent-slack": true,
 		"wordpress-ai-tools": true,
 		"wordpress-labs": false,
 		"wpcom-user-bootstrap": true


### PR DESCRIPTION
Part of BSKY-2075

## Proposed Changes

* Enable the `wordpress-agent-slack` feature in the Calypso production configuration.
* Enable the same feature in the Dashboard production configuration.

## Why are these changes being made?

* Release the existing WordPress Agent Slack connection experience to all production users after its gated testing period.

## Testing Instructions

* Confirm `wordpress-agent-slack` is `true` in `config/production.json`.
* Confirm `wordpress-agent-slack` is `true` in `config/dashboard-production.json`.
* Run `jq empty config/production.json config/dashboard-production.json`.
* Run `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
