### PR TITLE
A4A: Keep the disabled look on aria-disabled secondary buttons

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -106,7 +106,7 @@
 	// A4A secondary buttons keep a primary border. 37.0.0's border-color is forced off
 	// by the Calypso override and reinstated as a box-shadow; restore the border here
 	// and drop the box-shadow. Buttons with their own outline keep it (higher specificity).
-	:where(.components-button.is-secondary:not(.is-destructive):not(:disabled)) {
+	:where(.components-button.is-secondary:not(.is-destructive):not(:disabled):not([aria-disabled="true"])) {
 		border-color: var(--color-primary) !important;
 		box-shadow: none;
 	}
@@ -254,7 +254,7 @@
 /* 37.0.0 draws the secondary border with `border-color` instead of the inset box-shadow
  * Calypso and several packages still use, so it leaks as a stray accent outline. Turn it
  * off and keep the box-shadow as the border. Destructive buttons keep their red border. */
-:where(.components-button.is-secondary:not(.is-destructive):not(:disabled)) {
+:where(.components-button.is-secondary:not(.is-destructive):not(:disabled):not([aria-disabled="true"])) {
 	border-color: transparent !important;
 	box-shadow: inset 0 0 0 1px var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 }


### PR DESCRIPTION
Related to A4A-2859.

## Proposed Changes

* Disabled buttons that stay focusable for screen readers (they carry `aria-disabled` instead of the `disabled` attribute) now get the proper disabled styling: gray text with a gray border.
* Before this fix, two button style overrides only skipped buttons with the `disabled` attribute, so they painted the enabled border color onto these buttons. The result was a confusing half-and-half look: gray “disabled” text inside a blue “enabled” border.



## Why are these changes being made?

* A disabled button should look disabled. The accessible-when-disabled pattern keeps the button reachable by keyboard and screen readers, and it should not lose the visual disabled state because of that.
* The Partner Directory dashboard uses this pattern for its “Finish profile” / “Edit profile” button, which made the mismatch visible in the A4A app.
* The same combination exists in a few other places that load these styles, so this also fixes the disabled “Continue” buttons in the Reader onboarding modals and the disabled “Still need help?” button in the Help Center footer when it renders inside Calypso.

## Testing Instructions

Using this PR’s Calypso Live link with the `a8c-for-agencies` environment, sign in as an agency with no approved directories and open Partner Directories → Dashboard (`/partner-directory/dashboard`).

* The “Finish profile” / “Edit profile” button shows gray text with a gray border (see the After screenshot), instead of a blue border.
* Enabled secondary buttons across the A4A app keep their existing look: blue border and blue text.

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/eb11f2a8-2974-4115-808c-823b9695f340" alt="Disabled button with gray text but a blue border" /> | <img src="https://github.com/user-attachments/assets/f3490ee2-d1ba-4601-9a01-6fd77e30a985" alt="Disabled button with gray text and a gray border" /> |

Reader onboarding:

Using this PR’s Calypso Live link, open the Reader onboarding “What topics interest you?” modal. With nothing selected, the disabled “Continue” button shows gray text with a gray border instead of a blue border.

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/e966b76e-1256-452a-834e-a3638a9c6155" alt="Reader onboarding modal with a disabled Continue button that has a gray border" /> | <img src="https://github.com/user-attachments/assets/fbe75bbe-f3c4-422c-ae13-14f5218af214" alt="Reader onboarding modal with a disabled Continue button that has a blue border" /> |

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)



