### PR TITLE
Dashboard: fix legacy /domains/manage URLs resolving to a domain named "manage"

### DIFF
--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -1,4 +1,4 @@
-import { DomainSubtype, DomainTransferStatus } from '@automattic/api-core';
+import { DomainSubtype, DomainTransferStatus, isWpError } from '@automattic/api-core';
 import {
 	domainDiagnosticsQuery,
 	domainQuery,
@@ -115,6 +115,36 @@ export const domainsContactInfoRoute = createRoute( {
 	)
 );
 
+const fetchDomainOrNotFound = async ( domainName: string ) => {
+	try {
+		return await queryClient.ensureQueryData( domainQuery( domainName ) );
+	} catch ( error ) {
+		if ( isWpError( error ) && error.statusCode === 400 && error.error === 'invalid_domain' ) {
+			throw notFound();
+		}
+		throw error;
+	}
+};
+
+// Legacy Calypso domain management lived under `/domains/manage`. Those paths
+// would otherwise be read as `/domains/$domainName` with a domain named
+// "manage", so keep old links and bookmarks pointing at the domains list.
+export const domainsLegacyManageRoute = createRoute( {
+	getParentRoute: () => domainsRoute,
+	path: 'manage/$',
+	beforeLoad: () => {
+		throw dashboardRedirect( { to: '/domains' } );
+	},
+} );
+
+export const domainsLegacyManageIndexRoute = createRoute( {
+	getParentRoute: () => domainsRoute,
+	path: 'manage',
+	beforeLoad: () => {
+		throw dashboardRedirect( { to: '/domains' } );
+	},
+} );
+
 // Domain management root route
 export const domainRoute = createRoute( {
 	head: ( { params } ) => ( {
@@ -128,7 +158,7 @@ export const domainRoute = createRoute( {
 	path: 'domains/$domainName',
 	errorComponent: lazyRouteComponent( () => import( '../../domains/domain/error' ) ),
 	loader: async ( { params: { domainName }, location } ) => {
-		const domain = await queryClient.ensureQueryData( domainQuery( domainName ) );
+		const domain = await fetchDomainOrNotFound( domainName );
 		const isNameServersSubRoute = location.pathname.includes( '/name-servers' );
 		const isTransferSubRoute = location.pathname.includes( '/transfer' );
 		const isContactInfoSubRoute = location.pathname.includes( '/contact-info' );
@@ -729,7 +759,12 @@ export const domainConnectionSetupRoute = createRoute( {
 
 export const createDomainsRoutes = () => {
 	return [
-		domainsRoute.addChildren( [ domainsIndexRoute, domainsContactInfoRoute ] ),
+		domainsRoute.addChildren( [
+			domainsIndexRoute,
+			domainsContactInfoRoute,
+			domainsLegacyManageIndexRoute,
+			domainsLegacyManageRoute,
+		] ),
 		domainRoute.addChildren( [
 			domainOverviewRoute,
 			domainDnsRoute.addChildren( [ domainDnsIndexRoute, domainDnsAddRoute, domainDnsEditRoute ] ),

--- a/client/dashboard/app/router/domains.ts
+++ b/client/dashboard/app/router/domains.ts
@@ -39,6 +39,7 @@ import {
 	checkDomainNotPendingRegistration,
 } from '../../utils/domain-permissions';
 import { queryParamToArray } from '../../utils/url';
+import { resolveLegacyDomainPath } from './legacy-domain-paths';
 import { dashboardRedirect } from './redirect';
 import { rootRoute } from './root';
 
@@ -128,12 +129,15 @@ const fetchDomainOrNotFound = async ( domainName: string ) => {
 
 // Legacy Calypso domain management lived under `/domains/manage`. Those paths
 // would otherwise be read as `/domains/$domainName` with a domain named
-// "manage", so keep old links and bookmarks pointing at the domains list.
+// "manage", so translate them to their dashboard equivalent.
 export const domainsLegacyManageRoute = createRoute( {
 	getParentRoute: () => domainsRoute,
 	path: 'manage/$',
-	beforeLoad: () => {
-		throw dashboardRedirect( { to: '/domains' } );
+	beforeLoad: ( { params } ) => {
+		throw dashboardRedirect( {
+			href: resolveLegacyDomainPath( ( params as { _splat?: string } )._splat ?? '' ),
+			replace: true,
+		} );
 	},
 } );
 
@@ -141,7 +145,7 @@ export const domainsLegacyManageIndexRoute = createRoute( {
 	getParentRoute: () => domainsRoute,
 	path: 'manage',
 	beforeLoad: () => {
-		throw dashboardRedirect( { to: '/domains' } );
+		throw dashboardRedirect( { to: '/domains', replace: true } );
 	},
 } );
 

--- a/client/dashboard/app/router/legacy-domain-paths.ts
+++ b/client/dashboard/app/router/legacy-domain-paths.ts
@@ -1,0 +1,164 @@
+/**
+ * Classic Calypso kept domain management under `/domains/manage`. The dashboard
+ * serves `/domains/$domainName`, so those paths would otherwise resolve to a
+ * domain literally named "manage" and fail with `invalid_domain`. This
+ * translates the legacy grammar to its closest dashboard destination.
+ *
+ * The two families are `/domains/manage/<domain>/<slug>/<site>` and its
+ * `/domains/manage/all/…` counterpart. Anything unrecognized falls back to the
+ * domains list rather than guessing.
+ */
+
+const DOMAINS_LIST = '/domains';
+
+// Legacy slugs with no dashboard counterpart map to the domain overview.
+const SUBPAGE_BY_SLUG: Record< string, string > = {
+	edit: '',
+	'manage-consent': '',
+	redirect: '',
+	'redirect-settings': '',
+	'edit-contact-info': '/contact-info',
+	dns: '/dns',
+	'add-dns-record': '/dns/add',
+	'edit-dns-record': '/dns/edit',
+	security: '/security',
+	'domain-connect-mapping': '/domain-connection-setup',
+};
+
+const SUBPAGE_BY_TRANSFER_TYPE: Record< string, string > = {
+	'': '/transfer',
+	out: '/transfer',
+	in: '/domain-transfer-setup',
+	precheck: '/domain-transfer-setup',
+	'any-user': '/transfer/any-user',
+	'other-user': '/transfer/other-user',
+	'other-site': '/transfer/other-site',
+};
+
+// Legacy paths encode the domain twice so that site redirects, whose "domain"
+// can contain a slash, survive routing. One decode happens before we see it.
+function decodeDomain( segment: string ) {
+	try {
+		return decodeURIComponent( segment );
+	} catch {
+		return segment;
+	}
+}
+
+function domainPath( domain: string, subpage = '' ) {
+	return `${ DOMAINS_LIST }/${ encodeURIComponent( decodeDomain( domain ) ) }${ subpage }`;
+}
+
+/**
+ * Maps `<domain>/<slug>[/<extra>]/<site>` — the shape shared by the
+ * `/domains/manage/…` and `/domains/manage/all/…` families.
+ */
+function resolveDomainSubpage( segments: string[] ): string | undefined {
+	const [ domain, slug, ...rest ] = segments;
+
+	if ( ! domain || ! slug ) {
+		return undefined;
+	}
+
+	if ( slug === 'email' ) {
+		return `/emails/choose-email-solution/${ encodeURIComponent( decodeDomain( domain ) ) }`;
+	}
+
+	if ( slug === 'transfer' ) {
+		// The last segment is the site, so a transfer type is only present when
+		// more than one segment follows.
+		const transferType = rest.length > 1 ? rest[ 0 ] : '';
+		const subpage = SUBPAGE_BY_TRANSFER_TYPE[ transferType ];
+		return subpage === undefined ? undefined : domainPath( domain, subpage );
+	}
+
+	const subpage = SUBPAGE_BY_SLUG[ slug ];
+	return subpage === undefined ? undefined : domainPath( domain, subpage );
+}
+
+/**
+ * Maps the `/domains/manage/all/…` family, which nests the domain under a
+ * subpage root instead of leading with it.
+ */
+function resolveAllSubpage( segments: string[] ): string | undefined {
+	const [ root, ...rest ] = segments;
+
+	switch ( root ) {
+		case undefined:
+		case 'edit-selected-contact-info':
+			return DOMAINS_LIST;
+
+		case 'overview': {
+			const [ domain, ...tail ] = rest;
+			if ( ! domain ) {
+				return DOMAINS_LIST;
+			}
+			// `<domain>/<site>` is the overview itself; anything longer names a
+			// subpage between the domain and the site.
+			if ( tail.length <= 1 ) {
+				return domainPath( domain );
+			}
+			const [ subpageRoot, ...subpageRest ] = tail;
+			if ( subpageRoot === 'dns' ) {
+				const action = subpageRest.length > 1 ? subpageRest[ 0 ] : '';
+				if ( action === '' ) {
+					return domainPath( domain, '/dns' );
+				}
+				return action === 'add' || action === 'edit'
+					? domainPath( domain, `/dns/${ action }` )
+					: undefined;
+			}
+			if ( subpageRoot === 'transfer' && subpageRest[ 0 ] === 'other-site' ) {
+				return domainPath( domain, '/transfer/other-site' );
+			}
+			return undefined;
+		}
+
+		case 'email': {
+			const [ domain ] = rest;
+			return domain
+				? `/emails/choose-email-solution/${ encodeURIComponent( decodeDomain( domain ) ) }`
+				: '/emails';
+		}
+
+		case 'contact-info': {
+			const [ action, domain ] = rest;
+			return action === 'edit' && domain ? domainPath( domain, '/contact-info' ) : undefined;
+		}
+
+		default:
+			// `/domains/manage/all/<domain>/<slug>/<site>`, the `relativeTo`
+			// variant of the standard management pages.
+			return resolveDomainSubpage( segments );
+	}
+}
+
+/**
+ * Resolves the path following `/domains/manage` to a dashboard path.
+ */
+export function resolveLegacyDomainPath( splat: string ): string {
+	const segments = splat.split( '/' ).filter( Boolean );
+
+	if ( segments.length === 0 ) {
+		return DOMAINS_LIST;
+	}
+
+	const [ first, ...rest ] = segments;
+
+	// `select-site` and `edit` only ever led back to a list, and
+	// `edit-selected-contact-info` has no dashboard counterpart.
+	if ( first === 'select-site' || first === 'edit' || first === 'edit-selected-contact-info' ) {
+		return DOMAINS_LIST;
+	}
+
+	if ( first === 'all' ) {
+		return resolveAllSubpage( rest ) ?? DOMAINS_LIST;
+	}
+
+	// A lone segment is a site slug: the site's domain list.
+	if ( segments.length === 1 ) {
+		return `/sites/${ encodeURIComponent( first ) }/domains`;
+	}
+
+	return resolveDomainSubpage( segments ) ?? DOMAINS_LIST;
+}

--- a/client/dashboard/app/router/test/domains.test.ts
+++ b/client/dashboard/app/router/test/domains.test.ts
@@ -13,7 +13,7 @@ function matchedRouteIds( pathname: string ) {
 		context: { config: APP_CONTEXT_DEFAULT_CONFIG },
 	} );
 
-	return router.matchRoutes( { pathname, search: {} } ).map( ( match ) => match.routeId );
+	return router.matchRoutes( pathname, {} ).map( ( match ) => match.routeId );
 }
 
 describe( 'domains routes', () => {

--- a/client/dashboard/app/router/test/domains.test.ts
+++ b/client/dashboard/app/router/test/domains.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { createRouter } from '@tanstack/react-router';
+import { APP_CONTEXT_DEFAULT_CONFIG } from '../../context';
+import { createDomainsRoutes } from '../domains';
+import { rootRoute } from '../root';
+
+function matchedRouteIds( pathname: string ) {
+	const router = createRouter( {
+		routeTree: rootRoute.addChildren( createDomainsRoutes() ),
+		context: { config: APP_CONTEXT_DEFAULT_CONFIG },
+	} );
+
+	return router.matchRoutes( { pathname, search: {} } ).map( ( match ) => match.routeId );
+}
+
+describe( 'domains routes', () => {
+	test.each( [
+		'/domains/manage',
+		'/domains/manage/example.com',
+		'/domains/manage/all/overview/example.com/example.wordpress.com',
+	] )( 'legacy path %s does not match the domain overview route', ( pathname ) => {
+		const routeIds = matchedRouteIds( pathname );
+
+		expect( routeIds ).not.toContain( '/domains/$domainName' );
+		expect( routeIds.at( -1 ) ).toMatch( /\/domains\/manage/ );
+	} );
+
+	test( 'a domain name still matches the domain overview route', () => {
+		expect( matchedRouteIds( '/domains/example.com' ) ).toContain( '/domains/$domainName' );
+	} );
+} );

--- a/client/dashboard/app/router/test/legacy-domain-paths.test.ts
+++ b/client/dashboard/app/router/test/legacy-domain-paths.test.ts
@@ -1,0 +1,82 @@
+import { resolveLegacyDomainPath } from '../legacy-domain-paths';
+
+describe( 'resolveLegacyDomainPath', () => {
+	test.each( [
+		// The list itself, and the paths that only ever led back to it.
+		[ '', '/domains' ],
+		[ 'all', '/domains' ],
+		[ 'all/overview', '/domains' ],
+		[ 'select-site', '/domains' ],
+		[ 'select-site/example.wordpress.com', '/domains' ],
+		[ 'edit', '/domains' ],
+		[ 'edit/example.wordpress.com', '/domains' ],
+		[ 'all/edit-selected-contact-info', '/domains' ],
+		[ 'edit-selected-contact-info/example.wordpress.com', '/domains' ],
+
+		// A lone segment is a site slug.
+		[ 'example.wordpress.com', '/sites/example.wordpress.com/domains' ],
+
+		// `<domain>/<slug>/<site>`.
+		[ 'example.com/edit/example.wordpress.com', '/domains/example.com' ],
+		[ 'example.com/dns/example.wordpress.com', '/domains/example.com/dns' ],
+		[ 'example.com/add-dns-record/example.wordpress.com', '/domains/example.com/dns/add' ],
+		[ 'example.com/edit-dns-record/example.wordpress.com', '/domains/example.com/dns/edit' ],
+		[ 'example.com/edit-contact-info/example.wordpress.com', '/domains/example.com/contact-info' ],
+		[ 'example.com/security/example.wordpress.com', '/domains/example.com/security' ],
+		[
+			'example.com/domain-connect-mapping/example.wordpress.com',
+			'/domains/example.com/domain-connection-setup',
+		],
+		[ 'example.com/transfer/example.wordpress.com', '/domains/example.com/transfer' ],
+		[ 'example.com/transfer/out/example.wordpress.com', '/domains/example.com/transfer' ],
+		[
+			'example.com/transfer/in/example.wordpress.com',
+			'/domains/example.com/domain-transfer-setup',
+		],
+		[
+			'example.com/transfer/precheck/example.wordpress.com',
+			'/domains/example.com/domain-transfer-setup',
+		],
+		[
+			'example.com/transfer/any-user/example.wordpress.com',
+			'/domains/example.com/transfer/any-user',
+		],
+		[
+			'example.com/transfer/other-user/example.wordpress.com',
+			'/domains/example.com/transfer/other-user',
+		],
+		[
+			'example.com/transfer/other-site/example.wordpress.com',
+			'/domains/example.com/transfer/other-site',
+		],
+		[ 'example.com/email/example.wordpress.com', '/emails/choose-email-solution/example.com' ],
+
+		// The `all/` counterpart of the same pages.
+		[ 'all/example.com/dns/example.wordpress.com', '/domains/example.com/dns' ],
+		[ 'all/overview/example.com/example.wordpress.com', '/domains/example.com' ],
+		[ 'all/overview/example.com/dns/example.wordpress.com', '/domains/example.com/dns' ],
+		[ 'all/overview/example.com/dns/add/example.wordpress.com', '/domains/example.com/dns/add' ],
+		[ 'all/overview/example.com/dns/edit/example.wordpress.com', '/domains/example.com/dns/edit' ],
+		[
+			'all/overview/example.com/transfer/other-site/example.wordpress.com',
+			'/domains/example.com/transfer/other-site',
+		],
+		[
+			'all/contact-info/edit/example.com/example.wordpress.com',
+			'/domains/example.com/contact-info',
+		],
+		[ 'all/email/example.com/example.wordpress.com', '/emails/choose-email-solution/example.com' ],
+
+		// Unrecognized shapes fall back to the list rather than guessing.
+		[ 'example.com/not-a-real-slug/example.wordpress.com', '/domains' ],
+		[ 'all/overview/example.com/not-a-real-slug/example.wordpress.com', '/domains' ],
+	] )( '/domains/manage/%s → %s', ( splat, expected ) => {
+		expect( resolveLegacyDomainPath( splat ) ).toBe( expected );
+	} );
+
+	test( 'decodes the domain, which legacy paths encode twice', () => {
+		expect( resolveLegacyDomainPath( 'example.com%2Fpath/edit/example.wordpress.com' ) ).toBe(
+			'/domains/example.com%2Fpath'
+		);
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -16,7 +16,7 @@ import {
 	siteBySlugQuery,
 } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
-import { domainManagementEdit, domainUseMyDomain } from '@automattic/domains-table/src/utils/paths';
+import { domainUseMyDomain } from '@automattic/domains-table/src/utils/paths';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { INCOMING_DOMAIN_TRANSFER_STATUSES_IN_PROGRESS } from '@automattic/urls';
@@ -1241,7 +1241,7 @@ function DomainTransferInfo( { purchase }: { purchase: Purchase } ) {
 						'There was an error when initiating your domain transfer. Please <a>see the details or retry</a>.'
 					),
 					{
-						a: <a href={ domainManagementEdit( purchase.site_slug, domain.domain, null ) } />,
+						a: <Link to={ domainRoute.to } params={ { domainName: domain.domain } } />,
 					}
 				) }
 			</Text>
@@ -1260,10 +1260,12 @@ function DomainTransferInfo( { purchase }: { purchase: Purchase } ) {
 					{
 						a: (
 							<a
-								href={ domainUseMyDomain(
-									purchase.site_slug,
-									purchase.meta,
-									useMyDomainInputMode.startPendingTransfer
+								href={ wpcomLink(
+									domainUseMyDomain(
+										purchase.site_slug,
+										purchase.meta,
+										useMyDomainInputMode.startPendingTransfer
+									)
 								) }
 							/>
 						),


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Point the purchase settings transfer-error link at the Dashboard's own domain route, and send the "start the domain transfer" link through `wpcomLink()` so it leaves the Dashboard properly.
* Translate legacy `/domains/manage/*` URLs to their Dashboard equivalent instead of treating `manage` as a domain name. The mapping follows the one classic Calypso already uses when it redirects opted-in users, so the two agree.
* Turn a `400 invalid_domain` response in the domain route loader into a not-found, matching what the emails routes already do.

## Why are these changes being made?

Production error logs show `InvalidDomainError: The domain specified is not valid.` from `GET /domain-details/manage`.

The Dashboard mounts at the root of its own host, so a Calypso-shaped path like `/domains/manage/<domain>/edit/<site>` is matched by the Dashboard's `/domains/$domainName` route with the domain name `manage`. The route loader then asks the API for a domain called "manage" and the page dies.

The purchase settings screen was producing exactly that link: it built a classic Calypso path from a shared path helper and rendered it as a relative `href` without wrapping it, so the click never left the Dashboard. The same file wraps its other Calypso links correctly, so this was a missed wrapper rather than a deliberate choice.

Fixing that link removes the source, but the legacy paths are still live in bookmarks, wp-admin links and support documentation, so the router now handles them too. Users following an old link land on the domain they asked for rather than a broken page:

| Legacy | Dashboard |
|---|---|
| `/domains/manage` | `/domains` |
| `/domains/manage/<site>` | `/sites/<site>/domains` |
| `/domains/manage/<domain>/edit/<site>` | `/domains/<domain>` |
| `…/dns`, `…/add-dns-record`, `…/edit-dns-record` | `/domains/<domain>/dns`, `/dns/add`, `/dns/edit` |
| `…/edit-contact-info`, `…/security`, `…/domain-connect-mapping` | `/contact-info`, `/security`, `/domain-connection-setup` |
| `…/transfer[/in\|precheck\|out\|any-user\|other-user\|other-site]` | `/transfer…`, `/domain-transfer-setup` |
| `…/email` | `/emails/choose-email-solution/<domain>` |
| `/domains/manage/all/overview/<domain>/…`, `…/all/contact-info/edit/…` | the same targets |
| anything unrecognized | `/domains` |

Separately, the loader change stops a genuinely bad domain slug from being reported to Sentry. The Dashboard already renders a 404 for it, so the exception was noise on top of a case that was handled.

## Testing Instructions

1. On the Dashboard, open a domain purchase whose transfer has failed (`last_transfer_error` set) and follow the "see the details or retry" link. It should open the domain page in the Dashboard, not a broken page. Check the network tab for a request to `/domain-details/manage`; there should be none.
2. Visit `/domains/manage` on the Dashboard. You should land on the domains list.
3. Visit `/domains/manage/<your-domain>/dns/<your-site>`. You should land on that domain's DNS records.
4. Visit `/domains/<something-that-is-not-a-domain>`. You should get the not-found page, with no error reported to the console.

Unit tests cover the path mapping and the route matching:

```
yarn test-client client/dashboard/app/router/test/legacy-domain-paths.test.ts
yarn test-client client/dashboard/app/router/test/domains.test.ts
```

## Considerations

Classic Calypso already owns a legacy-to-Dashboard mapping table, applied per route when it redirects opted-in users, and this duplicates part of it. The alternative was to leave translation entirely to Calypso, but that only covers users passing through Calypso first — it does nothing for a link that lands on the Dashboard host directly, which is the case in the error logs. The mapping here deliberately mirrors Calypso's targets so the two do not drift apart.

`manage-consent`, `redirect` and `redirect-settings` have no Dashboard equivalent. They redirect to the domain overview, on the grounds that landing on the right domain beats a dead end. Making them 404 instead is a one-line change if reviewers prefer that.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
