### PR TITLE
Atomic transfer: bound the site transfer status polling

### DIFF
--- a/client/landing/stepper/hooks/test/use-site-transfer-status-query.tsx
+++ b/client/landing/stepper/hooks/test/use-site-transfer-status-query.tsx
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import { useSiteTransferStatusQuery } from '../use-site-transfer-status-query';
+
+const mockGetStatus = jest.fn();
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: { get: ( ...args: unknown[] ) => mockGetStatus( ...args ) },
+} ) );
+
+// The hook's own test-mode constants: 300ms between polls, a 6s watch on `none`, a 30s deadline
+// on a live transfer.
+const POLL_MS = 300;
+
+const respondWith = ( status: string ) => mockGetStatus.mockResolvedValue( { status } );
+
+const renderQuery = () => {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	} );
+	return renderHook( () => useSiteTransferStatusQuery( 1 ), {
+		wrapper: ( { children } ) => (
+			<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
+		),
+	} );
+};
+
+// Advance a poll at a time, flushing between: each refetch has to resolve before the query can
+// schedule the next one, so one big jump would silently count a single poll.
+const elapse = async ( ms: number ) => {
+	for ( let elapsed = 0; elapsed < ms; elapsed += POLL_MS ) {
+		await act( async () => {
+			jest.advanceTimersByTime( POLL_MS );
+			await Promise.resolve();
+		} );
+	}
+};
+
+describe( 'useSiteTransferStatusQuery', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		jest.useFakeTimers();
+	} );
+	afterEach( () => jest.useRealTimers() );
+
+	it( 'watches briefly for a transfer started in another tab', async () => {
+		respondWith( transferStates.NONE );
+		renderQuery();
+		await waitFor( () => expect( mockGetStatus ).toHaveBeenCalled() );
+
+		await elapse( POLL_MS * 4 );
+		expect( mockGetStatus.mock.calls.length ).toBeGreaterThan( 1 );
+	} );
+
+	// The bug: a site with no transfer polled every 3s for as long as the tab lived. Eleven
+	// forgotten tabs produced 96% of the traffic on this endpoint.
+	it( 'stops polling a site that has no transfer', async () => {
+		respondWith( transferStates.NONE );
+		renderQuery();
+		await waitFor( () => expect( mockGetStatus ).toHaveBeenCalled() );
+
+		await elapse( 10_000 );
+		const settled = mockGetStatus.mock.calls.length;
+
+		await elapse( 60_000 );
+		expect( mockGetStatus.mock.calls.length ).toBe( settled );
+	} );
+
+	it( 'keeps polling a transfer that is genuinely running', async () => {
+		respondWith( transferStates.ACTIVE );
+		renderQuery();
+		await waitFor( () => expect( mockGetStatus ).toHaveBeenCalled() );
+
+		await elapse( 10_000 );
+		expect( mockGetStatus.mock.calls.length ).toBeGreaterThan( 5 );
+	} );
+
+	it( 'gives up on a transfer that never leaves its status', async () => {
+		respondWith( transferStates.ACTIVE );
+		renderQuery();
+		await waitFor( () => expect( mockGetStatus ).toHaveBeenCalled() );
+
+		await elapse( 40_000 );
+		const settled = mockGetStatus.mock.calls.length;
+
+		await elapse( 40_000 );
+		expect( mockGetStatus.mock.calls.length ).toBe( settled );
+	} );
+
+	it( 'does not poll a site whose transfer already finished', async () => {
+		respondWith( transferStates.COMPLETED );
+		renderQuery();
+		await waitFor( () => expect( mockGetStatus ).toHaveBeenCalled() );
+
+		await elapse( 10_000 );
+		expect( mockGetStatus ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/client/landing/stepper/hooks/test/use-site-transfer-status-query.tsx
+++ b/client/landing/stepper/hooks/test/use-site-transfer-status-query.tsx
@@ -15,8 +15,7 @@ jest.mock( 'calypso/lib/wp', () => ( {
 	req: { get: ( ...args: unknown[] ) => mockGetStatus( ...args ) },
 } ) );
 
-// The hook's own test-mode constants: 300ms between polls, a 6s watch on `none`, a 30s deadline
-// on a live transfer.
+// Test-mode constants: 300ms per poll, 6s watch on `none`, 30s transfer deadline.
 const POLL_MS = 300;
 
 const respondWith = ( status: string ) => mockGetStatus.mockResolvedValue( { status } );
@@ -31,8 +30,7 @@ const renderQuery = ( siteId = 1, client = makeClient() ) =>
 		),
 	} );
 
-// Advance a poll at a time, flushing between: each refetch has to resolve before the query can
-// schedule the next one, so one big jump would silently count a single poll.
+// One poll at a time, flushing between: a refetch must resolve before the next is scheduled.
 const elapse = async ( ms: number ) => {
 	for ( let elapsed = 0; elapsed < ms; elapsed += POLL_MS ) {
 		await act( async () => {
@@ -58,8 +56,7 @@ describe( 'useSiteTransferStatusQuery', () => {
 		expect( mockGetStatus.mock.calls.length ).toBeGreaterThan( 1 );
 	} );
 
-	// The bug: a site with no transfer polled every 3s for as long as the tab lived. Eleven
-	// forgotten tabs produced 96% of the traffic on this endpoint.
+	// The bug: 11 forgotten tabs made 96% of this endpoint's traffic.
 	it( 'stops polling a site that has no transfer', async () => {
 		respondWith( transferStates.NONE );
 		renderQuery();
@@ -93,8 +90,7 @@ describe( 'useSiteTransferStatusQuery', () => {
 		expect( mockGetStatus.mock.calls.length ).toBe( settled );
 	} );
 
-	// Both sites sit in the same phase, so without keying the window by site the second one inherits
-	// the first one's spent clock and never polls at all.
+	// Same phase for both sites, so an unkeyed window hands the second one a spent clock.
 	it( 'gives a newly selected site its own watch window', async () => {
 		respondWith( transferStates.NONE );
 		const client = makeClient();
@@ -108,13 +104,12 @@ describe( 'useSiteTransferStatusQuery', () => {
 		rerender( { siteId: 2 } );
 		const afterFirstSite = mockGetStatus.mock.calls.length;
 
-		// A full window's worth of polls, not the handful a spent clock would allow before stopping.
+		// A full window of polls, not the handful a spent clock allows before stopping.
 		await elapse( 3000 );
 		expect( mockGetStatus.mock.calls.length - afterFirstSite ).toBeGreaterThanOrEqual( 8 );
 	} );
 
-	// Retries run on their own schedule, so a failing endpoint would otherwise keep the request
-	// lifecycle alive well past the window the interval already closed.
+	// Retries run on their own schedule, outliving the interval the window already closed.
 	it( 'stops retrying a failing poll once the window has closed', async () => {
 		respondWith( transferStates.NONE );
 		renderQuery();

--- a/client/landing/stepper/hooks/test/use-site-transfer-status-query.tsx
+++ b/client/landing/stepper/hooks/test/use-site-transfer-status-query.tsx
@@ -4,7 +4,10 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
-import { useSiteTransferStatusQuery } from '../use-site-transfer-status-query';
+import {
+	getSiteTransferStatusQueryKey,
+	useSiteTransferStatusQuery,
+} from '../use-site-transfer-status-query';
 
 const mockGetStatus = jest.fn();
 
@@ -18,16 +21,15 @@ const POLL_MS = 300;
 
 const respondWith = ( status: string ) => mockGetStatus.mockResolvedValue( { status } );
 
-const renderQuery = () => {
-	const client = new QueryClient( {
-		defaultOptions: { queries: { retry: false, gcTime: 0 } },
-	} );
-	return renderHook( () => useSiteTransferStatusQuery( 1 ), {
+const makeClient = () => new QueryClient( { defaultOptions: { queries: { gcTime: Infinity } } } );
+
+const renderQuery = ( siteId = 1, client = makeClient() ) =>
+	renderHook( ( props: { siteId: number } ) => useSiteTransferStatusQuery( props.siteId ), {
+		initialProps: { siteId },
 		wrapper: ( { children } ) => (
 			<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
 		),
 	} );
-};
 
 // Advance a poll at a time, flushing between: each refetch has to resolve before the query can
 // schedule the next one, so one big jump would silently count a single poll.
@@ -88,6 +90,41 @@ describe( 'useSiteTransferStatusQuery', () => {
 		const settled = mockGetStatus.mock.calls.length;
 
 		await elapse( 40_000 );
+		expect( mockGetStatus.mock.calls.length ).toBe( settled );
+	} );
+
+	// Both sites sit in the same phase, so without keying the window by site the second one inherits
+	// the first one's spent clock and never polls at all.
+	it( 'gives a newly selected site its own watch window', async () => {
+		respondWith( transferStates.NONE );
+		const client = makeClient();
+		client.setQueryData( getSiteTransferStatusQueryKey( 2 ), { status: transferStates.NONE } );
+
+		const { rerender } = renderQuery( 1, client );
+		await waitFor( () => expect( mockGetStatus ).toHaveBeenCalled() );
+
+		await elapse( 10_000 );
+
+		rerender( { siteId: 2 } );
+		const afterFirstSite = mockGetStatus.mock.calls.length;
+
+		// A full window's worth of polls, not the handful a spent clock would allow before stopping.
+		await elapse( 3000 );
+		expect( mockGetStatus.mock.calls.length - afterFirstSite ).toBeGreaterThanOrEqual( 8 );
+	} );
+
+	// Retries run on their own schedule, so a failing endpoint would otherwise keep the request
+	// lifecycle alive well past the window the interval already closed.
+	it( 'stops retrying a failing poll once the window has closed', async () => {
+		respondWith( transferStates.NONE );
+		renderQuery();
+		await waitFor( () => expect( mockGetStatus ).toHaveBeenCalled() );
+
+		mockGetStatus.mockRejectedValue( new Error( 'gateway timeout' ) );
+		await elapse( 20_000 );
+		const settled = mockGetStatus.mock.calls.length;
+
+		await elapse( 60_000 );
 		expect( mockGetStatus.mock.calls.length ).toBe( settled );
 	} );
 

--- a/client/landing/stepper/hooks/use-site-transfer-status-query.ts
+++ b/client/landing/stepper/hooks/use-site-transfer-status-query.ts
@@ -1,4 +1,5 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useRef } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { transferStates, type TransferStates } from 'calypso/state/automated-transfer/constants';
 
@@ -28,6 +29,14 @@ const fetchStatus = ( siteId: number ): Promise< TransferStatusResponse > => {
 
 const REFETCH_TIME = process.env.NODE_ENV === 'test' ? 300 : 3000;
 
+// A transfer started in another tab shows up within seconds, so watching for one is worth a short
+// burst and nothing more. Past it, window focus is the only moment a stale answer matters.
+const NONE_WATCH_MS = process.env.NODE_ENV === 'test' ? 6000 : 60 * 1000;
+
+// The same bound the Redux pollers got in DOTCOM-17961/17962: a transfer stuck server-side must not
+// poll for the life of the tab.
+const TRANSFER_DEADLINE_MS = process.env.NODE_ENV === 'test' ? 30_000 : 5 * 60 * 1000;
+
 const endStates: TransferState[] = [
 	transferStates.NONE,
 	transferStates.COMPLETE,
@@ -51,21 +60,21 @@ export function getSiteTransferStatusQueryKey( siteId: number ) {
 	return [ 'sites', siteId, 'atomic', 'transfers', 'latest' ];
 }
 
-const shouldRefetch = ( status: TransferStates | undefined ) => {
+// Which of the two bounded waits a status belongs to. Grouping by phase rather than raw status
+// keeps the deadline running while a live transfer moves through pending → active → provisioned.
+type WatchPhase = 'none' | 'transferring';
+
+const watchPhase = ( status: TransferStates | undefined ): WatchPhase | null => {
 	if ( ! status ) {
-		return false;
+		return null;
 	}
-
-	// This condition ensures that when the status is NONE,
-	// we expect it might change in another tab. This allows the UI to reflect any updates dynamically.
 	if ( transferStates.NONE === status ) {
-		return true;
+		return 'none';
 	}
-
-	return isTransferring( status );
+	return isTransferring( status ) ? 'transferring' : null;
 };
 
-type Options = Pick< UseQueryOptions, 'retry' | 'refetchIntervalInBackground' >;
+type Options = Pick< UseQueryOptions, 'retry' >;
 
 /**
  * Query hook to get the site transfer status, pooling the endpoint.
@@ -73,6 +82,13 @@ type Options = Pick< UseQueryOptions, 'retry' | 'refetchIntervalInBackground' >;
  * @returns
  */
 export const useSiteTransferStatusQuery = ( siteId: number | undefined, options?: Options ) => {
+	// Wall clock rather than a tick count: a throttled background tab would otherwise stretch either
+	// bound far past the time it is meant to describe.
+	const phaseRef = useRef< { phase: WatchPhase | null; since: number } >( {
+		phase: null,
+		since: Date.now(),
+	} );
+
 	return useQuery( {
 		queryKey: getSiteTransferStatusQueryKey( siteId! ),
 		queryFn: () => fetchStatus( siteId! ),
@@ -88,10 +104,23 @@ export const useSiteTransferStatusQuery = ( siteId: number | undefined, options?
 				error: null,
 			};
 		},
-		refetchOnWindowFocus: false,
-		refetchIntervalInBackground: !! options?.refetchIntervalInBackground,
-		refetchInterval: ( { state } ) =>
-			shouldRefetch( state.data?.status ) ? REFETCH_TIME : false,
+		// Once an interval has expired this is what still notices a transfer started elsewhere, at the
+		// only moment the answer can matter to anyone.
+		refetchOnWindowFocus: ( query ) => watchPhase( query.state.data?.status ) !== null,
+		refetchInterval: ( { state } ) => {
+			const phase = watchPhase( state.data?.status );
+
+			if ( phase !== phaseRef.current.phase ) {
+				phaseRef.current = { phase, since: Date.now() };
+			}
+
+			if ( ! phase ) {
+				return false;
+			}
+
+			const limit = phase === 'none' ? NONE_WATCH_MS : TRANSFER_DEADLINE_MS;
+			return Date.now() - phaseRef.current.since < limit ? REFETCH_TIME : false;
+		},
 		enabled: !! siteId,
 	} );
 };

--- a/client/landing/stepper/hooks/use-site-transfer-status-query.ts
+++ b/client/landing/stepper/hooks/use-site-transfer-status-query.ts
@@ -29,12 +29,10 @@ const fetchStatus = ( siteId: number ): Promise< TransferStatusResponse > => {
 
 const REFETCH_TIME = process.env.NODE_ENV === 'test' ? 300 : 3000;
 
-// A transfer started in another tab shows up within seconds, so watching for one is worth a short
-// burst and nothing more. Past it, window focus is the only moment a stale answer matters.
+// A transfer started in another tab appears within seconds; after that, window focus is enough.
 const NONE_WATCH_MS = process.env.NODE_ENV === 'test' ? 6000 : 60 * 1000;
 
-// The same bound the Redux pollers got in DOTCOM-17961/17962: a transfer stuck server-side must not
-// poll for the life of the tab.
+// Matches the deadline the Redux pollers got in DOTCOM-17961/17962.
 const TRANSFER_DEADLINE_MS = process.env.NODE_ENV === 'test' ? 30_000 : 5 * 60 * 1000;
 
 const endStates: TransferState[] = [
@@ -60,18 +58,14 @@ export function getSiteTransferStatusQueryKey( siteId: number ) {
 	return [ 'sites', siteId, 'atomic', 'transfers', 'latest' ];
 }
 
-// Which of the two bounded waits a status belongs to. Grouping by phase rather than raw status
-// keeps the deadline running while a live transfer moves through pending → active → provisioned.
+// Phase, not raw status: one deadline has to span pending → active → provisioned.
 type WatchPhase = 'none' | 'transferring';
 
 const watchPhase = ( status: TransferStates | undefined ): WatchPhase | null => {
-	if ( ! status ) {
-		return null;
-	}
-	if ( transferStates.NONE === status ) {
+	if ( status === transferStates.NONE ) {
 		return 'none';
 	}
-	return isTransferring( status ) ? 'transferring' : null;
+	return status && isTransferring( status ) ? 'transferring' : null;
 };
 
 type Options = Pick< UseQueryOptions, 'retry' >;
@@ -82,17 +76,10 @@ type Options = Pick< UseQueryOptions, 'retry' >;
  * @returns
  */
 export const useSiteTransferStatusQuery = ( siteId: number | undefined, options?: Options ) => {
-	// Wall clock rather than a tick count: a throttled background tab would otherwise stretch either
-	// bound far past the time it is meant to describe. Keyed by site as well as phase, so switching
-	// sites cannot hand the next one an already-spent window.
-	const phaseRef = useRef< {
-		siteId: number | undefined;
-		phase: WatchPhase | null;
-		since: number;
-	} >( { siteId, phase: null, since: Date.now() } );
+	// Wall clock, so a throttled tab cannot stretch the bound. Keyed by site so a switch starts fresh.
+	const phaseRef = useRef( { siteId, phase: null as WatchPhase | null, since: Date.now() } );
 
-	// Before any status arrives there is no window to be inside of, and the first load still needs
-	// its retries.
+	// No status yet means no window, so a first load keeps its full retry budget.
 	const isWithinWatchWindow = () => {
 		const { phase, since } = phaseRef.current;
 		if ( ! phase ) {
@@ -104,8 +91,7 @@ export const useSiteTransferStatusQuery = ( siteId: number | undefined, options?
 	return useQuery( {
 		queryKey: getSiteTransferStatusQueryKey( siteId! ),
 		queryFn: () => fetchStatus( siteId! ),
-		// Retries outlive the interval otherwise: a failing endpoint would keep a poll alive well past
-		// the bound this hook advertises.
+		// Retries run on their own schedule, so they need the bound too.
 		retry: options?.retry ?? ( ( failureCount ) => isWithinWatchWindow() && failureCount < 20 ),
 		select: ( data ) => {
 			return {
@@ -118,8 +104,7 @@ export const useSiteTransferStatusQuery = ( siteId: number | undefined, options?
 				error: null,
 			};
 		},
-		// Once an interval has expired this is what still notices a transfer started elsewhere, at the
-		// only moment the answer can matter to anyone.
+		// What notices a transfer started elsewhere once the interval has stopped.
 		refetchOnWindowFocus: ( query ) => watchPhase( query.state.data?.status ) !== null,
 		refetchInterval: ( { state } ) => {
 			const phase = watchPhase( state.data?.status );

--- a/client/landing/stepper/hooks/use-site-transfer-status-query.ts
+++ b/client/landing/stepper/hooks/use-site-transfer-status-query.ts
@@ -83,16 +83,30 @@ type Options = Pick< UseQueryOptions, 'retry' >;
  */
 export const useSiteTransferStatusQuery = ( siteId: number | undefined, options?: Options ) => {
 	// Wall clock rather than a tick count: a throttled background tab would otherwise stretch either
-	// bound far past the time it is meant to describe.
-	const phaseRef = useRef< { phase: WatchPhase | null; since: number } >( {
-		phase: null,
-		since: Date.now(),
-	} );
+	// bound far past the time it is meant to describe. Keyed by site as well as phase, so switching
+	// sites cannot hand the next one an already-spent window.
+	const phaseRef = useRef< {
+		siteId: number | undefined;
+		phase: WatchPhase | null;
+		since: number;
+	} >( { siteId, phase: null, since: Date.now() } );
+
+	// Before any status arrives there is no window to be inside of, and the first load still needs
+	// its retries.
+	const isWithinWatchWindow = () => {
+		const { phase, since } = phaseRef.current;
+		if ( ! phase ) {
+			return true;
+		}
+		return Date.now() - since < ( phase === 'none' ? NONE_WATCH_MS : TRANSFER_DEADLINE_MS );
+	};
 
 	return useQuery( {
 		queryKey: getSiteTransferStatusQueryKey( siteId! ),
 		queryFn: () => fetchStatus( siteId! ),
-		retry: options?.retry ?? 20,
+		// Retries outlive the interval otherwise: a failing endpoint would keep a poll alive well past
+		// the bound this hook advertises.
+		retry: options?.retry ?? ( ( failureCount ) => isWithinWatchWindow() && failureCount < 20 ),
 		select: ( data ) => {
 			return {
 				isTransferring: data?.status ? isTransferring( data.status as TransferStates ) : false,
@@ -110,16 +124,11 @@ export const useSiteTransferStatusQuery = ( siteId: number | undefined, options?
 		refetchInterval: ( { state } ) => {
 			const phase = watchPhase( state.data?.status );
 
-			if ( phase !== phaseRef.current.phase ) {
-				phaseRef.current = { phase, since: Date.now() };
+			if ( phase !== phaseRef.current.phase || siteId !== phaseRef.current.siteId ) {
+				phaseRef.current = { siteId, phase, since: Date.now() };
 			}
 
-			if ( ! phase ) {
-				return false;
-			}
-
-			const limit = phase === 'none' ? NONE_WATCH_MS : TRANSFER_DEADLINE_MS;
-			return Date.now() - phaseRef.current.since < limit ? REFETCH_TIME : false;
+			return phase && isWithinWatchWindow() ? REFETCH_TIME : false;
 		},
 		enabled: !! siteId,
 	} );

--- a/client/sites/hosting/components/hosting-features.tsx
+++ b/client/sites/hosting/components/hosting-features.tsx
@@ -60,9 +60,7 @@ const HostingFeatures = ( { path, showAsTools }: HostingFeaturesProps ) => {
 
 	const hasEnTranslation = useHasEnTranslation();
 
-	const { data: siteTransferData } = useSiteTransferStatusQuery( siteId || undefined, {
-		refetchIntervalInBackground: true,
-	} );
+	const { data: siteTransferData } = useSiteTransferStatusQuery( siteId || undefined );
 
 	const shouldRenderActivatingCopy =
 		( siteTransferData?.isTransferring || siteTransferData?.status === transferStates.COMPLETED ) &&


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18250/site-transfer-status-query-polls-every-3-seconds-forever-for-sites

## Proposed Changes

**The query that asks "is this site transferring?" now stops asking — it used to keep going every 3 seconds for as long as the tab was open, even when the site had no transfer at all.**

- When the answer is "no transfer", watch for 60 seconds, then wait for the window to regain focus instead of polling.
- Give a running transfer the same 5-minute limit the other pollers already have, so one stuck server-side cannot poll forever.
- Drop `refetchIntervalInBackground`, which kept buried tabs polling; no caller needs it now.

## Why are these changes being made?

The Hosting Features page is an upsell shown to sites that are *not* on Atomic — so the answer is almost always "no transfer here". The polling was intentional, to catch a transfer started in another tab, but nothing ever ended it.

Between 1 and 27 August that cost about 218,000 requests, all answered "no transfer". The median visit to that page is 2 seconds, but 11 tabs left open longer than an hour produced 96% of the traffic, the longest running 45 hours straight. Slowing the interval down would have shrunk that number and kept the shape; ending the poll removes it.

## Testing Instructions

1. `yarn start`, open devtools → Network, filter for `atomic/transfers/latest`.
2. Go to `/hosting-features/:site` on a site that is not on Atomic.
3. Requests stop about 60 seconds after load, instead of continuing every 3 seconds. Switch to another tab and back: one request fires on focus.
4. Start a transfer from that page and confirm the activation flow still tracks it through to completion.
