### PR TITLE
WordPress Agent credits: show self-hosted allowance status

### DIFF
--- a/apps/agents-manager/__tests__/jetpack-ai-sidebar-provider.test.js
+++ b/apps/agents-manager/__tests__/jetpack-ai-sidebar-provider.test.js
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const mockRegisterBlockEditorFilters = jest.fn();
+const mockUseJetpackFreeCreditChatNotice = jest.fn();
+
+jest.mock( '@automattic/jetpack-ai-sidebar', () => ( {
+	capabilities: {},
+	contextProvider: {},
+	getChatComponent: jest.fn(),
+	getEmptyViewSuggestions: jest.fn(),
+	registerBlockEditorFilters: mockRegisterBlockEditorFilters,
+	toolProvider: {},
+	useAbilitiesSetup: jest.fn(),
+	useCheckpoint: jest.fn(),
+	useJetpackFreeCreditChatNotice: mockUseJetpackFreeCreditChatNotice,
+	useSuggestions: jest.fn(),
+} ) );
+
+describe( 'Jetpack AI provider', () => {
+	afterEach( () => {
+		delete window.__JetpackAIProvider;
+		jest.resetModules();
+	} );
+
+	it( 'exposes the provider notice hook', () => {
+		jest.isolateModules( () => require( '../jetpack-ai-sidebar' ) );
+
+		expect( window.__JetpackAIProvider ).toEqual(
+			expect.objectContaining( {
+				useChatNotice: mockUseJetpackFreeCreditChatNotice,
+			} )
+		);
+		expect( mockRegisterBlockEditorFilters ).toHaveBeenCalled();
+	} );
+} );

--- a/apps/agents-manager/jetpack-ai-sidebar.js
+++ b/apps/agents-manager/jetpack-ai-sidebar.js
@@ -18,6 +18,7 @@ import {
 	getEmptyViewSuggestions,
 	useSuggestions,
 	useCheckpoint,
+	useJetpackFreeCreditChatNotice,
 	capabilities,
 	registerBlockEditorFilters,
 } from '@automattic/jetpack-ai-sidebar';
@@ -36,5 +37,6 @@ window.__JetpackAIProvider = {
 	getEmptyViewSuggestions,
 	useSuggestions,
 	useCheckpoint,
+	useChatNotice: useJetpackFreeCreditChatNotice,
 	capabilities,
 };

--- a/apps/agents-manager/jetpack-ai-sidebar.provider.mjs
+++ b/apps/agents-manager/jetpack-ai-sidebar.provider.mjs
@@ -22,6 +22,7 @@ export const getEmptyViewSuggestions = lazy( 'getEmptyViewSuggestions' );
 export const useSuggestions = lazy( 'useSuggestions' );
 export const useAbilitiesSetup = lazy( 'useAbilitiesSetup' );
 export const useCheckpoint = lazy( 'useCheckpoint' );
+export const useChatNotice = lazy( 'useChatNotice' );
 
 // toolProvider and contextProvider are objects, not functions — use getters.
 export const toolProvider = new Proxy(

--- a/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/orchestrator-chat.test.tsx
@@ -302,6 +302,7 @@ jest.mock(
 	} ),
 	{ virtual: true }
 );
+jest.mock( '@wordpress/api-fetch' );
 jest.mock( '@wordpress/data', () => {
 	const { useEffect, useReducer, useRef } = jest.requireActual< typeof import('react') >( 'react' );
 
@@ -347,6 +348,7 @@ jest.mock( '../../contexts', () => {
 				onSessionIdChange: ( sessionId: string ) => saveSessionId( sessionId, 'wp-orchestrator' ),
 			},
 			getTabSessionId: () => mockTabSessionId ?? '',
+			site: { ID: 123 },
 			siteKey: mockSiteKey,
 			currentUser: mockCurrentUserId === undefined ? undefined : { ID: mockCurrentUserId },
 		} ),
@@ -358,6 +360,7 @@ jest.mock( '../../hooks/custom-actions', () => ( {
 jest.mock( '../../utils/tracks', () => ( {
 	recordBigSkyTracksEvent: jest.fn(),
 	recordAgentsManagerTracksEvent: jest.fn(),
+	recordJetpackAiUpgradeButtonClick: jest.fn(),
 } ) );
 jest.mock( '../../hooks/use-abilities-registration', () => () => {} );
 jest.mock( '../../hooks/use-conversation', () => ( config: typeof mockConversationConfig ) => {
@@ -660,6 +663,164 @@ describe( 'OrchestratorChat', () => {
 		mockRevertedCheckpointIds.clear();
 		mockAgentChatConfig = undefined;
 		mockConversationConfig = undefined;
+		delete ( globalThis as { agentsManagerData?: unknown } ).agentsManagerData;
+	} );
+
+	it( 'refreshes provider status only after a submitted request settles', async () => {
+		let resolveSubmit: () => void = () => {};
+		const submitPromise = new Promise< void >( ( resolve ) => {
+			resolveSubmit = resolve;
+		} );
+		const useChatNotice = jest.fn();
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { onSubmit: jest.fn( () => submitPromise ) } )
+		);
+
+		render( chat( { useChatNotice } ) );
+		fireEvent.click( screen.getByText( 'Submit message' ) );
+
+		expect( useChatNotice ).toHaveBeenLastCalledWith(
+			expect.objectContaining( { settledRequestCount: 0 } )
+		);
+		await act( async () => {
+			resolveSubmit();
+			await submitPromise;
+		} );
+		await waitFor( () =>
+			expect( useChatNotice ).toHaveBeenLastCalledWith(
+				expect.objectContaining( { settledRequestCount: 1 } )
+			)
+		);
+	} );
+
+	it( 'refreshes provider status only after regeneration settles', async () => {
+		let resolveRegenerate: () => void = () => {};
+		const regeneratePromise = new Promise< void >( ( resolve ) => {
+			resolveRegenerate = resolve;
+		} );
+		const useChatNotice = jest.fn();
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { getRegenerateHandler: jest.fn( () => () => regeneratePromise ) } )
+		);
+
+		render( chat( { useChatNotice } ) );
+		const config = mockUseRegenerateAction.mock.calls.at( -1 )![ 0 ] as {
+			getRegenerateHandler?: ( message: unknown ) => ( () => Promise< void > ) | undefined;
+		};
+		const regenerate = config.getRegenerateHandler?.( { id: 'agent-1' } );
+		let pendingRegenerate: Promise< void > | undefined;
+		act( () => {
+			pendingRegenerate = regenerate?.();
+		} );
+
+		expect( useChatNotice ).toHaveBeenLastCalledWith(
+			expect.objectContaining( { settledRequestCount: 0 } )
+		);
+		await act( async () => {
+			resolveRegenerate();
+			await pendingRegenerate;
+		} );
+		await waitFor( () =>
+			expect( useChatNotice ).toHaveBeenLastCalledWith(
+				expect.objectContaining( { settledRequestCount: 1 } )
+			)
+		);
+	} );
+
+	it( 'passes terminal AI credits to the provider and clears them on omission and scope change', async () => {
+		const useChatNotice = jest.fn();
+		const view = render( chat( { useChatNotice } ) );
+		const aiCredits = {
+			credits_limit: 15_000,
+			credits_used: 3_000,
+			credits_remaining: 12_000,
+			blocked: false,
+			resets_at: '2026-10-01T00:00:00+00:00',
+			upgrade_url: null,
+		};
+
+		await act( async () => {
+			await mockAgentChatConfig?.onTaskUpdate?.( {
+				id: 'task-with-credits',
+				status: { state: 'completed' },
+				final: true,
+				text: '',
+				aiCredits,
+			} );
+		} );
+		expect( useChatNotice ).toHaveBeenLastCalledWith(
+			expect.objectContaining( { aiCredits, aiCreditsRevision: 1 } )
+		);
+
+		await act( async () => {
+			await mockAgentChatConfig?.onTaskUpdate?.( {
+				id: 'task-without-credits',
+				status: { state: 'completed' },
+				final: true,
+				text: '',
+			} );
+		} );
+		expect( useChatNotice ).toHaveBeenLastCalledWith(
+			expect.objectContaining( { aiCredits: undefined, aiCreditsRevision: 2 } )
+		);
+
+		await act( async () => {
+			await mockAgentChatConfig?.onTaskUpdate?.( {
+				id: 'task-with-new-credits',
+				status: { state: 'completed' },
+				final: true,
+				text: '',
+				aiCredits,
+			} );
+		} );
+		mockSiteKey = 'site-2';
+		view.rerender( chat( { useChatNotice } ) );
+		expect( useChatNotice ).toHaveBeenLastCalledWith(
+			expect.objectContaining( { aiCredits: undefined, aiCreditsRevision: undefined } )
+		);
+	} );
+
+	it( 'renders an exhausted provider notice without disabling submission', async () => {
+		const notice = {
+			message: 'You’ve used this month’s Jetpack AI allowance (0% left).',
+			status: 'error' as const,
+			dismissible: false,
+			suppressCurrentError: true,
+		};
+		const useChatNotice = jest.fn( () => notice );
+		const onSubmit = jest.fn().mockResolvedValue( undefined );
+		mockUseAgentChat.mockReturnValue(
+			agentChatReturn( { error: 'ai_credit_allowance_exhausted', onSubmit } )
+		);
+
+		render( chat( { useChatNotice } ) );
+
+		expect( useChatNotice ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				error: 'ai_credit_allowance_exhausted',
+				enabled: true,
+				settledRequestCount: 0,
+				siteId: 123,
+			} )
+		);
+		expect( mockAgentChat.mock.calls.at( -1 )![ 0 ] ).toEqual(
+			expect.objectContaining( { notice, error: null, isChatInputDisabled: undefined } )
+		);
+
+		fireEvent.click( screen.getByText( 'Submit message' ) );
+		await waitFor( () => expect( onSubmit ).toHaveBeenCalledWith( 'Describe these images' ) );
+	} );
+
+	it( 'keeps the provider notice disabled on Reader Chat', () => {
+		mockIsReaderChatAgent.mockReturnValue( true );
+		const useChatNotice = jest.fn( () => ( { message: 'No AI requests remaining' } ) );
+
+		render( chat( { useChatNotice } ) );
+
+		expect( useChatNotice ).toHaveBeenCalledWith( expect.objectContaining( { enabled: false } ) );
+		expect( mockAgentChat.mock.calls.at( -1 )![ 0 ] ).toEqual(
+			expect.objectContaining( { notice: undefined } )
+		);
 	} );
 
 	it( 'ignores a conversation result for a discarded agent', () => {

--- a/packages/agents-manager/src/components/agent-dock/index.tsx
+++ b/packages/agents-manager/src/components/agent-dock/index.tsx
@@ -38,6 +38,7 @@ import type {
 	TransformMessages,
 	UseCheckpointHook,
 	ProviderCapabilities,
+	UseChatNoticeHook,
 } from '../../utils/load-external-providers';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
 import './style.scss';
@@ -62,6 +63,8 @@ interface Props {
 	useCheckpoint?: UseCheckpointHook;
 	/** Optional capability flags declared by one or more loaded providers. */
 	capabilities?: ProviderCapabilities;
+	/** Provider-owned, display-only notice shown through AgentChat's shared notice slot. */
+	useChatNotice?: UseChatNoticeHook;
 }
 
 export default function AgentDock( {
@@ -75,6 +78,7 @@ export default function AgentDock( {
 	transformMessages,
 	useCheckpoint,
 	capabilities,
+	useChatNotice,
 }: Props ) {
 	const { agentConfig, siteKey, currentUser } = useAgentsManagerContext();
 
@@ -407,6 +411,7 @@ export default function AgentDock( {
 			transformMessages={ transformMessages }
 			useCheckpoint={ useCheckpoint }
 			capabilities={ capabilities }
+			useChatNotice={ useChatNotice }
 			isChatInputDisabled={ ! isChatEnabled }
 			onHasMessagesChange={ handleChatHasMessagesChange }
 		/>

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -356,6 +356,7 @@ function AgentSetup( { agentId: hostAgentId }: { agentId?: string } ): JSX.Eleme
 				transformMessages={ loadedProviders.transformMessages }
 				useCheckpoint={ loadedProviders.useCheckpoint }
 				capabilities={ loadedProviders.capabilities }
+				useChatNotice={ loadedProviders.useChatNotice }
 			/>
 		</>
 	);

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -9,6 +9,7 @@ import {
 	type MarkdownComponents,
 	type MarkdownExtensions,
 } from '@automattic/agenttic-ui';
+import apiFetch from '@wordpress/api-fetch';
 import { select as selectDataStore, useSelect } from '@wordpress/data';
 import {
 	useState,
@@ -59,6 +60,7 @@ import {
 	type ExternalContextCardAction,
 } from '../../utils/external-context';
 import { generateUUID } from '../../utils/generate-uuid';
+import { getAgentsManagerInlineData } from '../../utils/get-agents-manager-inline-data';
 import { isReaderChatAgent } from '../../utils/is-reader-chat-agent';
 import { mergeEmptyViewSuggestions } from '../../utils/merge-empty-view-suggestions';
 import { getOrchestratorErrorMessage } from '../../utils/orchestrator-error-message';
@@ -66,7 +68,11 @@ import { setProviderCheckpoints } from '../../utils/provider-checkpoints';
 import { getReaderChatErrorMessage } from '../../utils/reader-chat-error-message';
 import { isShowComponentTool } from '../../utils/show-component-tools';
 import { isBlockEditToolId } from '../../utils/tool-message-utils';
-import { recordAgentsManagerTracksEvent, recordBigSkyTracksEvent } from '../../utils/tracks';
+import {
+	recordAgentsManagerTracksEvent,
+	recordBigSkyTracksEvent,
+	recordJetpackAiUpgradeButtonClick,
+} from '../../utils/tracks';
 import AgentChat from '../agent-chat';
 import { type Options as ChatHeaderOptions } from '../chat-header';
 import type { BigSkyMessage } from '../../types';
@@ -78,6 +84,7 @@ import type {
 	TransformMessages,
 	UseCheckpointHook,
 	ProviderCapabilities,
+	UseChatNoticeHook,
 } from '../../utils/load-external-providers';
 
 const streamedCheckpointMessagesBySession = new Map< string, Map< string, UIMessage > >();
@@ -308,6 +315,8 @@ interface Props {
 	useCheckpoint?: UseCheckpointHook;
 	/** Optional capability flags declared by one or more loaded providers. */
 	capabilities?: ProviderCapabilities;
+	/** Provider-owned, display-only notice shown through AgentChat's shared notice slot. */
+	useChatNotice?: UseChatNoticeHook;
 	/** Renders the chat with a disabled input. Driven by `setChatEnabled( false )`. */
 	isChatInputDisabled?: boolean;
 	/** Called when the has-messages state changes. */
@@ -332,10 +341,12 @@ export default function OrchestratorChat( {
 	transformMessages,
 	useCheckpoint,
 	capabilities,
+	useChatNotice,
 	isChatInputDisabled,
 	onHasMessagesChange,
 }: Props ) {
-	const { agentConfig, getTabSessionId, siteKey, currentUser } = useAgentsManagerContext();
+	const { agentConfig, getTabSessionId, site, siteKey, currentUser } = useAgentsManagerContext();
+	const taskResultScopeKey = JSON.stringify( [ siteKey, agentConfig?.agentId ?? '' ] );
 
 	const [ inputValue, setInputValue ] = useState( '' );
 	const [ isThinking, setIsThinking ] = useState( false );
@@ -353,6 +364,18 @@ export default function OrchestratorChat( {
 	>( new Map() );
 	const [ isRegenerating, setIsRegenerating ] = useState( false );
 	const [ hasUserSentMessage, setHasUserSentMessage ] = useState( false );
+	const [ settledRequestCount, setSettledRequestCount ] = useState( 0 );
+	const [ latestTaskResult, setLatestTaskResult ] = useState< {
+		scopeKey: string;
+		aiCredits?: unknown;
+		revision: number;
+	} >();
+	const taskResultRevisionRef = useRef( 0 );
+	useEffect( () => {
+		setLatestTaskResult( ( current ) =>
+			current?.scopeKey === taskResultScopeKey ? current : undefined
+		);
+	}, [ taskResultScopeKey ] );
 	const currentPostId = useSelect( ( select ) => {
 		const editor = select( 'core/editor' ) as { getCurrentPostId?: () => number | string };
 		return editor?.getCurrentPostId?.();
@@ -489,6 +512,12 @@ export default function OrchestratorChat( {
 					update.final === true ||
 					[ 'completed', 'canceled', 'failed' ].includes( update.status.state );
 				if ( isTerminal && isCurrentStreamGeneration ) {
+					taskResultRevisionRef.current += 1;
+					setLatestTaskResult( {
+						scopeKey: taskResultScopeKey,
+						aiCredits: update.aiCredits,
+						revision: taskResultRevisionRef.current,
+					} );
 					const finalMessageId = update.status.message?.messageId ?? update.agentMessage?.messageId;
 					const completedSuccessfully =
 						update.status.state === 'completed' ||
@@ -515,7 +544,7 @@ export default function OrchestratorChat( {
 				await onTaskUpdate?.( update );
 			},
 		};
-	}, [ agentConfig, checkpointStreamGeneration ] );
+	}, [ agentConfig, checkpointStreamGeneration, taskResultScopeKey ] );
 
 	const {
 		addMessage,
@@ -633,6 +662,7 @@ export default function OrchestratorChat( {
 					await handler();
 				} finally {
 					streamedCheckpointMessagesRef.current.regeneratingMessageId = undefined;
+					setSettledRequestCount( ( count ) => count + 1 );
 				}
 			};
 		},
@@ -719,6 +749,25 @@ export default function OrchestratorChat( {
 	const chatError = isReaderChat
 		? getReaderChatErrorMessage( error )
 		: getOrchestratorErrorMessage( error );
+	// Providers resolve before this component mounts, so this hook stays stable for its lifetime.
+	const providerNoticeResult = useChatNotice?.( {
+		error,
+		enabled: ! isReaderChat,
+		isWpcomPlatform: getAgentsManagerInlineData()?.isWpcomPlatform,
+		aiCredits:
+			latestTaskResult?.scopeKey === taskResultScopeKey ? latestTaskResult.aiCredits : undefined,
+		aiCreditsRevision:
+			latestTaskResult?.scopeKey === taskResultScopeKey ? latestTaskResult.revision : undefined,
+		settledRequestCount,
+		siteId: typeof site?.ID === 'number' ? site.ID : undefined,
+		requestStatus: apiFetch,
+		recordUpgradeClick: recordJetpackAiUpgradeButtonClick,
+	} );
+	const providerNotice =
+		providerNoticeResult && 'message' in providerNoticeResult ? providerNoticeResult : undefined;
+	const chatNotice = isReaderChat ? undefined : providerNotice;
+	const displayedChatError =
+		! isReaderChat && providerNoticeResult?.suppressCurrentError ? null : chatError;
 
 	// Resume the conversation after a `wp-admin-navigate` full page reload;
 	// while such a resume is pending, hydration below must not replace the
@@ -726,12 +775,16 @@ export default function OrchestratorChat( {
 	const { hadParkedNavigation, flushPendingNavigation } = useNavigationContinuation( {
 		isProcessing,
 		sendToolResult: async ( params ) => {
-			await onSubmit( params.message, {
-				type: 'tool_result',
-				toolCallId: params.toolCallId,
-				toolId: params.toolId,
-				sessionId: params.sessionId,
-			} );
+			try {
+				await onSubmit( params.message, {
+					type: 'tool_result',
+					toolCallId: params.toolCallId,
+					toolId: params.toolId,
+					sessionId: params.sessionId,
+				} );
+			} finally {
+				setSettledRequestCount( ( count ) => count + 1 );
+			}
 		},
 	} );
 
@@ -1332,6 +1385,8 @@ export default function OrchestratorChat( {
 				submitDispatchedRef.current = false;
 				setInputValue( ( currentValue ) => ( currentValue === '' ? message : currentValue ) );
 				return;
+			} finally {
+				setSettledRequestCount( ( count ) => count + 1 );
 			}
 
 			consumeNextMessageExternalContextEntries();
@@ -1818,7 +1873,7 @@ export default function OrchestratorChat( {
 			thinkingMessage={
 				isUploadingImages ? __( 'Uploading images…', __i18n_text_domain__ ) : progressMessage
 			}
-			error={ chatError || uploadError }
+			error={ displayedChatError || uploadError }
 			onSubmit={ onSubmitWithImages }
 			onAbort={ handleAbort }
 			isLoadingConversation={ isLoadingConversation }
@@ -1837,6 +1892,7 @@ export default function OrchestratorChat( {
 			groupWritingSuggestions={ groupWritingSuggestions }
 			imageUpload={ imageUpload }
 			isChatInputDisabled={ isChatInputDisabled }
+			notice={ chatNotice }
 			showFeedbackInput={ showFeedbackInput }
 			onSubmitFeedbackText={ submitFeedbackText }
 			onCancelFeedback={ resetFeedback }

--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -185,6 +185,7 @@ describe( 'loadExternalProviders', () => {
 
 		expect( providers.toolProvider ).toBeUndefined();
 		expect( providers.contextProvider ).toBeUndefined();
+		expect( providers.useChatNotice ).toBeUndefined();
 		expect( providers.useSuggestions ).toEqual( expect.any( Function ) );
 	} );
 
@@ -768,6 +769,17 @@ describe( 'loadExternalProviders', () => {
 		const providers = await loadExternalProviders();
 
 		expect( providers.onTaskUpdate ).toBe( firstOnTaskUpdate );
+	} );
+
+	it( 'uses the first provider for useChatNotice', async () => {
+		const firstUseChatNotice = jest.fn();
+		setAgentsManagerData( {
+			agentProviders: [ { useChatNotice: firstUseChatNotice }, { useChatNotice: jest.fn() } ],
+		} );
+
+		const providers = await loadExternalProviders();
+
+		expect( providers.useChatNotice ).toBe( firstUseChatNotice );
 	} );
 
 	it( 'merges empty view suggestions from multiple providers and dedupes by id', async () => {

--- a/packages/agents-manager/src/utils/__tests__/tracks.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/tracks.test.ts
@@ -20,6 +20,7 @@ import {
 	getBigSkyTracksData,
 	recordAgentsManagerTracksEvent,
 	recordBigSkyTracksEvent,
+	recordJetpackAiUpgradeButtonClick,
 } from '../tracks';
 
 const mockRecordTracksEvent = recordTracksEvent as jest.MockedFunction< typeof recordTracksEvent >;
@@ -256,6 +257,28 @@ describe( 'tracks wrappers', () => {
 			setResolvedAgentId( 'reader-chat' );
 			recordAgentsManagerTracksEvent( 'calypso_agents_manager_chat_minimize' );
 			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'recordJetpackAiUpgradeButtonClick', () => {
+		it( 'records the shared funnel event without site or allowance data', () => {
+			( globalThis as { agentsManagerData?: unknown } ).agentsManagerData = {
+				isA11n: false,
+				site: { ID: 12345 },
+			};
+
+			recordJetpackAiUpgradeButtonClick();
+
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith( 'jetpack_ai_upgrade_button', {
+				ai_session_id: 'session-xyz',
+				is_a11n: false,
+				placement: 'jetpack-ai-sidebar-quota-notice',
+				sessionid: 'session-xyz',
+				surface: 'block_editor',
+			} );
+			expect( lastEventProps() ).not.toHaveProperty( 'blog_id' );
+			expect( lastEventProps() ).not.toHaveProperty( 'credits_remaining' );
+			expect( lastEventProps() ).not.toHaveProperty( 'requests_remaining' );
 		} );
 	} );
 

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -33,7 +33,7 @@ import type {
 	BigSkyMessage,
 } from '../types';
 import type { UseAgentChatReturn } from '@automattic/agenttic-client';
-import type { MarkdownComponents, MarkdownExtensions } from '@automattic/agenttic-ui';
+import type { MarkdownComponents, MarkdownExtensions, NoticeConfig } from '@automattic/agenttic-ui';
 import type { ReactNode } from 'react';
 
 /**
@@ -139,6 +139,36 @@ export interface ProviderCapabilities {
 	supportsRegenerateAction?: boolean;
 }
 
+export type ChatNoticeResult =
+	| ( NoticeConfig & {
+			/** Hide only the current error that this notice replaces. */
+			suppressCurrentError?: boolean;
+	  } )
+	| {
+			/** The provider handled the current error without rendering a notice. */
+			suppressCurrentError: true;
+	  };
+
+export type UseChatNoticeHook = ( props: {
+	error: string | null;
+	/** False on surfaces whose usage must not be fetched or displayed. */
+	enabled: boolean;
+	/** Whether the site is WordPress.com-hosted; absent when the host does not publish it. */
+	isWpcomPlatform?: boolean;
+	/** Credit status from the latest terminal task result in this site and agent scope. */
+	aiCredits?: unknown;
+	/** Changes whenever a terminal task result is received in this site and agent scope. */
+	aiCreditsRevision?: number;
+	/** Changes only after the complete request or stream promise settles. */
+	settledRequestCount: number;
+	/** Current site identity for provider-owned status requests. */
+	siteId?: number;
+	/** Authenticated same-origin REST requester supplied by Agents Manager. */
+	requestStatus: < T >( options: { path: string } ) => Promise< T >;
+	/** Records the shared upgrade funnel click without coupling providers to analytics packages. */
+	recordUpgradeClick: () => void;
+} ) => ChatNoticeResult | undefined;
+
 /**
  * OR-merge a provider's `capabilities` into the running map. Works on both
  * plain objects and lazy Proxies (probed by direct key access, not iteration).
@@ -184,6 +214,8 @@ export interface LoadedProviders {
 	transformMessages?: TransformMessages;
 	siteBuildUtils?: SiteBuildUtils;
 	useCheckpoint?: UseCheckpointHook;
+	/** Provider-owned, display-only notice shown through AgentChat's shared notice slot. */
+	useChatNotice?: UseChatNoticeHook;
 	/**
 	 * Streamed task-update callback, forwarded to useAgentChat's `onTaskUpdate`.
 	 * Lets a provider react to streamed tool-argument deltas as they arrive — e.g.
@@ -594,6 +626,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	let mergedGetChatComponent: GetChatComponent | undefined;
 	let mergedSiteBuildUtils: SiteBuildUtils | undefined;
 	let mergedOnTaskUpdate: LoadedProviders[ 'onTaskUpdate' ] | undefined;
+	let mergedUseChatNotice: UseChatNoticeHook | undefined;
 	// OR-merged across all providers.
 	const mergedCapabilities: ProviderCapabilities = {};
 	let mergedSuppressEmptyViewDefaults = false;
@@ -690,6 +723,9 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		}
 		if ( module.onTaskUpdate && ! mergedOnTaskUpdate ) {
 			mergedOnTaskUpdate = module.onTaskUpdate;
+		}
+		if ( module.useChatNotice && ! mergedUseChatNotice ) {
+			mergedUseChatNotice = module.useChatNotice;
 		}
 
 		mergeCapabilitiesInto( mergedCapabilities, module.capabilities );
@@ -850,6 +886,7 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 		providerIds: allProviderIds.length ? allProviderIds : undefined,
 		useAbilitiesSetup: mergedAbilitiesSetup,
 		onTaskUpdate: mergedOnTaskUpdate,
+		useChatNotice: mergedUseChatNotice,
 		useSuggestions: mergedUseSuggestions,
 		getChatComponent: mergedGetChatComponent,
 		transformMessages: mergedTransformMessages,

--- a/packages/agents-manager/src/utils/tracks.ts
+++ b/packages/agents-manager/src/utils/tracks.ts
@@ -171,3 +171,22 @@ export function recordAgentsManagerTracksEvent(
 ): void {
 	recordTracksEvent( eventName, { ...getUnifiedBaseProps(), ...props } );
 }
+
+/** Records the existing Jetpack AI upgrade-funnel click without allowance or site data. */
+export function recordJetpackAiUpgradeButtonClick(): void {
+	const sessionId = getActiveSessionId();
+	const isA11n = getIsA11n();
+	let surface: string | undefined;
+	try {
+		surface = select( 'core/editor' ) ? 'block_editor' : undefined;
+	} catch {
+		surface = undefined;
+	}
+
+	recordTracksEvent( 'jetpack_ai_upgrade_button', {
+		placement: 'jetpack-ai-sidebar-quota-notice',
+		...( surface ? { surface } : {} ),
+		...( sessionId ? { sessionid: sessionId, ai_session_id: sessionId } : {} ),
+		...( isA11n !== undefined ? { is_a11n: isA11n } : {} ),
+	} );
+}

--- a/packages/agenttic-client/src/client/index.test.ts
+++ b/packages/agenttic-client/src/client/index.test.ts
@@ -141,6 +141,99 @@ describe( 'Client', () => {
 			expect( result.text ).toBe( 'Done after tool call.' );
 		} );
 
+		it( 'preserves AI credits on a synthetic final agent message', async () => {
+			const aiCredits = {
+				credits_limit: 10_000,
+				credits_used: 1_700,
+				credits_remaining: 8_300,
+				blocked: false,
+			};
+			const mockToolProvider: ToolProvider = {
+				async getAvailableTools() {
+					return [
+						{
+							id: 'apply-edit',
+							name: 'Apply edit',
+							description: 'Apply an editor change',
+							input_schema: {
+								type: 'object',
+								properties: {},
+							},
+						},
+					];
+				},
+				async executeTool() {
+					return {
+						result: { success: true },
+						returnToAgent: false,
+						agentMessage: 'The edit was applied.',
+					};
+				},
+			};
+
+			const encoder = new TextEncoder();
+			mockFetch.mockResolvedValueOnce( {
+				ok: true,
+				status: 200,
+				headers: new Headers( {
+					'content-type': 'text/event-stream',
+				} ),
+				body: new ReadableStream( {
+					start( controller ) {
+						const inputRequiredEvent = JSON.stringify( {
+							jsonrpc: '2.0',
+							id: 'req-apply-edit',
+							result: {
+								type: 'TaskStatusUpdateEvent',
+								taskId: 'task-apply-edit',
+								status: {
+									state: 'input-required',
+									message: {
+										messageId: 'resp-apply-edit',
+										role: 'agent',
+										kind: 'message',
+										parts: [
+											{
+												type: 'data',
+												data: {
+													toolCallId: 'call-apply-edit',
+													toolId: 'apply-edit',
+													arguments: {},
+												},
+											},
+										],
+									},
+									final: true,
+								},
+								ai_credits: aiCredits,
+							},
+						} );
+
+						controller.enqueue( encoder.encode( `data: ${ inputRequiredEvent }\n\n` ) );
+						controller.close();
+					},
+				} ),
+			} );
+
+			const client = createClient( {
+				agentId: 'test-agent',
+				toolProvider: mockToolProvider,
+			} );
+			const updates = [];
+			for await ( const update of client.sendMessageStream( {
+				message: createTextMessage( 'Apply this edit' ),
+			} ) ) {
+				updates.push( update );
+			}
+
+			expect( mockFetch ).toHaveBeenCalledTimes( 1 );
+			expect( updates.at( -1 ) ).toMatchObject( {
+				final: true,
+				text: 'The edit was applied.',
+				aiCredits,
+			} );
+		} );
+
 		it( 'preserves final input-required events when an advertised tool has no executable handler', async () => {
 			const mockToolProvider: ToolProvider = {
 				async getAvailableTools() {

--- a/packages/agenttic-client/src/client/index.ts
+++ b/packages/agenttic-client/src/client/index.ts
@@ -982,6 +982,9 @@ async function* processAgentResponseStream(
 								state: 'completed',
 								message: finalAgentMessage,
 							},
+							...( enhancedUpdate.aiCredits !== undefined && {
+								aiCredits: enhancedUpdate.aiCredits,
+							} ),
 							final: true,
 							text: combinedAgentText,
 						};

--- a/packages/agenttic-client/src/client/types/index.ts
+++ b/packages/agenttic-client/src/client/types/index.ts
@@ -334,6 +334,8 @@ export interface TaskUpdate {
 	status: TaskStatus;
 	final?: boolean;
 	artifact?: Artifact;
+	/** Credit status from the server's task result. Not persisted to messages. */
+	aiCredits?: unknown;
 	text: string; // Extracted text from status.message
 	agentMessage?: Message; // Optional separate agent message for when returnToAgent is false
 	progressMessage?: string; // Optional progress message extracted from progress parts

--- a/packages/agenttic-client/src/client/utils/internal/streaming.test.ts
+++ b/packages/agenttic-client/src/client/utils/internal/streaming.test.ts
@@ -868,6 +868,121 @@ describe( 'parseSSEStream', () => {
 		expect( updates[ 0 ].final ).toBe( true );
 	} );
 
+	it( 'preserves AI credits from a terminal task result', async () => {
+		const aiCredits = {
+			credits_limit: 15_000,
+			credits_used: 3_000,
+			credits_remaining: 12_000,
+			blocked: false,
+			resets_at: '2026-10-01T00:00:00+00:00',
+			upgrade_url: null,
+		};
+		const updates = [];
+		const stream = streamFromEvents( [
+			{
+				jsonrpc: '2.0',
+				result: {
+					type: 'TaskStatusUpdateEvent',
+					taskId: 'task-with-extensions',
+					status: {
+						state: 'completed',
+						final: true,
+						message: {
+							kind: 'message',
+							messageId: 'response-with-extensions',
+							role: 'agent',
+							parts: [ { type: 'text', text: 'Done' } ],
+						},
+					},
+					ai_credits: aiCredits,
+				},
+			},
+		] );
+
+		for await ( const update of parseSSEStream( stream ) ) {
+			updates.push( update );
+		}
+
+		expect( updates ).toHaveLength( 1 );
+		expect( updates[ 0 ].aiCredits ).toEqual( aiCredits );
+	} );
+
+	it( 'yields terminal AI credits before propagating a protocol error', async () => {
+		const updates = [];
+		const stream = streamFromEvents( [
+			{
+				jsonrpc: '2.0',
+				error: { code: -32000, message: 'AI credit allowance exhausted' },
+				result: {
+					type: 'TaskStatusUpdateEvent',
+					taskId: 'task-exhausted',
+					status: {
+						state: 'failed',
+						final: true,
+						message: {
+							kind: 'message',
+							messageId: 'response-exhausted',
+							role: 'agent',
+							parts: [ { type: 'text', text: 'Allowance exhausted' } ],
+						},
+					},
+					ai_credits: {
+						credits_limit: 15_000,
+						credits_used: 15_000,
+						credits_remaining: 0,
+						blocked: true,
+						resets_at: '2026-10-01T00:00:00+00:00',
+						upgrade_url: null,
+					},
+				},
+			},
+		] );
+		let thrown: unknown;
+
+		try {
+			for await ( const update of parseSSEStream( stream ) ) {
+				updates.push( update );
+			}
+		} catch ( error ) {
+			thrown = error;
+		}
+
+		expect( updates ).toHaveLength( 1 );
+		expect( updates[ 0 ] ).toMatchObject( {
+			final: true,
+			status: { state: 'failed' },
+			aiCredits: { credits_remaining: 0, blocked: true },
+		} );
+		expect( thrown ).toEqual( new Error( 'Streaming error: AI credit allowance exhausted' ) );
+	} );
+
+	it( 'does not swallow an error when a combined payload is handled as a delta', async () => {
+		const stream = streamFromEvents( [
+			{
+				jsonrpc: '2.0',
+				method: 'message/delta',
+				params: {
+					id: 'task-with-error',
+					delta: { type: 'delta', deltaType: 'content', content: 'partial' },
+				},
+				error: { code: -32000, message: 'Terminal failure' },
+				result: { status: { state: 'failed', final: true } },
+			},
+		] );
+		const updates = [];
+		let thrown: unknown;
+		try {
+			for await ( const update of parseSSEStream( stream, { supportDeltas: true } ) ) {
+				updates.push( update );
+			}
+		} catch ( error ) {
+			thrown = error;
+		}
+
+		expect( updates ).toHaveLength( 1 );
+		expect( thrown ).toEqual( new Error( 'Streaming error: Terminal failure' ) );
+	} );
+
 	describe( 'delta pacing', () => {
 		afterEach( () => {
 			vi.unstubAllGlobals();

--- a/packages/agenttic-client/src/client/utils/internal/streaming.ts
+++ b/packages/agenttic-client/src/client/utils/internal/streaming.ts
@@ -199,8 +199,11 @@ export async function* parseSSEStream(
 				hasProcessedDelta = true;
 			}
 
-			if ( event.error ) {
-				throw new Error( `Streaming error: ${ event.error.message }` );
+			const streamError = event.error
+				? new Error( `Streaming error: ${ event.error.message }` )
+				: null;
+			if ( streamError && ! event.result?.status ) {
+				throw streamError;
 			}
 
 			// Handle delta messages
@@ -262,6 +265,9 @@ export async function* parseSSEStream(
 					sessionId: event.result.sessionId,
 					status: event.result.status,
 					final: isFinalTaskUpdate( event.result ),
+					...( event.result.ai_credits !== undefined && {
+						aiCredits: event.result.ai_credits,
+					} ),
 					text: extractTextFromMessage( statusMessage ),
 					progressMessage: progress?.summary,
 					progressPhase: progress?.phase,
@@ -288,6 +294,9 @@ export async function* parseSSEStream(
 						sessionId: event.result.sessionId,
 						status: event.result.status,
 						final: isFinalTaskUpdate( event.result ),
+						...( event.result.ai_credits !== undefined && {
+							aiCredits: event.result.ai_credits,
+						} ),
 						text: extractTextFromMessage( statusMessage ),
 						progressMessage: progress?.summary,
 						progressPhase: progress?.phase,
@@ -295,6 +304,10 @@ export async function* parseSSEStream(
 					};
 					yield update;
 				}
+			}
+
+			if ( streamError ) {
+				throw streamError;
 			}
 		}
 	};

--- a/packages/jetpack-ai-sidebar/src/free-credit-notice.test.ts
+++ b/packages/jetpack-ai-sidebar/src/free-credit-notice.test.ts
@@ -1,0 +1,408 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import {
+	formatRemainingPercentage,
+	getJetpackAiStatus,
+	type JetpackAiStatusRequester,
+	useJetpackFreeCreditChatNotice,
+} from './free-credit-notice';
+
+const LOCAL_API_ROOT = 'http://localhost/wp-json/';
+const STATUS_PATH = '/wpcom/v2/jetpack-ai/ai-assistant-feature';
+const UPGRADE_URL = 'http://localhost/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai';
+const QUOTA_ERROR = 'Protocol request error: ai_credit_allowance_exhausted.';
+const mockOpen = jest.fn();
+
+type HookProps = Parameters< typeof useJetpackFreeCreditChatNotice >[ 0 ];
+type TestWindow = Window & {
+	JetpackScriptData?: { site?: { is_wpcom_platform?: unknown } };
+	wpApiSettings?: { root?: unknown };
+};
+
+const testWindow = window as TestWindow;
+const originalJetpackScriptData = testWindow.JetpackScriptData;
+const originalWpApiSettings = testWindow.wpApiSettings;
+
+beforeAll( () => {
+	Object.defineProperty( window, 'open', {
+		configurable: true,
+		value: mockOpen,
+	} );
+} );
+
+const featureResponse = ( requestsCount = 0 ) => ( {
+	'is-over-limit': requestsCount >= 20,
+	'requests-count': requestsCount,
+	'requests-limit': 20,
+	'upgrade-url': UPGRADE_URL,
+	'current-tier': {
+		slug: 'jetpack_ai_free',
+		value: 0,
+		limit: 20,
+	},
+} );
+
+const creditSnapshot = ( used = 0, limit = 15_000 ) => {
+	const remaining = Math.max( 0, limit - used );
+	return {
+		credits_limit: limit,
+		credits_used: used,
+		credits_remaining: remaining,
+		blocked: remaining === 0,
+		exhausted: remaining === 0,
+		resets_at: '2026-10-01T00:00:00+00:00',
+		upgrade_url: null,
+	};
+};
+
+function makeProps(
+	requestStatus: JetpackAiStatusRequester,
+	overrides: Partial< HookProps > = {}
+): HookProps {
+	return {
+		error: null,
+		enabled: true,
+		isWpcomPlatform: false,
+		requestStatus,
+		settledRequestCount: 0,
+		siteId: 123,
+		...overrides,
+	};
+}
+
+beforeEach( () => {
+	mockOpen.mockReset();
+	delete testWindow.JetpackScriptData;
+	delete testWindow.wpApiSettings;
+} );
+
+afterEach( () => {
+	if ( originalJetpackScriptData === undefined ) {
+		delete testWindow.JetpackScriptData;
+	} else {
+		testWindow.JetpackScriptData = originalJetpackScriptData;
+	}
+	if ( originalWpApiSettings === undefined ) {
+		delete testWindow.wpApiSettings;
+	} else {
+		testWindow.wpApiSettings = originalWpApiSettings;
+	}
+} );
+
+describe( 'getJetpackAiStatus', () => {
+	it( 'prefers a valid terminal cost snapshot over legacy request fields', () => {
+		expect(
+			getJetpackAiStatus( { ...featureResponse(), 'requests-count': 19 }, creditSnapshot( 3_000 ) )
+		).toEqual( {
+			kind: 'cost',
+			limit: 15_000,
+			used: 3_000,
+			remaining: 12_000,
+			resetsAt: '2026-10-01T00:00:00+00:00',
+			isExhausted: false,
+			upgradeUrl: null,
+		} );
+	} );
+
+	it.each( [
+		[ 'positive limit', { credits_limit: 0 } ],
+		[ 'integer usage', { credits_used: 1.5 } ],
+		[ 'internally consistent balance', { credits_remaining: 1 } ],
+		[ 'required blocked state', { blocked: undefined } ],
+		[ 'boolean blocked state', { blocked: 'yes' } ],
+		[ 'blocked only at exhaustion', { blocked: true } ],
+		[ 'boolean exhaustion state', { exhausted: 'yes' } ],
+		[ 'exhaustion matching the balance', { exhausted: true } ],
+		[ 'UTC reset boundary', { resets_at: '2026-10-01T00:00:00-05:00' } ],
+		[ 'first-of-month reset boundary', { resets_at: '2026-10-02T00:00:00Z' } ],
+	] )( 'falls back to legacy requests when the snapshot has an invalid %s', ( _name, override ) => {
+		expect(
+			getJetpackAiStatus( featureResponse( 3 ), { ...creditSnapshot(), ...override } )
+		).toMatchObject( { kind: 'legacy', requestsRemaining: 17 } );
+	} );
+
+	it( 'does not invent a balance from a malformed snapshot without a valid legacy fallback', () => {
+		expect(
+			getJetpackAiStatus( {}, { ...creditSnapshot(), credits_used: '3000' } )
+		).toBeUndefined();
+	} );
+
+	it( 'separates exhausted allowance from backend admission', () => {
+		expect(
+			getJetpackAiStatus( {}, { ...creditSnapshot( 15_000 ), blocked: false } )
+		).toMatchObject( {
+			kind: 'cost',
+			remaining: 0,
+			isExhausted: true,
+		} );
+	} );
+
+	it( 'uses the legacy request tier only when no valid cost snapshot exists', () => {
+		expect( getJetpackAiStatus( featureResponse( 21 ) ) ).toEqual( {
+			kind: 'legacy',
+			requestsRemaining: 0,
+			isExhausted: true,
+			upgradeUrl: UPGRADE_URL,
+		} );
+	} );
+
+	it( 'does not reinterpret a paid legacy tier as credits', () => {
+		expect(
+			getJetpackAiStatus( {
+				...featureResponse(),
+				'current-tier': { slug: 'jetpack_ai_yearly', value: 1, limit: 100 },
+			} )
+		).toBeNull();
+	} );
+} );
+
+describe( 'formatRemainingPercentage', () => {
+	it.each( [
+		[ 15_000, 15_000, '100%' ],
+		[ 14_999, 15_000, '99%' ],
+		[ 150, 15_000, '1%' ],
+		[ 149, 15_000, '<1%' ],
+		[ 1, 15_000, '<1%' ],
+		[ 0, 15_000, '0%' ],
+	] )( 'formats %d of %d as %s', ( remaining, limit, expected ) => {
+		expect( formatRemainingPercentage( remaining, limit ) ).toBe( expected );
+	} );
+} );
+
+describe( 'useJetpackFreeCreditChatNotice', () => {
+	beforeEach( () => {
+		testWindow.wpApiSettings = { root: LOCAL_API_ROOT };
+	} );
+
+	it( 'excludes WordPress.com-hosted sites from fetching and display', () => {
+		const requestStatus = jest.fn().mockResolvedValue( featureResponse() );
+		const { result } = renderHook( () =>
+			useJetpackFreeCreditChatNotice(
+				makeProps( requestStatus, {
+					aiCredits: creditSnapshot( 3_000 ),
+					error: QUOTA_ERROR,
+					isWpcomPlatform: true,
+				} )
+			)
+		);
+
+		expect( requestStatus ).not.toHaveBeenCalled();
+		expect( result.current ).toBeUndefined();
+	} );
+
+	it( 'honors the WordPress.com platform signal when the explicit flag is absent', () => {
+		testWindow.JetpackScriptData = { site: { is_wpcom_platform: true } };
+		const requestStatus = jest.fn().mockResolvedValue( featureResponse() );
+		const { result } = renderHook( () =>
+			useJetpackFreeCreditChatNotice(
+				makeProps( requestStatus, { isWpcomPlatform: undefined, error: QUOTA_ERROR } )
+			)
+		);
+
+		expect( requestStatus ).not.toHaveBeenCalled();
+		expect( result.current ).toBeUndefined();
+	} );
+
+	it( 'uses the injected requester for the self-hosted legacy fallback', async () => {
+		const requestStatus = jest.fn().mockResolvedValue( featureResponse( 3 ) );
+		const { result, unmount } = renderHook( () =>
+			useJetpackFreeCreditChatNotice( makeProps( requestStatus ) )
+		);
+
+		await waitFor( () => expect( result.current?.message ).toBe( '17 free requests left' ) );
+		expect( requestStatus ).toHaveBeenCalledWith( { path: STATUS_PATH } );
+		unmount();
+	} );
+
+	it( 'keeps a valid terminal cost snapshot ahead of the fetched request count', async () => {
+		const requestStatus = jest.fn().mockResolvedValue( featureResponse( 19 ) );
+		const { result, unmount } = renderHook( () =>
+			useJetpackFreeCreditChatNotice(
+				makeProps( requestStatus, { aiCredits: creditSnapshot( 3_000 ), aiCreditsRevision: 1 } )
+			)
+		);
+
+		await waitFor( () => expect( requestStatus ).toHaveBeenCalledTimes( 1 ) );
+		expect( result.current ).toMatchObject( { dismissible: false } );
+		expect( result.current?.message ).toContain( '80% of this month’s Jetpack AI allowance left.' );
+		expect( result.current?.message ).not.toContain( 'free request' );
+		unmount();
+	} );
+
+	it( 'renders terminal exhaustion as a persistent error notice', () => {
+		const requestStatus = jest.fn().mockResolvedValue( featureResponse() );
+		const { result, unmount } = renderHook( () =>
+			useJetpackFreeCreditChatNotice(
+				makeProps( requestStatus, { aiCredits: creditSnapshot( 15_000 ), aiCreditsRevision: 1 } )
+			)
+		);
+
+		expect( result.current ).toMatchObject( {
+			status: 'error',
+			dismissible: false,
+		} );
+		expect( result.current?.message ).toContain( '(0% left)' );
+		unmount();
+	} );
+
+	it( 'refreshes the legacy fallback after a request settles', async () => {
+		const requestStatus = jest
+			.fn()
+			.mockResolvedValueOnce( featureResponse( 3 ) )
+			.mockResolvedValueOnce( featureResponse( 4 ) );
+		const initialProps = makeProps( requestStatus );
+		const { result, rerender, unmount } = renderHook(
+			( props: HookProps ) => useJetpackFreeCreditChatNotice( props ),
+			{ initialProps }
+		);
+
+		await waitFor( () => expect( result.current?.message ).toBe( '17 free requests left' ) );
+
+		rerender( { ...initialProps, settledRequestCount: 1 } );
+
+		await waitFor( () => expect( result.current?.message ).toBe( '16 free requests left' ) );
+		expect( requestStatus ).toHaveBeenNthCalledWith( 2, {
+			path: `${ STATUS_PATH }?skip_cache=true`,
+		} );
+		unmount();
+	} );
+
+	it( 'keeps the delayed cached fallback after the immediate refresh', async () => {
+		jest.useFakeTimers();
+		try {
+			const requestStatus = jest
+				.fn()
+				.mockResolvedValueOnce( featureResponse() )
+				.mockResolvedValueOnce( featureResponse( 1 ) )
+				.mockResolvedValueOnce( featureResponse( 1 ) );
+			const initialProps = makeProps( requestStatus );
+			const { result, rerender, unmount } = renderHook(
+				( props: HookProps ) => useJetpackFreeCreditChatNotice( props ),
+				{ initialProps }
+			);
+
+			await act( async () => Promise.resolve() );
+			rerender( { ...initialProps, settledRequestCount: 1 } );
+			await act( async () => Promise.resolve() );
+			expect( requestStatus ).toHaveBeenCalledTimes( 2 );
+			expect( requestStatus ).toHaveBeenNthCalledWith( 2, {
+				path: `${ STATUS_PATH }?skip_cache=true`,
+			} );
+			expect( result.current?.message ).toBe( '19 free requests left' );
+
+			act( () => jest.advanceTimersByTime( 60_999 ) );
+			expect( requestStatus ).toHaveBeenCalledTimes( 2 );
+
+			act( () => jest.advanceTimersByTime( 1 ) );
+			await act( async () => Promise.resolve() );
+			expect( requestStatus ).toHaveBeenNthCalledWith( 3, { path: STATUS_PATH } );
+			expect( result.current?.message ).toBe( '19 free requests left' );
+			unmount();
+		} finally {
+			jest.clearAllTimers();
+			jest.useRealTimers();
+		}
+	} );
+
+	it( 'retires the pre-upgrade snapshot after a focus refresh confirms a paid tier', async () => {
+		const paidResponse = {
+			...featureResponse(),
+			'is-over-limit': false,
+			'current-tier': { slug: 'jetpack_ai_yearly', value: 1, limit: 100 },
+		};
+		const requestStatus = jest
+			.fn()
+			.mockResolvedValueOnce( featureResponse( 20 ) )
+			.mockResolvedValueOnce( paidResponse );
+		const recordUpgradeClick = jest.fn();
+		const initialProps = makeProps( requestStatus, {
+			aiCredits: creditSnapshot( 15_000 ),
+			aiCreditsRevision: 1,
+			error: QUOTA_ERROR,
+			recordUpgradeClick,
+		} );
+		const { result, rerender, unmount } = renderHook(
+			( props: HookProps ) => useJetpackFreeCreditChatNotice( props ),
+			{ initialProps }
+		);
+
+		await waitFor( () => expect( result.current?.action ).toMatchObject( { label: 'Upgrade' } ) );
+		result.current?.action?.onClick();
+		expect( recordUpgradeClick ).toHaveBeenCalledTimes( 1 );
+		expect( mockOpen ).toHaveBeenCalledWith( UPGRADE_URL, '_blank', 'noopener,noreferrer' );
+		expect( requestStatus ).toHaveBeenCalledTimes( 1 );
+
+		act( () => window.dispatchEvent( new Event( 'focus' ) ) );
+
+		await waitFor( () => {
+			expect( requestStatus ).toHaveBeenNthCalledWith( 2, {
+				path: `${ STATUS_PATH }?skip_cache=true`,
+			} );
+			expect( result.current ).toEqual( { suppressCurrentError: true } );
+		} );
+
+		rerender( {
+			...initialProps,
+			aiCredits: creditSnapshot( 3_000 ),
+			aiCreditsRevision: 2,
+		} );
+		expect( result.current ).toMatchObject( { suppressCurrentError: true } );
+		expect( result.current?.message ).toContain( '80% of this month’s Jetpack AI allowance left.' );
+		unmount();
+	} );
+
+	it( 'does not fetch without a positive site ID or a trusted same-origin REST root', () => {
+		const requestStatus = jest.fn().mockResolvedValue( featureResponse() );
+		const { rerender } = renderHook(
+			( props: HookProps ) => useJetpackFreeCreditChatNotice( props ),
+			{ initialProps: makeProps( requestStatus, { siteId: 0 } ) }
+		);
+
+		expect( requestStatus ).not.toHaveBeenCalled();
+
+		testWindow.wpApiSettings = { root: 'https://public-api.wordpress.com/' };
+		rerender( makeProps( requestStatus, { siteId: 123 } ) );
+		expect( requestStatus ).not.toHaveBeenCalled();
+
+		testWindow.wpApiSettings = { root: 'blob:http://localhost/wp-json/' };
+		rerender( makeProps( requestStatus, { siteId: 456 } ) );
+		expect( requestStatus ).not.toHaveBeenCalled();
+	} );
+
+	it( 'coalesces settled-count changes while the injected request is in flight', async () => {
+		let resolveRefresh: ( response: ReturnType< typeof featureResponse > ) => void = () => {};
+		const requestStatus = jest
+			.fn()
+			.mockResolvedValueOnce( featureResponse() )
+			.mockImplementationOnce(
+				() =>
+					new Promise( ( resolve ) => {
+						resolveRefresh = resolve;
+					} )
+			)
+			.mockResolvedValueOnce( featureResponse( 3 ) );
+		const initialProps = makeProps( requestStatus );
+		const { result, rerender, unmount } = renderHook(
+			( props: HookProps ) => useJetpackFreeCreditChatNotice( props ),
+			{ initialProps }
+		);
+
+		await waitFor( () => expect( result.current?.message ).toBe( '20 free requests left' ) );
+		rerender( { ...initialProps, settledRequestCount: 1 } );
+		await waitFor( () => expect( requestStatus ).toHaveBeenCalledTimes( 2 ) );
+
+		rerender( { ...initialProps, settledRequestCount: 2 } );
+		rerender( { ...initialProps, settledRequestCount: 3 } );
+		expect( requestStatus ).toHaveBeenCalledTimes( 2 );
+
+		await act( async () => resolveRefresh( featureResponse( 1 ) ) );
+		await waitFor( () => expect( requestStatus ).toHaveBeenCalledTimes( 3 ) );
+		expect( requestStatus ).toHaveBeenNthCalledWith( 3, {
+			path: `${ STATUS_PATH }?skip_cache=true`,
+		} );
+		expect( result.current?.message ).toBe( '17 free requests left' );
+		unmount();
+	} );
+} );

--- a/packages/jetpack-ai-sidebar/src/free-credit-notice.ts
+++ b/packages/jetpack-ai-sidebar/src/free-credit-notice.ts
@@ -1,0 +1,696 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { _n, __, sprintf } from '@wordpress/i18n';
+import {
+	getTrustedUpgradeUrl,
+	openJetpackAiUpgrade,
+	type JetpackAiChatNoticeResult,
+	useChatNotice as useQuotaRejectionNotice,
+} from './quota-notice';
+
+const FREE_TIER_SLUGS = new Set( [ 'jetpack_ai_free', 'ai-assistant-tier-free' ] );
+const LOCAL_STATUS_PATH = '/wpcom/v2/jetpack-ai/ai-assistant-feature';
+
+// Older Jetpack versions ignore skip_cache, so keep a delayed read after the 60-second cache expires.
+const JETPACK_REFRESH_DELAY_MS = 61_000;
+
+interface AiAssistantFeatureResponse {
+	'is-over-limit'?: unknown;
+	'requests-count'?: unknown;
+	'requests-limit'?: unknown;
+	'upgrade-url'?: unknown;
+	'current-tier'?: {
+		slug?: unknown;
+		value?: unknown;
+		limit?: unknown;
+	};
+}
+
+interface AiCreditSnapshotPayload {
+	credits_limit?: unknown;
+	credits_used?: unknown;
+	credits_remaining?: unknown;
+	blocked?: unknown;
+	exhausted?: unknown;
+	resets_at?: unknown;
+	upgrade_url?: unknown;
+}
+
+interface AiCreditAllowanceStatus {
+	kind: 'cost';
+	limit: number;
+	used: number;
+	remaining: number;
+	resetsAt: string;
+	isExhausted: boolean;
+	upgradeUrl: string | null;
+}
+
+interface LegacyRequestStatus {
+	kind: 'legacy';
+	requestsRemaining: number;
+	isExhausted: boolean;
+	upgradeUrl: string | null;
+}
+
+type JetpackAiStatus = AiCreditAllowanceStatus | LegacyRequestStatus;
+
+interface CreditNoticeState {
+	key: string;
+	status: LegacyRequestStatus | null;
+	upgradeUrl: string | null;
+}
+
+interface TaskSnapshotIdentity {
+	revision: number;
+	scopeKey: string;
+}
+
+interface UpgradeReturnRefresh {
+	taskSnapshot?: TaskSnapshotIdentity;
+}
+
+export type JetpackAiStatusRequester = < T >( options: { path: string } ) => Promise< T >;
+
+interface JetpackAiCreditNoticeProps {
+	error: string | null;
+	enabled?: boolean;
+	isWpcomPlatform?: boolean;
+	aiCredits?: unknown;
+	aiCreditsRevision?: number;
+	settledRequestCount?: number;
+	siteId?: number;
+	requestStatus?: JetpackAiStatusRequester;
+	recordUpgradeClick?: () => void;
+}
+
+interface JetpackAiCreditNoticeOptions {
+	error: string | null;
+	enabled: boolean;
+	fetchEnabled: boolean;
+	refreshDelayMs: number;
+	aiCredits?: unknown;
+	aiCreditsRevision?: number;
+	settledRequestCount: number;
+	siteId?: number;
+	statusPath?: string;
+	requestStatus?: JetpackAiStatusRequester;
+	recordUpgradeClick?: () => void;
+}
+
+type HostWindow = Window & {
+	JetpackScriptData?: { site?: { is_wpcom_platform?: unknown } };
+	wpApiSettings?: { root?: unknown };
+};
+
+function isNonNegativeInteger( value: unknown ): value is number {
+	return typeof value === 'number' && Number.isInteger( value ) && value >= 0;
+}
+
+function isPositiveInteger( value: unknown ): value is number {
+	return isNonNegativeInteger( value ) && value > 0;
+}
+
+function getUtcMonthBoundary( value: unknown ): Date | null {
+	if ( typeof value !== 'string' ) {
+		return null;
+	}
+	const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.0+)?(?:Z|\+00:00)$/.exec(
+		value
+	);
+	if ( ! match ) {
+		return null;
+	}
+
+	const date = new Date( value );
+	if (
+		Number.isNaN( date.getTime() ) ||
+		date.getUTCFullYear() !== Number( match[ 1 ] ) ||
+		date.getUTCMonth() + 1 !== Number( match[ 2 ] ) ||
+		date.getUTCDate() !== Number( match[ 3 ] ) ||
+		date.getUTCHours() !== Number( match[ 4 ] ) ||
+		date.getUTCMinutes() !== Number( match[ 5 ] ) ||
+		date.getUTCSeconds() !== Number( match[ 6 ] ) ||
+		date.getUTCDate() !== 1 ||
+		date.getUTCHours() !== 0 ||
+		date.getUTCMinutes() !== 0 ||
+		date.getUTCSeconds() !== 0 ||
+		date.getUTCMilliseconds() !== 0
+	) {
+		return null;
+	}
+
+	return date;
+}
+
+function isNoticeEnabled( enabled: unknown ): boolean {
+	return enabled === undefined ? true : enabled === true;
+}
+
+function getSettledRequestCount( settledRequestCount: unknown ): number {
+	return isNonNegativeInteger( settledRequestCount ) ? settledRequestCount : 0;
+}
+
+function getIsWpcomPlatform( isWpcomPlatform: unknown ): boolean | undefined {
+	if ( typeof isWpcomPlatform === 'boolean' ) {
+		return isWpcomPlatform;
+	}
+	if ( typeof window === 'undefined' ) {
+		return undefined;
+	}
+
+	const scriptDataValue = ( window as HostWindow ).JetpackScriptData?.site?.is_wpcom_platform;
+	return typeof scriptDataValue === 'boolean' ? scriptDataValue : undefined;
+}
+
+function getSelfHostedStatusPath( wpcomPlatform: boolean | undefined ): string | undefined {
+	if ( wpcomPlatform !== false || typeof window === 'undefined' ) {
+		return undefined;
+	}
+
+	const root = ( window as HostWindow ).wpApiSettings?.root;
+	if ( typeof root !== 'string' ) {
+		return undefined;
+	}
+
+	try {
+		const url = new URL( root, window.location.href );
+		if ( url.username !== '' || url.password !== '' ) {
+			return undefined;
+		}
+		return url.protocol === window.location.protocol && url.origin === window.location.origin
+			? LOCAL_STATUS_PATH
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function getTrustedResponseUpgradeUrl( response: AiAssistantFeatureResponse ): string | null {
+	const rawUpgradeUrl = response[ 'upgrade-url' ];
+	return typeof rawUpgradeUrl === 'string' ? getTrustedUpgradeUrl( rawUpgradeUrl ) : null;
+}
+
+function getAiCreditAllowanceStatus( aiCredits: unknown ): AiCreditAllowanceStatus | undefined {
+	if ( ! aiCredits || typeof aiCredits !== 'object' || Array.isArray( aiCredits ) ) {
+		return undefined;
+	}
+
+	const snapshot = aiCredits as AiCreditSnapshotPayload;
+	const limit = snapshot.credits_limit;
+	const used = snapshot.credits_used;
+	const remaining = snapshot.credits_remaining;
+	const resetsAt = snapshot.resets_at;
+	const blocked = snapshot.blocked;
+	const hasExhaustionState = Object.prototype.hasOwnProperty.call( snapshot, 'exhausted' );
+	const isExhausted = hasExhaustionState ? snapshot.exhausted : blocked;
+
+	if (
+		! isPositiveInteger( limit ) ||
+		! isNonNegativeInteger( used ) ||
+		! isNonNegativeInteger( remaining ) ||
+		remaining !== Math.max( 0, limit - used ) ||
+		typeof blocked !== 'boolean' ||
+		typeof isExhausted !== 'boolean' ||
+		isExhausted !== ( remaining === 0 ) ||
+		( blocked && ! isExhausted ) ||
+		! getUtcMonthBoundary( resetsAt ) ||
+		typeof resetsAt !== 'string'
+	) {
+		return undefined;
+	}
+
+	return {
+		kind: 'cost',
+		limit,
+		used,
+		remaining,
+		resetsAt,
+		isExhausted,
+		upgradeUrl:
+			typeof snapshot.upgrade_url === 'string'
+				? getTrustedUpgradeUrl( snapshot.upgrade_url )
+				: null,
+	};
+}
+
+function getLegacyRequestStatus(
+	response: AiAssistantFeatureResponse
+): LegacyRequestStatus | null | undefined {
+	const currentTier = response[ 'current-tier' ];
+	const hasTierIdentity =
+		typeof currentTier?.slug === 'string' || typeof currentTier?.value === 'number';
+	if ( ! hasTierIdentity ) {
+		return undefined;
+	}
+
+	const isFreeTier =
+		currentTier?.value === 0 ||
+		( typeof currentTier?.slug === 'string' && FREE_TIER_SLUGS.has( currentTier.slug ) );
+	if ( ! isFreeTier ) {
+		return null;
+	}
+	if ( ! isNonNegativeInteger( response[ 'requests-count' ] ) ) {
+		return undefined;
+	}
+
+	const limit = isNonNegativeInteger( response[ 'requests-limit' ] )
+		? response[ 'requests-limit' ]
+		: currentTier?.limit;
+	if ( ! isNonNegativeInteger( limit ) ) {
+		return undefined;
+	}
+
+	const requestsRemaining = Math.max( 0, limit - response[ 'requests-count' ] );
+
+	return {
+		kind: 'legacy',
+		requestsRemaining,
+		isExhausted: response[ 'is-over-limit' ] === true || requestsRemaining === 0,
+		upgradeUrl: getTrustedResponseUpgradeUrl( response ),
+	};
+}
+
+export function getJetpackAiStatus(
+	response: AiAssistantFeatureResponse,
+	aiCredits?: unknown
+): JetpackAiStatus | null | undefined {
+	return getAiCreditAllowanceStatus( aiCredits ) ?? getLegacyRequestStatus( response );
+}
+
+export function formatRemainingPercentage( remaining: number, limit: number ): string {
+	const percentage = Math.max( 0, Math.min( 100, Math.floor( ( 100 * remaining ) / limit ) ) );
+	return remaining > 0 && percentage === 0 ? '<1%' : `${ percentage }%`;
+}
+
+function formatResetDate( resetsAt: string ): string {
+	return new Intl.DateTimeFormat( undefined, {
+		day: 'numeric',
+		month: 'long',
+		timeZone: 'UTC',
+		year: 'numeric',
+	} ).format( new Date( resetsAt ) );
+}
+
+function useJetpackAiCreditNotice( {
+	aiCredits,
+	aiCreditsRevision,
+	error,
+	enabled,
+	fetchEnabled,
+	recordUpgradeClick,
+	refreshDelayMs,
+	requestStatus,
+	settledRequestCount,
+	siteId,
+	statusPath,
+}: JetpackAiCreditNoticeOptions ): JetpackAiChatNoticeResult | undefined {
+	const [ creditNoticeState, setCreditNoticeState ] = useState< CreditNoticeState | undefined >();
+	const [ recoveryRevision, setRecoveryRevision ] = useState( 0 );
+	const [ retiredTaskSnapshot, setRetiredTaskSnapshot ] = useState<
+		TaskSnapshotIdentity | undefined
+	>();
+	const settledRequestCountRef = useRef( settledRequestCount );
+	const refreshAfterUpgradeRef = useRef< UpgradeReturnRefresh | null >( null );
+	const requestStatusRefresh = useRef<
+		( ( count: number, force?: boolean, upgradeReturn?: UpgradeReturnRefresh ) => void ) | null
+	>( null );
+	useEffect( () => {
+		settledRequestCountRef.current = settledRequestCount;
+	}, [ settledRequestCount ] );
+
+	const scopeKey = isPositiveInteger( siteId ) ? String( siteId ) : null;
+	const statusKey = scopeKey && statusPath ? `${ scopeKey }:${ statusPath }` : null;
+	const validAiCreditsRevision = isPositiveInteger( aiCreditsRevision )
+		? aiCreditsRevision
+		: undefined;
+	const parsedTaskStatus = useMemo( () => getAiCreditAllowanceStatus( aiCredits ), [ aiCredits ] );
+	const isTaskSnapshotRetired =
+		validAiCreditsRevision !== undefined &&
+		retiredTaskSnapshot?.scopeKey === scopeKey &&
+		retiredTaskSnapshot.revision === validAiCreditsRevision;
+	const taskStatus = isTaskSnapshotRetired ? undefined : parsedTaskStatus;
+	const taskSnapshotIdentity = useMemo(
+		() =>
+			taskStatus && scopeKey && validAiCreditsRevision !== undefined
+				? { revision: validAiCreditsRevision, scopeKey }
+				: undefined,
+		[ scopeKey, taskStatus, validAiCreditsRevision ]
+	);
+	const taskStatusRecoveryKey =
+		taskStatus && ! taskStatus.isExhausted && taskSnapshotIdentity
+			? `${ taskSnapshotIdentity.scopeKey }:${ taskSnapshotIdentity.revision }`
+			: null;
+	const quotaResult = useQuotaRejectionNotice( {
+		error: enabled ? error : null,
+		recordUpgradeClick,
+		recoveryRevision,
+		scopeKey,
+	} );
+	const rejectionNotice = quotaResult && 'message' in quotaResult ? quotaResult : undefined;
+	const suppressCurrentError = quotaResult?.suppressCurrentError === true;
+
+	useEffect( () => {
+		if ( taskStatusRecoveryKey ) {
+			setRecoveryRevision( ( revision ) => revision + 1 );
+		}
+	}, [ taskStatusRecoveryKey ] );
+
+	useEffect( () => {
+		if ( ! fetchEnabled || ! requestStatus || ! statusKey || ! statusPath ) {
+			requestStatusRefresh.current = null;
+			return;
+		}
+
+		const activeStatusKey = statusKey;
+		const activeStatusPath = statusPath;
+		const activeRequestStatus = requestStatus;
+		let active = true;
+		let cachedFallbackNeeded = false;
+		let fallbackUpgradeReturn: UpgradeReturnRefresh | undefined;
+		let immediateRefreshPending = false;
+		let queuedUpgradeReturn: UpgradeReturnRefresh | undefined;
+		let isRequestInFlight = false;
+		let consecutiveFailures = 0;
+		let lastCompletedAt: number | null = null;
+		let observedSettledRequestCount = settledRequestCountRef.current;
+		let refreshTimer: number | null = null;
+
+		const clearRefreshTimer = () => {
+			if ( refreshTimer !== null ) {
+				window.clearTimeout( refreshTimer );
+				refreshTimer = null;
+			}
+		};
+
+		const scheduleCachedFallback = () => {
+			if ( ! active || ! cachedFallbackNeeded || isRequestInFlight || refreshTimer !== null ) {
+				return;
+			}
+
+			const elapsed = lastCompletedAt === null ? 0 : Date.now() - lastCompletedAt;
+			const delay = Math.max( 0, refreshDelayMs - elapsed );
+			if ( delay === 0 ) {
+				startStatusRequest( false, false, fallbackUpgradeReturn );
+				return;
+			}
+
+			refreshTimer = window.setTimeout( () => {
+				refreshTimer = null;
+				startStatusRequest( false, false, fallbackUpgradeReturn );
+			}, delay );
+		};
+
+		function startStatusRequest(
+			skipCache: boolean,
+			isInitialRequest = false,
+			upgradeReturn?: UpgradeReturnRefresh
+		) {
+			if ( ! active || isRequestInFlight ) {
+				return;
+			}
+
+			isRequestInFlight = true;
+			if ( skipCache ) {
+				clearRefreshTimer();
+				cachedFallbackNeeded = true;
+				if ( upgradeReturn ) {
+					fallbackUpgradeReturn = upgradeReturn;
+				}
+			} else if ( ! isInitialRequest ) {
+				cachedFallbackNeeded = false;
+			}
+
+			void activeRequestStatus< AiAssistantFeatureResponse >( {
+				path: skipCache ? `${ activeStatusPath }?skip_cache=true` : activeStatusPath,
+			} )
+				.then( ( response ) => {
+					if ( ! active ) {
+						return;
+					}
+
+					const status = getLegacyRequestStatus( response );
+					if ( status !== undefined ) {
+						setCreditNoticeState( {
+							key: activeStatusKey,
+							status,
+							upgradeUrl: getTrustedResponseUpgradeUrl( response ),
+						} );
+						const hasRecovered =
+							status === null ? response[ 'is-over-limit' ] === false : ! status.isExhausted;
+						const confirmsPaidUpgrade =
+							upgradeReturn !== undefined &&
+							status === null &&
+							response[ 'is-over-limit' ] === false;
+						if ( confirmsPaidUpgrade ) {
+							if ( upgradeReturn.taskSnapshot ) {
+								setRetiredTaskSnapshot( upgradeReturn.taskSnapshot );
+							}
+							fallbackUpgradeReturn = undefined;
+							setRecoveryRevision( ( revision ) => revision + 1 );
+						} else if ( hasRecovered && ! skipCache && ! isInitialRequest ) {
+							setRecoveryRevision( ( revision ) => revision + 1 );
+						}
+					}
+
+					completeStatusRequest( status !== undefined, skipCache, upgradeReturn );
+				} )
+				.catch( () => {
+					if ( active ) {
+						completeStatusRequest( false, skipCache, upgradeReturn );
+					}
+				} );
+		}
+
+		function completeStatusRequest(
+			isUsableResponse: boolean,
+			skipCache: boolean,
+			upgradeReturn?: UpgradeReturnRefresh
+		) {
+			isRequestInFlight = false;
+			lastCompletedAt = Date.now();
+			consecutiveFailures = isUsableResponse ? 0 : consecutiveFailures + 1;
+			if ( ! skipCache && upgradeReturn === fallbackUpgradeReturn ) {
+				fallbackUpgradeReturn = undefined;
+			}
+
+			if ( ! skipCache && ! isUsableResponse && consecutiveFailures < 2 ) {
+				cachedFallbackNeeded = true;
+			}
+
+			if ( immediateRefreshPending ) {
+				immediateRefreshPending = false;
+				const nextUpgradeReturn = queuedUpgradeReturn;
+				queuedUpgradeReturn = undefined;
+				startStatusRequest( true, false, nextUpgradeReturn );
+				return;
+			}
+
+			scheduleCachedFallback();
+		}
+
+		const handleStatusRefresh = (
+			count: number,
+			force = false,
+			upgradeReturn?: UpgradeReturnRefresh
+		) => {
+			if ( ! force && count === observedSettledRequestCount ) {
+				return;
+			}
+
+			observedSettledRequestCount = count;
+			cachedFallbackNeeded = true;
+			consecutiveFailures = 0;
+			if ( upgradeReturn ) {
+				queuedUpgradeReturn = upgradeReturn;
+			}
+			if ( isRequestInFlight ) {
+				immediateRefreshPending = true;
+				return;
+			}
+
+			queuedUpgradeReturn = undefined;
+			startStatusRequest( true, false, upgradeReturn );
+		};
+		const handleUpgradeReturn = () => {
+			if ( ! refreshAfterUpgradeRef.current || document.visibilityState === 'hidden' ) {
+				return;
+			}
+
+			const upgradeReturn = refreshAfterUpgradeRef.current;
+			refreshAfterUpgradeRef.current = null;
+			handleStatusRefresh( settledRequestCountRef.current, true, upgradeReturn );
+		};
+
+		requestStatusRefresh.current = handleStatusRefresh;
+		window.addEventListener( 'focus', handleUpgradeReturn );
+		document.addEventListener( 'visibilitychange', handleUpgradeReturn );
+		startStatusRequest( false, true );
+
+		return () => {
+			active = false;
+			clearRefreshTimer();
+			refreshAfterUpgradeRef.current = null;
+			window.removeEventListener( 'focus', handleUpgradeReturn );
+			document.removeEventListener( 'visibilitychange', handleUpgradeReturn );
+			if ( requestStatusRefresh.current === handleStatusRefresh ) {
+				requestStatusRefresh.current = null;
+			}
+		};
+	}, [ fetchEnabled, refreshDelayMs, requestStatus, siteId, statusKey, statusPath ] );
+
+	useEffect( () => {
+		requestStatusRefresh.current?.( settledRequestCount );
+	}, [ settledRequestCount ] );
+
+	const fetchedStatus =
+		fetchEnabled && statusKey && creditNoticeState?.key === statusKey
+			? creditNoticeState.status
+			: undefined;
+	const fetchedUpgradeUrl =
+		fetchEnabled && statusKey && creditNoticeState?.key === statusKey
+			? creditNoticeState.upgradeUrl
+			: null;
+	const status = useMemo(
+		() =>
+			taskStatus
+				? { ...taskStatus, upgradeUrl: taskStatus.upgradeUrl ?? fetchedUpgradeUrl }
+				: fetchedStatus,
+		[ fetchedStatus, fetchedUpgradeUrl, taskStatus ]
+	);
+	const upgradeUrl = status?.upgradeUrl ?? fetchedUpgradeUrl;
+	const onUpgradeClick = useCallback( () => {
+		if ( ! upgradeUrl ) {
+			return;
+		}
+
+		openJetpackAiUpgrade( upgradeUrl, recordUpgradeClick );
+		refreshAfterUpgradeRef.current = { taskSnapshot: taskSnapshotIdentity };
+	}, [ recordUpgradeClick, taskSnapshotIdentity, upgradeUrl ] );
+	const onRejectionUpgradeClick = useCallback( () => {
+		if ( ! rejectionNotice?.action ) {
+			return;
+		}
+
+		rejectionNotice.action.onClick();
+		refreshAfterUpgradeRef.current = { taskSnapshot: taskSnapshotIdentity };
+	}, [ rejectionNotice, taskSnapshotIdentity ] );
+
+	return useMemo( () => {
+		if ( ! enabled ) {
+			return undefined;
+		}
+		const statusUpgradeAction = upgradeUrl
+			? { label: __( 'Upgrade', __i18n_text_domain__ ), onClick: onUpgradeClick }
+			: undefined;
+		const rejectionUpgradeAction = rejectionNotice?.action
+			? { ...rejectionNotice.action, onClick: onRejectionUpgradeClick }
+			: undefined;
+		const exhaustedUpgradeAction = statusUpgradeAction ?? rejectionUpgradeAction;
+		const quotaResultWithRefresh =
+			rejectionNotice?.action && rejectionUpgradeAction
+				? { ...rejectionNotice, action: rejectionUpgradeAction }
+				: quotaResult;
+
+		if ( status === null ) {
+			return quotaResultWithRefresh;
+		}
+
+		if ( status?.kind === 'cost' ) {
+			const resetDate = formatResetDate( status.resetsAt );
+			if ( status.isExhausted ) {
+				return {
+					message: sprintf(
+						/* translators: 1: exhausted allowance percentage, 2: UTC allowance reset date. */
+						__(
+							'You’ve used this month’s Jetpack AI allowance (%1$s left). It resets on %2$s (UTC).',
+							__i18n_text_domain__
+						),
+						formatRemainingPercentage( status.remaining, status.limit ),
+						resetDate
+					),
+					status: 'error' as const,
+					dismissible: false,
+					suppressCurrentError,
+					action: exhaustedUpgradeAction,
+				};
+			}
+			if ( rejectionNotice ) {
+				return quotaResultWithRefresh;
+			}
+
+			return {
+				message: sprintf(
+					/* translators: 1: remaining percentage, 2: UTC allowance reset date. */
+					__(
+						'%1$s of this month’s Jetpack AI allowance left. Resets on %2$s (UTC).',
+						__i18n_text_domain__
+					),
+					formatRemainingPercentage( status.remaining, status.limit ),
+					resetDate
+				),
+				dismissible: false,
+				...( suppressCurrentError && { suppressCurrentError: true as const } ),
+				action: statusUpgradeAction,
+			};
+		}
+
+		if ( status && ( status.isExhausted || rejectionNotice ) ) {
+			return {
+				message: __( 'You’re out of free requests.', __i18n_text_domain__ ),
+				status: 'error' as const,
+				dismissible: false,
+				suppressCurrentError,
+				action: exhaustedUpgradeAction,
+			};
+		}
+
+		if ( status ) {
+			return {
+				message: sprintf(
+					/* translators: %d is the number of free Jetpack AI requests remaining. */
+					_n(
+						'%d free request left',
+						'%d free requests left',
+						status.requestsRemaining,
+						__i18n_text_domain__
+					),
+					status.requestsRemaining
+				),
+				dismissible: false,
+				...( suppressCurrentError && { suppressCurrentError: true as const } ),
+				action: statusUpgradeAction,
+			};
+		}
+
+		return quotaResultWithRefresh;
+	}, [
+		enabled,
+		onUpgradeClick,
+		onRejectionUpgradeClick,
+		quotaResult,
+		rejectionNotice,
+		status,
+		suppressCurrentError,
+		upgradeUrl,
+	] );
+}
+
+export function useJetpackFreeCreditChatNotice( {
+	isWpcomPlatform,
+	...props
+}: JetpackAiCreditNoticeProps ): JetpackAiChatNoticeResult | undefined {
+	const enabled = isNoticeEnabled( props.enabled );
+	const wpcomPlatform = getIsWpcomPlatform( isWpcomPlatform );
+	const selfHostedEnabled = enabled && wpcomPlatform === false;
+	const statusPath = getSelfHostedStatusPath( wpcomPlatform );
+
+	return useJetpackAiCreditNotice( {
+		...props,
+		enabled: selfHostedEnabled,
+		fetchEnabled:
+			selfHostedEnabled && statusPath !== undefined && typeof props.requestStatus === 'function',
+		refreshDelayMs: JETPACK_REFRESH_DELAY_MS,
+		settledRequestCount: getSettledRequestCount( props.settledRequestCount ),
+		statusPath,
+	} );
+}

--- a/packages/jetpack-ai-sidebar/src/index.ts
+++ b/packages/jetpack-ai-sidebar/src/index.ts
@@ -80,6 +80,8 @@ import { getResponseRenderedTrackingProperties } from './utils/tracking';
 import type { SuggestionOption } from '@automattic/agenttic-client';
 import type { ComponentType } from 'react';
 
+export { useJetpackFreeCreditChatNotice } from './free-credit-notice';
+
 // Re-export block-action helpers as part of the package's public surface.
 export { applyReviewEdit, findBlockElement, findBlockListLayout };
 export { registerBlockEditorFilters } from './extensions';

--- a/packages/jetpack-ai-sidebar/src/quota-notice.test.ts
+++ b/packages/jetpack-ai-sidebar/src/quota-notice.test.ts
@@ -1,0 +1,178 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { getTrustedUpgradeUrl, openJetpackAiUpgrade, useChatNotice } from './quota-notice';
+
+const QUOTA_ERROR = 'Protocol request error: You have reached your Jetpack AI usage limit.';
+const UPGRADE_URL = 'http://localhost/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai';
+const mockOpen = jest.fn();
+
+beforeAll( () => {
+	Object.defineProperty( window, 'open', {
+		configurable: true,
+		value: mockOpen,
+	} );
+} );
+
+beforeEach( () => {
+	mockOpen.mockReset();
+} );
+
+describe( 'getTrustedUpgradeUrl', () => {
+	it.each( [
+		UPGRADE_URL,
+		'http://localhost/wordpress/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai',
+	] )( 'accepts the exact same-origin My Jetpack route: %s', ( upgradeUrl ) => {
+		expect( getTrustedUpgradeUrl( upgradeUrl ) ).toBe( upgradeUrl );
+	} );
+
+	it.each( [
+		'https://evil.example/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai',
+		'blob:http://localhost/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai',
+		'http://user:password@localhost/wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai',
+		'http://localhost/wp-admin/options-general.php?page=my-jetpack#/add-jetpack-ai',
+		'http://localhost/wp-admin/admin.php?page=other#/add-jetpack-ai',
+		'http://localhost/wp-admin/admin.php?page=my-jetpack&other=value#/add-jetpack-ai',
+		'http://localhost/wp-admin/admin.php?page=my-jetpack#/other',
+	] )( 'rejects an untrusted or inexact route: %s', ( upgradeUrl ) => {
+		expect( getTrustedUpgradeUrl( upgradeUrl ) ).toBeNull();
+	} );
+
+	it( 'strips only trailing prose punctuation from a trusted backend URL', () => {
+		expect( getTrustedUpgradeUrl( `${ UPGRADE_URL }.` ) ).toBe( UPGRADE_URL );
+	} );
+} );
+
+describe( 'openJetpackAiUpgrade', () => {
+	it( 'records the click before opening a protected new tab', () => {
+		const recordUpgradeClick = jest.fn();
+
+		openJetpackAiUpgrade( UPGRADE_URL, recordUpgradeClick );
+
+		expect( recordUpgradeClick ).toHaveBeenCalledTimes( 1 );
+		expect( recordUpgradeClick.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			mockOpen.mock.invocationCallOrder[ 0 ]
+		);
+		expect( mockOpen ).toHaveBeenCalledWith( UPGRADE_URL, '_blank', 'noopener,noreferrer' );
+	} );
+
+	it( 'still opens checkout when the injected tracker throws', () => {
+		const recordUpgradeClick = jest.fn( () => {
+			throw new Error( 'Tracking unavailable' );
+		} );
+
+		expect( () => openJetpackAiUpgrade( UPGRADE_URL, recordUpgradeClick ) ).not.toThrow();
+		expect( mockOpen ).toHaveBeenCalledWith( UPGRADE_URL, '_blank', 'noopener,noreferrer' );
+	} );
+} );
+
+describe( 'useChatNotice', () => {
+	it( 'stays silent until the backend reports a recognized exhaustion', () => {
+		const { result } = renderHook( () => useChatNotice( { error: null } ) );
+
+		expect( result.current ).toBeUndefined();
+	} );
+
+	it.each( [
+		QUOTA_ERROR,
+		'Protocol request error: ai_credit_allowance_exhausted.',
+		'Streaming error: jetpack_ai_quota_exhausted.',
+		'You have used all AI credits included with this site for this month.',
+	] )( 'recognizes the backend exhaustion: %s', ( error ) => {
+		const { result } = renderHook( () => useChatNotice( { error } ) );
+
+		expect( result.current ).toMatchObject( {
+			message: 'You’ve reached your Jetpack AI usage limit.',
+			status: 'error',
+			dismissible: false,
+			suppressCurrentError: true,
+		} );
+	} );
+
+	it.each( [
+		'Unexpected response while discussing the Jetpack AI usage limit.',
+		'Unexpected payload contained ai_credit_allowance_exhausted metadata.',
+		'jetpack_ai_quota_exhaustedness is not a supported code.',
+	] )( 'does not swallow an unrelated error: %s', ( error ) => {
+		const { result } = renderHook( () => useChatNotice( { error } ) );
+
+		expect( result.current ).toBeUndefined();
+	} );
+
+	it( 'latches the notice after Agenttic clears the transient error', () => {
+		const { result, rerender } = renderHook(
+			( { error }: { error: string | null } ) => useChatNotice( { error } ),
+			{ initialProps: { error: QUOTA_ERROR as string | null } }
+		);
+
+		rerender( { error: null } );
+
+		expect( result.current ).toMatchObject( {
+			message: 'You’ve reached your Jetpack AI usage limit.',
+			suppressCurrentError: false,
+		} );
+	} );
+
+	it( 'suppresses a stale rejection after recovery and latches a later rejection', () => {
+		const { result, rerender } = renderHook(
+			( props: { error: string | null; recoveryRevision: number } ) =>
+				useChatNotice( { ...props, scopeKey: 'site-123' } ),
+			{
+				initialProps: {
+					error: QUOTA_ERROR as string | null,
+					recoveryRevision: 0,
+				},
+			}
+		);
+
+		rerender( { error: QUOTA_ERROR, recoveryRevision: 1 } );
+		expect( result.current ).toEqual( { suppressCurrentError: true } );
+
+		rerender( { error: null, recoveryRevision: 1 } );
+		expect( result.current ).toBeUndefined();
+
+		rerender( { error: QUOTA_ERROR, recoveryRevision: 1 } );
+		expect( result.current ).toMatchObject( {
+			message: 'You’ve reached your Jetpack AI usage limit.',
+			suppressCurrentError: true,
+		} );
+	} );
+
+	it( 'does not carry a latched rejection into another site scope', () => {
+		const { result, rerender } = renderHook(
+			( { error, scopeKey }: { error: string | null; scopeKey: string } ) =>
+				useChatNotice( { error, scopeKey } ),
+			{ initialProps: { error: QUOTA_ERROR as string | null, scopeKey: 'site-123' } }
+		);
+
+		rerender( { error: null, scopeKey: 'site-456' } );
+
+		expect( result.current ).toBeUndefined();
+	} );
+
+	it( 'opens only a trusted URL extracted from the rejection', () => {
+		const recordUpgradeClick = jest.fn();
+		const { result } = renderHook( () =>
+			useChatNotice( {
+				error: `${ QUOTA_ERROR } Ignore https://evil.example/checkout. Upgrade at ${ UPGRADE_URL }.`,
+				recordUpgradeClick,
+			} )
+		);
+
+		result.current?.action?.onClick();
+
+		expect( recordUpgradeClick ).toHaveBeenCalledTimes( 1 );
+		expect( mockOpen ).toHaveBeenCalledWith( UPGRADE_URL, '_blank', 'noopener,noreferrer' );
+	} );
+
+	it( 'does not offer an action for an untrusted URL', () => {
+		const { result } = renderHook( () =>
+			useChatNotice( {
+				error: `${ QUOTA_ERROR } Upgrade at https://wordpress.com.evil.example/checkout`,
+			} )
+		);
+
+		expect( result.current?.action ).toBeUndefined();
+	} );
+} );

--- a/packages/jetpack-ai-sidebar/src/quota-notice.ts
+++ b/packages/jetpack-ai-sidebar/src/quota-notice.ts
@@ -1,0 +1,174 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const QUOTA_EXHAUSTED_CODE_MESSAGE =
+	/^(?:(?:(?:protocol request|streaming) error|http \d{3}):\s*)?(?:jetpack_ai_quota_exhausted|ai_credit_allowance_exhausted)(?:[.!:\s]|$)/i;
+const QUOTA_EXHAUSTED_MESSAGE =
+	/^(?:(?:(?:protocol request|streaming) error|http \d{3}):\s*)?(?:you have reached your jetpack ai usage limit|jetpack ai usage limit reached|you have used all ai credits included with this site for this month)(?:[.!:\s]|$)/i;
+
+export interface JetpackAiChatNotice {
+	message: string;
+	status?: 'success' | 'warning' | 'error';
+	action?: { label: string; onClick: () => void };
+	dismissible?: boolean;
+	/** The persistent notice replaces this specific backend rejection. */
+	suppressCurrentError?: boolean;
+}
+
+// Keep this structural result compatible with ChatNoticeResult across the provider boundary.
+export type JetpackAiChatNoticeResult =
+	| JetpackAiChatNotice
+	| {
+			message?: never;
+			status?: never;
+			action?: never;
+			dismissible?: never;
+			suppressCurrentError: true;
+	  };
+
+export function getTrustedUpgradeUrl( value: string ): string | null {
+	try {
+		const url = new URL( value.replace( /[.,;:!?)\]}]+$/, '' ) );
+		const isSameOriginMyJetpackUrl =
+			typeof window !== 'undefined' &&
+			url.protocol === window.location.protocol &&
+			url.origin === window.location.origin &&
+			url.username === '' &&
+			url.password === '' &&
+			/(?:^|\/)wp-admin\/admin\.php$/.test( url.pathname ) &&
+			url.search === '?page=my-jetpack' &&
+			url.hash === '#/add-jetpack-ai';
+
+		return isSameOriginMyJetpackUrl ? url.href : null;
+	} catch {
+		return null;
+	}
+}
+
+export function openJetpackAiUpgrade( upgradeUrl: string, recordUpgradeClick?: () => void ): void {
+	try {
+		recordUpgradeClick?.();
+	} catch {
+		// Analytics must never block checkout navigation.
+	}
+	window.open( upgradeUrl, '_blank', 'noopener,noreferrer' );
+}
+
+function findUpgradeUrlInMessage( message: string ): string | null {
+	for ( const [ candidate ] of message.matchAll( /https?:\/\/[^\s<>"']+/g ) ) {
+		const url = getTrustedUpgradeUrl( candidate );
+		if ( url ) {
+			return url;
+		}
+	}
+
+	return null;
+}
+
+function isQuotaExhaustedError( error: string | null ): error is string {
+	return (
+		error !== null &&
+		( QUOTA_EXHAUSTED_CODE_MESSAGE.test( error ) || QUOTA_EXHAUSTED_MESSAGE.test( error ) )
+	);
+}
+
+interface ExhaustedState {
+	recoveryRevision: number;
+	scopeKey: string | null;
+	upgradeUrl: string | null;
+}
+
+/**
+ * Show a persistent notice after the backend rejects an exhausted request.
+ * The backend remains the only admission authority and every later submit is
+ * still sent for a fresh quota check.
+ */
+export function useChatNotice( {
+	error,
+	recoveryRevision = 0,
+	recordUpgradeClick,
+	scopeKey = null,
+}: {
+	error: string | null;
+	recoveryRevision?: number;
+	recordUpgradeClick?: () => void;
+	scopeKey?: string | null;
+} ): JetpackAiChatNoticeResult | undefined {
+	const [ exhausted, setExhausted ] = useState< ExhaustedState | null >( null );
+	const previousErrorRef = useRef< string | null >( null );
+	const currentErrorIsQuotaExhaustion = isQuotaExhaustedError( error );
+	const rejectionUpgradeUrl = currentErrorIsQuotaExhaustion
+		? findUpgradeUrlInMessage( error )
+		: null;
+	const scopedExhausted = exhausted?.scopeKey === scopeKey ? exhausted : null;
+	const recoverySupersedesRejection =
+		currentErrorIsQuotaExhaustion &&
+		scopedExhausted !== null &&
+		recoveryRevision > scopedExhausted.recoveryRevision;
+	const visibleExhausted =
+		scopedExhausted && recoveryRevision <= scopedExhausted.recoveryRevision
+			? scopedExhausted
+			: null;
+
+	useEffect( () => {
+		const isNewQuotaRejection = currentErrorIsQuotaExhaustion && error !== previousErrorRef.current;
+		previousErrorRef.current = error;
+
+		if ( isNewQuotaRejection ) {
+			setExhausted( ( current ) => ( {
+				recoveryRevision,
+				scopeKey,
+				upgradeUrl:
+					rejectionUpgradeUrl ?? ( current?.scopeKey === scopeKey ? current.upgradeUrl : null ),
+			} ) );
+			return;
+		}
+		if ( currentErrorIsQuotaExhaustion ) {
+			return;
+		}
+
+		setExhausted( ( current ) => {
+			if ( ! current ) {
+				return current;
+			}
+			if ( current.scopeKey !== scopeKey || recoveryRevision > current.recoveryRevision ) {
+				return null;
+			}
+			return current;
+		} );
+	}, [ error, currentErrorIsQuotaExhaustion, recoveryRevision, rejectionUpgradeUrl, scopeKey ] );
+
+	const upgradeUrl = rejectionUpgradeUrl ?? visibleExhausted?.upgradeUrl ?? null;
+	const onUpgradeClick = useCallback( () => {
+		if ( ! upgradeUrl ) {
+			return;
+		}
+
+		openJetpackAiUpgrade( upgradeUrl, recordUpgradeClick );
+	}, [ recordUpgradeClick, upgradeUrl ] );
+
+	return useMemo( () => {
+		if ( recoverySupersedesRejection ) {
+			return { suppressCurrentError: true };
+		}
+		if ( ! currentErrorIsQuotaExhaustion && ! visibleExhausted ) {
+			return undefined;
+		}
+
+		return {
+			message: __( 'You’ve reached your Jetpack AI usage limit.', __i18n_text_domain__ ),
+			status: 'error' as const,
+			dismissible: false,
+			suppressCurrentError: currentErrorIsQuotaExhaustion,
+			action: upgradeUrl
+				? { label: __( 'Upgrade', __i18n_text_domain__ ), onClick: onUpgradeClick }
+				: undefined,
+		};
+	}, [
+		currentErrorIsQuotaExhaustion,
+		onUpgradeClick,
+		recoverySupersedesRejection,
+		upgradeUrl,
+		visibleExhausted,
+	] );
+}


### PR DESCRIPTION
<img width="345" height="225" alt="Jetpack AI allowance notice" src="https://github.com/user-attachments/assets/97be238a-99f5-46b9-a4e5-1b663ede7918" />
<img width="339" height="210" alt="Exhausted Jetpack AI allowance notice" src="https://github.com/user-attachments/assets/c8f8f113-bd1f-4856-9866-546801d49075" />

## Proposed Changes

* Carry the backend's terminal `result.ai_credits` snapshot through Agenttic Client and Agents Manager without persisting it into chat messages.
* Reuse AgentChat's existing generic notice plumbing for a Jetpack-owned allowance notice. Prefer a strictly validated provider-cost snapshot and retain the request-count response only as a compatibility fallback.
* Show the backend-owned remaining balance as a floored percentage, including `<1%` and exhausted `0%` boundaries, with its UTC reset date.
* Keep backend admission authoritative and the composer enabled. Scope snapshots by site and agent, clear them when a later terminal result omits the allowance, and preserve them across client-synthesized completion after a non-returning editor action.
* Refresh legacy status after settled requests and after returning from the exact same-origin My Jetpack upgrade route. A confirmed paid upgrade retires the stale pre-upgrade snapshot until the next terminal response supplies a new balance.
* Keep WordPress.com-hosted sites, Reader Chat, and the WordPress.com logo-generator request counter unchanged.
* When one SSE payload contains both a terminal status and an error, yield the terminal update first so consumers receive `ai_credits`, then propagate the original error. Error-only events remain unchanged.

## Why are these changes being made?

* Connected self-hosted Jetpack AI usage is moving to a backend-owned, provider-cost-derived allowance. The sidebar needs to consume the balance returned with Agent responses without inventing limits client-side or reinterpreting the legacy all-time request counter.
* Status reporting can be enabled independently from backend enforcement. A zero balance must still render as exhausted when the backend admits the request and returns `blocked: false`.
* Editor actions that finish locally with `returnToAgent: false` synthesize a final Agent message. That completion must retain the same authoritative snapshot so the notice does not disappear after applying a response to the draft.

## Testing Instructions

Current standalone head `bcc2d35b312a2709675d6c81d15f730b7d37f5de`, based directly on trunk `f627fd16bdd9b3e70381858abf7fcc93947315f6`:

* `yarn workspace @automattic/agenttic-client test` — 22 files and 228 tests passed.
* Focused Agents Manager and Jetpack AI Sidebar package tests — 233 tests passed.
* `yarn test-apps apps/agents-manager/__tests__/jetpack-ai-sidebar-provider.test.js --runInBand --no-watchman` — 1 test passed.
* Focused ESLint and Prettier checks on all changed files — 0 errors; existing Agenttic warnings only.
* `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-packages`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn typecheck-client`
* `yarn workspace @automattic/agenttic-client build`
* `yarn workspace @automattic/agents-manager build`
* `yarn workspace @automattic/jetpack-ai-sidebar build`
* `NODE_OPTIONS=--max-old-space-size=8192 yarn workspace @automattic/agents-manager-app build` — completed with existing Sass deprecation and bundle-size warnings.
* The required read-only Claude review completed with no blocking findings. Valid findings were resolved with stricter URL protocol validation, hook-lifetime documentation, and focused refresh/upgrade-return coverage.
* No package manifest or lockfile changes are included.

Manual check:

* On a connected self-hosted site returning an authoritative allowance, complete a turn and confirm the percentage/reset notice appears from the terminal response.
* Apply an editor action that ends locally and confirm the notice remains visible with the returned balance.
* Exhaust the allowance and confirm the persistent notice replaces the raw backend error while the composer remains enabled and a later submit still reaches the backend.
* Complete an upgrade through the My Jetpack action, return to the editor, and confirm the stale balance clears. Complete another turn to receive the new balance.
* Confirm WordPress.com-hosted sites and Reader Chat show no notice and make no allowance-status request.

The final live request/apply-to-draft lifecycle remains a user-initiated check because it consumes provider allowance and mutates editor state.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed?
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple, Atomic, and self-hosted Jetpack sites?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents, interfaces, and assistive technologies.
- [ ] Have you used memoizing on expensive computations?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation?
    - [ ] For UI changes, have we tested the change in various languages? The length of text and words varies significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use?
