### PR TITLE
Refactor copy for gift purchase in checkout

### DIFF
--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -368,7 +368,8 @@ function LineItemWrapper( {
 	let isDeletable = canItemBeRemovedFromCart( product, responseCart ) && ! isWooMobile;
 	const has100YearPlanProduct = has100YearPlan( responseCart );
 	const signupFlowName = getSignupCompleteFlowName();
-	const shouldShowComparison = isWpComPlan( product.product_slug );
+	const shouldShowComparison =
+		isWpComPlan( product.product_slug ) && ! responseCart.is_gift_purchase;
 
 	if ( isCopySiteFlow( signupFlowName ) && ! product.is_domain_registration ) {
 		isDeletable = false;

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1224,7 +1224,9 @@ export function LineItemSublabelAndPrice( {
 		return (
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
-				{ translate( '%(price)s per month', { args: { price } } ) }
+				{ product.is_gift_purchase
+					? translate( '%(price)s (one time payment)', { args: { price } } )
+					: translate( '%(price)s per month', { args: { price } } ) }
 				<LineItemExpiryDates product={ product } />
 			</>
 		);
@@ -1234,7 +1236,9 @@ export function LineItemSublabelAndPrice( {
 		return (
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
-				{ translate( '%(price)s per year', { args: { price } } ) }
+				{ product.is_gift_purchase
+					? translate( '%(price)s (one time payment)', { args: { price } } )
+					: translate( '%(price)s per year', { args: { price } } ) }
 				<LineItemExpiryDates product={ product } />
 			</>
 		);
@@ -1244,7 +1248,9 @@ export function LineItemSublabelAndPrice( {
 		return (
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
-				{ translate( '%(price)s per two years', { args: { price } } ) }
+				{ product.is_gift_purchase
+					? translate( '%(price)s (one time payment)', { args: { price } } )
+					: translate( '%(price)s per two years', { args: { price } } ) }
 				<LineItemExpiryDates product={ product } />
 			</>
 		);
@@ -1254,7 +1260,9 @@ export function LineItemSublabelAndPrice( {
 		return (
 			<>
 				<DefaultLineItemSublabel product={ product } />:{ ' ' }
-				{ translate( '%(price)s per three years', { args: { price } } ) }
+				{ product.is_gift_purchase
+					? translate( '%(price)s (one time payment)', { args: { price } } )
+					: translate( '%(price)s per three years', { args: { price } } ) }
 				<LineItemExpiryDates product={ product } />
 			</>
 		);


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes CHE-538

## Proposed Changes

| Before | After |
|--------|------|
| <img width="729" height="555" alt="Screenshot 2026-08-31 at 2 55 07 PM" src="https://github.com/user-attachments/assets/ecda3edd-5ccc-469f-8e00-5993e3c04dff" /> | <img width="753" height="580" alt="Screenshot 2026-08-31 at 2 53 03 PM" src="https://github.com/user-attachments/assets/c684d353-eb6d-4453-8cbb-d39580ec24f3" /> | 

- Makes it clear that gifts purchases are one-time purchases.
- Hide comparison to monthly on right-hand side.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particular
particularly when researching old changes in ly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Because gift purchase are one-time purchases for renewals, so the existing language can make customers feel like they are paying a recurring fee when they are only paying one time.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You will need two accounts to test this. Make sure one account (the recipient of the gift) has an active WordPress.com gift. Find the subscription id from SA. From the gifter's account:
- Visit `/checkout/<plan>/gift/<subscription id>` where `<plan>` is the same slug you would expect to see if you were checking out with this plan. This will probably be one of `value-bundle`, `personal-bundle`, `premium-bundle`, `business-bundle` or `ecommerce-bundle`.
- Observe that there is no mention of a recurring payment, that the gift purchase is a one time payment. Use the screenshots above as a visual comparison.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
