### PR TITLE
Site settings: drop the retired wpcom_legacy_contact type

### DIFF
--- a/packages/api-core/src/site-settings/types.ts
+++ b/packages/api-core/src/site-settings/types.ts
@@ -12,7 +12,6 @@ export interface SiteSettings {
 	wpcom_prevent_third_party_sharing?: boolean;
 	wpcom_gifting_subscription?: boolean;
 	wpcom_performance_report_url?: string;
-	wpcom_legacy_contact?: string;
 	wpcom_locked_mode?: boolean;
 	mcp_abilities?: SiteMcpAbilities;
 }


### PR DESCRIPTION
## Proposed Changes

* Remove `wpcom_legacy_contact` from the `SiteSettings` interface in `packages/api-core/src/site-settings/types.ts`.

That is the whole change — one line.

> [!IMPORTANT]
> **Stacked on #113892.** This PR is based on that branch, not `trunk`, because the last consumer of this field is the Dashboard's `contact-form.tsx`, which #113892 deletes. GitHub will retarget this to `trunk` automatically once #113892 merges. Please merge #113892 first.

## Why are these changes being made?

Final cleanup after #113892 (Dashboard) and #113893 (classic Calypso), which retired the site-level legacy contact capture form in favour of the account-level legacy contact setting on WordPress.com. Automattic/jetpack#51695 removes the `wpcom_legacy_contact` option registration, the v1 site settings API filters, and the Sync allowlist entry on the backend, so the field will stop being returned by the endpoint entirely.

With no readers or writers left, keeping the field in the type only invites someone to start using it again.

## Verification

Searching the repo for `wpcom_legacy_contact` (excluding `node_modules` and build output) returns only the type declaration and `client/dashboard/sites/settings-hundred-year-plan/contact-form.tsx`, which #113892 deletes. Notes on the near-misses:

* Many files import the `SiteSettings` **type** from `@automattic/api-core`, but none of them read or write the `wpcom_legacy_contact` **field**.
* Classic Calypso's `getFormSettings` in `client/sites/settings/site/index.tsx` referenced the key through a `settings: any` parameter, so it never depended on this type. #113893 removes that reference.
* The `SiteSettings` symbols in `client/blocks/*` and `client/landing/stepper/*` are an unrelated type from `@automattic/data-stores`.

Note that `@automattic/api-core` is a published package, so this is technically a public type change — but the field is dead, and removing an optional property cannot break a consumer that never set it.

## Testing Instructions

* `yarn typecheck-packages` — passes clean.
* `yarn typecheck-client` — no new errors (the 23 reported are pre-existing `Cannot find module` failures for unbuilt packages: `@automattic/omnibar`, `@automattic/date-range-picker`, `@automattic/site-launch-modals`).
* No runtime behavior changes; this is a type-only removal.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
