### PR TITLE
Plugins: stop an abandoned upload from taking the upload page over

### DIFF
--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -43,6 +43,7 @@ import {
 	hasLoadedSitePurchasesFromServer,
 } from 'calypso/state/purchases/selectors';
 import getPluginUploadError from 'calypso/state/selectors/get-plugin-upload-error';
+import getPluginUploadMethod from 'calypso/state/selectors/get-plugin-upload-method';
 import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id';
 import isPluginUploadComplete from 'calypso/state/selectors/is-plugin-upload-complete';
 import isPluginUploadInProgress from 'calypso/state/selectors/is-plugin-upload-in-progress';
@@ -259,6 +260,9 @@ const mapStateToProps = ( state ) => {
 	const hasUploadPluginsFeature = siteHasFeature( state, siteId, FEATURE_UPLOAD_PLUGINS );
 	const canUpload = hasSftpFeature || hasUploadPluginsFeature;
 	const isStandaloneJetpack = isJetpack && ! isAtomic;
+	// The retry on the install error screen clears the attempt but cannot abort its request. Without
+	// a method on record this page owns no upload, whatever that request reports afterwards.
+	const hasLiveUpload = !! getPluginUploadMethod( state, siteId );
 	const { eligibilityHolds, eligibilityWarnings } = getEligibility( state, siteId );
 	// Use this selector to take advantage of eligibility card placeholders
 	// before data has loaded.
@@ -276,8 +280,8 @@ const mapStateToProps = ( state ) => {
 		hasUploadPluginsFeature,
 		canUpload,
 		isStandaloneJetpack,
-		inProgress: isPluginUploadInProgress( state, siteId ),
-		complete: isPluginUploadComplete( state, siteId ),
+		inProgress: hasLiveUpload && isPluginUploadInProgress( state, siteId ),
+		complete: hasLiveUpload && isPluginUploadComplete( state, siteId ),
 		failed: !! error,
 		pluginId: getUploadedPluginId( state, siteId ),
 		error,

--- a/client/my-sites/plugins/plugin-upload/test/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/test/index.jsx
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { legacy_createStore as createStore } from 'redux';
+import PluginUpload from '../index';
+
+let mockUploadMethod = null;
+let mockInProgress = false;
+let mockUploadedPluginId = null;
+
+const mockPage = jest.fn();
+
+jest.mock( '@automattic/calypso-router', () => {
+	const page = ( ...args ) => mockPage( ...args );
+	page.back = () => {};
+	return page;
+} );
+
+jest.mock( 'calypso/state/selectors/get-plugin-upload-method', () => () => mockUploadMethod );
+jest.mock( 'calypso/state/selectors/is-plugin-upload-in-progress', () => () => mockInProgress );
+jest.mock(
+	'calypso/state/selectors/is-plugin-upload-complete',
+	() => () => ! mockInProgress && !! mockUploadedPluginId
+);
+jest.mock( 'calypso/state/selectors/get-uploaded-plugin-id', () => () => mockUploadedPluginId );
+jest.mock( 'calypso/state/selectors/get-plugin-upload-error', () => () => null );
+jest.mock( 'calypso/state/selectors/is-site-wpcom-atomic', () => () => true );
+jest.mock( 'calypso/state/selectors/site-has-feature', () => () => true );
+
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	getSiteAdminUrl: () => 'https://example.wordpress.com/wp-admin/',
+	isJetpackSite: () => false,
+	isJetpackSiteMultiSite: () => false,
+} ) );
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSiteId: () => 77203074,
+	getSelectedSite: () => ( { ID: 77203074, slug: 'example.wordpress.com' } ),
+	getSelectedSiteSlug: () => 'example.wordpress.com',
+} ) );
+jest.mock( 'calypso/state/automated-transfer/selectors', () => ( {
+	getEligibility: () => ( { eligibilityHolds: [], eligibilityWarnings: [] } ),
+	isEligibleForAutomatedTransfer: () => true,
+} ) );
+jest.mock( 'calypso/state/purchases/selectors', () => ( {
+	isFetchingSitePurchases: () => false,
+	hasLoadedSitePurchasesFromServer: () => true,
+} ) );
+jest.mock( 'calypso/sites-dashboard/utils', () => ( { isHostingTrialSite: () => false } ) );
+
+jest.mock( 'calypso/state/plugins/upload/actions', () => ( {
+	uploadPlugin: () => ( { type: 'PLUGIN_UPLOAD' } ),
+	clearPluginUpload: ( siteId ) => ( { type: 'PLUGIN_UPLOAD_CLEAR', siteId } ),
+} ) );
+jest.mock( 'calypso/state/automated-transfer/actions', () => ( {
+	fetchAutomatedTransferStatus: () => ( { type: 'FETCH_TRANSFER_STATUS' } ),
+	initiateAutomatedTransferWithPluginZip: () => ( { type: 'INITIATE_TRANSFER' } ),
+} ) );
+jest.mock( 'calypso/state/marketplace/purchase-flow/actions', () => ( {
+	productToBeInstalled: () => ( { type: 'PRODUCT_TO_BE_INSTALLED' } ),
+} ) );
+jest.mock( 'calypso/state/notices/actions', () => ( {
+	successNotice: () => ( { type: 'SUCCESS_NOTICE' } ),
+} ) );
+
+jest.mock( 'calypso/blocks/upload-drop-zone', () => () => <div>Drop zone</div> );
+jest.mock( 'calypso/blocks/eligibility-warnings', () => () => null );
+jest.mock( 'calypso/blocks/upsell-nudge', () => () => null );
+jest.mock( 'calypso/components/data/query-atat-eligibility', () => () => null );
+jest.mock( 'calypso/components/data/query-site-purchases', () => () => null );
+jest.mock( 'calypso/hosting/server-settings/hosting-activate-status', () => () => null );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => () => null );
+jest.mock( 'calypso/components/navigation-header', () => () => null );
+
+// The store's contents do not matter — every selector is mocked — but a real one lets a dispatch
+// push the new upload state through connect, which is what the page reacts to.
+const tick = ( state = 0, action ) => ( action.type === 'TICK' ? state + 1 : state );
+
+const renderUploadPage = () => {
+	const store = createStore( tick );
+	render(
+		<Provider store={ store }>
+			<PluginUpload />
+		</Provider>
+	);
+	return () => act( () => store.dispatch( { type: 'TICK' } ) );
+};
+
+describe( 'PluginUpload', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUploadMethod = null;
+		mockInProgress = false;
+		mockUploadedPluginId = null;
+	} );
+
+	it( 'offers the drop zone when no upload has been started', () => {
+		renderUploadPage();
+
+		expect( screen.getByText( 'Drop zone' ) ).toBeVisible();
+	} );
+
+	it( 'hides the drop zone while this page has an upload running', () => {
+		mockUploadMethod = 'direct';
+		mockInProgress = true;
+		renderUploadPage();
+
+		expect( screen.queryByText( 'Drop zone' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the drop zone once this page has an upload of its own that finished', () => {
+		mockUploadMethod = 'direct';
+		mockUploadedPluginId = 'give';
+		renderUploadPage();
+
+		expect( screen.queryByText( 'Drop zone' ) ).not.toBeInTheDocument();
+	} );
+
+	// The bug: the retry on the install error screen clears the attempt but cannot abort its
+	// request, so the abandoned upload finished a moment later and took the drop zone away again.
+	it( 'keeps the drop zone when an abandoned upload finishes afterwards', () => {
+		const settle = renderUploadPage();
+		expect( screen.getByText( 'Drop zone' ) ).toBeVisible();
+
+		mockUploadedPluginId = 'give';
+		settle();
+
+		expect( screen.getByText( 'Drop zone' ) ).toBeVisible();
+	} );
+
+	// The same abandoned attempt reaching the transfer status reducer, which reports it as running.
+	it( 'does not send the user to the install page for an abandoned upload', () => {
+		const settle = renderUploadPage();
+
+		mockInProgress = true;
+		settle();
+
+		expect( mockPage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'sends the user to the install page when this page starts an upload', () => {
+		const settle = renderUploadPage();
+
+		mockUploadMethod = 'direct';
+		mockInProgress = true;
+		settle();
+
+		expect( mockPage ).toHaveBeenCalledWith( '/marketplace/plugin/install/example.wordpress.com' );
+	} );
+} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18184/plugin-upload-page-drop-zone-vanishes-again-if-an-abandoned-upload

## Proposed Changes

**The plugin upload page now ignores an upload the user already walked away from.**

- Reads `inProgress` / `complete` only while an upload method is on record — which is exactly what **Try uploading again** retires.
- Also stops that abandoned attempt from bouncing the user to the install screen when a later transfer status reports it as running.

## Why are these changes being made?

When a zip install ends on the error screen, **Try uploading again** clears the upload and returns you to the upload page, where the drop zone is waiting. But the original upload request is still running — nothing cancels it. A few seconds later it finishes, writes its result back, and the page decides an upload is done: the drop zone disappears, leaving an empty card with no explanation and no way to pick a file.

Reloading fixes it, and nothing on screen tells you that ([DOTCOM-18184](https://linear.app/a8c/issue/DOTCOM-18184/plugin-upload-page-drop-zone-vanishes-again-if-an-abandoned-upload)). The upload state is stored per site rather than per attempt, so the page had no way to tell a live upload from one that had been retired.

## Testing Instructions

1. `yarn start`, go to `/plugins/upload/:site` on a Business-plan site and start a zip upload.
2. Force the wait to end on the timeout screen while the upload request is still in flight.
3. Click **Try uploading again** — the drop zone is there.
4. Wait for the original upload to finish server-side: the drop zone stays, and you are not sent to the install screen.
