### PR TITLE
Help Center: add Odie funnel impression and conversation start events

### DIFF
--- a/client/dashboard/app/omnibar/plugin-help-center.tsx
+++ b/client/dashboard/app/omnibar/plugin-help-center.tsx
@@ -10,6 +10,7 @@ import { withSiteContext } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
 import { useAnalytics } from '../analytics';
 import { useHelpCenter } from '../help-center';
 import { adminBarIcon } from './admin-bar-icon';
@@ -127,6 +128,24 @@ export function useHelpCenterPlugin( {
 	const { isShown: isHelpCenterShown, setShowHelpCenter } = useHelpCenter();
 	const { recordTracksEvent } = useAnalytics();
 	const { data: omnibarSiteId } = useQuery( omnibarSiteIdQuery() );
+
+	// One impression per section view, so it divides cleanly into the click events
+	// this plugin records; site context is whatever has resolved by then.
+	useEffect( () => {
+		recordTracksEvent(
+			'calypso_inlinehelp_impression',
+			withSiteContext(
+				{
+					location: 'help-center',
+					entry_point: 'omnibar',
+					section: sectionName,
+				},
+				'omnibar',
+				omnibarSiteId
+			)
+		);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ sectionName ] );
 
 	const helpNode = adminBarNodes.find( ( node ) => node.id === AGENTS_MANAGER_NODE_ID );
 

--- a/client/dashboard/app/omnibar/plugin-help-center.tsx
+++ b/client/dashboard/app/omnibar/plugin-help-center.tsx
@@ -118,14 +118,7 @@ function buildAgentsManagerMenuNodes(
 		);
 }
 
-export function useHelpCenterPlugin( {
-	sectionName,
-	adminBarNodes,
-}: {
-	sectionName?: string;
-	adminBarNodes: AdminBarNode[];
-} ): OmnibarNode {
-	const { isShown: isHelpCenterShown, setShowHelpCenter } = useHelpCenter();
+function HelpCenterIcon( { name, sectionName }: { name?: string; sectionName?: string } ) {
 	const { recordTracksEvent } = useAnalytics();
 	const { data: omnibarSiteId } = useQuery( omnibarSiteIdQuery() );
 
@@ -147,6 +140,20 @@ export function useHelpCenterPlugin( {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ sectionName ] );
 
+	return adminBarIcon( name, 'omnibar__help-icon' );
+}
+
+export function useHelpCenterPlugin( {
+	sectionName,
+	adminBarNodes,
+}: {
+	sectionName?: string;
+	adminBarNodes: AdminBarNode[];
+} ): OmnibarNode {
+	const { isShown: isHelpCenterShown, setShowHelpCenter } = useHelpCenter();
+	const { recordTracksEvent } = useAnalytics();
+	const { data: omnibarSiteId } = useQuery( omnibarSiteIdQuery() );
+
 	const helpNode = adminBarNodes.find( ( node ) => node.id === AGENTS_MANAGER_NODE_ID );
 
 	// The backend only sends these nodes to eligible users, so their presence is the gate.
@@ -161,7 +168,7 @@ export function useHelpCenterPlugin( {
 		return {
 			id: helpNode.id,
 			label: helpNode.meta?.menu_title,
-			icon: adminBarIcon( helpNode.meta?.icon, 'omnibar__help-icon' ),
+			icon: <HelpCenterIcon name={ helpNode.meta?.icon } sectionName={ sectionName } />,
 			tooltip: helpNode.meta?.menu_title,
 			// Disconnected sites get a link instead of a dropdown, opened in a new tab as in wp-admin.
 			...( children.length
@@ -173,7 +180,7 @@ export function useHelpCenterPlugin( {
 	return {
 		id: 'help-center',
 		label: __( 'Help' ),
-		icon: adminBarIcon( 'help', 'omnibar__help-icon' ),
+		icon: <HelpCenterIcon name="help" sectionName={ sectionName } />,
 		onClick: () => setShowHelpCenter( ! isHelpCenterShown ),
 	};
 }

--- a/client/dashboard/app/omnibar/test/plugin-help-center.test.tsx
+++ b/client/dashboard/app/omnibar/test/plugin-help-center.test.tsx
@@ -8,6 +8,7 @@ import {
 	openAgentsManagerChat,
 } from '@automattic/agents-manager';
 import { render, renderHook } from '@testing-library/react';
+import { useAnalytics } from '../../analytics';
 import { useHelpCenter } from '../../help-center';
 import { useHelpCenterPlugin } from '../plugin-help-center';
 import type { AdminBarNode, OmnibarNode } from '@automattic/omnibar';
@@ -41,6 +42,7 @@ const mockGetChatRoute = getAgentsManagerChatRoute as jest.MockedFunction<
 >;
 const mockUseHelpCenter = useHelpCenter as jest.MockedFunction< typeof useHelpCenter >;
 const setShowHelpCenter = jest.fn();
+const recordTracksEvent = jest.fn();
 
 const ICON = 'help';
 
@@ -90,12 +92,42 @@ const childrenOf = ( n: OmnibarNode | undefined, id: string ) =>
 describe( 'useHelpCenterPlugin', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		jest.mocked( useAnalytics ).mockReturnValue( {
+			recordTracksEvent,
+			recordPageView: jest.fn(),
+		} );
 		mockIsChatVisible.mockReturnValue( false );
 		mockGetChatRoute.mockReturnValue( undefined );
 		mockUseHelpCenter.mockReturnValue( {
 			isShown: false,
 			setShowHelpCenter,
 		} as unknown as ReturnType< typeof useHelpCenter > );
+	} );
+
+	it.each( [
+		[ 'agents manager', HELP_NODES ],
+		[ 'legacy help', [] ],
+	] )( 'does not track an unrendered %s node', ( _, nodes ) => {
+		renderPlugin( nodes );
+
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	it.each( [
+		[ 'agents manager', HELP_NODES ],
+		[ 'legacy help', [] ],
+	] )( 'tracks an impression only when the %s icon renders', ( _, nodes ) => {
+		const result = renderPlugin( nodes );
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+
+		render( result.icon as React.ReactElement );
+
+		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_inlinehelp_impression', {
+			location: 'help-center',
+			entry_point: 'omnibar',
+			section: 'sites',
+		} );
 	} );
 
 	it( 'takes its id, label and tooltip from the admin bar node', () => {

--- a/client/layout/masterbar/masterbar-help-center/index.jsx
+++ b/client/layout/masterbar/masterbar-help-center/index.jsx
@@ -46,6 +46,24 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 	const isMenuPanelExperimentEnabled =
 		! isLoadingExperimentAssignment && experimentAssignment?.variationName === 'menu_popover';
 
+	// One impression per section view, so it divides cleanly into the click events
+	// below; site context is whatever has resolved by then.
+	useEffect( () => {
+		recordTracksEvent(
+			'calypso_inlinehelp_impression',
+			withSiteContext(
+				{
+					location: 'help-center',
+					entry_point: 'masterbar',
+					section: sectionName,
+				},
+				siteContextSource,
+				siteId
+			)
+		);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ sectionName ] );
+
 	const trackIconInteraction = () => {
 		recordTracksEvent(
 			`wpcom_help_center_icon_interaction`,

--- a/packages/odie-client/src/components/message/intro-suggestions.tsx
+++ b/packages/odie-client/src/components/message/intro-suggestions.tsx
@@ -6,6 +6,7 @@ import { useMemo } from 'react';
 import { isPlansPresalesExperience, PLANS_PRESALES_LAUNCHER_CONTEXT } from '../../constants';
 import { useOdieAssistantContext } from '../../context';
 import { useSendChatMessage } from '../../hooks';
+import { trackConversationStart } from '../../utils/track-conversation-start';
 import type { Message } from '../../types';
 import './intro-suggestions.scss';
 
@@ -87,6 +88,7 @@ const PlansPresalesSuggestions = () => {
 					role: 'user',
 					type: 'message',
 				} as Message;
+				trackConversationStart( chat, selected.prompt ?? selected.label, trackEvent );
 				sendMessage( messageObj ).catch( () => {} );
 			} }
 		/>

--- a/packages/odie-client/src/components/message/test/intro-suggestions.test.tsx
+++ b/packages/odie-client/src/components/message/test/intro-suggestions.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render, screen } from '@testing-library/react';
+import { PLANS_PRESALES_LAUNCHER_CONTEXT } from '../../../constants';
+import { useOdieAssistantContext } from '../../../context';
+import { useSendChatMessage } from '../../../hooks';
+import { IntroSuggestions } from '../intro-suggestions';
+
+type Suggestion = { id: string; label: string; prompt?: string };
+
+interface SuggestionsProps {
+	suggestions: Suggestion[];
+	onSubmit: ( suggestion: Suggestion ) => void;
+}
+
+jest.mock(
+	'@automattic/agenttic-ui',
+	() => ( {
+		Suggestions: ( { suggestions, onSubmit }: SuggestionsProps ) => (
+			<button onClick={ () => onSubmit( suggestions[ 0 ] ) }>Send prompt</button>
+		),
+	} ),
+	{ virtual: true }
+);
+jest.mock( '@automattic/i18n-utils', () => ( {
+	useHasEnTranslation: () => () => true,
+} ) );
+jest.mock( '../../../context', () => ( { useOdieAssistantContext: jest.fn() } ) );
+jest.mock( '../../../hooks', () => ( { useSendChatMessage: jest.fn() } ) );
+
+const trackEvent = jest.fn();
+const sendMessage = jest.fn().mockResolvedValue( undefined );
+
+function setup(
+	messages: { role: string; content: string }[] = [],
+	status = 'loaded',
+	provider = 'odie'
+) {
+	jest.mocked( useOdieAssistantContext ).mockReturnValue( {
+		chat: { messages, status, provider },
+		launcherContext: PLANS_PRESALES_LAUNCHER_CONTEXT,
+		trackEvent,
+	} as unknown as ReturnType< typeof useOdieAssistantContext > );
+	jest.mocked( useSendChatMessage ).mockReturnValue( { sendMessage, abort: jest.fn() } );
+	return render( <IntroSuggestions /> );
+}
+
+describe( 'presales suggestion conversation starts', () => {
+	beforeEach( () => jest.clearAllMocks() );
+
+	it( 'tracks the first prompt before sending it', () => {
+		setup();
+		fireEvent.click( screen.getByRole( 'button', { name: 'Send prompt' } ) );
+
+		expect( trackEvent ).toHaveBeenCalledWith( 'chat_conversation_start', {
+			message_length: 'Compare the plans for me'.length,
+			provider: 'odie',
+		} );
+		expect( sendMessage ).toHaveBeenCalledTimes( 1 );
+		const startCall = trackEvent.mock.calls.findIndex(
+			( [ event ] ) => event === 'chat_conversation_start'
+		);
+		expect( trackEvent.mock.invocationCallOrder[ startCall ] ).toBeLessThan(
+			sendMessage.mock.invocationCallOrder[ 0 ]
+		);
+	} );
+
+	it( 'does not count a follow-up prompt as a start', () => {
+		setup( [ { role: 'user', content: 'Earlier question' } ] );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Send prompt' } ) );
+
+		expect( sendMessage ).toHaveBeenCalledTimes( 1 );
+		expect( trackEvent ).not.toHaveBeenCalledWith( 'chat_conversation_start', expect.anything() );
+	} );
+
+	it( 'does not send or track a start while busy', () => {
+		setup( [], 'loading' );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Send prompt' } ) );
+
+		expect( sendMessage ).not.toHaveBeenCalled();
+		expect( trackEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not offer prompts in a Zendesk conversation', () => {
+		setup( [], 'loaded', 'zendesk' );
+
+		expect( screen.queryByRole( 'button', { name: 'Send prompt' } ) ).toBeNull();
+		expect( trackEvent ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/odie-client/src/components/send-message-input/test/use-send-message-handler.test.ts
+++ b/packages/odie-client/src/components/send-message-input/test/use-send-message-handler.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { useSendMessageHandler } from '../use-send-message-handler';
+import type { Chat, Message } from '../../../types';
+
+jest.mock( 'smooch', () => ( {
+	__esModule: true,
+	default: { stopTyping: jest.fn() },
+} ) );
+
+const userMessage = ( content: string ): Message =>
+	( { content, role: 'user', type: 'message' } ) as Message;
+const botMessage = ( content: string ): Message =>
+	( { content, role: 'bot', type: 'message' } ) as Message;
+
+function makeChat( { provider = 'odie', messages = [] as Message[] } = {} ) {
+	return { provider, messages, conversationId: null } as unknown as Chat;
+}
+
+function setup( chat: Chat ) {
+	const trackEvent = jest.fn();
+	const sendMessage = jest.fn().mockResolvedValue( undefined );
+	const textareaRef = { current: { focus: jest.fn() } };
+
+	const { result } = renderHook( () =>
+		useSendMessageHandler( {
+			inputValue: 'How do I add a domain?',
+			setInputValue: jest.fn(),
+			hasAttachments: false,
+			isChatBusy: false,
+			chat,
+			sendAttachments: jest.fn(),
+			textareaRef: textareaRef as unknown as React.RefObject< HTMLTextAreaElement >,
+			trackEvent,
+			sendMessage,
+		} )
+	);
+
+	return { send: result.current, trackEvent };
+}
+
+const startEvents = ( trackEvent: jest.Mock ) =>
+	trackEvent.mock.calls.filter( ( [ name ] ) => name === 'chat_conversation_start' );
+
+describe( 'useSendMessageHandler conversation start tracking', () => {
+	it( 'records a conversation start on the first user message', async () => {
+		const { send, trackEvent } = setup( makeChat() );
+
+		await act( async () => {
+			await send();
+		} );
+
+		expect( startEvents( trackEvent ) ).toHaveLength( 1 );
+		expect( trackEvent ).toHaveBeenCalledWith( 'chat_conversation_start', {
+			message_length: 'How do I add a domain?'.length,
+			provider: 'odie',
+		} );
+	} );
+
+	it( 'still records a start when only the bot has spoken', async () => {
+		const { send, trackEvent } = setup( makeChat( { messages: [ botMessage( 'Hi there' ) ] } ) );
+
+		await act( async () => {
+			await send();
+		} );
+
+		expect( startEvents( trackEvent ) ).toHaveLength( 1 );
+	} );
+
+	it( 'does not record a start on a follow-up message', async () => {
+		const { send, trackEvent } = setup(
+			makeChat( { messages: [ userMessage( 'First' ), botMessage( 'Answer' ) ] } )
+		);
+
+		await act( async () => {
+			await send();
+		} );
+
+		expect( startEvents( trackEvent ) ).toHaveLength( 0 );
+	} );
+
+	it( 'does not record a start for a Zendesk conversation', async () => {
+		const { send, trackEvent } = setup( makeChat( { provider: 'zendesk' } ) );
+
+		await act( async () => {
+			await send();
+		} );
+
+		expect( startEvents( trackEvent ) ).toHaveLength( 0 );
+	} );
+
+	it( 'always records the message send event alongside the start', async () => {
+		const { send, trackEvent } = setup( makeChat() );
+
+		await act( async () => {
+			await send();
+		} );
+
+		expect( trackEvent ).toHaveBeenCalledWith( 'chat_message_action_send', {
+			message_length: 'How do I add a domain?'.length,
+			provider: 'odie',
+		} );
+	} );
+} );

--- a/packages/odie-client/src/components/send-message-input/use-send-message-handler.ts
+++ b/packages/odie-client/src/components/send-message-input/use-send-message-handler.ts
@@ -48,6 +48,18 @@ export function useSendMessageHandler( {
 		}
 
 		try {
+			// The user's message is appended by `sendMessage` below, so an empty user
+			// history here means this send opens the conversation.
+			const isConversationStart =
+				chat?.provider === 'odie' && ! chat.messages?.some( ( { role } ) => role === 'user' );
+
+			if ( isConversationStart ) {
+				trackEvent( 'chat_conversation_start', {
+					message_length: inputValue.length,
+					provider: chat?.provider,
+				} );
+			}
+
 			trackEvent( 'chat_message_action_send', {
 				message_length: inputValue.length,
 				provider: chat?.provider,
@@ -93,6 +105,7 @@ export function useSendMessageHandler( {
 		inputValue,
 		isChatBusy,
 		chat?.provider,
+		chat.messages,
 		sendMessage,
 		trackEvent,
 		chat.conversationId,

--- a/packages/odie-client/src/components/send-message-input/use-send-message-handler.ts
+++ b/packages/odie-client/src/components/send-message-input/use-send-message-handler.ts
@@ -1,6 +1,7 @@
 import { useCallback } from '@wordpress/element';
 import Smooch from 'smooch';
 import { Message, Chat } from '../../types';
+import { trackConversationStart } from '../../utils/track-conversation-start';
 import { MAX_MESSAGE_LENGTH } from '../notices/use-message-size-error-notice';
 
 interface UseSendMessageHandlerProps {
@@ -48,17 +49,7 @@ export function useSendMessageHandler( {
 		}
 
 		try {
-			// The user's message is appended by `sendMessage` below, so an empty user
-			// history here means this send opens the conversation.
-			const isConversationStart =
-				chat?.provider === 'odie' && ! chat.messages?.some( ( { role } ) => role === 'user' );
-
-			if ( isConversationStart ) {
-				trackEvent( 'chat_conversation_start', {
-					message_length: inputValue.length,
-					provider: chat?.provider,
-				} );
-			}
+			trackConversationStart( chat, inputValue, trackEvent );
 
 			trackEvent( 'chat_message_action_send', {
 				message_length: inputValue.length,

--- a/packages/odie-client/src/utils/track-conversation-start.ts
+++ b/packages/odie-client/src/utils/track-conversation-start.ts
@@ -1,0 +1,18 @@
+import type { Chat } from '../types';
+
+export function trackConversationStart(
+	chat: Chat,
+	message: string,
+	trackEvent: ( event: string, props?: Record< string, unknown > ) => void
+) {
+	// Check before sendMessage appends the user's message to the history.
+	const isConversationStart =
+		chat?.provider === 'odie' && ! chat.messages?.some( ( { role } ) => role === 'user' );
+
+	if ( isConversationStart ) {
+		trackEvent( 'chat_conversation_start', {
+			message_length: message.length,
+			provider: chat?.provider,
+		} );
+	}
+}

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -47,6 +47,7 @@
 		{ "path": "./launchpad" },
 		{ "path": "./mini-cart" },
 		{ "path": "./odie-client" },
+		{ "path": "./omnibar" },
 		{ "path": "./onboarding" },
 		{ "path": "./photon" },
 		{ "path": "./plans-grid-next" },


### PR DESCRIPTION
Part of DOTCOM-18466

## Proposed Changes

**Adds the two missing funnel steps needed to measure Odie usage: "the help button was seen" and "a conversation was started."**

- `calypso_inlinehelp_impression` now fires from the masterbar and the Dashboard omnibar, once per section view, with `entry_point` (`masterbar`, `omnibar`) to tell the two surfaces apart. The FAB already sent this event; the two main entry points did not.
- `calypso_odie_chat_conversation_start` fires when a send opens an Odie conversation, i.e. the first user message.

## Why are these changes being made?

The "Increase usage of Odie" project is measured on Odie conversation starts per exposed user, and on the click-through rate of the help entry point. Neither number can be computed today: nothing records that the help button was ever shown, and the only per-message event fires on every message, so a conversation start looks identical to a follow-up question. Landing the tracking first means the A/B test can read out the moment the UI changes ship, rather than waiting a full extra cycle to collect a baseline.

## Testing Instructions

1. `yarn start`, then open the browser network tab and filter for `tracks`.
2. Load any Calypso page — a `calypso_inlinehelp_impression` with `entry_point: masterbar` fires once. Navigate to a different section: one more fires. Re-render within the same section: nothing extra.
3. Open the Help Center, start a brand new chat, and send a message — `calypso_odie_chat_conversation_start` fires alongside `calypso_odie_chat_message_action_send`.
4. Send a second message in the same chat — only `calypso_odie_chat_message_action_send` fires.

