### PR TITLE
Checkout: add messages to email validation failed event

### DIFF
--- a/client/my-sites/checkout/src/lib/contact-validation.tsx
+++ b/client/my-sites/checkout/src/lib/contact-validation.tsx
@@ -113,7 +113,7 @@ async function runLoggedOutEmailValidationCheck(
 	contactInfo: ManagedContactDetails,
 	reduxDispatch: CalypsoDispatch,
 	translate: ReturnType< typeof useTranslate >
-): Promise< unknown > {
+): Promise< { validationResult: unknown; emailErrors: Record< string, string > } > {
 	const email = contactInfo.email?.value ?? '';
 	return getSignupEmailValidationResult( email, ( newEmail: string ) =>
 		getEmailTakenLoginRedirectMessage( newEmail, reduxDispatch, translate )
@@ -169,11 +169,8 @@ export async function validateContactDetails(
 	};
 
 	if ( isLoggedOutCart ) {
-		const loggedOutValidationResult = await runLoggedOutEmailValidationCheck(
-			contactInfo,
-			reduxDispatch,
-			translate
-		);
+		const { validationResult: loggedOutValidationResult, emailErrors } =
+			await runLoggedOutEmailValidationCheck( contactInfo, reduxDispatch, translate );
 		if ( shouldDisplayErrors ) {
 			handleContactValidationResult( {
 				translate,
@@ -189,6 +186,8 @@ export async function validateContactDetails(
 				reduxDispatch(
 					recordTracksEvent( 'calypso_checkout_contact_email_validation_failed', {
 						country: contactInfo.countryCode?.value,
+						error_codes: Object.keys( emailErrors ).join( ', ' ) || undefined,
+						messages: Object.values( emailErrors ).join( ', ' ) || undefined,
 					} )
 				);
 			}
@@ -441,6 +440,9 @@ async function getSignupEmailValidationResult(
 		email,
 		is_from_registrationless_checkout: true,
 	} );
+	// Keep the raw messages from the endpoint before they are replaced below; they
+	// are keyed by error code, which is what makes a failure attributable.
+	const emailErrors = response.messages?.email ?? {};
 	const signupValidationErrorResponse = getSignupValidationErrorResponse(
 		response,
 		email,
@@ -448,11 +450,11 @@ async function getSignupEmailValidationResult(
 	);
 
 	if ( Object.keys( signupValidationErrorResponse ).length === 0 ) {
-		return response;
+		return { validationResult: response, emailErrors };
 	}
 	const validationResponse = {
 		...response,
 		messages: signupValidationErrorResponse,
 	};
-	return validationResponse;
+	return { validationResult: validationResponse, emailErrors };
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2481

## Proposed Changes

Adds `messages` and `error_codes` to the `calypso_checkout_contact_email_validation_failed` Tracks event, so logged-out checkout email validation failures can be attributed to a cause. The raw, code-keyed messages from the validation endpoint are now captured before they are overwritten, and threaded back to the fire site.

* Capture `response.messages.email` in `getSignupEmailValidationResult` before `getSignupValidationErrorResponse` replaces it.
* Return `{ validationResult, emailErrors }` from `getSignupEmailValidationResult` and `runLoggedOutEmailValidationCheck` (both module-private; no external callers).
* Record `messages` (joined message text) and `error_codes` (joined error codes) on the event, omitting either when empty rather than sending an empty string.

## Why are these changes being made?

Over the 14 days to 2026-08-27 this event fired 4,138 times across 2,483 users with no `messages` property on any of them, while its sibling `calypso_checkout_contact_info_validation_failed` carried one on 100% of its 22,097 fires. Roughly 64% of those users also fired `calypso_checkout_wpcom_email_exists` the same day, so their cause is already known. The remaining ~888 users are indistinguishable today: a format rejection, a blocked domain and any other reason the endpoint can return all land in the same property-less event.

The fix is small but not quite a one-liner, because the obvious value is the wrong one. `loggedOutValidationResult` is in scope at the fire site and does have a `messages` property, but `getSignupEmailValidationResult` has already replaced the endpoint's response with the output of `getSignupValidationErrorResponse`, which is shaped `{ email: [ message ] }`. In the `taken` branch that message is a React element built by `translate()` with an `<a>` component, so recording it would have written `[object Object]` for the single largest cause. Capturing the raw messages first avoids that and preserves the error codes, which the reshaped value discards.

`error_codes` is recorded alongside `messages` because the validation request sends `locale: getLocaleSlug()`, so the message text arrives already translated and would fragment across languages when grouped. The codes are locale-independent and are what a query should actually group on.

One limitation worth recording: `wpcomValidateSignupEmail` throws on a failed request, so the event never fires when the endpoint is unavailable. This change separates the rejection reasons from each other, but "the endpoint was down" is still not a cause this event can carry.

## Testing Instructions

No automated tests — `contact-validation.tsx` has no existing test file, and the change is confined to what is passed to `recordTracksEvent`.

Manual testing:

* Open checkout while logged out, for example by adding a plan to the cart in a logged-out browser profile and proceeding to checkout.
* With the Tracks debug output enabled (`localStorage.setItem( 'debug', 'calypso:analytics*' )`), enter an email address that already has an account and submit the contact step.
* Confirm `calypso_checkout_contact_email_validation_failed` now fires with `error_codes: 'taken'` and a `messages` value containing the message text, alongside the existing `country`.
* Repeat with a malformed address (for example `not-an-email`) and confirm the event carries the corresponding code rather than `taken`.
* Confirm the error message rendered in the form is unchanged in both cases, including the "please log in" link in the taken case.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

This PR changes what we record on an existing Tracks event. The added properties are validation error codes and their server-supplied message text; no email address or other user-entered value is added to the event.
