### PR TITLE
Legacy Contact: add placeholder docs link to the intro copy

### DIFF
--- a/client/dashboard/me/security-legacy-contact/index.tsx
+++ b/client/dashboard/me/security-legacy-contact/index.tsx
@@ -1,4 +1,5 @@
 import { legacyContactsQuery } from '@automattic/api-queries';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
@@ -6,6 +7,7 @@ import {
 	Button,
 	Icon,
 } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { people } from '@wordpress/icons';
 import { useState } from 'react';
@@ -33,8 +35,14 @@ export default function SecurityLegacyContact() {
 				<PageHeader
 					prefix={ <Breadcrumbs length={ 2 } /> }
 					title={ __( 'Legacy contact' ) }
-					description={ __(
-						'A legacy contact is someone you trust to have access to your account after your death.'
+					description={ createInterpolateElement(
+						__(
+							'A legacy contact is someone you trust to have access to your account after your death. <link>Learn more</link>.'
+						),
+						{
+							// TODO: Replace with the docs link once available.
+							link: <a href={ localizeUrl( 'https://wordpress.com/support/legacy-contact/' ) } />,
+						}
 					) }
 				/>
 			}


### PR DESCRIPTION
Part of RSM-4570

## Proposed Changes

* Add a "Learn more" link to the end of the Legacy Contact intro description, pointing to a placeholder docs URL (`TODO` comment left in place) until the real documentation is published.

### Example - After

<img width="680" height="506" alt="Screenshot 2026-08-27 at 9 02 47 PM" src="https://github.com/user-attachments/assets/de9e3bcd-8352-4ca1-a268-d3c9cbfbbcba" />

## Why are these changes being made?

* The Legacy Contact settings page currently has no way to link out to further explanation. This wires up the link placement now so it's a one-line swap once the docs URL exists.

## Testing Instructions

* Visit the Legacy Contact settings page and confirm the intro copy now ends with a "Learn more" link.
* Note the link currently points to a placeholder URL — it's not expected to resolve to real content yet.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?