### PR TITLE
Agents Manager: send agent_manager_version on unified Tracks events

### DIFF
--- a/packages/agents-manager/src/global.d.ts
+++ b/packages/agents-manager/src/global.d.ts
@@ -32,6 +32,8 @@ declare const agentsManagerData:
 			isA11n?: boolean;
 			/** Whether the site is WordPress.com-hosted (Simple/WoA). */
 			isWpcomPlatform?: boolean;
+			/** The deployed bundle build, as `{variant}:{version}`. */
+			version?: string;
 			/** The site's canonical identity; injected on wp-admin only. */
 			site?: { ID?: number; domain?: string };
 			emptyViewHeading?: string;
@@ -161,6 +163,8 @@ interface AgentsManagerActions {
  */
 interface Window {
 	__agentsManagerActions?: AgentsManagerActions;
+	/** Build commit injected by Calypso's server-rendered document; absent on widgets.wp.com bundles. */
+	COMMIT_SHA?: string;
 	/** Big Sky injects this on editor surfaces. Narrowed to the fields AM consumes. */
 	bigSkyInitialState?: {
 		bigSkyVersion?: string;

--- a/packages/agents-manager/src/utils/__tests__/tracks.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/tracks.test.ts
@@ -207,6 +207,7 @@ describe( 'tracks wrappers', () => {
 			expect( props ).toMatchObject( {
 				ai_session_id: 'session-xyz',
 				agent_name: 'dolly',
+				agent_manager_version: 'none',
 				provider_ids: 'none',
 				surface: 'editor',
 				is_test: true,
@@ -286,6 +287,57 @@ describe( 'tracks wrappers', () => {
 			recordAgentsManagerTracksEvent( 'calypso_agents_manager_chat_minimize' );
 
 			expect( lastEventProps().provider_ids ).toBe( 'none' );
+		} );
+	} );
+
+	describe( 'agent_manager_version', () => {
+		afterEach( () => {
+			delete window.COMMIT_SHA;
+		} );
+
+		it( 'sends the Jetpack-injected build version when present', () => {
+			( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+				isDevMode: true,
+				version: 'gutenberg:abc123',
+			};
+
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_x' );
+
+			expect( lastEventProps().agent_manager_version ).toBe( 'gutenberg:abc123' );
+		} );
+
+		it( 'falls back to the Calypso commit on Calypso-rendered pages', () => {
+			window.COMMIT_SHA = 'deadbeef';
+
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_x' );
+
+			expect( lastEventProps().agent_manager_version ).toBe( 'calypso:deadbeef' );
+		} );
+
+		it( 'prefers the injected version over the Calypso commit', () => {
+			( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+				isDevMode: true,
+				version: 'wp-admin:abc123',
+			};
+			window.COMMIT_SHA = 'deadbeef';
+
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_x' );
+
+			expect( lastEventProps().agent_manager_version ).toBe( 'wp-admin:abc123' );
+		} );
+
+		it( "normalizes the dev server's '(unknown)' commit to calypso:dev", () => {
+			window.COMMIT_SHA = '(unknown)';
+
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_x' );
+
+			expect( lastEventProps().agent_manager_version ).toBe( 'calypso:dev' );
+		} );
+
+		it( 'sends none when neither source is available', () => {
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_x' );
+
+			expect( lastEventProps().agent_manager_version ).toBe( 'none' );
 		} );
 	} );
 

--- a/packages/agents-manager/src/utils/tracks.ts
+++ b/packages/agents-manager/src/utils/tracks.ts
@@ -149,12 +149,32 @@ export function recordBigSkyTracksEvent(
 	recordTracksEvent( eventName, mergedProps );
 }
 
+/**
+ * The running build's version: the Jetpack-injected `{variant}:{version}` on
+ * wp-admin surfaces, or Calypso's own commit on Calypso-rendered pages.
+ */
+function getAgentManagerVersion(): string {
+	const injected = getAgentsManagerInlineData()?.version;
+	if ( typeof injected === 'string' && injected !== '' ) {
+		return injected;
+	}
+
+	const commitSha = typeof window !== 'undefined' ? window.COMMIT_SHA : undefined;
+	if ( typeof commitSha === 'string' && commitSha !== '' ) {
+		// Local dev servers render the document with COMMIT_SHA set to '(unknown)'.
+		return 'calypso:' + ( commitSha === '(unknown)' ? 'dev' : commitSha );
+	}
+
+	return 'none';
+}
+
 function getUnifiedBaseProps(): TracksProps {
 	const isA11n = getIsA11n();
 	const blogId = getBlogId();
 	return {
 		ai_session_id: getActiveSessionId(),
 		agent_name: getResolvedAgentId() ?? DOLLY_AGENT_ID,
+		agent_manager_version: getAgentManagerVersion(),
 		// Sorted so the same provider set always yields the same value; 'none'
 		// until the providers load (events can fire before the chat mounts).
 		provider_ids: getLoadedProviderIds()?.slice().sort().join( ',' ) || 'none',


### PR DESCRIPTION
Part of AM-10

## Proposed Changes

* Send an `agent_manager_version` property with every unified Agents Manager Tracks event (`calypso_agents_manager_*`), resolved in order:
  1. `agentsManagerData.version` — the `{variant}:{version}` build identifier the Jetpack package injects on wp-admin/editor surfaces (added in Automattic/jetpack#51658).
  2. `calypso:{COMMIT_SHA}` — on Calypso-rendered pages (masterbar, Dashboard omnibar, Reader), where the Jetpack inline data does not exist but the server-rendered document injects the running build's commit. A local dev server's `(unknown)` commit normalizes to `calypso:dev`.
  3. `'none'` — when neither source is available.
* Type the new fields: `agentsManagerData.version` and `Window.COMMIT_SHA` in the package's global declarations.

Notes for reviewers:
* The property is named `agent_manager_version` rather than the standard's `agent_version` — the backend agents are not versioned, so the app build is what this reports. Agreed on AM-10.
* Until the Jetpack side deploys, wp-admin surfaces report `'none'`; Calypso surfaces report `calypso:{sha}` immediately.
* The Big Sky parity events (`jetpack_big_sky_*`) are unchanged; they keep sending `big_sky_version`.

## Why are these changes being made?

* The AI product Tracks standard expects a version property on every event, and Agents Manager events currently send none — `big_sky_version` on the parity path is a different product's version. This also completes the event shape ahead of event registration.

## Testing Instructions

* Open the browser DevTools, switch to the **Network** tab, and filter requests by `t.gif`.
* Sync the agents-manager app with your WordPress.com sandbox (`cd apps/agents-manager && yarn dev --sync`):
  * With the Jetpack PR's build also on the sandbox (`bin/jetpack-downloader test jetpack-mu-wpcom-plugin ai-1115-expose-agents-manager-version-to-frontend` from `public_html`), interact with the chat in wp-admin and confirm events carry `agent_manager_version: {variant}:{hash}`.
  * Without it, confirm they carry `agent_manager_version: none`.
* With Calypso running locally (`yarn start`): open http://my.localhost:3000/me/account, click the masterbar AI button, and confirm the event carries `agent_manager_version: calypso:dev`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
