### PR TITLE
Purchases: read the raw Purchase in the site-level actions page

### DIFF
--- a/client/me/purchases/site-level-actions/index.tsx
+++ b/client/me/purchases/site-level-actions/index.tsx
@@ -1,24 +1,21 @@
+import { purchaseQuery, sitePurchasesQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { Button, Card, FormLabel } from '@automattic/components';
+import { useQuery } from '@tanstack/react-query';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import FormattedHeader from 'calypso/components/formatted-header';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import HeaderCakeBack from 'calypso/components/header-cake/back';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useIsSplitCancelRemoveEnabled } from 'calypso/dashboard/me/billing-purchases/cancel-purchase/use-is-split-cancel-remove-enabled';
-import { getName, handleRenewMultiplePurchasesClick } from 'calypso/lib/purchases';
+import { handleRenewMultiplePurchasesClick } from 'calypso/lib/purchases';
 import { cancelPurchase, managePurchase } from 'calypso/me/purchases/paths';
 import PurchaseSiteHeader from 'calypso/me/purchases/purchases-site/header';
-import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
-import {
-	getByPurchaseId,
-	getSitePurchases,
-	hasLoadedUserPurchasesFromServer,
-} from 'calypso/state/purchases/selectors';
-import type { Purchase } from 'calypso/lib/purchases/types';
+import { useDispatch as useReduxDispatch } from 'calypso/state';
+import { getName } from '../lib/raw-purchase-helpers';
+import type { Purchase } from '@automattic/api-core';
 
 import './style.scss';
 
@@ -38,11 +35,17 @@ export default function SiteActionInterstitial( {
 	const moment = useLocalizedMoment();
 	const isSplitEnabled = useIsSplitCancelRemoveEnabled();
 
-	const purchase = useSelector( ( state ) => getByPurchaseId( state, purchaseId ) );
-	const purchases = useSelector( ( state ) =>
-		purchase ? getSitePurchases( state, purchase.siteId ) : null
-	);
-	const hasLoaded = useSelector( hasLoadedUserPurchasesFromServer );
+	const { data: purchase, isPending: isPendingPurchase } = useQuery( purchaseQuery( purchaseId ) );
+	const siteId = purchase ? Number( purchase.blog_id ) : undefined;
+	const { data: purchases, isPending: isPendingSitePurchases } = useQuery( {
+		...sitePurchasesQuery( siteId as number ),
+		enabled: Boolean( siteId ),
+	} );
+	// A disabled query stays `pending` forever, so only wait on the site
+	// purchases once there is a site to fetch them for. Otherwise a purchase
+	// that fails to load would leave this stuck on the skeleton instead of
+	// falling through to the redirect below.
+	const hasLoaded = ! isPendingPurchase && ( ! siteId || ! isPendingSitePurchases );
 
 	const [ selectedIds, setSelectedIds ] = useState< Set< number > >(
 		() => new Set( [ purchaseId ] )
@@ -56,9 +59,7 @@ export default function SiteActionInterstitial( {
 			return;
 		}
 		if ( purchase ) {
-			// Temporary bridge (SHILL-2256): this page still reads the camelCase
-			// Purchase from Redux. Remove once it reads the raw shape.
-			dispatch( handleRenewMultiplePurchasesClick( [ purchase.rawPurchase ], siteSlug ) );
+			dispatch( handleRenewMultiplePurchasesClick( [ purchase ], siteSlug ) );
 		} else {
 			page( managePurchase( siteSlug, String( purchaseId ) ) );
 		}
@@ -87,7 +88,6 @@ export default function SiteActionInterstitial( {
 	if ( ! hasLoaded || ! purchase || ! purchases ) {
 		return (
 			<>
-				<QueryUserPurchases />
 				<div className="site-level-actions__back">
 					<HeaderCakeBack
 						icon="chevron-left"
@@ -141,14 +141,9 @@ export default function SiteActionInterstitial( {
 	};
 
 	const handleContinue = () => {
-		const selectedPurchases = purchases.filter( ( p ) => selectedIds.has( p.id ) );
+		const selectedPurchases = purchases.filter( ( p ) => selectedIds.has( Number( p.ID ) ) );
 		if ( actionType === 'renew' ) {
-			dispatch(
-				handleRenewMultiplePurchasesClick(
-					selectedPurchases.map( ( p ) => p.rawPurchase ),
-					siteSlug
-				)
-			);
+			dispatch( handleRenewMultiplePurchasesClick( selectedPurchases, siteSlug ) );
 			return;
 		}
 		const intent = actionType;
@@ -199,41 +194,41 @@ export default function SiteActionInterstitial( {
 
 	const getRenewalText = ( p: Purchase ) => {
 		if ( isRemove ) {
-			if ( p.isPastExpiryDate ) {
+			if ( p.is_past_expiry_date ) {
 				return translate( 'Expired on %(date)s', {
-					args: { date: moment( p.expiryDate ).format( 'LL' ) },
+					args: { date: moment( p.expiry_date ).format( 'LL' ) },
 				} );
 			}
 			return translate( 'Expires on %(date)s', {
-				args: { date: moment( p.expiryDate ).format( 'LL' ) },
+				args: { date: moment( p.expiry_date ).format( 'LL' ) },
 			} );
 		}
-		const expiryDate = p.expiryDate ? moment( p.expiryDate ).format( 'LL' ) : null;
+		const expiryDate = p.expiry_date ? moment( p.expiry_date ).format( 'LL' ) : null;
 		// Once the expiry date has passed, lead with the expiry status rather
 		// than any scheduled auto-renewal date. During the grace period the UI
 		// should steer toward manual renewal — a remaining auto-renewal attempt
 		// is unlikely to succeed — so show "Expired on" even if `renewDate` is
 		// still set.
-		if ( p.isPastExpiryDate && expiryDate ) {
+		if ( p.is_past_expiry_date && expiryDate ) {
 			return translate( 'Renews at %(price)s. Expired on %(date)s', {
-				args: { price: p.priceText, date: expiryDate },
+				args: { price: p.price_text, date: expiryDate },
 			} );
 		}
 		// An upcoming scheduled renewal: show its date. `renewDate` is only
 		// populated when there is an upcoming auto-renewal, so an empty value
 		// means "not renewing".
-		if ( p.renewDate ) {
+		if ( p.renew_date ) {
 			return translate( 'Renews at %(price)s on %(date)s', {
 				args: {
-					price: p.priceText,
-					date: moment( p.renewDate ).format( 'LL' ),
+					price: p.price_text,
+					date: moment( p.renew_date ).format( 'LL' ),
 				},
 			} );
 		}
 		// Not yet expired and not renewing: show the upcoming expiry date.
 		if ( expiryDate ) {
 			return translate( 'Renews at %(price)s. Expires on %(date)s', {
-				args: { price: p.priceText, date: expiryDate },
+				args: { price: p.price_text, date: expiryDate },
 			} );
 		}
 		// One-time/perpetual purchase (no renewal, no expiry): no subtitle.
@@ -242,7 +237,6 @@ export default function SiteActionInterstitial( {
 
 	return (
 		<>
-			<QueryUserPurchases />
 			<div className="site-level-actions__back">
 				<HeaderCakeBack
 					icon="chevron-left"
@@ -262,17 +256,17 @@ export default function SiteActionInterstitial( {
 						<h3 className="site-level-actions__section-title">{ sectionLabel }</h3>
 						{ purchases.map( ( p ) => (
 							<div
-								key={ p.id }
+								key={ p.ID }
 								className={ clsx( 'site-level-actions__row', {
-									'is-selected': selectedIds.has( p.id ),
+									'is-selected': selectedIds.has( Number( p.ID ) ),
 								} ) }
 							>
 								<FormLabel className="site-level-actions__label">
 									<FormInputCheckbox
 										className="site-level-actions__checkbox"
-										checked={ selectedIds.has( p.id ) }
-										onChange={ () => handleToggle( p.id ) }
-										disabled={ p.id === purchaseId }
+										checked={ selectedIds.has( Number( p.ID ) ) }
+										onChange={ () => handleToggle( Number( p.ID ) ) }
+										disabled={ Number( p.ID ) === purchaseId }
 									/>
 									<span className="site-level-actions__name">{ getName( p ) }</span>
 								</FormLabel>
@@ -287,13 +281,7 @@ export default function SiteActionInterstitial( {
 					</Card>
 				</div>
 				<div className="site-level-actions__right">
-					<PurchaseSiteHeader
-						siteId={ purchase.siteId }
-						name={ purchase.siteName }
-						// Temporary bridge (SHILL-2256): this page still reads the
-						// camelCase Purchase from Redux.
-						purchase={ purchase.rawPurchase }
-					/>
+					<PurchaseSiteHeader siteId={ siteId } name={ purchase.blogname } purchase={ purchase } />
 				</div>
 			</div>
 		</>


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/SHILL-2256

## Proposed Changes

* Move `client/me/purchases/site-level-actions` off the Redux purchase selectors (`getByPurchaseId`, `getSitePurchases`, `hasLoadedUserPurchasesFromServer`) and onto `purchaseQuery` / `sitePurchasesQuery` from `@automattic/api-queries`, so the page reads the raw snake_case `Purchase` from `@automattic/api-core` instead of the camelCase assembled one.
* Drop both temporary `purchase.rawPurchase` bridges — the `handleRenewMultiplePurchasesClick` calls and `<PurchaseSiteHeader>` both already accept the raw shape. With these gone, `client/me/purchases` no longer bridges through the assembler anywhere.
* Remove the two `<QueryUserPurchases />` fetch triggers the page rendered; the TanStack queries fetch their own data.
* Field renames follow the raw shape: `id` → `ID`, `siteId` → `blog_id`, `siteName` → `blogname`, `isPastExpiryDate` → `is_past_expiry_date`, `expiryDate` → `expiry_date`, `priceText` → `price_text`, `renewDate` → `renew_date`. `getName` now comes from the local `lib/raw-purchase-helpers` port.

Two details worth a reviewer's eye:

* **`Number( p.ID )` coercion is deliberate.** Selection state is a `Set<number>` seeded from the URL's `parseInt`. Raw IDs are typed `number` but can arrive as strings — the assembler used to coerce them with `Number()`, so TypeScript cannot catch this. Every place an ID meets that set now coerces explicitly.
* **The loading gate needed a behavioural fix, not just a rename.** A *disabled* TanStack query stays `isPending` forever, so the naive `! isPendingPurchase && ! isPendingSitePurchases` would leave a purchase that fails to load stuck on the skeleton instead of falling through to the `managePurchase` redirect that the old `hasLoaded` produced. It is now `! isPendingPurchase && ( ! siteId || ! isPendingSitePurchases )`, with a comment explaining why.

## Why are these changes being made?

The data-stores purchases assembler (`createPurchaseObject`) produces a duplicate camelCase `Purchase` type that shadows the raw one the API actually returns. Removing it is being done page by page, and this page was one of the last holdouts in `client/me/purchases` — it still read camelCase from Redux and then converted back to raw at each of its two call sites that needed the real shape.

Beyond deleting the bridges, reading the raw type directly removes a class of silent bug: the assembler is not a pure rename (it coerces `ID` and `blog_id` with `Number()`), so a value that round-trips through it can differ from what the API sent.

## Testing Instructions

This page is behind the split cancel/remove feature flag and only renders when a site has more than one purchase.

1. Sign in as a user with a site that has **at least two** purchases.
2. Go to a purchase's management page, then visit `/me/billing/purchases/:purchaseId/site-level-actions` for one of them — or reach it through the Cancel / Remove / Renew CTAs.
3. Verify each of the three action types renders correctly:
   * `renew` — heading "Renew subscriptions", button "Continue to checkout".
   * `cancel` — heading "Cancel subscriptions", destructive button "Continue to cancel".
   * `remove` — heading "Remove upgrades", destructive button "Continue to remove".
4. Confirm the purchase list shows the right product names and renewal subtitles ("Renews at X on DATE", "Renews at X. Expired on DATE", "Expires on DATE"), and that the site header on the right shows the correct site name and domain.
5. Check the checkboxes: the purchase you arrived from must be checked and disabled, and the others must toggle.
6. With `renew`, select a couple of purchases and press Continue — checkout should open with all selected purchases in the cart. This is the path most worth exercising, since it is where the ID coercion matters.
7. With `cancel` / `remove`, press Continue and confirm the URL carries `?intent=` plus `additionalPurchaseIds` for any extra selections.
8. Sanity-check the loading and fallback paths: a hard refresh should show the skeleton and then the list, and a purchase ID that does not resolve should redirect to the manage-purchase page rather than hanging on the skeleton.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

No new strings and no visual changes, so string freeze, dark mode, and translation checks do not apply. There is no existing test file for this page.
