### PR TITLE
Domains: only show the pending primary domain notice while it is pending

### DIFF
--- a/client/dashboard/components/pending-primary-domain-notice/index.tsx
+++ b/client/dashboard/components/pending-primary-domain-notice/index.tsx
@@ -5,7 +5,8 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEffect, useRef } from 'react';
-import { isPendingPrimaryDomain } from '../../utils/domain';
+import { useAppContext } from '../../app/context';
+import { hasCustomPrimaryDomain, isPendingPrimaryDomain } from '../../utils/domain';
 import { Notice } from '../notice';
 
 interface PendingPrimaryDomainNoticeProps {
@@ -17,6 +18,8 @@ export default function PendingPrimaryDomainNotice( {
 	domainName,
 	onComplete,
 }: PendingPrimaryDomainNoticeProps ) {
+	const { queries } = useAppContext();
+
 	const { data: polledDomain } = useQuery( {
 		...domainQuery( domainName ),
 		refetchInterval: ( query ) => {
@@ -26,21 +29,36 @@ export default function PendingPrimaryDomainNotice( {
 		meta: { persist: false },
 	} );
 
-	const isPending = ! polledDomain || isPendingPrimaryDomain( polledDomain );
+	// WordPress.com only sets a domain as primary on its own when the site has no
+	// custom primary address yet.
+	const { data: allDomains } = useQuery( {
+		...queries.domainsQuery(),
+		enabled: !! polledDomain,
+	} );
+
+	const isPending =
+		!! polledDomain &&
+		!! allDomains &&
+		! hasCustomPrimaryDomain(
+			allDomains.filter( ( domain ) => domain.blog_id === polledDomain.blog_id )
+		) &&
+		isPendingPrimaryDomain( polledDomain );
 
 	// Track whether the domain was ever actually pending, so we don't fire
 	// a spurious snackbar when rendered for a non-pending domain.
 	const wasPendingRef = useRef( false );
-	if ( isPending && polledDomain ) {
+	if ( isPending ) {
 		wasPendingRef.current = true;
 	}
 
-	// Show completion snackbar when primary domain setup finishes.
+	// Announce the domain only once it has actually become the primary address.
+	// Setup finishing is not enough: the job promotes the domain on a later retry.
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const onCompleteRef = useRef( onComplete );
 	onCompleteRef.current = onComplete;
+	const isPrimary = !! polledDomain?.primary_domain;
 	useEffect( () => {
-		if ( ! isPending && wasPendingRef.current ) {
+		if ( isPrimary && wasPendingRef.current ) {
 			createSuccessNotice(
 				sprintf(
 					/* translators: %s is the domain name */
@@ -51,9 +69,9 @@ export default function PendingPrimaryDomainNotice( {
 			);
 			onCompleteRef.current?.();
 		}
-	}, [ isPending, createSuccessNotice, domainName ] );
+	}, [ isPrimary, createSuccessNotice, domainName ] );
 
-	if ( ! isPending || ! polledDomain ) {
+	if ( ! isPending ) {
 		return null;
 	}
 

--- a/client/dashboard/components/pending-primary-domain-notice/index.tsx
+++ b/client/dashboard/components/pending-primary-domain-notice/index.tsx
@@ -30,19 +30,22 @@ export default function PendingPrimaryDomainNotice( {
 	} );
 
 	// WordPress.com only sets a domain as primary on its own when the site has no
-	// custom primary address yet.
+	// custom primary address yet. Answering that needs the site's other domains, so
+	// only fetch them when this domain looks pending on its own.
+	const mayBePending = !! polledDomain && isPendingPrimaryDomain( polledDomain );
+
 	const { data: allDomains } = useQuery( {
 		...queries.domainsQuery(),
-		enabled: !! polledDomain,
+		enabled: mayBePending,
 	} );
 
 	const isPending =
+		mayBePending &&
 		!! polledDomain &&
 		!! allDomains &&
 		! hasCustomPrimaryDomain(
 			allDomains.filter( ( domain ) => domain.blog_id === polledDomain.blog_id )
-		) &&
-		isPendingPrimaryDomain( polledDomain );
+		);
 
 	// Track whether the domain was ever actually pending, so we don't fire
 	// a spurious snackbar when rendered for a non-pending domain.

--- a/client/dashboard/components/pending-primary-domain-notice/index.tsx
+++ b/client/dashboard/components/pending-primary-domain-notice/index.tsx
@@ -5,8 +5,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEffect, useRef } from 'react';
-import { useAppContext } from '../../app/context';
-import { hasCustomPrimaryDomain, isPendingPrimaryDomain } from '../../utils/domain';
+import { isPendingPrimaryDomain } from '../../utils/domain';
 import { Notice } from '../notice';
 
 interface PendingPrimaryDomainNoticeProps {
@@ -14,12 +13,16 @@ interface PendingPrimaryDomainNoticeProps {
 	onComplete?: () => void;
 }
 
+/**
+ * Announces that WordPress.com is setting a registered domain as the site's
+ * primary address. Callers own the site-level half of that condition: only
+ * render this when the site has no custom primary address yet, which
+ * hasCustomPrimaryDomain() answers from the site's domains.
+ */
 export default function PendingPrimaryDomainNotice( {
 	domainName,
 	onComplete,
 }: PendingPrimaryDomainNoticeProps ) {
-	const { queries } = useAppContext();
-
 	const { data: polledDomain } = useQuery( {
 		...domainQuery( domainName ),
 		refetchInterval: ( query ) => {
@@ -29,23 +32,7 @@ export default function PendingPrimaryDomainNotice( {
 		meta: { persist: false },
 	} );
 
-	// WordPress.com only sets a domain as primary on its own when the site has no
-	// custom primary address yet. Answering that needs the site's other domains, so
-	// only fetch them when this domain looks pending on its own.
-	const mayBePending = !! polledDomain && isPendingPrimaryDomain( polledDomain );
-
-	const { data: allDomains } = useQuery( {
-		...queries.domainsQuery(),
-		enabled: mayBePending,
-	} );
-
-	const isPending =
-		mayBePending &&
-		!! polledDomain &&
-		!! allDomains &&
-		! hasCustomPrimaryDomain(
-			allDomains.filter( ( domain ) => domain.blog_id === polledDomain.blog_id )
-		);
+	const isPending = !! polledDomain && isPendingPrimaryDomain( polledDomain );
 
 	// Track whether the domain was ever actually pending, so we don't fire
 	// a spurious snackbar when rendered for a non-pending domain.

--- a/client/dashboard/components/pending-primary-domain-notice/test/index.test.tsx
+++ b/client/dashboard/components/pending-primary-domain-notice/test/index.test.tsx
@@ -24,37 +24,7 @@ function mockDomainQuery( domainName: string, overrides = {} ) {
 		} );
 }
 
-// The site's primary address is still its included one, so WordPress.com may
-// still set a registered domain as primary on its own.
-function mockSiteDomains( overrides = {} ) {
-	nock( 'https://public-api.wordpress.com' )
-		.persist()
-		.get( '/rest/v1.2/all-domains' )
-		.query( true )
-		.reply( 200, {
-			domains: [
-				{
-					domain: 'example.com',
-					blog_id: 1,
-					subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Registration' },
-					primary_domain: false,
-					...overrides,
-				},
-				{
-					domain: 'example.wordpress.com',
-					blog_id: 1,
-					subtype: { id: DomainSubtype.DEFAULT_ADDRESS, label: 'Default' },
-					primary_domain: true,
-				},
-			],
-		} );
-}
-
 describe( '<PendingPrimaryDomainNotice>', () => {
-	beforeEach( () => {
-		mockSiteDomains();
-	} );
-
 	afterEach( () => {
 		nock.cleanAll();
 	} );
@@ -85,18 +55,6 @@ describe( '<PendingPrimaryDomainNotice>', () => {
 			points_to_wpcom: true,
 			ssl_status: 'active',
 		} );
-		render( <PendingPrimaryDomainNotice domainName="example.com" /> );
-
-		await waitFor( () => {
-			expect( scope.isDone() ).toBe( true );
-		} );
-		expect( screen.queryByText( 'Setting up your custom domain' ) ).not.toBeInTheDocument();
-	} );
-
-	test( 'renders nothing when the site already has a custom primary address', async () => {
-		nock.cleanAll();
-		mockSiteDomains( { primary_domain: true } );
-		const scope = mockDomainQuery( 'example.com' );
 		render( <PendingPrimaryDomainNotice domainName="example.com" /> );
 
 		await waitFor( () => {

--- a/client/dashboard/components/pending-primary-domain-notice/test/index.test.tsx
+++ b/client/dashboard/components/pending-primary-domain-notice/test/index.test.tsx
@@ -18,6 +18,7 @@ function mockDomainQuery( domainName: string, overrides = {} ) {
 			expired: false,
 			points_to_wpcom: false,
 			ssl_status: 'newly_registered',
+			registration_date: new Date().toISOString(),
 			...overrides,
 		} );
 }

--- a/client/dashboard/components/pending-primary-domain-notice/test/index.test.tsx
+++ b/client/dashboard/components/pending-primary-domain-notice/test/index.test.tsx
@@ -8,14 +8,16 @@ import { render } from '../../../test-utils';
 import PendingPrimaryDomainNotice from '../index';
 
 function mockDomainQuery( domainName: string, overrides = {} ) {
-	nock( 'https://public-api.wordpress.com' )
-		.persist()
+	return nock( 'https://public-api.wordpress.com' )
 		.get( `/rest/v1.2/domain-details/${ domainName }` )
 		.reply( 200, {
 			domain: domainName,
 			subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Registration' },
 			can_set_as_primary: true,
 			primary_domain: false,
+			expired: false,
+			points_to_wpcom: false,
+			ssl_status: 'newly_registered',
 			...overrides,
 		} );
 }
@@ -44,5 +46,18 @@ describe( '<PendingPrimaryDomainNotice>', () => {
 			expect( screen.getByText( 'Setting up your custom domain' ) ).toBeVisible();
 		} );
 		expect( screen.queryByRole( 'button', { name: 'Dismiss' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders nothing for a non-primary domain that is already set up', async () => {
+		const scope = mockDomainQuery( 'example.com', {
+			points_to_wpcom: true,
+			ssl_status: 'active',
+		} );
+		render( <PendingPrimaryDomainNotice domainName="example.com" /> );
+
+		await waitFor( () => {
+			expect( scope.isDone() ).toBe( true );
+		} );
+		expect( screen.queryByText( 'Setting up your custom domain' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/dashboard/components/pending-primary-domain-notice/test/index.test.tsx
+++ b/client/dashboard/components/pending-primary-domain-notice/test/index.test.tsx
@@ -16,6 +16,7 @@ function mockDomainQuery( domainName: string, overrides = {} ) {
 			can_set_as_primary: true,
 			primary_domain: false,
 			expired: false,
+			blog_id: 1,
 			points_to_wpcom: false,
 			ssl_status: 'newly_registered',
 			registration_date: new Date().toISOString(),
@@ -23,7 +24,37 @@ function mockDomainQuery( domainName: string, overrides = {} ) {
 		} );
 }
 
+// The site's primary address is still its included one, so WordPress.com may
+// still set a registered domain as primary on its own.
+function mockSiteDomains( overrides = {} ) {
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( '/rest/v1.2/all-domains' )
+		.query( true )
+		.reply( 200, {
+			domains: [
+				{
+					domain: 'example.com',
+					blog_id: 1,
+					subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Registration' },
+					primary_domain: false,
+					...overrides,
+				},
+				{
+					domain: 'example.wordpress.com',
+					blog_id: 1,
+					subtype: { id: DomainSubtype.DEFAULT_ADDRESS, label: 'Default' },
+					primary_domain: true,
+				},
+			],
+		} );
+}
+
 describe( '<PendingPrimaryDomainNotice>', () => {
+	beforeEach( () => {
+		mockSiteDomains();
+	} );
+
 	afterEach( () => {
 		nock.cleanAll();
 	} );
@@ -54,6 +85,18 @@ describe( '<PendingPrimaryDomainNotice>', () => {
 			points_to_wpcom: true,
 			ssl_status: 'active',
 		} );
+		render( <PendingPrimaryDomainNotice domainName="example.com" /> );
+
+		await waitFor( () => {
+			expect( scope.isDone() ).toBe( true );
+		} );
+		expect( screen.queryByText( 'Setting up your custom domain' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'renders nothing when the site already has a custom primary address', async () => {
+		nock.cleanAll();
+		mockSiteDomains( { primary_domain: true } );
+		const scope = mockDomainQuery( 'example.com' );
 		render( <PendingPrimaryDomainNotice domainName="example.com" /> );
 
 		await waitFor( () => {

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -1,5 +1,5 @@
-import { siteBySlugQuery, siteRedirectQuery } from '@automattic/api-queries';
-import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { domainQuery, siteBySlugQuery, siteRedirectQuery } from '@automattic/api-queries';
+import { useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { Link, useNavigate } from '@tanstack/react-router';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
@@ -27,7 +27,11 @@ import {
 	SITE_CONTEXT_VIEW,
 	useBulkActionsProgressNotice,
 } from '../../domains/dataviews';
-import { hasCustomPrimaryDomain, isPendingPrimaryDomainCandidate } from '../../utils/domain';
+import {
+	hasCustomPrimaryDomain,
+	isPendingPrimaryDomain,
+	isPendingPrimaryDomainCandidate,
+} from '../../utils/domain';
 import { SitesNoticeArbiter } from '../notice-arbiter';
 import PrimaryDomainSelectorNotice from './primary-domain-selector-notice';
 import type { DomainSummary } from '@automattic/api-core';
@@ -49,9 +53,17 @@ function SiteDomains() {
 		},
 	} );
 
-	const pendingDomain = hasCustomPrimaryDomain( siteDomains )
+	// Whether the domain is still pending depends on fields the domains list
+	// doesn't carry, so resolve the candidate before deciding which notice to show.
+	const primaryDomainCandidate = hasCustomPrimaryDomain( siteDomains )
 		? undefined
 		: siteDomains.find( isPendingPrimaryDomainCandidate );
+	const { data: candidateDomain, isLoading: isCheckingCandidate } = useQuery( {
+		...domainQuery( primaryDomainCandidate?.domain ?? '' ),
+		enabled: !! primaryDomainCandidate,
+	} );
+	const pendingDomain =
+		candidateDomain && isPendingPrimaryDomain( candidateDomain ) ? candidateDomain : undefined;
 
 	const { data: redirect } = useSuspenseQuery( siteRedirectQuery( site.ID ) );
 	const hasRedirect = redirect && Object.keys( redirect ).length > 0;
@@ -101,7 +113,7 @@ function SiteDomains() {
 								onComplete={ () => queryClient.invalidateQueries( queries.domainsQuery() ) }
 							/>
 						) }
-						{ ! hasRedirect && ! pendingDomain && (
+						{ ! hasRedirect && ! pendingDomain && ! isCheckingCandidate && (
 							<PrimaryDomainSelectorNotice domains={ siteDomains } site={ site } user={ user } />
 						) }
 						{ hasRedirect && (

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -27,7 +27,7 @@ import {
 	SITE_CONTEXT_VIEW,
 	useBulkActionsProgressNotice,
 } from '../../domains/dataviews';
-import { isPendingPrimaryDomain } from '../../utils/domain';
+import { hasCustomPrimaryDomain, isPendingPrimaryDomainCandidate } from '../../utils/domain';
 import { SitesNoticeArbiter } from '../notice-arbiter';
 import PrimaryDomainSelectorNotice from './primary-domain-selector-notice';
 import type { DomainSummary } from '@automattic/api-core';
@@ -49,7 +49,9 @@ function SiteDomains() {
 		},
 	} );
 
-	const pendingDomain = siteDomains.find( isPendingPrimaryDomain );
+	const pendingDomain = hasCustomPrimaryDomain( siteDomains )
+		? undefined
+		: siteDomains.find( isPendingPrimaryDomainCandidate );
 
 	const { data: redirect } = useSuspenseQuery( siteRedirectQuery( site.ID ) );
 	const hasRedirect = redirect && Object.keys( redirect ).length > 0;

--- a/client/dashboard/sites/domains/index.tsx
+++ b/client/dashboard/sites/domains/index.tsx
@@ -4,6 +4,7 @@ import { Link, useNavigate } from '@tanstack/react-router';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useRef } from 'react';
 import { useAuth } from '../../app/auth';
 import { useAppContext } from '../../app/context';
 import { usePersistentView } from '../../app/hooks/use-persistent-view';
@@ -62,8 +63,16 @@ function SiteDomains() {
 		...domainQuery( primaryDomainCandidate?.domain ?? '' ),
 		enabled: !! primaryDomainCandidate,
 	} );
+	const isCandidatePending = !! candidateDomain && isPendingPrimaryDomain( candidateDomain );
+	// Keep the notice mounted once it has appeared. It shares the polling query
+	// with this page, so dropping it as soon as the domain is set up would unmount
+	// it before it can announce completion and dismiss itself.
+	const hasShownPendingNotice = useRef( false );
+	if ( isCandidatePending ) {
+		hasShownPendingNotice.current = true;
+	}
 	const pendingDomain =
-		candidateDomain && isPendingPrimaryDomain( candidateDomain ) ? candidateDomain : undefined;
+		isCandidatePending || hasShownPendingNotice.current ? candidateDomain : undefined;
 
 	const { data: redirect } = useSuspenseQuery( siteRedirectQuery( site.ID ) );
 	const hasRedirect = redirect && Object.keys( redirect ).length > 0;

--- a/client/dashboard/sites/domains/test/index.test.tsx
+++ b/client/dashboard/sites/domains/test/index.test.tsx
@@ -90,7 +90,16 @@ const nonOwnerUser = {
 	meta: { data: { flags: { active_flags: [] } } },
 } as unknown as User;
 
-function mockApis() {
+// A registration that WordPress.com is still setting up, added to a site that
+// already has a primary address.
+const newlyRegisteredDomain = {
+	...domain,
+	domain: 'second-domain.com',
+	primary_domain: false,
+	can_set_as_primary: true,
+};
+
+function mockApis( domains = [ domain, defaultAddressDomain ] ) {
 	nock( 'https://public-api.wordpress.com' )
 		.get( `/rest/v1.1/sites/${ site.slug }` )
 		.query( true )
@@ -99,7 +108,7 @@ function mockApis() {
 	nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.2/all-domains' )
 		.query( true )
-		.reply( 200, { domains: [ domain, defaultAddressDomain ] } );
+		.reply( 200, { domains } );
 
 	nock( 'https://public-api.wordpress.com' )
 		.get( `/rest/v1.1/sites/${ SITE_ID }/domains/redirect` )
@@ -144,6 +153,28 @@ describe( '<SiteDomains>', () => {
 		render( <SiteDomains />, { user: ownerUser } );
 
 		expect( await screen.findByRole( 'dialog', { name: 'Change site address' } ) ).toBeVisible();
+	} );
+
+	test( 'does not announce a new primary address when the site already has one', async () => {
+		nock.cleanAll();
+		mockApis( [ domain, newlyRegisteredDomain, defaultAddressDomain ] );
+		nock( 'https://public-api.wordpress.com' )
+			.persist()
+			.get( `/rest/v1.2/domain-details/${ newlyRegisteredDomain.domain }` )
+			.query( true )
+			.reply( 200, {
+				...newlyRegisteredDomain,
+				points_to_wpcom: false,
+				ssl_status: 'newly_registered',
+			} );
+
+		render( <SiteDomains />, { user: ownerUser } );
+
+		// The site gets the primary address picker, not the "setting one up" notice.
+		expect(
+			await screen.findByRole( 'link', { name: 'Upgrade to an annual paid plan' } )
+		).toBeVisible();
+		expect( screen.queryByText( 'Setting up your custom domain' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'does not open a modal without the deep link', async () => {

--- a/client/dashboard/sites/domains/test/index.test.tsx
+++ b/client/dashboard/sites/domains/test/index.test.tsx
@@ -90,14 +90,34 @@ const nonOwnerUser = {
 	meta: { data: { flags: { active_flags: [] } } },
 } as unknown as User;
 
-// A registration that WordPress.com is still setting up, added to a site that
-// already has a primary address.
-const newlyRegisteredDomain = {
+const nonPrimaryDomain = {
 	...domain,
 	domain: 'second-domain.com',
 	primary_domain: false,
 	can_set_as_primary: true,
 };
+
+// A site whose primary address is still its included one, so WordPress.com may
+// still set a registered domain as primary on its own.
+const siteAddressIsPrimary = [
+	nonPrimaryDomain,
+	{ ...defaultAddressDomain, primary_domain: true },
+];
+
+function mockDomainDetails( domainName: string, overrides = {} ) {
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( `/rest/v1.2/domain-details/${ domainName }` )
+		.query( true )
+		.reply( 200, {
+			...nonPrimaryDomain,
+			domain: domainName,
+			points_to_wpcom: false,
+			ssl_status: 'newly_registered',
+			registration_date: new Date().toISOString(),
+			...overrides,
+		} );
+}
 
 function mockApis( domains = [ domain, defaultAddressDomain ] ) {
 	nock( 'https://public-api.wordpress.com' )
@@ -157,16 +177,8 @@ describe( '<SiteDomains>', () => {
 
 	test( 'does not announce a new primary address when the site already has one', async () => {
 		nock.cleanAll();
-		mockApis( [ domain, newlyRegisteredDomain, defaultAddressDomain ] );
-		nock( 'https://public-api.wordpress.com' )
-			.persist()
-			.get( `/rest/v1.2/domain-details/${ newlyRegisteredDomain.domain }` )
-			.query( true )
-			.reply( 200, {
-				...newlyRegisteredDomain,
-				points_to_wpcom: false,
-				ssl_status: 'newly_registered',
-			} );
+		mockApis( [ domain, nonPrimaryDomain, defaultAddressDomain ] );
+		mockDomainDetails( nonPrimaryDomain.domain );
 
 		render( <SiteDomains />, { user: ownerUser } );
 
@@ -175,6 +187,31 @@ describe( '<SiteDomains>', () => {
 			await screen.findByRole( 'link', { name: 'Upgrade to an annual paid plan' } )
 		).toBeVisible();
 		expect( screen.queryByText( 'Setting up your custom domain' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'does not announce a primary address the job has given up on', async () => {
+		nock.cleanAll();
+		mockApis( siteAddressIsPrimary );
+		mockDomainDetails( nonPrimaryDomain.domain, {
+			registration_date: '2023-07-10T00:00:00+00:00',
+		} );
+
+		render( <SiteDomains />, { user: ownerUser } );
+
+		expect(
+			await screen.findByRole( 'link', { name: 'Upgrade to an annual paid plan' } )
+		).toBeVisible();
+		expect( screen.queryByText( 'Setting up your custom domain' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'announces a primary address that is still being set up', async () => {
+		nock.cleanAll();
+		mockApis( siteAddressIsPrimary );
+		mockDomainDetails( nonPrimaryDomain.domain );
+
+		render( <SiteDomains />, { user: ownerUser } );
+
+		expect( await screen.findByText( 'Setting up your custom domain' ) ).toBeVisible();
 	} );
 
 	test( 'does not open a modal without the deep link', async () => {

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -413,15 +413,41 @@ export function isTldInMaintenance( domain: Domain ) {
 }
 
 /**
- * Returns true if a domain is a registration that should become primary but
- * the background job hasn't completed yet. Used on CIAB dashboards to show
- * a "setting up" notice.
+ * Returns true if the site already has a custom primary address. WordPress.com
+ * only sets a registered domain as the primary address on its own when the site
+ * doesn't have one yet.
  */
-export function isPendingPrimaryDomain( domain: DomainSummary ): boolean {
+export function hasCustomPrimaryDomain( siteDomains: DomainSummary[] ): boolean {
+	return siteDomains.some(
+		( domain ) => domain.primary_domain && domain.subtype.id !== DomainSubtype.DEFAULT_ADDRESS
+	);
+}
+
+/**
+ * Returns true if a domain is a registration that WordPress.com could set as
+ * the site's primary address on its own. Callers must also check that the site
+ * has no custom primary address yet with hasCustomPrimaryDomain().
+ */
+export function isPendingPrimaryDomainCandidate( domain: DomainSummary ): boolean {
 	return (
 		domain.subtype.id === DomainSubtype.DOMAIN_REGISTRATION &&
 		domain.can_set_as_primary &&
 		! domain.primary_domain &&
 		! domain.expired
+	);
+}
+
+/**
+ * Returns true if a registration is still waiting to be set as the site's
+ * primary address. The background job that does it waits for the domain to
+ * resolve to WordPress.com with a valid certificate, so a domain that already
+ * resolves is not waiting on anything.
+ */
+export function isPendingPrimaryDomain( domain: Domain ): boolean {
+	return (
+		isPendingPrimaryDomainCandidate( domain ) &&
+		( ! domain.points_to_wpcom ||
+			domain.ssl_status === 'pending' ||
+			domain.ssl_status === 'newly_registered' )
 	);
 }

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -437,15 +437,21 @@ export function isPendingPrimaryDomainCandidate( domain: DomainSummary ): boolea
 	);
 }
 
+// The job retries for about 44 hours before it gives up, so a domain registered
+// longer ago than that is not waiting on it any more.
+const PENDING_PRIMARY_DOMAIN_WINDOW_IN_MINUTES = 2 * 24 * 60;
+
 /**
  * Returns true if a registration is still waiting to be set as the site's
- * primary address. The background job that does it waits for the domain to
- * resolve to WordPress.com with a valid certificate, so a domain that already
- * resolves is not waiting on anything.
+ * primary address. The background job that does it is queued when the domain is
+ * registered and waits for the domain to resolve to WordPress.com with a valid
+ * certificate, so a domain that already resolves, or that was registered too
+ * long ago for the job to still be running, is not waiting on anything.
  */
 export function isPendingPrimaryDomain( domain: Domain ): boolean {
 	return (
 		isPendingPrimaryDomainCandidate( domain ) &&
+		isRecentlyRegistered( domain.registration_date, PENDING_PRIMARY_DOMAIN_WINDOW_IN_MINUTES ) &&
 		( ! domain.points_to_wpcom ||
 			domain.ssl_status === 'pending' ||
 			domain.ssl_status === 'newly_registered' )

--- a/client/dashboard/utils/test/domain.js
+++ b/client/dashboard/utils/test/domain.js
@@ -129,6 +129,7 @@ describe( 'utils', () => {
 			expired: false,
 			points_to_wpcom: false,
 			ssl_status: 'newly_registered',
+			registration_date: new Date().toISOString(),
 		};
 
 		test( 'returns true while the domain does not resolve to WordPress.com yet', () => {
@@ -157,6 +158,12 @@ describe( 'utils', () => {
 
 		test( 'returns false when domain is already primary', () => {
 			expect( isPendingPrimaryDomain( { ...baseDomain, primary_domain: true } ) ).toBe( false );
+		} );
+
+		test( 'returns false once the job has had time to give up', () => {
+			expect(
+				isPendingPrimaryDomain( { ...baseDomain, registration_date: '2023-07-10T00:00:00+00:00' } )
+			).toBe( false );
 		} );
 	} );
 

--- a/client/dashboard/utils/test/domain.js
+++ b/client/dashboard/utils/test/domain.js
@@ -3,7 +3,9 @@ import {
 	canEnableAutoRenew,
 	findRegistrantWhois,
 	findPrivacyServiceWhois,
+	hasCustomPrimaryDomain,
 	isPendingPrimaryDomain,
+	isPendingPrimaryDomainCandidate,
 } from '../domain';
 
 describe( 'utils', () => {
@@ -36,30 +38,73 @@ describe( 'utils', () => {
 		} );
 	} );
 
-	describe( 'isPendingPrimaryDomain', () => {
+	describe( 'hasCustomPrimaryDomain', () => {
+		const siteAddress = {
+			subtype: { id: DomainSubtype.DEFAULT_ADDRESS, label: 'Default' },
+			primary_domain: true,
+		};
+		const registration = {
+			subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Registration' },
+			primary_domain: false,
+		};
+
+		test( 'returns false when the included site address is still the primary', () => {
+			expect( hasCustomPrimaryDomain( [ siteAddress, registration ] ) ).toBe( false );
+		} );
+
+		test( 'returns true when a registration is the primary', () => {
+			expect(
+				hasCustomPrimaryDomain( [
+					{ ...siteAddress, primary_domain: false },
+					{ ...registration, primary_domain: true },
+				] )
+			).toBe( true );
+		} );
+
+		test( 'returns true when a connection is the primary', () => {
+			expect(
+				hasCustomPrimaryDomain( [
+					{ ...siteAddress, primary_domain: false },
+					{
+						subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Connection' },
+						primary_domain: true,
+					},
+				] )
+			).toBe( true );
+		} );
+	} );
+
+	describe( 'isPendingPrimaryDomainCandidate', () => {
 		const baseDomain = {
 			subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Registration' },
 			can_set_as_primary: true,
 			primary_domain: false,
+			expired: false,
 		};
 
-		test( 'returns true for a registered domain that can be set as primary but is not yet primary', () => {
-			expect( isPendingPrimaryDomain( baseDomain ) ).toBe( true );
+		test( 'returns true for a registration that is not yet primary', () => {
+			expect( isPendingPrimaryDomainCandidate( baseDomain ) ).toBe( true );
 		} );
 
 		test( 'returns false when domain is already primary', () => {
-			expect( isPendingPrimaryDomain( { ...baseDomain, primary_domain: true } ) ).toBe( false );
-		} );
-
-		test( 'returns false when domain cannot be set as primary', () => {
-			expect( isPendingPrimaryDomain( { ...baseDomain, can_set_as_primary: false } ) ).toBe(
+			expect( isPendingPrimaryDomainCandidate( { ...baseDomain, primary_domain: true } ) ).toBe(
 				false
 			);
 		} );
 
+		test( 'returns false when domain cannot be set as primary', () => {
+			expect(
+				isPendingPrimaryDomainCandidate( { ...baseDomain, can_set_as_primary: false } )
+			).toBe( false );
+		} );
+
+		test( 'returns false when domain is expired', () => {
+			expect( isPendingPrimaryDomainCandidate( { ...baseDomain, expired: true } ) ).toBe( false );
+		} );
+
 		test( 'returns false for non-registration domains', () => {
 			expect(
-				isPendingPrimaryDomain( {
+				isPendingPrimaryDomainCandidate( {
 					...baseDomain,
 					subtype: { id: DomainSubtype.DEFAULT_ADDRESS, label: 'Default' },
 				} )
@@ -68,11 +113,50 @@ describe( 'utils', () => {
 
 		test( 'returns false for domain connections', () => {
 			expect(
-				isPendingPrimaryDomain( {
+				isPendingPrimaryDomainCandidate( {
 					...baseDomain,
 					subtype: { id: DomainSubtype.DOMAIN_CONNECTION, label: 'Connection' },
 				} )
 			).toBe( false );
+		} );
+	} );
+
+	describe( 'isPendingPrimaryDomain', () => {
+		const baseDomain = {
+			subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Registration' },
+			can_set_as_primary: true,
+			primary_domain: false,
+			expired: false,
+			points_to_wpcom: false,
+			ssl_status: 'newly_registered',
+		};
+
+		test( 'returns true while the domain does not resolve to WordPress.com yet', () => {
+			expect( isPendingPrimaryDomain( baseDomain ) ).toBe( true );
+		} );
+
+		test( 'returns true while the certificate is still pending', () => {
+			expect(
+				isPendingPrimaryDomain( {
+					...baseDomain,
+					points_to_wpcom: true,
+					ssl_status: 'pending',
+				} )
+			).toBe( true );
+		} );
+
+		test( 'returns false for a domain that is already set up but is not primary', () => {
+			expect(
+				isPendingPrimaryDomain( {
+					...baseDomain,
+					points_to_wpcom: true,
+					ssl_status: 'active',
+				} )
+			).toBe( false );
+		} );
+
+		test( 'returns false when domain is already primary', () => {
+			expect( isPendingPrimaryDomain( { ...baseDomain, primary_domain: true } ) ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
Part of DOMENG-1081

## Proposed Changes

* Show the "Setting up your custom domain" notice only while WordPress.com is actually setting the domain up, matching the conditions of the backend job that does it (`WPCOM\Async_Flow\Set_Primary_Domain_If_None_Is_Set`): the site has no custom primary address yet, the domain doesn't resolve to WordPress.com with a valid certificate yet, and the job hasn't run out of retries.
* Restores the "Primary site address" notice, which the stale one had been suppressing.

## Why are these changes being made?

The old predicate matched any active registered domain that wasn't the site's primary, so the notice fired for every non-primary domain on every site and never cleared. Nothing was stale or cached, despite the reports: the banner was recomputed correctly from a predicate that had no pending state in it. `can_set_as_primary` means "the user is allowed to set this as primary", and `DomainSummary` carries no pending-primary field.

It shipped for Commerce in a Box, where one just-purchased domain and no prior custom primary made it hold. #109716 then dropped the CIAB guard, on the grounds that the predicate already returned false when it didn't apply.

The domains list decides between the two notices, but its payload carries neither the registration date nor whether the domain resolves, so it now resolves the candidate domain first. That's one extra request, only on sites that have a candidate at all.

## Testing Instructions

Unit tests (each new test fails without the change):

```
yarn test-client client/dashboard/utils/test/domain.js client/dashboard/sites/domains client/dashboard/components/pending-primary-domain-notice
```

Manual tests:

* Apply this PR to your sandbox and sandbox `wordpress.com`
* On a site whose primary address is a custom domain and that has another custom domain, open `/sites/<site>/domains`. The notice should be gone and "Primary site address" shown in its place. Open one of the non-primary domains — gone there too.
* On a site whose primary is still its `*.wordpress.com` address, take an old custom domain that doesn't resolve to WordPress.com (edit its A/CNAME records). The notice should be gone, with "Primary site address" in its place.
* On a site whose primary is still its `*.wordpress.com` address, register a domain. The notice should appear on both pages while it provisions, then clear on its own with a snackbar once the domain becomes primary.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

