### PR TITLE
Sites list: bound the transfer poll and stop hiding reverted transfers

### DIFF
--- a/client/sites-dashboard/hooks/test/use-check-site-transfer-status.tsx
+++ b/client/sites-dashboard/hooks/test/use-check-site-transfer-status.tsx
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook, act } from '@testing-library/react';
+import { useCheckSiteTransferStatus } from '../use-check-site-transfer-status';
+
+const mockDispatch = jest.fn();
+let mockTransfer: { status: string; is_stuck?: boolean } | undefined;
+
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => mockDispatch,
+	useSelector: ( selector: ( state: unknown ) => unknown ) => selector( {} ),
+} ) );
+
+jest.mock( 'calypso/state/atomic/transfers/selectors', () => ( {
+	getLatestAtomicTransfer: () => ( { transfer: mockTransfer } ),
+} ) );
+
+jest.mock( 'calypso/state/atomic/transfers/actions', () => ( {
+	requestLatestAtomicTransfer: ( siteId: number ) => ( { type: 'REQUEST_TRANSFER', siteId } ),
+} ) );
+
+jest.mock( 'calypso/state/sites/actions', () => ( {
+	requestSite: ( siteId: number ) => ( { type: 'REQUEST_SITE', siteId } ),
+} ) );
+
+const POLL_MS = 5000;
+
+// One interval at a time: a dispatch has to settle before the next tick is scheduled.
+const elapse = async ( ms: number ) => {
+	for ( let elapsed = 0; elapsed < ms; elapsed += POLL_MS ) {
+		await act( async () => {
+			jest.advanceTimersByTime( POLL_MS );
+			await Promise.resolve();
+		} );
+	}
+};
+
+const pollCount = () =>
+	mockDispatch.mock.calls.filter( ( [ action ] ) => action?.type === 'REQUEST_TRANSFER' ).length;
+
+const renderStatus = ( siteId = 1 ) =>
+	renderHook( ( props: { siteId: number } ) => useCheckSiteTransferStatus( props ), {
+		initialProps: { siteId, intervalTime: POLL_MS },
+	} );
+
+describe( 'useCheckSiteTransferStatus', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		jest.useFakeTimers();
+		mockTransfer = { status: 'active' };
+	} );
+	afterEach( () => jest.useRealTimers() );
+
+	it( 'polls while the transfer is running', async () => {
+		const { result } = renderStatus();
+		await elapse( 30_000 );
+
+		expect( result.current.isTransferring ).toBe( true );
+		expect( pollCount() ).toBeGreaterThan( 4 );
+	} );
+
+	// The bug: nothing ever ended this poll, so a stalled transfer kept a request going every
+	// five seconds for the life of the tab, under a notice that could never resolve.
+	it( 'stops polling and stops claiming activation once the wait runs out', async () => {
+		const { result } = renderStatus();
+		await elapse( 60_000 );
+		expect( result.current.wasTransferring ).toBe( true );
+
+		await elapse( 5 * 60 * 1000 );
+		const settled = pollCount();
+		expect( result.current.isTransferring ).toBe( false );
+		expect( result.current.wasTransferring ).toBe( false );
+
+		await elapse( 60_000 );
+		expect( pollCount() ).toBe( settled );
+	} );
+
+	it( 'never starts a poll for a transfer the server already calls stuck', async () => {
+		mockTransfer = { status: 'active', is_stuck: true };
+		const { result } = renderStatus();
+		await elapse( 30_000 );
+
+		expect( result.current.isTransferring ).toBe( false );
+		// Only the mount request, no interval on top of it.
+		expect( pollCount() ).toBe( 1 );
+	} );
+
+	it.each( [ 'reverted', 'reverting', 'relocating_revert', 'exporting', 'cleanup' ] )(
+		'reports a transfer in %s as failed',
+		async ( status ) => {
+			mockTransfer = { status };
+			const { result } = renderStatus();
+			await elapse( 10_000 );
+
+			expect( result.current.isErrored ).toBe( true );
+			expect( result.current.isTransferring ).toBe( false );
+		}
+	);
+
+	it( 'still treats a completed transfer as a success', async () => {
+		mockTransfer = { status: 'completed' };
+		const { result } = renderStatus();
+		await elapse( 10_000 );
+
+		expect( result.current.isTransferCompleted ).toBe( true );
+		expect( result.current.isErrored ).toBe( false );
+	} );
+
+	// The hook outlives a site switch for any consumer that does not remount it by key.
+	it( 'starts a newly selected site on its own clock', async () => {
+		const { result, rerender } = renderStatus( 1 );
+		await elapse( 5 * 60 * 1000 + 60_000 );
+		expect( result.current.wasTransferring ).toBe( false );
+
+		rerender( { siteId: 2, intervalTime: POLL_MS } );
+		await elapse( 30_000 );
+
+		expect( result.current.isTransferring ).toBe( true );
+		expect( result.current.wasTransferring ).toBe( true );
+	} );
+} );

--- a/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
+++ b/client/sites-dashboard/hooks/use-check-site-transfer-status.tsx
@@ -10,11 +10,27 @@ interface SiteTransferStatusProps {
 	intervalTime?: number;
 }
 
+// Matches the deadline the other transfer waits got in DOTCOM-17961/17962.
+const TRANSFER_DEADLINE_MS = 5 * 60 * 1000;
+
 const activeTransferStatuses = [
 	transferStates.PENDING,
 	transferStates.ACTIVE,
 	transferStates.PROVISIONED,
 	transferStates.RELOCATING_SWITCHEROO,
+] as const;
+
+// The lossless-revert family, plus the two finished failures. The site is on its way back to
+// Simple, so the row has to stop showing an activation in progress.
+const failedTransferStatuses = [
+	transferStates.ERROR,
+	transferStates.REVERTED,
+	transferStates.REVERTING,
+	transferStates.RELOCATING_REVERT,
+	transferStates.RENAMING,
+	transferStates.EXPORTING,
+	transferStates.IMPORTING,
+	transferStates.CLEANUP,
 ] as const;
 
 const isTransferInProgress = ( transferStatus: string | null ) => {
@@ -27,19 +43,34 @@ const isTransferInProgress = ( transferStatus: string | null ) => {
 	return activeTransferStatuses.includes( typedTransferStatus );
 };
 
+const isTransferFailed = ( transferStatus: string | null ) => {
+	if ( ! transferStatus ) {
+		return false;
+	}
+
+	const typedTransferStatus = transferStatus as ( typeof failedTransferStatuses )[ number ];
+
+	return failedTransferStatuses.includes( typedTransferStatus );
+};
+
 export const useCheckSiteTransferStatus = ( {
 	siteId,
 	intervalTime = 3000,
 }: SiteTransferStatusProps ) => {
 	const dispatch = useDispatch();
 
-	const transferStatus = useSelector(
-		( state ) => getLatestAtomicTransfer( state, siteId ).transfer?.status ?? null
-	);
+	const transfer = useSelector( ( state ) => getLatestAtomicTransfer( state, siteId ).transfer );
+	const transferStatus = transfer?.status ?? null;
+
+	// Keyed by site so a switch cannot inherit the previous site's verdict.
+	const [ stalledSiteId, setStalledSiteId ] = useState< number | null >( null );
+	const hasStalled = stalledSiteId === siteId;
 
 	const isTransferCompleted = transferStatus === transferStates.COMPLETED;
-	const isTransferring = isTransferInProgress( transferStatus );
-	const isErrored = transferStatus === transferStates.ERROR;
+	// `is_stuck` is the server's own verdict, so a long-abandoned transfer never starts a poll here.
+	const isTransferring =
+		! hasStalled && ! transfer?.is_stuck && isTransferInProgress( transferStatus );
+	const isErrored = isTransferFailed( transferStatus );
 
 	const [ wasTransferring, setWasTransferring ] = useState( false );
 
@@ -52,7 +83,15 @@ export const useCheckSiteTransferStatus = ( {
 			return;
 		}
 
+		// Wall clock, so a throttled background tab cannot stretch the bound.
+		const watchingSince = Date.now();
+
 		const intervalId = setInterval( () => {
+			if ( Date.now() - watchingSince >= TRANSFER_DEADLINE_MS ) {
+				setStalledSiteId( siteId );
+				return;
+			}
+
 			dispatch( requestLatestAtomicTransfer( siteId ) );
 		}, intervalTime );
 
@@ -83,6 +122,7 @@ export const useCheckSiteTransferStatus = ( {
 		isTransferring,
 		isTransferCompleted,
 		isErrored,
-		wasTransferring,
+		// Once the wait has run out the row stops claiming anything and falls back to its own status.
+		wasTransferring: wasTransferring && ! hasStalled,
 	};
 };


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18270/sites-list-polls-a-transfer-forever-no-deadline-only-an-error-branch

## Proposed Changes

**The sites list now gives up on a transfer that never finishes, and stops hiding the ones that were rolled back.**

- Five-minute deadline on the poll; past it the row drops the badge and shows its normal status again.
- A transfer the server already flags as `is_stuck` never starts a poll at all.
- The seven lossless-revert statuses (`reverting`, `renaming`, `exporting`, …) now count as a failed transfer instead of falling through every branch.

## Why are these changes being made?

Each site row on the list asks the server whether that site is transferring, and re-asks every five seconds while it is. Nothing ever stopped that: a transfer stuck part-way kept one request per row going for as long as the tab stayed open, under a spinner that could never resolve.

The row also only understood two endings — finished or errored. A transfer that gets rolled back to Simple ends a third way, and that outcome matched no branch, so the status cell rendered empty and stayed empty until the page was reloaded ([DOTCOM-18270](https://linear.app/a8c/issue/DOTCOM-18270/sites-list-polls-a-transfer-forever-no-deadline-only-an-error-branch)).

## Testing Instructions

1. `yarn start`, open the sites list on an account with a Business-plan Simple site.
2. Start a hosting activation on that site and watch the row show “Activating site”.
3. In devtools, stub the transfer status endpoint to keep answering `active`.
4. After five minutes the badge disappears, the row shows its usual status, and the network tab shows no further status requests.
