### PR TITLE
Login: send "Lost your password?" to the wp-login.php flow

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -24,7 +24,7 @@ import {
 } from 'calypso/lib/oauth2-clients';
 import { detectPartnerConfig, getPartnerFormattedWindowTitle } from 'calypso/lib/partner-branding';
 import isPassportRedirect from 'calypso/lib/passport/is-passport-redirect';
-import { login } from 'calypso/lib/paths';
+import { login, lostPassword } from 'calypso/lib/paths';
 import { getHeaderText } from 'calypso/login/wp-login/hooks/get-header-text';
 import {
 	recordPageViewWithClientId as recordPageView,
@@ -170,6 +170,28 @@ export class Login extends Component {
 	getLostPasswordLink() {
 		if ( this.props.twoFactorAuthType ) {
 			return null;
+		}
+
+		// Jetpack, Woo and OAuth2 sign-ins stay on the Calypso screen: it carries the
+		// passwordless magic-link branch and the client context, and wp-login.php has neither.
+		const keepCalypsoForm =
+			this.props.isWooJPC || this.props.isJetpack || !! this.props.oauth2Client;
+
+		if ( ! keepCalypsoForm ) {
+			return (
+				<a
+					className="one-login__footer-link"
+					// No redirect_to. wp-login.php honours it in place of checkemail=confirm, and
+					// the recovery-email and SMS steps hang off checkemail=confirm.
+					href={ lostPassword( { locale: this.props.locale } ) }
+					rel="external"
+					onClick={ () =>
+						this.props.recordTracksEvent( 'calypso_login_reset_password_link_click' )
+					}
+				>
+					{ this.props.translate( 'Lost your password?' ) }
+				</a>
+			);
 		}
 
 		return (


### PR DESCRIPTION
Closes DOTOBRD-377

## Proposed changes

The "Lost your password?" link in the login page (`/log-in`) now goes to `wp-login.php?action=lostpassword` instead of the Calypso Lost your password flow at `/log-in/lostpassword`.

Jetpack, Woo (JPC) and OAuth2 sign-ins will still go to the Calypso flow - it carries the passwordless magic-link branch and the client context, and `wp-login.php` has neither.

<img width="1147" height="909" alt="Screenshot 2026-09-04 at 00 02 50" src="https://github.com/user-attachments/assets/5bb8ef1b-d778-4b04-8bda-ee8a17d43769" />

## Why

The Lost your password flow is duplicated in Calypso ( `/log-in/lostpassword`) and the backend (`/wp-login.php?action=lostpassword`). As discussed in pet6gk-34u-p2, we want to keep only the backend flow, so the "Lost your password" link in Calypso now links to the backend flow.

More than duplication, the main issue of the Calypso flow is that it lacks support for password resets via SMS - if a user has a recovery phone, they can't use it to recover their account. Also, the Calypso flow sends a POST request to `wp-login.php?action=lostpassword` just to scrape the HTML response, and that inadvertently triggers a recovery SMS for accounts with a recovery phone set. The user would receive an SMS with a password reset code, but wouldn't be able to input it anywhere in the UI.

## Testing instructions

- Build this branch locally or open the live Calypso PR
- Go to the login page at `/log-in`
- Ensure the "Lost your password?" link goes to `wordpress.com/wp-login.php?action=lostpassword`, not `/log-in/lostpassword`
- From a Jetpack or Woo login, and from an OAuth2 login (Blaze Pro, Studio), the link still opens the Calypso flow

## Prior discussion

Which "Lost your password" flow WordPress.com should use has changed hands a few times:

- #68885 introduced the Calypso screen, for WooCommerce only.
- #96291 asked where WordPress.com users should go, and #98390 answered it by redirecting `/log-in/lostpassword` to `wp-login.php`.
- #104367 reversed that, moved every client onto the Calypso screen and removed the redirect. Its was noted that the Calypso form has gaps and it was proposed to send all usages to `wp-login.php` as the alternative. That is what this PR does, keeping the Calypso screen only for the clients that need their own branding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

