### PR TITLE
Dashboard DNS: add record type filter, search and view controls

### DIFF
--- a/client/dashboard/domains/dns/form.tsx
+++ b/client/dashboard/domains/dns/form.tsx
@@ -1,3 +1,4 @@
+import { DNS_RECORD_TYPES } from '@automattic/api-core';
 import { __experimentalVStack as VStack, Button } from '@wordpress/components';
 import { DataForm, Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -82,17 +83,7 @@ export default function DNSRecordForm( {
 			id: 'type',
 			label: __( 'Type' ),
 			Edit: 'select',
-			elements: [
-				{ label: 'A', value: 'A' },
-				{ label: 'AAAA', value: 'AAAA' },
-				{ label: 'ALIAS', value: 'ALIAS' },
-				{ label: 'CAA', value: 'CAA' },
-				{ label: 'CNAME', value: 'CNAME' },
-				{ label: 'MX', value: 'MX' },
-				{ label: 'NS', value: 'NS' },
-				{ label: 'SRV', value: 'SRV' },
-				{ label: 'TXT', value: 'TXT' },
-			],
+			elements: DNS_RECORD_TYPES.map( ( type ) => ( { label: type, value: type } ) ),
 			description: config.description,
 		},
 	];

--- a/client/dashboard/domains/domain-dns/fields.tsx
+++ b/client/dashboard/domains/domain-dns/fields.tsx
@@ -1,6 +1,18 @@
 import { __, sprintf } from '@wordpress/i18n';
-import type { DnsRecord } from '@automattic/api-core';
-import type { Field } from '@wordpress/dataviews';
+import type { DnsRecord, DnsRecordType } from '@automattic/api-core';
+import type { Field, Operator } from '@wordpress/dataviews';
+
+const DNS_RECORD_TYPES: DnsRecordType[] = [
+	'A',
+	'AAAA',
+	'ALIAS',
+	'CAA',
+	'CNAME',
+	'MX',
+	'NS',
+	'SRV',
+	'TXT',
+];
 
 const trimDot = ( str?: string ) => {
 	return str ? str.replace( /\.$/, '' ) : '';
@@ -13,6 +25,11 @@ export function useDnsFields( domainName: string ): Field< DnsRecord >[] {
 			label: __( 'Type' ),
 			enableHiding: false,
 			enableSorting: true,
+			enableGlobalSearch: true,
+			elements: DNS_RECORD_TYPES.map( ( type ) => ( { value: type, label: type } ) ),
+			filterBy: {
+				operators: [ 'isAny' as Operator ],
+			},
 			getValue: ( { item } ) => item.type,
 		},
 		{
@@ -20,6 +37,7 @@ export function useDnsFields( domainName: string ): Field< DnsRecord >[] {
 			label: __( 'Name' ),
 			enableHiding: false,
 			enableSorting: true,
+			enableGlobalSearch: true,
 			getValue: ( { item } ) => {
 				const { name, service, protocol, type } = item;
 
@@ -41,6 +59,7 @@ export function useDnsFields( domainName: string ): Field< DnsRecord >[] {
 			label: __( 'Value' ),
 			enableHiding: false,
 			enableSorting: true,
+			enableGlobalSearch: true,
 			getValue: ( { item } ) => {
 				const { type, aux, port, weight } = item;
 				const data = trimDot( item.data );

--- a/client/dashboard/domains/domain-dns/fields.tsx
+++ b/client/dashboard/domains/domain-dns/fields.tsx
@@ -1,18 +1,7 @@
+import { DNS_RECORD_TYPES } from '@automattic/api-core';
 import { __, sprintf } from '@wordpress/i18n';
-import type { DnsRecord, DnsRecordType } from '@automattic/api-core';
+import type { DnsRecord } from '@automattic/api-core';
 import type { Field, Operator } from '@wordpress/dataviews';
-
-const DNS_RECORD_TYPES: DnsRecordType[] = [
-	'A',
-	'AAAA',
-	'ALIAS',
-	'CAA',
-	'CNAME',
-	'MX',
-	'NS',
-	'SRV',
-	'TXT',
-];
 
 const trimDot = ( str?: string ) => {
 	return str ? str.replace( /\.$/, '' ) : '';

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -359,7 +359,13 @@ export default function DomainDns() {
 						getItemId={ getDnsRecordId }
 						isLoading={ isLoading }
 						defaultLayouts={ DEFAULT_LAYOUTS }
-						empty={ <p>{ __( 'No DNS records match your search.' ) }</p> }
+						empty={
+							<p>
+								{ view.search
+									? __( 'No DNS records match your search.' )
+									: __( 'No DNS records match the selected filters.' ) }
+							</p>
+						}
 					/>
 				) }
 			</DataViewsCard>

--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -37,13 +37,13 @@ import RestoreDefaultCnameRecord from './restore-default-cname-record';
 import RestoreDefaultEmailRecords from './restore-default-email-records';
 import { hasDefaultARecords, hasDefaultCnameRecord, hasDefaultEmailRecords } from './utils';
 import type { DnsRecord } from '@automattic/api-core';
-import type { ViewTable, ViewList, View } from '@wordpress/dataviews';
+import type { ViewTable, View } from '@wordpress/dataviews';
 
 function getDnsRecordId( record: DnsRecord ) {
 	return `${ record.id }-${ record.name }`;
 }
 
-type DnsView = ViewTable | ViewList;
+type DnsView = ViewTable;
 
 const DEFAULT_VIEW: DnsView = {
 	type: 'table',
@@ -61,7 +61,6 @@ const DEFAULT_VIEW: DnsView = {
 
 const DEFAULT_LAYOUTS = {
 	table: {},
-	list: {},
 };
 
 export default function DomainDns() {
@@ -353,19 +352,15 @@ export default function DomainDns() {
 						data={ filteredData || [] }
 						fields={ fields }
 						onChangeView={ ( view: View ) => setView( view as DnsView ) }
-						search={ false }
+						search
 						view={ view }
 						actions={ actions }
 						paginationInfo={ paginationInfo }
 						getItemId={ getDnsRecordId }
 						isLoading={ isLoading }
 						defaultLayouts={ DEFAULT_LAYOUTS }
-					>
-						<>
-							<DataViews.Layout />
-							<DataViews.Pagination />
-						</>
-					</DataViews>
+						empty={ <p>{ __( 'No DNS records match your search.' ) }</p> }
+					/>
 				) }
 			</DataViewsCard>
 			{ domain.has_wpcom_nameservers && <EmailSetup /> }

--- a/client/dashboard/domains/domain-dns/test/index.test.tsx
+++ b/client/dashboard/domains/domain-dns/test/index.test.tsx
@@ -3,7 +3,8 @@
  */
 import { DomainSubtype, type Domain, type DnsRecord } from '@automattic/api-core';
 import { QueryClient } from '@tanstack/react-query';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import DomainDns from '../index';
@@ -132,5 +133,48 @@ describe( 'DomainDns', () => {
 		render( <DomainDns /> );
 
 		expect( await screen.findByText( CNAME_WARNING ) ).toBeVisible();
+	} );
+
+	test( 'filters DNS records by type', async () => {
+		mockDomainApiRequest( getDefaultDomainData() );
+		mockDnsApiRequest( [
+			{ ...defaultCnameRecord, id: '1' },
+			{ id: '2', type: 'A', name: domainName, data: '192.0.2.1' },
+			{ id: '3', type: 'TXT', name: domainName, data: 'v=spf1 -all' },
+		] );
+		const user = userEvent.setup();
+
+		render( <DomainDns /> );
+
+		expect( await screen.findByText( '192.0.2.1' ) ).toBeVisible();
+		expect( screen.getByText( 'v=spf1 -all' ) ).toBeVisible();
+
+		await user.click( screen.getByRole( 'button', { name: 'Add filter' } ) );
+		await user.click( screen.getByRole( 'menuitem', { name: 'Type' } ) );
+		await user.click( await screen.findByRole( 'option', { name: 'TXT' } ) );
+
+		expect( await screen.findByText( 'v=spf1 -all' ) ).toBeVisible();
+		expect( screen.queryByText( '192.0.2.1' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'searches DNS records by name and value', async () => {
+		mockDomainApiRequest( getDefaultDomainData() );
+		mockDnsApiRequest( [
+			{ ...defaultCnameRecord, id: '1' },
+			{ id: '2', type: 'A', name: domainName, data: '192.0.2.1' },
+			{ id: '3', type: 'TXT', name: domainName, data: 'v=spf1 -all' },
+		] );
+		const user = userEvent.setup();
+
+		render( <DomainDns /> );
+
+		expect( await screen.findByText( '192.0.2.1' ) ).toBeVisible();
+
+		await user.type( screen.getByRole( 'searchbox', { name: 'Search' } ), 'spf' );
+
+		await waitFor( () => {
+			expect( screen.queryByText( '192.0.2.1' ) ).not.toBeInTheDocument();
+		} );
+		expect( screen.getByText( 'v=spf1 -all' ) ).toBeVisible();
 	} );
 } );

--- a/client/dashboard/domains/domain-dns/test/index.test.tsx
+++ b/client/dashboard/domains/domain-dns/test/index.test.tsx
@@ -157,6 +157,23 @@ describe( 'DomainDns', () => {
 		expect( screen.queryByText( '192.0.2.1' ) ).not.toBeInTheDocument();
 	} );
 
+	test( 'shows an empty state when no records match the selected filters', async () => {
+		mockDomainApiRequest( getDefaultDomainData() );
+		mockDnsApiRequest( [ { id: '2', type: 'A', name: domainName, data: '192.0.2.1' } ] );
+		const user = userEvent.setup();
+
+		render( <DomainDns /> );
+
+		expect( await screen.findByText( '192.0.2.1' ) ).toBeVisible();
+
+		await user.click( screen.getByRole( 'button', { name: 'Add filter' } ) );
+		await user.click( screen.getByRole( 'menuitem', { name: 'Type' } ) );
+		await user.click( await screen.findByRole( 'option', { name: 'TXT' } ) );
+
+		expect( await screen.findByText( 'No DNS records match the selected filters.' ) ).toBeVisible();
+		expect( screen.queryByText( '192.0.2.1' ) ).not.toBeInTheDocument();
+	} );
+
 	test( 'searches DNS records by name and value', async () => {
 		mockDomainApiRequest( getDefaultDomainData() );
 		mockDnsApiRequest( [
@@ -170,11 +187,26 @@ describe( 'DomainDns', () => {
 
 		expect( await screen.findByText( '192.0.2.1' ) ).toBeVisible();
 
-		await user.type( screen.getByRole( 'searchbox', { name: 'Search' } ), 'spf' );
+		const searchbox = screen.getByRole( 'searchbox', { name: 'Search' } );
+
+		await user.type( searchbox, 'spf' );
 
 		await waitFor( () => {
 			expect( screen.queryByText( '192.0.2.1' ) ).not.toBeInTheDocument();
 		} );
 		expect( screen.getByText( 'v=spf1 -all' ) ).toBeVisible();
+		expect( screen.queryByText( 'www' ) ).not.toBeInTheDocument();
+
+		await user.clear( searchbox );
+		await user.type( searchbox, 'www' );
+
+		expect( await screen.findByText( 'www' ) ).toBeVisible();
+		expect( screen.queryByText( 'v=spf1 -all' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( '192.0.2.1' ) ).not.toBeInTheDocument();
+
+		await user.clear( searchbox );
+		await user.type( searchbox, 'nomatch' );
+
+		expect( await screen.findByText( 'No DNS records match your search.' ) ).toBeVisible();
 	} );
 } );

--- a/packages/api-core/src/domain-dns-records/types.ts
+++ b/packages/api-core/src/domain-dns-records/types.ts
@@ -1,4 +1,16 @@
-export type DnsRecordType = 'A' | 'AAAA' | 'ALIAS' | 'CAA' | 'CNAME' | 'MX' | 'NS' | 'SRV' | 'TXT';
+export const DNS_RECORD_TYPES = [
+	'A',
+	'AAAA',
+	'ALIAS',
+	'CAA',
+	'CNAME',
+	'MX',
+	'NS',
+	'SRV',
+	'TXT',
+] as const;
+
+export type DnsRecordType = ( typeof DNS_RECORD_TYPES )[ number ];
 
 export type DnsRecord = {
 	aux?: number;


### PR DESCRIPTION
Fixes DOMENG-1089

It looks like this:

<img width="701" height="724" alt="Screenshot 2026-08-28 at 13 38 38" src="https://github.com/user-attachments/assets/646269d2-1946-47e6-a520-4d745e54d9a4" />
<img width="690" height="701" alt="Screenshot 2026-08-28 at 13 38 28" src="https://github.com/user-attachments/assets/323b882a-c659-4c7c-ba0e-ac6348652777" />


## Proposed Changes

* Add a **Type** filter to the DNS records DataViews table in the dashboard. The `type` field now declares `elements` for every `DnsRecordType` (A, AAAA, ALIAS, CAA, CNAME, MX, NS, SRV, TXT) with an `isAny` operator, so it shows up under "Add filter" as a multi-select.
* Enable the search box. `Type`, `Name` and `Value` are marked `enableGlobalSearch`, so search matches the displayed values (e.g. `@` for apex records, `spf` for a TXT value).
* Render DataViews' default toolbar (Search, Filter, Appearance) instead of the custom `Layout` + `Pagination` composition that suppressed it. The table is restricted to the `table` layout so the layout switcher is not shown.
* Add an `empty` message for when a search/filter matches nothing; the existing "No DNS records found for this domain." still covers a genuinely empty record set.
* Add tests that drive the real filter and search UI.

## Why are these changes being made?

* Domains with many DNS records (email providers, verification TXT records, etc.) are hard to scan. Filtering by record type and searching by name/value makes it much quicker to find a specific record. This also brings the DNS table in line with sibling screens (domain forwarding, glue records) which already expose the standard DataViews toolbar.

## Testing Instructions

1. Run the dashboard (`yarn start-dashboard`) and open **Domains → (a domain) → DNS records** for a domain with several records of different types.
2. Click the filter icon → **Type** and pick one or more types. Only records of those types should remain; clearing the filter restores the full list.
3. Type in the search box (e.g. part of a TXT value, or `www`). Only matching records should remain; an empty result shows "No DNS records match your search."
4. Open the Appearance (view config) dropdown: sorting and items-per-page are available, and there is **no** layout switcher.
5. Confirm the "No DNS records found for this domain." message still appears for a domain with no records.
6. `yarn test-client client/dashboard/domains/domain-dns` passes.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hrt1vVpA3M6ycRVtKY6Z4
