### PR TITLE
E2E: expect the invite signup block to be enforced

### DIFF
--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -11,6 +11,34 @@ import type {
 	AccountCredentials,
 } from './types/data-helper.types';
 
+// How much of an email address wpcom reads when it derives the username of a
+// passwordless signup: the local part, sanitized to alphanumerics and cut here
+// (`Passwordless_Helpers::generate_username`). Two users whose addresses match
+// over these characters are handed the same username, and whichever signup
+// arrives second fails with `username_reserved_but_may_be_available` or
+// `user_already_exists`.
+const MAX_DERIVED_USERNAME_LENGTH = 40;
+
+// Random characters at the end of a username, base 36. Long enough that two
+// users made in the same millisecond still differ.
+const RANDOM_SUFFIX_LENGTH = 4;
+
+// The namespace wpcom gates test accounts on: teardown refuses to close an
+// account whose username does not carry it (`RestAPIClient.closeAccount`), and
+// signup verification only enforces its verdicts on names inside it. It is
+// never what gives way to the budget below.
+const TEST_ACCOUNT_NAMESPACE = 'e2eflowtesting';
+
+/**
+ * Strips everything wpcom drops before it derives a username from an address.
+ *
+ * @param {string} value Text to sanitize.
+ * @returns {string} The alphanumeric characters of the text.
+ */
+function toAlphanumeric( value: string ): string {
+	return value.replace( /[^a-z0-9]/gi, '' );
+}
+
 /**
  * Returns a set of data required to sign up
  * as a new user and create a new site.
@@ -85,17 +113,39 @@ export function getTimestamp(): string {
  * and the timestamp.
  *
  * Example:
- * 	e2eflowtesting-1654124900-728
- * 	e2eflowtestingfree-1654124900-129
+ * 	e2eflowtestingtn0h9wzr7f4b
+ * 	e2eflowtestingfreetn0h9x1a02pk
+ *
+ * The name is kept short enough that a Gmail-aliased address built from it
+ * still fits in the part wpcom derives a username from, base address included.
+ * The prefix only names the suite that made the user, so it is what gives way
+ * when that leaves no room; the timestamp and random suffix are what keep the
+ * user unique, and they are written in base 36 to spend as few characters as
+ * possible saying it.
  *
  * @param param0 Object parameter.
  * @param {string} param0.prefix Prefix for the username.
  * @returns {string} Generated username.
  */
 export function getUsername( { prefix = '' }: { prefix?: string } = {} ): string {
-	const timestamp = getTimestamp();
-	const randomNumber = getRandomInteger( 0, 999 );
-	return `e2eflowtesting${ prefix }${ timestamp }${ randomNumber }`;
+	const timestamp = Number( getTimestamp() ).toString( 36 );
+	const randomSuffix = getRandomInteger( 0, 36 ** RANDOM_SUFFIX_LENGTH )
+		.toString( 36 )
+		.padStart( RANDOM_SUFFIX_LENGTH, '0' );
+	const unique = `${ timestamp }${ randomSuffix }`;
+
+	const gmailBase = toAlphanumeric( SecretsManager.secrets.gmailTestEmail.split( '@' )[ 0 ] );
+	const nameBudget = MAX_DERIVED_USERNAME_LENGTH - gmailBase.length - unique.length;
+
+	// Only the prefix gives way. A budget short enough to cut into the namespace
+	// leaves an account teardown will not close, and a negative one makes `slice`
+	// trim from the end instead of clamping, so the cut stops happening at all.
+	const name = `${ TEST_ACCOUNT_NAMESPACE }${ prefix }`.slice(
+		0,
+		Math.max( TEST_ACCOUNT_NAMESPACE.length, nameBudget )
+	);
+
+	return name + unique;
 }
 
 /**

--- a/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/user-signup-page.ts
@@ -1,4 +1,4 @@
-import { Page, Locator, Frame } from 'playwright';
+import { APIResponse, Page, Locator, Frame } from 'playwright';
 import { getCalypsoURL } from '../../../data-helper';
 import { handleActiveThrottles } from '../../throttle-flags';
 import type { NewUserResponse } from '../../../types/rest-api-client.types';
@@ -16,6 +16,34 @@ class TransientSignupError extends Error {}
 // fast rather than mask by retrying. Mirrors the phrases isServerErrorPage()
 // matches (Bad Gateway / Service Unavailable / Gateway Timeout).
 const TRANSIENT_UPSTREAM_STATUSES = [ 502, 503, 504 ];
+
+// The user creation endpoint. A pattern rather than a predicate: Playwright
+// collapses a route matched by a function to `**\/*` and hands every request in
+// the context to Node.
+const NEW_USER_ENDPOINT = /\/users\/new\?/;
+
+const HTTP_POST = 'POST';
+
+// The form load, the fill and the round trip together can take a while on a
+// loaded CI runner, so this sits well clear of them and only catches a response
+// that is never coming.
+const NEW_USER_RESPONSE_TIMEOUT = 60_000;
+
+/**
+ * Whether a `/users/new` response is the endpoint's answer to a signup.
+ *
+ * Not `ok()`: a refused signup carries the reason it was refused, and waiting
+ * for an ok response that is never coming turns it into a timeout. Still not a
+ * 5xx, which `captureUsersNewServerError` races the capture to reject with the
+ * retryable error the caller keys on, and not a redirect, whose body is no
+ * answer to parse.
+ *
+ * @param {APIResponse} response Response to the `/users/new` POST.
+ * @returns {boolean} True when the response answers the signup.
+ */
+function isSignupAnswer( response: APIResponse ): boolean {
+	return response.status() < 300 || ( response.status() >= 400 && response.status() < 500 );
+}
 
 /** Returns whether a value is a non-null object (arrays included). */
 function isRecord( value: unknown ): value is Record< string, unknown > {
@@ -222,27 +250,77 @@ export class UserSignupPage {
 		await this.page.goto( getCalypsoURL( targetUrl ), { waitUntil: 'domcontentloaded' } );
 	}
 	/**
+	 * Captures the body of the next `/users/new` response, buffered in Node.
+	 *
+	 * A page-side `response.json()` reads through the browser cache, which the
+	 * navigation that follows a signup — the accept-invite redirect, the next
+	 * step of a flow, the hop to WooCommerce — empties first: the read then fails
+	 * with "No resource with given identifier found". Fetching the request from
+	 * Node and buffering the answer before handing it back to the page leaves
+	 * nothing for the navigation to take away.
+	 *
+	 * Call before the click that triggers the request. The handler stays
+	 * registered for the life of the page; unrouting it while it holds a request
+	 * releases that request, and the fulfill below then dies with "Route is
+	 * already handled!".
+	 *
+	 * @param {Function} accepts Whether a response is the answer being waited
+	 * for. Anything else is handed back to the page and the capture goes on
+	 * waiting.
+	 * @returns {Promise<unknown>} Body of the first accepted response.
+	 */
+	private captureNewUserBody( accepts: ( response: APIResponse ) => boolean ): Promise< unknown > {
+		let captured = false;
+		let onBody: ( body: unknown ) => void = () => undefined;
+		let onFailure: ( error: Error ) => void = () => undefined;
+
+		const body = new Promise< unknown >( ( resolve, reject ) => {
+			onBody = resolve;
+			onFailure = reject;
+		} );
+
+		const routeRegistered = this.page.route( NEW_USER_ENDPOINT, async ( route ) => {
+			if ( captured || route.request().method() !== HTTP_POST ) {
+				return route.fallback();
+			}
+
+			try {
+				const response = await route.fetch();
+				const text = await response.text();
+				await route.fulfill( { response, body: text } );
+
+				if ( ! accepts( response ) ) {
+					return;
+				}
+
+				captured = true;
+				onBody( JSON.parse( text ) );
+			} catch ( error ) {
+				onFailure( error as Error );
+			}
+		} );
+
+		// A registration that never lands would otherwise surface as the capture
+		// timeout below rather than as the reason it failed.
+		routeRegistered.catch( ( error ) => onFailure( error as Error ) );
+
+		let timer: ReturnType< typeof setTimeout > | undefined;
+		const timeout = new Promise< never >( ( _, reject ) => {
+			timer = setTimeout(
+				() => reject( new Error( 'Timed out waiting for a /users/new response.' ) ),
+				NEW_USER_RESPONSE_TIMEOUT
+			);
+		} );
+
+		return Promise.race( [ body, timeout ] ).finally( () => clearTimeout( timer ) );
+	}
+
+	/**
 	 * Captures the response from the user creation API endpoint.
 	 * @returns {Promise<NewUserResponse>}
 	 */
 	private captureNewUserResponse(): Promise< NewUserResponse > {
-		return this.page
-			.waitForResponse(
-				// Not `ok()`: a refused signup carries the reason it was refused, and
-				// waiting for an ok response that is never coming turns it into a
-				// timeout. Still not a 5xx, which `captureUsersNewServerError` races
-				// this promise to reject with the retryable error the caller keys on,
-				// and not a redirect, whose body is no answer to parse.
-				( response ) =>
-					/\/users\/new\?/.test( response.url() ) &&
-					response.request().method() === 'POST' &&
-					( response.status() < 300 || ( response.status() >= 400 && response.status() < 500 ) ),
-				// Use an explicit timeout so the global actionTimeout (10s) does not
-				// apply here. The form load + fill + network round-trip can easily
-				// exceed 10s on a slow CI runner.
-				{ timeout: 60_000 }
-			)
-			.then( async ( response ) => assertSuccessfulNewUserResponse( await response.json() ) );
+		return this.captureNewUserBody( isSignupAnswer ).then( assertSuccessfulNewUserResponse );
 	}
 
 	/**
@@ -485,11 +563,7 @@ export class UserSignupPage {
 			this.page.on( 'framenavigated', handler );
 		} );
 
-		// Read the response body as soon as it arrives; waiting for the redirect
-		// first lets the navigation evict the body from the browser cache.
-		const responseBodyPromise = this.page
-			.waitForResponse( /\/users\/new\?[^?]*$/ )
-			.then( ( response ): Promise< NewUserResponse > => response.json() );
+		const responseBodyPromise = this.captureNewUserBody( () => true );
 
 		const [ responseBody ] = await Promise.all( [
 			responseBodyPromise,
@@ -516,18 +590,14 @@ export class UserSignupPage {
 		handleActiveThrottles( [ 'signup' ] );
 		await this.emailInput.fill( email );
 
-		// Read the response body as soon as it arrives; the accept-invite
-		// navigation that follows a successful signup evicts it from the
-		// browser cache before a later json() can get to it.
-		const responseBodyPromise = this.page
-			.waitForResponse(
-				( response ) => /\/users\/new\?[^?]*$/.test( response.url() ) && response.ok()
-			)
-			.then( ( response ): Promise< NewUserResponse > => response.json() );
+		// A refused invite signup is an answer the caller asserts on, so capture it
+		// the way every other flow does rather than waiting out an ok response the
+		// server is never going to send.
+		const responseBodyPromise = this.captureNewUserBody( isSignupAnswer );
 
 		await this.continueButton.click();
 
-		return await responseBodyPromise;
+		return ( await responseBodyPromise ) as NewUserResponse;
 	}
 
 	/**

--- a/packages/calypso-e2e/src/test/data-helper.test.ts
+++ b/packages/calypso-e2e/src/test/data-helper.test.ts
@@ -4,6 +4,7 @@ import {
 	getAccountCredential,
 	getCalypsoURL,
 	getAccountSiteURL,
+	getNewTestUser,
 	toTitleCase,
 	createSuiteTitle,
 } from '../data-helper';
@@ -11,6 +12,7 @@ import { SecretsManager } from '../secrets';
 import type { Secrets } from '../secrets';
 
 const fakeSecrets = {
+	gmailTestEmail: 'a8c.e2e@gmail.com',
 	testAccounts: {
 		basicUser: {
 			username: 'wpcomuser2',
@@ -39,6 +41,61 @@ describe( 'DataHelper Tests', function () {
 			expect( generated ).toBeGreaterThanOrEqual( min );
 			expect( expected.includes( generated ) );
 		} );
+	} );
+
+	describe( 'Test: getNewTestUser', function () {
+		// What wpcom keeps of a Gmail-aliased address when it derives the username
+		// of a passwordless signup: the local part, sanitized to alphanumerics and
+		// cut at 40 characters (`Passwordless_Helpers::generate_username`).
+		const deriveUsername = ( email: string ) =>
+			email
+				.split( '@' )[ 0 ]
+				.replace( /[^a-z0-9]/gi, '' )
+				.slice( 0, 40 );
+
+		test.each( [ '', 'blackbox', 'ftmepersonal' ] )(
+			'The username wpcom derives for the "%s" prefix keeps the whole address',
+			function ( usernamePrefix ) {
+				const { email } = getNewTestUser( { usernamePrefix } );
+				const localPart = email.split( '@' )[ 0 ].replace( /[^a-z0-9]/gi, '' );
+
+				// Anything past the cut is lost, and what is lost here is the
+				// timestamp and random suffix that make the user unique: two users
+				// generated milliseconds apart are then handed the same username and
+				// the second signup fails with `username_reserved_but_may_be_available`
+				// or `user_already_exists`.
+				expect( deriveUsername( email ) ).toBe( localPart );
+			}
+		);
+
+		test( 'The username stays inside the test-account namespace', function () {
+			const { username } = getNewTestUser( { usernamePrefix: 'ftmepersonal' } );
+
+			// wpcom gates test accounts on this prefix, e.g. discarding their Tracks
+			// events (`WPCOM_Tracks_Client::should_discard`).
+			expect( username.startsWith( 'e2eflowtesting' ) ).toBe( true );
+		} );
+
+		// Base addresses that spend the 40 characters wpcom reads before the
+		// namespace is written: the first leaves the budget short of it, the second
+		// takes the budget negative, which makes an unclamped `slice` trim from the
+		// end and stop cutting altogether.
+		test.each( [ 'e2e.flow.testing.suite@gmail.com', 'e2e.flow.testing.suite.account@gmail.com' ] )(
+			'The namespace survives the base address %s leaving no room for it',
+			function ( gmailTestEmail ) {
+				const baseEmail = fakeSecrets.gmailTestEmail;
+				fakeSecrets.gmailTestEmail = gmailTestEmail;
+
+				try {
+					const { username } = getNewTestUser( { usernamePrefix: 'ftmepersonal' } );
+					// The prefix gives way; the namespace must not, or teardown will
+					// not close the account it makes (`RestAPIClient.closeAccount`).
+					expect( username.startsWith( 'e2eflowtesting' ) ).toBe( true );
+				} finally {
+					fakeSecrets.gmailTestEmail = baseEmail;
+				}
+			}
+		);
 	} );
 
 	describe( 'Test: getCalypsoURL', function () {

--- a/packages/calypso-e2e/src/test/lib/pages/user-signup-page.test.ts
+++ b/packages/calypso-e2e/src/test/lib/pages/user-signup-page.test.ts
@@ -61,40 +61,143 @@ describe( 'assertSuccessfulNewUserResponse', () => {
 	} );
 } );
 
+type RouteHandler = ( route: unknown ) => Promise< unknown >;
+
+/**
+ * Lets everything already queued run, so a page object that registers its route
+ * before clicking has done so by the time the test drives that route.
+ */
+const settle = () => new Promise( ( resolve ) => setImmediate( resolve ) );
+
+/**
+ * A page whose route registrations are collected rather than performed, so a
+ * test can play the part of the network.
+ */
+const buildRoutedPage = () => {
+	const locator = {
+		click: jest.fn( async () => undefined ),
+		fill: jest.fn( async () => undefined ),
+		isVisible: jest.fn( async () => true ),
+		scrollIntoViewIfNeeded: jest.fn( async () => undefined ),
+		waitFor: jest.fn( async () => undefined ),
+	};
+	const handlers: RouteHandler[] = [];
+	const page = {
+		evaluate: jest.fn( async () => false ),
+		getByRole: jest.fn( () => locator ),
+		locator: jest.fn( () => locator ),
+		route: jest.fn( async ( _pattern: RegExp, handler: RouteHandler ) => {
+			handlers.push( handler );
+		} ),
+		waitForResponse: jest.fn( () => new Promise( () => undefined ) ),
+	} as unknown as Page;
+
+	return { handlers, page };
+};
+
+/**
+ * Answers the signup request the page object is holding, the way the browser
+ * would, and reports what was handed back to the page.
+ */
+const answerSignupRequest = async ( handler: RouteHandler, status: number, body: unknown ) => {
+	const fallback = jest.fn( async () => undefined );
+	const fulfill = jest.fn( async () => undefined );
+	const text = JSON.stringify( body );
+
+	await handler( {
+		fallback,
+		fetch: async () => ( {
+			ok: () => status >= 200 && status < 300,
+			status: () => status,
+			text: async () => text,
+		} ),
+		fulfill,
+		request: () => ( { method: () => 'POST' } ),
+	} );
+
+	return { fallback, fulfill };
+};
+
 describe( 'UserSignupPage', () => {
 	test( 'surfaces a rejected signup response without waiting for an ok response', async () => {
-		const locator = {
-			click: jest.fn( async () => undefined ),
-			fill: jest.fn( async () => undefined ),
-			isVisible: jest.fn( async () => true ),
-			scrollIntoViewIfNeeded: jest.fn( async () => undefined ),
-			waitFor: jest.fn( async () => undefined ),
-		};
-		const response = {
-			json: async () => ( {
-				body: { success: false, error: 'throttled', message: 'Limit reached.' },
-			} ),
-			ok: () => false,
-			request: () => ( { method: () => 'POST' } ),
-			status: () => 403,
-			url: () => 'https://public-api.wordpress.com/rest/v1.1/users/new?http_envelope=1',
-		};
-		const waitForResponse = jest.fn( async ( predicate: ( value: typeof response ) => boolean ) => {
-			if ( ! predicate( response ) ) {
-				throw new Error( 'response was not captured' );
-			}
-			return response;
-		} );
-		const page = {
-			getByRole: jest.fn( () => locator ),
-			locator: jest.fn( () => locator ),
-			waitForResponse,
-		} as unknown as Page;
+		const { handlers, page } = buildRoutedPage();
 
-		await expect(
-			new UserSignupPage( page ).signup( 'test@example.com', 'tester', 'password' )
-		).rejects.toThrow( 'User signup did not create a usable account: throttled: Limit reached.' );
-		expect( waitForResponse ).toHaveBeenCalledTimes( 1 );
+		const signup = new UserSignupPage( page ).signup( 'test@example.com', 'tester', 'password' );
+		await settle();
+
+		await answerSignupRequest( handlers[ 0 ], 403, {
+			body: { success: false, error: 'throttled', message: 'Limit reached.' },
+		} );
+
+		await expect( signup ).rejects.toThrow(
+			'User signup did not create a usable account: throttled: Limit reached.'
+		);
+	} );
+
+	test( 'reads the signup body from the network, not from the browser', async () => {
+		// The read has to be answered from what was buffered here, because the
+		// navigation a signup triggers empties the browser cache the page-side
+		// `response.json()` reads from: it fails with "No resource with given
+		// identifier found". This case fails if that read comes back.
+		const { handlers, page } = buildRoutedPage();
+		const response = {
+			code: 200,
+			body: { success: true, user_id: 123, username: 'e2eflowtesting123', bearer_token: 'token' },
+		};
+
+		const signup = new UserSignupPage( page ).signup( 'test@example.com', 'tester', 'password' );
+		await settle();
+
+		const { fulfill } = await answerSignupRequest( handlers[ 0 ], 200, response );
+
+		await expect( signup ).resolves.toEqual( response );
+		// The page still gets its answer: the capture reads the body, it does not
+		// swallow the request.
+		expect( fulfill ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'hands a transient upstream failure back and captures the retry that follows', async () => {
+		// The retry path of signupWithEmail: a 502 is left for
+		// captureUsersNewServerError to reject on, and the capture stays open for
+		// the attempt that follows rather than answering with the failure.
+		const { handlers, page } = buildRoutedPage();
+		const response = {
+			code: 200,
+			body: { success: true, user_id: 123, username: 'e2eflowtesting123', bearer_token: 'token' },
+		};
+
+		const signup = new UserSignupPage( page ).signup( 'test@example.com', 'tester', 'password' );
+		await settle();
+
+		const failure = await answerSignupRequest( handlers[ 0 ], 502, 'Bad Gateway' );
+		// The page still receives the failure: it is what the server-error watch
+		// keys on to ask for a retry.
+		expect( failure.fulfill ).toHaveBeenCalledTimes( 1 );
+
+		await answerSignupRequest( handlers[ 0 ], 200, response );
+
+		await expect( signup ).resolves.toEqual( response );
+	} );
+
+	test( 'leaves later signup requests alone once it has captured one', async () => {
+		const { handlers, page } = buildRoutedPage();
+		const response = {
+			code: 200,
+			body: { success: true, user_id: 123, username: 'e2eflowtesting123', bearer_token: 'token' },
+		};
+
+		const signup = new UserSignupPage( page ).signup( 'test@example.com', 'tester', 'password' );
+		await settle();
+
+		await answerSignupRequest( handlers[ 0 ], 200, response );
+		await expect( signup ).resolves.toEqual( response );
+
+		// The handler cannot be unrouted, so it has to stand aside on its own: it
+		// outlives the capture, and a later signup on the same page belongs to
+		// whichever capture is waiting for it.
+		const later = await answerSignupRequest( handlers[ 0 ], 200, response );
+		expect( later.fallback ).toHaveBeenCalledTimes( 1 );
+		expect( later.fulfill ).not.toHaveBeenCalled();
 	} );
 
 	test( 'returns a partial invite signup response so the caller can retain it for cleanup', async () => {
@@ -109,22 +212,30 @@ describe( 'UserSignupPage', () => {
 				username: 'e2eflowtesting123',
 			},
 		};
-		const locator = {
-			click: jest.fn( async () => undefined ),
-			fill: jest.fn( async () => undefined ),
+		const { handlers, page } = buildRoutedPage();
+
+		const signup = new UserSignupPage( page ).signupThroughInvite( 'test@example.com' );
+		await settle();
+
+		await answerSignupRequest( handlers[ 0 ], 200, partialResponse );
+
+		await expect( signup ).resolves.toEqual( partialResponse );
+	} );
+
+	test( 'returns a refused invite signup instead of waiting out an ok response', async () => {
+		// The blackbox invite spec asserts on the refusal itself. Capturing only an
+		// ok response would turn it into the capture timeout instead.
+		const refusal = {
+			code: 403,
+			body: { error: 'throttled', message: 'Limit reached.' },
 		};
-		const page = {
-			getByRole: jest.fn( () => locator ),
-			locator: jest.fn( () => locator ),
-			waitForResponse: jest.fn( async () => ( {
-				json: async () => partialResponse,
-			} ) ),
-		} as unknown as Page;
+		const { handlers, page } = buildRoutedPage();
 
-		const signupPage = new UserSignupPage( page );
+		const signup = new UserSignupPage( page ).signupThroughInvite( 'test@example.com' );
+		await settle();
 
-		await expect( signupPage.signupThroughInvite( 'test@example.com' ) ).resolves.toBe(
-			partialResponse
-		);
+		await answerSignupRequest( handlers[ 0 ], 403, refusal );
+
+		await expect( signup ).resolves.toEqual( refusal );
 	} );
 } );

--- a/packages/calypso-e2e/src/types/rest-api-client.types.ts
+++ b/packages/calypso-e2e/src/types/rest-api-client.types.ts
@@ -93,6 +93,10 @@ export interface NewUserResponse {
 		user_id: number;
 		username: string;
 		bearer_token: string;
+		// A refused signup answers in this same envelope: the HTTP status is 200,
+		// the refusal is the enveloped `code`, and these two say what it was.
+		error?: string;
+		message?: string;
 	};
 }
 

--- a/test/e2e/specs/authentication/authentication__blackbox-signup-invite.spec.ts
+++ b/test/e2e/specs/authentication/authentication__blackbox-signup-invite.spec.ts
@@ -19,10 +19,12 @@ import type { Page, Request } from '@playwright/test';
  * invite secret, which is only ever embedded in the emailed link — the REST
  * API exposes just the bare invite slug, which the server rejects.
  *
- * Signup verification currently runs in shadow mode on the server
- * (blackbox_signup_enforcement_enabled() is off), so a block verdict is
- * recorded but must not prevent the signup. When enforcement is enabled,
- * the block test below needs to assert a rejected signup instead.
+ * Signup verification enforces its verdicts on the closed test loop, which
+ * these signups are on and their gmail-aliased siblings are not: the loop wants
+ * a username in the `e2eflowtesting` namespace, and the passwordless form sends
+ * none, so the server derives one from the email local part. A Mailosaur
+ * address gives it `e2eflowtestingblackbox...`; a gmail alias gives it the base
+ * address first. Production stays in shadow mode either way.
  */
 test.describe( 'Signup: Blackbox invite accept', { tag: [ tags.AUTHENTICATION ] }, () => {
 	skipIfMailosaurLimitReached();
@@ -208,7 +210,7 @@ test.describe( 'Signup: Blackbox invite accept', { tag: [ tags.AUTHENTICATION ] 
 		} );
 	} );
 
-	test( 'As an invited new user, my signup still succeeds when Blackbox returns block (shadow mode)', async ( {
+	test( 'As an invited new user, my signup is refused when Blackbox returns block', async ( {
 		page,
 		clientEmail,
 	}, workerInfo ) => {
@@ -245,19 +247,36 @@ test.describe( 'Signup: Blackbox invite accept', { tag: [ tags.AUTHENTICATION ] 
 			const usersNewRequest = waitForUsersNewRequest( page );
 
 			newUserDetails = await new UserSignupPage( page ).signupThroughInvite( testUser.email );
-			accountsToCleanup.push( {
-				user: newUserDetails.body,
-				password: testUser.password,
-				email: testUser.email,
-			} );
+			// A refused signup leaves nothing to close. Queue teardown only for an
+			// account created anyway — off the test loop the verdict is not enforced
+			// — so it never leaks and an empty identity is never reported as a leak.
+			if ( newUserDetails.body.user_id ) {
+				accountsToCleanup.push( {
+					user: newUserDetails.body,
+					password: testUser.password,
+					email: testUser.email,
+				} );
+			}
 
 			const request = await usersNewRequest;
 			expect( request.postDataJSON()?.blackbox_session_id ).toBe( 'bbtest_block__________' );
 		} );
 
-		await test.step( 'Then the account is still created (enforcement is off)', async function () {
-			expect( newUserDetails.body.user_id ).toBeTruthy();
-			expect( newUserDetails.body.bearer_token ).toBeTruthy();
+		await test.step( 'Then the signup is refused and no account is created', async function () {
+			// The refusal is dressed as the signup throttle: same `throttled` slug,
+			// no ban behind it. See blackbox_verify_signup().
+			expect( newUserDetails.code ).toBe( 403 );
+			expect( newUserDetails.body.error ).toBe( 'throttled' );
+			expect( newUserDetails.body.user_id ).toBeUndefined();
+		} );
+
+		await test.step( 'And the page tells me why', async function () {
+			// The notice carries the server's own message, so read it back from the
+			// response rather than pinning the copy here.
+			expect( newUserDetails.body.message ).toBeTruthy();
+			await expect( page.locator( '.calypso-notice.is-error .calypso-notice__text' ) ).toHaveText(
+				newUserDetails.body.message as string
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
Stacked on #113842 — review that one first; this branch is based on it and will be retargeted to `trunk` once it lands. Only the last commit belongs to this PR.

## Proposed Changes

* Assert the enforced refusal in the invite block test: the enveloped `403`, the `throttled` slug the refusal is dressed as, no account, and the error notice.
* Read the expected notice copy back from the signup response instead of pinning the server's string in the spec.
* Queue the account teardown only when an account was actually created.
* `NewUserResponse.body` now carries the optional `error` / `message` a refused signup answers with.

## Why are these changes being made?

wpcom turned on Blackbox signup enforcement for the closed test loop (wpcom PR 237279, `68fec01e872`), so a canned `bbtest_block__________` verdict now refuses the signup rather than only being recorded. The spec still asserted the shadow-mode behaviour — "my signup still succeeds when Blackbox returns block" — and has failed on every Authentication E2E run since: builds `#5198` through `#5203`, all on `trunk`. The spec's own header predicted this update.

Only this spec is affected, and the reason is worth writing down. The test loop wants a username in the `e2eflowtesting` namespace, and the passwordless form sends no username, so the server derives one from the email local part. This spec signs up with Mailosaur addresses, which land in the namespace; its sibling blackbox signup specs use a Gmail alias, which puts the base address in front of it and keeps them off the loop. Production is unaffected either way — enforcement there is still shadow-only.

A refused signup used to be queued for teardown like any other, which is where the `e2E teardown leak: 1 test user(s) not closed` line in those builds came from: there was no account to close. The guard also keeps a run that is off the test loop — a local one, say — cleaning up after itself.

The same builds also failed the invite *allow* test on a response-body eviction race. That fix is #113842, which this branch is stacked on.

## Testing Instructions

The Authentication suite only runs against production, so it cannot be verified locally.

* TeamCity `Authentication E2E Tests` on this branch: all three invite tests pass, and no teardown-leak line in the log.
* Compare against builds `#5198`–`#5203` on `trunk` for the failing state.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
