### PR TITLE
Onboarding: stop the wow funnel importing the blueprint twice

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -157,6 +157,7 @@ const onboarding: FlowV2< typeof initialize > = {
 							siteId,
 							blueprintSlug,
 							ref: refParameter,
+							wowFunnel: wowFunnelSlug,
 						} ),
 						null,
 						null,

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -75,12 +75,14 @@ export function getBlueprintArchiveSiteSpecUrl( {
 	blueprintSlug,
 	ref,
 	source,
+	wowFunnel,
 }: {
 	siteSlug?: string | null;
 	siteId?: string | number | null;
 	blueprintSlug: string;
 	ref?: string | null;
 	source?: string | null;
+	wowFunnel?: string | null;
 } ): string {
 	return addQueryArgs( BLUEPRINT_ARCHIVE_SITE_SPEC_PATH, {
 		blueprint_archive_import: BLUEPRINT_ARCHIVE_IMPORT_QUERY_VALUE,
@@ -89,6 +91,10 @@ export function getBlueprintArchiveSiteSpecUrl( {
 		...( siteId && String( siteId ) !== '0' ? { siteId } : {} ),
 		...( ref ? { ref } : {} ),
 		...( source ? { source } : {} ),
+		// A funnel run's import already ran server-side, before checkout. site-spec keys its
+		// "do not start one" guard off this param, so it has to survive into the URL — without
+		// it the page cannot tell a funnel hand-off from a standalone run and imports again.
+		...( wowFunnel ? { wow_funnel: wowFunnel } : {} ),
 	} );
 }
 

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -4,6 +4,7 @@
 import wpcom from 'calypso/lib/wp';
 import {
 	applyBlueprintSpec,
+	getBlueprintArchiveSiteSpecUrl,
 	getSiteEditorUrl,
 	getStandaloneBlueprintArchiveSlug,
 } from '../blueprint-archive-import';
@@ -159,5 +160,35 @@ describe( 'getSiteEditorUrl', () => {
 		expect(
 			getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: false } )
 		).not.toContain( 'blueprint-walkthrough' );
+	} );
+} );
+
+describe( 'getBlueprintArchiveSiteSpecUrl', () => {
+	/**
+	 * site-spec decides whether to start a blueprint import by looking for wow_funnel in its
+	 * own query string. A funnel run's import already ran server-side before checkout, so
+	 * dropping the param here makes the page import a second time over the finished site.
+	 */
+	it( 'carries the funnel through so site-spec can skip its own import', () => {
+		const url = getBlueprintArchiveSiteSpecUrl( {
+			siteSlug: 'example.wordpress.com',
+			siteId: 123,
+			blueprintSlug: 'coachava',
+			wowFunnel: 'blueprint',
+		} );
+
+		expect( url ).toContain( 'wow_funnel=blueprint' );
+		expect( url ).toContain( 'blueprint_archive_import=1' );
+		expect( url ).toContain( 'blueprint_slug=coachava' );
+	} );
+
+	it( 'omits the funnel for a standalone run', () => {
+		const url = getBlueprintArchiveSiteSpecUrl( {
+			siteSlug: 'example.wordpress.com',
+			siteId: 123,
+			blueprintSlug: 'coachava',
+		} );
+
+		expect( url ).not.toContain( 'wow_funnel' );
 	} );
 } );


### PR DESCRIPTION
Found on a live funnel run. The blueprint gets imported **twice**: once server-side before checkout by the funnel's follow-up, then again by site-spec after checkout.

## The guard exists but can't see anything

`site-spec` already has the right check:

```js
const isWowFunnelRun = !! queryParams.get( 'wow_funnel' );
```

But `getBlueprintArchiveSiteSpecUrl()` — the builder for the funnel's own post-checkout hand-off — never put `wow_funnel` in the URL. The real one from the live run:

```
/setup/ai-site-builder-spec/site-spec?blueprint_archive_import=1&blueprint_slug=coachava&siteSlug=…&siteId=…&ref=theme-coachava
```

No `wow_funnel`. So `isWowFunnelRun` was always `false` on the one path it was written for, the guard never fired, and the kickoff effect ran.

## What that looks like

The site had already finished its pre-checkout import — `playground-blueprint-imported` and `has-imported` were both set — while the import record had gone back to step **1 of 9**, `download_archive`, for the duplicate.

That step is misleading, and it's why this reads as "stuck": `download_archive` is set *before* the blocking `wp wpcomsh backup-import` over SSH and isn't updated again until it returns. So the UI sits on `download_archive` for minutes while a full archive restore replays over a site that already has that archive.

## Fix

Thread the funnel slug through the URL builder and pass it from the funnel's post-checkout branch, so the guard can see what it was written to check. After Automattic/wp-calypso#113854 the funnel branch is the only caller, but the param is opt-in so a standalone run is unaffected.

## Testing

```
yarn test-client landing/stepper/utils/test/blueprint-archive-import
Tests: 17 passed, 17 total
```

Two new cases: the funnel carries `wow_funnel` into the URL, and a standalone run omits it. eslint clean.

## Worth a follow-up

This is a URL param standing in for "the import already ran". A reload that drops the param, or any new caller that forgets it, re-imports — which is what just happened. A server-side idempotency check (the import record and `playground-blueprint-imported` sticker are both already there) would be sturdier than a query string. Not in this PR.