### PR TITLE
Plans: show accurate domain upsell modal in the existing-site domain flow

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-modal-resolution-callback.tsx
@@ -12,6 +12,7 @@ import {
 
 type Props = {
 	isCustomDomainAllowedOnFreePlan?: boolean | null;
+	isDomainRetainedOnFreePlan?: boolean;
 	flowName?: string | null;
 	paidDomainName?: string | null;
 	intent?: string | null;
@@ -23,6 +24,7 @@ type Props = {
  */
 export function useModalResolutionCallback( {
 	isCustomDomainAllowedOnFreePlan,
+	isDomainRetainedOnFreePlan,
 	flowName,
 	paidDomainName,
 	intent,
@@ -48,6 +50,12 @@ export function useModalResolutionCallback( {
 				return FREE_PLAN_FREE_DOMAIN_DIALOG;
 			}
 
+			// The domain can still be purchased on the free plan (as a non-primary
+			// address), so show the dialog that keeps it in the cart.
+			if ( paidDomainName && isDomainRetainedOnFreePlan ) {
+				return FREE_PLAN_PAID_DOMAIN_DIALOG;
+			}
+
 			// TODO: look into decoupling the flowName from here as well.
 			if (
 				paidDomainName &&
@@ -61,6 +69,13 @@ export function useModalResolutionCallback( {
 
 			return null;
 		},
-		[ isCustomDomainAllowedOnFreePlan, flowName, paidDomainName, intent, selectedThemeType ]
+		[
+			isCustomDomainAllowedOnFreePlan,
+			isDomainRetainedOnFreePlan,
+			flowName,
+			paidDomainName,
+			intent,
+			selectedThemeType,
+		]
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/test/paid-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/test/paid-plan-paid-domain-dialog.tsx
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProvider } from '../../../../../test-helpers/testing-library';
+import { PaidPlanPaidDomainDialog } from '../paid-plan-paid-domain-dialog';
+
+jest.mock( 'calypso/lib/analytics/tracks', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( '../components/paid-domain-suggested-plan-section', () => () => (
+	<div data-testid="suggested-plan-section" />
+) );
+
+describe( 'PaidPlanPaidDomainDialog', () => {
+	const defaultProps = {
+		paidDomainName: 'yourgroovydomain.com',
+		generatedWPComSubdomain: {
+			isLoading: false,
+			result: { domain_name: 'yourgroovysite.wordpress.com' },
+		},
+		onFreePlanSelected: jest.fn(),
+		onPlanSelected: jest.fn(),
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'shows the onboarding copy and drops the domain by default', async () => {
+		renderWithProvider( <PaidPlanPaidDomainDialog { ...defaultProps } /> );
+
+		expect( screen.getByText( 'Paid plan required' ) ).toBeVisible();
+		expect(
+			screen.getByText(
+				/Custom domains are only available with a paid plan\. Choose annual billing and receive the domain's first year free\./
+			)
+		).toBeVisible();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Continue with Free plan' } ) );
+		expect( defaultProps.onFreePlanSelected ).toHaveBeenCalledTimes( 1 );
+		expect( defaultProps.onFreePlanSelected ).not.toHaveBeenCalledWith( true );
+	} );
+} );

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/test/plan-upsell-modal.test.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/test/plan-upsell-modal.test.tsx
@@ -149,6 +149,32 @@ describe( 'PlanUpsellModal tests', () => {
 	} );
 
 	describe( 'useModalResolutionCallback hook related tests', () => {
+		test( 'A paid domain retained on the free plan should show the FREE_PLAN_PAID_DOMAIN_DIALOG on the domain flow', () => {
+			const { result } = renderHook( () =>
+				useModalResolutionCallback( {
+					isCustomDomainAllowedOnFreePlan: false,
+					isDomainRetainedOnFreePlan: true,
+					flowName: 'domain',
+					paidDomainName: 'yourgroovydomain.com',
+					intent: null,
+				} )
+			);
+			expect( result.current( PLAN_FREE ) ).toBe( FREE_PLAN_PAID_DOMAIN_DIALOG );
+		} );
+
+		test( 'A paid domain not retained on the free plan should still show the PAID_PLAN_PAID_DOMAIN_DIALOG on the domain flow', () => {
+			const { result } = renderHook( () =>
+				useModalResolutionCallback( {
+					isCustomDomainAllowedOnFreePlan: false,
+					isDomainRetainedOnFreePlan: false,
+					flowName: 'domain',
+					paidDomainName: 'yourgroovydomain.com',
+					intent: null,
+				} )
+			);
+			expect( result.current( PLAN_FREE ) ).toBe( PAID_PLAN_PAID_DOMAIN_DIALOG );
+		} );
+
 		test( 'Free plan and free domain selection should not show any modals on the onboarding flow when all other modals are hidden', () => {
 			const { result } = renderHook( () =>
 				useModalResolutionCallback( {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -35,7 +35,7 @@ import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
 import { WpcomPlansUI, AddOns, Plans } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/number-formatters';
-import { isAnyHostingFlow } from '@automattic/onboarding';
+import { DOMAIN_FLOW, isAnyHostingFlow } from '@automattic/onboarding';
 import {
 	FeaturesGrid,
 	ComparisonGrid,
@@ -558,8 +558,13 @@ const PlansFeaturesMain = ( {
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
 	const getPlanTypeDestination = usePlanTypeDestinationCallback();
 
+	// In the domain flow for an existing site, continuing with the free plan keeps the
+	// paid domain in the cart — it just can't be used as the site's primary address.
+	const isDomainRetainedOnFreePlan = flowName === DOMAIN_FLOW && !! siteId;
+
 	const resolveModal = useModalResolutionCallback( {
 		isCustomDomainAllowedOnFreePlan,
+		isDomainRetainedOnFreePlan,
 		flowName,
 		paidDomainName,
 		intent: intentFromProps,
@@ -584,13 +589,16 @@ const PlansFeaturesMain = ( {
 		);
 
 	const resolvedSubdomainName: DataResponse< { domain_name: string } > = useMemo( () => {
+		if ( isDomainRetainedOnFreePlan && siteSlug ) {
+			return { isLoading: false, result: { domain_name: siteSlug } };
+		}
 		return {
 			isLoading: signupFlowSubdomain ? false : wpcomFreeDomainSuggestion.isLoading,
 			result: signupFlowSubdomain
 				? { domain_name: signupFlowSubdomain }
 				: wpcomFreeDomainSuggestion.result,
 		};
-	}, [ signupFlowSubdomain, wpcomFreeDomainSuggestion ] );
+	}, [ signupFlowSubdomain, wpcomFreeDomainSuggestion, isDomainRetainedOnFreePlan, siteSlug ] );
 
 	const filteredDisplayedIntervals = useFilteredDisplayedIntervals( {
 		productSlug: currentPlan?.productSlug,


### PR DESCRIPTION
Fixes DOMENG-1092

## Proposed Changes

* In `/setup/domain` on an existing free site, clicking "Start with a free plan" showed `PaidPlanPaidDomainDialog`, whose copy ("Custom domains are only available with a paid plan") overstates the restriction: the domain can be purchased on a free site — it just can't be set as the site's primary address.
* `useModalResolutionCallback` now accepts `isDomainRetainedOnFreePlan` and, when a paid domain is in the cart and the flag is set, resolves to the existing `FreePlanPaidDomainDialog` instead. That dialog already has the accurate copy ("A paid plan is required for a custom primary domain." with a link to the primary-address support doc) and already reports the domain as retained, matching what the flow actually does (the domain stays in the cart). No new strings are introduced.
* `PlansFeaturesMain` sets the flag for the domain flow with an existing site (`flowName === 'domain' && siteId`), and in that case resolves the modal's wpcom-subdomain line to the site's existing address instead of a freshly generated subdomain suggestion, so the "redirects to" sentence shows the address the site will actually keep.

Behavior is unchanged for onboarding and every other flow: signup flows either drop the domain when continuing free (where the old copy is accurate) or already set `isCustomDomainAllowedOnFreePlan`, and `/start/domain` (domain-only) skips the plans step entirely.

Note: this changes the Tracks `dialog_type` for this path from `paid_plan_is_required` to `custom_domain_and_free_plan` (modal view and CTA click events). The data team is being looped in to assess the impact on existing funnels.

## Why are these changes being made?

* The copy told users they can't do something they can, which risks losing domain purchases from free-site owners. Confirmed source in DOMENG-1092: completing checkout with the free plan registers the domain on the free site as a secondary address. The related "make domain primary" banner bug is tracked separately in DOMENG-568.

<img width="1780" height="1208" alt="Screenshot 2026-08-28 at 13 41 30" src="https://github.com/user-attachments/assets/4d8ff003-8188-451f-b782-37b7fe281b73" />


## Testing Instructions

1. On a free site, go to Domains → Add Domain → search and select a domain.
2. Continue to the plans page and click "Start with a free plan".
3. Verify the modal reads "A paid plan is required for a custom primary domain." and the free-plan row shows "yourdomain.com redirects to <your site's current address>" (not a random generated subdomain).
4. Click "Continue with Free plan" and verify checkout still contains the domain with no plan.
5. Regression: run a new-site signup (`/start` or `/setup/onboarding`), pick a paid domain, choose the free plan, and verify the previous "Paid plan required" modal still appears and choosing free still swaps the domain for a free subdomain.
6. `yarn test-client client/my-sites/plans-features-main/` passes (new resolver tests plus a regression test for the onboarding dialog).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)