### PR TITLE
Agents Manager: poll for the reply after a page change mid-turn

### DIFF
--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -735,9 +735,13 @@ export default function OrchestratorChat( {
 		},
 	} );
 
-	const { isLoading: isLoadingConversation } = useConversation( {
+	const { isLoading: isLoadingConversation, isAwaitingReply } = useConversation( {
 		maxPages: isReaderChat ? 1 : 10,
 		enabled: shouldLoadConversation,
+		// A transcript that ends on a user turn means the server is still
+		// answering a question asked before this page loaded. Poll for the reply
+		// unless the merchant has taken over the conversation in this tab.
+		refetchWhileAwaitingReply: ! isReaderChat && ! hasUserSentMessage && ! isProcessing,
 		onSuccess: ( loadedMessages, serverSessionId ) => {
 			if ( isReaderChat && ( hasUserSentMessage || messages.length > 0 || isProcessing ) ) {
 				return;
@@ -1732,8 +1736,15 @@ export default function OrchestratorChat( {
 	const shouldSuppressTransientThinking = Boolean(
 		latestDisplayedMessage?.role === 'agent' && latestDisplayedMessage.suppressThinking
 	);
+	let processingMessage = progressMessage;
+	if ( isUploadingImages ) {
+		processingMessage = __( 'Uploading images…', __i18n_text_domain__ );
+	} else if ( isAwaitingReply ) {
+		processingMessage = __( 'Waiting for the reply…', __i18n_text_domain__ );
+	}
 	const showProcessingIndicator =
-		( isProcessing || ( isThinking && ! isBuildingSite ) ) && ! shouldSuppressTransientThinking;
+		( isProcessing || isAwaitingReply || ( isThinking && ! isBuildingSite ) ) &&
+		! shouldSuppressTransientThinking;
 
 	// Determine which suggestions to show following Big Sky's logic:
 	// - Empty chat: show provider empty-view chips plus dynamic chips.
@@ -1815,9 +1826,7 @@ export default function OrchestratorChat( {
 			suggestions={ suggestions }
 			emptyViewSuggestions={ displayedEmptyViewSuggestions }
 			isProcessing={ showProcessingIndicator || isUploadingImages }
-			thinkingMessage={
-				isUploadingImages ? __( 'Uploading images…', __i18n_text_domain__ ) : progressMessage
-			}
+			thinkingMessage={ processingMessage }
 			error={ chatError || uploadError }
 			onSubmit={ onSubmitWithImages }
 			onAbort={ handleAbort }

--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -738,10 +738,9 @@ export default function OrchestratorChat( {
 	const { isLoading: isLoadingConversation, isAwaitingReply } = useConversation( {
 		maxPages: isReaderChat ? 1 : 10,
 		enabled: shouldLoadConversation,
-		// A transcript that ends on a user turn means the server is still
-		// answering a question asked before this page loaded. Poll for the reply
-		// unless the merchant has taken over the conversation in this tab.
-		refetchWhileAwaitingReply: ! isReaderChat && ! hasUserSentMessage && ! isProcessing,
+		// Poll for a reply to a question sent before this page loaded, unless the
+		// merchant has taken over the conversation in this tab.
+		refetchWhileAwaitingReply: ! hasUserSentMessage && ! isProcessing,
 		onSuccess: ( loadedMessages, serverSessionId ) => {
 			if ( isReaderChat && ( hasUserSentMessage || messages.length > 0 || isProcessing ) ) {
 				return;

--- a/packages/agents-manager/src/hooks/__tests__/use-conversation.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-conversation.test.ts
@@ -97,7 +97,7 @@ describe( 'useConversation', () => {
 			return refetchInterval( { state: { data: { messages } } } );
 		};
 
-		it( 'polls while the transcript ends on a user turn', () => {
+		it( 'polls while the transcript ends on a user turn', async () => {
 			setOrchestrator();
 			mockUseQuery.mockReturnValue( {
 				data: { messages: [ user ] },
@@ -107,13 +107,14 @@ describe( 'useConversation', () => {
 			} );
 
 			const { result } = renderHook( () => useConversation( { refetchWhileAwaitingReply: true } ) );
+			await waitFor( () => expect( loadConversation ).toHaveBeenCalled() );
 
 			expect( intervalFor( [ user ] ) ).toBe( 3000 );
 			expect( mockUseQuery.mock.calls[ 0 ][ 0 ].refetchIntervalInBackground ).toBe( true );
 			expect( result.current.isAwaitingReply ).toBe( true );
 		} );
 
-		it( 'stops once a reply lands', () => {
+		it( 'stops once a reply lands', async () => {
 			setOrchestrator();
 			mockUseQuery.mockReturnValue( {
 				data: { messages: [ user, agent ] },
@@ -123,6 +124,7 @@ describe( 'useConversation', () => {
 			} );
 
 			const { result } = renderHook( () => useConversation( { refetchWhileAwaitingReply: true } ) );
+			await waitFor( () => expect( loadConversation ).toHaveBeenCalled() );
 
 			expect( intervalFor( [ user, agent ] ) ).toBe( false );
 			expect( result.current.isAwaitingReply ).toBe( false );
@@ -132,6 +134,7 @@ describe( 'useConversation', () => {
 			setOrchestrator();
 			renderHook( () => useConversation( {} ) );
 			expect( intervalFor( [ user ] ) ).toBe( false );
+			expect( loadConversation ).not.toHaveBeenCalled();
 		} );
 
 		it( 'polls while a locally pending turn has no reply on the server yet', async () => {
@@ -161,10 +164,30 @@ describe( 'useConversation', () => {
 			expect( refetchInterval( { state: { data: { messages: answered } } } ) ).toBe( false );
 		} );
 
-		it( 'gives up after the timeout', () => {
+		it( 'does not poll on the lag case if the local store cannot be read', async () => {
+			setOrchestrator();
+			const consoleError = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+			( loadConversation as jest.Mock ).mockRejectedValueOnce( new Error( 'quota' ) );
+			mockUseQuery.mockReturnValue( {
+				data: { messages: [ user, agent ] },
+				error: null,
+				isError: false,
+				isLoading: false,
+			} );
+
+			const { result } = renderHook( () => useConversation( { refetchWhileAwaitingReply: true } ) );
+			await waitFor( () => expect( loadConversation ).toHaveBeenCalled() );
+
+			expect( result.current.isAwaitingReply ).toBe( false );
+			expect( intervalFor( [ user, agent ] ) ).toBe( false );
+			consoleError.mockRestore();
+		} );
+
+		it( 'gives up after the timeout', async () => {
 			setOrchestrator();
 			const now = jest.spyOn( Date, 'now' ).mockReturnValue( 1_000 );
 			renderHook( () => useConversation( { refetchWhileAwaitingReply: true } ) );
+			await waitFor( () => expect( loadConversation ).toHaveBeenCalled() );
 
 			expect( intervalFor( [ user ] ) ).toBe( 3000 );
 			now.mockReturnValue( 1_000 + 5 * 60_000 );

--- a/packages/agents-manager/src/hooks/__tests__/use-conversation.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-conversation.test.ts
@@ -75,4 +75,64 @@ describe( 'useConversation', () => {
 			} )
 		);
 	} );
+
+	describe( 'refetchWhileAwaitingReply', () => {
+		const setOrchestrator = () =>
+			mockUseAgentsManagerContext.mockReturnValue( {
+				agentConfig: { agentId: 'wp-orchestrator', sessionId: 's1', authProvider: {} },
+			} );
+		const user = { role: 'user', kind: 'message', messageId: 'u', parts: [] };
+		const agent = { role: 'agent', kind: 'message', messageId: 'a', parts: [] };
+		const intervalFor = ( messages: unknown[] ) => {
+			const { refetchInterval } = mockUseQuery.mock.calls[ 0 ][ 0 ];
+			return refetchInterval( { state: { data: { messages } } } );
+		};
+
+		it( 'polls while the transcript ends on a user turn', () => {
+			setOrchestrator();
+			mockUseQuery.mockReturnValue( {
+				data: { messages: [ user ] },
+				error: null,
+				isError: false,
+				isLoading: false,
+			} );
+
+			const { result } = renderHook( () => useConversation( { refetchWhileAwaitingReply: true } ) );
+
+			expect( intervalFor( [ user ] ) ).toBe( 3000 );
+			expect( result.current.isAwaitingReply ).toBe( true );
+		} );
+
+		it( 'stops once a reply lands', () => {
+			setOrchestrator();
+			mockUseQuery.mockReturnValue( {
+				data: { messages: [ user, agent ] },
+				error: null,
+				isError: false,
+				isLoading: false,
+			} );
+
+			const { result } = renderHook( () => useConversation( { refetchWhileAwaitingReply: true } ) );
+
+			expect( intervalFor( [ user, agent ] ) ).toBe( false );
+			expect( result.current.isAwaitingReply ).toBe( false );
+		} );
+
+		it( 'does not poll unless asked to', () => {
+			setOrchestrator();
+			renderHook( () => useConversation( {} ) );
+			expect( intervalFor( [ user ] ) ).toBe( false );
+		} );
+
+		it( 'gives up after the timeout', () => {
+			setOrchestrator();
+			const now = jest.spyOn( Date, 'now' ).mockReturnValue( 1_000 );
+			renderHook( () => useConversation( { refetchWhileAwaitingReply: true } ) );
+
+			expect( intervalFor( [ user ] ) ).toBe( 3000 );
+			now.mockReturnValue( 1_000 + 90_000 );
+			expect( intervalFor( [ user ] ) ).toBe( false );
+			now.mockRestore();
+		} );
+	} );
 } );

--- a/packages/agents-manager/src/hooks/__tests__/use-conversation.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-conversation.test.ts
@@ -6,6 +6,14 @@ jest.mock(
 	'@automattic/agenttic-client',
 	() => ( {
 		loadAllMessagesFromServer: jest.fn(),
+		loadConversation: jest.fn( async () => ( { messages: [] } ) ),
+		getUnresolvedMessages: ( messages: Array< { metadata?: { deliveryStatus?: string } } > ) =>
+			messages.filter( ( m ) => m.metadata?.deliveryStatus === 'pending' ),
+		messageTextContent: ( m: { parts: Array< { type: string; text?: string } > } ) =>
+			m.parts
+				.filter( ( part ) => part.type === 'text' )
+				.map( ( part ) => part.text )
+				.join( '\n' ),
 	} ),
 	{ virtual: true }
 );
@@ -18,8 +26,9 @@ jest.mock( '../../contexts', () => ( {
 	useAgentsManagerContext: jest.fn(),
 } ) );
 
+import { loadConversation } from '@automattic/agenttic-client';
 import { useQuery } from '@tanstack/react-query';
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { useAgentsManagerContext } from '../../contexts';
 import useConversation from '../use-conversation';
 
@@ -122,6 +131,33 @@ describe( 'useConversation', () => {
 			setOrchestrator();
 			renderHook( () => useConversation( {} ) );
 			expect( intervalFor( [ user ] ) ).toBe( false );
+		} );
+
+		it( 'polls while a locally pending turn has no reply on the server yet', async () => {
+			setOrchestrator();
+			const pendingUser = {
+				role: 'user',
+				kind: 'message',
+				messageId: 'p',
+				parts: [ { type: 'text', text: 'still waiting' } ],
+				metadata: { deliveryStatus: 'pending' },
+			};
+			( loadConversation as jest.Mock ).mockResolvedValueOnce( { messages: [ pendingUser ] } );
+			// Server transcript ends on an older agent turn and lacks the pending question.
+			mockUseQuery.mockReturnValue( {
+				data: { messages: [ user, agent ] },
+				error: null,
+				isError: false,
+				isLoading: false,
+			} );
+
+			const { result } = renderHook( () => useConversation( { refetchWhileAwaitingReply: true } ) );
+			await waitFor( () => expect( result.current.isAwaitingReply ).toBe( true ) );
+
+			const { refetchInterval } = mockUseQuery.mock.calls.at( -1 )[ 0 ];
+			expect( refetchInterval( { state: { data: { messages: [ user, agent ] } } } ) ).toBe( 3000 );
+			const answered = [ user, agent, { ...pendingUser, metadata: {} }, agent ];
+			expect( refetchInterval( { state: { data: { messages: answered } } } ) ).toBe( false );
 		} );
 
 		it( 'gives up after the timeout', () => {

--- a/packages/agents-manager/src/hooks/__tests__/use-conversation.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-conversation.test.ts
@@ -109,6 +109,7 @@ describe( 'useConversation', () => {
 			const { result } = renderHook( () => useConversation( { refetchWhileAwaitingReply: true } ) );
 
 			expect( intervalFor( [ user ] ) ).toBe( 3000 );
+			expect( mockUseQuery.mock.calls[ 0 ][ 0 ].refetchIntervalInBackground ).toBe( true );
 			expect( result.current.isAwaitingReply ).toBe( true );
 		} );
 

--- a/packages/agents-manager/src/hooks/__tests__/use-conversation.test.ts
+++ b/packages/agents-manager/src/hooks/__tests__/use-conversation.test.ts
@@ -167,7 +167,7 @@ describe( 'useConversation', () => {
 			renderHook( () => useConversation( { refetchWhileAwaitingReply: true } ) );
 
 			expect( intervalFor( [ user ] ) ).toBe( 3000 );
-			now.mockReturnValue( 1_000 + 90_000 );
+			now.mockReturnValue( 1_000 + 5 * 60_000 );
 			expect( intervalFor( [ user ] ) ).toBe( false );
 			now.mockRestore();
 		} );

--- a/packages/agents-manager/src/hooks/use-conversation.ts
+++ b/packages/agents-manager/src/hooks/use-conversation.ts
@@ -16,12 +16,9 @@ interface Config {
 	maxPages?: number;
 	enabled?: boolean;
 	/**
-	 * Keep refetching while a question is still unanswered on the server: the
-	 * loaded transcript ends on a user turn, or a turn this tab sent (still
-	 * `pending` in the local store) is not yet followed by a reply — the server
-	 * persists a turn only once it starts processing it, so right after a page
-	 * change it may be missing entirely. Stops once the reply lands or after
-	 * `POLL_TIMEOUT_MS`.
+	 * Refetch until a question is answered: the transcript ends on a user turn,
+	 * or a turn this tab sent (`pending` in the local store) has no reply yet —
+	 * the server persists a turn only once it starts processing it.
 	 */
 	refetchWhileAwaitingReply?: boolean;
 	onSuccess?: ( messages: Message[], sessionId: string ) => void;
@@ -31,7 +28,7 @@ interface Result {
 	data: { messages: Message[]; sessionId?: string } | undefined;
 	isLoading: boolean;
 	isError: boolean;
-	/** True while polling for a reply to a transcript-final user turn. */
+	/** True while polling for an unanswered question. */
 	isAwaitingReply: boolean;
 }
 
@@ -78,17 +75,9 @@ export default function useConversation( {
 	const [ pendingTexts, setPendingTexts ] = useState< string[] >( [] );
 
 	useEffect( () => {
-		if ( ! refetchWhileAwaitingReply || ! sessionId ) {
-			return;
+		if ( sessionId ) {
+			loadPendingTexts( sessionId ).then( setPendingTexts );
 		}
-		let cancelled = false;
-		loadPendingTexts( sessionId )
-			.then( ( texts ) => ! cancelled && setPendingTexts( texts ) )
-			.catch( () => {} );
-		return () => {
-			cancelled = true;
-		};
-		// eslint-disable-next-line react-hooks/exhaustive-deps -- read the local store once per session
 	}, [ sessionId ] );
 
 	const shouldPoll = ( current?: { messages: Message[] } ): boolean => {

--- a/packages/agents-manager/src/hooks/use-conversation.ts
+++ b/packages/agents-manager/src/hooks/use-conversation.ts
@@ -76,10 +76,28 @@ export default function useConversation( {
 	const [ pendingTexts, setPendingTexts ] = useState< string[] >( [] );
 
 	useEffect( () => {
-		if ( sessionId ) {
-			loadPendingTexts( sessionId ).then( setPendingTexts );
+		if ( ! refetchWhileAwaitingReply || ! sessionId ) {
+			setPendingTexts( [] );
+			return;
 		}
-	}, [ sessionId ] );
+		let cancelled = false;
+		loadPendingTexts( sessionId )
+			.then( ( texts ) => {
+				if ( ! cancelled ) {
+					setPendingTexts( texts );
+				}
+			} )
+			.catch( ( loadError ) => {
+				// eslint-disable-next-line no-console
+				console.error( '[useConversation] Error loading pending turns:', loadError );
+				if ( ! cancelled ) {
+					setPendingTexts( [] );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ refetchWhileAwaitingReply, sessionId ] );
 
 	const shouldPoll = ( current?: { messages: Message[] } ): boolean => {
 		const unanswered =

--- a/packages/agents-manager/src/hooks/use-conversation.ts
+++ b/packages/agents-manager/src/hooks/use-conversation.ts
@@ -1,6 +1,12 @@
-import { loadAllMessagesFromServer, type Message } from '@automattic/agenttic-client';
+import {
+	getUnresolvedMessages,
+	loadAllMessagesFromServer,
+	loadConversation,
+	messageTextContent,
+	type Message,
+} from '@automattic/agenttic-client';
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { API_BASE_URL } from '../constants';
 import { useAgentsManagerContext } from '../contexts';
 import { getConversationBotId } from '../utils/conversation-bot-id';
@@ -10,9 +16,12 @@ interface Config {
 	maxPages?: number;
 	enabled?: boolean;
 	/**
-	 * Keep refetching while the loaded transcript ends on a user turn — the
-	 * server has the question but is still answering (e.g. the page changed
-	 * mid-reply). Polling stops once a reply lands or after `POLL_TIMEOUT_MS`.
+	 * Keep refetching while a question is still unanswered on the server: the
+	 * loaded transcript ends on a user turn, or a turn this tab sent (still
+	 * `pending` in the local store) is not yet followed by a reply — the server
+	 * persists a turn only once it starts processing it, so right after a page
+	 * change it may be missing entirely. Stops once the reply lands or after
+	 * `POLL_TIMEOUT_MS`.
 	 */
 	refetchWhileAwaitingReply?: boolean;
 	onSuccess?: ( messages: Message[], sessionId: string ) => void;
@@ -34,6 +43,22 @@ function endsOnUserTurn( data?: { messages: Message[] } ): boolean {
 	return last?.role === 'user';
 }
 
+/** Whether the transcript has an agent reply after the last user turn with `text`. */
+function hasReplyTo( messages: Message[], text: string ): boolean {
+	const index = messages.findLastIndex(
+		( m ) => m.role === 'user' && messageTextContent( m ) === text
+	);
+	return index !== -1 && messages.slice( index + 1 ).some( ( m ) => m.role === 'agent' );
+}
+
+/** Text of user turns this tab sent that were still in flight when it last persisted. */
+async function loadPendingTexts( sessionId: string ): Promise< string[] > {
+	const { messages } = await loadConversation( sessionId );
+	return getUnresolvedMessages( messages )
+		.filter( ( m ) => m.role === 'user' )
+		.map( messageTextContent );
+}
+
 /**
  * Fetches a conversation from the server when a `sessionId` is available.
  */
@@ -50,9 +75,27 @@ export default function useConversation( {
 	const onSuccessRef = useRef( onSuccess );
 	onSuccessRef.current = onSuccess;
 	const pollStartedAtRef = useRef< number | null >( null );
+	const [ pendingTexts, setPendingTexts ] = useState< string[] >( [] );
+
+	useEffect( () => {
+		if ( ! refetchWhileAwaitingReply || ! sessionId ) {
+			return;
+		}
+		let cancelled = false;
+		loadPendingTexts( sessionId )
+			.then( ( texts ) => ! cancelled && setPendingTexts( texts ) )
+			.catch( () => {} );
+		return () => {
+			cancelled = true;
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps -- read the local store once per session
+	}, [ sessionId ] );
 
 	const shouldPoll = ( current?: { messages: Message[] } ): boolean => {
-		if ( ! refetchWhileAwaitingReply || ! endsOnUserTurn( current ) ) {
+		const unanswered =
+			endsOnUserTurn( current ) ||
+			( !! current && pendingTexts.some( ( text ) => ! hasReplyTo( current.messages, text ) ) );
+		if ( ! refetchWhileAwaitingReply || ! unanswered ) {
 			pollStartedAtRef.current = null;
 			return false;
 		}

--- a/packages/agents-manager/src/hooks/use-conversation.ts
+++ b/packages/agents-manager/src/hooks/use-conversation.ts
@@ -9,6 +9,12 @@ import { isReaderChatAgent } from '../utils/is-reader-chat-agent';
 interface Config {
 	maxPages?: number;
 	enabled?: boolean;
+	/**
+	 * Keep refetching while the loaded transcript ends on a user turn — the
+	 * server has the question but is still answering (e.g. the page changed
+	 * mid-reply). Polling stops once a reply lands or after `POLL_TIMEOUT_MS`.
+	 */
+	refetchWhileAwaitingReply?: boolean;
 	onSuccess?: ( messages: Message[], sessionId: string ) => void;
 }
 
@@ -16,6 +22,16 @@ interface Result {
 	data: { messages: Message[]; sessionId?: string } | undefined;
 	isLoading: boolean;
 	isError: boolean;
+	/** True while polling for a reply to a transcript-final user turn. */
+	isAwaitingReply: boolean;
+}
+
+const POLL_INTERVAL_MS = 3000;
+const POLL_TIMEOUT_MS = 90_000;
+
+function endsOnUserTurn( data?: { messages: Message[] } ): boolean {
+	const last = data?.messages[ data.messages.length - 1 ];
+	return last?.role === 'user';
 }
 
 /**
@@ -24,6 +40,7 @@ interface Result {
 export default function useConversation( {
 	maxPages = 10,
 	enabled = true,
+	refetchWhileAwaitingReply = false,
 	onSuccess = () => {},
 }: Config ): Result {
 	const { agentConfig } = useAgentsManagerContext();
@@ -32,6 +49,16 @@ export default function useConversation( {
 	// Keep a ref to the latest callback to avoid re-triggering effects when it changes.
 	const onSuccessRef = useRef( onSuccess );
 	onSuccessRef.current = onSuccess;
+	const pollStartedAtRef = useRef< number | null >( null );
+
+	const shouldPoll = ( current?: { messages: Message[] } ): boolean => {
+		if ( ! refetchWhileAwaitingReply || ! endsOnUserTurn( current ) ) {
+			pollStartedAtRef.current = null;
+			return false;
+		}
+		pollStartedAtRef.current ??= Date.now();
+		return Date.now() - pollStartedAtRef.current < POLL_TIMEOUT_MS;
+	};
 
 	const { data, isLoading, isError, error } = useQuery( {
 		// eslint-disable-next-line @tanstack/query/exhaustive-deps -- we only want to refetch when sessionId changes
@@ -57,6 +84,7 @@ export default function useConversation( {
 		// usually do not have.
 		enabled: enabled && !! sessionId && ! isReaderChatAgent( agentId ),
 		refetchOnWindowFocus: false,
+		refetchInterval: ( query ) => ( shouldPoll( query.state.data ) ? POLL_INTERVAL_MS : false ),
 	} );
 
 	useEffect(
@@ -76,5 +104,5 @@ export default function useConversation( {
 		}
 	}, [ error ] );
 
-	return { data, isLoading, isError };
+	return { data, isLoading, isError, isAwaitingReply: shouldPoll( data ) };
 }

--- a/packages/agents-manager/src/hooks/use-conversation.ts
+++ b/packages/agents-manager/src/hooks/use-conversation.ts
@@ -128,6 +128,8 @@ export default function useConversation( {
 		enabled: enabled && !! sessionId && ! isReaderChatAgent( agentId ),
 		refetchOnWindowFocus: false,
 		refetchInterval: ( query ) => ( shouldPoll( query.state.data ) ? POLL_INTERVAL_MS : false ),
+		// Keep waiting for the reply even if the merchant switches tabs meanwhile.
+		refetchIntervalInBackground: true,
 	} );
 
 	useEffect(

--- a/packages/agents-manager/src/hooks/use-conversation.ts
+++ b/packages/agents-manager/src/hooks/use-conversation.ts
@@ -33,7 +33,8 @@ interface Result {
 }
 
 const POLL_INTERVAL_MS = 3000;
-const POLL_TIMEOUT_MS = 90_000;
+// Tool-heavy turns (catalog reviews, batch edits) can run for minutes.
+const POLL_TIMEOUT_MS = 5 * 60_000;
 
 function endsOnUserTurn( data?: { messages: Message[] } ): boolean {
 	const last = data?.messages[ data.messages.length - 1 ];

--- a/packages/agenttic-client/src/index.ts
+++ b/packages/agenttic-client/src/index.ts
@@ -121,6 +121,8 @@ export {
 // server.
 export {
 	getUnresolvedMessages,
+	loadConversation,
+	messageTextContent,
 	reconcileWithServer,
 	type DeliveryStatus,
 } from './react/conversationStorage';

--- a/packages/agenttic-client/src/react/conversationStorage.ts
+++ b/packages/agenttic-client/src/react/conversationStorage.ts
@@ -315,7 +315,7 @@ export function getUnresolvedMessages( messages: Message[] ): Message[] {
  * Joined text parts — messageId is regenerated on restore, so text matches.
  * @param message - The message whose text parts to join.
  */
-function messageTextContent( message: Message ): string {
+export function messageTextContent( message: Message ): string {
 	return message.parts
 		.filter( ( part ): part is TextPart => part.type === 'text' )
 		.map( ( part ) => part.text )


### PR DESCRIPTION
Part of WOOAI-872, WOOAI-847

## Proposed Changes

* `useConversation`: new `refetchWhileAwaitingReply` option. Refetch every 3s (up to 5 minutes — tool-heavy Woo turns run long) while a question is still unanswered on the server — the loaded transcript ends on a user turn, **or** a turn this tab sent (still `pending` in agenttic's local store) has no reply yet. The second signal matters: the server persists a turn only once it starts processing it, so a transcript fetched right after a page change can still end on the previous agent turn. Exposes `isAwaitingReply`. `refetchIntervalInBackground: true` so a merchant who switches tabs while waiting still gets the reply.
* `@automattic/agenttic-client`: export `loadConversation` and `messageTextContent` (used to read the pending turns).
* `OrchestratorChat`: enable it for non-Reader agents unless the merchant has already sent a message in this tab or a send is in progress (so a refetch can never replace a live stream); show a "Waiting for the reply…" indicator meanwhile.

## Why are these changes being made?

When a merchant sends a message and the page changes before the reply comes back (own navigation, or the agent's `wp_admin__navigate`), the next page fetches the conversation once on mount. If the server is still answering, that fetch returns the question with no reply — and nothing ever fetches again, so the panel shows an unanswered bubble until the next full page load. Merchants read this as "the assistant didn't answer".

The turn *did* reach the server in this case, so no client-side recovery is needed — just keep fetching until the reply is there.

## Testing Instructions

```
yarn jest -c test/packages/jest.config.js packages/agents-manager/src/hooks/__tests__/use-conversation.test.ts
```

Sandbox (Simple/Atomic): sandbox `widgets.wp.com`, `cd apps/agents-manager && yarn dev --sync`, enable *Unified Chat* under Automattician Options on `/wp-admin/profile.php`.

1. In wp-admin, open the chat and send any message so a session exists.
2. Send a question that takes a while to answer, then immediately change admin page.
3. The question appears with "Waiting for the reply…"; the transcript is refetched every ~3s (Network tab: `odie/chat/...`) and the reply appears without reloading, indicator gone.
4. Send a message on the new page while waiting — polling stops and the normal flow takes over.

Calypso (`yarn start`): same steps within the Calypso chat.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? — Simple, via sandboxed `widgets.wp.com`
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
