### PR TITLE
MSD Billing: update active upgrades styles

### DIFF
--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -440,7 +440,7 @@ export function getFields( {
 			render: ( { item }: { item: Purchase } ) => {
 				const site = sites.find( ( site ) => site.ID === item.blog_id );
 				return (
-					<div>
+					<div className="active-upgrades__inline-status">
 						<PurchaseExpiryStatus purchase={ item } isSiteMissing={ ! site } />
 					</div>
 				);

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -74,7 +74,7 @@ export function BillingPurchaseInfoPopover( { children }: { children: ReactNode 
 }
 
 function ProductIcon( { icon, label }: { icon: ReactElement; label: string } ) {
-	const containerSize = 52;
+	const containerSize = 48;
 	const iconSize = 20;
 	return (
 		<span
@@ -97,7 +97,7 @@ function ProductIcon( { icon, label }: { icon: ReactElement; label: string } ) {
 }
 
 function PurchaseItemSiteIcon( { site, purchase }: { site?: Site; purchase: Purchase } ) {
-	const size = 52;
+	const size = 48;
 
 	if ( purchase.is_jetpack_plan_or_product ) {
 		return (

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -440,7 +440,7 @@ export function getFields( {
 			render: ( { item }: { item: Purchase } ) => {
 				const site = sites.find( ( site ) => site.ID === item.blog_id );
 				return (
-					<div className="billing-purchases__middle-valign">
+					<div>
 						<PurchaseExpiryStatus purchase={ item } isSiteMissing={ ! site } />
 					</div>
 				);
@@ -474,7 +474,7 @@ export function getFields( {
 				}
 				const site = sites.find( ( site ) => site.ID === item.blog_id );
 				return (
-					<HStack justify="flex-start" spacing={ 1 } className="billing-purchases__middle-valign">
+					<HStack justify="flex-start" spacing={ 1 }>
 						<PurchasePaymentMethod purchase={ item } isSiteMissing={ ! site } />
 						{ isBackupMethodAvailable && mightStillAutoRenew( item ) && (
 							<BackupPaymentMethodNotice />

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -74,7 +74,7 @@ export function BillingPurchaseInfoPopover( { children }: { children: ReactNode 
 }
 
 function ProductIcon( { icon, label }: { icon: ReactElement; label: string } ) {
-	const containerSize = 36;
+	const containerSize = 52;
 	const iconSize = 20;
 	return (
 		<span
@@ -97,7 +97,7 @@ function ProductIcon( { icon, label }: { icon: ReactElement; label: string } ) {
 }
 
 function PurchaseItemSiteIcon( { site, purchase }: { site?: Site; purchase: Purchase } ) {
-	const size = 36;
+	const size = 52;
 
 	if ( purchase.is_jetpack_plan_or_product ) {
 		return (
@@ -440,7 +440,7 @@ export function getFields( {
 			render: ( { item }: { item: Purchase } ) => {
 				const site = sites.find( ( site ) => site.ID === item.blog_id );
 				return (
-					<div className="active-upgrades__inline-status">
+					<div className="billing-purchases__middle-valign">
 						<PurchaseExpiryStatus purchase={ item } isSiteMissing={ ! site } />
 					</div>
 				);
@@ -474,7 +474,7 @@ export function getFields( {
 				}
 				const site = sites.find( ( site ) => site.ID === item.blog_id );
 				return (
-					<HStack justify="flex-start" spacing={ 1 }>
+					<HStack justify="flex-start" spacing={ 1 } className="billing-purchases__middle-valign">
 						<PurchasePaymentMethod purchase={ item } isSiteMissing={ ! site } />
 						{ isBackupMethodAvailable && mightStillAutoRenew( item ) && (
 							<BackupPaymentMethodNotice />

--- a/client/dashboard/me/billing-purchases/dataviews.tsx
+++ b/client/dashboard/me/billing-purchases/dataviews.tsx
@@ -309,7 +309,7 @@ export function getFields( {
 				return (
 					<HStack justify="flex-start" spacing={ 1 }>
 						<PurchaseSettingLink purchase={ item } disabled={ isTransferred }>
-							{ getTitleForListDisplay( item ) }
+							{ getTitleForListDisplay( item, false ) }
 						</PurchaseSettingLink>
 						<OwnerInfo purchase={ item } isTransferredOwnership={ isTransferred } />
 					</HStack>

--- a/client/dashboard/me/billing-purchases/purchase-product.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-product.tsx
@@ -34,6 +34,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 						{
 							siteName: (
 								<RouterLinkButton
+									className="billing-purchases__site-name"
 									variant="link"
 									to={ purchasesRoute.fullPath }
 									search={ { site: site.ID } }
@@ -48,7 +49,12 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 								</RouterLinkButton>
 							),
 							siteDomain: (
-								<ExternalLink href={ 'https://' + site.slug } rel="noreferrer" title={ linkTitle }>
+								<ExternalLink
+									className="billing-purchases__site-url"
+									href={ 'https://' + site.slug }
+									rel="noreferrer"
+									title={ linkTitle }
+								>
 									{ linkText }
 								</ExternalLink>
 							),
@@ -68,6 +74,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 							purchaseType: <span>{ productType }</span>,
 							siteDomain: (
 								<RouterLinkButton
+									className="billing-purchases__site-name"
 									variant="link"
 									to={ purchasesRoute.fullPath }
 									search={ { site: site.ID } }
@@ -83,6 +90,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 							),
 							viewSite: (
 								<ExternalLink
+									className="billing-purchases__site-url"
 									href={ 'https://' + site.slug }
 									rel="noreferrer"
 									title={ __( 'View site' ) }
@@ -111,6 +119,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 						{
 							siteName: (
 								<RouterLinkButton
+									className="billing-purchases__site-name"
 									variant="link"
 									to={ purchasesRoute.fullPath }
 									search={ { site: site.ID } }
@@ -125,7 +134,12 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 								</RouterLinkButton>
 							),
 							viewSite: (
-								<ExternalLink href={ 'https://' + site.slug } rel="noreferrer" title={ linkTitle }>
+								<ExternalLink
+									className="billing-purchases__site-url"
+									href={ 'https://' + site.slug }
+									rel="noreferrer"
+									title={ linkTitle }
+								>
 									{ linkText }
 								</ExternalLink>
 							),
@@ -151,6 +165,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 					{
 						viewSite: (
 							<ExternalLink
+								className="billing-purchases__site-url"
 								href={ 'https://' + purchase.domain }
 								rel="noreferrer"
 								title={ __( 'View site' ) }

--- a/client/dashboard/me/billing-purchases/purchase-product.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-product.tsx
@@ -62,11 +62,10 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 			return (
 				<div>
 					{ createInterpolateElement(
-						// translators: %(purchaseType)s: the product name. The string also contains the URL of the site and a link to visit the site (e.g. "Premium plan for blockstore.com (view site)")
-						sprintf( __( '%(purchaseType)s for <siteDomain /> (<viewSite />)' ), {
-							purchaseType: productType,
-						} ),
+						// translators: <purchaseType />: the product name. The string also contains the URL of the site and a link to visit the site (e.g. "Premium plan for blockstore.com (view site)")
+						__( '<purchaseType /> for <siteDomain /> (<viewSite />)' ),
 						{
+							purchaseType: <span>{ productType }</span>,
 							siteDomain: (
 								<RouterLinkButton
 									variant="link"
@@ -108,7 +107,7 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 				<div>
 					{ createInterpolateElement(
 						// translators: The string contains the name of the site, and the URL of the site e.g. for Block Store (blockstore.com)
-						__( 'for <siteName /> (<viewSite />)' ),
+						__( 'Site plan for <siteName /> (<viewSite />)' ),
 						{
 							siteName: (
 								<RouterLinkButton

--- a/client/dashboard/me/billing-purchases/purchase-product.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-product.tsx
@@ -115,7 +115,9 @@ export function PurchaseProduct( { purchase, site }: { purchase: Purchase; site?
 				<div>
 					{ createInterpolateElement(
 						// translators: The string contains the name of the site, and the URL of the site e.g. for Block Store (blockstore.com)
-						__( 'Site plan for <siteName /> (<viewSite />)' ),
+						purchase.is_plan
+							? __( 'Site plan for <siteName /> (<viewSite />)' )
+							: __( 'for <siteName /> (<viewSite />)' ),
 						{
 							siteName: (
 								<RouterLinkButton

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -1,5 +1,13 @@
 @use 'calypso/assets/stylesheets/shared/mixins/dark-theme' as ui-mixins;
 
+.dataviews-layout__container {
+	tr {
+		td:has(.billing-purchases__middle-valign), td.dataviews-view-table__actions-column--sticky {
+			vertical-align: middle;
+		}
+	}
+}
+
 img.payment-method-image {
 	vertical-align: middle;
 }
@@ -60,17 +68,6 @@ img.payment-method-image {
 
 .dataviews-view-table__cell-content-wrapper .billing-purchase__inline-status {
 	margin-top: 4px;
-}
-.dataviews-view-table__cell-content-wrapper .active-upgrades__inline-status {
-	height: 52px !important;
-	width: 100%;
-	display: grid;
-	place-items: center start;
-}
-
-.dataviews-view-table__cell-content-wrapper.dataviews-column-primary__media > a > div, img {
-	width: 52px !important;
-	height: 52px !important;
 }
 
 .dataviews-view-table__primary-column-content {

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -72,7 +72,7 @@ img.payment-method-image {
 
 a.is-link.billing-purchases__site-name {
 	text-decoration: none;
-	color: #1e1e1e;
+	color: var( --dashboard__text-color );
 	font-weight: 500;
 }
 

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -68,8 +68,14 @@ a.is-link.billing-purchases__site-name {
 	font-weight: 500;
 }
 
-a.components-external-link.billing-purchases__site-url > span.components-external-link__contents {
-	text-decoration: none;
+a.components-external-link.billing-purchases__site-url {
+	> span.components-external-link__contents {
+		text-decoration: none;
+	}
+
+	> .components-external-link__icon {
+		display: none;
+	}
 }
 
 button.purchase-payment-method__update {

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -1,13 +1,5 @@
 @use 'calypso/assets/stylesheets/shared/mixins/dark-theme' as ui-mixins;
 
-.dataviews-layout__container {
-	tr {
-		td:has(.billing-purchases__middle-valign), td.dataviews-view-table__actions-column--sticky {
-			vertical-align: middle;
-		}
-	}
-}
-
 img.payment-method-image {
 	vertical-align: middle;
 }
@@ -62,6 +54,14 @@ img.payment-method-image {
 	}
 }
 
+.dataviews-layout__container {
+	tr {
+		td:has(.billing-purchases__middle-valign), td.dataviews-view-table__actions-column--sticky {
+			vertical-align: middle;
+		}
+	}
+}
+
 .dataviews-view-table__cell-content-wrapper .purchase-payment-method__wrapper {
 	width: fit-content;
 }
@@ -70,15 +70,14 @@ img.payment-method-image {
 	margin-top: 4px;
 }
 
-.dataviews-view-table__primary-column-content {
-	a.components-button.is-link {
-		text-decoration: none;
-		color: #2f2f2f;
-		font-weight: 500;
-	}
-	a.components-external-link > span.components-external-link__contents {
-		text-decoration: none;
-	}
+a.is-link.billing-purchases__site-name {
+	text-decoration: none;
+	color: #1e1e1e;
+	font-weight: 500;
+}
+
+a.components-external-link.billing-purchases__site-url > span.components-external-link__contents {
+	text-decoration: none;
 }
 
 button.purchase-payment-method__update {

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -54,14 +54,6 @@ img.payment-method-image {
 	}
 }
 
-.dataviews-layout__container {
-	tr {
-		td:has(.billing-purchases__middle-valign), td.dataviews-view-table__actions-column--sticky {
-			vertical-align: middle;
-		}
-	}
-}
-
 .dataviews-view-table__cell-content-wrapper .purchase-payment-method__wrapper {
 	width: fit-content;
 }

--- a/client/dashboard/me/billing-purchases/style.scss
+++ b/client/dashboard/me/billing-purchases/style.scss
@@ -61,6 +61,28 @@ img.payment-method-image {
 .dataviews-view-table__cell-content-wrapper .billing-purchase__inline-status {
 	margin-top: 4px;
 }
+.dataviews-view-table__cell-content-wrapper .active-upgrades__inline-status {
+	height: 52px !important;
+	width: 100%;
+	display: grid;
+	place-items: center start;
+}
+
+.dataviews-view-table__cell-content-wrapper.dataviews-column-primary__media > a > div, img {
+	width: 52px !important;
+	height: 52px !important;
+}
+
+.dataviews-view-table__primary-column-content {
+	a.components-button.is-link {
+		text-decoration: none;
+		color: #2f2f2f;
+		font-weight: 500;
+	}
+	a.components-external-link > span.components-external-link__contents {
+		text-decoration: none;
+	}
+}
 
 button.purchase-payment-method__update {
 	// This button is inside a flexbox (HStack) which has `min-width: 0` set on

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -364,7 +364,7 @@ export function getBillPeriodLabel( purchase: Purchase ): string {
  * differently. For example, domains are displayed with the domain name as the
  * title and the product name as the subtitle (see `getSubtitleForDisplay`).
  */
-export function getTitleForDisplay( purchase: Purchase ): string {
+export function getTitleForDisplay( purchase: Purchase, includeProductType = true ): string {
 	if ( purchase.is_hundred_year_domain ) {
 		return __( '100-Year Domain Registration' );
 	}
@@ -432,16 +432,19 @@ export function getTitleForDisplay( purchase: Purchase ): string {
 	}
 
 	if ( purchase.is_plan ) {
-		/* translators: %(productName)s is the product name "WordPress.com Personal" */
-		return sprintf( __( '%(productName)s Plan' ), {
-			productName: purchase.product_name.replace( /\s*\(.*$/, '' ).trim(),
-		} );
+		if ( includeProductType ) {
+			/* translators: %(productName)s is the product name "WordPress.com Personal" */
+			return sprintf( __( '%(productName)s Plan' ), {
+				productName: purchase.product_name.replace( /\s*\(.*$/, '' ).trim(),
+			} );
+		}
+		return purchase.product_name.replace( /\s*\(.*$/, '' ).trim();
 	}
 
 	return purchase.product_name;
 }
 
-export function getTitleForListDisplay( purchase: Purchase ): string {
+export function getTitleForListDisplay( purchase: Purchase, includeProductType = true ): string {
 	if ( purchase.is_domain_registration && purchase.meta ) {
 		if ( purchase.is_hundred_year_domain ) {
 			// translators: %s is the domain name, e.g. "100-Year Domain Registration: example.com"
@@ -450,7 +453,7 @@ export function getTitleForListDisplay( purchase: Purchase ): string {
 		// translators: %s is the domain name, e.g. "Domain Registration: example.com"
 		return sprintf( __( 'Domain Registration: %s' ), purchase.meta );
 	}
-	return getTitleForDisplay( purchase );
+	return getTitleForDisplay( purchase, includeProductType );
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes CHE-532

## Proposed Changes

* Implement the design changes from the figma:
   * Icon size 36px -> 48px
   * Add "Site plan " before the word "for"
   * Change the style of the site plan to 500px font weight, darker color, no underline
   * Remove the word "Plan" from the product name (it is shown in the description)
   * Hide the arrow for the external link

| Before | <img width="1371" height="362" alt="Screenshot 2026-08-27 at 1 28 36 PM" src="https://github.com/user-attachments/assets/a9c3f0e8-aafd-4e5e-abb9-6a6c77078408" /> |
|--------|------|
| **After** | <img width="1369" height="367" alt="Screenshot 2026-08-31 at 11 47 53 AM" src="https://github.com/user-attachments/assets/3b8cfa58-0613-4060-ac43-99337d9a66d3" /> |




## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* To implement the design changes from the figma in the linear issue

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the MSD billing > active purchases page.
* Confirm that the screen shot matches
* Check other data views and make sure that there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
