### PR TITLE
Onboarding: wait for the wow-funnel build before handing the customer over

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -45,18 +45,17 @@ import {
 } from '../../../utils/build-wow';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import {
+	clearWowFunnelSite,
+	getRememberedWowFunnelSite,
+	getWowFunnelArgs,
 	getWowFunnelConfig,
 	getWowFunnelDest,
-	getWowFunnelArgs,
 	getWowFunnelSlug,
-	clearWowFunnelSite,
-	forgetWowFunnelRun,
-	getRememberedWowFunnelSite,
 	isKnownWowFunnel,
-	startWowFunnelSite,
-	wowFunnelSiteIsPaid,
 	logWowFunnelEvent,
+	wowFunnelSiteIsPaid,
 } from '../../../utils/wow-funnel';
+import { forgetWowFunnelRun, startWowFunnelSite } from '../../../utils/wow-funnel-site';
 import { getOnboardingPostCheckoutDestination } from '../../helpers/get-onboarding-post-checkout-destination';
 import { withLocale } from '../../helpers/with-locale';
 import { usePurchasePlanNotification } from '../../internals/hooks/use-purchase-plan-notification';

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -47,12 +47,10 @@ import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login
 import {
 	getWowFunnelConfig,
 	getWowFunnelDest,
-	getWowFunnelHandoffUrl,
 	getWowFunnelArgs,
 	getWowFunnelSlug,
 	getRememberedWowFunnelSite,
 	isKnownWowFunnel,
-	waitForWowFunnelReady,
 	startWowFunnelSite,
 	logWowFunnelEvent,
 } from '../../../utils/wow-funnel';
@@ -75,6 +73,7 @@ function initialize() {
 		STEPS.SITE_CREATION_STEP,
 		STEPS.PROCESSING,
 		STEPS.POST_CHECKOUT_ONBOARDING,
+		STEPS.WOW_FUNNEL_HANDOFF,
 		STEPS.SETUP_YOUR_SITE_AI,
 	];
 
@@ -168,18 +167,29 @@ const onboarding: FlowV2< typeof initialize > = {
 					];
 				}
 
-				// Wait for the build before handing over. Checkout can finish before the
-				// Simple->Atomic switcheroo does, and redirecting on the flow-start URL then
-				// lands the customer on the old Simple site. The hand-off URL is resolved from
-				// the site only once it is ready, so it always names the site that now exists.
-				const siteIdentifier = siteSlug || String( siteId );
-				await waitForWowFunnelReady( { funnelSlug: wowFunnelSlug, siteIdentifier } );
-				const handoffUrl = await getWowFunnelHandoffUrl( {
+				// Hand off through the funnel's own post-checkout page rather than pointing
+				// checkout straight at the built site. This function runs BEFORE checkout — its
+				// result becomes checkout's redirect_to — so the readiness wait cannot live
+				// here; it has to be on a page the customer reaches after paying.
+				logWowFunnelEvent( 'post_checkout_handoff', {
+					funnel: wowFunnelSlug,
+					blog_id: siteId,
 					dest: wowFunnelDest,
-					siteIdentifier,
 				} );
-				logWowFunnelEvent( 'post_checkout_editor', { funnel: wowFunnelSlug, blog_id: siteId } );
-				return [ handoffUrl, null, null ];
+				return [
+					addQueryArgs(
+						withLocale( `/setup/${ ONBOARDING_FLOW }/${ STEPS.WOW_FUNNEL_HANDOFF.slug }`, locale ),
+						{
+							wow_funnel: wowFunnelSlug,
+							dest: wowFunnelDest,
+							siteSlug,
+							// Skip siteId when it's 0/falsy: "0" in the URL poisons the site lookup.
+							...( siteId ? { siteId } : {} ),
+						}
+					),
+					null,
+					null,
+				];
 			}
 
 			if ( ! providedDependencies.hasExternalTheme && providedDependencies.hasPluginByGoal ) {
@@ -354,6 +364,10 @@ const onboarding: FlowV2< typeof initialize > = {
 				}
 				case 'create-site':
 					return navigate( 'processing', undefined, true );
+				case 'wow-funnel-handoff':
+					// Success replaces location with the built site itself, so the only thing
+					// that reaches navigation here is a failed or timed-out wait.
+					return navigate( STEPS.ERROR.slug );
 				case 'post-checkout-onboarding': {
 					setShouldShowNotification( providedDependencies?.siteId as number );
 					return navigate( 'processing' );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -45,10 +45,14 @@ import {
 } from '../../../utils/build-wow';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import {
+	getWowFunnelConfig,
 	getWowFunnelDest,
+	getWowFunnelHandoffUrl,
 	getWowFunnelArgs,
 	getWowFunnelSlug,
 	getRememberedWowFunnelSite,
+	isKnownWowFunnel,
+	waitForWowFunnelReady,
 	startWowFunnelSite,
 	logWowFunnelEvent,
 } from '../../../utils/wow-funnel';
@@ -123,7 +127,7 @@ const onboarding: FlowV2< typeof initialize > = {
 			buildDest
 		);
 		const wowFunnelSlug = getWowFunnelSlug( queryParams );
-		const wowFunnelDest = getWowFunnelDest( queryParams );
+		const wowFunnelDest = getWowFunnelDest( queryParams, wowFunnelSlug );
 
 		/**
 		 * Returns [destination, backDestination] for the post-checkout destination.
@@ -133,19 +137,19 @@ const onboarding: FlowV2< typeof initialize > = {
 			planCartItem: MinimalRequestCartProduct | null,
 			launchpadPersonalizationVariation: LaunchpadPersonalizationVariation
 		): Promise< [ string, string | null, string | null ] > => {
-			// A funnel CTA can ask for a specific post-checkout destination; today that means the
-			// Site Editor on the built Atomic site. The build ran during domain selection and
-			// checkout, so the transfer is normally complete; the URL goes through the site's own
-			// domain, which follows the Simple->Atomic switch (same shape as the ai-site-builder
-			// hand-off). With no dest, the ordinary destinations below apply.
-			if ( wowFunnelSlug && wowFunnelDest ) {
+			// Every funnel ends on the built site. A funnel with Calypso-side work hops to that
+			// interstitial first; the interstitial owns the readiness wait and the hand-off, via
+			// the same helpers used below, so a funnel's terminal behaviour is identical either
+			// way. A funnel with no interstitials waits and hands over right here.
+			if ( isKnownWowFunnel( wowFunnelSlug ) ) {
 				const siteSlug = providedDependencies.siteSlug as string;
 				const siteId = providedDependencies.siteId as number;
+				const { interstitials } = getWowFunnelConfig( wowFunnelSlug );
 
-				// dest=site-spec: the funnel's follow-up (e.g. the blueprint import) is already
-				// running server-side, so site-spec only waits on it and hands over. It must not
-				// start one — see the funnel guard on its kickoff effect.
-				if ( 'site-spec' === wowFunnelDest ) {
+				// site-spec: the funnel's follow-up (e.g. the blueprint import) is already running
+				// server-side, so site-spec only waits on it and hands over. It must not start
+				// one — see the funnel guard on its kickoff effect.
+				if ( interstitials.includes( 'site-spec' ) ) {
 					const blueprintSlug = queryParams.get( 'blueprint' ) ?? '';
 					logWowFunnelEvent( 'post_checkout_site_spec', {
 						funnel: wowFunnelSlug,
@@ -164,10 +168,18 @@ const onboarding: FlowV2< typeof initialize > = {
 					];
 				}
 
-				const site = await resolveSelect( SITE_STORE ).getSite( siteSlug );
-				const siteUrl = site?.URL ?? `https://${ siteSlug }`;
+				// Wait for the build before handing over. Checkout can finish before the
+				// Simple->Atomic switcheroo does, and redirecting on the flow-start URL then
+				// lands the customer on the old Simple site. The hand-off URL is resolved from
+				// the site only once it is ready, so it always names the site that now exists.
+				const siteIdentifier = siteSlug || String( siteId );
+				await waitForWowFunnelReady( { funnelSlug: wowFunnelSlug, siteIdentifier } );
+				const handoffUrl = await getWowFunnelHandoffUrl( {
+					dest: wowFunnelDest,
+					siteIdentifier,
+				} );
 				logWowFunnelEvent( 'post_checkout_editor', { funnel: wowFunnelSlug, blog_id: siteId } );
-				return [ `${ siteUrl }/wp-admin/site-editor.php?canvas=edit&p=%2F`, null, null ];
+				return [ handoffUrl, null, null ];
 			}
 
 			if ( ! providedDependencies.hasExternalTheme && providedDependencies.hasPluginByGoal ) {
@@ -520,7 +532,7 @@ const onboarding: FlowV2< typeof initialize > = {
 									// straight from checkout to their destination — no
 									// post-checkout-onboarding hop, no chooser.
 									redirect_to:
-										blueprintArchiveSlug || ( wowFunnelSlug && wowFunnelDest )
+										blueprintArchiveSlug || isKnownWowFunnel( wowFunnelSlug )
 											? destination
 											: redirectTo,
 									signup: 1,
@@ -534,7 +546,7 @@ const onboarding: FlowV2< typeof initialize > = {
 									steps_total: checkoutStepperPosition.total,
 								} )
 							);
-						} else if ( blueprintArchiveSlug || ( wowFunnelSlug && wowFunnelDest ) ) {
+						} else if ( blueprintArchiveSlug || isKnownWowFunnel( wowFunnelSlug ) ) {
 							// build_dest=wow and the WoW funnel never show the
 							// setup-your-site-ai chooser; go straight to their destination.
 							window.location.replace( destination );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -48,8 +48,11 @@ import {
 	getWowFunnelDest,
 	getWowFunnelArgs,
 	getWowFunnelSlug,
+	clearWowFunnelSite,
+	forgetWowFunnelRun,
 	getRememberedWowFunnelSite,
 	startWowFunnelSite,
+	wowFunnelSiteIsPaid,
 	logWowFunnelEvent,
 } from '../../../utils/wow-funnel';
 import { getOnboardingPostCheckoutDestination } from '../../helpers/get-onboarding-post-checkout-destination';
@@ -141,6 +144,11 @@ const onboarding: FlowV2< typeof initialize > = {
 			if ( wowFunnelSlug && wowFunnelDest ) {
 				const siteSlug = providedDependencies.siteSlug as string;
 				const siteId = providedDependencies.siteId as number;
+
+				// The run is over. Without this the remembered site outlives it for the whole
+				// browser session, and the next CTA click resumes this site instead of building
+				// a new one — offering a renewal of the plan just bought for it.
+				clearWowFunnelSite();
 
 				// dest=site-spec: the funnel's follow-up (e.g. the blueprint import) is already
 				// running server-side, so site-spec only waits on it and hands over. It must not
@@ -645,15 +653,36 @@ const onboarding: FlowV2< typeof initialize > = {
 			}
 			const queryParams = new URLSearchParams( window.location.search );
 			const funnelSlug = getWowFunnelSlug( queryParams );
-			if ( ! funnelSlug || getRememberedWowFunnelSite( funnelSlug ) ) {
+			const funnelArgs = getWowFunnelArgs( queryParams );
+			if ( ! funnelSlug ) {
 				return;
 			}
-			void startWowFunnelSite( {
-				funnelSlug,
-				funnelArgs: getWowFunnelArgs( queryParams ),
-			} ).catch( () => {
-				// Errors are logged in the util; the create-site step retries as a fallback.
-			} );
+
+			void ( async () => {
+				const remembered = getRememberedWowFunnelSite( funnelSlug, funnelArgs );
+				if ( remembered ) {
+					// A funnel run sells a plan for the site it builds, so a site that already has
+					// one must never be resumed: checkout would offer a second plan for a site
+					// that does not need one. Resume only while it is still unpaid.
+					const site = await resolveSelect( SITE_STORE )
+						.getSite( remembered.siteSlug )
+						.catch( () => null );
+
+					if ( ! wowFunnelSiteIsPaid( site ) ) {
+						return;
+					}
+
+					logWowFunnelEvent( 'remembered_site_already_paid', {
+						funnel: funnelSlug,
+						blog_id: remembered.blogId,
+					} );
+					forgetWowFunnelRun( funnelSlug, funnelArgs );
+				}
+
+				await startWowFunnelSite( { funnelSlug, funnelArgs } ).catch( () => {
+					// Errors are logged in the util; the create-site step retries as a fallback.
+				} );
+			} )();
 		}, [ currentStepSlug, isLoggedIn ] );
 	},
 };

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -157,6 +157,7 @@ const onboarding: FlowV2< typeof initialize > = {
 							siteId,
 							blueprintSlug,
 							ref: refParameter,
+							wowFunnel: wowFunnelSlug,
 						} ),
 						null,
 						null,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -31,9 +31,9 @@ import {
 	getWowFunnelArgs,
 	getWowFunnelSlug,
 	logWowFunnelEvent,
-	startWowFunnelSite,
 	wowFunnelSiteIsPaid,
 } from 'calypso/landing/stepper/utils/wow-funnel';
+import { startWowFunnelSite } from 'calypso/landing/stepper/utils/wow-funnel-site';
 import { resolveLaunchpadPersonalizationVariation } from 'calypso/lib/ai-launchpad';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import wpcom from 'calypso/lib/wp';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -30,7 +30,9 @@ import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import {
 	getWowFunnelArgs,
 	getWowFunnelSlug,
+	logWowFunnelEvent,
 	startWowFunnelSite,
+	wowFunnelSiteIsPaid,
 } from 'calypso/landing/stepper/utils/wow-funnel';
 import { resolveLaunchpadPersonalizationVariation } from 'calypso/lib/ai-launchpad';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -234,8 +236,25 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 				siteTitle: selectedSiteTitle,
 			} );
 
+			// Last line of defence against selling a second plan for the same site. The flow entry
+			// already refuses to resume a paid funnel site, but this is where money is actually
+			// committed, so re-check here rather than trusting that the site reaching this point
+			// is the unpaid one we built.
+			const funnelSiteIsPaid = wowFunnelSiteIsPaid(
+				await wpcom.req
+					.get( { path: `/sites/${ funnelSite.blogId }`, apiVersion: '1.1' } )
+					.catch( () => null )
+			);
+
+			if ( funnelSiteIsPaid ) {
+				logWowFunnelEvent( 'plan_skipped_site_already_paid', {
+					funnel: wowFunnelSlug,
+					blog_id: funnelSite.blogId,
+				} );
+			}
+
 			const funnelCartItems = [
-				...( planCartItem ? [ planCartItem ] : [] ),
+				...( planCartItem && ! funnelSiteIsPaid ? [ planCartItem ] : [] ),
 				...( productCartItems ?? [] ),
 				...mergedDomainCartItems,
 			];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -24,6 +24,13 @@ import {
 	logBuildWowEvent,
 	requestBuildWowSite,
 } from 'calypso/landing/stepper/utils/build-wow';
+import {
+	getWowFunnelDest,
+	getWowFunnelHandoffUrl,
+	getWowFunnelSlug,
+	isKnownWowFunnel,
+	waitForWowFunnelReady,
+} from 'calypso/landing/stepper/utils/wow-funnel';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { useSiteSpec } from 'calypso/lib/site-spec';
 import {
@@ -144,7 +151,13 @@ const SiteSpec: StepType = function SiteSpec() {
 	const shouldImportBlueprint = queryParams.get( 'blueprint_archive_import' ) === '1';
 	// A wow-funnel run already started the import server-side, before checkout. This page still
 	// waits on it and hands over, but must not start a second one.
-	const isWowFunnelRun = !! queryParams.get( 'wow_funnel' );
+	// An unregistered slug is not a funnel run: the server never enrolled the blog, so nothing
+	// started a build. Dropping it here makes this an ordinary blueprint-archive run, which does
+	// start (and wait on) its own import, rather than one that waits for work nobody queued.
+	const requestedWowFunnelSlug = getWowFunnelSlug( queryParams );
+	const wowFunnelSlug = isKnownWowFunnel( requestedWowFunnelSlug ) ? requestedWowFunnelSlug : null;
+	const wowFunnelDest = getWowFunnelDest( queryParams, wowFunnelSlug );
+	const isWowFunnelRun = !! wowFunnelSlug;
 	const blueprintArchiveSlug = queryParams.get( 'blueprint_slug' ) ?? '';
 	const blueprintArchiveSiteIdentifier = getBlueprintArchiveSiteIdentifier( {
 		siteSlug: queryParams.get( 'siteSlug' ),
@@ -390,8 +403,19 @@ const SiteSpec: StepType = function SiteSpec() {
 					site_identifier: blueprintArchiveSiteIdentifier,
 				} );
 
-				await waitForAtomicTransferComplete( blueprintArchiveSiteIdentifier );
-				await waitForBlueprintImportComplete( blueprintArchiveSiteIdentifier );
+				// As a funnel interstitial this step owns the funnel's readiness wait, so it
+				// goes through the shared helper — one definition of "ready" per funnel, and one
+				// timeout. Outside a funnel this is a plain blueprint-archive run, which keeps
+				// its own unbounded waits.
+				if ( wowFunnelSlug ) {
+					await waitForWowFunnelReady( {
+						funnelSlug: wowFunnelSlug,
+						siteIdentifier: blueprintArchiveSiteIdentifier,
+					} );
+				} else {
+					await waitForAtomicTransferComplete( blueprintArchiveSiteIdentifier );
+					await waitForBlueprintImportComplete( blueprintArchiveSiteIdentifier );
+				}
 
 				// Only once the restore is done: it replaces the site's options
 				// wholesale, so a spec applied earlier would be overwritten.
@@ -408,10 +432,16 @@ const SiteSpec: StepType = function SiteSpec() {
 					has_spec_id: Boolean( specId ),
 				} );
 
-				const adminUrl = await getSiteAdminUrl( blueprintArchiveSiteIdentifier );
-				const siteEditorUrl = getSiteEditorUrl( adminUrl, {
-					startWalkthrough: applied,
-				} );
+				// Resolved after the wait either way, so the URL names the site that now exists.
+				const siteEditorUrl = wowFunnelSlug
+					? await getWowFunnelHandoffUrl( {
+							dest: wowFunnelDest,
+							siteIdentifier: blueprintArchiveSiteIdentifier,
+							startWalkthrough: applied,
+					  } )
+					: getSiteEditorUrl( await getSiteAdminUrl( blueprintArchiveSiteIdentifier ), {
+							startWalkthrough: applied,
+					  } );
 
 				logBlueprintArchiveEvent( 'redirect_site_editor', {
 					site_identifier: blueprintArchiveSiteIdentifier,
@@ -427,7 +457,7 @@ const SiteSpec: StepType = function SiteSpec() {
 				isSubmittingRef.current = false;
 			}
 		},
-		[ blueprintArchiveSiteIdentifier, blueprintArchiveSlug ]
+		[ blueprintArchiveSiteIdentifier, blueprintArchiveSlug, wowFunnelSlug, wowFunnelDest ]
 	);
 
 	// Kick off the background transfer + blueprint-archive import as soon as the

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wow-funnel-handoff/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wow-funnel-handoff/index.tsx
@@ -1,0 +1,111 @@
+import { Step } from '@automattic/onboarding';
+import { useDispatch } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
+import { useEffect, useRef } from 'react';
+import Loading from 'calypso/components/loading';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
+import {
+	getWowFunnelDest,
+	getWowFunnelHandoffUrl,
+	getWowFunnelSlug,
+	isKnownWowFunnel,
+	logWowFunnelEvent,
+	waitForWowFunnelReady,
+} from 'calypso/landing/stepper/utils/wow-funnel';
+import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+import type { Step as StepType } from '../../types';
+
+/**
+ * The last hop of a WoW funnel: hold the customer on the loading screen until the build they
+ * paid for is actually ready, then hand them to it.
+ *
+ * The funnel used to point checkout's `redirect_to` straight at the built site, skipping the
+ * post-checkout hop entirely. That works right up until checkout finishes before the
+ * Simple->Atomic switcheroo does, at which point the customer lands in the editor of the
+ * pre-switcheroo Simple site. The site is fine and finishes seconds later — but their first
+ * look at what they just bought is the wrong site.
+ *
+ * This page is that missing hop. It exists so the wait happens AFTER payment: the whole point of
+ * a funnel is that the build overlaps the customer's own time in the flow, so blocking them
+ * before checkout would trade one bad experience for a worse one.
+ *
+ * Reached by URL from checkout, so everything it needs comes from query params rather than flow
+ * state, which does not survive the trip through checkout.
+ */
+const WowFunnelHandoff: StepType = function WowFunnelHandoff( { navigation, flow } ) {
+	const { __ } = useI18n();
+	const queryParams = useQuery();
+	const { submit } = navigation;
+	const { setSiteSetupError } = useDispatch( SITE_STORE );
+
+	const requestedFunnelSlug = getWowFunnelSlug( queryParams );
+	const funnelSlug = isKnownWowFunnel( requestedFunnelSlug ) ? requestedFunnelSlug : null;
+	const dest = getWowFunnelDest( queryParams, funnelSlug );
+	const siteSlug = queryParams.get( 'siteSlug' );
+	const siteId = queryParams.get( 'siteId' );
+	const siteIdentifier = siteSlug || ( siteId && siteId !== '0' ? siteId : null );
+
+	// Strict mode mounts effects twice, and this one navigates away; a second run would start a
+	// duplicate poll against the same site.
+	const hasStartedRef = useRef( false );
+
+	useEffect( () => {
+		if ( hasStartedRef.current ) {
+			return;
+		}
+		hasStartedRef.current = true;
+
+		const failToErrorStep = ( code: string, message: string ) => {
+			setSiteSetupError( code, message );
+			submit?.( { hasError: true } );
+		};
+
+		// Neither of these should be reachable — the flow only sends registered funnels here, and
+		// always with a site — but this page is URL-addressable, so it cannot assume that.
+		if ( ! funnelSlug || ! siteIdentifier ) {
+			logWowFunnelEvent( 'handoff_missing_context', {
+				funnel: requestedFunnelSlug,
+				has_site: !! siteIdentifier,
+			} );
+			failToErrorStep(
+				'wow_funnel_handoff_context',
+				__( 'Something went wrong while setting up your site.' )
+			);
+			return;
+		}
+
+		( async () => {
+			try {
+				await waitForWowFunnelReady( { funnelSlug, siteIdentifier } );
+
+				// Resolved only now, so it names the site that exists after the transfer rather
+				// than the one this flow started with.
+				const handoffUrl = await getWowFunnelHandoffUrl( { dest, siteIdentifier } );
+
+				logWowFunnelEvent( 'handoff_redirect', { funnel: funnelSlug, dest } );
+				window.location.replace( handoffUrl );
+			} catch ( error ) {
+				// waitForWowFunnelReady already reported which outcome this was, and its message
+				// is written for the customer — a timeout reads as "taking longer than expected"
+				// rather than as a failure.
+				failToErrorStep(
+					'wow_funnel_handoff',
+					error instanceof Error
+						? error.message
+						: __( 'Something went wrong while setting up your site.' )
+				);
+			}
+		} )();
+	}, [ __, dest, funnelSlug, requestedFunnelSlug, setSiteSetupError, siteIdentifier, submit ] );
+
+	const title = __( 'Getting your site ready…' );
+
+	if ( shouldUseStepContainerV2( flow ) ) {
+		return <Step.Loading title={ title } />;
+	}
+
+	return <Loading className="wpcom-loading__boot" title={ title } />;
+};
+
+export default WowFunnelHandoff;

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -334,6 +334,11 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/post-checkout/post-checkout-onboarding' ),
 	},
 
+	WOW_FUNNEL_HANDOFF: {
+		slug: 'wow-funnel-handoff',
+		asyncComponent: () => import( './steps-repository/wow-funnel-handoff' ),
+	},
+
 	SETUP_YOUR_SITE_AI: {
 		slug: 'setup-your-site-ai',
 		asyncComponent: () => import( './steps-repository/setup-your-site-ai' ),

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -290,7 +290,11 @@ export async function getSiteAdminUrl( siteIdentifier: string ): Promise< string
  */
 export function getSiteEditorUrl(
 	adminUrl: string,
-	{ startWalkthrough = false }: { startWalkthrough?: boolean } = {}
+	{
+		startWalkthrough = false,
+		canvasEdit = false,
+		path,
+	}: { startWalkthrough?: boolean; canvasEdit?: boolean; path?: string } = {}
 ): string {
 	const base = adminUrl.endsWith( '/' ) ? adminUrl : `${ adminUrl }/`;
 	const url = `${ base }site-editor.php`;
@@ -310,9 +314,19 @@ export function getSiteEditorUrl(
 	//
 	// Only set when the spec applied; there is nothing to personalize from
 	// otherwise.
-	const editorUrl = startWalkthrough
-		? addQueryArgs( url, { 'blueprint-walkthrough': 'go', canvas: 'edit' } )
-		: url;
+	const args: Record< string, string > = {};
+	if ( startWalkthrough ) {
+		args[ 'blueprint-walkthrough' ] = 'go';
+	}
+	// The walkthrough needs the editing canvas; a caller can also ask for it on its own, which is
+	// what the funnel hand-off does — a plain site-editor.php load stays in view mode.
+	if ( startWalkthrough || canvasEdit ) {
+		args.canvas = 'edit';
+	}
+	if ( path ) {
+		args.p = path;
+	}
+	const editorUrl = Object.keys( args ).length > 0 ? addQueryArgs( url, args ) : url;
 
 	return withJetpackSso( editorUrl );
 }

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -75,12 +75,14 @@ export function getBlueprintArchiveSiteSpecUrl( {
 	blueprintSlug,
 	ref,
 	source,
+	wowFunnel,
 }: {
 	siteSlug?: string | null;
 	siteId?: string | number | null;
 	blueprintSlug: string;
 	ref?: string | null;
 	source?: string | null;
+	wowFunnel?: string | null;
 } ): string {
 	return addQueryArgs( BLUEPRINT_ARCHIVE_SITE_SPEC_PATH, {
 		blueprint_archive_import: BLUEPRINT_ARCHIVE_IMPORT_QUERY_VALUE,
@@ -89,6 +91,10 @@ export function getBlueprintArchiveSiteSpecUrl( {
 		...( siteId && String( siteId ) !== '0' ? { siteId } : {} ),
 		...( ref ? { ref } : {} ),
 		...( source ? { source } : {} ),
+		// A funnel run's import already ran server-side, before checkout. site-spec keys its
+		// "do not start one" guard off this param, so it has to survive into the URL — without
+		// it the page cannot tell a funnel hand-off from a standalone run and imports again.
+		...( wowFunnel ? { wow_funnel: wowFunnel } : {} ),
 	} );
 }
 

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -4,6 +4,7 @@
 import wpcom from 'calypso/lib/wp';
 import {
 	applyBlueprintSpec,
+	getBlueprintArchiveSiteSpecUrl,
 	getSiteEditorUrl,
 	getStandaloneBlueprintArchiveSlug,
 } from '../blueprint-archive-import';
@@ -159,5 +160,35 @@ describe( 'getSiteEditorUrl', () => {
 		expect(
 			getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: false } )
 		).not.toContain( 'blueprint-walkthrough' );
+	} );
+} );
+
+describe( 'getBlueprintArchiveSiteSpecUrl', () => {
+	/**
+	 * site-spec decides whether to start a blueprint import by looking for wow_funnel in its
+	 * own query string. A funnel run's import already ran server-side before checkout, so
+	 * dropping the param here makes the page import a second time over the finished site.
+	 */
+	it( 'carries the funnel through so site-spec can skip its own import', () => {
+		const url = getBlueprintArchiveSiteSpecUrl( {
+			siteSlug: 'example.wordpress.com',
+			siteId: 123,
+			blueprintSlug: 'coachava',
+			wowFunnel: 'blueprint',
+		} );
+
+		expect( url ).toContain( 'wow_funnel=blueprint' );
+		expect( url ).toContain( 'blueprint_archive_import=1' );
+		expect( url ).toContain( 'blueprint_slug=coachava' );
+	} );
+
+	it( 'omits the funnel for a standalone run', () => {
+		const url = getBlueprintArchiveSiteSpecUrl( {
+			siteSlug: 'example.wordpress.com',
+			siteId: 123,
+			blueprintSlug: 'coachava',
+		} );
+
+		expect( url ).not.toContain( 'wow_funnel' );
 	} );
 } );

--- a/client/landing/stepper/utils/test/wow-funnel.ts
+++ b/client/landing/stepper/utils/test/wow-funnel.ts
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	clearWowFunnelSite,
+	getRememberedWowFunnelSite,
+	getWowFunnelKey,
+	wowFunnelSiteIsPaid,
+} from '../wow-funnel';
+
+const SESSION_KEY = 'wow-funnel-created-site';
+
+function remember( funnelSlug: string, funnelArgs: Record< string, string >, blogId: number ) {
+	window.sessionStorage.setItem(
+		SESSION_KEY,
+		JSON.stringify( {
+			funnelSlug,
+			funnelKey: getWowFunnelKey( funnelSlug, funnelArgs ),
+			blogId,
+			siteSlug: `site-${ blogId }.wordpress.com`,
+		} )
+	);
+}
+
+describe( 'getWowFunnelKey', () => {
+	it( 'separates runs that build different things', () => {
+		expect( getWowFunnelKey( 'blueprint', { blueprint_slug: 'coachava' } ) ).not.toBe(
+			getWowFunnelKey( 'blueprint', { blueprint_slug: 'other' } )
+		);
+	} );
+
+	it( 'is stable regardless of arg order', () => {
+		expect( getWowFunnelKey( 'blueprint', { a: '1', b: '2' } ) ).toBe(
+			getWowFunnelKey( 'blueprint', { b: '2', a: '1' } )
+		);
+	} );
+} );
+
+describe( 'getRememberedWowFunnelSite', () => {
+	beforeEach( () => {
+		window.sessionStorage.clear();
+	} );
+
+	it( 'resumes the site when the same CTA is re-entered', () => {
+		remember( 'blueprint', { blueprint_slug: 'coachava' }, 111 );
+
+		expect(
+			getRememberedWowFunnelSite( 'blueprint', { blueprint_slug: 'coachava' } )?.blogId
+		).toBe( 111 );
+	} );
+
+	/**
+	 * Two theme CTAs share the funnel slug and differ only in the blueprint. Matching on the slug
+	 * alone sent the customer back to a site built from the theme they did not pick.
+	 */
+	it( 'does not resume a site built from a different blueprint', () => {
+		remember( 'blueprint', { blueprint_slug: 'coachava' }, 111 );
+
+		expect( getRememberedWowFunnelSite( 'blueprint', { blueprint_slug: 'other' } ) ).toBeNull();
+	} );
+
+	it( 'forgets the site once the run is cleared', () => {
+		remember( 'blueprint', { blueprint_slug: 'coachava' }, 111 );
+		clearWowFunnelSite();
+
+		expect( getRememberedWowFunnelSite( 'blueprint', { blueprint_slug: 'coachava' } ) ).toBeNull();
+	} );
+
+	it( 'ignores a remembered site written before funnelKey existed', () => {
+		window.sessionStorage.setItem(
+			SESSION_KEY,
+			JSON.stringify( { funnelSlug: 'blueprint', blogId: 111, siteSlug: 'old.wordpress.com' } )
+		);
+
+		expect( getRememberedWowFunnelSite( 'blueprint', { blueprint_slug: 'coachava' } ) ).toBeNull();
+	} );
+} );
+
+describe( 'wowFunnelSiteIsPaid', () => {
+	/**
+	 * The funnel exists to sell a plan for the site it builds. Resuming a site that already has
+	 * one puts a second plan in the cart for a site that does not need it.
+	 */
+	it( 'is true for a site holding a paid plan', () => {
+		expect( wowFunnelSiteIsPaid( { plan: { is_free: false } } ) ).toBe( true );
+	} );
+
+	it( 'is false for a free site', () => {
+		expect( wowFunnelSiteIsPaid( { plan: { is_free: true } } ) ).toBe( false );
+	} );
+
+	it( 'is false when the site or its plan is unknown', () => {
+		expect( wowFunnelSiteIsPaid( undefined ) ).toBe( false );
+		expect( wowFunnelSiteIsPaid( {} ) ).toBe( false );
+	} );
+} );

--- a/client/landing/stepper/utils/test/wow-funnel.ts
+++ b/client/landing/stepper/utils/test/wow-funnel.ts
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	waitForAtomicTransferComplete,
+	waitForBlueprintImportComplete,
+} from '../blueprint-archive-import';
+import {
+	getWowFunnelConfig,
+	getWowFunnelDest,
+	isKnownWowFunnel,
+	waitForWowFunnelReady,
+} from '../wow-funnel';
+
+jest.mock( 'calypso/lib/logstash', () => ( {
+	logToLogstash: jest.fn( () => Promise.resolve() ),
+} ) );
+
+jest.mock( '../blueprint-archive-import', () => ( {
+	__esModule: true,
+	waitForAtomicTransferComplete: jest.fn( () => Promise.resolve() ),
+	waitForBlueprintImportComplete: jest.fn( () => Promise.resolve() ),
+	getSiteAdminUrl: jest.fn(),
+	getSiteEditorUrl: jest.fn(),
+} ) );
+
+const mockTransferWait = waitForAtomicTransferComplete as jest.Mock;
+const mockImportWait = waitForBlueprintImportComplete as jest.Mock;
+
+const never = () => new Promise< void >( () => {} );
+
+describe( 'isKnownWowFunnel', () => {
+	it( 'recognizes the registered funnels', () => {
+		expect( isKnownWowFunnel( 'default' ) ).toBe( true );
+		expect( isKnownWowFunnel( 'blueprint' ) ).toBe( true );
+	} );
+
+	it( 'rejects an unregistered slug, so it degrades to ordinary onboarding', () => {
+		// The server ignores an unknown slug and never starts a build; taking the funnel path
+		// here would strand the customer on the loading screen waiting for nothing.
+		expect( isKnownWowFunnel( 'not-a-funnel' ) ).toBe( false );
+		expect( isKnownWowFunnel( '' ) ).toBe( false );
+		expect( isKnownWowFunnel( null ) ).toBe( false );
+	} );
+
+	it( 'is not fooled by inherited Object properties', () => {
+		expect( isKnownWowFunnel( 'constructor' ) ).toBe( false );
+		expect( isKnownWowFunnel( 'toString' ) ).toBe( false );
+	} );
+} );
+
+describe( 'getWowFunnelConfig', () => {
+	it( 'gives an unconfigured funnel the defaults: no interstitials, editor, transfer', () => {
+		const config = getWowFunnelConfig( 'default' );
+		expect( config.interstitials ).toEqual( [] );
+		expect( config.dest ).toBe( 'editor' );
+		expect( config.readiness ).toBe( 'transfer' );
+	} );
+
+	it( 'applies per-funnel overrides over the defaults', () => {
+		const config = getWowFunnelConfig( 'blueprint' );
+		expect( config.interstitials ).toEqual( [ 'site-spec' ] );
+		expect( config.readiness ).toBe( 'import' );
+		// Not overridden, so it still comes from the defaults.
+		expect( config.dest ).toBe( 'editor' );
+	} );
+} );
+
+describe( 'getWowFunnelDest', () => {
+	it( "defaults to the funnel's destination when the CTA asks for nothing", () => {
+		expect( getWowFunnelDest( new URLSearchParams(), 'default' ) ).toBe( 'editor' );
+	} );
+
+	it( 'lets a recognized dest override the default', () => {
+		expect( getWowFunnelDest( new URLSearchParams( 'dest=editor' ), 'default' ) ).toBe( 'editor' );
+	} );
+
+	it( 'falls back to the default rather than returning null for an unrecognized dest', () => {
+		// A missing or bogus dest used to drop the customer into ordinary onboarding
+		// destinations, which looked like working onboarding and was not.
+		expect( getWowFunnelDest( new URLSearchParams( 'dest=nowhere' ), 'blueprint' ) ).toBe(
+			'editor'
+		);
+	} );
+} );
+
+describe( 'waitForWowFunnelReady', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockTransferWait.mockImplementation( () => Promise.resolve() );
+		mockImportWait.mockImplementation( () => Promise.resolve() );
+	} );
+
+	it( 'waits only on the transfer for a transfer-readiness funnel', async () => {
+		await waitForWowFunnelReady( { funnelSlug: 'default', siteIdentifier: 'site.example.com' } );
+
+		expect( mockTransferWait ).toHaveBeenCalledWith( 'site.example.com' );
+		expect( mockImportWait ).not.toHaveBeenCalled();
+	} );
+
+	it( 'waits on the transfer and then the import for an import-readiness funnel', async () => {
+		await waitForWowFunnelReady( { funnelSlug: 'blueprint', siteIdentifier: 'site.example.com' } );
+
+		expect( mockTransferWait ).toHaveBeenCalledWith( 'site.example.com' );
+		expect( mockImportWait ).toHaveBeenCalledWith( 'site.example.com' );
+	} );
+
+	it( 'throws when the build fails, so the flow routes to the error step', async () => {
+		mockTransferWait.mockImplementation( () =>
+			Promise.reject( new Error( 'Atomic transfer failed with status: reverted' ) )
+		);
+
+		await expect(
+			waitForWowFunnelReady( { funnelSlug: 'default', siteIdentifier: 'site.example.com' } )
+		).rejects.toThrow( /went wrong/i );
+	} );
+
+	it( 'throws a timeout once the funnel budget is spent, without hanging on the build', async () => {
+		jest.useFakeTimers();
+		// A build that never settles: only the timeout can end this wait.
+		mockTransferWait.mockImplementation( never );
+
+		const pending = waitForWowFunnelReady( {
+			funnelSlug: 'default',
+			siteIdentifier: 'site.example.com',
+		} );
+		const assertion = expect( pending ).rejects.toThrow( /taking longer than expected/i );
+
+		// The default funnel's budget is 180s.
+		await jest.advanceTimersByTimeAsync( 180 * 1000 );
+		await assertion;
+
+		jest.useRealTimers();
+	} );
+
+	it( 'does not raise an unhandled rejection when the build fails after a timeout', async () => {
+		jest.useFakeTimers();
+		let failBuild: ( error: Error ) => void = () => {};
+		mockTransferWait.mockImplementation(
+			() => new Promise< void >( ( _resolve, reject ) => ( failBuild = reject ) )
+		);
+
+		const pending = waitForWowFunnelReady( {
+			funnelSlug: 'default',
+			siteIdentifier: 'site.example.com',
+		} );
+		const assertion = expect( pending ).rejects.toThrow( /taking longer than expected/i );
+
+		await jest.advanceTimersByTimeAsync( 180 * 1000 );
+		await assertion;
+
+		// The abandoned build settles late. It must be swallowed: the wait already reported a
+		// timeout, and an unhandled rejection here would surface as a spurious flow exception.
+		failBuild( new Error( 'Atomic transfer failed with status: error' ) );
+		await Promise.resolve();
+
+		jest.useRealTimers();
+	} );
+} );

--- a/client/landing/stepper/utils/wow-funnel-site.ts
+++ b/client/landing/stepper/utils/wow-funnel-site.ts
@@ -1,0 +1,134 @@
+import { Visibility } from '@automattic/data-stores/src/site/types';
+import { ONBOARDING_FLOW, createSite } from '@automattic/onboarding';
+import {
+	clearWowFunnelSite,
+	getRememberedWowFunnelSite,
+	getWowFunnelKey,
+	logWowFunnelEvent,
+	rememberWowFunnelSite,
+} from './wow-funnel';
+import type { RememberedWowFunnelSite } from './wow-funnel';
+
+/**
+ * Creating a WoW funnel's site, kept apart from the rest of the funnel model on purpose.
+ *
+ * This is the only part of the funnel that needs `@automattic/onboarding` and the data-stores
+ * site types, and those barrels reach all the way into the component library — so importing them
+ * pulls i18n-calypso into every consumer. The hand-off side (readiness, destination, the
+ * post-checkout step) needs none of that, and site-spec's tests fall over when it arrives.
+ *
+ * The seam is the same one the funnel already has: creating the site, versus deciding where the
+ * customer goes once it is built.
+ */
+/**
+ * In-flight background-creation promises, keyed by funnel slug. Lets the create-site step await the
+ * same request the flow-entry side effect started, so we never create two sites for one funnel.
+ */
+const inFlight: Record< string, Promise< RememberedWowFunnelSite > | undefined > = {};
+
+/**
+ * Forget a funnel run completely, so the next entry builds a new site.
+ *
+ * Clearing sessionStorage alone is not enough: the in-flight cache holds the resolved promise for
+ * the run's site, and startWowFunnelSite() consults it after the remembered-site check — so the
+ * discarded site would be handed straight back.
+ * @param funnelSlug The funnel slug.
+ * @param funnelArgs Args from the entry URL.
+ */
+export function forgetWowFunnelRun(
+	funnelSlug: string,
+	funnelArgs: Record< string, string > = {}
+): void {
+	clearWowFunnelSite();
+	inFlight[ getWowFunnelKey( funnelSlug, funnelArgs ) ] = undefined;
+}
+
+/**
+ * Create the funnel's Simple site (which the server immediately fast-provisions to Atomic), once.
+ *
+ * Single-flight: concurrent callers for the same funnel share one request, and a site already
+ * remembered from this session is returned without a second create. The server generates an
+ * arbitrary subdomain (empty blog_name + find_available_url on the onboarding flow), so no
+ * siteUrl/title is needed here.
+ */
+export function startWowFunnelSite( {
+	funnelSlug,
+	funnelArgs,
+	siteTitle,
+}: {
+	funnelSlug: string;
+	funnelArgs?: Record< string, string >;
+	siteTitle?: string;
+} ): Promise< RememberedWowFunnelSite > {
+	const funnelKey = getWowFunnelKey( funnelSlug, funnelArgs );
+
+	const remembered = getRememberedWowFunnelSite( funnelSlug, funnelArgs );
+	if ( remembered ) {
+		return Promise.resolve( remembered );
+	}
+
+	const existing = inFlight[ funnelKey ];
+	if ( existing ) {
+		return existing;
+	}
+
+	const request = ( async () => {
+		logWowFunnelEvent( 'start_site_creation', { funnel: funnelSlug } );
+
+		const site = await createSite(
+			ONBOARDING_FLOW,
+			'', // themeSlugWithRepo — default theme.
+			Visibility.PublicNotIndexed, // coming soon.
+			siteTitle ?? '',
+			'#113AF5', // accent — backend requires a value.
+			false, // useThemeHeadstart.
+			// username: only ever a last-resort blog_name seed, and the server generates the
+			// funnel's arbitrary subdomain regardless — see /sites/new's wow-funnel block.
+			'',
+			null, // partnerBundle.
+			undefined, // storedSiteUrl — empty so the server generates an arbitrary subdomain.
+			undefined, // domainItem.
+			undefined, // sourceSlug.
+			undefined, // siteIntent.
+			undefined, // siteGoals.
+			null, // gardenName.
+			null, // gardenPartnerName.
+			undefined, // specId.
+			undefined, // ref.
+			undefined, // provisionTarget.
+			undefined, // aiLaunchpadEnabled.
+			funnelSlug,
+			funnelArgs
+		);
+
+		if ( ! site ) {
+			throw new Error( 'Failed to create WoW funnel site' );
+		}
+
+		const result: RememberedWowFunnelSite = {
+			funnelSlug,
+			funnelKey,
+			blogId: site.siteId,
+			siteSlug: site.siteSlug,
+		};
+		rememberWowFunnelSite( result );
+		logWowFunnelEvent( 'start_site_created', {
+			funnel: funnelSlug,
+			blog_id: result.blogId,
+			site_slug: result.siteSlug,
+		} );
+		return result;
+	} )();
+
+	inFlight[ funnelKey ] = request;
+	request.catch( ( error ) => {
+		logWowFunnelEvent( 'start_site_error', {
+			funnel: funnelSlug,
+			error: error instanceof Error ? error.message : String( error ),
+		} );
+		// Clear so a later attempt (e.g. the create-site fallback) can retry.
+		inFlight[ funnelKey ] = undefined;
+	} );
+
+	return request;
+}

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -1,5 +1,3 @@
-import { Site } from '@automattic/data-stores';
-import { ONBOARDING_FLOW, createSite } from '@automattic/onboarding';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { getTransferFailureMessage } from './atomic-transfer-outcome';
 import {
@@ -129,7 +127,6 @@ const SESSION_KEY = 'wow-funnel-created-site';
 
 /**
  * A stable identity for one funnel run: the slug plus the args that decide what gets built.
- *
  * @param funnelSlug The funnel slug.
  * @param funnelArgs Args from the entry URL.
  * @returns A key that changes whenever the run would build something different.
@@ -146,11 +143,12 @@ export function getWowFunnelKey(
 }
 
 /**
- * In-flight background-creation promises, keyed by funnel slug. Lets the create-site step await the
- * same request the flow-entry side effect started, so we never create two sites for one funnel.
+ * Input the funnel's server-side follow-up needs, read off the entry URL.
+ *
+ * Sent as `wow_funnel_args` to /sites/new, where the registered funnel's follow-up consumes it —
+ * the blueprint funnel, for instance, seeds its archive import from `blueprint_slug`. Empty for
+ * funnels that do no follow-up work.
  */
-const inFlight: Record< string, Promise< RememberedWowFunnelSite > | undefined > = {};
-
 export function getWowFunnelSlug( queryParams: URLSearchParams ): string | null {
 	const raw = queryParams.get( 'wow_funnel' );
 	if ( ! raw ) {
@@ -161,13 +159,6 @@ export function getWowFunnelSlug( queryParams: URLSearchParams ): string | null 
 	return slug || null;
 }
 
-/**
- * Input the funnel's server-side follow-up needs, read off the entry URL.
- *
- * Sent as `wow_funnel_args` to /sites/new, where the registered funnel's follow-up consumes it —
- * the blueprint funnel, for instance, seeds its archive import from `blueprint_slug`. Empty for
- * funnels that do no follow-up work.
- */
 export function getWowFunnelArgs( queryParams: URLSearchParams ): Record< string, string > {
 	const args: Record< string, string > = {};
 
@@ -234,7 +225,7 @@ export function getRememberedWowFunnelSite(
 	return remembered && remembered.funnelKey === key ? remembered : null;
 }
 
-function rememberWowFunnelSite( site: RememberedWowFunnelSite ): void {
+export function rememberWowFunnelSite( site: RememberedWowFunnelSite ): void {
 	try {
 		window.sessionStorage.setItem( SESSION_KEY, JSON.stringify( site ) );
 	} catch {
@@ -252,124 +243,15 @@ export function clearWowFunnelSite(): void {
 }
 
 /**
- * Forget a funnel run completely, so the next entry builds a new site.
- *
- * Clearing sessionStorage alone is not enough: the in-flight cache holds the resolved promise for
- * the run's site, and startWowFunnelSite() consults it after the remembered-site check — so the
- * discarded site would be handed straight back.
- *
- * @param funnelSlug The funnel slug.
- * @param funnelArgs Args from the entry URL.
- */
-export function forgetWowFunnelRun(
-	funnelSlug: string,
-	funnelArgs: Record< string, string > = {}
-): void {
-	clearWowFunnelSite();
-	inFlight[ getWowFunnelKey( funnelSlug, funnelArgs ) ] = undefined;
-}
-
-/**
  * Is this site already paid for?
  *
  * A funnel run exists to sell a plan for the site it builds, so a site that already has one must
  * never be resumed — checkout would offer a second plan for a site that does not need one.
- *
  * @param site The site, as returned by the site store.
  * @returns True when the site holds a paid plan.
  */
 export function wowFunnelSiteIsPaid( site: { plan?: { is_free?: boolean } } | undefined ): boolean {
 	return !! site?.plan && ! site.plan.is_free;
-}
-
-/**
- * Create the funnel's Simple site (which the server immediately fast-provisions to Atomic), once.
- *
- * Single-flight: concurrent callers for the same funnel share one request, and a site already
- * remembered from this session is returned without a second create. The server generates an
- * arbitrary subdomain (empty blog_name + find_available_url on the onboarding flow), so no
- * siteUrl/title is needed here.
- */
-export function startWowFunnelSite( {
-	funnelSlug,
-	funnelArgs,
-	siteTitle,
-}: {
-	funnelSlug: string;
-	funnelArgs?: Record< string, string >;
-	siteTitle?: string;
-} ): Promise< RememberedWowFunnelSite > {
-	const funnelKey = getWowFunnelKey( funnelSlug, funnelArgs );
-
-	const remembered = getRememberedWowFunnelSite( funnelSlug, funnelArgs );
-	if ( remembered ) {
-		return Promise.resolve( remembered );
-	}
-
-	const existing = inFlight[ funnelKey ];
-	if ( existing ) {
-		return existing;
-	}
-
-	const request = ( async () => {
-		logWowFunnelEvent( 'start_site_creation', { funnel: funnelSlug } );
-
-		const site = await createSite(
-			ONBOARDING_FLOW,
-			'', // themeSlugWithRepo — default theme.
-			Site.Visibility.PublicNotIndexed, // coming soon.
-			siteTitle ?? '',
-			'#113AF5', // accent — backend requires a value.
-			false, // useThemeHeadstart.
-			// username: only ever a last-resort blog_name seed, and the server generates the
-			// funnel's arbitrary subdomain regardless — see /sites/new's wow-funnel block.
-			'',
-			null, // partnerBundle.
-			undefined, // storedSiteUrl — empty so the server generates an arbitrary subdomain.
-			undefined, // domainItem.
-			undefined, // sourceSlug.
-			undefined, // siteIntent.
-			undefined, // siteGoals.
-			null, // gardenName.
-			null, // gardenPartnerName.
-			undefined, // specId.
-			undefined, // ref.
-			undefined, // provisionTarget.
-			undefined, // aiLaunchpadEnabled.
-			funnelSlug,
-			funnelArgs
-		);
-
-		if ( ! site ) {
-			throw new Error( 'Failed to create WoW funnel site' );
-		}
-
-		const result: RememberedWowFunnelSite = {
-			funnelSlug,
-			funnelKey,
-			blogId: site.siteId,
-			siteSlug: site.siteSlug,
-		};
-		rememberWowFunnelSite( result );
-		logWowFunnelEvent( 'start_site_created', {
-			funnel: funnelSlug,
-			blog_id: result.blogId,
-			site_slug: result.siteSlug,
-		} );
-		return result;
-	} )();
-
-	inFlight[ funnelKey ] = request;
-	request.catch( ( error ) => {
-		logWowFunnelEvent( 'start_site_error', {
-			funnel: funnelSlug,
-			error: error instanceof Error ? error.message : String( error ),
-		} );
-		// Clear so a later attempt (e.g. the create-site fallback) can retry.
-		inFlight[ funnelKey ] = undefined;
-	} );
-
-	return request;
 }
 
 const WAIT_TIMED_OUT = Symbol( 'wow-funnel-wait-timed-out' );

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -30,11 +30,35 @@ const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'editor', 'site-spec' ];
  */
 export type RememberedWowFunnelSite = {
 	funnelSlug: string;
+	/**
+	 * Identifies the run, not just the funnel. Two CTAs can share a funnel slug and differ in
+	 * what they build — the blueprint funnel's whole subject is its `blueprint_slug` — so the
+	 * slug alone would resume a site built from a different blueprint.
+	 */
+	funnelKey: string;
 	blogId: number;
 	siteSlug: string;
 };
 
 const SESSION_KEY = 'wow-funnel-created-site';
+
+/**
+ * A stable identity for one funnel run: the slug plus the args that decide what gets built.
+ *
+ * @param funnelSlug The funnel slug.
+ * @param funnelArgs Args from the entry URL.
+ * @returns A key that changes whenever the run would build something different.
+ */
+export function getWowFunnelKey(
+	funnelSlug: string,
+	funnelArgs: Record< string, string > = {}
+): string {
+	const args = Object.keys( funnelArgs )
+		.sort()
+		.map( ( key ) => `${ key }=${ funnelArgs[ key ] }` )
+		.join( '&' );
+	return args ? `${ funnelSlug }:${ args }` : funnelSlug;
+}
 
 /**
  * In-flight background-creation promises, keyed by funnel slug. Lets the create-site step await the
@@ -97,7 +121,7 @@ function readRemembered(): RememberedWowFunnelSite | null {
 			return null;
 		}
 		const parsed = JSON.parse( raw ) as RememberedWowFunnelSite;
-		if ( parsed && parsed.funnelSlug && parsed.blogId && parsed.siteSlug ) {
+		if ( parsed && parsed.funnelKey && parsed.blogId && parsed.siteSlug ) {
 			return parsed;
 		}
 	} catch {
@@ -106,9 +130,13 @@ function readRemembered(): RememberedWowFunnelSite | null {
 	return null;
 }
 
-export function getRememberedWowFunnelSite( funnelSlug: string ): RememberedWowFunnelSite | null {
+export function getRememberedWowFunnelSite(
+	funnelSlug: string,
+	funnelArgs: Record< string, string > = {}
+): RememberedWowFunnelSite | null {
 	const remembered = readRemembered();
-	return remembered && remembered.funnelSlug === funnelSlug ? remembered : null;
+	const key = getWowFunnelKey( funnelSlug, funnelArgs );
+	return remembered && remembered.funnelKey === key ? remembered : null;
 }
 
 function rememberWowFunnelSite( site: RememberedWowFunnelSite ): void {
@@ -129,6 +157,37 @@ export function clearWowFunnelSite(): void {
 }
 
 /**
+ * Forget a funnel run completely, so the next entry builds a new site.
+ *
+ * Clearing sessionStorage alone is not enough: the in-flight cache holds the resolved promise for
+ * the run's site, and startWowFunnelSite() consults it after the remembered-site check — so the
+ * discarded site would be handed straight back.
+ *
+ * @param funnelSlug The funnel slug.
+ * @param funnelArgs Args from the entry URL.
+ */
+export function forgetWowFunnelRun(
+	funnelSlug: string,
+	funnelArgs: Record< string, string > = {}
+): void {
+	clearWowFunnelSite();
+	inFlight[ getWowFunnelKey( funnelSlug, funnelArgs ) ] = undefined;
+}
+
+/**
+ * Is this site already paid for?
+ *
+ * A funnel run exists to sell a plan for the site it builds, so a site that already has one must
+ * never be resumed — checkout would offer a second plan for a site that does not need one.
+ *
+ * @param site The site, as returned by the site store.
+ * @returns True when the site holds a paid plan.
+ */
+export function wowFunnelSiteIsPaid( site: { plan?: { is_free?: boolean } } | undefined ): boolean {
+	return !! site?.plan && ! site.plan.is_free;
+}
+
+/**
  * Create the funnel's Simple site (which the server immediately fast-provisions to Atomic), once.
  *
  * Single-flight: concurrent callers for the same funnel share one request, and a site already
@@ -145,12 +204,14 @@ export function startWowFunnelSite( {
 	funnelArgs?: Record< string, string >;
 	siteTitle?: string;
 } ): Promise< RememberedWowFunnelSite > {
-	const remembered = getRememberedWowFunnelSite( funnelSlug );
+	const funnelKey = getWowFunnelKey( funnelSlug, funnelArgs );
+
+	const remembered = getRememberedWowFunnelSite( funnelSlug, funnelArgs );
 	if ( remembered ) {
 		return Promise.resolve( remembered );
 	}
 
-	const existing = inFlight[ funnelSlug ];
+	const existing = inFlight[ funnelKey ];
 	if ( existing ) {
 		return existing;
 	}
@@ -190,6 +251,7 @@ export function startWowFunnelSite( {
 
 		const result: RememberedWowFunnelSite = {
 			funnelSlug,
+			funnelKey,
 			blogId: site.siteId,
 			siteSlug: site.siteSlug,
 		};
@@ -202,14 +264,14 @@ export function startWowFunnelSite( {
 		return result;
 	} )();
 
-	inFlight[ funnelSlug ] = request;
+	inFlight[ funnelKey ] = request;
 	request.catch( ( error ) => {
 		logWowFunnelEvent( 'start_site_error', {
 			funnel: funnelSlug,
 			error: error instanceof Error ? error.message : String( error ),
 		} );
 		// Clear so a later attempt (e.g. the create-site fallback) can retry.
-		inFlight[ funnelSlug ] = undefined;
+		inFlight[ funnelKey ] = undefined;
 	} );
 
 	return request;

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -1,6 +1,13 @@
 import { Site } from '@automattic/data-stores';
 import { ONBOARDING_FLOW, createSite } from '@automattic/onboarding';
 import { logToLogstash } from 'calypso/lib/logstash';
+import { getTransferFailureMessage } from './atomic-transfer-outcome';
+import {
+	getSiteAdminUrl,
+	getSiteEditorUrl,
+	waitForAtomicTransferComplete,
+	waitForBlueprintImportComplete,
+} from './blueprint-archive-import';
 
 /**
  * A WoW funnel is a CTA-selected onboarding path whose end state is always an Atomic site,
@@ -12,17 +19,95 @@ import { logToLogstash } from 'calypso/lib/logstash';
  */
 
 /**
- * Where the customer lands after checkout, when the CTA asks for somewhere specific.
+ * Where the customer lands at the END of a funnel — always on the built site.
  *
- * - `editor`    — straight into the Site Editor on the built Atomic site.
- * - `site-spec` — the AI site-spec, which polls the funnel's build and hands over when it lands.
+ * - `editor` — straight into the Site Editor on the built Atomic site.
  *
- * No (or unrecognized) `dest` means no override: the flow's ordinary post-checkout destination
- * applies.
+ * Keeping every destination remote is what makes "end of funnel" a structural fact rather than
+ * something inferred from the dest value. Calypso-side work is not a destination; it is an
+ * interstitial that runs before the hand-off (see WowFunnelInterstitial).
  */
-export type WowFunnelDest = 'editor' | 'site-spec';
+export type WowFunnelDest = 'editor';
 
-const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'editor', 'site-spec' ];
+const WOW_FUNNEL_DESTS: WowFunnelDest[] = [ 'editor' ];
+
+/**
+ * A Calypso-side step a funnel inserts between checkout and the hand-off.
+ *
+ * - `site-spec` — collects the owner's details and applies them to the built site.
+ *
+ * Interstitials live in their own flows and are reached by URL, so they are an ordered list of
+ * hops rather than steps spliced into onboarding's step list. The last hop owns the readiness
+ * wait and the hand-off, both through the shared helpers below — so a funnel's terminal
+ * behaviour is identical whether or not it has interstitials.
+ */
+export type WowFunnelInterstitial = 'site-spec';
+
+/**
+ * What must be true before the customer is handed to the destination.
+ *
+ * One predicate per funnel is enough because each funnel's is transitively the last thing in its
+ * chain: the blueprint import runs behind the Atomic transfer (the backup_import job initiates
+ * the transfer as its first step), so `import` already implies `transfer`.
+ */
+export type WowFunnelReadiness = 'transfer' | 'import';
+
+export type WowFunnelConfig = {
+	/** Calypso-side hops between checkout and the hand-off, in order. */
+	interstitials: WowFunnelInterstitial[];
+	/** Where the customer lands when the CTA does not override it. */
+	dest: WowFunnelDest;
+	/** What the loading screen waits on before handing over. */
+	readiness: WowFunnelReadiness;
+	/** How long that wait runs before it gives up and raises a timeout. */
+	waitTimeoutSeconds: number;
+};
+
+const DEFAULT_WOW_FUNNEL_CONFIG: WowFunnelConfig = {
+	interstitials: [],
+	dest: 'editor',
+	readiness: 'transfer',
+	// The observed fast-provision build is well under a minute; this is headroom, not a target.
+	waitTimeoutSeconds: 180,
+};
+
+/**
+ * Per-funnel overrides. Anything unset falls back to DEFAULT_WOW_FUNNEL_CONFIG, so a new funnel
+ * that just wants "empty Atomic site, then the editor" needs no entry here at all.
+ *
+ * Mirrors the server-side registry in wp-content/lib/atomic/wow-funnels.php by slug only: PHP owns
+ * what the BUILD does (context, theme, follow-up), this owns what the FLOW does. Keeping flow
+ * config client-side also keeps it off the critical path of the post-checkout hand-off.
+ */
+const WOW_FUNNEL_CONFIG: Record< string, Partial< WowFunnelConfig > > = {
+	default: {},
+	blueprint: {
+		interstitials: [ 'site-spec' ],
+		readiness: 'import',
+		// The archive restore is genuinely long; this matches the wait site-spec already ran.
+		waitTimeoutSeconds: 900,
+	},
+};
+
+/**
+ * Whether the slug names a funnel this client knows how to run.
+ *
+ * The server ignores an unregistered slug outright — it never enrols the blog and never starts a
+ * build — so the client has to degrade the same way. Without this check a typo'd slug would take
+ * the funnel path and then sit on the loading screen waiting for a transfer that was never going
+ * to happen. Mirrors the server registry by slug; a funnel the server knows and this list does
+ * not falls back to ordinary onboarding, which is the same safe failure.
+ */
+export function isKnownWowFunnel( funnelSlug: string | null ): funnelSlug is string {
+	return !! funnelSlug && Object.prototype.hasOwnProperty.call( WOW_FUNNEL_CONFIG, funnelSlug );
+}
+
+export function getWowFunnelConfig( funnelSlug: string | null ): WowFunnelConfig {
+	return {
+		...DEFAULT_WOW_FUNNEL_CONFIG,
+		...( ( funnelSlug && WOW_FUNNEL_CONFIG[ funnelSlug ] ) || {} ),
+	};
+}
 
 /**
  * A funnel site created for this flow, remembered so the create-site step can consume it rather
@@ -70,9 +155,19 @@ export function getWowFunnelArgs( queryParams: URLSearchParams ): Record< string
 	return args;
 }
 
-export function getWowFunnelDest( queryParams: URLSearchParams ): WowFunnelDest | null {
+/**
+ * The funnel's destination. `dest` in the URL is an OVERRIDE for a CTA that wants somewhere other
+ * than the funnel's default; absent or unrecognized, the configured default applies.
+ *
+ * Never null: a missing `dest` used to drop the customer silently into ordinary onboarding
+ * destinations, which looked like working onboarding and wasn't.
+ */
+export function getWowFunnelDest(
+	queryParams: URLSearchParams,
+	funnelSlug: string | null
+): WowFunnelDest {
 	const dest = queryParams.get( 'dest' );
-	return WOW_FUNNEL_DESTS.find( ( d ) => d === dest ) ?? null;
+	return WOW_FUNNEL_DESTS.find( ( d ) => d === dest ) ?? getWowFunnelConfig( funnelSlug ).dest;
 }
 
 export function logWowFunnelEvent(
@@ -213,4 +308,98 @@ export function startWowFunnelSite( {
 	} );
 
 	return request;
+}
+
+const WAIT_TIMED_OUT = Symbol( 'wow-funnel-wait-timed-out' );
+
+/**
+ * Wait until the funnel's build is genuinely ready to be handed over.
+ *
+ * This is the gate that was missing: the hand-off used to fire the moment checkout returned, on
+ * the assumption that the build had finished during domain selection and checkout. It usually
+ * had. When it had not, the customer landed on the pre-switcheroo Simple site — the site was
+ * fine and finished moments later, but their first impression was the wrong site.
+ *
+ * Throws on failure or timeout, matching how every other Atomic wait in stepper reports (see
+ * bundle-transfer, use-wait-for-atomic), so the flow's existing exception handling routes it to
+ * the shared error step with a message that already reads correctly for a timeout.
+ */
+export async function waitForWowFunnelReady( {
+	funnelSlug,
+	siteIdentifier,
+}: {
+	funnelSlug: string;
+	siteIdentifier: string;
+} ): Promise< void > {
+	const { readiness, waitTimeoutSeconds } = getWowFunnelConfig( funnelSlug );
+
+	const work = ( async () => {
+		// Every readiness level starts with the transfer — the site cannot be ready before it is
+		// Atomic — and `import` simply waits for one more thing behind it.
+		await waitForAtomicTransferComplete( siteIdentifier );
+		if ( 'import' === readiness ) {
+			await waitForBlueprintImportComplete( siteIdentifier );
+		}
+	} )();
+
+	let timer: ReturnType< typeof setTimeout > | undefined;
+	const timeout = new Promise< typeof WAIT_TIMED_OUT >( ( resolve ) => {
+		timer = setTimeout( () => resolve( WAIT_TIMED_OUT ), waitTimeoutSeconds * 1000 );
+	} );
+
+	try {
+		// Settling the work promise here (rather than letting the race reject) keeps a late
+		// rejection from surfacing as an unhandled rejection after a timeout has already won.
+		const outcome = await Promise.race( [
+			work.then(
+				() => 'ready' as const,
+				() => 'failed' as const
+			),
+			timeout,
+		] );
+
+		if ( WAIT_TIMED_OUT === outcome ) {
+			logWowFunnelEvent( 'handoff_wait_timeout', {
+				funnel: funnelSlug,
+				readiness,
+				timeout_seconds: waitTimeoutSeconds,
+			} );
+			throw new Error( getTransferFailureMessage( 'timeout' ) );
+		}
+
+		if ( 'failed' === outcome ) {
+			logWowFunnelEvent( 'handoff_wait_failed', { funnel: funnelSlug, readiness } );
+			throw new Error( getTransferFailureMessage( 'error' ) );
+		}
+	} finally {
+		clearTimeout( timer );
+	}
+}
+
+/**
+ * Build the URL the funnel hands the customer over to.
+ *
+ * Resolved AFTER the readiness wait, deliberately: a funnel site's address changes mid-flow when
+ * the Simple site becomes Atomic, so a URL captured at flow start points at the old one. Goes
+ * through the site's own admin URL and Jetpack SSO for the same reason the blueprint hand-off
+ * does — the customer holds a WordPress.com session, not a session on their new Atomic site.
+ */
+export async function getWowFunnelHandoffUrl( {
+	dest,
+	siteIdentifier,
+	startWalkthrough = false,
+}: {
+	dest: WowFunnelDest;
+	siteIdentifier: string;
+	startWalkthrough?: boolean;
+} ): Promise< string > {
+	switch ( dest ) {
+		case 'editor':
+		default: {
+			const adminUrl = await getSiteAdminUrl( siteIdentifier );
+			// `p` opens the front page rather than whatever the editor last had; `canvasEdit`
+			// because a plain site-editor.php load stays in view mode.
+			return getSiteEditorUrl( adminUrl, { canvasEdit: true, path: '/', startWalkthrough } );
+		}
+	}
 }


### PR DESCRIPTION
## Proposed changes

The wow-funnel hand-off fired the moment checkout returned, on the assumption that the Atomic build had finished during domain selection and checkout. It usually has. When it hasn't, the redirect beats the Simple→Atomic switcheroo and the customer lands in the editor of the **pre-switcheroo Simple site** — the site is fine and finishes seconds later, but their first look at what they just bought is the wrong site.

Every funnel now runs the same shape, with the wait as a structural step rather than something each funnel remembers to do:

```
checkout → [interstitials…] → WAIT(ready) → dest

default:    checkout →        WAIT(transfer) → editor
blueprint:  checkout → spec →  WAIT(import)  → editor
```

* **The funnel definition** carries `interstitials`, `dest`, `readiness` and a wait budget. A funnel that just wants an empty Atomic site and the editor needs no entry at all.
* **`dest` is always on the built site.** That is what makes "end of funnel" a structural fact rather than something inferred from the dest value. Calypso-side work is an interstitial that runs *before* the hand-off, not a destination.
* **One readiness predicate per funnel is enough**, because each funnel's is transitively the last thing in its chain: the blueprint import runs behind the same transfer it waits on, so `import` already implies `transfer`.
* **`wow-funnel-handoff`** is a new step that holds the customer on the common loading screen and then hands over. It is dedicated rather than a branch in `post-checkout-onboarding`, which carries plugin-install, Big Sky and marketplace-theme logic a funnel does not want.
* **`site-spec` becomes an interstitial** rather than a destination, and routes its wait and hand-off through the shared helpers so both funnels agree on what "ready" means. Plain (non-funnel) blueprint-archive runs are untouched, so #113857's fix is undisturbed.
* **`dest` is now an override** rather than a requirement. It previously had to be present for the funnel branch to run at all, so a CTA that omitted it dropped the customer into ordinary onboarding destinations — which looked like working onboarding and was not.
* **An unregistered slug degrades to ordinary onboarding.** The server ignores such a slug and never starts a build, so taking the funnel path would park the customer on the loading screen waiting for work nobody queued.

The hand-off URL is resolved only *after* the wait, so it names the site that now exists rather than the one captured at flow start, and goes through Jetpack SSO for the same reason the blueprint hand-off does — the customer holds a WordPress.com session, not a session on their new Atomic site.

### One trap worth knowing

`getPostCheckoutDestination` runs **before** checkout — its result is what becomes checkout's `redirect_to`. The first attempt at this put the wait there, which blocked the customer on the way to the payment step. That is why the wait needs its own post-checkout page: a funnel exists so the build overlaps the customer's own time in the flow, and stalling them before they can pay trades one bad experience for a worse one. Ordinary onboarding already routes `redirect_to` through `post-checkout-onboarding`; the funnel skipped that hop, which is why there was nowhere for a wait to live.

Failure and timeout throw, matching every other Atomic wait in stepper, so existing handling routes them to the shared error step — where the timeout message already reads as "taking longer than expected" rather than as a failure.

This branch also carries the earlier funnel site-reuse work (scoping a remembered run by its args, and never resuming a site that already holds a plan). It is orthogonal — creation side vs. hand-off side — and merged cleanly apart from the two spots noted in the merge commit.

## Testing instructions

Unit: `yarn jest client/landing/stepper/utils/test/wow-funnel.ts` — 22 tests covering config resolution, the dest override, the known-funnel gate, readiness dispatch, and the failure/timeout/late-rejection paths.

End-to-end, as an Automattician (the funnel is internal-only server-side):

1. `ENTRY_LIMIT=entry-main,entry-stepper SECTION_LIMIT=signup,checkout yarn start`
2. Go to `/setup/onboarding?wow_funnel=default` and complete the flow.
3. You will most likely **not** see the wait — the build usually finishes during domain and plan selection, so the screen flashes past. That confirms nothing broke; it does not exercise the fix.
4. To exercise it, block `GET /wpcom/v2/sites/*/atomic/transfers/latest` in DevTools' network request-blocking once you reach `wow-funnel-handoff`. The loading screen should hold, and at 180s you should get the error step reading "taking longer than expected". Unblock mid-wait and it should proceed to the editor.

Note `wow_funnel=default` and `wow_funnel=blueprint` take different routes, so testing one does not exercise the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)