### PR TITLE
Notifications: record notes query response times in Tracks

### DIFF
--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -22,6 +22,48 @@ const settings = {
 	max_limit: 200,
 };
 
+// getNotesList is a background poll running on every logged-in page, so it is
+// sampled to keep it from swamping the other queries; weight by `sample_rate`.
+const QUERY_SAMPLE_RATES = {
+	getNote: 1,
+	getNotes: 1,
+	getFilteredNotes: 1,
+	getNotesList: 0.01,
+};
+
+/**
+ * Wrap a notes query callback so its round-trip time reaches Tracks.
+ *
+ * Timing stops before `callback` runs, so the measurement covers the request
+ * itself — network included — and not the store updates its response triggers.
+ * @param {string} request Name of the calling query, matching its logError tag.
+ * @param {Object} properties Extra props describing the query.
+ * @param {Function} callback The original wpcom callback.
+ * @returns {Function} A callback that records timing, then delegates.
+ */
+function timeQuery( request, properties, callback ) {
+	const sampleRate = QUERY_SAMPLE_RATES[ request ];
+	const isSampled = Math.random() < sampleRate;
+	const startedAt = isSampled ? performance.now() : 0;
+
+	return ( error, data ) => {
+		if ( isSampled ) {
+			recordTracksEvent( 'calypso_notification_query_response', {
+				request,
+				response_time_in_ms: Math.round( performance.now() - startedAt ),
+				sample_rate: sampleRate,
+				result: error ? 'error' : 'success',
+				status: error?.status ?? null,
+				code: error?.error ?? null,
+				note_count: data?.notes?.length ?? null,
+				...properties,
+			} );
+		}
+
+		callback( error, data );
+	};
+}
+
 export function Client() {
 	this.noteList = [];
 	this.gettingNotes = false;
@@ -167,14 +209,18 @@ function getNote( note_id ) {
 		fields: 'id,type,unread,body,subject,timestamp,meta,note_hash,variant',
 	};
 
-	fetchNote( note_id, parameters, ( error, data ) => {
-		if ( error ) {
-			logError( error, { request: 'getNote', note_id, status: error.status, code: error.error } );
-			return;
-		}
-		store.dispatch( actions.notes.addNotes( data.notes ) );
-		ready.call( this );
-	} );
+	fetchNote(
+		note_id,
+		parameters,
+		timeQuery( 'getNote', {}, ( error, data ) => {
+			if ( error ) {
+				logError( error, { request: 'getNote', note_id, status: error.status, code: error.error } );
+				return;
+			}
+			store.dispatch( actions.notes.addNotes( data.notes ) );
+			ready.call( this );
+		} )
+	);
 }
 
 /**
@@ -217,7 +263,7 @@ function getNotes( before ) {
 		store.dispatch( actions.ui.loadNotes() );
 	}
 
-	listNotes( parameters, ( error, data ) => {
+	const onNotes = ( error, data ) => {
 		this.gettingNotes = false;
 
 		if ( error ) {
@@ -324,7 +370,12 @@ function getNotes( before ) {
 		if ( this.filter ) {
 			this.getFilteredNotes();
 		}
-	} );
+	};
+
+	listNotes(
+		parameters,
+		timeQuery( 'getNotes', { number: parameters.number, is_load_more: Boolean( before ) }, onNotes )
+	);
 }
 
 function getNotesList() {
@@ -344,7 +395,7 @@ function getNotesList() {
 		number: settings.initial_limit,
 	};
 
-	listNotes( parameters, ( error, data ) => {
+	const onNotesList = ( error, data ) => {
 		debug( 'getNotesList callback:', error, data );
 		this.gettingNotes = false;
 		if ( error ) {
@@ -414,7 +465,9 @@ function getNotesList() {
 
 		/* Grab updates/changes from server if they exist */
 		return serverHasChanges ? this.getNotes() : ready.call( this );
-	} );
+	};
+
+	listNotes( parameters, timeQuery( 'getNotesList', { number: parameters.number }, onNotesList ) );
 }
 
 /**
@@ -478,7 +531,7 @@ function getFilteredNotes( before ) {
 		store.dispatch( actions.ui.loadNotes( { filter: key } ) );
 	}
 
-	listNotes( parameters, ( error, data ) => {
+	const onFilteredNotes = ( error, data ) => {
 		this.gettingFilteredNotes = false;
 
 		// A tab switch while this was in flight left the newly-active tab's own
@@ -551,7 +604,16 @@ function getFilteredNotes( before ) {
 		if ( activeTabNeedsFetch ) {
 			this.getFilteredNotes();
 		}
-	} );
+	};
+
+	listNotes(
+		parameters,
+		timeQuery(
+			'getFilteredNotes',
+			{ number: parameters.number, filter: key, is_load_more: Boolean( before ) },
+			onFilteredNotes
+		)
+	);
 }
 
 /**

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -786,4 +786,102 @@ describe( 'RestClient', () => {
 			expect( client.gettingFilteredNotes ).toBe( true );
 		} );
 	} );
+
+	describe( 'query timing', () => {
+		const timingEvents = () =>
+			( window._tkq || [] )
+				.filter( ( [ , event ] ) => event === 'calypso_notification_query_response' )
+				.map( ( [ , , properties ] ) => properties );
+
+		beforeEach( () => {
+			window._tkq = [];
+			// Sampling is a coin flip; pin it so every rate below 1 is excluded and
+			// each test opts in explicitly.
+			jest.spyOn( Math, 'random' ).mockReturnValue( 0.5 );
+		} );
+
+		afterEach( () => {
+			Math.random.mockRestore();
+		} );
+
+		it( 'records the round-trip time of a head refresh', () => {
+			client.getNotes();
+			expect( timingEvents() ).toEqual( [] );
+
+			jest.advanceTimersByTime( 250 );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 100 ), last_seen_time: 0 } );
+
+			expect( timingEvents() ).toEqual( [
+				{
+					request: 'getNotes',
+					response_time_in_ms: 250,
+					sample_rate: 1,
+					result: 'success',
+					status: null,
+					code: null,
+					note_count: 10,
+					number: 10,
+					is_load_more: false,
+				},
+			] );
+		} );
+
+		it( 'records a failed query with its status, and still runs the callback', () => {
+			client.getNotes();
+			jest.advanceTimersByTime( 80 );
+			getCalls[ 0 ].callback( { status: 503, error: 'unavailable' }, null );
+
+			expect( timingEvents() ).toEqual( [
+				expect.objectContaining( {
+					request: 'getNotes',
+					response_time_in_ms: 80,
+					result: 'error',
+					status: 503,
+					code: 'unavailable',
+					note_count: null,
+				} ),
+			] );
+			// The error path's own bookkeeping still ran.
+			expect( client.gettingNotes ).toBe( false );
+		} );
+
+		it( 'tags a load-more page and carries the filter on a filtered tab', () => {
+			seedFirstWindow();
+			window._tkq = [];
+
+			client.setFilter( 'unread' );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 100 ), last_seen_time: 0 } );
+
+			expect( timingEvents() ).toEqual( [
+				expect.objectContaining( {
+					request: 'getFilteredNotes',
+					filter: UNREAD_KEY,
+					is_load_more: false,
+				} ),
+			] );
+		} );
+
+		it( 'samples the background poll rather than recording every one', () => {
+			seedFirstWindow();
+			window._tkq = [];
+
+			// An unchanged window keeps the poll from cascading into a full fetch,
+			// so each call here is one isolated request.
+			const poll = () => {
+				client.getNotesList();
+				getCalls[ 0 ].callback( null, { notes: fullPage( 10, 100 ), last_seen_time: 0 } );
+				getCalls.length = 0;
+			};
+
+			poll();
+			expect( timingEvents() ).toEqual( [] );
+
+			Math.random.mockReturnValue( 0.001 );
+			poll();
+
+			expect( timingEvents() ).toEqual( [
+				expect.objectContaining( { request: 'getNotesList', sample_rate: 0.01 } ),
+			] );
+		} );
+	} );
 } );


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Notes queries in the notifications panel now report how long they took to Tracks, as `calypso_notification_query_response`.

## Why are these changes being made?

* Nothing records how long notes queries take, so there's no way to tell how slow the panel is for anyone.

## Testing Instructions

* Open the notifications panel with Tracks debugging on, switch tabs, and scroll to load more. Each request should fire `calypso_notification_query_response` with a `response_time_in_ms`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?