### PR TITLE
Stats: only show the omnibar sparkline when the Stats module is active

### DIFF
--- a/client/dashboard/app/omnibar/plugin-stats-sparkline.tsx
+++ b/client/dashboard/app/omnibar/plugin-stats-sparkline.tsx
@@ -1,7 +1,9 @@
+import { JetpackModules } from '@automattic/api-core';
 import { siteHourlyViewsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import { StatsSparkline } from '../../components/stats-sparkline';
+import { hasJetpackModule } from '../../utils/site-features';
 import type { Site } from '@automattic/api-core';
 import type { OmnibarNode } from '@automattic/omnibar';
 
@@ -9,7 +11,11 @@ import './plugin-stats-sparkline.scss';
 
 export function useStatsSparklinePlugin( { site }: { site?: Site } ): OmnibarNode | undefined {
 	const adminUrl = site?.options?.admin_url;
-	const canViewStats = !! site?.capabilities?.view_stats;
+	// The sparkline links to admin.php?page=stats, which isn't registered for a user without
+	// view_stats, nor on a Jetpack site with the Stats module switched off.
+	const canViewStats =
+		!! site?.capabilities?.view_stats &&
+		( ! site.jetpack || !! hasJetpackModule( site, JetpackModules.STATS ) );
 
 	const { data: hourlyViews } = useQuery( {
 		...siteHourlyViewsQuery( site?.ID ?? 0 ),

--- a/client/dashboard/app/omnibar/test/plugin-stats-sparkline.test.tsx
+++ b/client/dashboard/app/omnibar/test/plugin-stats-sparkline.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+import { useQuery } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { useStatsSparklinePlugin } from '../plugin-stats-sparkline';
+import type { Site } from '@automattic/api-core';
+
+jest.mock( '@tanstack/react-query', () => ( {
+	useQuery: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/api-queries', () => ( {
+	siteHourlyViewsQuery: jest.fn( () => ( { queryKey: [ 'site-hourly-views' ] } ) ),
+} ) );
+
+const mockUseQuery = useQuery as jest.MockedFunction< typeof useQuery >;
+
+const simpleSite = {
+	ID: 1,
+	options: { admin_url: 'https://example.com/wp-admin/' },
+	capabilities: { view_stats: true },
+} as unknown as Site;
+
+describe( 'useStatsSparklinePlugin', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseQuery.mockReturnValue( { data: [ 1, 2, 3 ] } as never );
+	} );
+
+	test( 'renders the sparkline on a Simple site', () => {
+		const { result } = renderHook( () => useStatsSparklinePlugin( { site: simpleSite } ) );
+
+		expect( result.current?.href ).toBe( 'https://example.com/wp-admin/admin.php?page=stats' );
+	} );
+
+	test( 'renders the sparkline when the Jetpack site has the Stats module active', () => {
+		const site = { ...simpleSite, jetpack: true, jetpack_modules: [ 'stats', 'monitor' ] } as Site;
+
+		const { result } = renderHook( () => useStatsSparklinePlugin( { site } ) );
+
+		expect( result.current ).toBeDefined();
+	} );
+
+	// Without the module there is no admin.php?page=stats screen, so the sparkline would link
+	// to "Sorry, you are not allowed to access this page".
+	test( 'renders nothing when the Jetpack site has the Stats module off', () => {
+		const site = { ...simpleSite, jetpack: true, jetpack_modules: [ 'monitor' ] } as Site;
+
+		const { result } = renderHook( () => useStatsSparklinePlugin( { site } ) );
+
+		expect( result.current ).toBeUndefined();
+	} );
+
+	test( 'renders nothing when the user cannot view stats', () => {
+		const site = { ...simpleSite, capabilities: { view_stats: false } } as unknown as Site;
+
+		const { result } = renderHook( () => useStatsSparklinePlugin( { site } ) );
+
+		expect( result.current ).toBeUndefined();
+	} );
+} );


### PR DESCRIPTION
Part of Automattic/jetpack#51590

## Proposed Changes

* The omnibar's stats sparkline only checked `view_stats` before linking to `admin.php?page=stats`, so on a Jetpack site with the Stats module switched off it kept pointing at "Sorry, you are not allowed to access this page". It now checks the module too, with `hasJetpackModule( site, JetpackModules.STATS )` - same shape as the existing check in `sites/site-fields`.
* Tests for the four cases (Simple site, Jetpack site with the module, Jetpack site without it, and a user without `view_stats`).

## Why are these changes being made?

`view_stats` isn't a proxy for the module being on. The Stats package registers its `map_meta_cap` handler on any wp-admin or REST request (the `is_admin()` branch in `class.jetpack.php`), so an admin keeps the capability after the module is switched off, while `admin.php?page=stats` stops being registered. So the check we had was passing while the destination didn't exist.

The Stats item in the site-name menu needs nothing on our side, which I didn't realise at first - thanks @fushar for asking. The omnibar takes that menu from `wpcom/v2/sites/%d/admin-bar`, which is the Jetpack plugin's own endpoint proxied out to the site, so it just renders the site's real admin bar. On Atomic and Simple that node comes from jetpack-mu-wpcom's `wpcom_add_stats_to_site_menu()`, which Automattic/jetpack#51693 gates on the module. On self-hosted it comes from `stats_add_link_to_admin_bar_site_menu()`, which lives inside `modules/stats.php` - module off, the file never loads, so no node. The sparkline is the only Stats affordance the omnibar still builds client side, so it's all that's left here.

Earlier revisions of this PR also fixed the interim omnibar and the classic masterbar, which did build that menu item client side with no check at all. I've dropped both now that #113827 turned `dashboard/omnibar-radical` on in production, since neither renders a Stats link there anymore - the interim omnibar doesn't boot, and `layout/index.jsx` only falls back to `MasterbarLoggedIn` on checkout, where `render()` returns from `renderCheckout()` before the site menu is built. Happy to bring them back if we think a revert of the flag is on the cards.

## Testing Instructions

* Connect a self-hosted Jetpack site to WordPress.com, and make sure Jetpack Stats is active.
* Go to the sites dashboard and select that site, so the omnibar picks it up.
* Ensure the stats sparkline shows in the omnibar and goes to `/wp-admin/admin.php?page=stats`.
* Now deactivate the Stats module on the site (`wp jetpack module deactivate stats`).
* Reload and ensure the sparkline is gone, and that you don't land on "Sorry, you are not allowed to access this page" anymore.
* Ensure a Simple site still shows the sparkline, since the module can't be switched off there.
* As a user without `view_stats` on the site (an Editor, say), ensure the sparkline doesn't show either.
* `yarn test-client client/dashboard/app/omnibar/test/plugin-stats-sparkline.test.tsx` covers the four cases.

Tested end to end on a self-hosted Jetpack site in my local docker env - deactivated the Stats module for real, the sparkline goes; reactivated it, the sparkline comes back. Screenshots and the wp-cli evidence are in a comment below. Simple and Atomic are only covered by the unit tests here.

## Related

* JETPACK-2366
* STATS-287
* Automattic/jetpack#51693 - the jetpack-mu-wpcom half, for the Atomic admin bar link.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
