### PR TITLE
Signup launch-site: keep the plan step for free-trial sites

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -5,6 +5,11 @@ import {
 	PRODUCT_1GB_SPACE,
 	getPlan,
 	TERM_MONTHLY,
+	PLAN_PERSONAL_TRIAL_MONTHLY,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_MIGRATION_TRIAL_MONTHLY,
+	PLAN_HOSTING_TRIAL_MONTHLY,
+	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Site, AddOns } from '@automattic/data-stores';
@@ -1088,10 +1093,22 @@ export function maybeAddStorageAddonToCart( stepName, defaultDependencies, nextP
 	}
 }
 
+const FREE_TRIAL_PLAN_SLUGS = [
+	PLAN_PERSONAL_TRIAL_MONTHLY,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_MIGRATION_TRIAL_MONTHLY,
+	PLAN_HOSTING_TRIAL_MONTHLY,
+	PLAN_WOO_HOSTED_FREE_TRIAL_MONTHLY,
+];
+
 export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 	const { isPaidPlan, sitePlanSlug, submitSignupStep } = nextProps;
 	const fulfilledDependencies = [];
 	const dependenciesFromDefaults = {};
+
+	// A free trial has a non-free product ID, so it reads as a paid plan. Keep the plan
+	// step available so trial sites can still purchase the underlying plan on launch.
+	const isFreeTrialPlan = FREE_TRIAL_PLAN_SLUGS.includes( sitePlanSlug );
 
 	// Check for plan-specific default theme
 	if ( defaultDependencies && defaultDependencies.themeSlugWithRepo ) {
@@ -1099,7 +1116,7 @@ export function isPlanFulfilled( stepName, defaultDependencies, nextProps ) {
 		dependenciesFromDefaults.themeSlugWithRepo = defaultDependencies.themeSlugWithRepo;
 	}
 
-	if ( isPaidPlan ) {
+	if ( isPaidPlan && ! isFreeTrialPlan ) {
 		const cartItems = undefined;
 		submitSignupStep(
 			{ stepName, cartItems, wasSkipped: true },

--- a/client/lib/signup/test/step-actions.js
+++ b/client/lib/signup/test/step-actions.js
@@ -6,6 +6,7 @@ import {
 	PLAN_PERSONAL,
 	PLAN_PERSONAL_MONTHLY,
 	PLAN_BUSINESS_2_YEARS,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 } from '@automattic/calypso-products';
 import nock from 'nock';
 import flows from 'calypso/signup/config/flows';
@@ -262,6 +263,23 @@ describe( 'isPlanFulfilled()', () => {
 		const nextProps = {
 			isPaidPlan: false,
 			sitePlanSlug: 'sitePlanSlug',
+			submitSignupStep,
+		};
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+		expect( submitSignupStep ).not.toHaveBeenCalled();
+
+		isPlanFulfilled( stepName, undefined, nextProps );
+
+		expect( flows.excludeStep ).not.toHaveBeenCalled();
+		expect( submitSignupStep ).not.toHaveBeenCalled();
+	} );
+
+	test( 'should not remove a step for a free trial plan', () => {
+		const stepName = 'plans';
+		const nextProps = {
+			isPaidPlan: true,
+			sitePlanSlug: PLAN_ECOMMERCE_TRIAL_MONTHLY,
 			submitSignupStep,
 		};
 

--- a/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
@@ -27,15 +27,6 @@ const usePlanIntentFromSiteMeta = (): IntentFromSiteMeta => {
 		};
 	}
 
-	// A site on the eCommerce free trial has no `site_intent` (the trial is created
-	// without a plan in the cart), so scope its plans to the commerce-oriented grid.
-	if ( isECommerceTrial ) {
-		return {
-			processing: false,
-			intent: 'plans-business-trial',
-		};
-	}
-
 	const siteIntent = siteIntentResponse.data?.site_intent;
 
 	// ai-site-builder flow is specifically the free trial for big sky
@@ -61,6 +52,15 @@ const usePlanIntentFromSiteMeta = (): IntentFromSiteMeta => {
 		return {
 			processing: false,
 			intent: 'plans-videopress',
+		};
+	}
+
+	// A site on the eCommerce free trial has no `site_intent` (the trial is created
+	// without a plan in the cart), so scope its plans to the commerce-oriented grid.
+	if ( isECommerceTrial ) {
+		return {
+			processing: false,
+			intent: 'plans-business-trial',
 		};
 	}
 

--- a/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
@@ -27,6 +27,17 @@ const usePlanIntentFromSiteMeta = (): IntentFromSiteMeta => {
 		};
 	}
 
+	// A site on the eCommerce free trial has no `site_intent` (the trial is created
+	// without a plan in the cart), so scope its plans to the commerce-oriented grid.
+	// Only the eCommerce trial is handled here; the other trial types (personal,
+	// migration, hosting, woo-hosted) are intentionally left untouched in this change.
+	if ( isECommerceTrial ) {
+		return {
+			processing: false,
+			intent: 'plans-business-trial',
+		};
+	}
+
 	const siteIntent = siteIntentResponse.data?.site_intent;
 
 	// ai-site-builder flow is specifically the free trial for big sky
@@ -52,17 +63,6 @@ const usePlanIntentFromSiteMeta = (): IntentFromSiteMeta => {
 		return {
 			processing: false,
 			intent: 'plans-videopress',
-		};
-	}
-
-	// A site on the eCommerce free trial has no `site_intent` (the trial is created
-	// without a plan in the cart), so scope its plans to the commerce-oriented grid.
-	// Only the eCommerce trial is handled here; the other trial types (personal,
-	// migration, hosting, woo-hosted) are intentionally left untouched in this change.
-	if ( isECommerceTrial ) {
-		return {
-			processing: false,
-			intent: 'plans-business-trial',
 		};
 	}
 

--- a/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
@@ -1,5 +1,6 @@
 import { useSiteIntent, Onboard } from '@automattic/data-stores';
 import { useSelector } from 'react-redux';
+import isSiteOnECommerceTrial from 'calypso/state/sites/plans/selectors/trials/is-site-on-ecommerce-trial';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import type { PlansIntent } from '@automattic/plans-grid-next';
@@ -14,12 +15,24 @@ interface IntentFromSiteMeta {
 const usePlanIntentFromSiteMeta = (): IntentFromSiteMeta => {
 	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	const isECommerceTrial = useSelector( ( state ) =>
+		isSiteOnECommerceTrial( state, selectedSiteId ?? null )
+	);
 	const siteIntentResponse = useSiteIntent( selectedSiteId );
 
 	if ( siteIntentResponse.isFetching ) {
 		return {
 			processing: true,
 			intent: undefined, // undefined -> we haven't observed any metadata yet
+		};
+	}
+
+	// A site on the eCommerce free trial has no `site_intent` (the trial is created
+	// without a plan in the cart), so scope its plans to the commerce-oriented grid.
+	if ( isECommerceTrial ) {
+		return {
+			processing: false,
+			intent: 'plans-business-trial',
 		};
 	}
 

--- a/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
@@ -57,6 +57,8 @@ const usePlanIntentFromSiteMeta = (): IntentFromSiteMeta => {
 
 	// A site on the eCommerce free trial has no `site_intent` (the trial is created
 	// without a plan in the cart), so scope its plans to the commerce-oriented grid.
+	// Only the eCommerce trial is handled here; the other trial types (personal,
+	// migration, hosting, woo-hosted) are intentionally left untouched in this change.
 	if ( isECommerceTrial ) {
 		return {
 			processing: false,


### PR DESCRIPTION
Fixes p1787825846047019-slack-C02BGMUPFEC

## Proposed Changes

* In `isPlanFulfilled` (`client/lib/signup/step-actions/index.js`), don't exclude the `plans-launch` step when the site's current plan is a free-trial plan, detected by plan slug.
* Scope the plan grid for eCommerce-trial sites: `usePlanIntentFromSiteMeta` now resolves an eCommerce-trial site to the `plans-business-trial` intent (Business + Commerce) instead of the full WPCOM plan list.
* Added a unit test covering the eCommerce free-trial case.

## Why are these changes being made?

When a site on a free trial (e.g. the eCommerce trial, `ecommerce-trial-bundle-monthly`) launches via `start/launch-site`, the flow only offered `domains-launch` and never let the user purchase the underlying plan.

The flow defines steps `[ 'domains-launch', 'plans-launch', 'launch' ]`, but `isPlanFulfilled` skips and excludes `plans-launch` whenever `isPaidPlan` is true. `isPaidPlan` comes from `isCurrentPlanPaid`, which only checks the plan's `product_id` against a hardcoded free-plan list. A trial has a non-free `product_id`, so it is misclassified as a fully paid plan and the plan step is dropped.

Even once the step is shown, it displayed the whole plan list. The eCommerce trial is created without a plan in the cart, so the site never gets a `sell` `site_intent`, and `PlansFeaturesMain` fell back to the default WPCOM grid. Keying off the current plan and returning the `plans-business-trial` intent scopes it to the commerce plans.

This mirrors the `/plans/<site>` page, which correctly detects the free trial and prompts the user to complete their purchase. `isCurrentPlanPaid` is left untouched (it is used widely).

Scope notes:
* Only the **eCommerce** trial gets a scoped grid here; the other trial types (personal, migration, hosting, woo-hosted) are intentionally left untouched in this PR.
* The trial-slug list is kept local rather than added to `@automattic/calypso-products`, per that package's `AGENTS.md` direction to treat it as frozen and not add new slug lists/predicates.

## Testing Instructions

1. Use a site on the eCommerce trial plan.
2. Go to `start/launch-site/launch?siteSlug=<trial-site>` and click Launch.
3. After `domains-launch`, confirm the flow now shows the plan-selection step (`plans-launch`), scoped to the commerce plans (Business + Commerce), instead of launching directly.
4. Confirm a site on a regular paid plan still skips the plan step, and a free-plan site still shows it.
5. `yarn test-client client/lib/signup/test/step-actions.js` passes.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)