### PR TITLE
E2E: support Gutenberg 23.9 block styles radiogroup in CoverBlock

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/cover-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/cover-block.ts
@@ -71,7 +71,12 @@ export class CoverBlock {
 	 */
 	async setCoverStyle( style: coverStyles ): Promise< void > {
 		const editorParent = await this.editor.parent();
-		await editorParent.locator( `button[aria-label="${ style }"]` ).click();
+		// Gutenberg >= 23.9 renders block styles as a radiogroup with visible labels;
+		// older versions render buttons labelled via aria-label.
+		const styleButton = editorParent
+			.getByRole( 'radio', { name: style, exact: true } )
+			.or( editorParent.locator( `button[aria-label="${ style }"]` ) );
+		await styleButton.first().click();
 
 		const blockId = await this.block.getAttribute( 'data-block' );
 		const styleSelector = `.is-style-${ style.toLowerCase().replace( ' ', '-' ) }`;


### PR DESCRIPTION
Part of the Gutenberg v23.9.0-rc.1 edge rotation (tracking issue #113507).

## Proposed Changes

* Update `CoverBlock.setCoverStyle` in `@automattic/calypso-e2e` to locate block style controls via `getByRole( 'radio', { name: style } )`, falling back to the previous `button[aria-label="..."]` selector.

## Why are these changes being made?

* Gutenberg 23.9 rewrote the block styles picker in the settings sidebar ([WordPress/gutenberg compare v23.8.0...v23.9.0-rc.1](https://github.com/WordPress/gutenberg/compare/v23.8.0...v23.9.0-rc.1), `packages/block-editor/src/components/block-styles/index.js`). Styles are now rendered as a `Composite` radiogroup whose items expose `role="radio"` with the style label as the accessible name. The old markup was a plain `Button` with an `aria-label`.
* Since v23.9.0-rc.1 was activated on edge (27 Aug), `Gutenberg simple E2E tests edge (mobile)` fails on `blocks__coblocks__extensions__cover-styles.spec.ts` with a timeout waiting for `button[aria-label="Default"]` (first failing build: #2154).
* The `.or()` fallback keeps the suite green on non-edge sites still running Gutenberg 23.8.

## Testing Instructions

* `yarn workspace wp-e2e-tests test -- blocks__coblocks__extensions__cover-styles` against a `gutenberg-edge` simple site (GB 23.9.0-rc.1) and against a stable (23.8.0) site; both should pass.
* The failing TeamCity build for reference: calypso_WPComTests_gutenberg_simple_edge_mobile #2157.
