### PR TITLE
Notifications: raise the panel's note cap to 500

### DIFF
--- a/apps/notifications/src/panel/rest-client/index.js
+++ b/apps/notifications/src/panel/rest-client/index.js
@@ -19,7 +19,7 @@ const settings = {
 	// window (NOTES_PER_PAGE); the list fetches as many pages as needed to fill
 	// the window, so the window never outruns the loaded notes.
 	increment_limit: 10,
-	max_limit: 200,
+	max_limit: 500,
 };
 
 export function Client() {

--- a/apps/notifications/src/panel/rest-client/test/index.test.js
+++ b/apps/notifications/src/panel/rest-client/test/index.test.js
@@ -11,7 +11,7 @@ import Client from '../index';
 import { init } from '../wpcom';
 
 // Mirrors settings.max_limit in the client.
-const MAX_LIMIT = 200;
+const MAX_LIMIT = 500;
 
 // Every filtered test here uses the Unread tab; its id list is cached under its name.
 const UNREAD_KEY = 'unread';
@@ -552,15 +552,19 @@ describe( 'RestClient', () => {
 		// Reaching the cap with a full page must clear `filteredHasMore`, or the next
 		// load-more fires a zero-count request (number = max_limit - 100).
 		it( 'stops filtered paging at the cap without a zero-count request', () => {
+			// Ids run from TOP_ID down to 10, so a full window lands exactly on the cap.
+			const TOP_ID = MAX_LIMIT + 9;
 			client.setFilter( 'unread' );
-			getCalls[ 0 ].callback( null, { notes: fullPage( 10, 209 ), last_seen_time: 0 } );
+			getCalls[ 0 ].callback( null, { notes: fullPage( 10, TOP_ID ), last_seen_time: 0 } );
 
 			// Page in full older pages (10 at a time) until the list reaches max_limit.
-			// Starts at 10 loaded (ids 209..200); each page adds the next 10 older ids.
-			for ( let oldest = 199; oldest >= 219 - MAX_LIMIT; oldest -= 10 ) {
+			for ( let loaded = 10; loaded < MAX_LIMIT; loaded += 10 ) {
 				getCalls.length = 0;
 				client.loadMore();
-				getCalls[ 0 ].callback( null, { notes: fullPage( 10, oldest ), last_seen_time: 0 } );
+				getCalls[ 0 ].callback( null, {
+					notes: fullPage( 10, TOP_ID - loaded ),
+					last_seen_time: 0,
+				} );
 			}
 
 			expect( getFilteredNoteIds( store.getState(), UNREAD_KEY ) ).toHaveLength( MAX_LIMIT );


### PR DESCRIPTION
## Proposed Changes

* Raise the notifications panel's maximum number of loaded notes from 200 to 500.

## Why are these changes being made?

* The panel stops paging once 200 notes are loaded, so anyone with a busy site hits the end of their history well before they run out of notifications to read. 500 gives a lot more headroom while still bounding what the panel keeps in memory.

## Testing Instructions

* Open the notifications panel on an account with more than 200 notifications.
* Scroll to the bottom of the All tab and keep scrolling: the list should keep loading past 200 and settle at 500 (or when the account runs out of notifications).
* Repeat on a filtered tab (e.g. Unread) — paging should behave the same and stop cleanly at the cap without firing an empty request.
* `yarn test-apps apps/notifications` passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?