### PR TITLE
Signup domains: fix mobile hero overlap on domain search results

### DIFF
--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -1,3 +1,4 @@
+@import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
 .domain-search--step-wrapper {
@@ -31,5 +32,41 @@
 
 	.step-wrapper__navigation-link {
 		color: #1d2327;
+	}
+}
+
+// The shared @automattic/domain-search overlay is built for the Stepper, which
+// pins a fixed top bar, publishes its height as --step-container-v2-top-bar-height,
+// and drops the H1 on mobile once results show. The classic signup StepWrapper
+// does none of that, so the overlay (position: fixed; inset-block-start:
+// var(..., 0)) pins to the viewport top and covers the hero while the results
+// reserve ~123px for it, producing the reported overlap plus a large gap. Give
+// signup the same context on mobile in the results state: pin the nav as a fixed
+// top bar, publish its height so the overlay sits directly below it, drop the
+// hero (the overlay's compact banner replaces it, as in the Stepper), and push
+// the content below the bar. Scoped to the results state + mobile so the
+// initial/empty state and desktop stay untouched.
+@media ( max-width: #{ $break-small - 1px } ) {
+	.step-wrapper--domain-search:has( .domain-search--results ) {
+		--step-container-v2-top-bar-height: 56px;
+
+		.step-wrapper__navigation.action-buttons.no-sticky {
+			position: fixed;
+			inset-block-start: 0;
+			inset-inline: 0;
+			height: var( --step-container-v2-top-bar-height );
+			margin: 0;
+			padding-inline: 16px;
+			background-color: var( --color-surface );
+			z-index: 1;
+		}
+
+		.step-wrapper__header {
+			display: none;
+		}
+
+		.step-wrapper__content {
+			padding-block-start: var( --step-container-v2-top-bar-height );
+		}
 	}
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -36,37 +36,49 @@
 }
 
 // The shared @automattic/domain-search overlay is built for the Stepper, which
-// pins a fixed top bar, publishes its height as --step-container-v2-top-bar-height,
-// and drops the H1 on mobile once results show. The classic signup StepWrapper
-// does none of that, so the overlay (position: fixed; inset-block-start:
-// var(..., 0)) pins to the viewport top and covers the hero while the results
-// reserve ~123px for it, producing the reported overlap plus a large gap. Give
-// signup the same context on mobile in the results state: pin the nav as a fixed
-// top bar, publish its height so the overlay sits directly below it, drop the
-// hero (the overlay's compact banner replaces it, as in the Stepper), and push
-// the content below the bar. Scoped to the results state + mobile so the
-// initial/empty state and desktop stay untouched.
+// pins a fixed WP top bar (setting --step-container-v2-top-bar-height) and hides
+// the H1 on mobile. The classic signup StepWrapper does neither, and it also has
+// its own SignupHeader (logo + progress bar) pinned at the top, so the package's
+// fixed overlay (inset-block-start: var(..., 0)) lands on the viewport top and
+// covers the hero, while the results reserve ~123px for it, producing the reported
+// overlap plus a large gap. Make the overlay sticky instead: it flows below the
+// signup header and hero, pins on scroll, and never paints over the top chrome.
+// With the overlay in flow the reservation is unnecessary. Scoped to the signup
+// wrapper and the results state so Stepper flows and the empty state are untouched.
 @media ( max-width: #{ $break-small - 1px } ) {
-	.step-wrapper--domain-search:has( .domain-search--results ) {
-		--step-container-v2-top-bar-height: 56px;
-
-		.step-wrapper__navigation.action-buttons.no-sticky {
-			position: fixed;
-			inset-block-start: 0;
-			inset-inline: 0;
-			height: var( --step-container-v2-top-bar-height );
-			margin: 0;
-			padding-inline: 16px;
-			background-color: var( --color-surface );
-			z-index: 1;
+	.step-wrapper--domain-search {
+		.domain-search--results__sticky-overlay {
+			position: sticky;
+			// The StepWrapper pads its content horizontally, which would box the
+			// overlay in; break it out to the full viewport width so it reaches the
+			// edges like the Stepper's fixed overlay. The overlay's own rows keep
+			// their 1rem inline padding, so the search field still lines up with the
+			// results below.
+			margin-inline: calc( 50% - 50vw );
 		}
 
+		.domain-search--results {
+			padding-block-start: 0;
+		}
+	}
+
+	// Once results show, drop the hero (H1 + subheader) to reclaim vertical space,
+	// as the Stepper does on mobile. The WordPress logo (SignupHeader) and the
+	// "Use a domain I own" action are separate elements, so they stay.
+	.step-wrapper--domain-search:has( .domain-search--results ) {
 		.step-wrapper__header {
 			display: none;
 		}
 
-		.step-wrapper__content {
-			padding-block-start: var( --step-container-v2-top-bar-height );
+		// With the hero gone, pull the nav action up toward the top edge.
+		.step-wrapper__navigation.action-buttons.no-sticky {
+			inset-block-start: 6px;
 		}
+	}
+
+	// The logo lives in SignupHeader, a sibling of the steps, so scope it via the
+	// flow wrapper. Pull it up toward the top edge now that the hero is hidden.
+	.signup:has( .step-wrapper--domain-search .domain-search--results ) .signup-header {
+		margin-block-start: -8px;
 	}
 }

--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -35,25 +35,14 @@
 	}
 }
 
-// The shared @automattic/domain-search overlay is built for the Stepper, which
-// pins a fixed WP top bar (setting --step-container-v2-top-bar-height) and hides
-// the H1 on mobile. The classic signup StepWrapper does neither, and it also has
-// its own SignupHeader (logo + progress bar) pinned at the top, so the package's
-// fixed overlay (inset-block-start: var(..., 0)) lands on the viewport top and
-// covers the hero, while the results reserve ~123px for it, producing the reported
-// overlap plus a large gap. Make the overlay sticky instead: it flows below the
-// signup header and hero, pins on scroll, and never paints over the top chrome.
-// With the overlay in flow the reservation is unnecessary. Scoped to the signup
-// wrapper and the results state so Stepper flows and the empty state are untouched.
+// The shared @automattic/domain-search overlay is built for the Stepper's fixed
+// top bar; the signup StepWrapper has none, so its fixed positioning covered the
+// hero and left a gap. Make it sticky so it flows below the signup header/hero.
 @media ( max-width: #{ $break-small - 1px } ) {
 	.step-wrapper--domain-search {
 		.domain-search--results__sticky-overlay {
 			position: sticky;
-			// The StepWrapper pads its content horizontally, which would box the
-			// overlay in; break it out to the full viewport width so it reaches the
-			// edges like the Stepper's fixed overlay. The overlay's own rows keep
-			// their 1rem inline padding, so the search field still lines up with the
-			// results below.
+			// Break out of the StepWrapper's horizontal padding to reach the edges.
 			margin-inline: calc( 50% - 50vw );
 		}
 
@@ -62,22 +51,19 @@
 		}
 	}
 
-	// Once results show, drop the hero (H1 + subheader) to reclaim vertical space,
-	// as the Stepper does on mobile. The WordPress logo (SignupHeader) and the
-	// "Use a domain I own" action are separate elements, so they stay.
+	// Drop the hero once results show (as the Stepper does); the logo and the
+	// "Use a domain I own" action are separate elements and stay, nudged up.
 	.step-wrapper--domain-search:has( .domain-search--results ) {
 		.step-wrapper__header {
 			display: none;
 		}
 
-		// With the hero gone, pull the nav action up toward the top edge.
 		.step-wrapper__navigation.action-buttons.no-sticky {
 			inset-block-start: 6px;
 		}
 	}
 
-	// The logo lives in SignupHeader, a sibling of the steps, so scope it via the
-	// flow wrapper. Pull it up toward the top edge now that the hero is hidden.
+	// Logo lives in SignupHeader (outside the step), so scope it via the flow.
 	.signup:has( .step-wrapper--domain-search .domain-search--results ) .signup-header {
 		margin-block-start: -8px;
 	}


### PR DESCRIPTION
Fixes DOMENG-1096

## Proposed Changes

* On mobile, the `/start` signup domain search results view rendered the hero heading partially hidden behind the fixed search overlay, with a large empty gap before the first domain result.
* The shared `@automattic/domain-search` overlay is built for the Stepper, which pins a fixed top bar (setting `--step-container-v2-top-bar-height`) and drops the H1 on mobile once results show. The classic signup `StepWrapper` does neither, and it also renders its own `SignupHeader` (WordPress logo + progress bar) at the top, so the package's fixed overlay (`inset-block-start: var(..., 0)`) pinned to the viewport top and covered the hero, while the results reserved ~123px for it.
* This makes the overlay `sticky` (full-bleed) in the signup context so it flows below the signup header and hero and pins on scroll, never painting over the top chrome, and drops the reservation gap. Once results show, the hero (H1 + subheader) is hidden on mobile to reclaim vertical space (as the Stepper does), while the logo and the "Use a domain I own" action are kept and nudged toward the top edge.

### /start/domain-domain-only
| Before | After |
|--------|--------|
| <img width="807" height="810" alt="Screenshot 2026-08-28 at 17 49 41" src="https://github.com/user-attachments/assets/76c334d4-777d-4952-8406-4e8df9fb044a" /> | <img width="788" height="791" alt="Screenshot 2026-08-28 at 17 49 02" src="https://github.com/user-attachments/assets/839303cf-7305-4db3-a50c-2b94ad78533a" /> | 

### /start/onboarding-with-email/mailbox-domain

| Before | After |
|--------|--------|
| <img width="1188" height="855" alt="Screenshot 2026-08-28 at 18 39 50" src="https://github.com/user-attachments/assets/9239fead-0799-4fe6-a24c-1d961718e975" /> | <img width="1190" height="853" alt="Screenshot 2026-08-28 at 18 40 00" src="https://github.com/user-attachments/assets/c01d6112-b2a8-43ca-8cad-a96d4abcbb10" /> | 

### /start/launch-site/domains-launch

| Before | After |
|--------|--------|
| <img width="897" height="855" alt="Screenshot 2026-08-28 at 18 45 10" src="https://github.com/user-attachments/assets/3374a2d1-4d4c-4da3-ade7-5e6c0b8a38bb" /> | <img width="965" height="852" alt="Screenshot 2026-08-28 at 18 44 59" src="https://github.com/user-attachments/assets/1e2e3a8f-af09-4c21-b9fd-738da61438f3" /> | 


## Why are these changes being made?

The signup framework reuses the shared domain-search package but does not provide the fixed-top-bar layout context the package's persistent mobile overlay assumes, so the overlay landed on top of the signup hero and header chrome. Rather than change the shared package (whose Stepper consumers rely on the current behavior), the fix adapts the overlay on the signup side with a sticky, full-bleed layout that coexists with the existing `SignupHeader`.

The change is scoped to the signup wrapper (`.step-wrapper--domain-search`), the results state (`:has(.domain-search--results)`), and mobile widths, so the Stepper (`/setup`), desktop, and the initial/empty search state are untouched.

Note: the one component behind `.step-wrapper--domain-search` backs five signup step variants (`domains`, `domain-only`, `domains-launch`, `domains-theme-preselected`, `mailbox-domain`), all of which render the persistent overlay, so the fix applies consistently to all of them.

## Testing Instructions

1. In a mobile viewport (or a real phone), open `/start/domain/domain-only` and search for a domain.
2. Verify the WordPress logo and the "Use a domain I own" action remain visible at the top and are not covered.
3. Verify the hero heading is hidden once results show, with no overlap and no large empty gap before the first result.
4. Scroll the results and confirm the search bar spans edge-to-edge and stays pinned at the top.
5. Confirm desktop is unchanged, and that the initial/empty state (before searching) still shows the hero on mobile.
6. Sanity-check the other signup domain variants on mobile (for example `mailbox-domain` and `domains-launch`).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
