### PR TITLE
Blueprint hand-off: stop starting the copy walkthrough on arrival

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -437,10 +437,9 @@ const SiteSpec: StepType = function SiteSpec() {
 					? await getWowFunnelHandoffUrl( {
 							dest: wowFunnelDest,
 							siteIdentifier: blueprintArchiveSiteIdentifier,
-							startWalkthrough: applied,
 					  } )
 					: getSiteEditorUrl( await getSiteAdminUrl( blueprintArchiveSiteIdentifier ), {
-							startWalkthrough: applied,
+							canvasEdit: applied,
 					  } );
 
 				logBlueprintArchiveEvent( 'redirect_site_editor', {

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -318,37 +318,26 @@ export async function getSiteAdminUrl( siteIdentifier: string ): Promise< string
  */
 export function getSiteEditorUrl(
 	adminUrl: string,
-	{
-		startWalkthrough = false,
-		canvasEdit = false,
-		path,
-	}: { startWalkthrough?: boolean; canvasEdit?: boolean; path?: string } = {}
+	{ canvasEdit = false, path }: { canvasEdit?: boolean; path?: string } = {}
 ): string {
 	const base = adminUrl.endsWith( '/' ) ? adminUrl : `${ adminUrl }/`;
 	const url = `${ base }site-editor.php`;
 
-	// `go` tells Big Sky this arrival came from onboarding, so it personalizes the
-	// copy instead of waiting to be spoken to. It never re-runs: the flag stays in
-	// the editor URL, so a site that has already been personalized has to see it
-	// and do nothing. `reset` is the way to run it again.
+	// The hand-off used to carry `blueprint-walkthrough=go`, which told Big Sky to
+	// open the conversation itself and rewrite the page's copy while the customer
+	// watched. That walkthrough is rolled back for now, so nothing here starts it
+	// and the editor opens quietly. The wpcom side still understands the
+	// parameter, so bringing it back is a small change here.
 	//
-	// `canvas=edit` is load-bearing: Big Sky's assembler only mounts on the
-	// editing canvas (useShouldLoadBigSky requires canvasMode === 'edit'), and a
-	// plain site-editor.php load stays in view mode — the kickoff, the copy mask,
-	// and the walkthrough all silently never run without it. The welcome-guide
-	// overlay this parameter was once blamed for came from sites where Big Sky
-	// had not been enabled by hand-off time (the enable race fixed on the wpcom
-	// side); when Big Sky mounts, it suppresses the guide itself.
-	//
-	// Only set when the spec applied; there is nothing to personalize from
-	// otherwise.
+	// `canvas=edit` stays, and is load-bearing for reasons of its own: Big Sky's
+	// assembler only mounts on the editing canvas (useShouldLoadBigSky requires
+	// canvasMode === 'edit'), and a plain site-editor.php load stays in view mode,
+	// so the assistant never appears at all. The welcome-guide overlay this
+	// parameter was once blamed for came from sites where Big Sky had not been
+	// enabled by hand-off time (the enable race fixed on the wpcom side); when Big
+	// Sky mounts, it suppresses the guide itself.
 	const args: Record< string, string > = {};
-	if ( startWalkthrough ) {
-		args[ 'blueprint-walkthrough' ] = 'go';
-	}
-	// The walkthrough needs the editing canvas; a caller can also ask for it on its own, which is
-	// what the funnel hand-off does — a plain site-editor.php load stays in view mode.
-	if ( startWalkthrough || canvasEdit ) {
+	if ( canvasEdit ) {
 		args.canvas = 'edit';
 	}
 	if ( path ) {

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -130,37 +130,37 @@ describe( 'getSiteEditorUrl', () => {
 	 */
 	it( 'keeps the redirect relative', () => {
 		const url = getSiteEditorUrl( 'https://example.com/wp-admin/', {
-			startWalkthrough: true,
+			canvasEdit: true,
 		} );
 		const redirect = new URL( url ).searchParams.get( 'redirect_to' );
 
-		expect( redirect ).toBe( '/wp-admin/site-editor.php?blueprint-walkthrough=go&canvas=edit' );
-	} );
-
-	/**
-	 * The flag is how Big Sky knows to open the copy walkthrough instead of
-	 * waiting for the customer to speak first.
-	 */
-	it( 'flags the walkthrough when the spec was applied', () => {
-		expect(
-			getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } )
-		).toContain( encodeURIComponent( 'blueprint-walkthrough=go' ) );
+		expect( redirect ).toBe( '/wp-admin/site-editor.php?canvas=edit' );
 	} );
 
 	/**
 	 * Big Sky's assembler only mounts on the editing canvas; a plain
-	 * site-editor.php load stays in view mode and the walkthrough silently
-	 * never starts. The hand-off must force edit mode.
+	 * site-editor.php load stays in view mode and the assistant never appears.
+	 * The hand-off must force edit mode.
 	 */
 	it( 'forces the editing canvas so Big Sky mounts', () => {
-		expect(
-			getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: true } )
-		).toContain( encodeURIComponent( 'canvas=edit' ) );
+		expect( getSiteEditorUrl( 'https://example.com/wp-admin/', { canvasEdit: true } ) ).toContain(
+			encodeURIComponent( 'canvas=edit' )
+		);
 	} );
 
-	it( 'leaves the flag off when the spec did not apply', () => {
+	it( 'leaves the canvas alone when the spec did not apply', () => {
 		expect(
-			getSiteEditorUrl( 'https://example.com/wp-admin/', { startWalkthrough: false } )
+			getSiteEditorUrl( 'https://example.com/wp-admin/', { canvasEdit: false } )
+		).not.toContain( 'canvas' );
+	} );
+
+	/**
+	 * The copy walkthrough is rolled back: the editor opens quietly and the
+	 * customer speaks first. Nothing on the hand-off may start it.
+	 */
+	it( 'never asks Big Sky to start the copy walkthrough', () => {
+		expect(
+			getSiteEditorUrl( 'https://example.com/wp-admin/', { canvasEdit: true, path: '/' } )
 		).not.toContain( 'blueprint-walkthrough' );
 	} );
 } );

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -338,11 +338,9 @@ export async function waitForWowFunnelReady( {
 export async function getWowFunnelHandoffUrl( {
 	dest,
 	siteIdentifier,
-	startWalkthrough = false,
 }: {
 	dest: WowFunnelDest;
 	siteIdentifier: string;
-	startWalkthrough?: boolean;
 } ): Promise< string > {
 	switch ( dest ) {
 		case 'editor':
@@ -350,7 +348,7 @@ export async function getWowFunnelHandoffUrl( {
 			const adminUrl = await getSiteAdminUrl( siteIdentifier );
 			// `p` opens the front page rather than whatever the editor last had; `canvasEdit`
 			// because a plain site-editor.php load stays in view mode.
-			return getSiteEditorUrl( adminUrl, { canvasEdit: true, path: '/', startWalkthrough } );
+			return getSiteEditorUrl( adminUrl, { canvasEdit: true, path: '/' } );
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* The editor URL built after blueprint spec confirm no longer carries `blueprint-walkthrough=go`. The customer lands in the editor and it stays quiet until they say something.
* `getSiteEditorUrl()` drops the `startWalkthrough` option outright rather than keeping a flag nothing sets. `canvasEdit` already existed beside it and stays — Big Sky's assembler only mounts when `canvasMode === 'edit'`, so without it the assistant never appears at all, and dropping it is what broke this flow in #113751. The blueprint hand-off now asks for `canvasEdit` on the same condition the walkthrough used to run on, so which arrivals get edit mode is unchanged.
* `getWowFunnelHandoffUrl()` only threaded the flag through to the same place, so it loses it too. The funnel hand-off already passed `canvasEdit: true` on its own and is otherwise untouched.

## Why are these changes being made?

The hand-off flag told Big Sky to open the conversation itself and rewrite the page's copy while the customer watched it happen. That is more than the hand-off should be doing unasked, so the copy walkthrough is paused while we reconsider it.

Removing the flag here is only half of it. The backend used to activate the walkthrough on any blueprint-built site, so without a matching change the editor would still greet people with an offer to rewrite their page. The wpcom half — `237570-ghe-Automattic/wpcom` — gates activation on the parameter, so with nothing sending it the flow is dormant end to end. Merge order does not matter: either half alone is a partial rollback, neither is a breakage.

The parameter is still understood on both sides, so turning this back on is a small change here.

## Testing Instructions

* Run the blueprint onboarding flow to the spec-confirm step (the `site-spec` step with `blueprint_archive_import=1&blueprint_slug=<slug>`) and confirm the spec.
* Watch the redirect. The editor URL should be `…/wp-admin/site-editor.php?canvas=edit` behind the SSO round trip — `canvas=edit` present, `blueprint-walkthrough` gone.
* The editor loads in edit mode with the Big Sky assistant docked. The page copy is not blurred, no message is sent on your behalf, and no offer to rewrite the copy appears. Type something and the assistant answers normally.
* Confirm the SSO leg still works: you arrive logged in to wp-admin rather than at a login form.
* Run the wow-funnel hand-off too (`wow_funnel` in the site-spec query string). It should still land on the front page in edit mode — `canvas=edit&p=%2F` — with no walkthrough parameter and no rewrite.
* Then append `&blueprint-walkthrough=reset` to either editor URL by hand. The walkthrough still runs in full — proof the mechanism is paused rather than removed.

## Related to

* `237570-ghe-Automattic/wpcom` — the wpcom half, which gates walkthrough activation on the parameter
* Reverses the hand-off flag added in #113693; keeps the `canvas=edit` fix from #113787
