### PR TITLE
Revert "Omnibar: enable in production"

### DIFF
--- a/config/dashboard-production.json
+++ b/config/dashboard-production.json
@@ -36,7 +36,6 @@
 		"dashboard/account-recovery-interstitial": false,
 		"dashboard/dark-mode-rollout": false,
 		"dashboard/enable-percentage-rollout": true,
-		"dashboard/omnibar-radical": true,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,
 		"dolly/telegram": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -34,7 +34,6 @@
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
 		"dashboard/force-opt-in-visibility": false,
-		"dashboard/omnibar-radical": true,
 		"dashboard/plans": true,
 		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": true,

--- a/config/production.json
+++ b/config/production.json
@@ -46,7 +46,6 @@
 		"current-site/notice": true,
 		"dark-mode": false,
 		"dashboard/enable-percentage-rollout": true,
-		"dashboard/omnibar-radical": true,
 		"dashboard/rollout-advance-notice": true,
 		"dashboard/simulate-full-rollout": false,
 		"dashboard/wp-beta-program": true,


### PR DESCRIPTION
Just in case, this reverts https://github.com/Automattic/wp-calypso/pull/113827.
