### PR TITLE
Dashboard: classify auth errors in one place

### DIFF
--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -1,18 +1,19 @@
 import { isWpError } from '@automattic/api-core';
 import { Button, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { reauthRequiredLink, wpcomLink } from '../../utils/link';
 import { AuthContext } from '../auth';
 
-function isAuthorizationError( error: Error ) {
-	return (
-		error.name === 'AuthorizationRequiredError' ||
-		( isWpError( error ) && error.error === 'authorization_required' )
-	);
+function ReauthRedirect() {
+	useEffect( () => {
+		window.location.href = reauthRequiredLink();
+	}, [] );
+
+	return null;
 }
 
 function SessionError() {
@@ -61,16 +62,7 @@ function SessionError() {
 	);
 }
 
-function UnknownError( { error }: { error: Error } ) {
-	if ( isWpError( error ) && error.error === 'reauthorization_required' ) {
-		window.location.href = reauthRequiredLink();
-		return null;
-	}
-
-	if ( isAuthorizationError( error ) ) {
-		return <SessionError />;
-	}
-
+function GenericError( { error }: { error: Error } ) {
 	return (
 		<PageLayout
 			header={
@@ -79,6 +71,31 @@ function UnknownError( { error }: { error: Error } ) {
 			notices={ <Notice variant="error">{ error.message }</Notice> }
 		></PageLayout>
 	);
+}
+
+/**
+ * The dashboard's last-resort error screen.
+ *
+ * Route error boundaries fall back to this, and the area-specific error
+ * components (site, domain) delegate to it for anything they do not recognise.
+ * Only add a branch here for a failure that can happen anywhere in the app;
+ * anything scoped to one area belongs in that area's error component.
+ */
+function UnknownError( { error }: { error: Error } ) {
+	if ( isWpError( error ) ) {
+		if ( error.error === 'reauthorization_required' ) {
+			return <ReauthRedirect />;
+		}
+
+		// The API marks a request that carried no usable credential with this
+		// reason. An authorization failure without it is a genuine permission
+		// error, where signing in again would not help.
+		if ( error.reason === 'no_identity' ) {
+			return <SessionError />;
+		}
+	}
+
+	return <GenericError error={ error } />;
 }
 
 export default UnknownError;

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -17,10 +17,8 @@ function ReauthRedirect() {
 	return null;
 }
 
-// A refused request means either that the session can no longer authenticate or
-// that the account simply is not allowed to see this, and the error says the same
-// thing in both cases. The v1 endpoints report the code as `error` and the ones
-// registered through the WP REST infrastructure report it as `code`.
+// `authorization_required` covers both a dead session and a plain permission
+// error. v1 endpoints report the code as `error`, WP REST ones as `code`.
 function isAuthorizationError( error: Error ) {
 	if ( error.name === 'AuthorizationRequiredError' ) {
 		return true;
@@ -37,13 +35,13 @@ function isAuthorizationError( error: Error ) {
 function RefusedRequestError() {
 	const { data: sessionState, isPending } = useSessionStateQuery();
 
-	// Better a moment of nothing than a moment of the wrong advice.
+	// Render nothing rather than flash the wrong advice.
 	if ( isPending ) {
 		return null;
 	}
 
-	// A session we could not reach is treated as gone: wrong advice the user can
-	// act on beats correct advice they cannot.
+	// An unreachable session is treated as dead: wrong advice the user can act on
+	// beats correct advice they cannot.
 	return sessionState === 'alive' ? <PermissionError /> : <SessionError />;
 }
 
@@ -66,21 +64,17 @@ function PermissionError() {
 }
 
 function SessionError() {
-	// `useAuth` throws when there is no provider, and this component is the last
-	// thing standing between the user and a blank screen.
+	// `useAuth` would throw without a provider, and this is the last screen before
+	// a blank page.
 	const auth = useContext( AuthContext );
 
-	// Counts the users we failed to send to log in and left to recover by hand,
-	// which is the half of DOTCOM-14911 nothing measures today. The probe has
-	// confirmed the session by this point, so this is not diluted by people who
-	// merely lack a permission.
+	// Counts users left to recover by hand (DOTCOM-14911).
 	useEffect( () => {
 		bumpStat( 'dashboard-error', 'dead-session' );
 	}, [] );
 
 	// Logging out loads a chunk and clears stored state, either of which can fail
-	// in the very state that got the user here. Send them to log in regardless, so
-	// the button is never a dead end.
+	// in the state that got the user here.
 	const handleLogout = async () => {
 		try {
 			await auth?.logout();

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -65,7 +65,7 @@ function RefusedRequestError() {
 					}
 				>
 					{ __(
-						'We’re having trouble accessing data from your account at the moment. Please log out and log back in to try again. We apologize for the error.'
+						'We’re having trouble accessing data from your account at the moment. Please log out and log back in to try again.'
 					) }
 				</Notice>
 			}

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -1,5 +1,4 @@
-import { fetchUser, isWpError } from '@automattic/api-core';
-import { useQuery } from '@tanstack/react-query';
+import { isWpError } from '@automattic/api-core';
 import { Button, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useContext, useEffect } from 'react';
@@ -8,7 +7,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { reauthRequiredLink, wpcomLink } from '../../utils/link';
 import { bumpStat } from '../analytics';
-import { AuthContext } from '../auth';
+import { AuthContext, useSessionStateQuery } from '../auth';
 
 function ReauthRedirect() {
 	useEffect( () => {
@@ -35,38 +34,17 @@ function isAuthorizationError( error: Error ) {
 	return code === 'authorization_required' || code === 'rest_forbidden';
 }
 
-/**
- * Whether the session behind this screen still works.
- *
- * Asking for the current user is the only way to tell the two causes apart: it
- * succeeds for an account that is merely missing a permission, and fails the same
- * way as everything else once the session is gone.
- */
-function useHasWorkingSession() {
-	const { data, isPending } = useQuery( {
-		queryKey: [ 'auth', 'session-probe' ],
-		queryFn: () =>
-			fetchUser().then(
-				() => true,
-				() => false
-			),
-		retry: false,
-		gcTime: 0,
-		meta: { persist: false },
-	} );
-
-	return { hasWorkingSession: data ?? false, isPending };
-}
-
 function RefusedRequestError() {
-	const { hasWorkingSession, isPending } = useHasWorkingSession();
+	const { data: sessionState, isPending } = useSessionStateQuery();
 
 	// Better a moment of nothing than a moment of the wrong advice.
 	if ( isPending ) {
 		return null;
 	}
 
-	return hasWorkingSession ? <PermissionError /> : <SessionError />;
+	// A session we could not reach is treated as gone: wrong advice the user can
+	// act on beats correct advice they cannot.
+	return sessionState === 'alive' ? <PermissionError /> : <SessionError />;
 }
 
 function PermissionError() {

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -6,6 +6,7 @@ import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { reauthRequiredLink, wpcomLink } from '../../utils/link';
+import { bumpStat } from '../analytics';
 import { AuthContext } from '../auth';
 
 function ReauthRedirect() {
@@ -31,6 +32,12 @@ function RefusedRequestError() {
 	// `useAuth` throws when there is no provider, and this component is the last
 	// thing standing between the user and a blank screen.
 	const auth = useContext( AuthContext );
+
+	// Counts the users we failed to send to log in and left to recover by hand,
+	// which is the half of DOTCOM-14911 nothing measures today.
+	useEffect( () => {
+		bumpStat( 'dashboard-error', 'refused-request' );
+	}, [] );
 
 	// Logging out loads a chunk and clears stored state, either of which can fail
 	// in the very state that got the user here. Send them to log in regardless, so
@@ -79,7 +86,16 @@ function GenericError( { error }: { error: Error } ) {
 			header={
 				<PageHeader title={ __( '500 Error' ) } description={ __( 'Something wrong happened.' ) } />
 			}
-			notices={ <Notice variant="error">{ error.message }</Notice> }
+			notices={
+				<Notice
+					variant="error"
+					actions={
+						<ExternalLink href={ wpcomLink( '/help' ) }>{ __( 'Contact support' ) }</ExternalLink>
+					}
+				>
+					{ error.message }
+				</Notice>
+			}
 		></PageLayout>
 	);
 }

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -1,4 +1,5 @@
-import { isWpError } from '@automattic/api-core';
+import { fetchUser, isWpError } from '@automattic/api-core';
+import { useQuery } from '@tanstack/react-query';
 import { Button, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useContext, useEffect } from 'react';
@@ -17,26 +18,86 @@ function ReauthRedirect() {
 	return null;
 }
 
-// `authorization_required` covers both a session that can no longer authenticate
-// and an account that is authenticated but not allowed to see something, and the
-// API gives us no way to tell them apart. So suggest the fix for the first rather
-// than diagnosing either, and offer support for when it does not help.
+// A refused request means either that the session can no longer authenticate or
+// that the account simply is not allowed to see this, and the error says the same
+// thing in both cases. The v1 endpoints report the code as `error` and the ones
+// registered through the WP REST infrastructure report it as `code`.
 function isAuthorizationError( error: Error ) {
-	return (
-		error.name === 'AuthorizationRequiredError' ||
-		( isWpError( error ) && error.error === 'authorization_required' )
-	);
+	if ( error.name === 'AuthorizationRequiredError' ) {
+		return true;
+	}
+
+	if ( ! isWpError( error ) ) {
+		return false;
+	}
+
+	const code = typeof error.error === 'string' ? error.error : error.code;
+	return code === 'authorization_required' || code === 'rest_forbidden';
+}
+
+/**
+ * Whether the session behind this screen still works.
+ *
+ * Asking for the current user is the only way to tell the two causes apart: it
+ * succeeds for an account that is merely missing a permission, and fails the same
+ * way as everything else once the session is gone.
+ */
+function useHasWorkingSession() {
+	const { data, isPending } = useQuery( {
+		queryKey: [ 'auth', 'session-probe' ],
+		queryFn: () =>
+			fetchUser().then(
+				() => true,
+				() => false
+			),
+		retry: false,
+		gcTime: 0,
+		meta: { persist: false },
+	} );
+
+	return { hasWorkingSession: data ?? false, isPending };
 }
 
 function RefusedRequestError() {
+	const { hasWorkingSession, isPending } = useHasWorkingSession();
+
+	// Better a moment of nothing than a moment of the wrong advice.
+	if ( isPending ) {
+		return null;
+	}
+
+	return hasWorkingSession ? <PermissionError /> : <SessionError />;
+}
+
+function PermissionError() {
+	return (
+		<PageLayout
+			header={ <PageHeader title={ __( 'You don’t have access to this' ) } /> }
+			notices={
+				<Notice
+					variant="error"
+					actions={
+						<ExternalLink href={ wpcomLink( '/help' ) }>{ __( 'Contact support' ) }</ExternalLink>
+					}
+				>
+					{ __( 'Your account doesn’t have permission to view this page.' ) }
+				</Notice>
+			}
+		></PageLayout>
+	);
+}
+
+function SessionError() {
 	// `useAuth` throws when there is no provider, and this component is the last
 	// thing standing between the user and a blank screen.
 	const auth = useContext( AuthContext );
 
 	// Counts the users we failed to send to log in and left to recover by hand,
-	// which is the half of DOTCOM-14911 nothing measures today.
+	// which is the half of DOTCOM-14911 nothing measures today. The probe has
+	// confirmed the session by this point, so this is not diluted by people who
+	// merely lack a permission.
 	useEffect( () => {
-		bumpStat( 'dashboard-error', 'refused-request' );
+		bumpStat( 'dashboard-error', 'dead-session' );
 	}, [] );
 
 	// Logging out loads a chunk and clears stored state, either of which can fail

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -16,7 +16,18 @@ function ReauthRedirect() {
 	return null;
 }
 
-function SessionError() {
+// `authorization_required` covers both a session that can no longer authenticate
+// and an account that is authenticated but not allowed to see something, and the
+// API gives us no way to tell them apart. So suggest the fix for the first rather
+// than diagnosing either, and offer support for when it does not help.
+function isAuthorizationError( error: Error ) {
+	return (
+		error.name === 'AuthorizationRequiredError' ||
+		( isWpError( error ) && error.error === 'authorization_required' )
+	);
+}
+
+function RefusedRequestError() {
 	// `useAuth` throws when there is no provider, and this component is the last
 	// thing standing between the user and a blank screen.
 	const auth = useContext( AuthContext );
@@ -34,7 +45,7 @@ function SessionError() {
 
 	return (
 		<PageLayout
-			header={ <PageHeader title={ __( 'There’s a problem with your session' ) } /> }
+			header={ <PageHeader title={ __( 'Something went wrong' ) } /> }
 			notices={
 				<Notice
 					variant="error"
@@ -82,17 +93,12 @@ function GenericError( { error }: { error: Error } ) {
  * anything scoped to one area belongs in that area's error component.
  */
 function UnknownError( { error }: { error: Error } ) {
-	if ( isWpError( error ) ) {
-		if ( error.error === 'reauthorization_required' ) {
-			return <ReauthRedirect />;
-		}
+	if ( isWpError( error ) && error.error === 'reauthorization_required' ) {
+		return <ReauthRedirect />;
+	}
 
-		// The API marks a request that carried no usable credential with this
-		// reason. An authorization failure without it is a genuine permission
-		// error, where signing in again would not help.
-		if ( error.reason === 'no_identity' ) {
-			return <SessionError />;
-		}
+	if ( isAuthorizationError( error ) ) {
+		return <RefusedRequestError />;
 	}
 
 	return <GenericError error={ error } />;

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -1,14 +1,74 @@
 import { isWpError } from '@automattic/api-core';
+import { Button, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useContext } from 'react';
 import Notice from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
-import { reauthRequiredLink } from '../../utils/link';
+import { reauthRequiredLink, wpcomLink } from '../../utils/link';
+import { AuthContext } from '../auth';
+
+function isAuthorizationError( error: Error ) {
+	return (
+		error.name === 'AuthorizationRequiredError' ||
+		( isWpError( error ) && error.error === 'authorization_required' )
+	);
+}
+
+function SessionError() {
+	// `useAuth` throws when there is no provider, and this component is the last
+	// thing standing between the user and a blank screen.
+	const auth = useContext( AuthContext );
+
+	// Logging out loads a chunk and clears stored state, either of which can fail
+	// in the very state that got the user here. Send them to log in regardless, so
+	// the button is never a dead end.
+	const handleLogout = async () => {
+		try {
+			await auth?.logout();
+		} catch {
+			window.location.href = wpcomLink( '/log-in' );
+		}
+	};
+
+	return (
+		<PageLayout
+			header={ <PageHeader title={ __( 'There’s a problem with your session' ) } /> }
+			notices={
+				<Notice
+					variant="error"
+					actions={
+						<>
+							{ auth ? (
+								<Button variant="primary" onClick={ handleLogout }>
+									{ __( 'Log out' ) }
+								</Button>
+							) : (
+								<Button variant="primary" href={ wpcomLink( '/log-in' ) }>
+									{ __( 'Log in again' ) }
+								</Button>
+							) }
+							<ExternalLink href={ wpcomLink( '/help' ) }>{ __( 'Contact support' ) }</ExternalLink>
+						</>
+					}
+				>
+					{ __(
+						'We’re having trouble accessing data from your account at the moment. Please log out and log back in to try again. We apologize for the error.'
+					) }
+				</Notice>
+			}
+		></PageLayout>
+	);
+}
 
 function UnknownError( { error }: { error: Error } ) {
 	if ( isWpError( error ) && error.error === 'reauthorization_required' ) {
 		window.location.href = reauthRequiredLink();
 		return null;
+	}
+
+	if ( isAuthorizationError( error ) ) {
+		return <SessionError />;
 	}
 
 	return (

--- a/client/dashboard/app/500/index.tsx
+++ b/client/dashboard/app/500/index.tsx
@@ -1,4 +1,4 @@
-import { isWpError } from '@automattic/api-core';
+import { classifyAuthError, isWpError } from '@automattic/api-core';
 import { Button, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useContext, useEffect } from 'react';
@@ -15,21 +15,6 @@ function ReauthRedirect() {
 	}, [] );
 
 	return null;
-}
-
-// `authorization_required` covers both a dead session and a plain permission
-// error. v1 endpoints report the code as `error`, WP REST ones as `code`.
-function isAuthorizationError( error: Error ) {
-	if ( error.name === 'AuthorizationRequiredError' ) {
-		return true;
-	}
-
-	if ( ! isWpError( error ) ) {
-		return false;
-	}
-
-	const code = typeof error.error === 'string' ? error.error : error.code;
-	return code === 'authorization_required' || code === 'rest_forbidden';
 }
 
 function RefusedRequestError() {
@@ -146,7 +131,7 @@ function UnknownError( { error }: { error: Error } ) {
 		return <ReauthRedirect />;
 	}
 
-	if ( isAuthorizationError( error ) ) {
+	if ( classifyAuthError( error ) !== null ) {
 		return <RefusedRequestError />;
 	}
 

--- a/client/dashboard/app/500/test/index.test.tsx
+++ b/client/dashboard/app/500/test/index.test.tsx
@@ -20,12 +20,11 @@ function wpError( fields: Record< string, unknown >, message = RAW_API_MESSAGE )
 	} );
 }
 
-/** No credential was accepted, so signing in again is the fix. */
-function noIdentityError() {
-	return wpError( { error: 'authorization_required', reason: 'no_identity' } );
+function authorizationError() {
+	return wpError( { error: 'authorization_required' } );
 }
 
-/** Authenticated, but not allowed to see this. Signing in again changes nothing. */
+/** Authenticated, but not allowed to see this. Indistinguishable from the above. */
 function forbiddenError() {
 	return wpError(
 		{ error: 'authorization_required' },
@@ -63,13 +62,13 @@ describe( 'UnknownError', () => {
 			);
 
 			expect( window.location.href ).toContain( '/me/reauth-required' );
-			expect( container ).not.toHaveTextContent( /problem with your session/i );
+			expect( container ).not.toHaveTextContent( /trouble accessing data/i );
 		} );
 	} );
 
-	describe( 'when the request carried no usable credential', () => {
+	describe( 'when a request is refused', () => {
 		it( 'explains the problem instead of showing the raw API message', async () => {
-			renderWithLogout( noIdentityError(), jest.fn() );
+			renderWithLogout( authorizationError(), jest.fn() );
 
 			expect(
 				await screen.findByText( /trouble accessing data from your account/i )
@@ -79,7 +78,7 @@ describe( 'UnknownError', () => {
 
 		it( 'offers a way to log out and back in', async () => {
 			const logout = jest.fn();
-			renderWithLogout( noIdentityError(), logout );
+			renderWithLogout( authorizationError(), logout );
 
 			await userEvent.click( await screen.findByRole( 'button', { name: /log out/i } ) );
 
@@ -87,20 +86,21 @@ describe( 'UnknownError', () => {
 		} );
 
 		it( 'links to support', async () => {
-			renderWithLogout( noIdentityError(), jest.fn() );
+			renderWithLogout( authorizationError(), jest.fn() );
 
 			expect( await screen.findByRole( 'link', { name: /support/i } ) ).toBeVisible();
 		} );
 	} );
 
 	describe( 'when the account simply lacks access', () => {
-		it( 'does not tell the user to log in again', async () => {
+		// The API reports this identically to an unusable session, so the same
+		// screen is shown. The copy suggests logging back in rather than claiming
+		// it is the cause, and support is offered for when it does not help.
+		it( 'still offers a recovery path', async () => {
 			renderWithLogout( forbiddenError(), jest.fn() );
 
-			expect(
-				await screen.findByText( 'User or Token does not have access to specified site.' )
-			).toBeVisible();
-			expect( screen.queryByRole( 'button', { name: /log out/i } ) ).not.toBeInTheDocument();
+			expect( await screen.findByRole( 'button', { name: /log out/i } ) ).toBeVisible();
+			expect( screen.getByRole( 'link', { name: /support/i } ) ).toBeVisible();
 		} );
 	} );
 

--- a/client/dashboard/app/500/test/index.test.tsx
+++ b/client/dashboard/app/500/test/index.test.tsx
@@ -11,13 +11,26 @@ import type { User } from '@automattic/api-core';
 const RAW_API_MESSAGE =
 	'An active access token must be used to query information about the current user.';
 
-function authorizationError() {
-	return Object.assign( new Error( RAW_API_MESSAGE ), {
+function wpError( fields: Record< string, unknown >, message = RAW_API_MESSAGE ) {
+	return Object.assign( new Error( message ), {
 		name: 'AuthorizationRequiredError',
 		status: 403,
 		statusCode: 403,
-		error: 'authorization_required',
+		...fields,
 	} );
+}
+
+/** No credential was accepted, so signing in again is the fix. */
+function noIdentityError() {
+	return wpError( { error: 'authorization_required', reason: 'no_identity' } );
+}
+
+/** Authenticated, but not allowed to see this. Signing in again changes nothing. */
+function forbiddenError() {
+	return wpError(
+		{ error: 'authorization_required' },
+		'User or Token does not have access to specified site.'
+	);
 }
 
 function renderWithLogout( error: Error, logout: () => Promise< void > ) {
@@ -30,9 +43,33 @@ function renderWithLogout( error: Error, logout: () => Promise< void > ) {
 }
 
 describe( 'UnknownError', () => {
-	describe( 'when the session cannot authenticate', () => {
+	describe( 'when re-authentication is required', () => {
+		const originalLocation = window.location;
+
+		beforeEach( () => {
+			Object.defineProperty( window, 'location', {
+				writable: true,
+				value: { href: '', origin: 'http://localhost', pathname: '/sites' },
+			} );
+		} );
+
+		afterEach( () => {
+			Object.defineProperty( window, 'location', { writable: true, value: originalLocation } );
+		} );
+
+		it( 'sends the user to re-authenticate instead of rendering', () => {
+			const { container } = render(
+				<UnknownError error={ wpError( { error: 'reauthorization_required' } ) } />
+			);
+
+			expect( window.location.href ).toContain( '/me/reauth-required' );
+			expect( container ).not.toHaveTextContent( /problem with your session/i );
+		} );
+	} );
+
+	describe( 'when the request carried no usable credential', () => {
 		it( 'explains the problem instead of showing the raw API message', async () => {
-			renderWithLogout( authorizationError(), jest.fn() );
+			renderWithLogout( noIdentityError(), jest.fn() );
 
 			expect(
 				await screen.findByText( /trouble accessing data from your account/i )
@@ -42,18 +79,28 @@ describe( 'UnknownError', () => {
 
 		it( 'offers a way to log out and back in', async () => {
 			const logout = jest.fn();
-			renderWithLogout( authorizationError(), logout );
+			renderWithLogout( noIdentityError(), logout );
 
-			const button = await screen.findByRole( 'button', { name: /log out/i } );
-			await userEvent.click( button );
+			await userEvent.click( await screen.findByRole( 'button', { name: /log out/i } ) );
 
 			expect( logout ).toHaveBeenCalled();
 		} );
 
 		it( 'links to support', async () => {
-			renderWithLogout( authorizationError(), jest.fn() );
+			renderWithLogout( noIdentityError(), jest.fn() );
 
 			expect( await screen.findByRole( 'link', { name: /support/i } ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'when the account simply lacks access', () => {
+		it( 'does not tell the user to log in again', async () => {
+			renderWithLogout( forbiddenError(), jest.fn() );
+
+			expect(
+				await screen.findByText( 'User or Token does not have access to specified site.' )
+			).toBeVisible();
+			expect( screen.queryByRole( 'button', { name: /log out/i } ) ).not.toBeInTheDocument();
 		} );
 	} );
 

--- a/client/dashboard/app/500/test/index.test.tsx
+++ b/client/dashboard/app/500/test/index.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../test-utils';
+import { AuthContext } from '../../auth';
+import UnknownError from '../index';
+import type { User } from '@automattic/api-core';
+
+const RAW_API_MESSAGE =
+	'An active access token must be used to query information about the current user.';
+
+function authorizationError() {
+	return Object.assign( new Error( RAW_API_MESSAGE ), {
+		name: 'AuthorizationRequiredError',
+		status: 403,
+		statusCode: 403,
+		error: 'authorization_required',
+	} );
+}
+
+function renderWithLogout( error: Error, logout: () => Promise< void > ) {
+	const user = { ID: 1, username: 'testuser', language: 'en' } as User;
+	return render(
+		<AuthContext.Provider value={ { user, logout } }>
+			<UnknownError error={ error } />
+		</AuthContext.Provider>
+	);
+}
+
+describe( 'UnknownError', () => {
+	describe( 'when the session cannot authenticate', () => {
+		it( 'explains the problem instead of showing the raw API message', async () => {
+			renderWithLogout( authorizationError(), jest.fn() );
+
+			expect(
+				await screen.findByText( /trouble accessing data from your account/i )
+			).toBeVisible();
+			expect( screen.queryByText( RAW_API_MESSAGE ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'offers a way to log out and back in', async () => {
+			const logout = jest.fn();
+			renderWithLogout( authorizationError(), logout );
+
+			const button = await screen.findByRole( 'button', { name: /log out/i } );
+			await userEvent.click( button );
+
+			expect( logout ).toHaveBeenCalled();
+		} );
+
+		it( 'links to support', async () => {
+			renderWithLogout( authorizationError(), jest.fn() );
+
+			expect( await screen.findByRole( 'link', { name: /support/i } ) ).toBeVisible();
+		} );
+	} );
+
+	describe( 'for any other failure', () => {
+		it( 'keeps showing the underlying message', async () => {
+			render( <UnknownError error={ new Error( 'Something specific broke' ) } /> );
+
+			expect( await screen.findByText( 'Something specific broke' ) ).toBeVisible();
+			expect( screen.queryByRole( 'button', { name: /log out/i } ) ).not.toBeInTheDocument();
+		} );
+	} );
+} );

--- a/client/dashboard/app/500/test/index.test.tsx
+++ b/client/dashboard/app/500/test/index.test.tsx
@@ -41,6 +41,11 @@ function forbiddenError() {
 	);
 }
 
+/** The same refusal from a WP REST endpoint, which reports the code in `code`. */
+function restForbiddenError() {
+	return wpError( { code: 'rest_forbidden' }, 'Sorry, you are not allowed to do that.' );
+}
+
 function mockDeadSession() {
 	nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.1/me' )
@@ -121,6 +126,16 @@ describe( 'UnknownError', () => {
 
 			await screen.findByRole( 'button', { name: /log out/i } );
 			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-error', 'dead-session' );
+		} );
+	} );
+
+	describe( 'when a WP REST endpoint refuses the request', () => {
+		beforeEach( mockWorkingSession );
+
+		it( 'is recognised as an authorization problem, not an unknown failure', async () => {
+			renderWithLogout( restForbiddenError(), jest.fn() );
+
+			expect( await screen.findByText( /doesn’t have permission/i ) ).toBeVisible();
 		} );
 	} );
 

--- a/client/dashboard/app/500/test/index.test.tsx
+++ b/client/dashboard/app/500/test/index.test.tsx
@@ -4,9 +4,17 @@
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '../../../test-utils';
+import { bumpStat } from '../../analytics';
 import { AuthContext } from '../../auth';
 import UnknownError from '../index';
 import type { User } from '@automattic/api-core';
+
+jest.mock( '../../analytics', () => ( {
+	...jest.requireActual( '../../analytics' ),
+	bumpStat: jest.fn(),
+} ) );
+
+const mockedBumpStat = jest.mocked( bumpStat );
 
 const RAW_API_MESSAGE =
 	'An active access token must be used to query information about the current user.';
@@ -90,6 +98,13 @@ describe( 'UnknownError', () => {
 
 			expect( await screen.findByRole( 'link', { name: /support/i } ) ).toBeVisible();
 		} );
+
+		it( 'counts the user as stranded', async () => {
+			renderWithLogout( authorizationError(), jest.fn() );
+
+			await screen.findByRole( 'button', { name: /log out/i } );
+			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-error', 'refused-request' );
+		} );
 	} );
 
 	describe( 'when the account simply lacks access', () => {
@@ -110,6 +125,19 @@ describe( 'UnknownError', () => {
 
 			expect( await screen.findByText( 'Something specific broke' ) ).toBeVisible();
 			expect( screen.queryByRole( 'button', { name: /log out/i } ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'still offers support, since the message alone is no help', async () => {
+			render( <UnknownError error={ new Error( 'Something specific broke' ) } /> );
+
+			expect( await screen.findByRole( 'link', { name: /support/i } ) ).toBeVisible();
+		} );
+
+		it( 'is not counted as a refused request', async () => {
+			render( <UnknownError error={ new Error( 'Something specific broke' ) } /> );
+
+			await screen.findByText( 'Something specific broke' );
+			expect( mockedBumpStat ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/client/dashboard/app/500/test/index.test.tsx
+++ b/client/dashboard/app/500/test/index.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import nock from 'nock';
 import { render } from '../../../test-utils';
 import { bumpStat } from '../../analytics';
 import { AuthContext } from '../../auth';
@@ -40,6 +41,22 @@ function forbiddenError() {
 	);
 }
 
+/** The session is gone: asking who we are fails like everything else. */
+function mockDeadSession() {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me' )
+		.query( true )
+		.reply( 403, { error: 'authorization_required', message: 'No active access token' } );
+}
+
+/** The session works; this account just cannot see this particular thing. */
+function mockWorkingSession() {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me' )
+		.query( true )
+		.reply( 200, { ID: 1, username: 'testuser', language: 'en' } );
+}
+
 function renderWithLogout( error: Error, logout: () => Promise< void > ) {
 	const user = { ID: 1, username: 'testuser', language: 'en' } as User;
 	return render(
@@ -74,7 +91,9 @@ describe( 'UnknownError', () => {
 		} );
 	} );
 
-	describe( 'when a request is refused', () => {
+	describe( 'when a request is refused and the session is gone', () => {
+		beforeEach( mockDeadSession );
+
 		it( 'explains the problem instead of showing the raw API message', async () => {
 			renderWithLogout( authorizationError(), jest.fn() );
 
@@ -103,19 +122,46 @@ describe( 'UnknownError', () => {
 			renderWithLogout( authorizationError(), jest.fn() );
 
 			await screen.findByRole( 'button', { name: /log out/i } );
-			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-error', 'refused-request' );
+			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-error', 'dead-session' );
 		} );
 	} );
 
 	describe( 'when the account simply lacks access', () => {
-		// The API reports this identically to an unusable session, so the same
-		// screen is shown. The copy suggests logging back in rather than claiming
-		// it is the cause, and support is offered for when it does not help.
-		it( 'still offers a recovery path', async () => {
+		beforeEach( mockWorkingSession );
+
+		it( 'says so instead of blaming the session', async () => {
 			renderWithLogout( forbiddenError(), jest.fn() );
 
-			expect( await screen.findByRole( 'button', { name: /log out/i } ) ).toBeVisible();
-			expect( screen.getByRole( 'link', { name: /support/i } ) ).toBeVisible();
+			expect( await screen.findByText( /doesn’t have permission/i ) ).toBeVisible();
+			expect( screen.queryByRole( 'button', { name: /log out/i } ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'still offers support', async () => {
+			renderWithLogout( forbiddenError(), jest.fn() );
+
+			expect( await screen.findByRole( 'link', { name: /support/i } ) ).toBeVisible();
+		} );
+
+		it( 'is not counted as a dead session', async () => {
+			renderWithLogout( forbiddenError(), jest.fn() );
+
+			await screen.findByText( /doesn’t have permission/i );
+			expect( mockedBumpStat ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'when the session cannot be checked at all', () => {
+		it( 'falls back to suggesting a fresh log in', async () => {
+			nock( 'https://public-api.wordpress.com' )
+				.get( '/rest/v1.1/me' )
+				.query( true )
+				.replyWithError( 'offline' );
+			renderWithLogout( authorizationError(), jest.fn() );
+
+			// Wrong advice a user can act on beats correct advice they cannot.
+			await waitFor( async () =>
+				expect( await screen.findByRole( 'button', { name: /log out/i } ) ).toBeVisible()
+			);
 		} );
 	} );
 
@@ -133,7 +179,7 @@ describe( 'UnknownError', () => {
 			expect( await screen.findByRole( 'link', { name: /support/i } ) ).toBeVisible();
 		} );
 
-		it( 'is not counted as a refused request', async () => {
+		it( 'is not counted as a dead session either', async () => {
 			render( <UnknownError error={ new Error( 'Something specific broke' ) } /> );
 
 			await screen.findByText( 'Something specific broke' );

--- a/client/dashboard/app/500/test/index.test.tsx
+++ b/client/dashboard/app/500/test/index.test.tsx
@@ -33,7 +33,7 @@ function authorizationError() {
 	return wpError( { error: 'authorization_required' } );
 }
 
-/** Authenticated, but not allowed to see this. Indistinguishable from the above. */
+/** Authenticated, but not allowed to see this — identical to the above. */
 function forbiddenError() {
 	return wpError(
 		{ error: 'authorization_required' },
@@ -41,7 +41,6 @@ function forbiddenError() {
 	);
 }
 
-/** The session is gone: asking who we are fails like everything else. */
 function mockDeadSession() {
 	nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.1/me' )
@@ -49,7 +48,6 @@ function mockDeadSession() {
 		.reply( 403, { error: 'authorization_required', message: 'No active access token' } );
 }
 
-/** The session works; this account just cannot see this particular thing. */
 function mockWorkingSession() {
 	nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.1/me' )
@@ -158,7 +156,6 @@ describe( 'UnknownError', () => {
 				.replyWithError( 'offline' );
 			renderWithLogout( authorizationError(), jest.fn() );
 
-			// Wrong advice a user can act on beats correct advice they cannot.
 			await waitFor( async () =>
 				expect( await screen.findByRole( 'button', { name: /log out/i } ) ).toBeVisible()
 			);

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -76,6 +76,46 @@ function isAuthBounceRecord( value: unknown ): value is AuthBounceRecord {
 	);
 }
 
+/**
+ * Whether the session behind the current page can still authenticate.
+ *
+ * `unknown` is kept apart from `dead` because callers disagree about what to do
+ * with a probe that never got an answer: nobody should be bounced on a guess,
+ * but a user already looking at an error screen is better off being told to log
+ * in again than being told nothing.
+ */
+export type SessionState = 'alive' | 'dead' | 'unknown';
+
+export const SESSION_STATE_QUERY_KEY = [ 'auth', 'session-state' ];
+
+/**
+ * Asks the API who we are, which is the only way to tell a session that can no
+ * longer authenticate from an account that is merely missing a permission: the
+ * two are reported identically on the request that failed.
+ *
+ * Shared so that one incident costs one request. A dead session fails every
+ * request alike, so the answer holds for the rest of the page.
+ */
+export const sessionStateQuery = () => ( {
+	queryKey: SESSION_STATE_QUERY_KEY,
+	queryFn: (): Promise< SessionState > =>
+		fetchUser().then(
+			() => 'alive' as const,
+			( error: unknown ) =>
+				isWpError( error ) &&
+				( error.statusCode === 401 || error.error === 'authorization_required' )
+					? ( 'dead' as const )
+					: ( 'unknown' as const )
+		),
+	retry: false,
+	staleTime: Infinity,
+	meta: { persist: false },
+} );
+
+export function useSessionStateQuery() {
+	return useQuery( sessionStateQuery() );
+}
+
 function getOAuthAuthorizeUrl( {
 	state,
 	next = '',

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -79,22 +79,17 @@ function isAuthBounceRecord( value: unknown ): value is AuthBounceRecord {
 /**
  * Whether the session behind the current page can still authenticate.
  *
- * `unknown` is kept apart from `dead` because callers disagree about what to do
- * with a probe that never got an answer: nobody should be bounced on a guess,
- * but a user already looking at an error screen is better off being told to log
- * in again than being told nothing.
+ * `unknown` is separate from `dead` so a caller can choose not to act on a
+ * guess.
  */
 export type SessionState = 'alive' | 'dead' | 'unknown';
 
 export const SESSION_STATE_QUERY_KEY = [ 'auth', 'session-state' ];
 
 /**
- * Asks the API who we are, which is the only way to tell a session that can no
- * longer authenticate from an account that is merely missing a permission: the
- * two are reported identically on the request that failed.
- *
- * Shared so that one incident costs one request. A dead session fails every
- * request alike, so the answer holds for the rest of the page.
+ * Requesting the current user is the only way to tell a dead session from an
+ * account that merely lacks a permission: the failing request reports both the
+ * same way.
  */
 export const sessionStateQuery = () => ( {
 	queryKey: SESSION_STATE_QUERY_KEY,
@@ -108,6 +103,7 @@ export const sessionStateQuery = () => ( {
 					: ( 'unknown' as const )
 		),
 	retry: false,
+	// One answer serves the whole page: a dead session fails every request alike.
 	staleTime: Infinity,
 	meta: { persist: false },
 } );

--- a/client/dashboard/app/auth/index.tsx
+++ b/client/dashboard/app/auth/index.tsx
@@ -1,4 +1,4 @@
-import { fetchUser, isWpError, User } from '@automattic/api-core';
+import { classifyAuthError, fetchUser, User } from '@automattic/api-core';
 import { clearQueryClient, disablePersistQueryClient } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { setUser } from '@automattic/calypso-sentry';
@@ -16,7 +16,6 @@ import { wpcomLink } from '../../utils/link';
 import { bumpStat } from '../analytics';
 import { useAppContext } from '../context';
 import { OAUTH_CALLBACK_PATH } from './oauth-callback';
-import type { WPError } from '@automattic/api-core';
 
 export const AUTH_QUERY_KEY = [ 'auth', 'user' ];
 
@@ -96,11 +95,11 @@ export const sessionStateQuery = () => ( {
 	queryFn: (): Promise< SessionState > =>
 		fetchUser().then(
 			() => 'alive' as const,
+			// `/me` has no per-resource permission dimension, so any auth failure
+			// against it means the session itself is gone, not that this account
+			// may not look.
 			( error: unknown ) =>
-				isWpError( error ) &&
-				( error.statusCode === 401 || error.error === 'authorization_required' )
-					? ( 'dead' as const )
-					: ( 'unknown' as const )
+				classifyAuthError( error ) !== null ? ( 'dead' as const ) : ( 'unknown' as const )
 		),
 	retry: false,
 	// One answer serves the whole page: a dead session fails every request alike.
@@ -172,10 +171,7 @@ function getAuthErrorReason( error: unknown ): string {
 	if ( error instanceof Error && error.message === BOOTSTRAP_ERROR_MESSAGE ) {
 		return 'bootstrap';
 	}
-	if (
-		isWpError( error ) &&
-		( error.error === 'authorization_required' || error.statusCode === 401 )
-	) {
+	if ( classifyAuthError( error ) !== null ) {
 		return 'unauthorized';
 	}
 	return 'error';
@@ -259,10 +255,6 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 	// Subscribe to network errors and when errors occur due to being logged
 	// out, redirect the user to the log in screen.
 	useEffect( () => {
-		const isAuthError = ( { statusCode, error = '' }: WPError ) => {
-			return statusCode === 401 && [ 'authorization_required', 'rest_forbidden' ].includes( error );
-		};
-
 		const handleEvent = ( event: MutationCacheNotifyEvent | QueryCacheNotifyEvent ) => {
 			// Errors fetching the user object itself are handled (and classified) below.
 			if ( 'query' in event && event.query.queryHash === hashKey( AUTH_QUERY_KEY ) ) {
@@ -272,8 +264,7 @@ export function AuthProvider( { children }: { children: React.ReactNode } ) {
 			if (
 				event.type === 'updated' &&
 				event.action.type === 'error' &&
-				isWpError( event.action.error ) &&
-				isAuthError( event.action.error )
+				classifyAuthError( event.action.error ) === 'expired'
 			) {
 				handleAuthError( 'expired' );
 			}

--- a/client/dashboard/app/auth/test/index.test.tsx
+++ b/client/dashboard/app/auth/test/index.test.tsx
@@ -224,9 +224,8 @@ describe( 'useSessionStateQuery', () => {
 			.get( '/rest/v1.1/me' )
 			.query( true )
 			.reply( 200, testUser );
-		// Queued for a refetch to consume. Serving stale data while revalidating would
-		// still read as 'alive' at first, so flipping the answer is what makes an
-		// extra request visible.
+		// A refetch would consume this and flip the answer, so an extra request shows
+		// up rather than passing unnoticed.
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.1/me' )
 			.query( true )

--- a/client/dashboard/app/auth/test/index.test.tsx
+++ b/client/dashboard/app/auth/test/index.test.tsx
@@ -19,7 +19,7 @@ const mockedBumpStat = jest.mocked( bumpStat );
 
 const testUser = { ID: 1, username: 'testuser', language: 'en' } as User;
 
-function wpError( fields: { status: number; statusCode: number; error?: string } ) {
+function wpError( fields: { status: number; statusCode: number; error?: string; code?: string } ) {
 	return Object.assign( new Error( 'boom' ), fields );
 }
 
@@ -241,5 +241,56 @@ describe( 'useSessionStateQuery', () => {
 			waitFor( () => expect( nock.isDone() ).toBe( true ), { timeout: 250 } )
 		).rejects.toThrow();
 		expect( result.current.data ).toBe( 'alive' );
+	} );
+} );
+
+describe( '<AuthProvider> reaction to a failing request elsewhere in the app', () => {
+	beforeEach( () => {
+		Object.defineProperty( window, 'location', {
+			writable: true,
+			value: { href: 'https://example.com/sites', pathname: '/sites', search: '' },
+		} );
+
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me' )
+			.query( true )
+			.reply( 200, testUser );
+	} );
+
+	async function failOneRequest( error: Error ) {
+		const { queryClient } = renderAuth();
+		expect( await screen.findByText( 'signed in' ) ).toBeVisible();
+
+		await queryClient
+			.fetchQuery( {
+				queryKey: [ 'somewhere-else' ],
+				queryFn: () => Promise.reject( error ),
+				retry: false,
+			} )
+			.catch( () => {} );
+
+		return queryClient;
+	}
+
+	test( 'bounces when a WP REST endpoint reports the request was never authenticated', async () => {
+		await failOneRequest( wpError( { status: 401, statusCode: 401, code: 'rest_forbidden' } ) );
+
+		await waitFor( () => expect( window.location.href ).toContain( '/log-in?redirect_to=' ) );
+	} );
+
+	test( 'leaves a refused-but-authenticated request to the error screen', async () => {
+		await failOneRequest(
+			wpError( { status: 403, statusCode: 403, error: 'authorization_required' } )
+		);
+
+		await waitFor( () => expect( screen.getByText( 'signed in' ) ).toBeVisible() );
+		expect( window.location.href ).not.toContain( '/log-in' );
+	} );
+
+	test( 'ignores a failure that is not about authorization', async () => {
+		await failOneRequest( wpError( { status: 401, statusCode: 401, error: 'server_error' } ) );
+
+		await waitFor( () => expect( screen.getByText( 'signed in' ) ).toBeVisible() );
+		expect( window.location.href ).not.toContain( '/log-in' );
 	} );
 } );

--- a/client/dashboard/app/auth/test/index.test.tsx
+++ b/client/dashboard/app/auth/test/index.test.tsx
@@ -3,11 +3,11 @@
  */
 import config from '@automattic/calypso-config';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { bumpStat } from '../../analytics';
 import { AppProvider, APP_CONTEXT_DEFAULT_CONFIG } from '../../context';
-import { AuthProvider } from '../index';
+import { AuthProvider, sessionStateQuery, useSessionStateQuery } from '../index';
 import type { User } from '@automattic/api-core';
 
 jest.mock( '../../analytics', () => ( {
@@ -174,5 +174,73 @@ describe( '<AuthProvider> stats', () => {
 		await waitFor( () =>
 			expect( mockedBumpStat ).toHaveBeenCalledWith( 'dashboard-auth', 'bounce:expired' )
 		);
+	} );
+} );
+
+describe( 'useSessionStateQuery', () => {
+	function renderSessionState( queryClient = new QueryClient() ) {
+		return renderHook( () => useSessionStateQuery(), {
+			wrapper: ( { children } ) => (
+				<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+			),
+		} );
+	}
+
+	test( 'reports a session that can no longer authenticate as dead', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me' )
+			.query( true )
+			.reply( 403, { error: 'authorization_required', message: 'User cannot access this' } );
+
+		const { result } = renderSessionState();
+
+		await waitFor( () => expect( result.current.data ).toBe( 'dead' ) );
+	} );
+
+	test( 'reports an account that merely lacks a permission as alive', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me' )
+			.query( true )
+			.reply( 200, testUser );
+
+		const { result } = renderSessionState();
+
+		await waitFor( () => expect( result.current.data ).toBe( 'alive' ) );
+	} );
+
+	test( 'separates a probe that never answered from a dead session', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me' )
+			.query( true )
+			.replyWithError( 'offline' );
+
+		const { result } = renderSessionState();
+
+		await waitFor( () => expect( result.current.data ).toBe( 'unknown' ) );
+	} );
+
+	test( 'reuses an answer already in the cache', async () => {
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me' )
+			.query( true )
+			.reply( 200, testUser );
+		// Queued for a refetch to consume. Serving stale data while revalidating would
+		// still read as 'alive' at first, so flipping the answer is what makes an
+		// extra request visible.
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me' )
+			.query( true )
+			.reply( 403, { error: 'authorization_required', message: 'User cannot access this' } );
+
+		const queryClient = new QueryClient();
+		await queryClient.fetchQuery( sessionStateQuery() );
+
+		const { result } = renderSessionState( queryClient );
+
+		await waitFor( () => expect( result.current.data ).toBe( 'alive' ) );
+		await expect(
+			waitFor( () => expect( nock.isDone() ).toBe( true ), { timeout: 250 } )
+		).rejects.toThrow();
+		expect( result.current.data ).toBe( 'alive' );
 	} );
 } );

--- a/packages/api-core/src/__tests__/error.test.ts
+++ b/packages/api-core/src/__tests__/error.test.ts
@@ -1,0 +1,48 @@
+import { classifyAuthError } from '../error';
+
+function wpError( fields: Record< string, unknown > ) {
+	const status = ( fields.statusCode as number ) ?? 403;
+	return Object.assign( new Error( 'nope' ), { status, statusCode: status, ...fields } );
+}
+
+describe( 'classifyAuthError', () => {
+	test.each( [
+		[
+			'a v1 endpoint that did not authenticate the request',
+			401,
+			{ error: 'authorization_required' },
+		],
+		[ 'a WP REST endpoint that did not authenticate the request', 401, { code: 'rest_forbidden' } ],
+	] )( 'reports %s as expired', ( _label, statusCode, fields ) => {
+		expect( classifyAuthError( wpError( { statusCode, ...fields } ) ) ).toBe( 'expired' );
+	} );
+
+	test.each( [
+		[ 'a v1 endpoint refusing an authenticated request', 403, { error: 'authorization_required' } ],
+		[ 'a WP REST endpoint refusing an authenticated request', 403, { code: 'rest_forbidden' } ],
+	] )( 'reports %s as forbidden', ( _label, statusCode, fields ) => {
+		expect( classifyAuthError( wpError( { statusCode, ...fields } ) ) ).toBe( 'forbidden' );
+	} );
+
+	it( 'reads the code from `error` when both fields are present', () => {
+		expect(
+			classifyAuthError(
+				wpError( { statusCode: 403, error: 'authorization_required', code: 'x' } )
+			)
+		).toBe( 'forbidden' );
+	} );
+
+	it( 'ignores an unrelated API failure', () => {
+		expect( classifyAuthError( wpError( { statusCode: 500, error: 'server_error' } ) ) ).toBeNull();
+	} );
+
+	it( 'ignores a 401 that is not an auth code', () => {
+		expect( classifyAuthError( wpError( { statusCode: 401, error: 'server_error' } ) ) ).toBeNull();
+	} );
+
+	it( 'ignores anything that is not a WPError', () => {
+		expect( classifyAuthError( new Error( 'boom' ) ) ).toBeNull();
+		expect( classifyAuthError( undefined ) ).toBeNull();
+		expect( classifyAuthError( { statusCode: 401, error: 'authorization_required' } ) ).toBeNull();
+	} );
+} );

--- a/packages/api-core/src/error.ts
+++ b/packages/api-core/src/error.ts
@@ -30,3 +30,27 @@ export function isInaccessibleJetpackError( error: unknown ): boolean {
 	}
 	return false;
 }
+
+export type AuthErrorKind = 'expired' | 'forbidden';
+
+/**
+ * Classifies an auth failure, or returns null when the error is something else.
+ *
+ * `expired` means the request was not authenticated at all; `forbidden` means it
+ * was, but the account may not do this. The two are worth telling apart because
+ * only the first is recoverable by logging in again.
+ *
+ * v1 endpoints report the code in `error`, WP REST ones in `code`.
+ */
+export function classifyAuthError( error: unknown ): AuthErrorKind | null {
+	if ( ! isWpError( error ) ) {
+		return null;
+	}
+
+	const code = error.error ?? error.code;
+	if ( code !== 'authorization_required' && code !== 'rest_forbidden' ) {
+		return null;
+	}
+
+	return error.statusCode === 401 ? 'expired' : 'forbidden';
+}


### PR DESCRIPTION
Part of DOTCOM-14911. Targets `update/active-access-token-error-message` rather than trunk.

## Proposed Changes

* Add a single auth-error classifier to API Core and route the dashboard's four separate checks through it.

## Why are these changes being made?

The dashboard had four independent predicates answering "is this an auth error", two of which arrived with the base branch. They disagreed with each other in two ways: which status codes count, and which field carries the error code.

That disagreement is the bug the base branch exists to fix. The global auth handler only reacted to 401, the API sends 403 for an expired session, so nothing caught it and the user saw a raw API message. The base branch adds a recovery screen downstream of the miss; this PR removes the miss.

One of the four checks could never match at all. It looked for `rest_forbidden` in the field that v1 endpoints use, but WP REST endpoints report it in a different one — a fact the base branch documents in a comment a few files away without applying it. That arm now fires, which is the only behavior change here: a WP REST endpoint reporting an unauthenticated request at 401 now redirects to log in, as was always intended. Requests refused at 403 still fall through to the recovery screen, so the base branch's work is untouched.

## Testing Instructions

* `yarn test-client client/dashboard/app/auth client/dashboard/app/500` and `yarn test-packages packages/api-core/src/__tests__` — 37 tests, including the 25 that came with the base branch, unchanged.
* The new coverage pins the behavior that was previously unreachable: an unauthenticated WP REST failure redirects to log in, a refused-but-authenticated request does not, and a non-auth failure is ignored.
* No user-visible change beyond that redirect. The recovery screen, the permission screen, and the generic error screen all render as they do on the base branch.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?