### PR TITLE
Fix E2E selectors for Gutenberg edge and wp-admin

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/cover-block.ts
+++ b/packages/calypso-e2e/src/lib/blocks/cover-block.ts
@@ -73,10 +73,11 @@ export class CoverBlock {
 		const editorParent = await this.editor.parent();
 		// Gutenberg >= 23.9 renders block styles as a radiogroup with visible labels;
 		// older versions render buttons labelled via aria-label.
-		const styleButton = editorParent
-			.getByRole( 'radio', { name: style, exact: true } )
-			.or( editorParent.locator( `button[aria-label="${ style }"]` ) );
-		await styleButton.first().click();
+		const styleButton = editorParent.locator( `button[aria-label="${ style }"]` );
+		const styleRadio = editorParent.getByRole( 'radio', { name: style, exact: true } );
+		// `editorParent` is the whole editor body, so a same-labelled control in a mounted but
+		// hidden panel can win DOM order; only the rendered style preview is clickable.
+		await styleButton.or( styleRadio ).filter( { visible: true } ).first().click();
 
 		const blockId = await this.block.getAttribute( 'data-block' );
 		const styleSelector = `.is-style-${ style.toLowerCase().replace( ' ', '-' ) }`;

--- a/packages/calypso-e2e/src/lib/pages/posts-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/posts-page.ts
@@ -8,6 +8,15 @@ type GenericMenuItems = 'Trash';
 type MenuItems = TrashedMenuItems | GenericMenuItems;
 type PostsPageTabs = 'Published' | 'Drafts' | 'Scheduled' | 'Trash';
 
+// wp-admin pluralizes the status filter labels ("Draft (1)" vs "Drafts (2)") and
+// translates them, so the tabs are located by the status they link to instead.
+const tabPostStatus: Record< PostsPageTabs, string > = {
+	Published: 'publish',
+	Drafts: 'draft',
+	Scheduled: 'future',
+	Trash: 'trash',
+};
+
 const selectors = {
 	// General
 	addNewPostButton: 'a.page-title-action, span.split-page-title-action>a',
@@ -18,7 +27,7 @@ const selectors = {
 		`a.row-title:has-text("${ title }"), strong>span:has-text("${ title }")`,
 
 	// Status Filter
-	statusItem: ( item: string ) => `ul.subsubsub a:has-text("${ item }")`,
+	statusItem: ( postStatus: string ) => `ul.subsubsub a[href*="post_status=${ postStatus }"]`,
 
 	// Actions
 	actionItem: ( item: string ) => `.row-actions a:has-text("${ item }")`,
@@ -83,7 +92,7 @@ export class PostsPage {
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickTab( name: PostsPageTabs ): Promise< void > {
-		const locator = this.page.locator( selectors.statusItem( name ) );
+		const locator = this.page.locator( selectors.statusItem( tabPostStatus[ name ] ) );
 		await locator.click();
 	}
 

--- a/packages/calypso-e2e/src/lib/utils/translate.ts
+++ b/packages/calypso-e2e/src/lib/utils/translate.ts
@@ -8,16 +8,18 @@ export async function translateFromPage(
 	string: string,
 	context?: string
 ): Promise< string > {
-	return (
-		locator.evaluate(
-			// eslint-disable-next-line @wordpress/i18n-no-variables
-			( _el, [ string, context ] ) =>
-				context === undefined
-					? // eslint-disable-next-line @wordpress/i18n-no-variables
-					  ( window as any )?.wp?.i18n?.__( string )
-					: // eslint-disable-next-line @wordpress/i18n-no-variables
-					  ( window as any )?.wp?.i18n?._x( string, context ),
-			[ string, context ]
-		) || Promise.resolve( string )
+	const translated = await locator.evaluate(
+		// eslint-disable-next-line @wordpress/i18n-no-variables
+		( _el, [ string, context ] ) =>
+			context === undefined
+				? // eslint-disable-next-line @wordpress/i18n-no-variables
+				  ( window as any )?.wp?.i18n?.__( string )
+				: // eslint-disable-next-line @wordpress/i18n-no-variables
+				  ( window as any )?.wp?.i18n?._x( string, context ),
+		[ string, context ]
 	);
+
+	// `wp.i18n` is absent until the editor boots, and callers pass the result
+	// straight to locators that reject `undefined`.
+	return translated ?? string;
 }


### PR DESCRIPTION
Part of the recurring Gutenberg E2E failure triage. No Linear issue was open for these; happy to link one if it should be tracked.

## Proposed Changes

Three shared page-object fixes, all in `packages/calypso-e2e`:

* `CoverBlock.setCoverStyle` — Gutenberg 23.9.0-rc.1 renders block style previews as radios instead of buttons, so `button[aria-label="…"]` matched nothing on the edge sites. Now accepts either role and clicks the visible one, so stable keeps working.
* `PostsPage.clickTab` — wp-admin pluralises the posts status filter, so a site holding exactly one draft renders `Draft (1)` and `a:has-text("Drafts")` never matched. Tabs are now located by the `post_status` they link to, which is immune to both pluralisation and translation.
* `translateFromPage` — the `locator.evaluate( … ) || Promise.resolve( string )` fallback tested the truthiness of a **Promise**, which is always true, so the fallback was dead code and callers got `undefined` whenever `wp.i18n` had not booted. Now awaited and coalesced.

## Why are these changes being made?

The nightly Gutenberg builds went red on 2026-08-27 with four failing specs. Three were test-side defects:

* `blocks__coblocks__extensions__cover-styles` broke on both edge configs the moment Gutenberg 23.9.0-rc.1 landed — an intentional upstream a11y change (buttons to a radiogroup) that our page object did not follow.
* `editor__post-advanced-flow` failed intermittently on atomic, which the singular/plural mismatch explains exactly: it only fails when leftover site state leaves precisely one draft behind.
* The `translateFromPage` bug did not fail a build on its own, but it replaced the real error with an opaque `Cannot read properties of undefined (reading 'unicode')` on retries, because locators reject an `undefined` name. Fixing it keeps future failures diagnosable.

**One failure is deliberately not fixed here.** `editor__post-basic-flow` still fails on the edge configs at the link-preview step. Gutenberg 23.9.0-rc.1 drops Jetpack's "Share to social media" and "Link preview" sidebar panels entirely — verified as an upstream regression, not a selector drift:

* Both panels render on Gutenberg 23.8.0 and neither renders on 23.9.0-rc.1.
* `Jetpack_Editor_Initial_State` is identical on both sites (`republicize_enabled: true`, same modules, same plan).
* Publicize connections are irrelevant — the atomic site has zero connections and renders the panels fine.

Papering over that in the page object would hide a real product regression, so the spec is left to keep reporting it.

## Testing Instructions

Verified with personal builds carrying this diff, against the configs that were failing:

| Build | Before | After |
| --- | --- | --- |
| Gutenberg simple edge (desktop) #2279 | 2 failed / 27 passed | 1 failed / 28 passed |
| Gutenberg simple edge (mobile) #2158 | 2 failed / 26 passed | 1 failed / 27 passed |
| Gutenberg atomic nightly (mobile) #1964 | 1 failed / 26 passed | **0 failed / 27 passed** |
| Gutenberg E2E Tests (aggregate) #243 | 4 failed batches, 4 specs | 2 failed batches, 1 spec |
| I18N Tests #2051 | — | **53 passed** |

The only remaining failure in every run is `editor__post-basic-flow` on edge, for the upstream reason above.

The I18N run matters because `translateFromPage` exists to serve that suite, and its eight call sites in `editor-toolbar-component.ts` (publish, `View`, settings, `Close plugin`, `Options`) are exercised by far more specs than the ones fixed here.

To run locally:

```bash
cd test/e2e
yarn workspace @automattic/calypso-e2e build   # specs load the package from dist

CALYPSO_BASE_URL=https://wordpress.com GUTENBERG_EDGE=true \
  yarn playwright test --project=chrome \
  specs/blocks/blocks__coblocks__extensions__cover-styles.spec.ts --reporter=list

CALYPSO_BASE_URL=https://wordpress.com BRANCH_NAME=trunk TEST_ON_ATOMIC=true \
  GUTENBERG_NIGHTLY=true yarn playwright test --project=mobile \
  specs/editor/editor__post-advanced-flow.spec.ts --reporter=list
```

Both fail on trunk and pass with this branch. `yarn typecheck-packages` is clean.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Notes on the unchecked items: no new tests — this fixes existing specs; tested on Simple and Atomic but not self-hosted Jetpack; the remaining items are UI/data concerns that do not apply to E2E page objects.
