### PR TITLE
Domain search: bundle lookup comment no longer says logged-in only

### DIFF
--- a/packages/api-core/src/domain-suggestions/fetchers.ts
+++ b/packages/api-core/src/domain-suggestions/fetchers.ts
@@ -120,9 +120,10 @@ export async function fetchBundleMetadata( search: string ): Promise< BundleMeta
  *
  * Calls the per-FQDN `GET /wpcom/v2/domains/bundle` endpoint (DOMAINS-2207),
  * used lazily by the inline-bundle frontend once the user adds a trigger domain
- * (e.g. `flowers.com`) to the cart. The endpoint is logged-in only (401 when
- * anonymous), flag-gated (404 when off) and query-guarded (400 on empty query);
- * it returns `{ bundle_suggestion: BundleSuggestion | null }`, where the added
+ * (e.g. `flowers.com`) to the cart. The endpoint serves anonymous callers too
+ * (DOMAINS-2239: the group id is not bound to a user), is flag-gated (404 when
+ * off) and query-guarded (400 on empty query); it returns
+ * `{ bundle_suggestion: BundleSuggestion | null }`, where the added
  * domain is the `primary` member and the rest are `companion`s.
  * @param fqdn The fully-qualified trigger domain (e.g. "flowers.com").
  * @returns A bundle suggestion, or null when no bundle applies.


### PR DESCRIPTION
Related to #DOMAINS-2239

## Proposed Changes

Comment-only. `fetchBundleForDomain()` documents `GET /wpcom/v2/domains/bundle` as "logged-in only (401 when anonymous)". That stops being true with 237749-ghe-Automattic/wpcom, which drops the owner binding from the bundle group id and serves anonymous callers. No behaviour change: `useInlineBundles` and `useSuggestionsList` already run for anonymous visitors.

## Why are these changes being made?

Keep the fetcher's contract comment in step with the backend.

## Testing Instructions

None; comment only.

Co-Authored-By: Claude <noreply@anthropic.com>