### PR TITLE
E2E: wait out the cold-boot plugin CTA render

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -297,7 +297,11 @@ export class PluginsPage {
 	async clickInstallPlugin(): Promise< void > {
 		const button = await this.page.locator( selectors.installButton );
 
-		const text = await button.innerText();
+		// The CTA is gated behind the marketplace queries, which a cold Calypso
+		// boot leaves past the 10s global actionTimeout.
+		const installButtonTimeout = 30 * 1000;
+
+		const text = await button.innerText( { timeout: installButtonTimeout } );
 		if ( /^(Purchase|Upgrade) and activate$/.test( text ) ) {
 			await Promise.all( [ this.page.waitForResponse( /eligibility/ ), button.click() ] );
 			// Modal will appear to re-confirm to the user that an upgrade is necessary.


### PR DESCRIPTION
## Proposed Changes

* Give the install-CTA label read in `PluginsPage.clickInstallPlugin()` a 30s timeout instead of the 10s global `actionTimeout`.

## Why are these changes being made?

* The install button is gated behind the marketplace queries. A cold Calypso boot leaves it past 10s, so the label read times out before the CTA paints and `plugins__purchase.spec.ts` fails on both attempts — most recently on the pre-release build for build 19168616.
* Measured over five cold loads on staging: 8.1s at worst against a 10s cap, and CI runs about 1.7x slower. Historical rate is ~1%, which matches a cold-boot-only race.
* The trace showed all API responses at 200, so this is not a throttle ban and the existing throttle-skip machinery correctly stayed silent.

## Testing Instructions

* Reproduced before the fix with a scratch spec delaying `**/marketplace/products/**` by 14s via `page.route` — produced the identical `locator.innerText: Timeout 10000ms exceeded` signature. Passes after.
* `plugins__purchase.spec.ts` against staging: 5/5 on `chrome`, 5/5 on `mobile`, plus 3/3 after rebasing onto current trunk.
* `yarn typecheck-packages` clean.

Note: the underlying ~8s cold-boot CTA render is a real staging performance signal this test no longer surfaces. Worth tracking separately.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
