### PR TITLE
Themes: bound the theme upload install wait with a deadline

### DIFF
--- a/client/lib/analytics/wait-heartbeat/index.ts
+++ b/client/lib/analytics/wait-heartbeat/index.ts
@@ -9,7 +9,8 @@ import { useInterval } from 'calypso/lib/interval';
 export type WaitSurface =
 	| 'marketplace_install'
 	| 'checkout_thank_you_transfer'
-	| 'stepper_processing';
+	| 'stepper_processing'
+	| 'theme_upload';
 
 /** Why a beat fired. A browser that throttles hidden tabs produces only the visibility ones. */
 type BeatTrigger = 'interval' | 'visibility';

--- a/client/my-sites/themes/theme-upload/index.jsx
+++ b/client/my-sites/themes/theme-upload/index.jsx
@@ -7,7 +7,7 @@ import {
 	getPlan,
 	isFreePlan,
 } from '@automattic/calypso-products';
-import { Card, ProgressBar, Button } from '@automattic/components';
+import { Card, Button } from '@automattic/components';
 import { isEmpty } from '@automattic/js-utils';
 import debugFactory from 'debug';
 import { localize } from 'i18n-calypso';
@@ -70,6 +70,7 @@ import {
 	getSelectedSite,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import ThemeUploadProgress from './upload-progress';
 
 import './style.scss';
 
@@ -96,6 +97,8 @@ class Upload extends Component {
 		isJetpack: PropTypes.bool,
 		backPath: PropTypes.string,
 		showEligibility: PropTypes.bool,
+		siteSlug: PropTypes.string,
+		themeId: PropTypes.string,
 	};
 
 	state = {
@@ -170,25 +173,31 @@ class Upload extends Component {
 	}
 
 	renderProgressBar() {
-		const { translate, progressTotal, progressLoaded, installing } = this.props;
-
-		const uploadingMessage = translate( 'Uploading your theme…' );
-		const installingMessage = this.props.isJetpack
-			? translate( 'Installing your theme…' )
-			: translate( 'Configuring your site…' );
+		const {
+			siteId,
+			siteSlug,
+			selectedSite,
+			themeId,
+			progressTotal,
+			progressLoaded,
+			installing,
+			isJetpack,
+		} = this.props;
 
 		return (
-			<div>
-				<span className="theme-upload__title">
-					{ installing ? installingMessage : uploadingMessage }
-				</span>
-				<ProgressBar
-					value={ progressLoaded || 0 }
-					total={ progressTotal || 100 }
-					title={ translate( 'Uploading progress' ) }
-					isPulsing={ installing }
-				/>
-			</div>
+			// Keyed by site: the wait's clock, its verdict and its heartbeat belong to one site's
+			// upload, and switching sites mid-upload would otherwise inherit all three.
+			<ThemeUploadProgress
+				key={ siteId }
+				siteId={ siteId }
+				siteSlug={ siteSlug }
+				siteUrl={ selectedSite?.URL }
+				themeId={ themeId }
+				installing={ installing }
+				isJetpack={ isJetpack }
+				progressLoaded={ progressLoaded }
+				progressTotal={ progressTotal }
+			/>
 		);
 	}
 

--- a/client/my-sites/themes/theme-upload/style.scss
+++ b/client/my-sites/themes/theme-upload/style.scss
@@ -50,3 +50,9 @@
 		margin: 0 20px 0 0;
 	}
 }
+
+// View: the install phase ran past its deadline
+.theme-upload__timeout-message {
+	margin: 0;
+	color: var(--color-text-subtle);
+}

--- a/client/my-sites/themes/theme-upload/test/upload-progress.jsx
+++ b/client/my-sites/themes/theme-upload/test/upload-progress.jsx
@@ -1,0 +1,204 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useWaitHeartbeat } from 'calypso/lib/analytics/wait-heartbeat';
+import ThemeUploadProgress from '../upload-progress';
+
+const mockSetOpenOdieWithContext = jest.fn();
+let mockIsWpMobileApp = false;
+
+jest.mock( 'calypso/lib/mobile-app', () => ( { isWpMobileApp: () => mockIsWpMobileApp } ) );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( { recordTracksEvent: jest.fn() } ) );
+jest.mock( 'calypso/lib/analytics/wait-heartbeat', () => ( { useWaitHeartbeat: jest.fn() } ) );
+jest.mock( '@automattic/data-stores', () => ( {
+	HelpCenter: { register: () => 'automattic/help-center' },
+} ) );
+// `@automattic/components` pulls in `@wordpress/rich-text`, which registers a store on import, so
+// the mock has to cover the registration surface and not only the dispatch this component uses.
+jest.mock( '@wordpress/data', () => {
+	const noop = () => ( {} );
+	const identity = ( fn ) => fn;
+	return {
+		useDispatch: () => ( { setOpenOdieWithContext: mockSetOpenOdieWithContext } ),
+		useSelect: ( selector ) => selector( () => undefined ),
+		combineReducers: ( reducers ) => reducers,
+		createSelector: identity,
+		createReduxStore: noop,
+		createRegistrySelector: identity,
+		register: noop,
+		registerStore: noop,
+		use: noop,
+		plugins: { persistence: noop },
+		dispatch: () => ( {} ),
+		select: () => ( {} ),
+		subscribe: () => () => {},
+	};
+} );
+
+const defaults = {
+	siteId: 1,
+	siteSlug: 'example.wordpress.com',
+	siteUrl: 'https://example.wordpress.com',
+	themeId: 'my-theme',
+	installing: true,
+	isJetpack: false,
+	progressLoaded: 100,
+	progressTotal: 100,
+};
+const renderProgress = ( props ) => render( <ThemeUploadProgress { ...defaults } { ...props } /> );
+const elapse = ( ms ) => act( () => jest.advanceTimersByTime( ms ) );
+
+describe( 'ThemeUploadProgress', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockIsWpMobileApp = false;
+		jest.useFakeTimers();
+		jest.setSystemTime( new Date( '2026-08-26T10:00:00Z' ) );
+	} );
+	afterEach( () => jest.useRealTimers() );
+
+	it( 'counts real bytes while the file is still uploading', () => {
+		renderProgress( { installing: false, progressLoaded: 20, progressTotal: 100 } );
+		expect( screen.getByText( 'Uploading your theme…' ) ).toBeVisible();
+	} );
+
+	it( 'names the transfer while the install runs on a Simple site', () => {
+		renderProgress();
+		expect( screen.getByText( 'Configuring your site…' ) ).toBeVisible();
+	} );
+
+	it( 'names the install instead on a Jetpack site', () => {
+		renderProgress( { isJetpack: true } );
+		expect( screen.getByText( 'Installing your theme…' ) ).toBeVisible();
+	} );
+
+	it( 'keeps waiting for a transfer that is merely slow', () => {
+		renderProgress();
+		elapse( 179_000 );
+		expect( screen.getByText( 'Configuring your site…' ) ).toBeVisible();
+		expect( screen.queryByText( /taking longer than expected/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'ends the wait in a verdict once the install phase passes its deadline', () => {
+		renderProgress();
+		elapse( 181_000 );
+		expect( screen.getByText( /taking longer than expected/ ) ).toBeVisible();
+		expect( screen.queryByText( 'Configuring your site…' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'offers a way out of the timed-out wait', () => {
+		renderProgress();
+		elapse( 181_000 );
+		expect( screen.getByRole( 'link', { name: 'Go to themes' } ) ).toHaveAttribute(
+			'href',
+			'/themes/example.wordpress.com'
+		);
+	} );
+
+	it( 'opens the Help Center in place, carrying the site and the failure into the chat', async () => {
+		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
+		renderProgress();
+		elapse( 181_000 );
+		const contact = screen.getByRole( 'button', { name: 'Contact support' } );
+		expect( contact ).not.toHaveAttribute( 'href' );
+
+		await user.click( contact );
+		expect( mockSetOpenOdieWithContext ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				section: 'themes',
+				siteId: 1,
+				siteUrl: 'https://example.wordpress.com',
+				initialMessage: expect.stringContaining( 'stuck' ),
+			} )
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_theme_upload_wait_timeout_click', {
+			action: 'contact_support',
+			site_id: 1,
+		} );
+	} );
+
+	// The mobile app never mounts the Help Center, so the dispatch would be a dead click there.
+	it( 'links out to support instead in the mobile app, where the Help Center is absent', async () => {
+		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
+		mockIsWpMobileApp = true;
+		renderProgress();
+		elapse( 181_000 );
+
+		const contact = screen.getByRole( 'link', { name: 'Contact support' } );
+		expect( contact ).toHaveAttribute( 'href', 'https://wordpress.com/support/' );
+
+		await user.click( contact );
+		expect( mockSetOpenOdieWithContext ).not.toHaveBeenCalled();
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_theme_upload_wait_timeout_click', {
+			action: 'contact_support',
+			site_id: 1,
+		} );
+	} );
+
+	// `installing` is derived from two progress figures that are both undefined at mount, so it
+	// reads true before a single byte is reported. Arming the deadline there would time out an
+	// upload that is still perfectly healthy.
+	it( 'does not arm the deadline before the upload has reported any progress', () => {
+		renderProgress( { progressLoaded: undefined, progressTotal: undefined } );
+		elapse( 300_000 );
+		expect( screen.getByText( 'Uploading your theme…' ) ).toBeVisible();
+		expect( screen.queryByText( /taking longer than expected/ ) ).not.toBeInTheDocument();
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	// The upload phase reports real progress, so a slow one is not the silent wait this bounds.
+	it( 'does not run the deadline while the file is still uploading', () => {
+		renderProgress( { installing: false } );
+		elapse( 300_000 );
+		expect( screen.getByText( 'Uploading your theme…' ) ).toBeVisible();
+		expect( screen.queryByText( /taking longer than expected/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'records the timeout once, not on every tick', () => {
+		renderProgress();
+		elapse( 179_000 );
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+
+		elapse( 5_000 );
+		elapse( 30_000 );
+		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_theme_upload_wait_timeout', {
+			site_id: 1,
+			theme_id: 'my-theme',
+			is_jetpack: false,
+		} );
+	} );
+
+	// Mirrors how the page mounts this: keyed by site, so a site switch mid-upload cannot inherit
+	// the previous site's clock, verdict or heartbeat.
+	it( 'starts the next site fresh instead of inheriting a timed-out wait', () => {
+		const Wrapper = ( { siteId } ) => (
+			<ThemeUploadProgress { ...defaults } key={ siteId } siteId={ siteId } />
+		);
+		const { rerender } = render( <Wrapper siteId={ 1 } /> );
+		elapse( 181_000 );
+		expect( screen.getByText( /taking longer than expected/ ) ).toBeVisible();
+
+		rerender( <Wrapper siteId={ 2 } /> );
+		expect( screen.getByText( 'Configuring your site…' ) ).toBeVisible();
+		expect( screen.queryByText( /taking longer than expected/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'beats for the theme_upload surface, and stops once the wait has a verdict', () => {
+		renderProgress();
+		expect( useWaitHeartbeat ).toHaveBeenLastCalledWith(
+			expect.objectContaining( { surface: 'theme_upload', enabled: true } )
+		);
+
+		elapse( 181_000 );
+		expect( useWaitHeartbeat ).toHaveBeenLastCalledWith(
+			expect.objectContaining( {
+				enabled: false,
+				properties: expect.objectContaining( { outcome: 'timeout' } ),
+			} )
+		);
+	} );
+} );

--- a/client/my-sites/themes/theme-upload/upload-progress.jsx
+++ b/client/my-sites/themes/theme-upload/upload-progress.jsx
@@ -1,0 +1,167 @@
+import { Button, ProgressBar } from '@automattic/components';
+import { HelpCenter } from '@automattic/data-stores';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { useEffect, useRef, useState } from 'react';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useWaitHeartbeat } from 'calypso/lib/analytics/wait-heartbeat';
+import { useInterval } from 'calypso/lib/interval';
+import { isWpMobileApp } from 'calypso/lib/mobile-app';
+
+// The install phase waits on an Atomic transfer the client cannot observe finishing. The slowest
+// real one in a week of transfers took 123s, so this cuts off no legitimate wait.
+const INSTALL_DEADLINE_MS = 180 * 1000;
+
+const TICK_MS = 1000;
+
+const HELP_CENTER_STORE = HelpCenter.register();
+
+/**
+ * The upload's two phases. The first counts real bytes; the second pulses, because the transfer
+ * and install behind it report nothing until they are done. Give that second phase a deadline, so
+ * a poll that dies ends in a verdict rather than in a bar that pulses forever.
+ *
+ * Mount this keyed by site: everything below belongs to one site's upload.
+ */
+export default function ThemeUploadProgress( {
+	siteId,
+	siteSlug,
+	siteUrl,
+	themeId,
+	installing,
+	isJetpack,
+	progressLoaded,
+	progressTotal,
+} ) {
+	const translate = useTranslate();
+	const { setOpenOdieWithContext } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const [ timedOut, setTimedOut ] = useState( false );
+
+	// `installing` is a selector comparing the two progress figures, so it reads true before either
+	// exists — an upload that has not reported a byte yet looks identical to a finished one. Both
+	// upload paths populate these, so real progress is what separates the phases.
+	const isInstalling =
+		installing && progressTotal != null && progressTotal > 0 && progressLoaded != null;
+
+	// Wall clock rather than a timeout: a backgrounded tab throttles timers, and the deadline should
+	// measure the wait, not how often the browser let us look at it.
+	const installingSinceRef = useRef( null );
+	if ( isInstalling && installingSinceRef.current === null ) {
+		installingSinceRef.current = Date.now();
+	} else if ( ! isInstalling && installingSinceRef.current !== null ) {
+		installingSinceRef.current = null;
+	}
+
+	useInterval(
+		() => {
+			const startedAt = installingSinceRef.current;
+			if ( startedAt !== null && Date.now() - startedAt >= INSTALL_DEADLINE_MS ) {
+				setTimedOut( true );
+			}
+		},
+		isInstalling && ! timedOut ? TICK_MS : null
+	);
+
+	useWaitHeartbeat( {
+		surface: 'theme_upload',
+		enabled: !! siteId && ! timedOut,
+		properties: {
+			site_id: siteId,
+			theme_id: themeId ?? null,
+			phase: isInstalling ? 'install' : 'upload',
+			is_jetpack: !! isJetpack,
+			outcome: timedOut ? 'timeout' : null,
+		},
+	} );
+
+	const reportedTimeoutRef = useRef( false );
+	useEffect( () => {
+		if ( ! timedOut || reportedTimeoutRef.current ) {
+			return;
+		}
+		reportedTimeoutRef.current = true;
+		recordTracksEvent( 'calypso_theme_upload_wait_timeout', {
+			site_id: siteId,
+			theme_id: themeId ?? null,
+			is_jetpack: !! isJetpack,
+		} );
+	}, [ timedOut, siteId, themeId, isJetpack ] );
+
+	const recordCtaClick = ( action ) =>
+		recordTracksEvent( 'calypso_theme_upload_wait_timeout_click', { action, site_id: siteId } );
+
+	// In place rather than /help/contact: that route leaves Calypso entirely, and the support
+	// conversation would start without the site or the failure that prompted it.
+	const openHelpCenter = () => {
+		recordCtaClick( 'contact_support' );
+		setOpenOdieWithContext( {
+			initialMessage: translate(
+				'My theme upload is stuck. The install has been running for several minutes without finishing.'
+			),
+			section: 'themes',
+			siteUrl,
+			siteId,
+		} );
+	};
+
+	// The mobile app never mounts the Help Center, so opening it there would do nothing visible.
+	const supportButtonProps = isWpMobileApp()
+		? {
+				href: localizeUrl( 'https://wordpress.com/support' ),
+				onClick: () => recordCtaClick( 'contact_support' ),
+		  }
+		: { onClick: openHelpCenter };
+
+	if ( timedOut ) {
+		return (
+			<div className="theme-upload__timeout">
+				<p className="theme-upload__timeout-message">
+					{ translate(
+						'Installing this theme is taking longer than expected. It may still finish on its own — check your themes in a few minutes.'
+					) }
+				</p>
+				<div className="theme-upload__action-buttons">
+					<Button { ...supportButtonProps }>{ translate( 'Contact support' ) }</Button>
+					<Button
+						primary
+						href={ `/themes/${ siteSlug }` }
+						onClick={ () => recordCtaClick( 'go_to_themes' ) }
+					>
+						{ translate( 'Go to themes' ) }
+					</Button>
+				</div>
+			</div>
+		);
+	}
+
+	const installingMessage = isJetpack
+		? translate( 'Installing your theme…' )
+		: translate( 'Configuring your site…' );
+
+	return (
+		<div>
+			<span className="theme-upload__title">
+				{ isInstalling ? installingMessage : translate( 'Uploading your theme…' ) }
+			</span>
+			<ProgressBar
+				value={ progressLoaded || 0 }
+				total={ progressTotal || 100 }
+				title={ translate( 'Uploading progress' ) }
+				isPulsing={ isInstalling }
+			/>
+		</div>
+	);
+}
+
+ThemeUploadProgress.propTypes = {
+	siteId: PropTypes.number,
+	siteSlug: PropTypes.string,
+	siteUrl: PropTypes.string,
+	themeId: PropTypes.string,
+	installing: PropTypes.bool,
+	isJetpack: PropTypes.bool,
+	progressLoaded: PropTypes.number,
+	progressTotal: PropTypes.number,
+};


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-17971/theme-upload-the-transfer-wait-can-pulse-forever-with-no-timeout-and

## Proposed Changes

**The theme upload wait has two parts — sending the file, then setting up the site — and the second part had no time limit. It does now.**

- After 3 minutes it stops pulsing and says so, offering **Go to themes** and **Contact support** (which opens the Help Center already knowing which site is stuck).
- The page now reports how long people wait, via `useWaitHeartbeat`, plus `calypso_theme_upload_wait_timeout` and `calypso_theme_upload_wait_timeout_click`.

## Why are these changes being made?

Uploading a theme to a Simple site kicks off a site transfer that can take a minute or two. The bar pulses while that happens, but nothing was watching the clock: if the browser stopped hearing back, the bar pulsed forever, with no error and nothing to click. People sat on a page that was never going to finish.

About 1,850 theme uploads a month go through this wait ([DOTCOM-17971](https://linear.app/a8c/issue/DOTCOM-17971/theme-upload-the-transfer-wait-can-pulse-forever-with-no-timeout-and)). None observed in the last 28 days took longer than 180 seconds, so the new limit cannot cut a real one short.

## Testing Instructions

1. `yarn start`, then go to `/themes/upload/:site` on a Simple site.
2. Lower `INSTALL_DEADLINE_MS` in `client/my-sites/themes/theme-upload/upload-progress.jsx` to a few seconds.
3. Upload a theme zip. Once the bar starts pulsing, wait past the deadline.
4. The bar is replaced by "Installing this theme is taking longer than expected…" with both buttons. **Contact support** opens the Help Center panel.
