### PR TITLE
Onboarding: never resume a paid wow-funnel site, and scope the run

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -48,8 +48,11 @@ import {
 	getWowFunnelDest,
 	getWowFunnelArgs,
 	getWowFunnelSlug,
+	clearWowFunnelSite,
+	forgetWowFunnelRun,
 	getRememberedWowFunnelSite,
 	startWowFunnelSite,
+	wowFunnelSiteIsPaid,
 	logWowFunnelEvent,
 } from '../../../utils/wow-funnel';
 import { getOnboardingPostCheckoutDestination } from '../../helpers/get-onboarding-post-checkout-destination';
@@ -141,6 +144,11 @@ const onboarding: FlowV2< typeof initialize > = {
 			if ( wowFunnelSlug && wowFunnelDest ) {
 				const siteSlug = providedDependencies.siteSlug as string;
 				const siteId = providedDependencies.siteId as number;
+
+				// The run is over. Without this the remembered site outlives it for the whole
+				// browser session, and the next CTA click resumes this site instead of building
+				// a new one — offering a renewal of the plan just bought for it.
+				clearWowFunnelSite();
 
 				// dest=site-spec: the funnel's follow-up (e.g. the blueprint import) is already
 				// running server-side, so site-spec only waits on it and hands over. It must not
@@ -645,15 +653,36 @@ const onboarding: FlowV2< typeof initialize > = {
 			}
 			const queryParams = new URLSearchParams( window.location.search );
 			const funnelSlug = getWowFunnelSlug( queryParams );
-			if ( ! funnelSlug || getRememberedWowFunnelSite( funnelSlug ) ) {
+			const funnelArgs = getWowFunnelArgs( queryParams );
+			if ( ! funnelSlug ) {
 				return;
 			}
-			void startWowFunnelSite( {
-				funnelSlug,
-				funnelArgs: getWowFunnelArgs( queryParams ),
-			} ).catch( () => {
-				// Errors are logged in the util; the create-site step retries as a fallback.
-			} );
+
+			void ( async () => {
+				const remembered = getRememberedWowFunnelSite( funnelSlug, funnelArgs );
+				if ( remembered ) {
+					// A funnel run sells a plan for the site it builds, so a site that already has
+					// one must never be resumed: checkout would offer a second plan for a site
+					// that does not need one. Resume only while it is still unpaid.
+					const site = await resolveSelect( SITE_STORE )
+						.getSite( remembered.siteSlug )
+						.catch( () => null );
+
+					if ( ! wowFunnelSiteIsPaid( site ) ) {
+						return;
+					}
+
+					logWowFunnelEvent( 'remembered_site_already_paid', {
+						funnel: funnelSlug,
+						blog_id: remembered.blogId,
+					} );
+					forgetWowFunnelRun( funnelSlug, funnelArgs );
+				}
+
+				await startWowFunnelSite( { funnelSlug, funnelArgs } ).catch( () => {
+					// Errors are logged in the util; the create-site step retries as a fallback.
+				} );
+			} )();
 		}, [ currentStepSlug, isLoggedIn ] );
 	},
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -30,7 +30,9 @@ import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import {
 	getWowFunnelArgs,
 	getWowFunnelSlug,
+	logWowFunnelEvent,
 	startWowFunnelSite,
+	wowFunnelSiteIsPaid,
 } from 'calypso/landing/stepper/utils/wow-funnel';
 import { resolveLaunchpadPersonalizationVariation } from 'calypso/lib/ai-launchpad';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -234,8 +236,25 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 				siteTitle: selectedSiteTitle,
 			} );
 
+			// Last line of defence against selling a second plan for the same site. The flow entry
+			// already refuses to resume a paid funnel site, but this is where money is actually
+			// committed, so re-check here rather than trusting that the site reaching this point
+			// is the unpaid one we built.
+			const funnelSiteIsPaid = wowFunnelSiteIsPaid(
+				await wpcom.req
+					.get( { path: `/sites/${ funnelSite.blogId }`, apiVersion: '1.1' } )
+					.catch( () => null )
+			);
+
+			if ( funnelSiteIsPaid ) {
+				logWowFunnelEvent( 'plan_skipped_site_already_paid', {
+					funnel: wowFunnelSlug,
+					blog_id: funnelSite.blogId,
+				} );
+			}
+
 			const funnelCartItems = [
-				...( planCartItem ? [ planCartItem ] : [] ),
+				...( planCartItem && ! funnelSiteIsPaid ? [ planCartItem ] : [] ),
 				...( productCartItems ?? [] ),
 				...mergedDomainCartItems,
 			];

--- a/client/landing/stepper/utils/test/wow-funnel.ts
+++ b/client/landing/stepper/utils/test/wow-funnel.ts
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	clearWowFunnelSite,
+	getRememberedWowFunnelSite,
+	getWowFunnelKey,
+	wowFunnelSiteIsPaid,
+} from '../wow-funnel';
+
+const SESSION_KEY = 'wow-funnel-created-site';
+
+function remember( funnelSlug: string, funnelArgs: Record< string, string >, blogId: number ) {
+	window.sessionStorage.setItem(
+		SESSION_KEY,
+		JSON.stringify( {
+			funnelSlug,
+			funnelKey: getWowFunnelKey( funnelSlug, funnelArgs ),
+			blogId,
+			siteSlug: `site-${ blogId }.wordpress.com`,
+		} )
+	);
+}
+
+describe( 'getWowFunnelKey', () => {
+	it( 'separates runs that build different things', () => {
+		expect( getWowFunnelKey( 'blueprint', { blueprint_slug: 'coachava' } ) ).not.toBe(
+			getWowFunnelKey( 'blueprint', { blueprint_slug: 'other' } )
+		);
+	} );
+
+	it( 'is stable regardless of arg order', () => {
+		expect( getWowFunnelKey( 'blueprint', { a: '1', b: '2' } ) ).toBe(
+			getWowFunnelKey( 'blueprint', { b: '2', a: '1' } )
+		);
+	} );
+} );
+
+describe( 'getRememberedWowFunnelSite', () => {
+	beforeEach( () => {
+		window.sessionStorage.clear();
+	} );
+
+	it( 'resumes the site when the same CTA is re-entered', () => {
+		remember( 'blueprint', { blueprint_slug: 'coachava' }, 111 );
+
+		expect(
+			getRememberedWowFunnelSite( 'blueprint', { blueprint_slug: 'coachava' } )?.blogId
+		).toBe( 111 );
+	} );
+
+	/**
+	 * Two theme CTAs share the funnel slug and differ only in the blueprint. Matching on the slug
+	 * alone sent the customer back to a site built from the theme they did not pick.
+	 */
+	it( 'does not resume a site built from a different blueprint', () => {
+		remember( 'blueprint', { blueprint_slug: 'coachava' }, 111 );
+
+		expect( getRememberedWowFunnelSite( 'blueprint', { blueprint_slug: 'other' } ) ).toBeNull();
+	} );
+
+	it( 'forgets the site once the run is cleared', () => {
+		remember( 'blueprint', { blueprint_slug: 'coachava' }, 111 );
+		clearWowFunnelSite();
+
+		expect( getRememberedWowFunnelSite( 'blueprint', { blueprint_slug: 'coachava' } ) ).toBeNull();
+	} );
+
+	it( 'ignores a remembered site written before funnelKey existed', () => {
+		window.sessionStorage.setItem(
+			SESSION_KEY,
+			JSON.stringify( { funnelSlug: 'blueprint', blogId: 111, siteSlug: 'old.wordpress.com' } )
+		);
+
+		expect( getRememberedWowFunnelSite( 'blueprint', { blueprint_slug: 'coachava' } ) ).toBeNull();
+	} );
+} );
+
+describe( 'wowFunnelSiteIsPaid', () => {
+	/**
+	 * The funnel exists to sell a plan for the site it builds. Resuming a site that already has
+	 * one puts a second plan in the cart for a site that does not need it.
+	 */
+	it( 'is true for a site holding a paid plan', () => {
+		expect( wowFunnelSiteIsPaid( { plan: { is_free: false } } ) ).toBe( true );
+	} );
+
+	it( 'is false for a free site', () => {
+		expect( wowFunnelSiteIsPaid( { plan: { is_free: true } } ) ).toBe( false );
+	} );
+
+	it( 'is false when the site or its plan is unknown', () => {
+		expect( wowFunnelSiteIsPaid( undefined ) ).toBe( false );
+		expect( wowFunnelSiteIsPaid( {} ) ).toBe( false );
+	} );
+} );

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -30,11 +30,35 @@ const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'editor', 'site-spec' ];
  */
 export type RememberedWowFunnelSite = {
 	funnelSlug: string;
+	/**
+	 * Identifies the run, not just the funnel. Two CTAs can share a funnel slug and differ in
+	 * what they build — the blueprint funnel's whole subject is its `blueprint_slug` — so the
+	 * slug alone would resume a site built from a different blueprint.
+	 */
+	funnelKey: string;
 	blogId: number;
 	siteSlug: string;
 };
 
 const SESSION_KEY = 'wow-funnel-created-site';
+
+/**
+ * A stable identity for one funnel run: the slug plus the args that decide what gets built.
+ *
+ * @param funnelSlug The funnel slug.
+ * @param funnelArgs Args from the entry URL.
+ * @returns A key that changes whenever the run would build something different.
+ */
+export function getWowFunnelKey(
+	funnelSlug: string,
+	funnelArgs: Record< string, string > = {}
+): string {
+	const args = Object.keys( funnelArgs )
+		.sort()
+		.map( ( key ) => `${ key }=${ funnelArgs[ key ] }` )
+		.join( '&' );
+	return args ? `${ funnelSlug }:${ args }` : funnelSlug;
+}
 
 /**
  * In-flight background-creation promises, keyed by funnel slug. Lets the create-site step await the
@@ -97,7 +121,7 @@ function readRemembered(): RememberedWowFunnelSite | null {
 			return null;
 		}
 		const parsed = JSON.parse( raw ) as RememberedWowFunnelSite;
-		if ( parsed && parsed.funnelSlug && parsed.blogId && parsed.siteSlug ) {
+		if ( parsed && parsed.funnelKey && parsed.blogId && parsed.siteSlug ) {
 			return parsed;
 		}
 	} catch {
@@ -106,9 +130,13 @@ function readRemembered(): RememberedWowFunnelSite | null {
 	return null;
 }
 
-export function getRememberedWowFunnelSite( funnelSlug: string ): RememberedWowFunnelSite | null {
+export function getRememberedWowFunnelSite(
+	funnelSlug: string,
+	funnelArgs: Record< string, string > = {}
+): RememberedWowFunnelSite | null {
 	const remembered = readRemembered();
-	return remembered && remembered.funnelSlug === funnelSlug ? remembered : null;
+	const key = getWowFunnelKey( funnelSlug, funnelArgs );
+	return remembered && remembered.funnelKey === key ? remembered : null;
 }
 
 function rememberWowFunnelSite( site: RememberedWowFunnelSite ): void {
@@ -129,6 +157,37 @@ export function clearWowFunnelSite(): void {
 }
 
 /**
+ * Forget a funnel run completely, so the next entry builds a new site.
+ *
+ * Clearing sessionStorage alone is not enough: the in-flight cache holds the resolved promise for
+ * the run's site, and startWowFunnelSite() consults it after the remembered-site check — so the
+ * discarded site would be handed straight back.
+ *
+ * @param funnelSlug The funnel slug.
+ * @param funnelArgs Args from the entry URL.
+ */
+export function forgetWowFunnelRun(
+	funnelSlug: string,
+	funnelArgs: Record< string, string > = {}
+): void {
+	clearWowFunnelSite();
+	inFlight[ getWowFunnelKey( funnelSlug, funnelArgs ) ] = undefined;
+}
+
+/**
+ * Is this site already paid for?
+ *
+ * A funnel run exists to sell a plan for the site it builds, so a site that already has one must
+ * never be resumed — checkout would offer a second plan for a site that does not need one.
+ *
+ * @param site The site, as returned by the site store.
+ * @returns True when the site holds a paid plan.
+ */
+export function wowFunnelSiteIsPaid( site: { plan?: { is_free?: boolean } } | undefined ): boolean {
+	return !! site?.plan && ! site.plan.is_free;
+}
+
+/**
  * Create the funnel's Simple site (which the server immediately fast-provisions to Atomic), once.
  *
  * Single-flight: concurrent callers for the same funnel share one request, and a site already
@@ -145,12 +204,14 @@ export function startWowFunnelSite( {
 	funnelArgs?: Record< string, string >;
 	siteTitle?: string;
 } ): Promise< RememberedWowFunnelSite > {
-	const remembered = getRememberedWowFunnelSite( funnelSlug );
+	const funnelKey = getWowFunnelKey( funnelSlug, funnelArgs );
+
+	const remembered = getRememberedWowFunnelSite( funnelSlug, funnelArgs );
 	if ( remembered ) {
 		return Promise.resolve( remembered );
 	}
 
-	const existing = inFlight[ funnelSlug ];
+	const existing = inFlight[ funnelKey ];
 	if ( existing ) {
 		return existing;
 	}
@@ -190,6 +251,7 @@ export function startWowFunnelSite( {
 
 		const result: RememberedWowFunnelSite = {
 			funnelSlug,
+			funnelKey,
 			blogId: site.siteId,
 			siteSlug: site.siteSlug,
 		};
@@ -202,14 +264,14 @@ export function startWowFunnelSite( {
 		return result;
 	} )();
 
-	inFlight[ funnelSlug ] = request;
+	inFlight[ funnelKey ] = request;
 	request.catch( ( error ) => {
 		logWowFunnelEvent( 'start_site_error', {
 			funnel: funnelSlug,
 			error: error instanceof Error ? error.message : String( error ),
 		} );
 		// Clear so a later attempt (e.g. the create-site fallback) can retry.
-		inFlight[ funnelSlug ] = undefined;
+		inFlight[ funnelKey ] = undefined;
 	} );
 
 	return request;


### PR DESCRIPTION
Found on a live run: re-entering the theme CTA kept landing back on the site from the previous run, at a checkout offering a **renewal of the plan that site had already bought**.

## 1. The remembered site outlived its run

The funnel remembers the site it created so a mid-flow refresh doesn't build a second one. But it was keyed on the funnel slug alone:

```js
return remembered && remembered.funnelSlug === funnelSlug ? remembered : null;
```

and `clearWowFunnelSite()` — which exists — **had no callers anywhere**. So the sessionStorage entry survived for the whole browser session and every later CTA click with the same slug resumed that site.

Two consequences:

- **Wrong site across themes.** Every theme CTA uses `wow_funnel=blueprint`; they differ only in `blueprint_slug`. Matching on the slug alone meant picking a *different* theme resumed a site built from the first one.
- **Finished runs got resumed**, which is how checkout ended up offering a renewal.

Now keyed by slug + args, and cleared at the post-checkout hand-off where the run actually ends.

## 2. Nothing checked whether the site was already paid for

This is the part worth scrutinising, because it is the one that can take money. Two guards:

- **Flow entry** refuses to resume a site holding a paid plan and builds a new one instead.
- **create-site re-checks** before assembling the cart and drops the plan item if the site is already paid. That's where money is committed, so it shouldn't trust that the site reaching it is the unpaid one we built.

`forgetWowFunnelRun()` clears sessionStorage **and** the in-flight cache. Clearing storage alone is not enough — `startWowFunnelSite()` consults the in-flight promise *after* the remembered-site check, so the discarded site would be handed straight back.

## Testing

```
yarn test-client landing/stepper/utils/test/wow-funnel
Tests: 9 passed, 9 total
```

New file covering: the key separating different blueprints, arg-order stability, resume-on-re-entry, refusing a different blueprint's site, clearing, ignoring pre-existing storage written before `funnelKey` (so anyone mid-session doesn't resume a stale entry), and the paid-plan predicate. eslint + `tsc --noEmit` clean.

## Related

Stacks alongside Automattic/wp-calypso#113857 (double blueprint import) and Automattic/wp-calypso#113854 (`build_dest` retirement). All three touch `onboarding.ts`; I'll rebase whichever lands second.