### PR TITLE
Onboarding: route the blueprint funnel through the hand-off loading screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -26,10 +26,9 @@ import {
 } from 'calypso/landing/stepper/utils/build-wow';
 import {
 	getWowFunnelDest,
-	getWowFunnelHandoffUrl,
+	getWowFunnelHandoffStepUrl,
 	getWowFunnelSlug,
 	isKnownWowFunnel,
-	waitForWowFunnelReady,
 } from 'calypso/landing/stepper/utils/wow-funnel';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { useSiteSpec } from 'calypso/lib/site-spec';
@@ -403,19 +402,35 @@ const SiteSpec: StepType = function SiteSpec() {
 					site_identifier: blueprintArchiveSiteIdentifier,
 				} );
 
-				// As a funnel interstitial this step owns the funnel's readiness wait, so it
-				// goes through the shared helper — one definition of "ready" per funnel, and one
-				// timeout. Outside a funnel this is a plain blueprint-archive run, which keeps
-				// its own unbounded waits.
+				// As a funnel interstitial, this step's job ends the moment the spec is confirmed.
+				// Hand straight to wow-funnel-handoff and let it own the rest — waiting for the
+				// import, applying the spec, and the redirect. Doing that here instead left the
+				// customer sitting on this form with no indication anything was happening, and
+				// duplicated a terminal sequence that is supposed to live in one place.
 				if ( wowFunnelSlug ) {
-					await waitForWowFunnelReady( {
+					const handoffUrl = getWowFunnelHandoffStepUrl( {
 						funnelSlug: wowFunnelSlug,
-						siteIdentifier: blueprintArchiveSiteIdentifier,
+						dest: wowFunnelDest,
+						siteSlug: queryParams.get( 'siteSlug' ),
+						siteId: queryParams.get( 'siteId' ),
+						specId: getSpecId( specData ),
+						blueprintSlug: blueprintArchiveSlug,
+						// No locale segment: reading it here needs the redux store, which this
+						// step renders without. The hand-off step translates its own copy from
+						// the account locale, and its destination is the site's wp-admin, so the
+						// segment buys nothing worth a store dependency.
 					} );
-				} else {
-					await waitForAtomicTransferComplete( blueprintArchiveSiteIdentifier );
-					await waitForBlueprintImportComplete( blueprintArchiveSiteIdentifier );
+					logBlueprintArchiveEvent( 'redirect_funnel_handoff', {
+						site_identifier: blueprintArchiveSiteIdentifier,
+					} );
+					window.location.assign( handoffUrl );
+					return;
 				}
+
+				// Outside a funnel this is a plain blueprint-archive run, which keeps its own
+				// waits and its own hand-off.
+				await waitForAtomicTransferComplete( blueprintArchiveSiteIdentifier );
+				await waitForBlueprintImportComplete( blueprintArchiveSiteIdentifier );
 
 				// Only once the restore is done: it replaces the site's options
 				// wholesale, so a spec applied earlier would be overwritten.
@@ -432,16 +447,11 @@ const SiteSpec: StepType = function SiteSpec() {
 					has_spec_id: Boolean( specId ),
 				} );
 
-				// Resolved after the wait either way, so the URL names the site that now exists.
-				const siteEditorUrl = wowFunnelSlug
-					? await getWowFunnelHandoffUrl( {
-							dest: wowFunnelDest,
-							siteIdentifier: blueprintArchiveSiteIdentifier,
-							startWalkthrough: applied,
-					  } )
-					: getSiteEditorUrl( await getSiteAdminUrl( blueprintArchiveSiteIdentifier ), {
-							startWalkthrough: applied,
-					  } );
+				// Resolved after the wait, so the URL names the site that now exists.
+				const siteEditorUrl = getSiteEditorUrl(
+					await getSiteAdminUrl( blueprintArchiveSiteIdentifier ),
+					{ startWalkthrough: applied }
+				);
 
 				logBlueprintArchiveEvent( 'redirect_site_editor', {
 					site_identifier: blueprintArchiveSiteIdentifier,
@@ -457,7 +467,13 @@ const SiteSpec: StepType = function SiteSpec() {
 				isSubmittingRef.current = false;
 			}
 		},
-		[ blueprintArchiveSiteIdentifier, blueprintArchiveSlug, wowFunnelSlug, wowFunnelDest ]
+		[
+			blueprintArchiveSiteIdentifier,
+			blueprintArchiveSlug,
+			queryParams,
+			wowFunnelSlug,
+			wowFunnelDest,
+		]
 	);
 
 	// Kick off the background transfer + blueprint-archive import as soon as the

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wow-funnel-handoff/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wow-funnel-handoff/index.tsx
@@ -11,6 +11,7 @@ import {
 	getWowFunnelSlug,
 	isKnownWowFunnel,
 	logWowFunnelEvent,
+	runWowFunnelAfterReady,
 	waitForWowFunnelReady,
 } from 'calypso/landing/stepper/utils/wow-funnel';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
@@ -44,6 +45,10 @@ const WowFunnelHandoff: StepType = function WowFunnelHandoff( { navigation, flow
 	const dest = getWowFunnelDest( queryParams, funnelSlug );
 	const siteSlug = queryParams.get( 'siteSlug' );
 	const siteId = queryParams.get( 'siteId' );
+	// Input for the funnel's post-ready work, carried here because flow state does not survive
+	// the page loads between checkout, an interstitial and this step.
+	const specId = queryParams.get( 'spec_id' );
+	const blueprintSlug = queryParams.get( 'blueprint_slug' );
 	const siteIdentifier = siteSlug || ( siteId && siteId !== '0' ? siteId : null );
 
 	// Strict mode mounts effects twice, and this one navigates away; a second run would start a
@@ -79,9 +84,24 @@ const WowFunnelHandoff: StepType = function WowFunnelHandoff( { navigation, flow
 			try {
 				await waitForWowFunnelReady( { funnelSlug, siteIdentifier } );
 
+				// Whatever the funnel does between "ready" and "handed over" — for the blueprint
+				// funnel, writing the confirmed spec onto the imported site. Ordering is the
+				// point: the archive restore replaces the site's options wholesale, so this can
+				// only run once the wait above says the import is done.
+				const { startWalkthrough } = await runWowFunnelAfterReady( {
+					funnelSlug,
+					siteIdentifier,
+					specId,
+					blueprintSlug,
+				} );
+
 				// Resolved only now, so it names the site that exists after the transfer rather
 				// than the one this flow started with.
-				const handoffUrl = await getWowFunnelHandoffUrl( { dest, siteIdentifier } );
+				const handoffUrl = await getWowFunnelHandoffUrl( {
+					dest,
+					siteIdentifier,
+					startWalkthrough,
+				} );
 
 				logWowFunnelEvent( 'handoff_redirect', { funnel: funnelSlug, dest } );
 				window.location.replace( handoffUrl );
@@ -97,7 +117,17 @@ const WowFunnelHandoff: StepType = function WowFunnelHandoff( { navigation, flow
 				);
 			}
 		} )();
-	}, [ __, dest, funnelSlug, requestedFunnelSlug, setSiteSetupError, siteIdentifier, submit ] );
+	}, [
+		__,
+		blueprintSlug,
+		dest,
+		funnelSlug,
+		requestedFunnelSlug,
+		setSiteSetupError,
+		siteIdentifier,
+		specId,
+		submit,
+	] );
 
 	const title = __( 'Getting your site ready…' );
 

--- a/client/landing/stepper/utils/test/wow-funnel.ts
+++ b/client/landing/stepper/utils/test/wow-funnel.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import {
+	applyBlueprintSpec,
 	waitForAtomicTransferComplete,
 	waitForBlueprintImportComplete,
 } from '../blueprint-archive-import';
@@ -10,8 +11,10 @@ import {
 	getRememberedWowFunnelSite,
 	getWowFunnelConfig,
 	getWowFunnelDest,
+	getWowFunnelHandoffStepUrl,
 	getWowFunnelKey,
 	isKnownWowFunnel,
+	runWowFunnelAfterReady,
 	waitForWowFunnelReady,
 	wowFunnelSiteIsPaid,
 } from '../wow-funnel';
@@ -26,10 +29,12 @@ jest.mock( '../blueprint-archive-import', () => ( {
 	waitForBlueprintImportComplete: jest.fn( () => Promise.resolve() ),
 	getSiteAdminUrl: jest.fn(),
 	getSiteEditorUrl: jest.fn(),
+	applyBlueprintSpec: jest.fn( () => Promise.resolve( true ) ),
 } ) );
 
 const mockTransferWait = waitForAtomicTransferComplete as jest.Mock;
 const mockImportWait = waitForBlueprintImportComplete as jest.Mock;
+const mockApplySpec = applyBlueprintSpec as jest.Mock;
 
 const never = () => new Promise< void >( () => {} );
 
@@ -246,5 +251,89 @@ describe( 'waitForWowFunnelReady', () => {
 		await Promise.resolve();
 
 		jest.useRealTimers();
+	} );
+} );
+
+describe( 'getWowFunnelHandoffStepUrl', () => {
+	it( 'carries everything the hand-off needs, since flow state does not survive the page loads', () => {
+		const url = getWowFunnelHandoffStepUrl( {
+			funnelSlug: 'blueprint',
+			dest: 'editor',
+			siteSlug: 'site.example.com',
+			siteId: 123,
+			specId: 'spec-abc',
+			blueprintSlug: 'coachava',
+		} );
+
+		expect( url ).toContain( '/setup/onboarding/wow-funnel-handoff' );
+		expect( url ).toContain( 'wow_funnel=blueprint' );
+		expect( url ).toContain( 'spec_id=spec-abc' );
+		expect( url ).toContain( 'blueprint_slug=coachava' );
+	} );
+
+	it( "omits a zero site id, which would poison the next page's site lookup", () => {
+		const url = getWowFunnelHandoffStepUrl( {
+			funnelSlug: 'default',
+			dest: 'editor',
+			siteSlug: 'site.example.com',
+			siteId: 0,
+		} );
+
+		expect( url ).not.toContain( 'siteId' );
+	} );
+} );
+
+describe( 'runWowFunnelAfterReady', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockApplySpec.mockImplementation( () => Promise.resolve( true ) );
+	} );
+
+	it( 'does nothing for a funnel with no post-ready work', async () => {
+		const result = await runWowFunnelAfterReady( {
+			funnelSlug: 'default',
+			siteIdentifier: 'site.example.com',
+			specId: 'spec-abc',
+		} );
+
+		expect( mockApplySpec ).not.toHaveBeenCalled();
+		expect( result.startWalkthrough ).toBe( false );
+	} );
+
+	it( 'applies the spec for the blueprint funnel and starts the walkthrough', async () => {
+		const result = await runWowFunnelAfterReady( {
+			funnelSlug: 'blueprint',
+			siteIdentifier: 'site.example.com',
+			specId: 'spec-abc',
+			blueprintSlug: 'coachava',
+		} );
+
+		expect( mockApplySpec ).toHaveBeenCalledWith( 'site.example.com', 'spec-abc', 'coachava' );
+		expect( result.startWalkthrough ).toBe( true );
+	} );
+
+	it( 'skips the work when there is no spec to apply', async () => {
+		const result = await runWowFunnelAfterReady( {
+			funnelSlug: 'blueprint',
+			siteIdentifier: 'site.example.com',
+			specId: null,
+		} );
+
+		expect( mockApplySpec ).not.toHaveBeenCalled();
+		expect( result.startWalkthrough ).toBe( false );
+	} );
+
+	it( 'does not start the walkthrough when applying the spec failed', async () => {
+		// applyBlueprintSpec resolves either way by design: losing personalization must not
+		// cost the customer the site they paid for.
+		mockApplySpec.mockImplementation( () => Promise.resolve( false ) );
+
+		const result = await runWowFunnelAfterReady( {
+			funnelSlug: 'blueprint',
+			siteIdentifier: 'site.example.com',
+			specId: 'spec-abc',
+		} );
+
+		expect( result.startWalkthrough ).toBe( false );
 	} );
 } );

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -1,6 +1,9 @@
+import { addQueryArgs } from '@wordpress/url';
+import { withLocale } from 'calypso/landing/stepper/declarative-flow/helpers/with-locale';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { getTransferFailureMessage } from './atomic-transfer-outcome';
 import {
+	applyBlueprintSpec,
 	getSiteAdminUrl,
 	getSiteEditorUrl,
 	waitForAtomicTransferComplete,
@@ -50,6 +53,17 @@ export type WowFunnelInterstitial = 'site-spec';
  */
 export type WowFunnelReadiness = 'transfer' | 'import';
 
+/**
+ * Work a funnel runs once its build is ready and before the customer is handed over.
+ *
+ * - `apply-blueprint-spec` — writes the owner's confirmed details onto the imported site.
+ *
+ * It has to happen here rather than in the interstitial that collected the input, because the
+ * blueprint restore replaces the site's options wholesale: anything applied before the import
+ * finishes is overwritten. Ready, then apply, then hand over.
+ */
+export type WowFunnelAfterReady = 'apply-blueprint-spec';
+
 export type WowFunnelConfig = {
 	/** Calypso-side hops between checkout and the hand-off, in order. */
 	interstitials: WowFunnelInterstitial[];
@@ -59,6 +73,8 @@ export type WowFunnelConfig = {
 	readiness: WowFunnelReadiness;
 	/** How long that wait runs before it gives up and raises a timeout. */
 	waitTimeoutSeconds: number;
+	/** Optional work to run after the build is ready, before the hand-off. */
+	afterReady?: WowFunnelAfterReady;
 };
 
 const DEFAULT_WOW_FUNNEL_CONFIG: WowFunnelConfig = {
@@ -82,6 +98,7 @@ const WOW_FUNNEL_CONFIG: Record< string, Partial< WowFunnelConfig > > = {
 	blueprint: {
 		interstitials: [ 'site-spec' ],
 		readiness: 'import',
+		afterReady: 'apply-blueprint-spec',
 		// The archive restore is genuinely long; this matches the wait site-spec already ran.
 		waitTimeoutSeconds: 900,
 	},
@@ -353,4 +370,92 @@ export async function getWowFunnelHandoffUrl( {
 			return getSiteEditorUrl( adminUrl, { canvasEdit: true, path: '/', startWalkthrough } );
 		}
 	}
+}
+
+/**
+ * Slug of the step that holds the customer while the build finishes, then hands over.
+ *
+ * Every funnel ends here, whether it reached it straight from checkout or by way of an
+ * interstitial, so the terminal behaviour is defined in exactly one place.
+ */
+export const WOW_FUNNEL_HANDOFF_STEP = 'wow-funnel-handoff';
+
+// Mirrors ONBOARDING_FLOW rather than importing it: that constant lives in the
+// '@automattic/onboarding' barrel, which is precisely what this module was split away from (see
+// wow-funnel-site.ts). One string is a cheaper price than dragging the component library back in.
+const WOW_FUNNEL_FLOW = 'onboarding';
+
+/**
+ * URL of the hand-off step, with everything it needs to finish the funnel on its own.
+ *
+ * It is reached by a fresh page load — from checkout, or from an interstitial in another flow —
+ * so nothing can be assumed to survive in flow state. Whatever the last leg needs travels in the
+ * query string.
+ */
+export function getWowFunnelHandoffStepUrl( {
+	funnelSlug,
+	dest,
+	siteSlug,
+	siteId,
+	specId,
+	blueprintSlug,
+	locale = '',
+}: {
+	funnelSlug: string;
+	dest: WowFunnelDest;
+	siteSlug?: string | null;
+	siteId?: string | number | null;
+	specId?: string | null;
+	blueprintSlug?: string | null;
+	locale?: string;
+} ): string {
+	return addQueryArgs(
+		withLocale( `/setup/${ WOW_FUNNEL_FLOW }/${ WOW_FUNNEL_HANDOFF_STEP }`, locale ),
+		{
+			wow_funnel: funnelSlug,
+			dest,
+			...( siteSlug ? { siteSlug } : {} ),
+			// Skip a 0/falsy siteId: "0" in the URL poisons the next page's site lookup.
+			...( siteId && String( siteId ) !== '0' ? { siteId: String( siteId ) } : {} ),
+			...( specId ? { spec_id: specId } : {} ),
+			...( blueprintSlug ? { blueprint_slug: blueprintSlug } : {} ),
+		}
+	);
+}
+
+/**
+ * Run the funnel's post-ready work, if its definition has any.
+ *
+ * Mirrors the server registry's `follow_up`: the funnel decides what happens, the hand-off step
+ * only knows that something might. Returns whether the hand-off should start the walkthrough,
+ * which today is the same question as "did a spec get applied".
+ *
+ * Never throws. A funnel that gets this far has a built site the customer paid for; failing to
+ * personalise it costs them some copy, not their site, so it must not turn into an error screen.
+ */
+export async function runWowFunnelAfterReady( {
+	funnelSlug,
+	siteIdentifier,
+	specId,
+	blueprintSlug,
+}: {
+	funnelSlug: string;
+	siteIdentifier: string;
+	specId?: string | null;
+	blueprintSlug?: string | null;
+} ): Promise< { startWalkthrough: boolean } > {
+	const { afterReady } = getWowFunnelConfig( funnelSlug );
+
+	if ( 'apply-blueprint-spec' !== afterReady || ! specId ) {
+		return { startWalkthrough: false };
+	}
+
+	const applied = await applyBlueprintSpec( siteIdentifier, specId, blueprintSlug );
+	logWowFunnelEvent( 'after_ready_applied', {
+		funnel: funnelSlug,
+		action: afterReady,
+		applied,
+	} );
+
+	return { startWalkthrough: applied };
 }


### PR DESCRIPTION
Follow-up to #113876 and #113881, which introduced the hand-off step but only wired the `default` funnel to it.

## Proposed changes

Confirming the spec left the customer sitting on the spec form with nothing to show for it. The wait was real and correct — it just had no UI, because site-spec still ran the whole terminal sequence inline and never reached `wow-funnel-handoff`.

Both funnels now end the same way:

```
default:    checkout →        WAIT(transfer) →                 hand-off
blueprint:  checkout → spec →  WAIT(import)  → apply spec →    hand-off
```

* **site-spec's job ends when the spec is confirmed.** It hands to `wow-funnel-handoff`, which owns waiting for the import, applying the spec, and the redirect. That was the point of the interstitial model: a funnel's terminal behaviour lives in one place no matter how many Calypso steps precede it.
* **Post-ready work is declared on the funnel, not branched on in the step.** `afterReady: 'apply-blueprint-spec'` mirrors the server registry's `follow_up`, so a second funnel needing its own finishing work is a config edit rather than another conditional in the hand-off.
* **The ordering constraint is why this can't stay in site-spec.** The archive restore replaces the site's options wholesale, so the spec can only be applied *after* the import finishes. Ready, then apply, then hand over.
* **Plain blueprint-archive runs are untouched.** Without `wow_funnel` in the URL, site-spec keeps its own inline waits and hand-off.

The hand-off URL carries `spec_id` and `blueprint_slug` because the step is reached by a fresh page load from another flow, where nothing survives in flow state.

Two deliberate omissions worth reviewing:

* **No locale segment on the hand-off URL.** Reading one needs the redux store, which site-spec's tests render without, and the step translates its own copy from the account locale regardless. Adding it broke three existing tests for a URL segment that buys nothing here.
* **`runWowFunnelAfterReady` never throws.** A funnel that reaches it has a built site the customer paid for; failing to personalise costs them some copy, not their site, so it must not become an error screen.

## Testing instructions

Unit: `yarn jest client/landing/stepper/utils/test/wow-funnel.ts` — 28 tests, including the hand-off URL contents, the zero-site-id guard, and the four `afterReady` paths (no-op funnel, spec applied, no spec, apply failed). Whole stepper suite is green at 124 suites / 898 tests.

End-to-end, as an Automattician:

1. `ENTRY_LIMIT=entry-main,entry-stepper SECTION_LIMIT=signup,checkout yarn start`
2. Enter the blueprint funnel and go through checkout to the site-spec step.
3. Confirm the spec. **You should now leave the form immediately** and land on the hand-off loading screen, instead of the form sitting there while the import finishes.
4. When the import completes you should land in the Site Editor with the walkthrough started, which is the signal the spec was applied after the restore rather than being overwritten by it.
5. Separately, confirm a non-funnel blueprint-archive run — a `blueprint_archive_import=1` URL with no `wow_funnel` — still finishes the way it did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)