### PR TITLE
Sites: include a8c-owned sites for non-Automatticians

### DIFF
--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -72,20 +72,20 @@ const getFetchPaginatedSitesOptions = (
 ): FetchPaginatedSitesOptions => {
 	const filters = view.filters ?? [];
 
-	const isA8COwnedExcludedByFilter = filters.some(
+	const isA8COwnedIncludedByFilter = ! filters.some(
 		( item: Filter ) => item.field === 'is_a8c' && item.value === false
 	);
 
 	// Non-Automatticians can be members of a8c-owned sites but have no filter to
 	// control their visibility, so always include them.
-	const shouldIncludeA8COwned = ! isAutomattician || ! isA8COwnedExcludedByFilter;
+	const shouldIncludeA8COwned = ! isAutomattician || isA8COwnedIncludedByFilter;
 
 	// Hidden sites are only returned under 'all', which we opt into when the user
 	// searches, is restoring their account, or is an Automattician who wants a8c-owned
 	// sites — some P2s are not retrievable otherwise.
 	// See: https://github.com/Automattic/wp-calypso/pull/104220.
 	const shouldRequestAllVisibility =
-		!! view.search || isRestoringAccount || ( isAutomattician && ! isA8COwnedExcludedByFilter );
+		!! view.search || isRestoringAccount || ( isAutomattician && isA8COwnedIncludedByFilter );
 
 	const options: FetchPaginatedSitesOptions = {
 		source: isDashboardBackport() && isDefaultView ? 'dashboard-site-list-default' : undefined,

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -72,18 +72,25 @@ const getFetchPaginatedSitesOptions = (
 ): FetchPaginatedSitesOptions => {
 	const filters = view.filters ?? [];
 
+	const isA8COwnedExcludedByFilter = filters.some(
+		( item: Filter ) => item.field === 'is_a8c' && item.value === false
+	);
+
 	// Non-Automatticians can be members of a8c-owned sites but have no filter to
 	// control their visibility, so always include them.
-	const shouldIncludeA8COwned =
-		! isAutomattician ||
-		! filters.some( ( item: Filter ) => item.field === 'is_a8c' && item.value === false );
+	const shouldIncludeA8COwned = ! isAutomattician || ! isA8COwnedExcludedByFilter;
+
+	// Hidden sites are only returned under 'all', which we opt into when the user
+	// searches, is restoring their account, or is an Automattician who wants a8c-owned
+	// sites — some P2s are not retrievable otherwise.
+	// See: https://github.com/Automattic/wp-calypso/pull/104220.
+	const shouldRequestAllVisibility =
+		!! view.search || isRestoringAccount || ( isAutomattician && ! isA8COwnedExcludedByFilter );
 
 	const options: FetchPaginatedSitesOptions = {
 		source: isDashboardBackport() && isDefaultView ? 'dashboard-site-list-default' : undefined,
 
-		// Some P2 sites are not retrievable unless site_visibility is set to 'all'.
-		// See: https://github.com/Automattic/wp-calypso/pull/104220.
-		site_visibility: view.search || shouldIncludeA8COwned || isRestoringAccount ? 'all' : 'visible',
+		site_visibility: shouldRequestAllVisibility ? 'all' : 'visible',
 		include_a8c_owned: shouldIncludeA8COwned,
 		include_staging: getIncludeStaging( filters ),
 		search: view.search,

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -72,10 +72,8 @@ const getFetchPaginatedSitesOptions = (
 ): FetchPaginatedSitesOptions => {
 	const filters = view.filters ?? [];
 
-	// Only Automatticians have the is_a8c filter. If the filter is set to exclude then do
-	// not include these sites. Otherwise, a regular user might still be a member of an
-	// a8c-owned site, so always include those sites in the result as there's no way to
-	// filter them.
+	// Non-Automatticians can be members of a8c-owned sites but have no filter to
+	// control their visibility, so always include them.
 	const shouldIncludeA8COwned =
 		! isAutomattician ||
 		! filters.some( ( item: Filter ) => item.field === 'is_a8c' && item.value === false );

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -76,9 +76,9 @@ const getFetchPaginatedSitesOptions = (
 	// not include these sites. Otherwise, a regular user might still be a member of an
 	// a8c-owned site, so always include those sites in the result as there's no way to
 	// filter them.
-	const shouldIncludeA8COwned = isAutomattician
-		? ! filters.some( ( item: Filter ) => item.field === 'is_a8c' && item.value === false )
-		: true;
+	const shouldIncludeA8COwned =
+		! isAutomattician ||
+		! filters.some( ( item: Filter ) => item.field === 'is_a8c' && item.value === false );
 
 	const options: FetchPaginatedSitesOptions = {
 		source: isDashboardBackport() && isDefaultView ? 'dashboard-site-list-default' : undefined,

--- a/client/dashboard/sites/index.tsx
+++ b/client/dashboard/sites/index.tsx
@@ -72,10 +72,13 @@ const getFetchPaginatedSitesOptions = (
 ): FetchPaginatedSitesOptions => {
 	const filters = view.filters ?? [];
 
-	// Include A8C sites unless explicitly excluded from the filter.
-	const shouldIncludeA8COwned =
-		isAutomattician &&
-		! filters.some( ( item: Filter ) => item.field === 'is_a8c' && item.value === false );
+	// Only Automatticians have the is_a8c filter. If the filter is set to exclude then do
+	// not include these sites. Otherwise, a regular user might still be a member of an
+	// a8c-owned site, so always include those sites in the result as there's no way to
+	// filter them.
+	const shouldIncludeA8COwned = isAutomattician
+		? ! filters.some( ( item: Filter ) => item.field === 'is_a8c' && item.value === false )
+		: true;
 
 	const options: FetchPaginatedSitesOptions = {
 		source: isDashboardBackport() && isDefaultView ? 'dashboard-site-list-default' : undefined,


### PR DESCRIPTION
Part of DOTMSD-1491

## Proposed Changes

* Always request `include_a8c_owned` sites for users who are not Automatticians. Previously `shouldIncludeA8COwned` required `isAutomattician`, so a8c-owned sites were excluded for everyone else.
* Automatticians keep the existing behaviour: a8c-owned sites are included unless the `is_a8c` filter is explicitly set to `false`.

## Why are these changes being made?

* The `is_a8c` filter is only exposed to Automatticians, but a regular user can still be a member of an a8c-owned site. With the old logic those sites were silently missing from their site list, and there was no filter they could use to bring them back.

## Testing Instructions

* Log in as a non-Automattician account that is a member of an a8c-owned site and open the sites dashboard. The a8c-owned site should now appear in the list.
* As an Automattician, confirm the site list still includes a8c-owned sites by default, and that setting the "A8C" filter to exclude removes them.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01EE6fVjw6DZiarMheomhS1P