### PR TITLE
Education: Update domains step and un-hardcode TLD list from the domains step

### DIFF
--- a/client/landing/stepper/README.md
+++ b/client/landing/stepper/README.md
@@ -377,8 +377,10 @@ flows keep working unchanged:
 - The `domain-search` step exposes `headerText`, `subHeaderText`, `hideUseMyDomainLink`
   (suppresses the "Use a domain I own" CTA on both V2 top bar and V1 skip-button surfaces),
   `hideFreeDomainPromo` (hides the free-domain-for-a-year banner), `freeDomainPromoTitle`
-  and `freeDomainPromoSubtitle` (copy overrides for that banner), and `allowedTlds`
-  (per-flow TLD filter that the URL `?tld=` query param can override). All optional and
+  and `freeDomainPromoSubtitle` (copy overrides for that banner), `allowedTlds`
+  (per-flow TLD filter that the URL `?tld=` query param can override), and
+  `freeForFirstYearTlds` (TLDs priced as free for the first year in suggestions and the cart).
+  All optional and
   default-safe; the same prop is applied across all three render paths
   (HundredYearPlanStepWrapper, V2 `Step.CenteredColumnLayout`, V1 `StepContainer`). See
   [`steps-repository/domain-search/index.tsx`](/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx).

--- a/client/landing/stepper/declarative-flow/flows/education/education.ts
+++ b/client/landing/stepper/declarative-flow/flows/education/education.ts
@@ -1,5 +1,6 @@
 import { clearStepPersistedState, EDUCATION_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import { useEffect } from 'react';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
@@ -29,6 +30,7 @@ import type { OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 export const STUDENT_PLAN_SLUG = 'wp_bundle_student_yearly';
+export const EDUCATION_BUNDLED_TLDS = [ 'blog', 'art' ];
 
 function initialize() {
 	const steps = [
@@ -48,6 +50,20 @@ const education: FlowV2< typeof initialize > = {
 	__experimentalUseBuiltinAuth: true,
 	isSignupFlow: true,
 	initialize,
+	useStepsProps() {
+		const { __ } = useI18n();
+
+		return {
+			[ STEPS.DOMAIN_SEARCH.slug ]: {
+				headerText: __( 'Your plan includes a free domain name' ),
+				subHeaderText: __(
+					'Get a .blog or .art domain name for free, or choose a different extension at regular price.'
+				),
+				hideFreeDomainPromo: true,
+				freeForFirstYearTlds: EDUCATION_BUNDLED_TLDS,
+			},
+		};
+	},
 	useStepNavigation( currentStepSlug, navigate ) {
 		const flowName = this.name;
 		const locale = useFlowLocale();

--- a/client/landing/stepper/declarative-flow/flows/education/education.ts
+++ b/client/landing/stepper/declarative-flow/flows/education/education.ts
@@ -55,9 +55,9 @@ const education: FlowV2< typeof initialize > = {
 
 		return {
 			[ STEPS.DOMAIN_SEARCH.slug ]: {
-				headerText: __( 'Your plan includes a free domain name' ),
+				headerText: __( 'Your Student Plan includes a free domain name' ),
 				subHeaderText: __(
-					'Get a .blog or .art domain name for free, or choose a different extension at regular price.'
+					'Get a .blog or .art domain name for free, or choose a different extension at regular price. You can also connect a domain you already own.'
 				),
 				hideFreeDomainPromo: true,
 				freeForFirstYearTlds: EDUCATION_BUNDLED_TLDS,

--- a/client/landing/stepper/declarative-flow/flows/education/test/education.tsx
+++ b/client/landing/stepper/declarative-flow/flows/education/test/education.tsx
@@ -234,9 +234,9 @@ describe( 'Education Flow', () => {
 		renderWithProvider( <StepsProps /> );
 
 		expect( stepsProps?.[ STEPS.DOMAIN_SEARCH.slug ] ).toEqual( {
-			headerText: 'Your plan includes a free domain name',
+			headerText: 'Your Student Plan includes a free domain name',
 			subHeaderText:
-				'Get a .blog or .art domain name for free, or choose a different extension at regular price.',
+				'Get a .blog or .art domain name for free, or choose a different extension at regular price. You can also connect a domain you already own.',
 			hideFreeDomainPromo: true,
 			freeForFirstYearTlds: [ 'blog', 'art' ],
 		} );

--- a/client/landing/stepper/declarative-flow/flows/education/test/education.tsx
+++ b/client/landing/stepper/declarative-flow/flows/education/test/education.tsx
@@ -224,6 +224,24 @@ describe( 'Education Flow', () => {
 		} );
 	} );
 
+	it( 'personalizes the domain search copy and hides the free-domain promo', () => {
+		let stepsProps: ReturnType< NonNullable< typeof educationFlow.useStepsProps > > | undefined;
+		const StepsProps = () => {
+			stepsProps = educationFlow.useStepsProps?.();
+			return null;
+		};
+
+		renderWithProvider( <StepsProps /> );
+
+		expect( stepsProps?.[ STEPS.DOMAIN_SEARCH.slug ] ).toEqual( {
+			headerText: 'Your plan includes a free domain name',
+			subHeaderText:
+				'Get a .blog or .art domain name for free, or choose a different extension at regular price.',
+			hideFreeDomainPromo: true,
+			freeForFirstYearTlds: [ 'blog', 'art' ],
+		} );
+	} );
+
 	describe( 'deep-link guard', () => {
 		const renderSideEffect = ( currentStepSlug: string ) => {
 			const navigate = jest.fn();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -11,7 +11,6 @@ import {
 	isNewHostedSiteCreationFlow,
 	isNewsletterFlow,
 	isOnboardingFlow,
-	EDUCATION_FLOW,
 	Step,
 	StepContainer,
 } from '@automattic/onboarding';
@@ -61,7 +60,6 @@ import type { HelpCenterSelect, OnboardSelect } from '@automattic/data-stores';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const HUNDRED_YEAR_DOMAIN_TLDS = [ 'com', 'net', 'org', 'blog' ];
-const EDUCATION_BUNDLED_TLDS = [ 'blog', 'art' ];
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
@@ -97,6 +95,7 @@ const DomainSearchStep: StepType< {
 		freeDomainPromoTitle?: string;
 		freeDomainPromoSubtitle?: string;
 		allowedTlds?: string[];
+		freeForFirstYearTlds?: string[];
 	};
 } > = function DomainSearchStep( {
 	navigation,
@@ -108,6 +107,7 @@ const DomainSearchStep: StepType< {
 	freeDomainPromoTitle,
 	freeDomainPromoSubtitle,
 	allowedTlds: allowedTldsProp,
+	freeForFirstYearTlds: freeForFirstYearTldsProp,
 } ) {
 	const userSiteCount = useSelector( getCurrentUserSiteCount );
 	const isLoggedIn = useSelector( isUserLoggedIn );
@@ -201,7 +201,7 @@ const DomainSearchStep: StepType< {
 			priceRules: {
 				hidePrice: isHundredYearPlanFlow( flow ),
 				oneTimePrice: isHundredYearDomainFlow( flow ),
-				freeForFirstYearTlds: flow === EDUCATION_FLOW ? EDUCATION_BUNDLED_TLDS : undefined,
+				freeForFirstYearTlds: freeForFirstYearTldsProp,
 			},
 			skippable:
 				! isHundredYearPlanFlow( flow ) &&
@@ -230,7 +230,17 @@ const DomainSearchStep: StepType< {
 				! isHundredYearPlanFlow( flow ) &&
 				( isHundredYearDomainFlow( flow ) ? !! query : true ),
 		};
-	}, [ __, flow, isCiab, isWooHostingSolutions, isWowFunnel, tldQuery, query, allowedTldsProp ] );
+	}, [
+		__,
+		flow,
+		isCiab,
+		isWooHostingSolutions,
+		isWowFunnel,
+		tldQuery,
+		query,
+		allowedTldsProp,
+		freeForFirstYearTldsProp,
+	] );
 
 	const { submit } = navigation;
 


### PR DESCRIPTION
Fixes DOTCOM-17873

## Proposed Changes
Note: Exact copy TBD.

* Personalize the domains step via `useStepsProps()`
    * header: “Your plan includes a free domain name”
    * subheader: “Get a .blog or .art domain name for free, or choose a different extension at regular price.”.
    * The “Claim your first domain—Free!” promo (banner and cart text) is hidden.
* Domain search step: add a `freeForFirstYearTlds` prop to the `accepts:` block and remove the hardcoded `flow === EDUCATION_FLOW` check. 
    * The education flow now passes `[ 'blog', 'art' ]` itself. 

<img width="4568" height="2242" alt="CleanShot 2026-08-28 at 14 57 37@2x" src="https://github.com/user-attachments/assets/301a0853-b41d-48e3-bd54-30374670c2dd" />


## Why are these changes being made?
* The generic domains-step copy doesn’t reassure students that the Student plan includes a free domain name, and the “Claim your first domain—Free!” promo is inaccurate for them (only .blog and .art are free).
* Flow-specific copy belongs in the flow, not the step. Using the `accepts:`/`useStepsProps()` mechanism and removes the one remaining hardcoded education check from the step. 
    * All props default to unset, so every other flow renders exactly as before.

## Testing Instructions

1. Go to `/setup/education` and complete the student validation step with a valid invite code (LMK if you need one)
2. On the domains step, verify the new header/subheader, no “Claim your first domain—Free!” banner above the results and no promo text in the cart view, .blog and .art suggestions still priced free for the first year with other TLDs at regular price, and the “Start Free” option still present.
3. Regression: go through `/setup/onboarding` and verify the domains step is unchanged (header “Claim your space on the web”, promo banner present).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
