### PR TITLE
Scan: use Badge from @wordpress/ui

### DIFF
--- a/client/dashboard/sites/scan-history/dataviews/fields.tsx
+++ b/client/dashboard/sites/scan-history/dataviews/fields.tsx
@@ -1,16 +1,17 @@
-import { Badge } from '@automattic/ui';
 import {
 	Icon,
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { FormattedTime } from '../../../components/formatted-time';
 import { formatYmd } from '../../../utils/datetime';
 import { SeverityBadge, getSeverityLabel } from '../../scan/severity-badge';
 import { getThreatIcon, sortSeverity } from '../../scan/utils';
 import type { Threat } from '@automattic/api-core';
 import type { Field } from '@wordpress/dataviews';
+import type { ComponentProps } from 'react';
 
 const getStatusLabel = ( status: string ): string => {
 	switch ( status ) {
@@ -23,14 +24,14 @@ const getStatusLabel = ( status: string ): string => {
 	}
 };
 
-const getStatusIntent = ( status: string ): 'default' | 'success' | 'warning' => {
+const getStatusIntent = ( status: string ): ComponentProps< typeof Badge >[ 'intent' ] => {
 	switch ( status ) {
 		case 'fixed':
-			return 'success';
+			return 'stable';
 		case 'ignored':
-			return 'warning';
+			return 'informational';
 		default:
-			return 'default';
+			return 'draft';
 	}
 };
 

--- a/client/dashboard/sites/scan-history/dataviews/fields.tsx
+++ b/client/dashboard/sites/scan-history/dataviews/fields.tsx
@@ -29,7 +29,7 @@ const getStatusIntent = ( status: string ): ComponentProps< typeof Badge >[ 'int
 		case 'fixed':
 			return 'stable';
 		case 'ignored':
-			return 'informational';
+			return 'low';
 		default:
 			return 'draft';
 	}

--- a/client/dashboard/sites/scan/severity-badge.tsx
+++ b/client/dashboard/sites/scan/severity-badge.tsx
@@ -32,7 +32,7 @@ export const getSeverityIntent = (
 	if ( severity >= 3 ) {
 		return 'draft';
 	}
-	return 'low';
+	return 'draft';
 };
 
 export const SeverityBadge = ( { severity }: { severity: number } ) => {

--- a/client/dashboard/sites/scan/severity-badge.tsx
+++ b/client/dashboard/sites/scan/severity-badge.tsx
@@ -1,5 +1,6 @@
-import { Badge } from '@automattic/ui';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
+import type { ComponentProps } from 'react';
 
 export const getSeverityLabel = ( severity: number ): string => {
 	if ( severity >= 5 ) {
@@ -19,14 +20,16 @@ export const getSeverityLabel = ( severity: number ): string => {
 	return __( 'Low' );
 };
 
-export const getSeverityIntent = ( severity: number ): 'default' | 'error' | 'warning' => {
+export const getSeverityIntent = (
+	severity: number
+): ComponentProps< typeof Badge >[ 'intent' ] => {
 	if ( severity >= 5 ) {
-		return 'error';
+		return 'high';
 	}
 	if ( severity >= 4 ) {
-		return 'warning';
+		return 'medium';
 	}
-	return 'default';
+	return 'low';
 };
 
 export const SeverityBadge = ( { severity }: { severity: number } ) => {

--- a/client/dashboard/sites/scan/severity-badge.tsx
+++ b/client/dashboard/sites/scan/severity-badge.tsx
@@ -29,6 +29,9 @@ export const getSeverityIntent = (
 	if ( severity >= 4 ) {
 		return 'medium';
 	}
+	if ( severity >= 3 ) {
+		return 'draft';
+	}
 	return 'low';
 };
 


### PR DESCRIPTION
Pre-requirement for removal of the Badge from `@automattic/ui` as we're now focusing on `@wordpress/ui` [Badge](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge-usage-guidelines--docs).

Part of https://github.com/Automattic/wp-calypso/issues/113835

<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

## Proposed Changes

* Replace `@automattic/ui` `Badge` imports with `@wordpress/ui` in dashboard sites screens.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Badge is being removed from `@automattic/ui`, so dashboard sites now imports Badge from `@wordpress/ui`.


## Testing Instructions

See "Scan" section from multi-site-dashboard and see that Scan colors still make sense.

## Active threats
### Before
<img width="1375" height="257" alt="Screenshot 2026-08-31 at 11 44 13" src="https://github.com/user-attachments/assets/515cd360-7acf-4b7d-a25e-3d9747d7a4ce" />


### After
<img width="1381" height="262" alt="Screenshot 2026-08-31 at 11 44 09" src="https://github.com/user-attachments/assets/7388a5c0-1a70-4a6a-b566-9f3597d7640b" />

## Threats history

### Before
#### Ignored
<img width="693" height="86" alt="image" src="https://github.com/user-attachments/assets/223a8fe2-9b46-4525-ad05-2bf52471f6f6" />

#### Severity Critical
<img width="129" height="94" alt="image" src="https://github.com/user-attachments/assets/15bc1782-e8ce-4a1d-9860-0e857993f922" />

#### Severity high
<img width="113" height="110" alt="image" src="https://github.com/user-attachments/assets/a5df2e1d-867c-4290-8186-c223a898790f" />

#### Severity medium
<img width="129" height="108" alt="image" src="https://github.com/user-attachments/assets/207fef42-13c0-4222-83d5-6ab1af6447a0" />

#### Severity low
<img width="118" height="104" alt="image" src="https://github.com/user-attachments/assets/3eac4b75-454d-44cf-a33b-eec8ddf2c84e" />


### After
#### Ignored
<img width="315" height="73" alt="image" src="https://github.com/user-attachments/assets/e0d0bd6a-f4cb-4f6d-a22b-c9bf083e8e16" />

#### Severity Critical
<img width="123" height="108" alt="image" src="https://github.com/user-attachments/assets/196002c9-fd79-492e-8546-85d636687ae6" />

#### Severity high
<img width="125" height="104" alt="image" src="https://github.com/user-attachments/assets/1637f6ec-846e-4fd9-a14c-63fda1291751" />

#### Severity medium
<img width="133" height="93" alt="image" src="https://github.com/user-attachments/assets/7275ada6-f44e-465e-a9ad-b0b0a68c8578" />

#### Severity low
<img width="136" height="107" alt="image" src="https://github.com/user-attachments/assets/1b01397b-8e11-4c62-a6d6-d0f79731339b" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
