### PR TITLE
A4A: only show the expansion offer to agencies on an eligible plan

### DIFF
--- a/client/a8c-for-agencies/components/a4a-pressable-offer/hooks/use-is-eligible-for-expansion-offer.ts
+++ b/client/a8c-for-agencies/components/a4a-pressable-offer/hooks/use-is-eligible-for-expansion-offer.ts
@@ -12,6 +12,22 @@ import {
 import { PRESSABLE_Q3_2026_OFFER_START_DATE } from '../constants';
 import type { License } from 'calypso/state/partner-portal/types';
 
+// The offer only covers moves up within the Signature and Premium tiers, the
+// same plans the checkout coupon is built from. The trailing hyphen keeps the
+// legacy bare 'pressable-premium' plan out.
+const EXPANSION_OFFER_PLAN_PREFIXES = [ 'pressable-signature-', 'pressable-premium-' ];
+
+function getAgencyPlanLicenses( licenses: License[] | undefined ): License[] {
+	return (
+		licenses?.filter(
+			( license ) =>
+				isPressableHostingProduct( license.licenseKey ) &&
+				! isPressableAddonProduct( license.licenseKey ) &&
+				! license.referral
+		) ?? []
+	);
+}
+
 // The introductory offer applies automatically to plans purchased after its
 // start date, so an agency whose earliest plan license was issued on or after
 // that date has benefited from it (or is a new customer who bought outside the
@@ -19,13 +35,7 @@ import type { License } from 'calypso/state/partner-portal/types';
 export function hasBenefitedFromIntroductoryOffer(
 	licenses: License[] | undefined
 ): boolean | null {
-	const planLicenses =
-		licenses?.filter(
-			( license ) =>
-				isPressableHostingProduct( license.licenseKey ) &&
-				! isPressableAddonProduct( license.licenseKey ) &&
-				! license.referral
-		) ?? [];
+	const planLicenses = getAgencyPlanLicenses( licenses );
 
 	if ( ! planLicenses.length ) {
 		return null;
@@ -38,11 +48,19 @@ export function hasBenefitedFromIntroductoryOffer(
 	return earliestLicense.issuedAt.slice( 0, 10 ) >= PRESSABLE_Q3_2026_OFFER_START_DATE;
 }
 
-// The expansion offer is only for agencies that did not benefit from the
-// introductory offer; unknown history (query pending, or no plan license
-// found) counts as ineligible so the offer stays hidden. Fires a licenses API
-// request on mount, so callers should only mount the component using it once
-// usePressableOfferEligibility's cheaper checks have passed.
+// An agency on a legacy plan has no upgrade path the offer applies to, so the
+// discount would never materialize at checkout.
+export function hasPlanEligibleForExpansionOffer( licenses: License[] | undefined ): boolean {
+	return getAgencyPlanLicenses( licenses ).some( ( license ) =>
+		EXPANSION_OFFER_PLAN_PREFIXES.some( ( prefix ) => license.licenseKey.startsWith( prefix ) )
+	);
+}
+
+// The expansion offer is only for agencies on an eligible plan that did not
+// benefit from the introductory offer; unknown history (query pending, or no
+// plan license found) counts as ineligible so the offer stays hidden. Fires a
+// licenses API request on mount, so callers should only mount the component
+// using it once usePressableOfferEligibility's cheaper checks have passed.
 export default function useIsEligibleForExpansionOffer(): boolean {
 	const { data, isFetched } = useFetchLicenses(
 		LicenseFilter.NotRevoked,
@@ -54,7 +72,10 @@ export default function useIsEligibleForExpansionOffer(): boolean {
 	);
 
 	return useMemo(
-		() => isFetched && hasBenefitedFromIntroductoryOffer( data?.items ) === false,
+		() =>
+			isFetched &&
+			hasPlanEligibleForExpansionOffer( data?.items ) &&
+			hasBenefitedFromIntroductoryOffer( data?.items ) === false,
 		[ data?.items, isFetched ]
 	);
 }


### PR DESCRIPTION
Part of A4A-3146

<img width="1240" height="346" alt="Screenshot 2026-08-13 at 13 13 52" src="https://github.com/user-attachments/assets/5bbd7a16-a48d-4cf8-ae36-cab647f9ca55" />

<img width="927" height="304" alt="Screenshot 2026-08-13 at 13 21 14" src="https://github.com/user-attachments/assets/266e989c-05d7-4b05-afb1-52a7de2ebbe4" />

## Proposed Changes

* Only show the Pressable expansion offer to agencies whose current Pressable plan is a Signature or Premium plan.
* Agencies on legacy plans (`pressable-wp-*`, `pressable-build`, `pressable-business*`, `pressable-enterprise-*`, and the bare `pressable-premium`) no longer see the offer.
* This covers both places the offer appears: the banner on the Pressable marketplace page and the card in "News and updates" on the overview page.

## Why are these changes being made?

The offer only applies to Signature and Premium plans, but the banner was shown to any agency with a Pressable plan bought through A4A. Agencies on a legacy plan were being told about a discount they can't get: checkout finds no eligible plan switch, so no coupon is applied and the price is unchanged.

The new check mirrors the plans the server accepts when it auto-applies the coupon at checkout.

## Testing Instructions

1. SU as an agency on a legacy Pressable plan (for example a Pressable Business plan).
2. Go to Marketplace → Hosting → Pressable and confirm the expansion offer banner is **not** shown.
3. Go to the Overview page and confirm the expansion offer card is **not** listed under "News and updates".
4. SU as an agency on a Pressable Signature or Premium plan.
5. Confirm the banner and the overview card **are** shown in both places.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
