### PR TITLE
Hosting: give the activation wait a refresh and a deadline

### DIFF
--- a/client/sites/hosting/components/activation-wait.ts
+++ b/client/sites/hosting/components/activation-wait.ts
@@ -1,3 +1,21 @@
+import { useEffect, useState } from 'react';
+
 // A transfer reports `completed` once the software job is queued, so the site answers as Atomic a
 // moment later. Past this the wait has stopped being informative and needs an ending.
 export const ACTIVATION_DEADLINE_MS = 2 * 60 * 1000;
+
+// Keyed by site: SPA navigation keeps the caller mounted across a site switch, so the next site
+// inherits neither the previous one's clock nor its verdict.
+export function useActivationDeadline( siteId: number | null, isWaiting: boolean ) {
+	const [ stalledSiteId, setStalledSiteId ] = useState< number | null >( null );
+
+	useEffect( () => {
+		if ( ! isWaiting || siteId === null ) {
+			return;
+		}
+		const timer = setTimeout( () => setStalledSiteId( siteId ), ACTIVATION_DEADLINE_MS );
+		return () => clearTimeout( timer );
+	}, [ isWaiting, siteId ] );
+
+	return stalledSiteId !== null && stalledSiteId === siteId;
+}

--- a/client/sites/hosting/components/activation-wait.ts
+++ b/client/sites/hosting/components/activation-wait.ts
@@ -10,6 +10,7 @@ export function useActivationDeadline( siteId: number | null, isWaiting: boolean
 	const [ stalledSiteId, setStalledSiteId ] = useState< number | null >( null );
 
 	useEffect( () => {
+		setStalledSiteId( null );
 		if ( ! isWaiting || siteId === null ) {
 			return;
 		}
@@ -17,5 +18,5 @@ export function useActivationDeadline( siteId: number | null, isWaiting: boolean
 		return () => clearTimeout( timer );
 	}, [ isWaiting, siteId ] );
 
-	return stalledSiteId !== null && stalledSiteId === siteId;
+	return isWaiting && stalledSiteId !== null && stalledSiteId === siteId;
 }

--- a/client/sites/hosting/components/activation-wait.ts
+++ b/client/sites/hosting/components/activation-wait.ts
@@ -1,0 +1,3 @@
+// A transfer reports `completed` once the software job is queued, so the site answers as Atomic a
+// moment later. Past this the wait has stopped being informative and needs an ending.
+export const ACTIVATION_DEADLINE_MS = 2 * 60 * 1000;

--- a/client/sites/hosting/components/hosting-callout/index.tsx
+++ b/client/sites/hosting/components/hosting-callout/index.tsx
@@ -34,6 +34,7 @@ export function HostingActivationCallout( {
 		...siteLatestAtomicTransferQuery( site.ID ),
 		refetchInterval: ( query ) =>
 			query.state.data && isAtomicTransferInProgress( query.state.data.status ) ? 5000 : false,
+		refetchIntervalInBackground: true,
 	} );
 
 	const isTransferCompleted = latestAtomicTransfer?.status === 'completed';

--- a/client/sites/hosting/components/hosting-callout/index.tsx
+++ b/client/sites/hosting/components/hosting-callout/index.tsx
@@ -30,7 +30,11 @@ export function HostingActivationCallout( {
 	redirectUrl?: string;
 } ) {
 	const dispatch = useDispatch();
-	const [ activationStalled, setActivationStalled ] = useState( false );
+
+	// Keyed by site: SPA navigation keeps this component mounted, so the next site must inherit
+	// neither the previous one's clock nor its verdict.
+	const [ stalledSiteId, setStalledSiteId ] = useState< number | null >( null );
+	const activationStalled = stalledSiteId === site.ID;
 
 	const { data: latestAtomicTransfer } = useQuery( {
 		...siteLatestAtomicTransferQuery( site.ID ),
@@ -42,9 +46,15 @@ export function HostingActivationCallout( {
 
 	// The transfer says `completed` before the site answers as Atomic, so this is the wait that
 	// needs the deadline — without one it polls for the life of the tab.
-	const completedSinceRef = useRef< number | null >( null );
-	if ( isTransferCompleted && completedSinceRef.current === null ) {
-		completedSinceRef.current = Date.now();
+	const waitRef = useRef< { siteId: number; since: number | null } >( {
+		siteId: site.ID,
+		since: null,
+	} );
+	if ( waitRef.current.siteId !== site.ID ) {
+		waitRef.current = { siteId: site.ID, since: null };
+	}
+	if ( isTransferCompleted && waitRef.current.since === null ) {
+		waitRef.current.since = Date.now();
 	}
 
 	const { data: atomicSite } = useQuery( {
@@ -64,8 +74,8 @@ export function HostingActivationCallout( {
 
 	useInterval(
 		() => {
-			if ( Date.now() - ( completedSinceRef.current ?? Date.now() ) >= ACTIVATION_DEADLINE_MS ) {
-				setActivationStalled( true );
+			if ( Date.now() - ( waitRef.current.since ?? Date.now() ) >= ACTIVATION_DEADLINE_MS ) {
+				setStalledSiteId( site.ID );
 			}
 		},
 		isTransferCompleted && ! isActivated && ! activationStalled ? EVERY_SECOND : null

--- a/client/sites/hosting/components/hosting-callout/index.tsx
+++ b/client/sites/hosting/components/hosting-callout/index.tsx
@@ -5,16 +5,18 @@ import { useQuery } from '@tanstack/react-query';
 import { Button, __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Callout } from 'calypso/dashboard/components/callout';
 import HostingFeatureList from 'calypso/dashboard/sites/hosting-feature-list';
 import {
 	isAtomicTransferInProgress,
 	isAtomicTransferredSite,
 } from 'calypso/dashboard/utils/site-atomic-transfers';
+import { EVERY_SECOND, useInterval } from 'calypso/lib/interval';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestSite } from 'calypso/state/sites/actions';
+import { ACTIVATION_DEADLINE_MS } from '../activation-wait';
 import HostingActivationButton from '../hosting-activation-button';
 import illustrationUrl from './hosting-callout-illustration.svg';
 
@@ -28,40 +30,46 @@ export function HostingActivationCallout( {
 	redirectUrl?: string;
 } ) {
 	const dispatch = useDispatch();
+	const [ activationStalled, setActivationStalled ] = useState( false );
+
 	const { data: latestAtomicTransfer } = useQuery( {
 		...siteLatestAtomicTransferQuery( site.ID ),
-		refetchInterval: ( query ) => {
-			if ( ! query.state.data ) {
-				return 0;
-			}
-
-			return isAtomicTransferInProgress( query.state.data.status ) ? 5000 : false;
-		},
-		refetchIntervalInBackground: true,
+		refetchInterval: ( query ) =>
+			query.state.data && isAtomicTransferInProgress( query.state.data.status ) ? 5000 : false,
 	} );
+
+	const isTransferCompleted = latestAtomicTransfer?.status === 'completed';
+
+	// The transfer says `completed` before the site answers as Atomic, so this is the wait that
+	// needs the deadline — without one it polls for the life of the tab.
+	const completedSinceRef = useRef< number | null >( null );
+	if ( isTransferCompleted && completedSinceRef.current === null ) {
+		completedSinceRef.current = Date.now();
+	}
 
 	const { data: atomicSite } = useQuery( {
 		...siteByIdQuery( site.ID ),
-		refetchInterval: ( query ) => {
-			if ( ! query.state.data ) {
-				return 0;
-			}
-
-			return ! isAtomicTransferredSite( query.state.data ) ? 2000 : false;
-		},
-		enabled: latestAtomicTransfer?.status === 'completed',
+		refetchInterval: ( query ) =>
+			query.state.data && isAtomicTransferredSite( query.state.data ) ? false : 2000,
+		enabled: isTransferCompleted && ! activationStalled,
 	} );
 
 	const isActivating =
+		! activationStalled &&
 		latestAtomicTransfer &&
-		( isAtomicTransferInProgress( latestAtomicTransfer.status ) ||
-			// Keep displaying “Activating…” until the page redirects.
-			latestAtomicTransfer?.status === 'completed' );
+		// Keep displaying “Activating…” until the page redirects.
+		( isAtomicTransferInProgress( latestAtomicTransfer.status ) || isTransferCompleted );
 
-	const isActivated =
-		latestAtomicTransfer?.status === 'completed' &&
-		atomicSite &&
-		isAtomicTransferredSite( atomicSite );
+	const isActivated = isTransferCompleted && atomicSite && isAtomicTransferredSite( atomicSite );
+
+	useInterval(
+		() => {
+			if ( Date.now() - ( completedSinceRef.current ?? Date.now() ) >= ACTIVATION_DEADLINE_MS ) {
+				setActivationStalled( true );
+			}
+		},
+		isTransferCompleted && ! isActivated && ! activationStalled ? EVERY_SECOND : null
+	);
 
 	useEffect( () => {
 		const handleActivated = async () => {

--- a/client/sites/hosting/components/hosting-callout/index.tsx
+++ b/client/sites/hosting/components/hosting-callout/index.tsx
@@ -5,18 +5,17 @@ import { useQuery } from '@tanstack/react-query';
 import { Button, __experimentalText as Text } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect } from 'react';
 import { Callout } from 'calypso/dashboard/components/callout';
 import HostingFeatureList from 'calypso/dashboard/sites/hosting-feature-list';
 import {
 	isAtomicTransferInProgress,
 	isAtomicTransferredSite,
 } from 'calypso/dashboard/utils/site-atomic-transfers';
-import { EVERY_SECOND, useInterval } from 'calypso/lib/interval';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { requestSite } from 'calypso/state/sites/actions';
-import { ACTIVATION_DEADLINE_MS } from '../activation-wait';
+import { useActivationDeadline } from '../activation-wait';
 import HostingActivationButton from '../hosting-activation-button';
 import illustrationUrl from './hosting-callout-illustration.svg';
 
@@ -31,11 +30,6 @@ export function HostingActivationCallout( {
 } ) {
 	const dispatch = useDispatch();
 
-	// Keyed by site: SPA navigation keeps this component mounted, so the next site must inherit
-	// neither the previous one's clock nor its verdict.
-	const [ stalledSiteId, setStalledSiteId ] = useState< number | null >( null );
-	const activationStalled = stalledSiteId === site.ID;
-
 	const { data: latestAtomicTransfer } = useQuery( {
 		...siteLatestAtomicTransferQuery( site.ID ),
 		refetchInterval: ( query ) =>
@@ -46,40 +40,24 @@ export function HostingActivationCallout( {
 
 	// The transfer says `completed` before the site answers as Atomic, so this is the wait that
 	// needs the deadline — without one it polls for the life of the tab.
-	const waitRef = useRef< { siteId: number; since: number | null } >( {
-		siteId: site.ID,
-		since: null,
-	} );
-	if ( waitRef.current.siteId !== site.ID ) {
-		waitRef.current = { siteId: site.ID, since: null };
-	}
-	if ( isTransferCompleted && waitRef.current.since === null ) {
-		waitRef.current.since = Date.now();
-	}
+	const deadlinePassed = useActivationDeadline( site.ID, isTransferCompleted );
 
 	const { data: atomicSite } = useQuery( {
 		...siteByIdQuery( site.ID ),
 		refetchInterval: ( query ) =>
 			query.state.data && isAtomicTransferredSite( query.state.data ) ? false : 2000,
-		enabled: isTransferCompleted && ! activationStalled,
+		enabled: isTransferCompleted && ! deadlinePassed,
 	} );
+
+	const isActivated = isTransferCompleted && atomicSite && isAtomicTransferredSite( atomicSite );
+
+	const activationStalled = deadlinePassed && ! isActivated;
 
 	const isActivating =
 		! activationStalled &&
 		latestAtomicTransfer &&
 		// Keep displaying “Activating…” until the page redirects.
 		( isAtomicTransferInProgress( latestAtomicTransfer.status ) || isTransferCompleted );
-
-	const isActivated = isTransferCompleted && atomicSite && isAtomicTransferredSite( atomicSite );
-
-	useInterval(
-		() => {
-			if ( Date.now() - ( waitRef.current.since ?? Date.now() ) >= ACTIVATION_DEADLINE_MS ) {
-				setStalledSiteId( site.ID );
-			}
-		},
-		isTransferCompleted && ! isActivated && ! activationStalled ? EVERY_SECOND : null
-	);
 
 	useEffect( () => {
 		const handleActivated = async () => {

--- a/client/sites/hosting/components/hosting-features.tsx
+++ b/client/sites/hosting/components/hosting-features.tsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
-import { useRef, useEffect, useState } from 'react';
+import { useRef, useEffect } from 'react';
 import { HostingCard, HostingCardGrid } from 'calypso/components/hosting-card';
 import { HostingHero, HostingHeroButton } from 'calypso/components/hosting-hero';
 import InlineSupportLink from 'calypso/components/inline-support-link';
@@ -17,7 +17,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { ACTIVATION_DEADLINE_MS } from './activation-wait';
+import { useActivationDeadline } from './activation-wait';
 import HostingActivationButton from './hosting-activation-button';
 
 import './hosting-features.scss';
@@ -67,25 +67,11 @@ const HostingFeatures = ( { path, showAsTools }: HostingFeaturesProps ) => {
 
 	const isTransferCompleted = siteTransferData?.status === transferStates.COMPLETED;
 
-	// Keyed by site: the page stays mounted across a site switch, so the next site must inherit
-	// neither the previous one's clock nor its verdict.
-	const [ stalledSiteId, setStalledSiteId ] = useState< number | null >( null );
-	const activationStalled = stalledSiteId !== null && stalledSiteId === siteId;
-
-	const waitRef = useRef< { siteId: number | null; since: number | null } >( {
-		siteId,
-		since: null,
-	} );
-	if ( waitRef.current.siteId !== siteId ) {
-		waitRef.current = { siteId, since: null };
-	}
-	if ( isTransferCompleted && waitRef.current.since === null ) {
-		waitRef.current.since = Date.now();
-	}
-
 	// The redirect below reads Redux, which nothing here refreshes, so a completed transfer would
 	// otherwise never reach it and the page would spin on a success.
 	const awaitingAtomicSiteId = isTransferCompleted && ! isSiteAtomic ? siteId : null;
+
+	const activationStalled = useActivationDeadline( siteId, awaitingAtomicSiteId !== null );
 
 	useEffect( () => {
 		if ( awaitingAtomicSiteId ) {
@@ -96,10 +82,6 @@ const HostingFeatures = ( { path, showAsTools }: HostingFeaturesProps ) => {
 	useInterval(
 		() => {
 			if ( ! awaitingAtomicSiteId ) {
-				return;
-			}
-			if ( Date.now() - ( waitRef.current.since ?? Date.now() ) >= ACTIVATION_DEADLINE_MS ) {
-				setStalledSiteId( awaitingAtomicSiteId );
 				return;
 			}
 			dispatch( requestSite( awaitingAtomicSiteId ) );

--- a/client/sites/hosting/components/hosting-features.tsx
+++ b/client/sites/hosting/components/hosting-features.tsx
@@ -66,11 +66,21 @@ const HostingFeatures = ( { path, showAsTools }: HostingFeaturesProps ) => {
 	const { data: siteTransferData } = useSiteTransferStatusQuery( siteId || undefined );
 
 	const isTransferCompleted = siteTransferData?.status === transferStates.COMPLETED;
-	const [ activationStalled, setActivationStalled ] = useState( false );
 
-	const completedSinceRef = useRef< number | null >( null );
-	if ( isTransferCompleted && completedSinceRef.current === null ) {
-		completedSinceRef.current = Date.now();
+	// Keyed by site: the page stays mounted across a site switch, so the next site must inherit
+	// neither the previous one's clock nor its verdict.
+	const [ stalledSiteId, setStalledSiteId ] = useState< number | null >( null );
+	const activationStalled = stalledSiteId !== null && stalledSiteId === siteId;
+
+	const waitRef = useRef< { siteId: number | null; since: number | null } >( {
+		siteId,
+		since: null,
+	} );
+	if ( waitRef.current.siteId !== siteId ) {
+		waitRef.current = { siteId, since: null };
+	}
+	if ( isTransferCompleted && waitRef.current.since === null ) {
+		waitRef.current.since = Date.now();
 	}
 
 	// The redirect below reads Redux, which nothing here refreshes, so a completed transfer would
@@ -85,8 +95,8 @@ const HostingFeatures = ( { path, showAsTools }: HostingFeaturesProps ) => {
 
 	useInterval(
 		() => {
-			if ( Date.now() - ( completedSinceRef.current ?? Date.now() ) >= ACTIVATION_DEADLINE_MS ) {
-				setActivationStalled( true );
+			if ( Date.now() - ( waitRef.current.since ?? Date.now() ) >= ACTIVATION_DEADLINE_MS ) {
+				setStalledSiteId( siteId );
 				return;
 			}
 			dispatch( requestSite( siteId ) );

--- a/client/sites/hosting/components/hosting-features.tsx
+++ b/client/sites/hosting/components/hosting-features.tsx
@@ -3,18 +3,21 @@ import page from '@automattic/calypso-router';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { Spinner } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useState } from 'react';
 import { HostingCard, HostingCardGrid } from 'calypso/components/hosting-card';
 import { HostingHero, HostingHeroButton } from 'calypso/components/hosting-hero';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import { useSiteTransferStatusQuery } from 'calypso/landing/stepper/hooks/use-site-transfer-status-query';
+import { EVERY_FIVE_SECONDS, useInterval } from 'calypso/lib/interval';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { transferStates } from 'calypso/state/atomic-transfer/constants';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { requestSite } from 'calypso/state/sites/actions';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { ACTIVATION_DEADLINE_MS } from './activation-wait';
 import HostingActivationButton from './hosting-activation-button';
 
 import './hosting-features.scss';
@@ -62,9 +65,39 @@ const HostingFeatures = ( { path, showAsTools }: HostingFeaturesProps ) => {
 
 	const { data: siteTransferData } = useSiteTransferStatusQuery( siteId || undefined );
 
+	const isTransferCompleted = siteTransferData?.status === transferStates.COMPLETED;
+	const [ activationStalled, setActivationStalled ] = useState( false );
+
+	const completedSinceRef = useRef< number | null >( null );
+	if ( isTransferCompleted && completedSinceRef.current === null ) {
+		completedSinceRef.current = Date.now();
+	}
+
+	// The redirect below reads Redux, which nothing here refreshes, so a completed transfer would
+	// otherwise never reach it and the page would spin on a success.
+	const isAwaitingAtomic = !! siteId && isTransferCompleted && ! isSiteAtomic;
+
+	useEffect( () => {
+		if ( isAwaitingAtomic ) {
+			dispatch( requestSite( siteId ) );
+		}
+	}, [ isAwaitingAtomic, siteId, dispatch ] );
+
+	useInterval(
+		() => {
+			if ( Date.now() - ( completedSinceRef.current ?? Date.now() ) >= ACTIVATION_DEADLINE_MS ) {
+				setActivationStalled( true );
+				return;
+			}
+			dispatch( requestSite( siteId ) );
+		},
+		isAwaitingAtomic && ! activationStalled ? EVERY_FIVE_SECONDS : null
+	);
+
 	const shouldRenderActivatingCopy =
-		( siteTransferData?.isTransferring || siteTransferData?.status === transferStates.COMPLETED ) &&
-		! isPlanExpired;
+		( siteTransferData?.isTransferring || isTransferCompleted ) &&
+		! isPlanExpired &&
+		! activationStalled;
 
 	useEffect( () => {
 		if ( isSiteAtomic && ! isPlanExpired ) {
@@ -126,6 +159,14 @@ const HostingFeatures = ( { path, showAsTools }: HostingFeaturesProps ) => {
 		: translate( 'Activate all developer tools' );
 
 	const activateTitleAsTools = translate( 'Activate all advanced tools' );
+
+	const activationStalledTitle = translate( 'Activation is taking longer than expected' );
+	const activationStalledDescription = translate(
+		'Your site is still being set up. Check back in a few minutes — there is nothing you need to do.',
+		{
+			comment: 'Shown when a site takes unusually long to finish activating hosting features.',
+		}
+	);
 
 	const activationStatusTitle = translate( 'Activating hosting features' );
 	const activationStatusTitleAsTools = translate( 'Activating advanced tools' );
@@ -197,7 +238,15 @@ const HostingFeatures = ( { path, showAsTools }: HostingFeaturesProps ) => {
 	let title;
 	let description;
 	let buttons;
-	if ( shouldRenderActivatingCopy ) {
+	if ( activationStalled ) {
+		title = activationStalledTitle;
+		description = activationStalledDescription;
+		buttons = (
+			<HostingHeroButton href={ `/overview/${ siteId }` }>
+				{ translate( 'Go to your site' ) }
+			</HostingHeroButton>
+		);
+	} else if ( shouldRenderActivatingCopy ) {
 		title = showAsTools ? activationStatusTitleAsTools : activationStatusTitle;
 		description = showAsTools ? activationStatusDescriptionAsTools : activationStatusDescription;
 	} else if ( showActivationButton ) {

--- a/client/sites/hosting/components/hosting-features.tsx
+++ b/client/sites/hosting/components/hosting-features.tsx
@@ -85,23 +85,26 @@ const HostingFeatures = ( { path, showAsTools }: HostingFeaturesProps ) => {
 
 	// The redirect below reads Redux, which nothing here refreshes, so a completed transfer would
 	// otherwise never reach it and the page would spin on a success.
-	const isAwaitingAtomic = !! siteId && isTransferCompleted && ! isSiteAtomic;
+	const awaitingAtomicSiteId = isTransferCompleted && ! isSiteAtomic ? siteId : null;
 
 	useEffect( () => {
-		if ( isAwaitingAtomic ) {
-			dispatch( requestSite( siteId ) );
+		if ( awaitingAtomicSiteId ) {
+			dispatch( requestSite( awaitingAtomicSiteId ) );
 		}
-	}, [ isAwaitingAtomic, siteId, dispatch ] );
+	}, [ awaitingAtomicSiteId, dispatch ] );
 
 	useInterval(
 		() => {
-			if ( Date.now() - ( waitRef.current.since ?? Date.now() ) >= ACTIVATION_DEADLINE_MS ) {
-				setStalledSiteId( siteId );
+			if ( ! awaitingAtomicSiteId ) {
 				return;
 			}
-			dispatch( requestSite( siteId ) );
+			if ( Date.now() - ( waitRef.current.since ?? Date.now() ) >= ACTIVATION_DEADLINE_MS ) {
+				setStalledSiteId( awaitingAtomicSiteId );
+				return;
+			}
+			dispatch( requestSite( awaitingAtomicSiteId ) );
 		},
-		isAwaitingAtomic && ! activationStalled ? EVERY_FIVE_SECONDS : null
+		awaitingAtomicSiteId && ! activationStalled ? EVERY_FIVE_SECONDS : null
 	);
 
 	const shouldRenderActivatingCopy =

--- a/client/sites/hosting/components/test/activation-wait.tsx
+++ b/client/sites/hosting/components/test/activation-wait.tsx
@@ -1,0 +1,35 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { ACTIVATION_DEADLINE_MS, useActivationDeadline } from '../activation-wait';
+
+const elapse = async ( ms: number ) => {
+	await act( async () => {
+		await jest.advanceTimersByTimeAsync( ms );
+	} );
+};
+
+describe( 'useActivationDeadline', () => {
+	beforeEach( () => jest.useFakeTimers() );
+	afterEach( () => jest.useRealTimers() );
+
+	it( 'resets after a stalled wait ends and a retry starts', async () => {
+		const { result, rerender } = renderHook(
+			( { isWaiting } ) => useActivationDeadline( 1, isWaiting ),
+			{ initialProps: { isWaiting: true } }
+		);
+
+		await elapse( ACTIVATION_DEADLINE_MS );
+		expect( result.current ).toBe( true );
+
+		rerender( { isWaiting: false } );
+		expect( result.current ).toBe( false );
+
+		rerender( { isWaiting: true } );
+		expect( result.current ).toBe( false );
+
+		await elapse( ACTIVATION_DEADLINE_MS );
+		expect( result.current ).toBe( true );
+	} );
+} );

--- a/client/sites/hosting/components/test/hosting-callout.tsx
+++ b/client/sites/hosting/components/test/hosting-callout.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, act } from '@testing-library/react';
+import { HostingActivationCallout } from '../hosting-callout';
+import type { Site } from '@automattic/api-core';
+
+const mockTransfer = jest.fn();
+const mockSite = jest.fn();
+
+jest.mock( '@automattic/api-queries', () => ( {
+	...jest.requireActual( '@automattic/api-queries' ),
+	siteLatestAtomicTransferQuery: ( siteId: number ) => ( {
+		queryKey: [ 'transfer', siteId ],
+		queryFn: () => mockTransfer(),
+	} ),
+	siteByIdQuery: ( siteId: number ) => ( {
+		queryKey: [ 'site', siteId ],
+		queryFn: () => mockSite(),
+	} ),
+} ) );
+
+jest.mock( 'calypso/state', () => ( { useDispatch: () => jest.fn() } ) );
+jest.mock( '@automattic/calypso-router', () => ( { replace: jest.fn(), show: jest.fn() } ) );
+jest.mock( 'calypso/dashboard/sites/hosting-feature-list', () => () => null );
+jest.mock( '../hosting-activation-button', () => ( { text }: { text: string } ) => (
+	<button>{ text }</button>
+) );
+
+const site = { ID: 1, slug: 'example.wordpress.com' } as Site;
+
+const renderCallout = () =>
+	render(
+		<QueryClientProvider
+			client={ new QueryClient( { defaultOptions: { queries: { retry: false } } } ) }
+		>
+			<HostingActivationCallout site={ site } path="/hosting-features/:site" />
+		</QueryClientProvider>
+	);
+
+const elapse = async ( ms: number ) => {
+	for ( let elapsed = 0; elapsed < ms; elapsed += 1000 ) {
+		await act( async () => {
+			jest.advanceTimersByTime( 1000 );
+			await Promise.resolve();
+		} );
+	}
+};
+
+describe( 'HostingActivationCallout', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		jest.useFakeTimers();
+		mockSite.mockResolvedValue( { ID: 1, is_wpcom_atomic: false } );
+	} );
+	afterEach( () => jest.useRealTimers() );
+
+	it( 'shows the transfer as running while it is in progress', async () => {
+		mockTransfer.mockResolvedValue( { status: 'active' } );
+		renderCallout();
+
+		await elapse( 2000 );
+		expect( await screen.findByText( 'Activating…' ) ).toBeVisible();
+	} );
+
+	// The trap: `completed` pins the label true, so a site that never turns Atomic held
+	// "Activating…" and polled every 2s for the life of the tab.
+	it( 'stops claiming activation when the site never becomes Atomic', async () => {
+		mockTransfer.mockResolvedValue( { status: 'completed' } );
+		renderCallout();
+
+		await elapse( 5000 );
+		expect( screen.getByText( 'Activating…' ) ).toBeVisible();
+
+		await elapse( 125_000 );
+		expect( screen.getByText( 'Activate' ) ).toBeVisible();
+	} );
+
+	it( 'stops polling the site once the wait has run out', async () => {
+		mockTransfer.mockResolvedValue( { status: 'completed' } );
+		renderCallout();
+
+		await elapse( 125_000 );
+		const settled = mockSite.mock.calls.length;
+
+		await elapse( 60_000 );
+		expect( mockSite.mock.calls.length ).toBe( settled );
+	} );
+
+	it( 'keeps the label honest for a transfer that failed outright', async () => {
+		mockTransfer.mockResolvedValue( { status: 'error' } );
+		renderCallout();
+
+		await elapse( 3000 );
+		expect( screen.getByText( 'Activate' ) ).toBeVisible();
+	} );
+} );

--- a/client/sites/hosting/components/test/hosting-callout.tsx
+++ b/client/sites/hosting/components/test/hosting-callout.tsx
@@ -46,12 +46,9 @@ const renderCallout = ( siteId = 1 ) => {
 };
 
 const elapse = async ( ms: number ) => {
-	for ( let elapsed = 0; elapsed < ms; elapsed += 1000 ) {
-		await act( async () => {
-			jest.advanceTimersByTime( 1000 );
-			await Promise.resolve();
-		} );
-	}
+	await act( async () => {
+		await jest.advanceTimersByTimeAsync( ms );
+	} );
 };
 
 describe( 'HostingActivationCallout', () => {

--- a/client/sites/hosting/components/test/hosting-callout.tsx
+++ b/client/sites/hosting/components/test/hosting-callout.tsx
@@ -30,14 +30,20 @@ jest.mock( '../hosting-activation-button', () => ( { text }: { text: string } ) 
 
 const site = { ID: 1, slug: 'example.wordpress.com' } as Site;
 
-const renderCallout = () =>
-	render(
-		<QueryClientProvider
-			client={ new QueryClient( { defaultOptions: { queries: { retry: false } } } ) }
-		>
-			<HostingActivationCallout site={ site } path="/hosting-features/:site" />
-		</QueryClientProvider>
+const renderCallout = ( siteId = 1 ) => {
+	const client = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	return render(
+		<QueryClientProvider client={ client }>
+			<HostingActivationCallout
+				site={ { ...site, ID: siteId } as Site }
+				path="/hosting-features/:site"
+			/>
+		</QueryClientProvider>,
+		{
+			wrapper: undefined,
+		}
 	);
+};
 
 const elapse = async ( ms: number ) => {
 	for ( let elapsed = 0; elapsed < ms; elapsed += 1000 ) {
@@ -86,6 +92,27 @@ describe( 'HostingActivationCallout', () => {
 
 		await elapse( 60_000 );
 		expect( mockSite.mock.calls.length ).toBe( settled );
+	} );
+
+	// SPA navigation keeps this component mounted, so a spent clock must not follow the user.
+	it( 'starts a newly selected site on its own clock', async () => {
+		mockTransfer.mockResolvedValue( { status: 'completed' } );
+		const { rerender } = renderCallout( 1 );
+		await elapse( 125_000 );
+		expect( screen.getByText( 'Activate' ) ).toBeVisible();
+
+		rerender(
+			<QueryClientProvider
+				client={ new QueryClient( { defaultOptions: { queries: { retry: false } } } ) }
+			>
+				<HostingActivationCallout
+					site={ { ...site, ID: 2 } as Site }
+					path="/hosting-features/:site"
+				/>
+			</QueryClientProvider>
+		);
+		await elapse( 3000 );
+		expect( screen.getByText( 'Activating…' ) ).toBeVisible();
 	} );
 
 	it( 'keeps the label honest for a transfer that failed outright', async () => {

--- a/client/sites/hosting/components/test/hosting-features.tsx
+++ b/client/sites/hosting/components/test/hosting-features.tsx
@@ -37,12 +37,9 @@ jest.mock( '../hosting-activation-button', () => () => null );
 jest.mock( 'calypso/components/inline-support-link', () => () => null );
 
 const elapse = async ( ms: number ) => {
-	for ( let elapsed = 0; elapsed < ms; elapsed += 1000 ) {
-		await act( async () => {
-			jest.advanceTimersByTime( 1000 );
-			await Promise.resolve();
-		} );
-	}
+	await act( async () => {
+		await jest.advanceTimersByTimeAsync( ms );
+	} );
 };
 
 const requestSiteCalls = () =>

--- a/client/sites/hosting/components/test/hosting-features.tsx
+++ b/client/sites/hosting/components/test/hosting-features.tsx
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, act } from '@testing-library/react';
+import HostingFeatures from '../hosting-features';
+
+const mockDispatch = jest.fn();
+let mockTransferStatus = 'completed';
+let mockIsSiteAtomic = false;
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site-transfer-status-query', () => ( {
+	useSiteTransferStatusQuery: () => ( {
+		data: { status: mockTransferStatus, isTransferring: mockTransferStatus === 'active' },
+	} ),
+} ) );
+
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+	useSelector: ( selector: ( state: unknown ) => unknown ) => selector( {} ),
+} ) );
+
+jest.mock( 'calypso/state/selectors/is-site-wpcom-atomic', () => () => mockIsSiteAtomic );
+jest.mock( 'calypso/state/selectors/site-has-feature', () => () => true );
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	getSiteSlug: () => 'example.wordpress.com',
+} ) );
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSiteId: () => 1,
+	getSelectedSite: () => ( { plan: { expired: false } } ),
+} ) );
+jest.mock( 'calypso/state/sites/actions', () => ( {
+	requestSite: ( siteId: number ) => ( { type: 'REQUEST_SITE', siteId } ),
+} ) );
+jest.mock( '@automattic/calypso-router', () => ( { replace: jest.fn() } ) );
+jest.mock( '../hosting-activation-button', () => () => null );
+jest.mock( 'calypso/components/inline-support-link', () => () => null );
+
+const elapse = async ( ms: number ) => {
+	for ( let elapsed = 0; elapsed < ms; elapsed += 1000 ) {
+		await act( async () => {
+			jest.advanceTimersByTime( 1000 );
+			await Promise.resolve();
+		} );
+	}
+};
+
+const requestSiteCalls = () =>
+	mockDispatch.mock.calls.filter( ( [ action ] ) => action?.type === 'REQUEST_SITE' ).length;
+
+describe( 'HostingFeatures', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		jest.useFakeTimers();
+		mockTransferStatus = 'completed';
+		mockIsSiteAtomic = false;
+	} );
+	afterEach( () => jest.useRealTimers() );
+
+	// The bug: Redux owns the redirect's condition and nothing here refreshed it, so a successful
+	// transfer parked the user on the activating spinner until they reloaded by hand.
+	it( 'refreshes the Redux site once the transfer completes', async () => {
+		render( <HostingFeatures /> );
+		await elapse( 1000 );
+		expect( requestSiteCalls() ).toBeGreaterThan( 0 );
+	} );
+
+	it( 'does not refresh while the transfer is still running', async () => {
+		mockTransferStatus = 'active';
+		render( <HostingFeatures /> );
+		await elapse( 10_000 );
+		expect( requestSiteCalls() ).toBe( 0 );
+	} );
+
+	it( 'stops refreshing once the site reports as Atomic', async () => {
+		mockIsSiteAtomic = true;
+		render( <HostingFeatures /> );
+		await elapse( 30_000 );
+		expect( requestSiteCalls() ).toBe( 0 );
+	} );
+
+	it( 'gives the activation wait an ending instead of spinning forever', async () => {
+		render( <HostingFeatures /> );
+		await elapse( 5000 );
+		expect( screen.getByText( 'Activating hosting features' ) ).toBeVisible();
+
+		await elapse( 125_000 );
+		expect( screen.getByText( 'Activation is taking longer than expected' ) ).toBeVisible();
+		expect( screen.queryByText( 'Activating hosting features' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'stops refreshing the site once the wait has run out', async () => {
+		render( <HostingFeatures /> );
+		await elapse( 125_000 );
+		const settled = requestSiteCalls();
+
+		await elapse( 60_000 );
+		expect( requestSiteCalls() ).toBe( settled );
+	} );
+} );

--- a/client/sites/hosting/components/test/hosting-features.tsx
+++ b/client/sites/hosting/components/test/hosting-features.tsx
@@ -7,6 +7,7 @@ import HostingFeatures from '../hosting-features';
 const mockDispatch = jest.fn();
 let mockTransferStatus = 'completed';
 let mockIsSiteAtomic = false;
+let mockSiteId = 1;
 
 jest.mock( 'calypso/landing/stepper/hooks/use-site-transfer-status-query', () => ( {
 	useSiteTransferStatusQuery: () => ( {
@@ -25,7 +26,7 @@ jest.mock( 'calypso/state/sites/selectors', () => ( {
 	getSiteSlug: () => 'example.wordpress.com',
 } ) );
 jest.mock( 'calypso/state/ui/selectors', () => ( {
-	getSelectedSiteId: () => 1,
+	getSelectedSiteId: () => mockSiteId,
 	getSelectedSite: () => ( { plan: { expired: false } } ),
 } ) );
 jest.mock( 'calypso/state/sites/actions', () => ( {
@@ -53,6 +54,7 @@ describe( 'HostingFeatures', () => {
 		jest.useFakeTimers();
 		mockTransferStatus = 'completed';
 		mockIsSiteAtomic = false;
+		mockSiteId = 1;
 	} );
 	afterEach( () => jest.useRealTimers() );
 
@@ -86,6 +88,21 @@ describe( 'HostingFeatures', () => {
 		await elapse( 125_000 );
 		expect( screen.getByText( 'Activation is taking longer than expected' ) ).toBeVisible();
 		expect( screen.queryByText( 'Activating hosting features' ) ).not.toBeInTheDocument();
+	} );
+
+	// The page stays mounted across a site switch, so a spent clock must not follow the user.
+	it( 'starts a newly selected site on its own clock', async () => {
+		const { rerender } = render( <HostingFeatures /> );
+		await elapse( 125_000 );
+		expect( screen.getByText( 'Activation is taking longer than expected' ) ).toBeVisible();
+
+		mockSiteId = 2;
+		rerender( <HostingFeatures /> );
+		await elapse( 1000 );
+		expect( screen.getByText( 'Activating hosting features' ) ).toBeVisible();
+		expect(
+			screen.queryByText( 'Activation is taking longer than expected' )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'stops refreshing the site once the wait has run out', async () => {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18248/hosting-features-page-shows-activating-forever-after-the-transfer
Fixes https://linear.app/a8c/issue/DOTCOM-18269/hosting-callout-sticks-on-activating-forever-no-deadline-no-error

## Proposed Changes

**Both hosting activation screens now finish their wait: one was stuck after a transfer that succeeded, the other polled forever when a site never turned Atomic.**

- The Hosting Features page refreshes the site once the transfer completes, so its redirect actually fires, and retries every five seconds until the site reports as Atomic.
- Both screens share a two-minute deadline. Past it the page says the activation is taking longer than expected and offers a way to the site, and the callout button returns to `Activate`.
- The callout drops `refetchIntervalInBackground`, and no longer uses a `0` refetch interval when it has no data — that means "as fast as possible", so a failing request spun at network speed.

## Why are these changes being made?

A transfer reports `completed` when the software job is handed to a queue, not when the site is ready, so there is a short gap where the transfer is finished but the site still answers as Simple. Neither screen handled that gap.

The Hosting Features page decides whether to redirect you away by reading Redux, and nothing on the page ever refreshed it — so a transfer that *succeeded* left you watching a spinner until you reloaded by hand. Success that looks exactly like failure. The callout had the narrower version: if the site never turned Atomic it polled every two seconds for as long as the tab stayed open, with the button pinned on "Activating…".

## Testing Instructions

1. `yarn start`, then activate hosting features on a site with a plan that supports them.
2. Watch the page: it should redirect you to the site's settings on its own once the transfer finishes, with no manual reload.
3. To see the deadline, lower `ACTIVATION_DEADLINE_MS` in `client/sites/hosting/components/activation-wait.ts` and block the site request in devtools so the site never reports as Atomic.
4. Expected: the page swaps to "Activation is taking longer than expected" with a **Go to your site** button, and the network requests stop.

