### PR TITLE
Onboarding: don't make a finished funnel build wait out a poll interval

### DIFF
--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -148,7 +148,11 @@ export async function startBlueprintArchiveImport(
  */
 export async function waitForBlueprintImportComplete(
 	siteIdentifier: string,
-	{ totalTimeoutSeconds = 900, pollIntervalMs = 5000, initialDelayMs = pollIntervalMs } = {}
+	{
+		totalTimeoutSeconds = 900,
+		pollIntervalMs = 5000,
+		initialDelayMs = pollIntervalMs,
+	}: { totalTimeoutSeconds?: number; pollIntervalMs?: number; initialDelayMs?: number } = {}
 ): Promise< void > {
 	const maxFinishTime = Date.now() + totalTimeoutSeconds * 1000;
 	let lastStatus: string | null | undefined;
@@ -208,7 +212,11 @@ export async function waitForBlueprintImportComplete(
  */
 export async function waitForAtomicTransferComplete(
 	siteIdentifier: string,
-	{ totalTimeoutSeconds = 900, pollIntervalMs = 5000, initialDelayMs = pollIntervalMs } = {}
+	{
+		totalTimeoutSeconds = 900,
+		pollIntervalMs = 5000,
+		initialDelayMs = pollIntervalMs,
+	}: { totalTimeoutSeconds?: number; pollIntervalMs?: number; initialDelayMs?: number } = {}
 ): Promise< void > {
 	const maxFinishTime = Date.now() + totalTimeoutSeconds * 1000;
 	let lastStatus: TransferStates | undefined;

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -139,16 +139,26 @@ export async function startBlueprintArchiveImport(
 /**
  * Poll the site's import status until the backup import finishes.
  * Resolves on success; throws on a terminal failure or timeout.
+ *
+ * `initialDelayMs` defaults to a full poll interval, because a caller that has just *started* the
+ * work must not read the previous run's terminal state: `/atomic/transfers/latest` returns the
+ * site's latest transfer, not the one you asked about (see createRevertedTransferWatcher). Pass 0
+ * only when the work was started before this page existed, where an immediate check is both safe
+ * and the difference between handing over at once and sitting on a loading screen for nothing.
  */
 export async function waitForBlueprintImportComplete(
 	siteIdentifier: string,
-	{ totalTimeoutSeconds = 900, pollIntervalMs = 5000 } = {}
+	{ totalTimeoutSeconds = 900, pollIntervalMs = 5000, initialDelayMs = pollIntervalMs } = {}
 ): Promise< void > {
 	const maxFinishTime = Date.now() + totalTimeoutSeconds * 1000;
 	let lastStatus: string | null | undefined;
+	let delayMs = initialDelayMs;
 
 	while ( Date.now() < maxFinishTime ) {
-		await wait( pollIntervalMs );
+		if ( delayMs > 0 ) {
+			await wait( delayMs );
+		}
+		delayMs = pollIntervalMs;
 
 		try {
 			const status = ( await wpcom.req.get( {
@@ -189,16 +199,26 @@ export async function waitForBlueprintImportComplete(
  * archive restore afterwards, so transfer-complete happens before the content
  * is restored. Pair this with waitForBlueprintImportComplete() for full
  * readiness.
+ *
+ * `initialDelayMs` defaults to a full poll interval, because a caller that has just *started* the
+ * work must not read the previous run's terminal state: `/atomic/transfers/latest` returns the
+ * site's latest transfer, not the one you asked about (see createRevertedTransferWatcher). Pass 0
+ * only when the work was started before this page existed, where an immediate check is both safe
+ * and the difference between handing over at once and sitting on a loading screen for nothing.
  */
 export async function waitForAtomicTransferComplete(
 	siteIdentifier: string,
-	{ totalTimeoutSeconds = 900, pollIntervalMs = 5000 } = {}
+	{ totalTimeoutSeconds = 900, pollIntervalMs = 5000, initialDelayMs = pollIntervalMs } = {}
 ): Promise< void > {
 	const maxFinishTime = Date.now() + totalTimeoutSeconds * 1000;
 	let lastStatus: TransferStates | undefined;
+	let delayMs = initialDelayMs;
 
 	while ( Date.now() < maxFinishTime ) {
-		await wait( pollIntervalMs );
+		if ( delayMs > 0 ) {
+			await wait( delayMs );
+		}
+		delayMs = pollIntervalMs;
 
 		try {
 			const transfer = ( await wpcom.req.get( {

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -7,11 +7,12 @@ import {
 	getBlueprintArchiveSiteSpecUrl,
 	getSiteEditorUrl,
 	getStandaloneBlueprintArchiveSlug,
+	waitForAtomicTransferComplete,
 } from '../blueprint-archive-import';
 
 jest.mock( 'calypso/lib/wp', () => ( {
 	__esModule: true,
-	default: { req: { post: jest.fn() } },
+	default: { req: { post: jest.fn(), get: jest.fn() } },
 } ) );
 
 jest.mock( 'calypso/lib/logstash', () => ( {
@@ -19,6 +20,7 @@ jest.mock( 'calypso/lib/logstash', () => ( {
 } ) );
 
 const mockPost = wpcom.req.post as jest.Mock;
+const mockGet = wpcom.req.get as jest.Mock;
 
 describe( 'getStandaloneBlueprintArchiveSlug', () => {
 	it( 'returns the Blueprint archive slug for a standalone build_dest=wow flow', () => {
@@ -190,5 +192,65 @@ describe( 'getBlueprintArchiveSiteSpecUrl', () => {
 		} );
 
 		expect( url ).not.toContain( 'wow_funnel' );
+	} );
+} );
+
+describe( 'waitForAtomicTransferComplete first-poll timing', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'waits a full interval before its first request by default', async () => {
+		jest.useFakeTimers();
+		mockGet.mockResolvedValue( { status: 'completed' } );
+
+		const pending = waitForAtomicTransferComplete( 'site.example.com', { pollIntervalMs: 5000 } );
+
+		// A caller that just started the work must not read the previous run's terminal state,
+		// so nothing may be asked until an interval has passed.
+		await Promise.resolve();
+		expect( mockGet ).not.toHaveBeenCalled();
+
+		await jest.advanceTimersByTimeAsync( 5000 );
+		await pending;
+		expect( mockGet ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'asks immediately when initialDelayMs is 0, so an already-finished build hands over at once', async () => {
+		jest.useFakeTimers();
+		mockGet.mockResolvedValue( { status: 'completed' } );
+
+		// The funnel's build starts before checkout; making the customer sit through a poll
+		// interval to learn something already true is the whole bug this guards.
+		await waitForAtomicTransferComplete( 'site.example.com', {
+			pollIntervalMs: 5000,
+			initialDelayMs: 0,
+		} );
+
+		expect( mockGet ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'still spaces out later polls when the first says not-yet', async () => {
+		jest.useFakeTimers();
+		mockGet
+			.mockResolvedValueOnce( { status: 'relocating_switcheroo' } )
+			.mockResolvedValue( { status: 'completed' } );
+
+		const pending = waitForAtomicTransferComplete( 'site.example.com', {
+			pollIntervalMs: 5000,
+			initialDelayMs: 0,
+		} );
+
+		await Promise.resolve();
+		await Promise.resolve();
+		expect( mockGet ).toHaveBeenCalledTimes( 1 );
+
+		await jest.advanceTimersByTimeAsync( 5000 );
+		await pending;
+		expect( mockGet ).toHaveBeenCalledTimes( 2 );
 	} );
 } );

--- a/client/landing/stepper/utils/test/wow-funnel.ts
+++ b/client/landing/stepper/utils/test/wow-funnel.ts
@@ -185,15 +185,15 @@ describe( 'waitForWowFunnelReady', () => {
 	it( 'waits only on the transfer for a transfer-readiness funnel', async () => {
 		await waitForWowFunnelReady( { funnelSlug: 'default', siteIdentifier: 'site.example.com' } );
 
-		expect( mockTransferWait ).toHaveBeenCalledWith( 'site.example.com' );
+		expect( mockTransferWait ).toHaveBeenCalledWith( 'site.example.com', { initialDelayMs: 0 } );
 		expect( mockImportWait ).not.toHaveBeenCalled();
 	} );
 
 	it( 'waits on the transfer and then the import for an import-readiness funnel', async () => {
 		await waitForWowFunnelReady( { funnelSlug: 'blueprint', siteIdentifier: 'site.example.com' } );
 
-		expect( mockTransferWait ).toHaveBeenCalledWith( 'site.example.com' );
-		expect( mockImportWait ).toHaveBeenCalledWith( 'site.example.com' );
+		expect( mockTransferWait ).toHaveBeenCalledWith( 'site.example.com', { initialDelayMs: 0 } );
+		expect( mockImportWait ).toHaveBeenCalledWith( 'site.example.com', { initialDelayMs: 0 } );
 	} );
 
 	it( 'throws when the build fails, so the flow routes to the error step', async () => {

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -277,12 +277,19 @@ export async function waitForWowFunnelReady( {
 } ): Promise< void > {
 	const { readiness, waitTimeoutSeconds } = getWowFunnelConfig( funnelSlug );
 
+	// Check before sleeping. A funnel's build starts before checkout, so by the time this runs it
+	// has usually already finished — and the default poll waits a full interval before its first
+	// request, which would hold the customer on a loading screen for five seconds to learn
+	// something that was already true. Safe here precisely because the work predates this page:
+	// there is no risk of reading a previous run's terminal state.
+	const pollNow = { initialDelayMs: 0 };
+
 	const work = ( async () => {
 		// Every readiness level starts with the transfer — the site cannot be ready before it is
 		// Atomic — and `import` simply waits for one more thing behind it.
-		await waitForAtomicTransferComplete( siteIdentifier );
+		await waitForAtomicTransferComplete( siteIdentifier, pollNow );
 		if ( 'import' === readiness ) {
-			await waitForBlueprintImportComplete( siteIdentifier );
+			await waitForBlueprintImportComplete( siteIdentifier, pollNow );
 		}
 	} )();
 


### PR DESCRIPTION
Follow-up to #113876, reported from a real run: about ten seconds on the funnel loading screen while the status requests visible in the network tab already said the transfer was complete.

## Proposed changes

The wait itself was working. The floor was the poll loop: `waitForAtomicTransferComplete` sleeps a full interval **before** its first request, so a build that finished minutes ago still costs five seconds to confirm — and then the transfer poll, the admin-URL lookup and the SSO hop land on top. For the site that prompted this, the build finished 38 seconds after the flow started, long before checkout, so there was never anything to wait for.

`initialDelayMs` is opt-in rather than a change of default, because polling first is **not** safe everywhere: a caller that has just *started* a transfer must not read the site's previous terminal state, since `/atomic/transfers/latest` returns the site's latest transfer rather than the one you asked about. That is the same hazard `createRevertedTransferWatcher` exists for. A funnel's build starts before checkout, so by the time the hand-off page runs there is no earlier run to confuse it with, and an immediate check is both safe and the whole difference between handing over at once and staring at a spinner.

Applied to both waiters, since a funnel with `readiness: 'import'` has the same property — its import is queued server-side before checkout too.

## Testing instructions

`yarn jest client/landing/stepper/utils/test/` — three new tests pin the behaviour:

* the default still waits a full interval before asking (the safety property);
* `initialDelayMs: 0` asks immediately, so an already-finished build hands over at once;
* later polls stay spaced out when the first one says not-yet.

Also ran the whole stepper suite: 124 suites, 892 tests, all passing.

End-to-end, as an Automattician: run `/setup/onboarding?wow_funnel=default` through checkout. The hand-off should be effectively immediate now when the build has already finished, rather than pausing on the loading screen first. The timeout and failure paths are unchanged — block `GET /wpcom/v2/sites/*/atomic/transfers/latest` in DevTools to exercise those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)