### PR TITLE
Omnibar: map the Emails and Plugins nodes to their legacy masterbar events

### DIFF
--- a/client/dashboard/app/omnibar/tracking.ts
+++ b/client/dashboard/app/omnibar/tracking.ts
@@ -10,6 +10,8 @@ const LEGACY_MASTERBAR_EVENTS: Record< string, string > = {
 	'wp-logo': 'calypso_masterbar_my_sites_clicked',
 	'wpcom-sites': 'calypso_masterbar_sites_clicked',
 	'wpcom-domains': 'calypso_masterbar_domains_clicked',
+	'wpcom-emails': 'calypso_masterbar_emails_clicked',
+	'wpcom-plugins': 'calypso_masterbar_plugins_clicked',
 	about: 'calypso_masterbar_about_wordpress_clicked',
 	contribute: 'calypso_masterbar_get_involved_clicked',
 	'view-site': 'calypso_masterbar_visit_site_clicked',


### PR DESCRIPTION
Related to DOTMSD-1338
Follow-up to #111871

## Proposed Changes

* Fire the legacy `calypso_masterbar_emails_clicked` and `calypso_masterbar_plugins_clicked` events when the Emails and Plugins items in the omnibar's W-icon menu are clicked.

## Why are these changes being made?

#111871 added Emails and Plugins to the W-icon dropdown in the classic Calypso masterbar, where each item records a legacy masterbar tracks event. The omnibar builds the same menu from the admin bar API instead, and keeps a map of node IDs to those same legacy events so the old data series stay continuous while the omnibar rolls out. That map was missed in the original PR, so the two new items would be the only ones in the menu without their legacy event.

The matching admin bar nodes are added in Automattic/jetpack#49822; this PR only covers the tracking side, and is a no-op until those nodes ship.

## Testing Instructions

* With `dashboard/omnibar-radical` enabled and the Jetpack branch above sandboxed, open the WordPress.com logo menu and click Emails, then Plugins.
* In the tracks debug output, confirm each click records both `calypso_omnibar_node_click` and the corresponding legacy `calypso_masterbar_*_clicked` event, matching the behaviour of the Sites and Domains items alongside them.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01RqVXFvpNwz4GeFfssYkV9G
