### PR TITLE
Switch to Site Spec 1.16.2

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -225,7 +225,7 @@
 	"blackbox_url": "https://blackbox-api.wp.com/v1/dist/v.js",
 	"blackbox_api_key": "1b4f123e7dae4d83bbd18170c4358f8e",
 	"site_spec": {
-		"script_url": "https://widgets.wp.com/site-spec/v1.16.0/index.js",
-		"css_url": "https://widgets.wp.com/site-spec/v1.16.0/style.css"
+		"script_url": "https://widgets.wp.com/site-spec/v1.16.2/index.js",
+		"css_url": "https://widgets.wp.com/site-spec/v1.16.2/style.css"
 	}
 }


### PR DESCRIPTION
Fixes BSKY-2019, BSKY-2018

## Proposed Changes

* Updates to Site Spec 1.16.2, which changes the H1 of the first page of site spec and removes the startup chip optoons.

## Why are these changes being made?
* Chips weren't being used and when they were used, resulted in a dip in completing site spec.

## Testing Instructions
TBC: https://my.wordpress.com/setup

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
