### PR TITLE
Omnibar: let the AI chat node be found as the chat entry button

### DIFF
--- a/client/dashboard/app/omnibar/plugin-ai-chat.tsx
+++ b/client/dashboard/app/omnibar/plugin-ai-chat.tsx
@@ -55,6 +55,7 @@ export function useAiChatPlugin( {
 		id: 'ai-chat',
 		label: __( 'Ask AI' ),
 		icon: <BigSkyIcon />,
+		className: 'masterbar__item-agents-manager-ai-chat',
 		onClick: handleClick,
 	};
 }

--- a/client/dashboard/app/omnibar/test/plugin-ai-chat.test.tsx
+++ b/client/dashboard/app/omnibar/test/plugin-ai-chat.test.tsx
@@ -41,6 +41,12 @@ describe( 'useAiChatPlugin', () => {
 		expect( result.current ).toBeUndefined();
 	} );
 
+	it( 'carries the class that marks it as the chat entry button', () => {
+		const { result } = renderHook( () => useAiChatPlugin( { sectionName: 'sites' } ) );
+
+		expect( result.current?.className ).toBe( 'masterbar__item-agents-manager-ai-chat' );
+	} );
+
 	it( 'records the masterbar event with the section and opens the chat on click', () => {
 		const { result } = renderHook( () => useAiChatPlugin( { sectionName: 'sites' } ) );
 		result.current?.onClick?.( {} as React.MouseEvent );


### PR DESCRIPTION
Part of AM-34

## Proposed Changes

* Set `className: 'masterbar__item-agents-manager-ai-chat'` on the omnibar's Ask AI node.

## Why are these changes being made?

`hasAiChatEntryButton()` finds the chat's entry point by `#wp-admin-bar-agents-manager-ai-chat` (wp-admin) or `.masterbar__item-agents-manager-ai-chat` (Calypso masterbar). The omnibar renders neither — it emits no DOM `id`, only `omnibar__menu` plus `node.className` — so the chat treated itself as having no entry point and reopened from a floating bubble instead of from the button.

wp-admin and the old masterbar already satisfy that lookup, so only the omnibar path needed this.

## Testing Instructions

The omnibar is behind `dashboard/omnibar-radical` (on in development, off in production).

1. `yarn start`, open `/home/:site` with the unified AI chat experience enabled
2. Console: `document.querySelector( '.masterbar__item-agents-manager-ai-chat' )` returns an element (previously `null`)
3. Open the AI chat and close it — it collapses back into the Ask AI button instead of leaving a floating bubble

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label?

🤖 Generated with [Claude Code](https://claude.com/claude-code)