### PR TITLE
wpcom-block-editor: Show an upgrade nudge for plan-gated video upload errors

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/editor.jsx
+++ b/apps/wpcom-block-editor/src/wpcom/editor.jsx
@@ -8,6 +8,7 @@ import './features/tracking';
 import { OnboardingNextStepAfterPublishingPost } from './features/onboarding-next-step-after-publishing-post';
 import InserterMenuTrackingEvent from './features/tracking/wpcom-inserter-menu-search-term';
 import './features/site-editor-env-consistency';
+import './features/video-upload-plan-nudge';
 import './editor.scss';
 import './features/tracking/site-editor-load';
 

--- a/apps/wpcom-block-editor/src/wpcom/features/video-upload-plan-nudge.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/video-upload-plan-nudge.js
@@ -1,0 +1,69 @@
+import { getCalypsoUrl } from '@automattic/calypso-url';
+import { dispatch, select, subscribe } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import tracksRecordEvent from './tracking/track-record-event';
+
+/**
+ * On sites whose plan doesn't include video uploads, dropping a video into
+ * blocks like Cover, Story, Slideshow, or Media & Text surfaces the generic
+ * core error "Sorry, you are not allowed to upload this file type." as a
+ * snackbar notice, with no hint that upgrading the plan would fix it.
+ *
+ * This feature watches the notices store and replaces that notice with an
+ * upgrade nudge when the rejected file is a video. On plans that support
+ * video uploads the error never fires for video files, so no plan check is
+ * needed. Non-video rejections (e.g. .exe) keep the original error.
+ * @see https://linear.app/a8c/issue/EDI-195
+ */
+
+// Video extensions accepted by WordPress core, matched against the file name
+// prefix that @wordpress/media-utils includes in the error message.
+const VIDEO_FILE_IN_MESSAGE =
+	/\.(asf|asx|avi|divx|flv|mkv|mov|mp4|m4v|mpe|mpeg|mpg|ogv|qt|webm|wm|wmv|wmx|3g2|3gp|3gp2|3gpp)\s*:/i;
+
+// The same sentence is produced client-side by @wordpress/media-utils and
+// server-side by core uploads; matching its translation keeps this working in
+// every locale.
+const coreUploadError = () => __( 'Sorry, you are not allowed to upload this file type.' );
+
+const seenNoticeIds = new Set();
+let previousNotices;
+
+subscribe( () => {
+	const notices = select( 'core/notices' ).getNotices();
+	if ( notices === previousNotices ) {
+		return;
+	}
+	previousNotices = notices;
+
+	for ( const notice of notices ) {
+		if ( seenNoticeIds.has( notice.id ) ) {
+			continue;
+		}
+		seenNoticeIds.add( notice.id );
+
+		if (
+			notice.status !== 'error' ||
+			typeof notice.content !== 'string' ||
+			! notice.content.includes( coreUploadError() ) ||
+			! VIDEO_FILE_IN_MESSAGE.test( notice.content )
+		) {
+			continue;
+		}
+
+		dispatch( 'core/notices' ).removeNotice( notice.id );
+		dispatch( 'core/notices' ).createErrorNotice(
+			__( 'Your site’s plan doesn’t support video uploads. Upgrade your plan to upload videos.' ),
+			{
+				type: notice.type,
+				actions: [
+					{
+						label: __( 'Upgrade plan' ),
+						url: `${ getCalypsoUrl() }/plans/${ window._currentSiteId }`,
+					},
+				],
+			}
+		);
+		tracksRecordEvent( 'wpcom_block_editor_video_upload_plan_nudge_show' );
+	}
+} );


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/EDI-195/feature-request-personal-plan-blocks-better-communication-regarding
Part of #95730

## Proposed Changes

* Add a small `wpcom-block-editor` feature (`video-upload-plan-nudge`) that watches the `core/notices` store in the wp-admin block editor.
* When an error notice appears containing the core message "Sorry, you are not allowed to upload this file type." **and** the file name in the message has a video extension, the notice is replaced with: *"Your site's plan doesn't support video uploads. Upgrade your plan to upload videos."* plus an **Upgrade plan** action linking to `wordpress.com/plans/<site>`.
* The replacement preserves the original notice type (snackbar), and fires a `wpcom_block_editor_video_upload_plan_nudge_show` Tracks event.

## Why are these changes being made?

* On Personal/Free plans, video mime types are stripped from `allowedMimeTypes`, so dropping a video into blocks like Cover, Story, Slideshow, or Media & Text fails `validateMimeTypeForUser()` in `@wordpress/media-utils` and surfaces the generic core error with no hint that upgrading the plan would fix it. Users read it as the site being broken (see the Linear issue and 8933408-zen).
* Intercepting the notice in `wpcom-block-editor` fixes all affected blocks at once (plus any future block using the same upload path), without PRs to Gutenberg or Jetpack.
* Safety: the rewrite only happens when the message matches the core sentence (via its translation, so it works in all locales) and the file is a video. Disallowed non-video uploads (e.g. `.exe`) keep the original error. Plans that support video never produce this error for video files, so no plan check is needed.
* Known trade-off: this is a string match on the notice content. If core rewords the sentence, the feature degrades gracefully back to the generic error.

## Testing Instructions

1. On a **Simple site with the Free or Personal plan**, open the post editor and add a Cover (or Media & Text / Story / Slideshow) block.
2. Drag and drop an `.mp4` file into the block.
3. Confirm the snackbar shows "Your site's plan doesn't support video uploads. Upgrade your plan to upload videos." with an **Upgrade plan** action that opens `wordpress.com/plans/<site>` — instead of "Sorry, you are not allowed to upload this file type."
4. Try a disallowed non-video file (e.g. a `.zip`): the original generic error should still appear.
5. On a plan with video support, confirm video uploads behave as before.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
