### PR TITLE
Help Center chat: stop messages leaking across tabs

### DIFF
--- a/packages/odie-client/src/data/broadcast-messages.ts
+++ b/packages/odie-client/src/data/broadcast-messages.ts
@@ -1,34 +1,65 @@
 import { useEffect } from 'react';
+import { useCurrentSupportInteractionId } from './use-current-support-interaction';
 import type { Message } from '../types';
 
 const messageEventName = 'odieMessageEvent';
 
-export const broadcastOdieMessage = ( message: Message, origin: string ) => {
+type OdieBroadcastData = {
+	type: typeof messageEventName;
+	message: Message;
+	odieBroadcastClientId: string;
+	/**
+	 * The support interaction the sending tab is showing, or `null` when it has
+	 * none yet. Receivers only accept messages for the interaction they show, so
+	 * a message never leaks into a different chat open in another tab (DOTSUP-470).
+	 */
+	supportInteractionId: string | null;
+};
+
+export const broadcastOdieMessage = (
+	message: Message,
+	origin: string,
+	supportInteractionId: string | null
+) => {
 	const bc = new BroadcastChannel( 'odieChannel' );
 	bc.postMessage( {
 		type: messageEventName,
 		message,
 		odieBroadcastClientId: origin,
-	} );
+		supportInteractionId,
+	} satisfies OdieBroadcastData );
 };
 
 export const useOdieBroadcastWithCallbacks = (
 	callbacks: { addMessage?: ( message: Message ) => void },
 	listenerClientId: string
 ) => {
+	const supportInteractionId = useCurrentSupportInteractionId();
+
 	useEffect( () => {
 		const bc = new BroadcastChannel( 'odieChannel' );
 		bc.onmessage = ( event ) => {
-			const odieBroadcastClientId = event.data.odieBroadcastClientId;
-			if ( listenerClientId !== odieBroadcastClientId ) {
-				if ( event.data.type === messageEventName && callbacks.addMessage ) {
-					callbacks.addMessage( event.data.message );
-				}
+			const data = event.data as Partial< OdieBroadcastData > | undefined;
+
+			if ( data?.type !== messageEventName || ! data.message || ! callbacks.addMessage ) {
+				return;
 			}
+
+			// Ignore our own broadcasts.
+			if ( data.odieBroadcastClientId === listenerClientId ) {
+				return;
+			}
+
+			// Only accept messages for the support interaction this tab is showing.
+			if ( ! supportInteractionId || data.supportInteractionId !== supportInteractionId ) {
+				return;
+			}
+
+			callbacks.addMessage( data.message );
 		};
 
 		return () => {
 			bc.close();
 		};
-	}, [ callbacks, listenerClientId ] );
+	}, [ callbacks, listenerClientId, supportInteractionId ] );
 };

--- a/packages/odie-client/src/data/broadcast-messages.ts
+++ b/packages/odie-client/src/data/broadcast-messages.ts
@@ -55,7 +55,18 @@ export const useOdieBroadcastWithCallbacks = (
 				return;
 			}
 
-			callbacks.addMessage( data.message );
+			// The sending tab owns the send lifecycle. Here the message is already on
+			// its way, so render it as sent instead of stuck in the greyed "sending"
+			// state that a user message without `received` gets.
+			const message =
+				data.message.role === 'user' && ! data.message.received
+					? {
+							...data.message,
+							received: data.message.metadata?.local_timestamp ?? Date.now() / 1000,
+					  }
+					: data.message;
+
+			callbacks.addMessage( message );
 		};
 
 		return () => {

--- a/packages/odie-client/src/data/broadcast-messages.ts
+++ b/packages/odie-client/src/data/broadcast-messages.ts
@@ -2,6 +2,7 @@ import { isTestModeEnvironment } from '@automattic/zendesk-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useCurrentSupportInteractionId } from './use-current-support-interaction';
+import { getSupportInteractionQueryKey } from './use-get-support-interaction-by-id';
 import type { Message } from '../types';
 
 const messageEventName = 'odieMessageEvent';
@@ -9,6 +10,11 @@ const interactionUpdatedEventName = 'odieInteractionUpdatedEvent';
 
 type OdieBroadcastData = {
 	type: typeof messageEventName;
+	/**
+	 * Crosses tabs through structured clone, so `content` has to be plain text:
+	 * a React element makes `postMessage` throw a `DataCloneError`. Every sender
+	 * passes plain text today (user input, Odie replies, the built-in notices).
+	 */
 	message: Message;
 	odieBroadcastClientId: string;
 	/**
@@ -30,27 +36,32 @@ type OdieInteractionUpdatedData = {
 	supportInteractionId: string;
 };
 
+const postToOdieChannel = ( data: OdieBroadcastData | OdieInteractionUpdatedData ) => {
+	const bc = new BroadcastChannel( 'odieChannel' );
+	bc.postMessage( data );
+	// The message is already queued for the other tabs; nothing else goes out on this channel.
+	bc.close();
+};
+
 export const broadcastOdieMessage = (
 	message: Message,
 	origin: string,
 	supportInteractionId: string | null
 ) => {
-	const bc = new BroadcastChannel( 'odieChannel' );
-	bc.postMessage( {
+	postToOdieChannel( {
 		type: messageEventName,
 		message,
 		odieBroadcastClientId: origin,
 		supportInteractionId,
-	} satisfies OdieBroadcastData );
+	} );
 };
 
 export const broadcastOdieInteractionUpdated = ( origin: string, supportInteractionId: string ) => {
-	const bc = new BroadcastChannel( 'odieChannel' );
-	bc.postMessage( {
+	postToOdieChannel( {
 		type: interactionUpdatedEventName,
 		odieBroadcastClientId: origin,
 		supportInteractionId,
-	} satisfies OdieInteractionUpdatedData );
+	} );
 };
 
 export const useOdieBroadcastWithCallbacks = (
@@ -83,12 +94,7 @@ export const useOdieBroadcastWithCallbacks = (
 				// the Odie chat so the history it rebuilds from is not the stale copy
 				// cached before the other tab escalated.
 				queryClient.invalidateQueries( {
-					queryKey: [
-						'support-interactions',
-						'get-interaction-by-id',
-						supportInteractionId,
-						isTestModeEnvironment(),
-					],
+					queryKey: getSupportInteractionQueryKey( supportInteractionId, isTestModeEnvironment() ),
 				} );
 				queryClient.invalidateQueries( { queryKey: [ 'odie-chat' ] } );
 				return;
@@ -98,14 +104,17 @@ export const useOdieBroadcastWithCallbacks = (
 				return;
 			}
 
-			// The sending tab owns the send lifecycle. Here the message is already on
-			// its way, so render it as sent instead of stuck in the greyed "sending"
-			// state that a user message without `received` gets.
+			// The sending tab owns the send lifecycle. A Zendesk user message (the only
+			// kind carrying `temporary_id`) renders greyed as "sending" until `received`
+			// is set, and only the sending tab ever sets it. The message is already on
+			// its way here, so stamp it and render it as sent.
 			const message =
-				data.message.role === 'user' && ! data.message.received
+				data.message.role === 'user' &&
+				data.message.metadata?.temporary_id &&
+				! data.message.received
 					? {
 							...data.message,
-							received: data.message.metadata?.local_timestamp ?? Date.now() / 1000,
+							received: data.message.metadata.local_timestamp ?? Date.now() / 1000,
 					  }
 					: data.message;
 

--- a/packages/odie-client/src/data/broadcast-messages.ts
+++ b/packages/odie-client/src/data/broadcast-messages.ts
@@ -79,6 +79,9 @@ export const useOdieBroadcastWithCallbacks = (
 			}
 
 			if ( data.type === interactionUpdatedEventName ) {
+				// Refetch the interaction so this tab picks up the new conversation, and
+				// the Odie chat so the history it rebuilds from is not the stale copy
+				// cached before the other tab escalated.
 				queryClient.invalidateQueries( {
 					queryKey: [
 						'support-interactions',
@@ -87,6 +90,7 @@ export const useOdieBroadcastWithCallbacks = (
 						isTestModeEnvironment(),
 					],
 				} );
+				queryClient.invalidateQueries( { queryKey: [ 'odie-chat' ] } );
 				return;
 			}
 

--- a/packages/odie-client/src/data/broadcast-messages.ts
+++ b/packages/odie-client/src/data/broadcast-messages.ts
@@ -1,8 +1,11 @@
+import { isTestModeEnvironment } from '@automattic/zendesk-client';
+import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useCurrentSupportInteractionId } from './use-current-support-interaction';
 import type { Message } from '../types';
 
 const messageEventName = 'odieMessageEvent';
+const interactionUpdatedEventName = 'odieInteractionUpdatedEvent';
 
 type OdieBroadcastData = {
 	type: typeof messageEventName;
@@ -14,6 +17,17 @@ type OdieBroadcastData = {
 	 * a message never leaks into a different chat open in another tab (DOTSUP-470).
 	 */
 	supportInteractionId: string | null;
+};
+
+/**
+ * Sent when a tab changes the support interaction itself, e.g. escalates it to
+ * a Zendesk conversation. Other tabs on the same interaction refetch it so they
+ * switch too, instead of staying on the Odie chat.
+ */
+type OdieInteractionUpdatedData = {
+	type: typeof interactionUpdatedEventName;
+	odieBroadcastClientId: string;
+	supportInteractionId: string;
 };
 
 export const broadcastOdieMessage = (
@@ -30,28 +44,53 @@ export const broadcastOdieMessage = (
 	} satisfies OdieBroadcastData );
 };
 
+export const broadcastOdieInteractionUpdated = ( origin: string, supportInteractionId: string ) => {
+	const bc = new BroadcastChannel( 'odieChannel' );
+	bc.postMessage( {
+		type: interactionUpdatedEventName,
+		odieBroadcastClientId: origin,
+		supportInteractionId,
+	} satisfies OdieInteractionUpdatedData );
+};
+
 export const useOdieBroadcastWithCallbacks = (
 	callbacks: { addMessage?: ( message: Message ) => void },
 	listenerClientId: string
 ) => {
 	const supportInteractionId = useCurrentSupportInteractionId();
+	const queryClient = useQueryClient();
 
 	useEffect( () => {
 		const bc = new BroadcastChannel( 'odieChannel' );
 		bc.onmessage = ( event ) => {
-			const data = event.data as Partial< OdieBroadcastData > | undefined;
-
-			if ( data?.type !== messageEventName || ! data.message || ! callbacks.addMessage ) {
-				return;
-			}
+			const data = event.data as
+				| Partial< OdieBroadcastData >
+				| Partial< OdieInteractionUpdatedData >
+				| undefined;
 
 			// Ignore our own broadcasts.
-			if ( data.odieBroadcastClientId === listenerClientId ) {
+			if ( ! data || data.odieBroadcastClientId === listenerClientId ) {
 				return;
 			}
 
-			// Only accept messages for the support interaction this tab is showing.
+			// Only act on broadcasts for the support interaction this tab is showing.
 			if ( ! supportInteractionId || data.supportInteractionId !== supportInteractionId ) {
+				return;
+			}
+
+			if ( data.type === interactionUpdatedEventName ) {
+				queryClient.invalidateQueries( {
+					queryKey: [
+						'support-interactions',
+						'get-interaction-by-id',
+						supportInteractionId,
+						isTestModeEnvironment(),
+					],
+				} );
+				return;
+			}
+
+			if ( data.type !== messageEventName || ! data.message || ! callbacks.addMessage ) {
 				return;
 			}
 
@@ -72,5 +111,5 @@ export const useOdieBroadcastWithCallbacks = (
 		return () => {
 			bc.close();
 		};
-	}, [ callbacks, listenerClientId, supportInteractionId ] );
+	}, [ callbacks, listenerClientId, supportInteractionId, queryClient ] );
 };

--- a/packages/odie-client/src/data/broadcast-messages.ts
+++ b/packages/odie-client/src/data/broadcast-messages.ts
@@ -1,6 +1,7 @@
 import { isTestModeEnvironment } from '@automattic/zendesk-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useCurrentSupportInteractionId } from './use-current-support-interaction';
 import { getSupportInteractionQueryKey } from './use-get-support-interaction-by-id';
 import type { Message } from '../types';
@@ -33,7 +34,17 @@ type OdieBroadcastData = {
 type OdieInteractionUpdatedData = {
 	type: typeof interactionUpdatedEventName;
 	odieBroadcastClientId: string;
+	/**
+	 * The interaction the sending tab started from. Other tabs are showing this
+	 * one, so it is what they match on.
+	 */
 	supportInteractionId: string;
+	/**
+	 * The interaction that owns the conversation now. Usually the same, but the
+	 * support interaction service can move the event onto another interaction;
+	 * tabs on the original then follow the sending tab there.
+	 */
+	updatedSupportInteractionId: string;
 };
 
 const postToOdieChannel = ( data: OdieBroadcastData | OdieInteractionUpdatedData ) => {
@@ -56,11 +67,16 @@ export const broadcastOdieMessage = (
 	} );
 };
 
-export const broadcastOdieInteractionUpdated = ( origin: string, supportInteractionId: string ) => {
+export const broadcastOdieInteractionUpdated = (
+	origin: string,
+	supportInteractionId: string,
+	updatedSupportInteractionId: string = supportInteractionId
+) => {
 	postToOdieChannel( {
 		type: interactionUpdatedEventName,
 		odieBroadcastClientId: origin,
 		supportInteractionId,
+		updatedSupportInteractionId,
 	} );
 };
 
@@ -70,6 +86,8 @@ export const useOdieBroadcastWithCallbacks = (
 ) => {
 	const supportInteractionId = useCurrentSupportInteractionId();
 	const queryClient = useQueryClient();
+	const location = useLocation();
+	const navigate = useNavigate();
 
 	useEffect( () => {
 		const bc = new BroadcastChannel( 'odieChannel' );
@@ -90,13 +108,28 @@ export const useOdieBroadcastWithCallbacks = (
 			}
 
 			if ( data.type === interactionUpdatedEventName ) {
+				const isTestMode = isTestModeEnvironment();
+				const updatedSupportInteractionId =
+					data.updatedSupportInteractionId ?? supportInteractionId;
+
 				// Refetch the interaction so this tab picks up the new conversation, and
 				// the Odie chat so the history it rebuilds from is not the stale copy
 				// cached before the other tab escalated.
 				queryClient.invalidateQueries( {
-					queryKey: getSupportInteractionQueryKey( supportInteractionId, isTestModeEnvironment() ),
+					queryKey: getSupportInteractionQueryKey( supportInteractionId, isTestMode ),
 				} );
 				queryClient.invalidateQueries( { queryKey: [ 'odie-chat' ] } );
+
+				if ( updatedSupportInteractionId !== supportInteractionId ) {
+					// The conversation ended up on another interaction. Follow the sending
+					// tab there; the one this tab shows will never get the conversation.
+					queryClient.invalidateQueries( {
+						queryKey: getSupportInteractionQueryKey( updatedSupportInteractionId, isTestMode ),
+					} );
+					const params = new URLSearchParams( location.search );
+					params.set( 'id', updatedSupportInteractionId );
+					navigate( `${ location.pathname }?${ params.toString() }`, { replace: true } );
+				}
 				return;
 			}
 
@@ -124,5 +157,13 @@ export const useOdieBroadcastWithCallbacks = (
 		return () => {
 			bc.close();
 		};
-	}, [ callbacks, listenerClientId, supportInteractionId, queryClient ] );
+	}, [
+		callbacks,
+		listenerClientId,
+		supportInteractionId,
+		queryClient,
+		navigate,
+		location.pathname,
+		location.search,
+	] );
 };

--- a/packages/odie-client/src/data/index.ts
+++ b/packages/odie-client/src/data/index.ts
@@ -6,3 +6,7 @@ export { useSendOdieMessage } from './use-send-odie-message';
 export { useOdieChat } from './use-odie-chat';
 export { useSendOdieFeedback } from './use-send-odie-feedback';
 export { useGetSupportInteractionById } from './use-get-support-interaction-by-id';
+export {
+	useCurrentSupportInteraction,
+	useCurrentSupportInteractionId,
+} from './use-current-support-interaction';

--- a/packages/odie-client/src/data/index.ts
+++ b/packages/odie-client/src/data/index.ts
@@ -1,7 +1,11 @@
 export { handleSupportInteractionsFetch } from './handle-support-interactions-fetch';
 export { useGetZendeskConversation, useGetUnreadConversations } from '@automattic/zendesk-client';
 export { useManageSupportInteraction } from './use-manage-support-interaction';
-export { broadcastOdieMessage, useOdieBroadcastWithCallbacks } from './broadcast-messages';
+export {
+	broadcastOdieInteractionUpdated,
+	broadcastOdieMessage,
+	useOdieBroadcastWithCallbacks,
+} from './broadcast-messages';
 export { useSendOdieMessage } from './use-send-odie-message';
 export { useOdieChat } from './use-odie-chat';
 export { useSendOdieFeedback } from './use-send-odie-feedback';

--- a/packages/odie-client/src/data/test/broadcast-messages.test.ts
+++ b/packages/odie-client/src/data/test/broadcast-messages.test.ts
@@ -2,12 +2,23 @@
  * @jest-environment jsdom
  */
 import { renderHook } from '@testing-library/react';
-import { broadcastOdieMessage, useOdieBroadcastWithCallbacks } from '../broadcast-messages';
+import {
+	broadcastOdieInteractionUpdated,
+	broadcastOdieMessage,
+	useOdieBroadcastWithCallbacks,
+} from '../broadcast-messages';
 import type { Message } from '../../types';
 
 let mockSearch = '?id=interaction-1';
 jest.mock( 'react-router-dom', () => ( {
 	useLocation: () => ( { search: mockSearch } ),
+} ) );
+const mockInvalidateQueries = jest.fn();
+jest.mock( '@tanstack/react-query', () => ( {
+	useQueryClient: () => ( { invalidateQueries: mockInvalidateQueries } ),
+} ) );
+jest.mock( '@automattic/zendesk-client', () => ( {
+	isTestModeEnvironment: () => false,
 } ) );
 // Only `useLocation` matters here; keep the zendesk client out of the import graph.
 jest.mock( '../use-get-support-interaction-by-id', () => ( {
@@ -46,6 +57,7 @@ describe( 'odie broadcast gating', () => {
 	beforeEach( () => {
 		FakeBroadcastChannel.channels = [];
 		mockSearch = '?id=interaction-1';
+		mockInvalidateQueries.mockClear();
 		( globalThis as unknown as { BroadcastChannel: typeof BroadcastChannel } ).BroadcastChannel =
 			FakeBroadcastChannel as unknown as typeof BroadcastChannel;
 	} );
@@ -119,5 +131,23 @@ describe( 'odie broadcast gating', () => {
 		broadcastOdieMessage( message, 'same-tab', 'interaction-1' );
 
 		expect( addMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'refetches the support interaction when another tab updates it', () => {
+		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage: jest.fn() }, 'listener-tab' ) );
+
+		broadcastOdieInteractionUpdated( 'sender-tab', 'interaction-1' );
+
+		expect( mockInvalidateQueries ).toHaveBeenCalledWith( {
+			queryKey: [ 'support-interactions', 'get-interaction-by-id', 'interaction-1', false ],
+		} );
+	} );
+
+	it( 'ignores an interaction update for a different support interaction', () => {
+		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage: jest.fn() }, 'listener-tab' ) );
+
+		broadcastOdieInteractionUpdated( 'sender-tab', 'interaction-2' );
+
+		expect( mockInvalidateQueries ).not.toHaveBeenCalled();
 	} );
 } );

--- a/packages/odie-client/src/data/test/broadcast-messages.test.ts
+++ b/packages/odie-client/src/data/test/broadcast-messages.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { broadcastOdieMessage, useOdieBroadcastWithCallbacks } from '../broadcast-messages';
+import type { Message } from '../../types';
+
+let mockSearch = '?id=interaction-1';
+jest.mock( 'react-router-dom', () => ( {
+	useLocation: () => ( { search: mockSearch } ),
+} ) );
+// Only `useLocation` matters here; keep the zendesk client out of the import graph.
+jest.mock( '../use-get-support-interaction-by-id', () => ( {
+	useGetSupportInteractionById: jest.fn(),
+} ) );
+
+// jsdom does not implement BroadcastChannel. Provide a minimal same-realm
+// implementation so a "broadcast" is delivered synchronously to every other
+// channel on the same name.
+class FakeBroadcastChannel {
+	static channels: FakeBroadcastChannel[] = [];
+	name: string;
+	onmessage: ( ( event: { data: unknown } ) => void ) | null = null;
+
+	constructor( name: string ) {
+		this.name = name;
+		FakeBroadcastChannel.channels.push( this );
+	}
+
+	postMessage( data: unknown ) {
+		FakeBroadcastChannel.channels
+			.filter( ( channel ) => channel !== this && channel.name === this.name )
+			.forEach( ( channel ) => channel.onmessage?.( { data } ) );
+	}
+
+	close() {
+		FakeBroadcastChannel.channels = FakeBroadcastChannel.channels.filter(
+			( channel ) => channel !== this
+		);
+	}
+}
+
+const message = { type: 'message', content: 'hello', role: 'user' } as unknown as Message;
+
+describe( 'odie broadcast gating', () => {
+	beforeEach( () => {
+		FakeBroadcastChannel.channels = [];
+		mockSearch = '?id=interaction-1';
+		( globalThis as unknown as { BroadcastChannel: typeof BroadcastChannel } ).BroadcastChannel =
+			FakeBroadcastChannel as unknown as typeof BroadcastChannel;
+	} );
+
+	it( 'delivers a message to another tab showing the same support interaction', () => {
+		const addMessage = jest.fn();
+		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'listener-tab' ) );
+
+		broadcastOdieMessage( message, 'sender-tab', 'interaction-1' );
+
+		expect( addMessage ).toHaveBeenCalledWith( message );
+	} );
+
+	it( 'reads the legacy odieInteractionId param too', () => {
+		const addMessage = jest.fn();
+		mockSearch = '?odieInteractionId=interaction-1';
+		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'listener-tab' ) );
+
+		broadcastOdieMessage( message, 'sender-tab', 'interaction-1' );
+
+		expect( addMessage ).toHaveBeenCalledWith( message );
+	} );
+
+	it( 'drops a message from a tab showing a different support interaction', () => {
+		const addMessage = jest.fn();
+		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'listener-tab' ) );
+
+		broadcastOdieMessage( message, 'sender-tab', 'interaction-2' );
+
+		expect( addMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'drops a message when the receiving tab has no support interaction yet', () => {
+		const addMessage = jest.fn();
+		mockSearch = '';
+		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'listener-tab' ) );
+
+		broadcastOdieMessage( message, 'sender-tab', null );
+
+		expect( addMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'ignores the tab’s own broadcast', () => {
+		const addMessage = jest.fn();
+		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'same-tab' ) );
+
+		broadcastOdieMessage( message, 'same-tab', 'interaction-1' );
+
+		expect( addMessage ).not.toHaveBeenCalled();
+	} );
+} );

--- a/packages/odie-client/src/data/test/broadcast-messages.test.ts
+++ b/packages/odie-client/src/data/test/broadcast-messages.test.ts
@@ -20,10 +20,6 @@ jest.mock( '@tanstack/react-query', () => ( {
 jest.mock( '@automattic/zendesk-client', () => ( {
 	isTestModeEnvironment: () => false,
 } ) );
-// Only `useLocation` matters here; keep the zendesk client out of the import graph.
-jest.mock( '../use-get-support-interaction-by-id', () => ( {
-	useGetSupportInteractionById: jest.fn(),
-} ) );
 
 // jsdom does not implement BroadcastChannel. Provide a minimal same-realm
 // implementation so a "broadcast" is delivered synchronously to every other
@@ -51,7 +47,14 @@ class FakeBroadcastChannel {
 	}
 }
 
-const message = { type: 'message', content: 'hello', role: 'user' } as unknown as Message;
+// A user message sent to Odie: the composer attaches no metadata to those.
+const odieUserMessage = { type: 'message', content: 'hello', role: 'user' } as unknown as Message;
+
+// A user message sent to Zendesk: the composer attaches the ids it is tracked by.
+const zendeskUserMessage = {
+	...odieUserMessage,
+	metadata: { temporary_id: 'temp-1', local_timestamp: 1700000000 },
+} as unknown as Message;
 
 describe( 'odie broadcast gating', () => {
 	beforeEach( () => {
@@ -62,22 +65,29 @@ describe( 'odie broadcast gating', () => {
 			FakeBroadcastChannel as unknown as typeof BroadcastChannel;
 	} );
 
-	it( 'delivers a message to another tab showing the same support interaction, marked as sent', () => {
+	it( 'delivers a message to another tab showing the same support interaction', () => {
 		const addMessage = jest.fn();
 		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'listener-tab' ) );
 
-		broadcastOdieMessage( message, 'sender-tab', 'interaction-1' );
+		broadcastOdieMessage( odieUserMessage, 'sender-tab', 'interaction-1' );
 
-		// The receiving tab does not own the send lifecycle, so an unsent user
-		// message is stamped with `received` to avoid the greyed "sending" state.
-		expect( addMessage ).toHaveBeenCalledWith(
-			expect.objectContaining( { content: 'hello', role: 'user', received: expect.any( Number ) } )
-		);
+		expect( addMessage ).toHaveBeenCalledWith( odieUserMessage );
 	} );
 
-	it( 'passes an already-sent message through untouched', () => {
+	it( 'marks a mirrored Zendesk user message as sent, using its local timestamp', () => {
 		const addMessage = jest.fn();
-		const sentMessage = { ...message, received: 111 };
+		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'listener-tab' ) );
+
+		broadcastOdieMessage( zendeskUserMessage, 'sender-tab', 'interaction-1' );
+
+		// The receiving tab does not own the send lifecycle, so it would otherwise
+		// render the message greyed as "sending" forever.
+		expect( addMessage ).toHaveBeenCalledWith( { ...zendeskUserMessage, received: 1700000000 } );
+	} );
+
+	it( 'passes an already-sent Zendesk message through untouched', () => {
+		const addMessage = jest.fn();
+		const sentMessage = { ...zendeskUserMessage, received: 111 };
 		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'listener-tab' ) );
 
 		broadcastOdieMessage( sentMessage, 'sender-tab', 'interaction-1' );
@@ -87,7 +97,7 @@ describe( 'odie broadcast gating', () => {
 
 	it( 'passes a bot message through untouched', () => {
 		const addMessage = jest.fn();
-		const botMessage = { ...message, role: 'bot' } as Message;
+		const botMessage = { ...odieUserMessage, role: 'bot' } as Message;
 		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'listener-tab' ) );
 
 		broadcastOdieMessage( botMessage, 'sender-tab', 'interaction-1' );
@@ -100,7 +110,7 @@ describe( 'odie broadcast gating', () => {
 		mockSearch = '?odieInteractionId=interaction-1';
 		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'listener-tab' ) );
 
-		broadcastOdieMessage( message, 'sender-tab', 'interaction-1' );
+		broadcastOdieMessage( odieUserMessage, 'sender-tab', 'interaction-1' );
 
 		expect( addMessage ).toHaveBeenCalled();
 	} );
@@ -109,7 +119,7 @@ describe( 'odie broadcast gating', () => {
 		const addMessage = jest.fn();
 		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'listener-tab' ) );
 
-		broadcastOdieMessage( message, 'sender-tab', 'interaction-2' );
+		broadcastOdieMessage( odieUserMessage, 'sender-tab', 'interaction-2' );
 
 		expect( addMessage ).not.toHaveBeenCalled();
 	} );
@@ -119,7 +129,7 @@ describe( 'odie broadcast gating', () => {
 		mockSearch = '';
 		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'listener-tab' ) );
 
-		broadcastOdieMessage( message, 'sender-tab', null );
+		broadcastOdieMessage( odieUserMessage, 'sender-tab', null );
 
 		expect( addMessage ).not.toHaveBeenCalled();
 	} );
@@ -128,12 +138,22 @@ describe( 'odie broadcast gating', () => {
 		const addMessage = jest.fn();
 		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'same-tab' ) );
 
-		broadcastOdieMessage( message, 'same-tab', 'interaction-1' );
+		broadcastOdieMessage( odieUserMessage, 'same-tab', 'interaction-1' );
 
 		expect( addMessage ).not.toHaveBeenCalled();
 	} );
 
-	it( 'refetches the support interaction when another tab updates it', () => {
+	it( 'closes the channel it posted on', () => {
+		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage: jest.fn() }, 'listener-tab' ) );
+
+		broadcastOdieMessage( odieUserMessage, 'sender-tab', 'interaction-1' );
+		broadcastOdieInteractionUpdated( 'sender-tab', 'interaction-1' );
+
+		// Only the listener's channel is left open.
+		expect( FakeBroadcastChannel.channels ).toHaveLength( 1 );
+	} );
+
+	it( 'refetches the support interaction and the Odie chat when another tab updates it', () => {
 		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage: jest.fn() }, 'listener-tab' ) );
 
 		broadcastOdieInteractionUpdated( 'sender-tab', 'interaction-1' );
@@ -141,6 +161,7 @@ describe( 'odie broadcast gating', () => {
 		expect( mockInvalidateQueries ).toHaveBeenCalledWith( {
 			queryKey: [ 'support-interactions', 'get-interaction-by-id', 'interaction-1', false ],
 		} );
+		expect( mockInvalidateQueries ).toHaveBeenCalledWith( { queryKey: [ 'odie-chat' ] } );
 	} );
 
 	it( 'ignores an interaction update for a different support interaction', () => {

--- a/packages/odie-client/src/data/test/broadcast-messages.test.ts
+++ b/packages/odie-client/src/data/test/broadcast-messages.test.ts
@@ -10,8 +10,10 @@ import {
 import type { Message } from '../../types';
 
 let mockSearch = '?id=interaction-1';
+const mockNavigate = jest.fn();
 jest.mock( 'react-router-dom', () => ( {
-	useLocation: () => ( { search: mockSearch } ),
+	useLocation: () => ( { search: mockSearch, pathname: '/odie' } ),
+	useNavigate: () => mockNavigate,
 } ) );
 const mockInvalidateQueries = jest.fn();
 jest.mock( '@tanstack/react-query', () => ( {
@@ -61,6 +63,7 @@ describe( 'odie broadcast gating', () => {
 		FakeBroadcastChannel.channels = [];
 		mockSearch = '?id=interaction-1';
 		mockInvalidateQueries.mockClear();
+		mockNavigate.mockClear();
 		( globalThis as unknown as { BroadcastChannel: typeof BroadcastChannel } ).BroadcastChannel =
 			FakeBroadcastChannel as unknown as typeof BroadcastChannel;
 	} );
@@ -162,6 +165,32 @@ describe( 'odie broadcast gating', () => {
 			queryKey: [ 'support-interactions', 'get-interaction-by-id', 'interaction-1', false ],
 		} );
 		expect( mockInvalidateQueries ).toHaveBeenCalledWith( { queryKey: [ 'odie-chat' ] } );
+		expect( mockNavigate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'follows the interaction that now owns the conversation when it moved', () => {
+		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage: jest.fn() }, 'listener-tab' ) );
+
+		// The sending tab started from interaction-1, which this tab shows, but the
+		// service put the conversation on interaction-2.
+		broadcastOdieInteractionUpdated( 'sender-tab', 'interaction-1', 'interaction-2' );
+
+		expect( mockInvalidateQueries ).toHaveBeenCalledWith( {
+			queryKey: [ 'support-interactions', 'get-interaction-by-id', 'interaction-1', false ],
+		} );
+		expect( mockInvalidateQueries ).toHaveBeenCalledWith( {
+			queryKey: [ 'support-interactions', 'get-interaction-by-id', 'interaction-2', false ],
+		} );
+		expect( mockNavigate ).toHaveBeenCalledWith( '/odie?id=interaction-2', { replace: true } );
+	} );
+
+	it( 'ignores a move announced for an interaction this tab does not show', () => {
+		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage: jest.fn() }, 'listener-tab' ) );
+
+		broadcastOdieInteractionUpdated( 'sender-tab', 'interaction-3', 'interaction-1' );
+
+		expect( mockInvalidateQueries ).not.toHaveBeenCalled();
+		expect( mockNavigate ).not.toHaveBeenCalled();
 	} );
 
 	it( 'ignores an interaction update for a different support interaction', () => {

--- a/packages/odie-client/src/data/test/broadcast-messages.test.ts
+++ b/packages/odie-client/src/data/test/broadcast-messages.test.ts
@@ -50,13 +50,37 @@ describe( 'odie broadcast gating', () => {
 			FakeBroadcastChannel as unknown as typeof BroadcastChannel;
 	} );
 
-	it( 'delivers a message to another tab showing the same support interaction', () => {
+	it( 'delivers a message to another tab showing the same support interaction, marked as sent', () => {
 		const addMessage = jest.fn();
 		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'listener-tab' ) );
 
 		broadcastOdieMessage( message, 'sender-tab', 'interaction-1' );
 
-		expect( addMessage ).toHaveBeenCalledWith( message );
+		// The receiving tab does not own the send lifecycle, so an unsent user
+		// message is stamped with `received` to avoid the greyed "sending" state.
+		expect( addMessage ).toHaveBeenCalledWith(
+			expect.objectContaining( { content: 'hello', role: 'user', received: expect.any( Number ) } )
+		);
+	} );
+
+	it( 'passes an already-sent message through untouched', () => {
+		const addMessage = jest.fn();
+		const sentMessage = { ...message, received: 111 };
+		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'listener-tab' ) );
+
+		broadcastOdieMessage( sentMessage, 'sender-tab', 'interaction-1' );
+
+		expect( addMessage ).toHaveBeenCalledWith( sentMessage );
+	} );
+
+	it( 'passes a bot message through untouched', () => {
+		const addMessage = jest.fn();
+		const botMessage = { ...message, role: 'bot' } as Message;
+		renderHook( () => useOdieBroadcastWithCallbacks( { addMessage }, 'listener-tab' ) );
+
+		broadcastOdieMessage( botMessage, 'sender-tab', 'interaction-1' );
+
+		expect( addMessage ).toHaveBeenCalledWith( botMessage );
 	} );
 
 	it( 'reads the legacy odieInteractionId param too', () => {
@@ -66,7 +90,7 @@ describe( 'odie broadcast gating', () => {
 
 		broadcastOdieMessage( message, 'sender-tab', 'interaction-1' );
 
-		expect( addMessage ).toHaveBeenCalledWith( message );
+		expect( addMessage ).toHaveBeenCalled();
 	} );
 
 	it( 'drops a message from a tab showing a different support interaction', () => {

--- a/packages/odie-client/src/data/test/use-send-odie-message.test.ts
+++ b/packages/odie-client/src/data/test/use-send-odie-message.test.ts
@@ -1,0 +1,273 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react';
+import { broadcastOdieMessage } from '..';
+import { useOdieAssistantContext } from '../../context';
+import { useSendOdieMessage } from '../use-send-odie-message';
+import type { Chat, Message, ReturnedChat } from '../../types';
+
+/**
+ * Mutable state backing the mocked dependencies. Each test mutates these to
+ * drive the hook through the scenario under test.
+ */
+const mockSetChat = jest.fn();
+const mockTrackEvent = jest.fn();
+const mockCreateZendeskConversation = jest.fn();
+const mockUseMutation = jest.fn();
+let mockHasReachedLimit = false;
+
+jest.mock( '@automattic/data-stores', () => ( {
+	HelpCenter: { register: () => 'automattic/help-center' },
+} ) );
+
+jest.mock( '@tanstack/react-query', () => ( {
+	useMutation: ( options: unknown ) => mockUseMutation( options ),
+	useQueryClient: () => ( { invalidateQueries: jest.fn() } ),
+} ) );
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( { setLoggedOutOdieChat: jest.fn() } ),
+	// The hook's only useSelect call returns the current user.
+	useSelect: () => ( { ID: 1 } ),
+} ) );
+
+jest.mock( 'react-router-dom', () => ( {
+	useLocation: () => ( { search: '?id=int-1', pathname: '/odie' } ),
+	useNavigate: () => jest.fn(),
+} ) );
+
+jest.mock( 'wpcom-proxy-request', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+	canAccessWpcomApis: () => true,
+} ) );
+
+jest.mock( '../../constants', () => ( {
+	getOdieRateLimitMessage: () => ( { content: 'rate-limited', role: 'bot', type: 'message' } ),
+	getOdieEmailFallbackMessage: () => ( {
+		content: 'email-fallback',
+		role: 'bot',
+		type: 'message',
+	} ),
+	getOdieErrorMessageNonEligible: () => 'offline',
+	getExistingConversationMessage: () => ( {
+		content: '',
+		role: 'bot',
+		type: 'message',
+		internal_message_id: 'existing-conversation-message',
+	} ),
+	getConversationLimitReachedMessage: () => ( {
+		content: 'limit-reached',
+		role: 'bot',
+		type: 'message',
+		internal_message_id: 'conversation-limit-reached-message',
+	} ),
+	getErrorMessageUnknownError: () => ( { content: 'unknown-error', role: 'bot', type: 'message' } ),
+} ) );
+
+jest.mock( '../../context', () => ( {
+	useOdieAssistantContext: jest.fn(),
+} ) );
+
+jest.mock( '../../hooks', () => ( {
+	useCreateZendeskConversation: () => mockCreateZendeskConversation,
+} ) );
+
+jest.mock( '../../hooks/use-logged-out-session', () => ( {
+	useLoggedOutSession: () => ( {
+		isLoggedOutSession: false,
+		loggedOutOdieChatId: null,
+		sessionId: null,
+		botSlug: null,
+	} ),
+} ) );
+
+jest.mock( '../../hooks/use-open-interaction-status-map', () => ( {
+	useOpenInteractionStatusMap: () => new Map(),
+} ) );
+
+jest.mock( '../../utils', () => ( {
+	generateUUID: () => 'internal-1',
+	// Matches the chat id Odie returns below, so no interaction event is added.
+	getOdieIdFromInteraction: () => '7',
+	getIsRequestingHumanSupport: ( message: {
+		context?: { flags?: { forward_to_human_support?: boolean } };
+	} ) => message.context?.flags?.forward_to_human_support ?? false,
+} ) );
+
+jest.mock( '../../utils/chat-utils', () => ( {
+	hasRecentEscalationAttempt: () => false,
+} ) );
+
+jest.mock( '../../utils/get-bot-slug', () => ( {
+	getBotSlug: () => 'wpcom-support-chat',
+} ) );
+
+jest.mock( '../../utils/get-open-live-interactions', () => ( {
+	getOpenLiveInteractions: () => ( {
+		mostRecentSupportInteractionId: null,
+		hasReachedLimit: mockHasReachedLimit,
+	} ),
+} ) );
+
+jest.mock( '../../utils/is-agents-manager-available', () => ( {
+	getIsAgentsManagerAvailable: () => false,
+} ) );
+
+jest.mock( '../request-logged-out-wpcom-odie', () => ( {
+	requestLoggedOutWpcomOdie: jest.fn(),
+} ) );
+
+jest.mock( '../use-current-support-interaction', () => ( {
+	useCurrentSupportInteraction: () => ( { data: { uuid: 'int-1' } } ),
+} ) );
+
+jest.mock( '..', () => ( {
+	useManageSupportInteraction: () => ( {
+		addEventToInteraction: jest.fn(),
+		startNewInteraction: jest.fn(),
+	} ),
+	broadcastOdieMessage: jest.fn(),
+} ) );
+
+const baseChat: Chat = {
+	odieId: 7,
+	conversationId: null,
+	messages: [],
+	wpcomUserId: 99,
+	provider: 'odie',
+	status: 'loaded',
+};
+
+type MutationOptions = {
+	onSuccess: ( returnedChat: ReturnedChat ) => Promise< void >;
+	onError: ( error: Error ) => void;
+};
+
+// Renders the hook and returns the callbacks it registered with useMutation.
+const renderSendOdieMessage = (): MutationOptions => {
+	renderHook( () => useSendOdieMessage( new AbortController().signal ) );
+	return mockUseMutation.mock.calls.at( -1 )?.[ 0 ];
+};
+
+const odieReply = ( overrides: Partial< Message > = {} ): ReturnedChat => ( {
+	chat_id: 7,
+	session_id: '',
+	wpcom_user_id: 99,
+	experiment_name: null,
+	messages: [
+		{ content: 'bot reply', message_id: 1, role: 'bot', type: 'message', ...overrides } as Message,
+	],
+} );
+
+// Every message the hook appended, by replaying its setChat updaters on an empty chat.
+const appendedMessages = () =>
+	mockSetChat.mock.calls.flatMap( ( [ update ] ) =>
+		typeof update === 'function' ? update( baseChat ).messages : update.messages
+	);
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	mockHasReachedLimit = false;
+	( useOdieAssistantContext as jest.Mock ).mockReturnValue( {
+		selectedSiteId: 1,
+		version: null,
+		setChat: mockSetChat,
+		odieBroadcastClientId: 'this-tab',
+		setChatStatus: jest.fn(),
+		setExperimentVariationName: jest.fn(),
+		chat: baseChat,
+		isUserEligibleForPaidSupport: true,
+		canConnectToZendesk: true,
+		forceEmailSupport: false,
+		trackEvent: mockTrackEvent,
+		newInteractionsBotSlug: 'wpcom-support-chat',
+		newLoggedOutInteractionsBotSlug: 'wpcom-support-chat',
+		externalChatProvider: null,
+		externalChatId: null,
+	} );
+} );
+
+describe( 'useSendOdieMessage — mirroring replies into other tabs', () => {
+	it( 'mirrors the bot reply to other tabs on the same support interaction', async () => {
+		const { onSuccess } = renderSendOdieMessage();
+
+		await act( async () => {
+			await onSuccess( odieReply() );
+		} );
+
+		expect( appendedMessages() ).toEqual( [
+			expect.objectContaining( { content: 'bot reply', role: 'bot' } ),
+		] );
+		expect( broadcastOdieMessage ).toHaveBeenCalledWith(
+			expect.objectContaining( { content: 'bot reply', role: 'bot' } ),
+			'this-tab',
+			'int-1'
+		);
+	} );
+
+	it( 'keeps a send failure in the tab that sent the message', () => {
+		const { onError } = renderSendOdieMessage();
+
+		act( () => {
+			onError( new Error( 'Request failed with status 500' ) );
+		} );
+
+		expect( appendedMessages() ).toEqual( [
+			expect.objectContaining( { content: 'unknown-error' } ),
+		] );
+		expect( broadcastOdieMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'keeps a rate limit notice in the tab that hit it', () => {
+		const { onError } = renderSendOdieMessage();
+
+		act( () => {
+			onError( new Error( 'Request failed with status 429' ) );
+		} );
+
+		expect( appendedMessages() ).toEqual( [
+			expect.objectContaining( { content: 'rate-limited' } ),
+		] );
+		expect( broadcastOdieMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not mirror a reply this tab replaces with an automatic escalation', async () => {
+		const { onSuccess } = renderSendOdieMessage();
+
+		await act( async () => {
+			await onSuccess(
+				odieReply( { context: { site_id: null, flags: { forward_to_human_support: true } } } )
+			);
+		} );
+
+		// This tab never shows the reply: it moves the chat to Zendesk instead, and
+		// the other tabs follow through the interaction-updated broadcast.
+		expect( appendedMessages() ).toEqual( [] );
+		expect( mockCreateZendeskConversation ).toHaveBeenCalledWith(
+			expect.objectContaining( { createdFrom: 'automatic_escalation' } )
+		);
+		expect( broadcastOdieMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'mirrors the notice shown in place of the reply when the conversation limit is reached', async () => {
+		mockHasReachedLimit = true;
+		const { onSuccess } = renderSendOdieMessage();
+
+		await act( async () => {
+			await onSuccess(
+				odieReply( { context: { site_id: null, flags: { forward_to_human_support: true } } } )
+			);
+		} );
+
+		const limitNotice = expect.objectContaining( {
+			internal_message_id: 'conversation-limit-reached-message',
+		} );
+		expect( appendedMessages() ).toEqual( [ limitNotice ] );
+		expect( broadcastOdieMessage ).toHaveBeenCalledTimes( 1 );
+		expect( broadcastOdieMessage ).toHaveBeenCalledWith( limitNotice, 'this-tab', 'int-1' );
+	} );
+} );

--- a/packages/odie-client/src/data/use-current-support-interaction.ts
+++ b/packages/odie-client/src/data/use-current-support-interaction.ts
@@ -8,7 +8,8 @@ import { useGetSupportInteractionById } from './use-get-support-interaction-by-i
  */
 export const getSupportInteractionIdFromSearch = ( search: string ): string | null => {
 	const params = new URLSearchParams( search );
-	// Adopt a new less generic ID with backwards compatibility.
+	// `id` is the param every navigation writes. `odieInteractionId` is only read,
+	// for Help Center history persisted before the rename.
 	return params.get( 'id' ) || params.get( 'odieInteractionId' ) || null;
 };
 

--- a/packages/odie-client/src/data/use-current-support-interaction.ts
+++ b/packages/odie-client/src/data/use-current-support-interaction.ts
@@ -1,17 +1,36 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useGetSupportInteractionById } from './use-get-support-interaction-by-id';
+
+/**
+ * Read the support interaction ID from a MemoryRouter search string.
+ * @returns The support interaction ID, or `null` when the URL has none.
+ */
+export const getSupportInteractionIdFromSearch = ( search: string ): string | null => {
+	const params = new URLSearchParams( search );
+	// Adopt a new less generic ID with backwards compatibility.
+	return params.get( 'id' ) || params.get( 'odieInteractionId' ) || null;
+};
+
+/**
+ * Get the support interaction ID from the MemoryRouter search params.
+ *
+ * Every tab/window has its own MemoryRouter, so this identifies the chat *this*
+ * tab is showing without any extra state.
+ * @returns The support interaction ID, or `null` when the URL has none.
+ */
+export const useCurrentSupportInteractionId = () => {
+	const { search } = useLocation();
+	return getSupportInteractionIdFromSearch( search );
+};
+
 /**
  * Get the support interaction based in the MemoryRouter ID param.
  * @returns The support interaction.
  */
 export const useCurrentSupportInteraction = () => {
-	const { search } = useLocation();
 	const navigate = useNavigate();
-	const oldId = new URLSearchParams( search ).get( 'id' );
-	// Adopt a new less generic ID with backwards compatibility.
-	const newId = new URLSearchParams( search ).get( 'odieInteractionId' );
-	const id = oldId || newId;
+	const id = useCurrentSupportInteractionId();
 	const query = useGetSupportInteractionById( id || null );
 
 	useEffect( () => {

--- a/packages/odie-client/src/data/use-get-support-interaction-by-id.ts
+++ b/packages/odie-client/src/data/use-get-support-interaction-by-id.ts
@@ -4,6 +4,18 @@ import { SupportInteraction } from '../types';
 import { handleSupportInteractionsFetch } from './handle-support-interactions-fetch';
 
 /**
+ * Query key of one support interaction. Shared with the code that writes to or
+ * invalidates this cache entry, so none of it can drift from the query.
+ * @param interactionId - The uuid of the Support Interaction.
+ * @param isTestMode - Whether the interaction lives in the staging environment.
+ * @returns The query key.
+ */
+export const getSupportInteractionQueryKey = (
+	interactionId: string | null,
+	isTestMode: boolean
+) => [ 'support-interactions', 'get-interaction-by-id', interactionId, isTestMode ] as const;
+
+/**
  * Get the support interaction.
  * @param interactionId - The uuid of the Support Interaction.
  * @returns The support interaction.
@@ -11,7 +23,7 @@ import { handleSupportInteractionsFetch } from './handle-support-interactions-fe
 export const useGetSupportInteractionById = ( interactionId: string | null ) => {
 	const isTestMode = isTestModeEnvironment();
 	const query = useQuery< SupportInteraction >( {
-		queryKey: [ 'support-interactions', 'get-interaction-by-id', interactionId, isTestMode ],
+		queryKey: getSupportInteractionQueryKey( interactionId, isTestMode ),
 		queryFn: () =>
 			handleSupportInteractionsFetch(
 				'GET',

--- a/packages/odie-client/src/data/use-manage-support-interaction.ts
+++ b/packages/odie-client/src/data/use-manage-support-interaction.ts
@@ -2,6 +2,7 @@ import { isTestModeEnvironment } from '@automattic/zendesk-client';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useOdieAssistantContext } from '../context';
 import { handleSupportInteractionsFetch } from './handle-support-interactions-fetch';
+import { getSupportInteractionQueryKey } from './use-get-support-interaction-by-id';
 import type { SupportInteraction, SupportInteractionEvent } from '../types';
 
 /**
@@ -23,12 +24,7 @@ export const useManageSupportInteraction = () => {
 			} ) as unknown as Promise< SupportInteraction >,
 		onSuccess: ( interaction ) => {
 			const isTestMode = isTestModeEnvironment();
-			const queryKey = [
-				'support-interactions',
-				'get-interaction-by-id',
-				interaction.uuid,
-				isTestMode,
-			];
+			const queryKey = getSupportInteractionQueryKey( interaction.uuid, isTestMode );
 			// Save the interaction to the query client to avoid a new API call.
 			queryClient.setQueryData( queryKey, interaction );
 			// Add the new interaction to the list of interactions without refetching them.
@@ -76,12 +72,7 @@ export const useManageSupportInteraction = () => {
 			) as unknown as Promise< SupportInteraction >,
 		onSuccess: ( interaction ) => {
 			const isTestMode = isTestModeEnvironment();
-			const queryKey = [
-				'support-interactions',
-				'get-interaction-by-id',
-				interaction.uuid,
-				isTestMode,
-			];
+			const queryKey = getSupportInteractionQueryKey( interaction.uuid, isTestMode );
 			// Update the interaction with the new events.
 			queryClient.setQueryData( queryKey, interaction );
 			// The support history relies on the list of interactions to have fresh events.

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -245,12 +245,24 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 			}
 		}
 
+		const messagesToAdd = Array.isArray( message ) ? message : [ message ];
+
 		setChat( ( prevChat ) => ( {
 			...prevChat,
 			...props,
-			messages: [ ...prevChat.messages, ...( Array.isArray( message ) ? message : [ message ] ) ],
+			messages: [ ...prevChat.messages, ...messagesToAdd ],
 			status: 'loaded',
 		} ) );
+
+		// Mirror the bot reply (or error message) into other tabs showing the same
+		// support interaction, like the user's message already is on send.
+		messagesToAdd.forEach( ( messageToBroadcast ) =>
+			broadcastOdieMessage(
+				messageToBroadcast,
+				odieBroadcastClientId,
+				supportInteractionIdRef.current
+			)
+		);
 	};
 
 	return useMutation< ReturnedChat, Error, Message >( {

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -2,7 +2,7 @@ import { HelpCenter, HelpCenterSelect } from '@automattic/data-stores';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import {
@@ -23,10 +23,7 @@ import { getBotSlug } from '../utils/get-bot-slug';
 import { getOpenLiveInteractions } from '../utils/get-open-live-interactions';
 import { getIsAgentsManagerAvailable } from '../utils/is-agents-manager-available';
 import { requestLoggedOutWpcomOdie } from './request-logged-out-wpcom-odie';
-import {
-	getSupportInteractionIdFromSearch,
-	useCurrentSupportInteraction,
-} from './use-current-support-interaction';
+import { useCurrentSupportInteraction } from './use-current-support-interaction';
 import { useManageSupportInteraction, broadcastOdieMessage } from '.';
 import type { Chat, Message, ReturnedChat, SupportInteraction } from '../types';
 
@@ -62,12 +59,6 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
 	const { setLoggedOutOdieChat } = useDispatch( HELP_CENTER_STORE );
 	const location = useLocation();
-
-	// The support interaction this tab is showing, read from the MemoryRouter
-	// URL. Kept in a ref because the broadcasts below run inside the mutation,
-	// after `updateInteractionContext` may have just put a fresh id in the URL.
-	const supportInteractionIdRef = useRef( getSupportInteractionIdFromSearch( location.search ) );
-	supportInteractionIdRef.current = getSupportInteractionIdFromSearch( location.search );
 
 	const {
 		isLoggedOutSession,
@@ -137,7 +128,6 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 		( interaction: SupportInteraction ) => {
 			const params = new URLSearchParams( location.search );
 			params.set( 'id', interaction.uuid );
-			supportInteractionIdRef.current = interaction.uuid;
 			navigate( `${ location.pathname }?${ params.toString() }`, { replace: true } );
 		},
 		[ location.pathname, location.search, navigate ]
@@ -168,15 +158,19 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 		Adds a message to the chat.
 		If the message is a request for human support, it will escalate the chat to human support, if eligible.
 		If email support is forced, it will add an email fallback message.
+		`supportInteractionId` is the interaction the message belongs to; it is
+		passed in because a brand new chat only gets its interaction mid-send.
 	*/
 	const addMessage = ( {
 		message,
 		props = {},
 		isFromError = false,
+		supportInteractionId,
 	}: {
 		message: Message | Message[];
 		props?: Partial< Chat >;
 		isFromError: boolean;
+		supportInteractionId: string | null;
 	} ) => {
 		// Compute from a fresh Smooch snapshot at call time: Smooch can mutate its
 		// conversation list outside React without triggering a re-render.
@@ -192,7 +186,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 						messages: [ ...prevChat.messages, getConversationLimitReachedMessage() ],
 						status: 'loaded',
 					} ) );
-					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionIdRef.current );
+					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionId );
 					return;
 				} else if ( forceEmailSupport ) {
 					setChat( ( prevChat ) => ( {
@@ -201,7 +195,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 						messages: [ ...prevChat.messages, getOdieEmailFallbackMessage() ],
 						status: 'loaded',
 					} ) );
-					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionIdRef.current );
+					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionId );
 					return;
 				} else if (
 					warnAboutExistingConversation &&
@@ -215,7 +209,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 						messages: [ ...prevChat.messages, getExistingConversationMessage() ],
 						status: 'loaded',
 					} ) );
-					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionIdRef.current );
+					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionId );
 					return;
 				} else if ( ! chat.conversationId && canConnectToZendesk && isUserEligibleForPaidSupport ) {
 					setChat( ( prevChat ) => ( {
@@ -230,7 +224,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 						isFromError,
 						escalationOnSecondAttempt: hasTriedToEscalateToSupport,
 					} );
-					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionIdRef.current );
+					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionId );
 					return;
 				}
 
@@ -257,11 +251,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 		// Mirror the bot reply (or error message) into other tabs showing the same
 		// support interaction, like the user's message already is on send.
 		messagesToAdd.forEach( ( messageToBroadcast ) =>
-			broadcastOdieMessage(
-				messageToBroadcast,
-				odieBroadcastClientId,
-				supportInteractionIdRef.current
-			)
+			broadcastOdieMessage( messageToBroadcast, odieBroadcastClientId, supportInteractionId )
 		);
 	};
 
@@ -353,7 +343,12 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 						internal_message_id
 					);
 
-					addMessage( { message: errorMessage, props: {}, isFromError: true } );
+					addMessage( {
+						message: errorMessage,
+						props: {},
+						isFromError: true,
+						supportInteractionId: currentSupportInteraction?.uuid ?? null,
+					} );
 				}
 				return;
 			}
@@ -406,6 +401,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 				message: botMessage,
 				props: { odieId: returnedChat.chat_id },
 				isFromError: false,
+				supportInteractionId: supportInteraction?.uuid ?? null,
 			} );
 		},
 		onSettled: () => {
@@ -423,10 +419,20 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 			if ( isRateLimitError ) {
 				// Handle rate limit error with standard rate limit message
 				const message: Message = { ...getOdieRateLimitMessage(), internal_message_id };
-				addMessage( { message, props: {}, isFromError: true } );
+				addMessage( {
+					message,
+					props: {},
+					isFromError: true,
+					supportInteractionId: currentSupportInteraction?.uuid ?? null,
+				} );
 			} else if ( isUserEligibleForPaidSupport && canConnectToZendesk ) {
 				const errorMessage = getErrorMessageUnknownError();
-				addMessage( { message: errorMessage, props: {}, isFromError: true } );
+				addMessage( {
+					message: errorMessage,
+					props: {},
+					isFromError: true,
+					supportInteractionId: currentSupportInteraction?.uuid ?? null,
+				} );
 
 				trackEvent( 'error_sending_odie_message', {
 					error_message: error instanceof Error ? error.toString() : 'unknown_error',
@@ -438,7 +444,12 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 					internal_message_id
 				);
 
-				addMessage( { message: errorMessage, props: {}, isFromError: true } );
+				addMessage( {
+					message: errorMessage,
+					props: {},
+					isFromError: true,
+					supportInteractionId: currentSupportInteraction?.uuid ?? null,
+				} );
 			}
 		},
 	} );

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -177,25 +177,34 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 		const { mostRecentSupportInteractionId: warnAboutExistingConversation, hasReachedLimit } =
 			getOpenLiveInteractions( interactionStatusByUuid );
 
+		// Append to this tab's chat and mirror into other tabs showing the same
+		// support interaction, like the user's message already is on send. A send
+		// failure is not mirrored: it belongs to the tab that sent the message, and
+		// a reload would not show it either.
+		const appendMessages = ( messagesToAdd: Message[] ) => {
+			setChat( ( prevChat ) => ( {
+				...prevChat,
+				...props,
+				messages: [ ...prevChat.messages, ...messagesToAdd ],
+				status: 'loaded',
+			} ) );
+
+			if ( ! isFromError ) {
+				messagesToAdd.forEach( ( messageToBroadcast ) =>
+					broadcastOdieMessage( messageToBroadcast, odieBroadcastClientId, supportInteractionId )
+				);
+			}
+		};
+
 		if ( ! Array.isArray( message ) ) {
 			if ( getIsRequestingHumanSupport( message ) ) {
+				// Each branch shows a notice in place of the bot's reply, so the notice is
+				// what other tabs get too: they have to render the same thing as this tab.
 				if ( hasReachedLimit ) {
-					setChat( ( prevChat ) => ( {
-						...prevChat,
-						...props,
-						messages: [ ...prevChat.messages, getConversationLimitReachedMessage() ],
-						status: 'loaded',
-					} ) );
-					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionId );
+					appendMessages( [ getConversationLimitReachedMessage() ] );
 					return;
 				} else if ( forceEmailSupport ) {
-					setChat( ( prevChat ) => ( {
-						...prevChat,
-						...props,
-						messages: [ ...prevChat.messages, getOdieEmailFallbackMessage() ],
-						status: 'loaded',
-					} ) );
-					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionId );
+					appendMessages( [ getOdieEmailFallbackMessage() ] );
 					return;
 				} else if (
 					warnAboutExistingConversation &&
@@ -203,13 +212,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 					! hasTriedToEscalateToSupport
 				) {
 					trackEvent( 'chat_existing_conversation_prompt' );
-					setChat( ( prevChat ) => ( {
-						...prevChat,
-						...props,
-						messages: [ ...prevChat.messages, getExistingConversationMessage() ],
-						status: 'loaded',
-					} ) );
-					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionId );
+					appendMessages( [ getExistingConversationMessage() ] );
 					return;
 				} else if ( ! chat.conversationId && canConnectToZendesk && isUserEligibleForPaidSupport ) {
 					setChat( ( prevChat ) => ( {
@@ -224,7 +227,10 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 						isFromError,
 						escalationOnSecondAttempt: hasTriedToEscalateToSupport,
 					} );
-					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionId );
+					// Deliberately not mirrored: this tab never shows the bot's reply, it moves
+					// to Zendesk instead, and other tabs follow through the interaction-updated
+					// broadcast once the conversation exists. Mirroring the reply would give
+					// them a live "get support" button that opens a second conversation.
 					return;
 				}
 
@@ -239,20 +245,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 			}
 		}
 
-		const messagesToAdd = Array.isArray( message ) ? message : [ message ];
-
-		setChat( ( prevChat ) => ( {
-			...prevChat,
-			...props,
-			messages: [ ...prevChat.messages, ...messagesToAdd ],
-			status: 'loaded',
-		} ) );
-
-		// Mirror the bot reply (or error message) into other tabs showing the same
-		// support interaction, like the user's message already is on send.
-		messagesToAdd.forEach( ( messageToBroadcast ) =>
-			broadcastOdieMessage( messageToBroadcast, odieBroadcastClientId, supportInteractionId )
-		);
+		appendMessages( Array.isArray( message ) ? message : [ message ] );
 	};
 
 	return useMutation< ReturnedChat, Error, Message >( {

--- a/packages/odie-client/src/data/use-send-odie-message.ts
+++ b/packages/odie-client/src/data/use-send-odie-message.ts
@@ -2,7 +2,7 @@ import { HelpCenter, HelpCenterSelect } from '@automattic/data-stores';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 import {
@@ -23,7 +23,10 @@ import { getBotSlug } from '../utils/get-bot-slug';
 import { getOpenLiveInteractions } from '../utils/get-open-live-interactions';
 import { getIsAgentsManagerAvailable } from '../utils/is-agents-manager-available';
 import { requestLoggedOutWpcomOdie } from './request-logged-out-wpcom-odie';
-import { useCurrentSupportInteraction } from './use-current-support-interaction';
+import {
+	getSupportInteractionIdFromSearch,
+	useCurrentSupportInteraction,
+} from './use-current-support-interaction';
 import { useManageSupportInteraction, broadcastOdieMessage } from '.';
 import type { Chat, Message, ReturnedChat, SupportInteraction } from '../types';
 
@@ -59,6 +62,12 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
 	const { setLoggedOutOdieChat } = useDispatch( HELP_CENTER_STORE );
 	const location = useLocation();
+
+	// The support interaction this tab is showing, read from the MemoryRouter
+	// URL. Kept in a ref because the broadcasts below run inside the mutation,
+	// after `updateInteractionContext` may have just put a fresh id in the URL.
+	const supportInteractionIdRef = useRef( getSupportInteractionIdFromSearch( location.search ) );
+	supportInteractionIdRef.current = getSupportInteractionIdFromSearch( location.search );
 
 	const {
 		isLoggedOutSession,
@@ -128,6 +137,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 		( interaction: SupportInteraction ) => {
 			const params = new URLSearchParams( location.search );
 			params.set( 'id', interaction.uuid );
+			supportInteractionIdRef.current = interaction.uuid;
 			navigate( `${ location.pathname }?${ params.toString() }`, { replace: true } );
 		},
 		[ location.pathname, location.search, navigate ]
@@ -182,7 +192,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 						messages: [ ...prevChat.messages, getConversationLimitReachedMessage() ],
 						status: 'loaded',
 					} ) );
-					broadcastOdieMessage( message, odieBroadcastClientId );
+					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionIdRef.current );
 					return;
 				} else if ( forceEmailSupport ) {
 					setChat( ( prevChat ) => ( {
@@ -191,7 +201,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 						messages: [ ...prevChat.messages, getOdieEmailFallbackMessage() ],
 						status: 'loaded',
 					} ) );
-					broadcastOdieMessage( message, odieBroadcastClientId );
+					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionIdRef.current );
 					return;
 				} else if (
 					warnAboutExistingConversation &&
@@ -205,7 +215,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 						messages: [ ...prevChat.messages, getExistingConversationMessage() ],
 						status: 'loaded',
 					} ) );
-					broadcastOdieMessage( message, odieBroadcastClientId );
+					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionIdRef.current );
 					return;
 				} else if ( ! chat.conversationId && canConnectToZendesk && isUserEligibleForPaidSupport ) {
 					setChat( ( prevChat ) => ( {
@@ -220,7 +230,7 @@ export const useSendOdieMessage = ( signal: AbortSignal ) => {
 						isFromError,
 						escalationOnSecondAttempt: hasTriedToEscalateToSupport,
 					} );
-					broadcastOdieMessage( message, odieBroadcastClientId );
+					broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionIdRef.current );
 					return;
 				}
 

--- a/packages/odie-client/src/hooks/test/use-create-zendesk-conversation.test.tsx
+++ b/packages/odie-client/src/hooks/test/use-create-zendesk-conversation.test.tsx
@@ -156,7 +156,7 @@ describe( 'useCreateZendeskConversation — Smooch-not-ready retry loop', () => 
 		const success = lastTrackedProps( 'new_zendesk_conversation' );
 		expect( success ).toMatchObject( { smooch_attempts: 1, smooch_waited_ms: 0 } );
 		// Other tabs on this interaction are told to follow the escalation.
-		expect( broadcastOdieInteractionUpdated ).toHaveBeenCalledWith( 'this-tab', 'int-1' );
+		expect( broadcastOdieInteractionUpdated ).toHaveBeenCalledWith( 'this-tab', 'int-1', 'int-1' );
 	} );
 
 	it( 'broadcasts the interaction that ends up owning the conversation', async () => {
@@ -173,8 +173,9 @@ describe( 'useCreateZendeskConversation — Smooch-not-ready retry loop', () => 
 		expect( Smooch.updateConversation ).toHaveBeenCalledWith( 'conv-1', {
 			metadata: expect.objectContaining( { supportInteractionId: 'int-2' } ),
 		} );
+		// Other tabs show int-1, so that is what they match on; they then follow to int-2.
 		expect( broadcastOdieInteractionUpdated ).toHaveBeenCalledTimes( 1 );
-		expect( broadcastOdieInteractionUpdated ).toHaveBeenCalledWith( 'this-tab', 'int-2' );
+		expect( broadcastOdieInteractionUpdated ).toHaveBeenCalledWith( 'this-tab', 'int-1', 'int-2' );
 	} );
 
 	it( 'surfaces the error after the 10s deadline if the SDK never becomes ready', async () => {

--- a/packages/odie-client/src/hooks/test/use-create-zendesk-conversation.test.tsx
+++ b/packages/odie-client/src/hooks/test/use-create-zendesk-conversation.test.tsx
@@ -4,6 +4,7 @@
 import { renderHook } from '@testing-library/react';
 import Smooch from 'smooch';
 import { useOdieAssistantContext } from '../../context';
+import { broadcastOdieInteractionUpdated } from '../../data';
 import { useCreateZendeskConversation } from '../use-create-zendesk-conversation';
 
 /**
@@ -110,6 +111,7 @@ beforeEach( () => {
 		},
 		trackEvent: mockTrackEvent,
 		isChatLoaded: true,
+		odieBroadcastClientId: 'this-tab',
 	} );
 } );
 
@@ -153,6 +155,26 @@ describe( 'useCreateZendeskConversation — Smooch-not-ready retry loop', () => 
 		expect( smoochCreateConversation ).toHaveBeenCalledTimes( 1 );
 		const success = lastTrackedProps( 'new_zendesk_conversation' );
 		expect( success ).toMatchObject( { smooch_attempts: 1, smooch_waited_ms: 0 } );
+		// Other tabs on this interaction are told to follow the escalation.
+		expect( broadcastOdieInteractionUpdated ).toHaveBeenCalledWith( 'this-tab', 'int-1' );
+	} );
+
+	it( 'broadcasts the interaction that ends up owning the conversation', async () => {
+		smoochCreateConversation.mockResolvedValueOnce( { id: 'conv-1', metadata: {} } );
+		// The support interaction service moved the event onto another interaction.
+		mockAddEventToInteraction.mockResolvedValueOnce( { uuid: 'int-2' } );
+
+		const { result } = renderHook( () => useCreateZendeskConversation() );
+
+		await expect( result.current( { createdFrom: 'automatic_escalation' } ) ).resolves.toBe(
+			'conv-1'
+		);
+
+		expect( Smooch.updateConversation ).toHaveBeenCalledWith( 'conv-1', {
+			metadata: expect.objectContaining( { supportInteractionId: 'int-2' } ),
+		} );
+		expect( broadcastOdieInteractionUpdated ).toHaveBeenCalledTimes( 1 );
+		expect( broadcastOdieInteractionUpdated ).toHaveBeenCalledWith( 'this-tab', 'int-2' );
 	} );
 
 	it( 'surfaces the error after the 10s deadline if the SDK never becomes ready', async () => {
@@ -174,6 +196,8 @@ describe( 'useCreateZendeskConversation — Smooch-not-ready retry loop', () => 
 		expect( error.smooch_waited_ms ).toBeLessThanOrEqual( 10_000 );
 		// The user is shown the try-again message.
 		expect( mockSetChat ).toHaveBeenCalled();
+		// Nothing to follow: no other tab is told the interaction changed.
+		expect( broadcastOdieInteractionUpdated ).not.toHaveBeenCalled();
 	} );
 
 	it( 'duplicates the critical user fields as ticket-field metadata on the conversation', async () => {

--- a/packages/odie-client/src/hooks/test/use-create-zendesk-conversation.test.tsx
+++ b/packages/odie-client/src/hooks/test/use-create-zendesk-conversation.test.tsx
@@ -46,6 +46,7 @@ jest.mock( '../../context', () => ( {
 } ) );
 
 jest.mock( '../../data', () => ( {
+	broadcastOdieInteractionUpdated: jest.fn(),
 	useManageSupportInteraction: () => ( {
 		addEventToInteraction: mockAddEventToInteraction,
 		startNewInteraction: mockStartNewInteraction,

--- a/packages/odie-client/src/hooks/test/use-get-combined-chat.test.tsx
+++ b/packages/odie-client/src/hooks/test/use-get-combined-chat.test.tsx
@@ -27,6 +27,7 @@ jest.mock( '@wordpress/data', () => ( {
 
 jest.mock( '@tanstack/react-query', () => ( {
 	useIsMutating: () => 0,
+	useQueryClient: () => ( { invalidateQueries: jest.fn( () => Promise.resolve() ) } ),
 } ) );
 
 jest.mock( '@automattic/calypso-analytics', () => ( {

--- a/packages/odie-client/src/hooks/test/use-get-combined-chat.test.tsx
+++ b/packages/odie-client/src/hooks/test/use-get-combined-chat.test.tsx
@@ -444,9 +444,31 @@ describe( 'useGetCombinedChat — the interaction is escalated from another tab'
 		expect( mockNavigate ).not.toHaveBeenCalled();
 	} );
 
+	it( 'keeps the interaction when the initial load fails for a transient reason', async () => {
+		mockGetZendeskConversation.mockImplementation( () =>
+			Promise.reject( new Error( 'Failed to fetch' ) )
+		);
+		mockCurrentSupportInteraction = escalatedInteraction();
+
+		const { result } = renderCombinedChat();
+
+		// The conversation may well exist: show it with the history we have and let
+		// the next reconnect retry, instead of dropping the interaction.
+		await waitFor( () => {
+			expect( result.current.mainChatState.status ).toBe( 'loaded' );
+		} );
+		expect( result.current.mainChatState.provider ).toBe( 'zendesk' );
+		expect( result.current.mainChatState.conversationId ).toBe( 'conv-1' );
+		expect( result.current.mainChatState.messages.some( ( m ) => m.message_id === 10 ) ).toBe(
+			true
+		);
+		expect( mockNavigate ).not.toHaveBeenCalled();
+		expect( mockGetZendeskConversation ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	it( 'starts over with a fresh chat when the initial load cannot find the conversation', async () => {
 		mockGetZendeskConversation.mockImplementation( () =>
-			Promise.reject( new Error( 'conversation not found' ) )
+			Promise.reject( Object.assign( new Error( 'Not Found' ), { status: 404 } ) )
 		);
 		mockCurrentSupportInteraction = escalatedInteraction();
 

--- a/packages/odie-client/src/hooks/test/use-get-combined-chat.test.tsx
+++ b/packages/odie-client/src/hooks/test/use-get-combined-chat.test.tsx
@@ -15,7 +15,11 @@ let mockCurrentSupportInteraction: Record< string, unknown > | undefined;
 let mockConversation: { id: string; messages: Message[] } | null;
 let mockOdieChat: Record< string, unknown > | undefined;
 const mockGetZendeskConversation = jest.fn();
-const mockStartNewInteraction = jest.fn();
+const mockNavigate = jest.fn();
+
+jest.mock( 'react-router-dom', () => ( {
+	useNavigate: () => mockNavigate,
+} ) );
 
 jest.mock( '@wordpress/data', () => ( {
 	// The hook's only useSelect call returns { isChatLoaded, connectionStatus }.
@@ -43,7 +47,6 @@ jest.mock( '../use-logged-out-session', () => ( {
 
 jest.mock( '../../data', () => ( {
 	useGetZendeskConversation: () => mockGetZendeskConversation,
-	useManageSupportInteraction: () => ( { startNewInteraction: mockStartNewInteraction } ),
 	useOdieChat: () => ( { data: mockOdieChat, isFetching: false } ),
 } ) );
 
@@ -374,7 +377,7 @@ describe( 'useGetCombinedChat — the interaction is escalated from another tab'
 		expect( result.current.mainChatState.status ).toBe( 'transfer' );
 	} );
 
-	it( 'fetches a conversation it cannot load only once', async () => {
+	it( 'switches to the conversation with the history it has when the fetch fails', async () => {
 		mockGetZendeskConversation.mockImplementation( () =>
 			Promise.reject( new Error( 'conversation not found' ) )
 		);
@@ -387,9 +390,18 @@ describe( 'useGetCombinedChat — the interaction is escalated from another tab'
 		mockCurrentSupportInteraction = escalatedInteraction();
 		rerender();
 
+		// The conversation exists (another tab just created it), so the tab moves to
+		// it anyway: live messages arrive through the listener and the next reconnect
+		// re-downloads the history. The chat is not thrown away.
 		await waitFor( () => {
-			expect( mockStartNewInteraction ).toHaveBeenCalledTimes( 1 );
+			expect( result.current.mainChatState.provider ).toBe( 'zendesk' );
+			expect( result.current.mainChatState.conversationId ).toBe( 'conv-1' );
 		} );
+		expect( result.current.mainChatState.messages.some( ( m ) => m.message_id === 10 ) ).toBe(
+			true
+		);
+		expect( mockNavigate ).not.toHaveBeenCalled();
+
 		// The failed fetch flips `isFetchingConversation` back, which re-runs the
 		// effect. Give those re-runs room to fire before counting.
 		await act( async () => {
@@ -402,6 +414,56 @@ describe( 'useGetCombinedChat — the interaction is escalated from another tab'
 		} );
 
 		expect( mockGetZendeskConversation ).toHaveBeenCalledTimes( 1 );
-		expect( mockStartNewInteraction ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'keeps the conversation it already shows when a refresh fails', async () => {
+		mockCurrentSupportInteraction = escalatedInteraction();
+		const { result, rerender } = renderCombinedChat();
+
+		await waitFor( () => {
+			expect( result.current.mainChatState.messages.some( ( m ) => m.message_id === 1 ) ).toBe(
+				true
+			);
+		} );
+
+		// The reconnect refresh cannot reach the server this time.
+		mockGetZendeskConversation.mockImplementation( () => Promise.reject( new Error( 'network' ) ) );
+		act( () => {
+			mockConnectionStatus = 'connected';
+		} );
+		rerender();
+
+		await waitFor( () => {
+			expect( mockGetZendeskConversation ).toHaveBeenCalledTimes( 2 );
+			expect( result.current.mainChatState.status ).toBe( 'loaded' );
+		} );
+		expect( result.current.mainChatState.provider ).toBe( 'zendesk' );
+		expect( result.current.mainChatState.messages.some( ( m ) => m.message_id === 1 ) ).toBe(
+			true
+		);
+		expect( mockNavigate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'starts over with a fresh chat when the initial load cannot find the conversation', async () => {
+		mockGetZendeskConversation.mockImplementation( () =>
+			Promise.reject( new Error( 'conversation not found' ) )
+		);
+		mockCurrentSupportInteraction = escalatedInteraction();
+
+		const { result, rerender } = renderCombinedChat();
+
+		await waitFor( () => {
+			expect( mockNavigate ).toHaveBeenCalledWith( '/odie' );
+		} );
+
+		// The navigation drops the interaction from the URL.
+		mockCurrentSupportInteraction = undefined;
+		rerender();
+
+		await waitFor( () => {
+			expect( result.current.mainChatState.status ).toBe( 'loaded' );
+		} );
+		expect( result.current.mainChatState.provider ).toBe( 'odie' );
+		expect( result.current.mainChatState.conversationId ).toBeNull();
 	} );
 } );

--- a/packages/odie-client/src/hooks/test/use-get-combined-chat.test.tsx
+++ b/packages/odie-client/src/hooks/test/use-get-combined-chat.test.tsx
@@ -27,7 +27,6 @@ jest.mock( '@wordpress/data', () => ( {
 
 jest.mock( '@tanstack/react-query', () => ( {
 	useIsMutating: () => 0,
-	useQueryClient: () => ( { invalidateQueries: jest.fn( () => Promise.resolve() ) } ),
 } ) );
 
 jest.mock( '@automattic/calypso-analytics', () => ( {

--- a/packages/odie-client/src/hooks/test/use-get-combined-chat.test.tsx
+++ b/packages/odie-client/src/hooks/test/use-get-combined-chat.test.tsx
@@ -311,3 +311,97 @@ describe( 'useGetCombinedChat — message recovery on Smooch re-init', () => {
 		expect( mockGetZendeskConversation ).not.toHaveBeenCalled();
 	} );
 } );
+
+describe( 'useGetCombinedChat — the interaction is escalated from another tab', () => {
+	const odieOnlyInteraction = () => ( {
+		uuid: 'int-1',
+		conversationId: undefined,
+		odieId: 42,
+		status: 'open',
+	} );
+	const escalatedInteraction = () => ( {
+		uuid: 'int-1',
+		conversationId: 'conv-1',
+		odieId: 42,
+		status: 'open',
+	} );
+
+	beforeEach( () => {
+		mockCurrentSupportInteraction = odieOnlyInteraction();
+		mockOdieChat = { odieId: 42, wpcomUserId: 99, messages: [ agentMessage( 10, 'odie reply' ) ] };
+		mockConversation = { id: 'conv-1', messages: [ agentMessage( 1, 'Happiness Engineer here' ) ] };
+	} );
+
+	it( 'switches to the Zendesk conversation once the interaction gains one', async () => {
+		const { result, rerender } = renderCombinedChat();
+
+		await waitFor( () => {
+			expect( result.current.mainChatState.provider ).toBe( 'odie' );
+		} );
+		expect( mockGetZendeskConversation ).not.toHaveBeenCalled();
+
+		// Another tab escalated: the refetched interaction now carries the conversation.
+		mockCurrentSupportInteraction = escalatedInteraction();
+		rerender();
+
+		await waitFor( () => {
+			expect( result.current.mainChatState.provider ).toBe( 'zendesk' );
+			expect( result.current.mainChatState.conversationId ).toBe( 'conv-1' );
+		} );
+		expect( result.current.mainChatState.messages.some( ( m ) => m.message_id === 1 ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'leaves the chat alone while this tab is the one transferring', async () => {
+		const { result, rerender } = renderCombinedChat();
+
+		await waitFor( () => {
+			expect( result.current.mainChatState.provider ).toBe( 'odie' );
+		} );
+
+		// This tab started the escalation itself; it sets the conversation when done.
+		act( () => {
+			result.current.setMainChatState( ( chat ) => ( { ...chat, status: 'transfer' } ) );
+		} );
+		mockCurrentSupportInteraction = escalatedInteraction();
+		rerender();
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect( mockGetZendeskConversation ).not.toHaveBeenCalled();
+		expect( result.current.mainChatState.status ).toBe( 'transfer' );
+	} );
+
+	it( 'fetches a conversation it cannot load only once', async () => {
+		mockGetZendeskConversation.mockImplementation( () =>
+			Promise.reject( new Error( 'conversation not found' ) )
+		);
+		const { result, rerender } = renderCombinedChat();
+
+		await waitFor( () => {
+			expect( result.current.mainChatState.provider ).toBe( 'odie' );
+		} );
+
+		mockCurrentSupportInteraction = escalatedInteraction();
+		rerender();
+
+		await waitFor( () => {
+			expect( mockStartNewInteraction ).toHaveBeenCalledTimes( 1 );
+		} );
+		// The failed fetch flips `isFetchingConversation` back, which re-runs the
+		// effect. Give those re-runs room to fire before counting.
+		await act( async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+		} );
+		rerender();
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect( mockGetZendeskConversation ).toHaveBeenCalledTimes( 1 );
+		expect( mockStartNewInteraction ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -14,7 +14,7 @@ import {
 	getZendeskChatStartedMetaMessage,
 } from '../constants';
 import { useOdieAssistantContext } from '../context';
-import { useManageSupportInteraction } from '../data';
+import { broadcastOdieInteractionUpdated, useManageSupportInteraction } from '../data';
 import { useCurrentSupportInteraction } from '../data/use-current-support-interaction';
 import { getOpenLiveInteractions } from '../utils/get-open-live-interactions';
 import { useOpenInteractionStatusMap } from './use-open-interaction-status-map';
@@ -29,6 +29,7 @@ export const useCreateZendeskConversation = () => {
 		chat,
 		trackEvent,
 		isChatLoaded,
+		odieBroadcastClientId,
 	} = useOdieAssistantContext();
 	const { data: currentSupportInteraction } = useCurrentSupportInteraction();
 	const { isPending: isSubmittingZendeskUserFields, mutateAsync: submitUserFields } =
@@ -268,6 +269,12 @@ export const useCreateZendeskConversation = () => {
 				provider: 'zendesk',
 				status: 'loaded',
 			} ) );
+
+			// Let other tabs on this interaction know it moved to Zendesk, so they
+			// refetch it and switch too.
+			if ( activeInteractionId ) {
+				broadcastOdieInteractionUpdated( odieBroadcastClientId, activeInteractionId );
+			}
 
 			// Track success only if conversation was created
 			trackEvent( 'new_zendesk_conversation', {

--- a/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
+++ b/packages/odie-client/src/hooks/use-create-zendesk-conversation.ts
@@ -271,9 +271,17 @@ export const useCreateZendeskConversation = () => {
 			} ) );
 
 			// Let other tabs on this interaction know it moved to Zendesk, so they
-			// refetch it and switch too.
-			if ( activeInteractionId ) {
-				broadcastOdieInteractionUpdated( odieBroadcastClientId, activeInteractionId );
+			// refetch it and switch too. They show the interaction this tab started
+			// from, so that is what they match on; `activeInteractionId` is where the
+			// conversation ended up, which can differ when the service moved the event.
+			// A chat that had no interaction yet cannot be open elsewhere.
+			const sourceInteractionId = currentSupportInteraction?.uuid;
+			if ( sourceInteractionId && activeInteractionId ) {
+				broadcastOdieInteractionUpdated(
+					odieBroadcastClientId,
+					sourceInteractionId,
+					activeInteractionId
+				);
 			}
 
 			// Track success only if conversation was created

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -144,15 +144,26 @@ export const useGetCombinedChat = (
 			// so interactionHasChanged is false, but we still need to reload the chat.
 			mainChatState.odieId?.toString() !== odieId?.toString();
 
+		// The interaction gained a Zendesk conversation this tab is not showing yet:
+		// it was escalated from another tab. Reload so this tab switches too,
+		// otherwise it keeps sending to Odie. Skipped while this tab is the one
+		// transferring (`status === 'transfer'`), which sets the conversation itself.
+		const conversationHasChanged =
+			!! conversationId &&
+			mainChatState.conversationId !== conversationId &&
+			chatStatus !== 'transfer';
+
+		const needsReload = interactionHasChanged || conversationHasChanged;
+
 		previousOdieIdRef.current = odieId;
 
 		if (
-			( isOdieChatLoading && ! interactionHasChanged ) ||
+			( isOdieChatLoading && ! needsReload ) ||
 			isLoadingCurrentSupportInteraction ||
 			isFetchingConversation ||
 			isUploadingUnsentMessages ||
 			isLoadingCanConnectToZendesk ||
-			( chatStatus !== 'loading' && ! interactionHasChanged )
+			( chatStatus !== 'loading' && ! needsReload )
 		) {
 			return;
 		}
@@ -199,9 +210,14 @@ export const useGetCombinedChat = (
 				?.then( ( conversation ) => {
 					if ( conversation ) {
 						setMainChatState( ( prevChat ) => {
-							const isSameConversation =
+							// Keep the user's queued messages when the tab already shows this
+							// conversation, and also while it is switching to it from the Odie
+							// chat (no conversation id yet): a message sent right after the
+							// escalation - from this tab or mirrored from another one - may
+							// not be in the server response yet and would otherwise be dropped.
+							const keepQueuedMessages =
 								prevChat.odieId?.toString() === odieId?.toString() &&
-								prevChat.conversationId === conversation.id;
+								( prevChat.conversationId === conversation.id || ! prevChat.conversationId );
 
 							return {
 								odieId: odieId ? Number( odieId ) : null,
@@ -217,7 +233,7 @@ export const useGetCombinedChat = (
 									getZendeskChatStartedMetaMessage(),
 									...( deduplicateZDMessages( [
 										// During connection recovery, the user queued messages can be deleted. This ensure they remain. And `deduplicateZDMessages` takes of duplication.
-										...( isSameConversation
+										...( keepQueuedMessages
 											? prevChat.messages.filter( isQueuedZendeskMessage )
 											: [] ),
 										...conversation.messages,
@@ -266,6 +282,7 @@ export const useGetCombinedChat = (
 		hasEnTranslation,
 		mainChatState?.messages?.length,
 		mainChatState?.odieId,
+		mainChatState?.conversationId,
 		odieChat,
 	] );
 

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -23,6 +23,28 @@ import { useLoggedOutSession } from './use-logged-out-session';
 import type { Chat, Message } from '../types';
 
 /**
+ * Whether a failed conversation fetch says the conversation is gone for good (deleted, or
+ * no longer visible to this user) rather than temporarily unreachable. Smooch forwards
+ * its HTTP failures as-is, so both the status code and the message are checked.
+ * @param error - The fetch rejection.
+ * @returns True when the conversation should be treated as gone.
+ */
+const isConversationGoneError = ( error: unknown ) => {
+	const failure = error as {
+		status?: number;
+		statusCode?: number;
+		response?: { status?: number };
+	} | null;
+	const status = failure?.status ?? failure?.statusCode ?? failure?.response?.status;
+	if ( status === 403 || status === 404 ) {
+		return true;
+	}
+
+	const message = error instanceof Error ? error.message : String( error );
+	return /not found|does not exist|\b40[34]\b/i.test( message );
+};
+
+/**
  * This combines the ODIE chat with the ZENDESK conversation.
  * @returns The combined chat.
  */
@@ -229,17 +251,25 @@ export const useGetCombinedChat = (
 						error: error instanceof Error ? error.message : String( error ),
 					} );
 
-					if ( isSwitchingLoadedChat || refreshingAfterReconnect ) {
-						// The conversation exists: another tab just created it, or this chat
-						// was already showing it. The failure is most likely transient, so
-						// keep what we have rather than start over. Live messages still
-						// arrive through the Zendesk listener, and the next reconnect or
-						// Smooch re-init re-downloads the history.
+					if (
+						isSwitchingLoadedChat ||
+						refreshingAfterReconnect ||
+						! isConversationGoneError( error )
+					) {
+						// The conversation exists: another tab just created it, this chat
+						// was already showing it, or the failure does not say it is gone. So
+						// treat it as transient and keep what we have rather than start
+						// over. Live messages still arrive through the Zendesk listener, and
+						// the next reconnect or Smooch re-init re-downloads the history.
 						setMainChatState( ( prevChat ) =>
 							prevChat.conversationId === conversationId
 								? { ...prevChat, status: 'loaded' }
 								: {
 										...prevChat,
+										// Same identity the success path sets: a chat whose odieId does not
+										// match the interaction reads as "changed" and would be fetched again.
+										odieId: odieId ? Number( odieId ) : null,
+										wpcomUserId: odieChat?.wpcomUserId || prevChat.wpcomUserId,
 										conversationId,
 										messages: buildZendeskMessages(
 											prevChat.messages.filter( isQueuedZendeskMessage ),

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
-import { useIsMutating } from '@tanstack/react-query';
+import { useIsMutating, useQueryClient } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { getMessageUniqueIdentifier } from '../components/message/utils/get-message-unique-identifier';
@@ -90,6 +90,7 @@ export const useGetCombinedChat = (
 	const [ isFetchingConversation, setIsFetchingConversation ] = useState( false );
 
 	const { startNewInteraction } = useManageSupportInteraction();
+	const queryClient = useQueryClient();
 	const isUploadingUnsentMessages = useIsMutating( {
 		mutationKey: [ 'send-zendesk-messages' ],
 	} );
@@ -130,6 +131,10 @@ export const useGetCombinedChat = (
 		}
 	}, [ isChatLoaded, conversationId, refreshConversation ] );
 
+	// The conversation id the Odie chat was last refetched for (see below).
+	const odieChatRefetchedForRef = useRef< string | null >( null );
+	const [ isRefetchingOdieChat, setIsRefetchingOdieChat ] = useState( false );
+
 	useEffect( () => {
 		// Logged out chats don't have interactions. Only direct odie IDs.
 		const interactionHasChanged =
@@ -157,8 +162,27 @@ export const useGetCombinedChat = (
 
 		previousOdieIdRef.current = odieId;
 
+		// The Odie chat cached here is missing whatever was said in the other tab
+		// since this tab loaded it. Refetch it first and come back once that is
+		// done, so the reload rebuilds the full history. Only for a tab that was
+		// already showing this chat; a fresh load has nothing stale.
 		if (
-			( isOdieChatLoading && ! needsReload ) ||
+			conversationHasChanged &&
+			! interactionHasChanged &&
+			odieId &&
+			odieChatRefetchedForRef.current !== conversationId
+		) {
+			odieChatRefetchedForRef.current = conversationId;
+			setIsRefetchingOdieChat( true );
+			queryClient
+				.invalidateQueries( { queryKey: [ 'odie-chat' ] } )
+				.finally( () => setIsRefetchingOdieChat( false ) );
+			return;
+		}
+
+		if (
+			isRefetchingOdieChat ||
+			( isOdieChatLoading && ! interactionHasChanged ) ||
 			isLoadingCurrentSupportInteraction ||
 			isFetchingConversation ||
 			isUploadingUnsentMessages ||
@@ -283,6 +307,8 @@ export const useGetCombinedChat = (
 		mainChatState?.messages?.length,
 		mainChatState?.odieId,
 		mainChatState?.conversationId,
+		isRefetchingOdieChat,
+		queryClient,
 		odieChat,
 	] );
 

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -4,52 +4,23 @@ import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useIsMutating } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
-import { getMessageUniqueIdentifier } from '../components/message/utils/get-message-unique-identifier';
+import { useNavigate } from 'react-router-dom';
 import {
 	HELP_CENTER_STORE,
 	getOdieTransferMessages,
 	getZendeskChatStartedMetaMessage,
 } from '../constants';
 import { emptyChat } from '../context';
-import { useGetZendeskConversation, useManageSupportInteraction, useOdieChat } from '../data';
+import { useGetZendeskConversation, useOdieChat } from '../data';
 import { useCurrentSupportInteraction } from '../data/use-current-support-interaction';
 import {
 	getConversationIdFromInteraction,
 	getOdieIdFromInteraction,
 	getIsRequestingHumanSupport,
 } from '../utils';
+import { deduplicateZDMessages, isQueuedZendeskMessage } from '../utils/deduplicate-zd-messages';
 import { useLoggedOutSession } from './use-logged-out-session';
 import type { Chat, Message } from '../types';
-
-function isEqual( message1: Message, message2: Message ) {
-	const message1Id = getMessageUniqueIdentifier( message1 );
-	const message2Id = getMessageUniqueIdentifier( message2 );
-	return message1Id && message1Id === message2Id;
-}
-
-/**
- * A user message sent through Zendesk: only those carry a `temporary_id`, so Odie messages don't match.
- * @param message - The message to check.
- * @returns Whether the message is a Zendesk message sent by the user.
- */
-function isQueuedZendeskMessage( message: Message ) {
-	return message.role === 'user' && !! message.metadata?.temporary_id;
-}
-
-/**
- * Deduplicate Zendesk messages by their temporary id. During connection recovery, some duplication can occur.
- * @param messages - The messages to deduplicate.
- * @returns The deduplicated messages.
- */
-export function deduplicateZDMessages( messages: Message[] ) {
-	const distinctMessages: Message[] = [];
-	for ( const message of messages ) {
-		if ( ! distinctMessages.some( ( otherMessage ) => isEqual( message, otherMessage ) ) ) {
-			distinctMessages.push( message );
-		}
-	}
-	return distinctMessages;
-}
 
 /**
  * This combines the ODIE chat with the ZENDESK conversation.
@@ -76,7 +47,6 @@ export const useGetCombinedChat = (
 	}, [] );
 	const previousUuidRef = useRef< string | undefined >( undefined );
 	const previousOdieIdRef = useRef< string | null | undefined >( undefined );
-	const attemptedConversationIdRef = useRef< string | undefined >( undefined );
 	const wasChatLoadedRef = useRef( isChatLoaded );
 	const [ mainChatState, setMainChatState ] = useState< Chat >( emptyChat );
 	const conversationId = getConversationIdFromInteraction( currentSupportInteraction );
@@ -89,8 +59,8 @@ export const useGetCombinedChat = (
 		botSlug
 	);
 	const [ isFetchingConversation, setIsFetchingConversation ] = useState( false );
+	const navigate = useNavigate();
 
-	const { startNewInteraction } = useManageSupportInteraction();
 	const isUploadingUnsentMessages = useIsMutating( {
 		mutationKey: [ 'send-zendesk-messages' ],
 	} );
@@ -148,16 +118,15 @@ export const useGetCombinedChat = (
 		// The interaction gained a Zendesk conversation this tab is not showing yet:
 		// it was escalated from another tab. Reload so this tab switches too,
 		// otherwise it keeps sending to Odie. Skipped while this tab is the one
-		// transferring (`status === 'transfer'`), which sets the conversation itself,
-		// and once that conversation was already fetched: a failed fetch lands in the
-		// `catch` below and starts a new interaction, so re-triggering on every state
-		// change would keep creating them. A reconnect still retries the fetch through
-		// `refreshConversation`.
+		// transferring (`status === 'transfer'`), which sets the conversation itself.
 		const conversationHasChanged =
 			!! conversationId &&
 			mainChatState.conversationId !== conversationId &&
-			chatStatus !== 'transfer' &&
-			attemptedConversationIdRef.current !== conversationId;
+			chatStatus !== 'transfer';
+
+		// A loaded chat picking up a conversation, as opposed to the initial load or a
+		// refresh of a conversation the chat already shows.
+		const isSwitchingLoadedChat = conversationHasChanged && chatStatus !== 'loading';
 
 		const needsReload = interactionHasChanged || conversationHasChanged;
 
@@ -175,8 +144,6 @@ export const useGetCombinedChat = (
 		}
 
 		previousUuidRef.current = currentSupportInteraction?.uuid;
-
-		const supportInteractionId = currentSupportInteraction?.uuid ?? null;
 
 		// We don't have a conversation id, so our chat is simply the odie chat
 		if ( ! conversationId ) {
@@ -211,46 +178,49 @@ export const useGetCombinedChat = (
 		}
 
 		if ( conversationId && ( isChatLoaded || refreshingAfterReconnect ) ) {
-			attemptedConversationIdRef.current = conversationId;
+			// The conversation's part of the chat: the Odie history, the hand-over
+			// notices, then the Zendesk messages. `queuedMessages` are the user's
+			// messages not in `conversationMessages` yet; `deduplicateZDMessages` drops
+			// the ones that are, keeping the server's copy.
+			const buildZendeskMessages = (
+				queuedMessages: Message[],
+				conversationMessages: Message[]
+			) => [
+				...( odieChat ? filteredOdieMessages : [] ),
+				...getOdieTransferMessages( currentSupportInteraction?.bot_slug, hasEnTranslation ),
+				getZendeskChatStartedMetaMessage(),
+				...deduplicateZDMessages( [ ...queuedMessages, ...conversationMessages ] ),
+			];
+
 			setIsFetchingConversation( true );
 			getZendeskConversation( conversationId )
 				?.then( ( conversation ) => {
-					if ( conversation ) {
-						setMainChatState( ( prevChat ) => {
-							// Keep the user's queued messages when the tab already shows this
-							// conversation, and also while it is switching to it from the Odie
-							// chat (no conversation id yet): a message sent right after the
-							// escalation - from this tab or mirrored from another one - may
-							// not be in the server response yet and would otherwise be dropped.
-							const keepQueuedMessages =
-								prevChat.odieId?.toString() === odieId?.toString() &&
-								( prevChat.conversationId === conversation.id || ! prevChat.conversationId );
-
-							return {
-								odieId: odieId ? Number( odieId ) : null,
-								wpcomUserId: odieChat?.wpcomUserId || prevChat.wpcomUserId,
-								supportInteractionId,
-								conversationId: conversation.id,
-								messages: [
-									...( odieChat ? filteredOdieMessages : [] ),
-									...getOdieTransferMessages(
-										currentSupportInteraction?.bot_slug,
-										hasEnTranslation
-									),
-									getZendeskChatStartedMetaMessage(),
-									...( deduplicateZDMessages( [
-										// During connection recovery, the user queued messages can be deleted. This ensure they remain. And `deduplicateZDMessages` takes of duplication.
-										...( keepQueuedMessages
-											? prevChat.messages.filter( isQueuedZendeskMessage )
-											: [] ),
-										...conversation.messages,
-									] ) as Message[] ),
-								],
-								provider: 'zendesk',
-								status: currentSupportInteraction?.status === 'closed' ? 'closed' : 'loaded',
-							};
-						} );
+					if ( ! conversation ) {
+						throw new Error( 'Conversation not found' );
 					}
+
+					setMainChatState( ( prevChat ) => {
+						// Keep the user's queued messages when the tab already shows this
+						// conversation, and also while it is switching to it from the Odie
+						// chat (no conversation id yet): a message sent right after the
+						// escalation - from this tab or mirrored from another one - may
+						// not be in the server response yet and would otherwise be dropped.
+						const keepQueuedMessages =
+							prevChat.odieId?.toString() === odieId?.toString() &&
+							( prevChat.conversationId === conversation.id || ! prevChat.conversationId );
+
+						return {
+							odieId: odieId ? Number( odieId ) : null,
+							wpcomUserId: odieChat?.wpcomUserId || prevChat.wpcomUserId,
+							conversationId: conversation.id,
+							messages: buildZendeskMessages(
+								keepQueuedMessages ? prevChat.messages.filter( isQueuedZendeskMessage ) : [],
+								conversation.messages as Message[]
+							),
+							provider: 'zendesk',
+							status: currentSupportInteraction?.status === 'closed' ? 'closed' : 'loaded',
+						};
+					} );
 				} )
 				.catch( ( error ) => {
 					recordTracksEvent( 'calypso_odie_zendesk_conversation_not_found', {
@@ -259,10 +229,34 @@ export const useGetCombinedChat = (
 						error: error instanceof Error ? error.message : String( error ),
 					} );
 
-					startNewInteraction( {
-						event_source: 'odie',
-						event_external_id: crypto.randomUUID(),
-					} );
+					if ( isSwitchingLoadedChat || refreshingAfterReconnect ) {
+						// The conversation exists: another tab just created it, or this chat
+						// was already showing it. The failure is most likely transient, so
+						// keep what we have rather than start over. Live messages still
+						// arrive through the Zendesk listener, and the next reconnect or
+						// Smooch re-init re-downloads the history.
+						setMainChatState( ( prevChat ) =>
+							prevChat.conversationId === conversationId
+								? { ...prevChat, status: 'loaded' }
+								: {
+										...prevChat,
+										conversationId,
+										messages: buildZendeskMessages(
+											prevChat.messages.filter( isQueuedZendeskMessage ),
+											[]
+										),
+										provider: 'zendesk',
+										status: 'loaded',
+								  }
+						);
+						return;
+					}
+
+					// Initial load: the conversation is gone for good, e.g. the Zendesk user
+					// was deleted. Start over with a fresh chat, the way a not-found
+					// interaction is handled; the fresh chat creates its own interaction on
+					// the first message.
+					navigate( '/odie' );
 				} )
 				.finally( () => {
 					setRefreshingAfterReconnect( false );
@@ -281,7 +275,7 @@ export const useGetCombinedChat = (
 		currentSupportInteraction,
 		canConnectToZendesk,
 		getZendeskConversation,
-		startNewInteraction,
+		navigate,
 		isLoadingCanConnectToZendesk,
 		sessionId,
 		botSlug,

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -1,7 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenterSelect } from '@automattic/data-stores';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
-import { useIsMutating, useQueryClient } from '@tanstack/react-query';
+import { useIsMutating } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
 import { getMessageUniqueIdentifier } from '../components/message/utils/get-message-unique-identifier';
@@ -90,7 +90,6 @@ export const useGetCombinedChat = (
 	const [ isFetchingConversation, setIsFetchingConversation ] = useState( false );
 
 	const { startNewInteraction } = useManageSupportInteraction();
-	const queryClient = useQueryClient();
 	const isUploadingUnsentMessages = useIsMutating( {
 		mutationKey: [ 'send-zendesk-messages' ],
 	} );
@@ -131,10 +130,6 @@ export const useGetCombinedChat = (
 		}
 	}, [ isChatLoaded, conversationId, refreshConversation ] );
 
-	// The conversation id the Odie chat was last refetched for (see below).
-	const odieChatRefetchedForRef = useRef< string | null >( null );
-	const [ isRefetchingOdieChat, setIsRefetchingOdieChat ] = useState( false );
-
 	useEffect( () => {
 		// Logged out chats don't have interactions. Only direct odie IDs.
 		const interactionHasChanged =
@@ -162,26 +157,7 @@ export const useGetCombinedChat = (
 
 		previousOdieIdRef.current = odieId;
 
-		// The Odie chat cached here is missing whatever was said in the other tab
-		// since this tab loaded it. Refetch it first and come back once that is
-		// done, so the reload rebuilds the full history. Only for a tab that was
-		// already showing this chat; a fresh load has nothing stale.
 		if (
-			conversationHasChanged &&
-			! interactionHasChanged &&
-			odieId &&
-			odieChatRefetchedForRef.current !== conversationId
-		) {
-			odieChatRefetchedForRef.current = conversationId;
-			setIsRefetchingOdieChat( true );
-			queryClient
-				.invalidateQueries( { queryKey: [ 'odie-chat' ] } )
-				.finally( () => setIsRefetchingOdieChat( false ) );
-			return;
-		}
-
-		if (
-			isRefetchingOdieChat ||
 			( isOdieChatLoading && ! interactionHasChanged ) ||
 			isLoadingCurrentSupportInteraction ||
 			isFetchingConversation ||
@@ -307,8 +283,6 @@ export const useGetCombinedChat = (
 		mainChatState?.messages?.length,
 		mainChatState?.odieId,
 		mainChatState?.conversationId,
-		isRefetchingOdieChat,
-		queryClient,
 		odieChat,
 	] );
 

--- a/packages/odie-client/src/hooks/use-get-combined-chat.ts
+++ b/packages/odie-client/src/hooks/use-get-combined-chat.ts
@@ -76,6 +76,7 @@ export const useGetCombinedChat = (
 	}, [] );
 	const previousUuidRef = useRef< string | undefined >( undefined );
 	const previousOdieIdRef = useRef< string | null | undefined >( undefined );
+	const attemptedConversationIdRef = useRef< string | undefined >( undefined );
 	const wasChatLoadedRef = useRef( isChatLoaded );
 	const [ mainChatState, setMainChatState ] = useState< Chat >( emptyChat );
 	const conversationId = getConversationIdFromInteraction( currentSupportInteraction );
@@ -147,11 +148,16 @@ export const useGetCombinedChat = (
 		// The interaction gained a Zendesk conversation this tab is not showing yet:
 		// it was escalated from another tab. Reload so this tab switches too,
 		// otherwise it keeps sending to Odie. Skipped while this tab is the one
-		// transferring (`status === 'transfer'`), which sets the conversation itself.
+		// transferring (`status === 'transfer'`), which sets the conversation itself,
+		// and once that conversation was already fetched: a failed fetch lands in the
+		// `catch` below and starts a new interaction, so re-triggering on every state
+		// change would keep creating them. A reconnect still retries the fetch through
+		// `refreshConversation`.
 		const conversationHasChanged =
 			!! conversationId &&
 			mainChatState.conversationId !== conversationId &&
-			chatStatus !== 'transfer';
+			chatStatus !== 'transfer' &&
+			attemptedConversationIdRef.current !== conversationId;
 
 		const needsReload = interactionHasChanged || conversationHasChanged;
 
@@ -205,6 +211,7 @@ export const useGetCombinedChat = (
 		}
 
 		if ( conversationId && ( isChatLoaded || refreshingAfterReconnect ) ) {
+			attemptedConversationIdRef.current = conversationId;
 			setIsFetchingConversation( true );
 			getZendeskConversation( conversationId )
 				?.then( ( conversation ) => {

--- a/packages/odie-client/src/hooks/use-send-chat-message.ts
+++ b/packages/odie-client/src/hooks/use-send-chat-message.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from '@wordpress/element';
 import { useOdieAssistantContext } from '../context';
-import { broadcastOdieMessage, useSendOdieMessage } from '../data';
+import { broadcastOdieMessage, useCurrentSupportInteractionId, useSendOdieMessage } from '../data';
 import { useSendZendeskMessage } from './use-send-zendesk-message';
 import type { Message } from '../types';
 
@@ -9,6 +9,7 @@ import type { Message } from '../types';
  */
 export const useSendChatMessage = () => {
 	const { addMessage, odieBroadcastClientId, chat } = useOdieAssistantContext();
+	const supportInteractionId = useCurrentSupportInteractionId();
 
 	const [ abortController, setAbortController ] = useState< AbortController >(
 		() => new AbortController()
@@ -24,7 +25,7 @@ export const useSendChatMessage = () => {
 			if ( ! message.payload ) {
 				// Add the user message to the chat and broadcast it to the client.
 				addMessage( message );
-				broadcastOdieMessage( message, odieBroadcastClientId );
+				broadcastOdieMessage( message, odieBroadcastClientId, supportInteractionId );
 			}
 
 			if ( chat.provider === 'zendesk' ) {
@@ -32,7 +33,14 @@ export const useSendChatMessage = () => {
 			}
 			return sendOdieMessage( message );
 		},
-		[ sendOdieMessage, sendZendeskMessage, addMessage, odieBroadcastClientId, chat?.provider ]
+		[
+			sendOdieMessage,
+			sendZendeskMessage,
+			addMessage,
+			odieBroadcastClientId,
+			supportInteractionId,
+			chat?.provider,
+		]
 	);
 
 	return { sendMessage, abort: abortController.abort.bind( abortController ) };

--- a/packages/odie-client/src/hooks/use-zendesk-message-listener.ts
+++ b/packages/odie-client/src/hooks/use-zendesk-message-listener.ts
@@ -5,7 +5,7 @@ import { useCallback, useEffect } from '@wordpress/element';
 import Smooch from 'smooch';
 import { HELP_CENTER_STORE } from '../constants';
 import { useOdieAssistantContext } from '../context';
-import { deduplicateZDMessages } from './use-get-combined-chat';
+import { deduplicateZDMessages } from '../utils/deduplicate-zd-messages';
 import type { ZendeskMessage } from '@automattic/zendesk-client';
 
 /**

--- a/packages/odie-client/src/utils/deduplicate-zd-messages.ts
+++ b/packages/odie-client/src/utils/deduplicate-zd-messages.ts
@@ -1,0 +1,50 @@
+import { getMessageUniqueIdentifier } from '../components/message/utils/get-message-unique-identifier';
+import type { Message } from '../types';
+
+/**
+ * A user message sent through Zendesk: only those carry a `temporary_id`, so Odie messages don't match.
+ * @param message - The message to check.
+ * @returns Whether the message is a Zendesk message sent by the user.
+ */
+export function isQueuedZendeskMessage( message: Message ) {
+	return message.role === 'user' && !! message.metadata?.temporary_id;
+}
+
+/**
+ * Deduplicate Zendesk messages by their unique identifier (the `temporary_id` for a
+ * user message, the Smooch id otherwise).
+ *
+ * The same message can show up twice: the optimistic copy the composer adds and the
+ * server's echo, a copy mirrored from another tab and the server's echo, or a queued
+ * message and the re-downloaded history after a reconnect. On a collision the later
+ * copy wins and replaces the earlier one in place, so the server's version (with its
+ * id, timestamp and converted content) supersedes any placeholder. The one exception:
+ * a confirmed message (`received` set) is never overwritten by an unsent copy.
+ * @param messages - The messages to deduplicate, earliest first.
+ * @returns The deduplicated messages, in their original order.
+ */
+export function deduplicateZDMessages( messages: Message[] ) {
+	const distinctMessages: Message[] = [];
+	const indexById = new Map< unknown, number >();
+
+	for ( const message of messages ) {
+		const id = getMessageUniqueIdentifier( message );
+		const existingIndex = id ? indexById.get( id ) : undefined;
+
+		if ( existingIndex === undefined ) {
+			if ( id ) {
+				indexById.set( id, distinctMessages.length );
+			}
+			distinctMessages.push( message );
+			continue;
+		}
+
+		const existing = distinctMessages[ existingIndex ];
+		if ( existing.received && ! message.received ) {
+			continue;
+		}
+		distinctMessages[ existingIndex ] = message;
+	}
+
+	return distinctMessages;
+}

--- a/packages/odie-client/src/utils/test/deduplicate-zd-messages.test.ts
+++ b/packages/odie-client/src/utils/test/deduplicate-zd-messages.test.ts
@@ -1,0 +1,72 @@
+import { deduplicateZDMessages, isQueuedZendeskMessage } from '../deduplicate-zd-messages';
+import type { Message } from '../../types';
+
+const userMessage = ( temporaryId: string, extra: Partial< Message > = {} ): Message =>
+	( {
+		content: `text ${ temporaryId }`,
+		role: 'user',
+		type: 'message',
+		metadata: { temporary_id: temporaryId },
+		...extra,
+	} ) as Message;
+
+const agentMessage = ( id: string, extra: Partial< Message > = {} ): Message =>
+	( {
+		content: `agent ${ id }`,
+		role: 'business',
+		type: 'message',
+		id,
+		received: 1700000000,
+		...extra,
+	} ) as Message;
+
+describe( 'deduplicateZDMessages', () => {
+	it( 'keeps distinct messages in their original order', () => {
+		const messages = [ userMessage( 'a' ), agentMessage( 'x' ), userMessage( 'b' ) ];
+
+		expect( deduplicateZDMessages( messages ) ).toEqual( messages );
+	} );
+
+	it( 'lets the server echo replace a mirrored placeholder in place', () => {
+		// A copy mirrored from another tab: stamped as sent, but without the Smooch id.
+		const placeholder = userMessage( 'a', { received: 1700000000 } );
+		// The server's echo of the same message, with everything the server assigns.
+		const echo = userMessage( 'a', { id: 'smooch-1', received: 1700000001, content: 'text a' } );
+		const other = agentMessage( 'x' );
+
+		expect( deduplicateZDMessages( [ placeholder, other, echo ] ) ).toEqual( [ echo, other ] );
+	} );
+
+	it( 'lets the re-downloaded history replace a queued copy', () => {
+		const queued = userMessage( 'a' );
+		const fromServer = userMessage( 'a', { id: 'smooch-1', received: 1700000000 } );
+
+		expect( deduplicateZDMessages( [ queued, fromServer ] ) ).toEqual( [ fromServer ] );
+	} );
+
+	it( 'never overwrites a confirmed message with an unsent copy', () => {
+		const confirmed = userMessage( 'a', { id: 'smooch-1', received: 1700000000 } );
+		const unsent = userMessage( 'a' );
+
+		expect( deduplicateZDMessages( [ confirmed, unsent ] ) ).toEqual( [ confirmed ] );
+	} );
+
+	it( 'keeps every message that has no identifier', () => {
+		const anonymous = { content: 'hi', role: 'bot', type: 'message' } as Message;
+
+		expect( deduplicateZDMessages( [ anonymous, anonymous ] ) ).toEqual( [ anonymous, anonymous ] );
+	} );
+} );
+
+describe( 'isQueuedZendeskMessage', () => {
+	it( 'matches a user message with a temporary id', () => {
+		expect( isQueuedZendeskMessage( userMessage( 'a' ) ) ).toBe( true );
+	} );
+
+	it( 'does not match an Odie user message or an agent message', () => {
+		const odieUserMessage = { content: 'hi', role: 'user', type: 'message' } as Message;
+
+		expect( isQueuedZendeskMessage( odieUserMessage ) ).toBe( false );
+		expect( isQueuedZendeskMessage( agentMessage( 'x' ) ) ).toBe( false );
+	} );
+} );


### PR DESCRIPTION
## Why

[DOTSUP-470](https://linear.app/a8c/issue/DOTSUP-470) — when a user has more than one Help Center chat open (multiple tabs/windows) as the same signed-in user, messages typed in one chat show up in the others. The `odieChannel` `BroadcastChannel` that mirrors messages between tabs only had a "not my own broadcast" check, so every tab for that user received every message. (The Smooch `message:received` listener already filters by conversation id, so live Zendesk messages were not part of the leak.)

Two follow-on symptoms for the *same* chat open twice:

- a message sent in tab B showed up in tab A stuck greyed-out with `is-sending`, because only the sending tab ever sets `received` on it;
- once tab A escalated to Zendesk, tab B kept sending to Odie: nothing told it the interaction had changed.

## What

- **Scope the broadcast to the support interaction.** `broadcastOdieMessage` / `useOdieBroadcastWithCallbacks` now carry the sending tab's `supportInteractionId` (read from the tab's MemoryRouter URL through the new `useCurrentSupportInteractionId`). A message is only delivered to another tab showing that same interaction. A chat with no interaction yet, including logged-out sessions, never syncs.
- **The receiving tab marks a mirrored Zendesk user message as sent** (`received` stamped from `metadata.local_timestamp`), so it renders settled instead of greyed `is-sending`. The tab that sent it still owns the send lifecycle.
- **`deduplicateZDMessages` reworked and moved to `utils/deduplicate-zd-messages.ts`.** On an id collision the later copy now wins and replaces the earlier one in place, except that a confirmed message (`received` set) is never overwritten by an unsent copy. So the server's echo of a message (with its Smooch id, timestamp and converted content) supersedes the optimistic or mirrored placeholder, both in the live Zendesk listener and in the reconnect merge. Previously the first copy won and the server's version was dropped.
- **Odie replies are mirrored too.** Odie has no shared realtime channel, so without this a second tab on the same interaction only ever saw the user's half of the conversation until it reloaded. Two deliberate exceptions:
  - a local send failure (rate limit, unknown error, "offline" notice) stays in the tab that sent the message. It is about that tab's request, and a reload would not show it either;
  - the reply that triggers an automatic escalation is not mirrored. The sending tab never shows it, and mirroring it gave other tabs a live "Get support" button that could open a second Zendesk conversation on the same interaction.
  The escalation notices (conversation limit reached, email fallback, existing conversation) mirror the notice the sending tab shows, not the bot's original reply.
- **Other tabs follow an escalation.** `useCreateZendeskConversation` broadcasts a new `odieInteractionUpdatedEvent` once the conversation exists. Tabs on that interaction invalidate the interaction and the Odie chat, and `useGetCombinedChat` reloads when the interaction has a conversation the tab isn't showing (`conversationHasChanged`), skipped while the tab is the one transferring. If that fetch fails, the tab still switches to the conversation with the history it has instead of starting a new interaction: the conversation was just created by another tab so it exists, live messages keep arriving through the Zendesk listener, and the next reconnect or Smooch re-init re-downloads the history. `keepQueuedMessages` also keeps queued Zendesk messages while the tab switches from Odie, so a message mirrored right after the escalation survives the reload.
- **Housekeeping.** `getSupportInteractionQueryKey` is shared between the query, the mutations that write to its cache, and the broadcast invalidation. The sender-side channels are closed after posting. The undeclared `supportInteractionId` property on the chat state is gone; the URL is the source of truth.

## Testing

- `packages/odie-client` + `packages/help-center` pass. New coverage: `deduplicate-zd-messages.test.ts` (the tie-break rules), `broadcast-messages.test.ts` (gating, `received` stamping, channel close, invalidation), `use-send-odie-message.test.ts` (which replies are mirrored), the cross-tab escalation cases in `use-get-combined-chat.test.tsx` (switch, skip while transferring, failed fetch), and the escalation broadcast in `use-create-zendesk-conversation.test.tsx`.
- `tsc` + lint clean on the package.

Manual: open a Help Center chat in two tabs.

**Different chats**
1. Open two different Odie chats in different tabs (different `?id=`).
2. Messages stay in their own chat instead of crossing over.

**Same chat, full flow**
1. Open a new Odie chat in tab 1.
2. Write to Odie and wait for the reply so the interaction is created.
3. Open a new tab and load the same chat there.
4. Write in either tab: the user message and the Odie reply appear in the other, the user message as a normal sent message (not greyed).
5. Escalate to Zendesk in one tab: the other switches to the Zendesk conversation too, and further messages are reflected across both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
