### PR TITLE
Onboarding: retire the build_dest=wow blueprint path

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -33,10 +33,7 @@ import { isPlanProductFree } from '../../../../../../packages/data-stores/src/pl
 import { useFlowLocale } from '../../../hooks/use-flow-locale';
 import { useQuery } from '../../../hooks/use-query';
 import { ONBOARD_STORE, SITE_STORE } from '../../../stores';
-import {
-	getBlueprintArchiveSiteSpecUrl,
-	getStandaloneBlueprintArchiveSlug,
-} from '../../../utils/blueprint-archive-import';
+import { getBlueprintArchiveSiteSpecUrl } from '../../../utils/blueprint-archive-import';
 import {
 	getBuildWowSiteIdentifier,
 	getBuildWowSiteSpecUrl,
@@ -116,12 +113,6 @@ const onboarding: FlowV2< typeof initialize > = {
 		const { setShouldShowNotification } = usePurchasePlanNotification();
 
 		const playgroundId = queryParams.get( 'playground' );
-		const buildDest = queryParams.get( 'build_dest' );
-		const blueprintArchiveSlug = getStandaloneBlueprintArchiveSlug(
-			blueprint,
-			playgroundId,
-			buildDest
-		);
 		const wowFunnelSlug = getWowFunnelSlug( queryParams );
 		const wowFunnelDest = getWowFunnelDest( queryParams );
 
@@ -187,24 +178,6 @@ const onboarding: FlowV2< typeof initialize > = {
 					siteSlug: providedDependencies.siteSlug as string,
 					siteId: providedDependencies.siteId as number,
 				};
-
-				// build_dest=wow: skip the Playground-based importer and land on the AI
-				// site-spec, which kicks off the background transfer-to-Atomic +
-				// blueprint-archive import and, on confirm, polls the import and
-				// redirects to the Site Editor. The blueprint step already verified the
-				// archive exists (and stripped build_dest when it does not).
-				if ( blueprintArchiveSlug ) {
-					return [
-						getBlueprintArchiveSiteSpecUrl( {
-							siteSlug: providedDependencies.siteSlug as string,
-							siteId: providedDependencies.siteId as number,
-							blueprintSlug: blueprintArchiveSlug,
-							ref: refParameter,
-						} ),
-						null,
-						null,
-					];
-				}
 
 				if ( playgroundId ) {
 					params.playground = playgroundId;
@@ -515,13 +488,10 @@ const onboarding: FlowV2< typeof initialize > = {
 							// replace the location to delete processing step from history.
 							window.location.replace(
 								addQueryArgs( `/checkout/${ encodeURIComponent( siteSlug ) }`, {
-									// build_dest=wow and the WoW funnel (dest=editor) go
-									// straight from checkout to their destination — no
-									// post-checkout-onboarding hop, no chooser.
-									redirect_to:
-										blueprintArchiveSlug || ( wowFunnelSlug && wowFunnelDest )
-											? destination
-											: redirectTo,
+									// The WoW funnel goes straight from checkout to its
+									// destination — no post-checkout-onboarding hop, no
+									// chooser.
+									redirect_to: wowFunnelSlug && wowFunnelDest ? destination : redirectTo,
 									signup: 1,
 									flow: ONBOARDING_FLOW,
 									checkoutBackUrl: pathToUrl( backDestination ?? '' ),
@@ -533,9 +503,9 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if ( blueprintArchiveSlug || ( wowFunnelSlug && wowFunnelDest ) ) {
-							// build_dest=wow and the WoW funnel never show the
-							// setup-your-site-ai chooser; go straight to their destination.
+						} else if ( wowFunnelSlug && wowFunnelDest ) {
+							// The WoW funnel never shows the setup-your-site-ai chooser;
+							// go straight to its destination.
 							window.location.replace( destination );
 						} else if (
 							refParameter === WOO_HOSTING_SOLUTIONS_REF &&

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/index.tsx
@@ -22,8 +22,7 @@ export const BlueprintStep: StepType = ( { navigation } ) => {
 	const hasSubmitted = useRef( false );
 
 	const blueprintParam = query.get( 'blueprint' ) ?? '';
-	const buildDestParam = query.get( 'build_dest' ) ?? '';
-	// The wow funnel builds the Atomic site from the same archive, before checkout.
+	// The wow funnel builds the Atomic site from the blueprint's archive, before checkout.
 	const wowFunnelParam = query.get( 'wow_funnel' ) ?? '';
 
 	useEffect( () => {
@@ -40,14 +39,17 @@ export const BlueprintStep: StepType = ( { navigation } ) => {
 				return;
 			}
 
-			// Both Atomic paths restore the blueprint's pre-built archive, so both need that
-			// archive to exist on the library post: build_dest=wow imports after checkout, the
-			// wow funnel before it. Verify up front; when missing, fall back to the legacy
-			// Simple-site import by stripping the params (tracked, so missing archives surface).
-			if ( 'wow' === buildDestParam || 'blueprint' === wowFunnelParam ) {
+			// The wow funnel restores the blueprint's pre-built archive onto the Atomic site it
+			// builds before checkout, so that archive has to exist on the library post. Verify
+			// up front; when missing, fall back to the legacy Simple-site import by stripping
+			// the params (tracked, so missing archives surface).
+			if ( 'blueprint' === wowFunnelParam ) {
 				const hasArchive = await checkBlueprintExists( id );
 
 				if ( ! hasArchive ) {
+					// Event name predates the retired build_dest=wow param it was written for.
+					// Kept as-is so existing dashboards keep working; it now means "the wow
+					// funnel found no archive".
 					recordTracksEvent( 'calypso_blueprint_build_dest_wow_archive_missing', {
 						blueprint: id,
 					} );
@@ -64,7 +66,6 @@ export const BlueprintStep: StepType = ( { navigation } ) => {
 					// Atomic site with nothing to import onto it, and leaving dest on would
 					// send the customer to a site-spec waiting for an import that never runs.
 					const sanitized = new URLSearchParams( query );
-					sanitized.delete( 'build_dest' );
 					sanitized.delete( 'wow_funnel' );
 					sanitized.delete( 'dest' );
 					setQuery( sanitized, { replace: true } );
@@ -80,7 +81,7 @@ export const BlueprintStep: StepType = ( { navigation } ) => {
 
 		fetchBlueprint();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ blueprintParam, buildDestParam, wowFunnelParam ] );
+	}, [ blueprintParam, wowFunnelParam ] );
 
 	return (
 		<>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/blueprint/test/index.tsx
@@ -43,40 +43,6 @@ describe( 'BlueprintStep', () => {
 		currentSearch = '';
 	} );
 
-	it( 'keeps build_dest=wow when the blueprint has an archive', async () => {
-		( checkBlueprintExists as jest.Mock ).mockResolvedValue( true );
-		let searchAtSubmit = '';
-		const submit = jest.fn( () => {
-			searchAtSubmit = currentSearch;
-		} );
-
-		render( '/blueprint?blueprint=961&build_dest=wow', submit );
-
-		await waitFor( () => expect( submit ).toHaveBeenCalled() );
-		expect( checkBlueprintExists ).toHaveBeenCalledWith( '961' );
-		expect( searchAtSubmit ).toContain( 'build_dest=wow' );
-	} );
-
-	it( 'strips build_dest from the router before submitting when the archive is missing', async () => {
-		( checkBlueprintExists as jest.Mock ).mockResolvedValue( false );
-		let searchAtSubmit = '';
-		const submit = jest.fn( () => {
-			searchAtSubmit = currentSearch;
-		} );
-
-		render( '/blueprint?blueprint=961&build_dest=wow', submit );
-
-		await waitFor( () => expect( submit ).toHaveBeenCalled() );
-		// The fallback must be visible in the router's own params, otherwise the
-		// logged-out auth branch re-adds build_dest after sign-in.
-		expect( searchAtSubmit ).not.toContain( 'build_dest' );
-		expect( searchAtSubmit ).toContain( 'blueprint=961' );
-		expect( submit ).toHaveBeenCalledTimes( 1 );
-		expect( logBlueprintArchiveEvent ).toHaveBeenCalledWith( 'wow_archive_missing', {
-			blueprint: '961',
-		} );
-	} );
-
 	it( 'keeps the wow funnel when the blueprint has an archive', async () => {
 		( checkBlueprintExists as jest.Mock ).mockResolvedValue( true );
 		let searchAtSubmit = '';
@@ -104,11 +70,18 @@ describe( 'BlueprintStep', () => {
 		await waitFor( () => expect( submit ).toHaveBeenCalled() );
 		// Leaving the funnel on would build an Atomic site with nothing to import onto it, and
 		// leaving dest on would hand over to a site-spec waiting for an import that never runs.
+		// The fallback must be visible in the router's own params, otherwise the logged-out auth
+		// branch re-adds them after sign-in.
 		expect( searchAtSubmit ).not.toContain( 'wow_funnel' );
 		expect( searchAtSubmit ).not.toContain( 'dest' );
+		expect( searchAtSubmit ).toContain( 'blueprint=961' );
+		expect( submit ).toHaveBeenCalledTimes( 1 );
+		expect( logBlueprintArchiveEvent ).toHaveBeenCalledWith( 'wow_archive_missing', {
+			blueprint: '961',
+		} );
 	} );
 
-	it( 'does not look up an archive without build_dest=wow', async () => {
+	it( 'does not look up an archive outside the wow funnel', async () => {
 		const submit = jest.fn();
 
 		render( '/blueprint?blueprint=941', submit );
@@ -121,7 +94,7 @@ describe( 'BlueprintStep', () => {
 		( checkBlueprintExists as jest.Mock ).mockResolvedValue( true );
 		const submit = jest.fn();
 
-		render( '/blueprint?blueprint=coachava&build_dest=wow', submit );
+		render( '/blueprint?blueprint=coachava&wow_funnel=blueprint', submit );
 
 		await waitFor( () => expect( submit ).toHaveBeenCalled() );
 		expect( checkBlueprintExists ).toHaveBeenCalledWith( 'coachava' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/test/get-plans-intent.test.ts
@@ -26,19 +26,10 @@ describe( 'getPlansIntent', () => {
 			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-playground' );
 		} );
 
-		it( 'hides the free plan when the blueprint targets Atomic via build_dest=wow', () => {
-			window.history.replaceState( {}, '', '/?blueprint=945&build_dest=wow' );
-			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-ai-assembler-paid-only' );
-		} );
-
-		it( 'keeps the default grid when build_dest is not wow', () => {
-			window.history.replaceState( {}, '', '/?blueprint=945&build_dest=simple' );
+		it( 'keeps the default grid for a plain blueprint import', () => {
+			// Without a funnel the blueprint builds on a Simple site, so the free plan stays.
+			window.history.replaceState( {}, '', '/?blueprint=945' );
 			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBeNull();
-		} );
-
-		it( 'keeps playground precedence when build_dest=wow is present alongside playground', () => {
-			window.history.replaceState( {}, '', '/?blueprint=123&playground=abc&build_dest=wow' );
-			expect( getPlansIntent( ONBOARDING_FLOW ) ).toBe( 'plans-playground' );
 		} );
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/util/get-plans-intent.ts
@@ -47,12 +47,6 @@ export function getPlansIntent( flowName: string | null ): PlansIntent | null {
 			if ( search.has( 'wow_funnel' ) ) {
 				return 'plans-ai-assembler-paid-only';
 			}
-			// Blueprint imports targeting Atomic (build_dest=wow) need a plan that
-			// supports the transfer, so hide the free plan. Plain blueprint imports
-			// build on a Simple site and keep the default grid.
-			if ( search.has( 'blueprint' ) && search.get( 'build_dest' ) === 'wow' ) {
-				return 'plans-ai-assembler-paid-only';
-			}
 			if ( search.get( 'ref' ) === WOO_HOSTING_SOLUTIONS_REF ) {
 				return 'plans-woo-hosting-solutions';
 			}

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -8,14 +8,6 @@ export const BLUEPRINT_ARCHIVE_IMPORT_QUERY_VALUE = '1';
 // Reuse the flow that already hosts the AI site-spec step.
 const BLUEPRINT_ARCHIVE_SITE_SPEC_PATH = '/setup/ai-site-builder-spec/site-spec';
 
-export function getStandaloneBlueprintArchiveSlug(
-	blueprint: string | null,
-	playgroundId: string | null,
-	buildDest: string | null
-): string | null {
-	return ! playgroundId && buildDest === 'wow' ? blueprint : null;
-}
-
 type ImportStatusResponse = {
 	importId?: string | null;
 	siteId?: number | null;

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -2,11 +2,7 @@
  * @jest-environment jsdom
  */
 import wpcom from 'calypso/lib/wp';
-import {
-	applyBlueprintSpec,
-	getSiteEditorUrl,
-	getStandaloneBlueprintArchiveSlug,
-} from '../blueprint-archive-import';
+import { applyBlueprintSpec, getSiteEditorUrl } from '../blueprint-archive-import';
 
 jest.mock( 'calypso/lib/wp', () => ( {
 	__esModule: true,
@@ -18,21 +14,6 @@ jest.mock( 'calypso/lib/logstash', () => ( {
 } ) );
 
 const mockPost = wpcom.req.post as jest.Mock;
-
-describe( 'getStandaloneBlueprintArchiveSlug', () => {
-	it( 'returns the Blueprint archive slug for a standalone build_dest=wow flow', () => {
-		expect( getStandaloneBlueprintArchiveSlug( 'coaching-1', null, 'wow' ) ).toBe( 'coaching-1' );
-	} );
-
-	it( 'ignores Blueprint values without build_dest=wow', () => {
-		expect( getStandaloneBlueprintArchiveSlug( '945', null, null ) ).toBeNull();
-	} );
-
-	it( 'ignores retained Blueprint values after a Playground ID exists', () => {
-		expect( getStandaloneBlueprintArchiveSlug( '945', 'playground-uuid', null ) ).toBeNull();
-		expect( getStandaloneBlueprintArchiveSlug( '945', 'playground-uuid', 'wow' ) ).toBeNull();
-	} );
-} );
 
 describe( 'applyBlueprintSpec', () => {
 	beforeEach( () => {


### PR DESCRIPTION
Follow-up to #113825, which switched the theme-sheet CTA from `build_dest=wow` to `wow_funnel=blueprint`.

That CTA was the only producer of `build_dest=wow`. Nothing emits the param any more — not here, and not in wpcom (its three remaining references are docblocks, fixed separately in `237070-ghe-Automattic/wpcom`). What's left is dead code that reads like a live alternative to the funnel.

## Why not just leave it

Both paths ended in the same place — an Atomic site restored from the blueprint's archive, handed to the AI site-spec — but they differ in *when*: `build_dest=wow` imported **after** checkout, the funnel builds **before** it. Two near-identical branches where the difference is invisible at the call site is how the wrong one gets extended.

## What goes

| Removed | Why it's safe |
|---|---|
| `getStandaloneBlueprintArchiveSlug()` | Its only input was `build_dest`; always returns null now |
| The `blueprintArchiveSlug` post-checkout branch | The funnel's `dest=site-spec` branch runs **earlier** and calls the same `getBlueprintArchiveSiteSpecUrl()` — destination unchanged |
| The `build_dest` arm of the blueprint step's archive check | The `wow_funnel` arm already covers it, including strip-and-fall-back |
| The `build_dest` arm of the paid-only plans intent | `wow_funnel` has its own, checked first |

The backend the funnel path depends on is all merged: `236636-ghe-Automattic/wpcom` (funnel core) and `236646-ghe-Automattic/wpcom` (blueprint funnel).

## One judgment call for review

The `calypso_blueprint_build_dest_wow_archive_missing` Tracks event keeps its name, so existing dashboards keep working, with a comment noting the name outlived the param. Renaming it to something like `calypso_blueprint_wow_funnel_archive_missing` would read better but breaks event continuity. Happy to take the break if you'd rather.

## Testing

```
yarn test-client landing/stepper/.../blueprint/test/index \
                 landing/stepper/.../unified-plans/test/get-plans-intent \
                 landing/stepper/utils/test/blueprint-archive-import

Test Suites: 3 passed, 3 total
Tests:       25 passed, 25 total
```

eslint and `tsc --noEmit` clean on the touched files. Net -98 lines.
