### PR TITLE
Domains: redirect failed inbound transfers to the domain overview

### DIFF
--- a/client/dashboard/domains/dataviews/field-domain-name.tsx
+++ b/client/dashboard/domains/dataviews/field-domain-name.tsx
@@ -1,4 +1,4 @@
-import { DomainSubtype } from '@automattic/api-core';
+import { DomainStatus, DomainSubtype } from '@automattic/api-core';
 import config from '@automattic/calypso-config';
 import { Link, useMatches } from '@tanstack/react-router';
 import { Tooltip, __experimentalVStack as VStack } from '@wordpress/components';
@@ -28,6 +28,7 @@ export const DomainNameField = ( {
 
 	const href =
 		domain.subtype.id === DomainSubtype.DOMAIN_TRANSFER &&
+		domain.domain_status.id !== DomainStatus.TRANSFER_ERROR &&
 		config.isEnabled( 'domain-transfer-redesign' )
 			? domainTransferRoute.fullPath
 			: domainOverviewRoute.fullPath;

--- a/client/dashboard/domains/dataviews/test/field-domain-name.test.tsx
+++ b/client/dashboard/domains/dataviews/test/field-domain-name.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment jsdom
+ */
+import { DomainStatus, DomainSubtype } from '@automattic/api-core';
+import config from '@automattic/calypso-config';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RouterProvider, createRootRoute, createRoute, createRouter } from '@tanstack/react-router';
+import { render, screen } from '@testing-library/react';
+import { AnalyticsProvider } from '../../../app/analytics';
+import { createDomainsRoutes } from '../../../app/router/domains';
+import { rootRoute } from '../../../app/router/root';
+import { DomainNameField } from '../field-domain-name';
+import type { DomainSummary } from '@automattic/api-core';
+
+// The `domainOverviewRoute`/`domainTransferRoute` singletons only get their
+// `fullPath` populated once a router builds the real route tree. Build it once
+// here so the field's `to={ route.fullPath }` resolves to a real template.
+beforeAll( () => {
+	createRouter( { routeTree: rootRoute.addChildren( createDomainsRoutes() ) } );
+} );
+
+const getMockedDomain = ( customProps: Partial< DomainSummary > = {} ): DomainSummary =>
+	( {
+		domain: 'example.com',
+		site_slug: 'example.wordpress.com',
+		blog_id: 123,
+		subscription_id: 'sub123',
+		subtype: { id: DomainSubtype.DOMAIN_TRANSFER, label: 'Transfer' },
+		domain_status: {
+			id: DomainStatus.TRANSFER_PENDING,
+			label: 'Pending transfer',
+			type: 'neutral',
+		},
+		...customProps,
+	} ) as DomainSummary;
+
+// The shared test-utils router only registers a root route, so TanStack `Link`
+// can't interpolate the `/domains/$domainName[/transfer]` route templates and
+// falls back to `/`. Register both destinations here so the built href reflects
+// which route the field actually points at.
+function renderField( domain: DomainSummary ) {
+	const fieldRoute = createRootRoute( {
+		component: () => (
+			<AnalyticsProvider client={ { recordTracksEvent: jest.fn(), recordPageView: jest.fn() } }>
+				<DomainNameField domain={ domain } value={ domain.domain } />
+			</AnalyticsProvider>
+		),
+	} );
+	const overviewRoute = createRoute( {
+		getParentRoute: () => fieldRoute,
+		path: 'domains/$domainName',
+		component: () => null,
+	} );
+	const transferRoute = createRoute( {
+		getParentRoute: () => fieldRoute,
+		path: 'domains/$domainName/transfer',
+		component: () => null,
+	} );
+	const router = createRouter( {
+		routeTree: fieldRoute.addChildren( [ overviewRoute, transferRoute ] ),
+	} );
+
+	return render(
+		<QueryClientProvider client={ new QueryClient() }>
+			<RouterProvider router={ router } />
+		</QueryClientProvider>
+	);
+}
+
+describe( '<DomainNameField>', () => {
+	afterEach( () => {
+		config.disable( 'domain-transfer-redesign' );
+	} );
+
+	test( 'links a pending transfer to the transfer management route', async () => {
+		config.enable( 'domain-transfer-redesign' );
+
+		renderField( getMockedDomain() );
+
+		expect( await screen.findByRole( 'link' ) ).toHaveAttribute(
+			'href',
+			'/domains/example.com/transfer'
+		);
+	} );
+
+	test( 'links a failed transfer to the domain overview route', async () => {
+		config.enable( 'domain-transfer-redesign' );
+
+		renderField(
+			getMockedDomain( {
+				domain_status: {
+					id: DomainStatus.TRANSFER_ERROR,
+					label: 'Transfer failed',
+					type: 'error',
+				},
+			} )
+		);
+
+		expect( await screen.findByRole( 'link' ) ).toHaveAttribute( 'href', '/domains/example.com' );
+	} );
+
+	test( 'links to the domain overview route when the transfer redesign is disabled', async () => {
+		renderField( getMockedDomain() );
+
+		expect( await screen.findByRole( 'link' ) ).toHaveAttribute( 'href', '/domains/example.com' );
+	} );
+
+	test( 'links a non-transfer domain to the domain overview route even with the transfer redesign enabled', async () => {
+		config.enable( 'domain-transfer-redesign' );
+
+		renderField(
+			getMockedDomain( {
+				subtype: { id: DomainSubtype.DOMAIN_REGISTRATION, label: 'Registration' },
+			} )
+		);
+
+		expect( await screen.findByRole( 'link' ) ).toHaveAttribute( 'href', '/domains/example.com' );
+	} );
+
+	test( 'renders the domain name without a link when there is no subscription', async () => {
+		renderField( getMockedDomain( { subscription_id: undefined } ) );
+
+		expect( await screen.findByText( 'example.com' ) ).toBeVisible();
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/domains/dataviews/test/field-domain-name.test.tsx
+++ b/client/dashboard/domains/dataviews/test/field-domain-name.test.tsx
@@ -7,6 +7,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider, createRootRoute, createRoute, createRouter } from '@tanstack/react-router';
 import { render, screen } from '@testing-library/react';
 import { AnalyticsProvider } from '../../../app/analytics';
+import { APP_CONTEXT_DEFAULT_CONFIG } from '../../../app/context';
 import { createDomainsRoutes } from '../../../app/router/domains';
 import { rootRoute } from '../../../app/router/root';
 import { DomainNameField } from '../field-domain-name';
@@ -14,9 +15,13 @@ import type { DomainSummary } from '@automattic/api-core';
 
 // The `domainOverviewRoute`/`domainTransferRoute` singletons only get their
 // `fullPath` populated once a router builds the real route tree. Build it once
-// here so the field's `to={ route.fullPath }` resolves to a real template.
+// here so the field's `to={ route.fullPath }` resolves to a real template. The
+// router is never navigated, so the context value only has to satisfy the type.
 beforeAll( () => {
-	createRouter( { routeTree: rootRoute.addChildren( createDomainsRoutes() ) } );
+	createRouter( {
+		routeTree: rootRoute.addChildren( createDomainsRoutes() ),
+		context: { config: APP_CONTEXT_DEFAULT_CONFIG },
+	} );
 } );
 
 const getMockedDomain = ( customProps: Partial< DomainSummary > = {} ): DomainSummary =>


### PR DESCRIPTION
Part of DOMENG-1003

## Proposed Changes

* In the domains list, route a **failed** inbound transfer (`domain_status.id === 'transfer_error'`) to the domain overview page (`/domains/<domain>`) instead of the inbound-transfer view (`/domains/<domain>/transfer`).
* In-progress and pending transfers still open the `/transfer` view as before.

<img width="3454" height="2042" alt="Screen Capture on 2026-08-28 at 14-35-43" src="https://github.com/user-attachments/assets/88206f57-6f9f-46fa-9207-b22f238eeb7f" />

## Why are these changes being made?

Clicking a failed transfer's row previously landed on the `/transfer` view, which offers no way to cancel. The overview page already surfaces everything a user needs for a failed transfer: why it failed, a **Restart transfer** CTA, and a **Cancel transfer** action. Redirecting there resolves the reported issue without adding a new button to the transfer view.

This supersedes #113848, which added a Cancel link to the transfer view directly. Once this lands, that PR will be closed.

## Testing Instructions

* In the domains list, click a domain whose status is "Incoming transfer failed" and confirm it opens the domain overview page (`/domains/<domain>`) with the Restart transfer and Cancel transfer options.
* Click a domain with an in-progress or pending transfer and confirm it still opens the `/transfer` view.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
