### PR TITLE
Stats post detail: prefetch email tab availability and seed it from the email pages

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -426,10 +426,15 @@ export function post( context, next ) {
 	// Module state is often not loaded yet at route time (QueryJetpackModules runs
 	// after mount, and /me/sites does not carry active_modules), so only a definite
 	// "inactive" skips the warm-up; the page's own `enabled` check stays strict.
+	// The module store is read directly first: the fallback variant discards a
+	// definite `false` and can fall through to an unknown site option.
+	const subscriptionsModuleActive = isJetpackModuleActive( state, siteId, 'subscriptions' );
 	const canHaveEmailStats =
 		!! supportsEmailStats &&
 		( isSimpleSite( state, siteId ) ||
-			isJetpackModuleActive( state, siteId, 'subscriptions', true ) !== false );
+			( subscriptionsModuleActive !== null
+				? subscriptionsModuleActive
+				: isJetpackModuleActive( state, siteId, 'subscriptions', true ) !== false ) );
 	if ( canHaveEmailStats && postId > 0 ) {
 		context.queryClient.prefetchQuery( postEmailStatsAvailabilityQueryOptions( siteId, postId ) );
 	}

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -6,10 +6,13 @@ import AsyncLoad from 'calypso/components/async-load';
 import { bumpStat } from 'calypso/lib/analytics/mc';
 import { getSiteFragment, getStatsDefaultSitePage } from 'calypso/lib/route';
 import { getMomentSiteZone } from 'calypso/my-sites/stats/hooks/use-moment-site-zone';
-import { getSite } from 'calypso/state/sites/selectors';
+import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
+import { getSite, isSimpleSite } from 'calypso/state/sites/selectors';
+import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { postEmailStatsAvailabilityQueryOptions } from './hooks/use-post-email-stats-availability-query';
 import { rangeOfPeriod, getSiteFilters } from './pages/shared/helpers';
 import PageLoading from './pages/shared/page-loading';
 import StatsSite from './site';
@@ -414,6 +417,19 @@ export function post( context, next ) {
 	if ( 0 === siteId ) {
 		window.location = '/stats';
 		return next();
+	}
+
+	// Resolve email tab availability in parallel with the chunk download, so the
+	// tab strip doesn't pop in after the page renders.
+	const state = context.store.getState();
+	const { supportsEmailStats } = getEnvStatsFeatureSupportChecks( state, siteId );
+	const canHaveEmailStats =
+		!! supportsEmailStats &&
+		!! (
+			isSimpleSite( state, siteId ) || isJetpackModuleActive( state, siteId, 'subscriptions', true )
+		);
+	if ( canHaveEmailStats && postId > 0 ) {
+		context.queryClient.prefetchQuery( postEmailStatsAvailabilityQueryOptions( siteId, postId ) );
 	}
 
 	context.primary = (

--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -423,11 +423,13 @@ export function post( context, next ) {
 	// tab strip doesn't pop in after the page renders.
 	const state = context.store.getState();
 	const { supportsEmailStats } = getEnvStatsFeatureSupportChecks( state, siteId );
+	// Module state is often not loaded yet at route time (QueryJetpackModules runs
+	// after mount, and /me/sites does not carry active_modules), so only a definite
+	// "inactive" skips the warm-up; the page's own `enabled` check stays strict.
 	const canHaveEmailStats =
 		!! supportsEmailStats &&
-		!! (
-			isSimpleSite( state, siteId ) || isJetpackModuleActive( state, siteId, 'subscriptions', true )
-		);
+		( isSimpleSite( state, siteId ) ||
+			isJetpackModuleActive( state, siteId, 'subscriptions', true ) !== false );
 	if ( canHaveEmailStats && postId > 0 ) {
 		context.queryClient.prefetchQuery( postEmailStatsAvailabilityQueryOptions( siteId, postId ) );
 	}

--- a/client/my-sites/stats/hooks/test/use-post-email-stats-availability-query.test.ts
+++ b/client/my-sites/stats/hooks/test/use-post-email-stats-availability-query.test.ts
@@ -51,6 +51,15 @@ describe( 'seedPostEmailStatsAvailability', () => {
 		expect( queryClient.getQueryState( queryKey )?.dataUpdatedAt ).toBe( 0 );
 	} );
 
+	it( 'is a no-op without a valid siteId and postId', () => {
+		const queryClient = new QueryClient();
+
+		seedPostEmailStatsAvailability( queryClient, null, POST_ID );
+		seedPostEmailStatsAvailability( queryClient, SITE_ID, 0 );
+
+		expect( queryClient.getQueryCache().getAll() ).toHaveLength( 0 );
+	} );
+
 	it( 'leaves a cached positive untouched', () => {
 		const queryClient = new QueryClient();
 		const real = { total_sends: 68036, total_opens: 9109 };

--- a/client/my-sites/stats/hooks/test/use-post-email-stats-availability-query.test.ts
+++ b/client/my-sites/stats/hooks/test/use-post-email-stats-availability-query.test.ts
@@ -1,4 +1,9 @@
-import { hasEmailStats } from '../use-post-email-stats-availability-query';
+import { QueryClient } from '@tanstack/react-query';
+import {
+	hasEmailStats,
+	postEmailStatsAvailabilityQueryOptions,
+	seedPostEmailStatsAvailability,
+} from '../use-post-email-stats-availability-query';
 
 describe( 'hasEmailStats', () => {
 	it( 'returns false when there is no data', () => {
@@ -17,5 +22,44 @@ describe( 'hasEmailStats', () => {
 
 	it( 'returns true when the post has opens even if sends are not reported', () => {
 		expect( hasEmailStats( { total_sends: 0, total_opens: 9109 } ) ).toBe( true );
+	} );
+} );
+
+describe( 'seedPostEmailStatsAvailability', () => {
+	const SITE_ID = 1;
+	const POST_ID = 2;
+	const { queryKey } = postEmailStatsAvailabilityQueryOptions( SITE_ID, POST_ID );
+
+	it( 'seeds an empty cache with an already-stale positive', () => {
+		const queryClient = new QueryClient();
+
+		seedPostEmailStatsAvailability( queryClient, SITE_ID, POST_ID );
+
+		expect( hasEmailStats( queryClient.getQueryData( queryKey ) ) ).toBe( true );
+		// Stale from birth: the mount refetch still runs, so a wrongly seeded
+		// post (deep link to a never-emailed post's email page) corrects itself.
+		expect( queryClient.getQueryState( queryKey )?.dataUpdatedAt ).toBe( 0 );
+	} );
+
+	it( 'overwrites a cached negative so the tab strip renders immediately', () => {
+		const queryClient = new QueryClient();
+		queryClient.setQueryData( queryKey, { total_sends: 0, total_opens: 0 } );
+
+		seedPostEmailStatsAvailability( queryClient, SITE_ID, POST_ID );
+
+		expect( hasEmailStats( queryClient.getQueryData( queryKey ) ) ).toBe( true );
+		expect( queryClient.getQueryState( queryKey )?.dataUpdatedAt ).toBe( 0 );
+	} );
+
+	it( 'leaves a cached positive untouched', () => {
+		const queryClient = new QueryClient();
+		const real = { total_sends: 68036, total_opens: 9109 };
+		queryClient.setQueryData( queryKey, real );
+		const updatedAt = queryClient.getQueryState( queryKey )?.dataUpdatedAt;
+
+		seedPostEmailStatsAvailability( queryClient, SITE_ID, POST_ID );
+
+		expect( queryClient.getQueryData( queryKey ) ).toEqual( real );
+		expect( queryClient.getQueryState( queryKey )?.dataUpdatedAt ).toBe( updatedAt );
 	} );
 } );

--- a/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
+++ b/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { queryOptions, useQuery, type QueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import getDefaultQueryParams from './default-query-params';
 
@@ -15,6 +15,38 @@ function queryEmailRate( siteId: number | null, postId: number ): Promise< Email
 	return wpcom.req.get( `/sites/${ siteId }/stats/opens/emails/${ postId }/rate` );
 }
 
+export function postEmailStatsAvailabilityQueryOptions( siteId: number | null, postId: number ) {
+	return queryOptions( {
+		...getDefaultQueryParams(),
+		queryKey: [ 'stats', 'emails', 'opens', 'rate', siteId, postId ],
+		queryFn: () => queryEmailRate( siteId, postId ),
+		// A "no email stats" answer can be transient while a newsletter is still being sent,
+		// so only a positive result is kept for a while.
+		staleTime: ( query ) => ( hasEmailStats( query.state.data ) ? 1000 * 60 * 5 : 1000 * 30 ),
+		// A failed request reads the same as "no email stats" and hides the tabs, so
+		// let a remount retry instead of pinning the error until a full reload
+		// (the shared defaults set retryOnMount: false).
+		retryOnMount: true,
+		meta: { persist: false },
+	} );
+}
+
+/**
+ * Mark a post as having email stats without waiting for the request, for navigations
+ * from a page that already proves they exist (e.g. the email detail tabs). The counts
+ * are a placeholder; nothing reads them besides hasEmailStats. Real responses win.
+ */
+export function seedPostEmailStatsAvailability(
+	queryClient: QueryClient,
+	siteId: number | null,
+	postId: number
+) {
+	const { queryKey } = postEmailStatsAvailabilityQueryOptions( siteId, postId );
+	if ( queryClient.getQueryData( queryKey ) === undefined ) {
+		queryClient.setQueryData( queryKey, { total_sends: 1 } );
+	}
+}
+
 /**
  * Whether a post was ever sent as a newsletter email, based on the email stats themselves
  * rather than post metadata, which does not always reflect what was actually sent.
@@ -25,18 +57,8 @@ export default function usePostEmailStatsAvailabilityQuery(
 	enabled = true
 ) {
 	return useQuery( {
-		...getDefaultQueryParams(),
-		queryKey: [ 'stats', 'emails', 'opens', 'rate', siteId, postId ],
-		queryFn: () => queryEmailRate( siteId, postId ),
+		...postEmailStatsAvailabilityQueryOptions( siteId, postId ),
 		enabled: !! enabled && !! siteId && postId > 0,
-		// A "no email stats" answer can be transient while a newsletter is still being sent,
-		// so only a positive result is kept for a while.
-		staleTime: ( query ) => ( hasEmailStats( query.state.data ) ? 1000 * 60 * 5 : 1000 * 30 ),
-		// A failed request reads the same as "no email stats" and hides the tabs, so
-		// let a remount retry instead of pinning the error until a full reload
-		// (the shared defaults set retryOnMount: false).
-		retryOnMount: true,
-		meta: { persist: false },
 		select: hasEmailStats,
 	} );
 }

--- a/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
+++ b/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
@@ -33,8 +33,15 @@ export function postEmailStatsAvailabilityQueryOptions( siteId: number | null, p
 
 /**
  * Mark a post as having email stats without waiting for the request, for navigations
- * from a page that already proves they exist (e.g. the email detail tabs). The counts
- * are a placeholder; nothing reads them besides hasEmailStats. Real responses win.
+ * from a page that suggests they exist (e.g. the email detail tabs). The counts are a
+ * placeholder; nothing reads them besides hasEmailStats.
+ *
+ * The seed is written as already-stale data (updatedAt: 0): the tab strip renders
+ * from it immediately, but the mount refetch still runs, so a wrong seed (a deep
+ * link to the email page of a never-emailed post) corrects itself within one round
+ * trip. That also makes it safe to overwrite a stale cached negative. A cached
+ * positive is left untouched - it needs no seed, and replacing it would only queue
+ * a pointless refetch.
  */
 export function seedPostEmailStatsAvailability(
 	queryClient: QueryClient,
@@ -42,9 +49,10 @@ export function seedPostEmailStatsAvailability(
 	postId: number
 ) {
 	const { queryKey } = postEmailStatsAvailabilityQueryOptions( siteId, postId );
-	if ( queryClient.getQueryData( queryKey ) === undefined ) {
-		queryClient.setQueryData( queryKey, { total_sends: 1 } );
+	if ( hasEmailStats( queryClient.getQueryData( queryKey ) ) ) {
+		return;
 	}
+	queryClient.setQueryData( queryKey, { total_sends: 1 }, { updatedAt: 0 } );
 }
 
 /**

--- a/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
+++ b/client/my-sites/stats/hooks/use-post-email-stats-availability-query.ts
@@ -48,6 +48,9 @@ export function seedPostEmailStatsAvailability(
 	siteId: number | null,
 	postId: number
 ) {
+	if ( ! siteId || postId <= 0 ) {
+		return;
+	}
 	const { queryKey } = postEmailStatsAvailabilityQueryOptions( siteId, postId );
 	if ( hasEmailStats( queryClient.getQueryData( queryKey ) ) ) {
 		return;

--- a/client/my-sites/stats/stats-details-navigation/index.tsx
+++ b/client/my-sites/stats/stats-details-navigation/index.tsx
@@ -1,8 +1,12 @@
 import page from '@automattic/calypso-router';
+import { useQueryClient } from '@tanstack/react-query';
 import { TabPanel } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useMemo } from 'react';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { seedPostEmailStatsAvailability } from '../hooks/use-post-email-stats-availability-query';
 
 interface StatsDetailsNavigationProps {
 	postId: number;
@@ -18,6 +22,8 @@ function StatsDetailsNavigationImproved( {
 	givenSiteId,
 }: StatsDetailsNavigationProps ) {
 	const translate = useTranslate();
+	const queryClient = useQueryClient();
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const tabs = useMemo(
 		() => ( {
 			highlights: translate( 'Post traffic' ),
@@ -55,6 +61,12 @@ function StatsDetailsNavigationImproved( {
 				if ( tabName !== selectedTab ) {
 					const tab = tabPanelTabs.find( ( tab ) => tab.name === tabName );
 					if ( tab?.path ) {
+						if ( tabName === 'highlights' && [ 'opens', 'clicks' ].includes( selectedTab ) ) {
+							// Being on an email tab proves this post has email stats; seed the
+							// availability cache so the post detail page shows the tabs
+							// without waiting for the /rate request.
+							seedPostEmailStatsAvailability( queryClient, selectedSiteId, postId );
+						}
 						page( tab.path );
 					}
 				}


### PR DESCRIPTION
Part of STATS-464.

Follow-up to #113843 (merged); rebased onto trunk.

## Proposed Changes

* Extract the email tab availability query into a shared `postEmailStatsAvailabilityQueryOptions` factory and prefetch it from the `post()` route controller. The gate skips the warm-up only when subscriptions is provably inactive: at route time the Jetpack module state is usually not loaded yet (`QueryJetpackModules` runs after mount and `/me/sites` does not request `active_modules`), so an unknown state still prefetches, while the page's own `enabled` check stays strict. The `/rate` request now runs in parallel with the post detail chunk download instead of after mount.
* When clicking **Post traffic** from the Email opens/clicks pages, seed the availability cache first (`seedPostEmailStatsAvailability`): being on an email tab already proves the post has email stats, so that navigation renders the tab strip immediately.

## Why are these changes being made?

* After #113843 the **Post traffic / Email opens / Email clicks** tab strip is driven by an async `/rate` query that is deliberately not persisted, so on a fresh visit the strip appears only once the request resolves. Review of #113843 measured a ~760ms gap when navigating from the Emails page (a pre-existing behavior on trunk, ~640ms).
* Prefetching at the route level hides the request latency behind the chunk download on all entry paths; seeding on the Emails → Post traffic navigation removes the flash entirely on the one path where the answer is already known. A stale seeded entry cannot mislead: it is only written when email stats provably exist, and real responses overwrite it.

## Testing Instructions

1. On a site with newsletter posts, open **Stats → Traffic** and click a post that was sent as an email. In DevTools' Network tab, observe the `.../stats/opens/emails/<post>/rate` request starting together with the `async-load-...-stats-post-detail` chunk rather than after it.
2. Open the same post's **Email opens** page, then click **Post traffic**: the tab strip should be present as soon as the page renders, with no `/rate` request needed for it to appear.
3. Regression checks: a post that was never emailed still shows no tabs; the home page entry (post ID 0) shows no tabs and issues no `/rate` request; sites without email stats support (no subscriptions module) issue no `/rate` request from the controller.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? *(Simple and Atomic verified on local dev: prefetch runs in parallel with the chunk — on a full reload of the post detail page the tabs are present on first paint, where before they popped in late; Emails → Post traffic shows the tabs immediately with no `/rate` request. Self-hosted Jetpack / Odyssey not tested yet.)*
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?




