### PR TITLE
Help Center: label recent conversation by chat type

### DIFF
--- a/packages/help-center/src/components/help-center-recent-conversations.tsx
+++ b/packages/help-center/src/components/help-center-recent-conversations.tsx
@@ -30,7 +30,9 @@ const HelpCenterRecentConversations: React.FC = () => {
 	if ( ! lastMessage ) {
 		return null;
 	}
-	const messageDisplayName = lastMessage
+	// Zendesk conversations carry `lastUpdatedAt`; Odie ones don't.
+	const isHappinessChat = 'lastUpdatedAt' in recentConversation;
+	const messageDisplayName = isHappinessChat
 		? __( 'Happiness chat', __i18n_text_domain__ )
 		: __( 'Support assistant chat', __i18n_text_domain__ );
 

--- a/packages/help-center/src/components/test/help-center-recent-conversations.tsx
+++ b/packages/help-center/src/components/test/help-center-recent-conversations.tsx
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { useGetHistoryChats } from '../../hooks';
+import HelpCenterRecentConversations from '../help-center-recent-conversations';
+
+jest.mock( 'react-router-dom', () => ( {
+	useNavigate: () => jest.fn(),
+} ) );
+
+jest.mock( '@automattic/components/src/summary-button', () => ( {
+	__esModule: true,
+	default: ( { title, description }: { title: string; description: React.ReactNode } ) => (
+		<button>
+			<span>{ title }</span>
+			{ description }
+		</button>
+	),
+} ) );
+
+jest.mock( '../../hooks', () => ( {
+	useGetHistoryChats: jest.fn(),
+} ) );
+
+jest.mock( '../../hooks/use-help-center-tracks-event', () => ( {
+	useHelpCenterTracksEvent: () => jest.fn(),
+} ) );
+
+jest.mock( '../../contexts/HelpCenterContext', () => ( {
+	useHelpCenterContext: () => ( { sectionName: 'test' } ),
+} ) );
+
+jest.mock( '../utils', () => ( {
+	getChatLinkFromConversation: () => '/odie',
+	getLastMessage: jest.requireActual( '../utils' ).getLastMessage,
+} ) );
+
+const mockUseGetHistoryChats = useGetHistoryChats as jest.Mock;
+
+const odieConversation = {
+	id: '123',
+	createdAt: 1756000000,
+	messages: [ { received: 1756000000, role: 'user', text: 'How do I connect a custom domain?' } ],
+};
+
+const zendeskConversation = {
+	id: 'zd-1',
+	lastUpdatedAt: 1756000000,
+	messages: [
+		{ id: 'zd-message-1', received: 1756000000, role: 'user', text: 'Cancelling my plan' },
+	],
+};
+
+describe( 'HelpCenterRecentConversations', () => {
+	afterEach( () => {
+		mockUseGetHistoryChats.mockReset();
+	} );
+
+	it( 'labels an AI conversation as a support assistant chat', () => {
+		mockUseGetHistoryChats.mockReturnValue( { recentConversations: [ odieConversation ] } );
+
+		render( <HelpCenterRecentConversations /> );
+
+		expect( screen.getByText( 'Support assistant chat' ) ).toBeVisible();
+		expect( screen.queryByText( 'Happiness chat' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'labels a Zendesk conversation as a Happiness chat', () => {
+		mockUseGetHistoryChats.mockReturnValue( { recentConversations: [ zendeskConversation ] } );
+
+		render( <HelpCenterRecentConversations /> );
+
+		expect( screen.getByText( 'Happiness chat' ) ).toBeVisible();
+	} );
+
+	it( 'renders nothing when there are no conversations', () => {
+		mockUseGetHistoryChats.mockReturnValue( { recentConversations: [] } );
+
+		const { container } = render( <HelpCenterRecentConversations /> );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/packages/help-center/src/test/__mocks__/automattic-components.js
+++ b/packages/help-center/src/test/__mocks__/automattic-components.js
@@ -5,4 +5,5 @@ const React = require( 'react' );
 
 module.exports = {
 	FormInputValidation: ( { text } ) => React.createElement( 'p', null, text ),
+	TimeSince: ( { date } ) => React.createElement( 'time', { dateTime: date }, date ),
 };


### PR DESCRIPTION
Part of DOTSUP-539

## Proposed Changes

* Pick the "Recent Conversation" card subtitle from the conversation type instead of a condition that could only ever be true, so AI threads read "Support assistant chat" and Zendesk threads read "Happiness chat".
* Add unit tests covering both labels and the empty-history case.

## Why are these changes being made?

The card's label came from this ternary:

```js
if ( ! lastMessage ) {
	return null;
}
const messageDisplayName = lastMessage
	? __( 'Happiness chat' )
	: __( 'Support assistant chat' );
```

The guard directly above returns early when `lastMessage` is falsy, so the false branch was unreachable and every recent conversation was labelled "Happiness chat" — including conversations that never left the AI assistant. Users could not tell from their history whether they had talked to a Happiness Engineer or to the Support Assistant.

`use-get-history-chats` already distinguishes the two conversation shapes with `'lastUpdatedAt' in conversation` (present on Zendesk conversations, absent on Odie ones); this uses the same check.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Open the Help Center with a recent AI-only conversation in your history. The "Recent Conversation" card subtitle reads **Support assistant chat**.
3. Escalate a conversation to a Happiness Engineer, reopen the Help Center home. The card for that conversation reads **Happiness chat**.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/help-center && yarn dev --sync`.
3. Visit any Simple, Atomic, or CIAB site (the site itself does not need sandboxing).
4. Open the Help Center and repeat steps 2-3 above.

Unit tests: `npx jest -c packages/help-center/jest.config.js`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
