### PR TITLE
Omnibar: show the command palette on Calypso pages

### DIFF
--- a/client/layout/masterbar/command-palette.tsx
+++ b/client/layout/masterbar/command-palette.tsx
@@ -1,0 +1,49 @@
+import page from '@automattic/calypso-router';
+// @ts-expect-error The commands package is not yet typed.
+import { CommandMenu, useCommandLoader } from '@wordpress/commands';
+import { navigationCommands } from 'calypso/dashboard/app/command-palette/commands';
+
+import '@wordpress/commands/build-style/style.css';
+
+// Calypso and the dashboard don't share an information architecture, so the
+// shared command definitions are mapped onto their Calypso routes here.
+// Commands without a Calypso equivalent (e.g. Preferences) are left out.
+const CALYPSO_COMMAND_PATHS: Record< string, string > = {
+	'dashboard-go-to-sites': '/sites',
+	'dashboard-go-to-domains': '/domains/manage',
+	'dashboard-go-to-emails': '/email',
+	'dashboard-go-to-plugins': '/plugins',
+	'dashboard-go-to-account': '/me/account',
+	'dashboard-go-to-billing': '/me/billing',
+	'dashboard-go-to-purchases': '/me/purchases',
+	'dashboard-go-to-security': '/me/security',
+	'dashboard-go-to-notifications': '/me/notifications',
+};
+
+function useNavigationCommandLoader() {
+	return {
+		commands: navigationCommands
+			.filter( ( command ) => CALYPSO_COMMAND_PATHS[ command.name ] )
+			.map( ( command ) => ( {
+				name: command.name,
+				label: command.label,
+				searchLabel: command.searchLabel,
+				icon: command.icon,
+				callback: ( { close }: { close: () => void } ) => {
+					close();
+					page( CALYPSO_COMMAND_PATHS[ command.name ] );
+				},
+			} ) ),
+		isLoading: false,
+	};
+}
+
+export default function CommandPalette() {
+	useCommandLoader( {
+		name: 'calypso/navigation',
+		hook: useNavigationCommandLoader,
+		context: 'root',
+	} );
+
+	return <CommandMenu search="" />;
+}

--- a/client/layout/masterbar/omnibar.tsx
+++ b/client/layout/masterbar/omnibar.tsx
@@ -14,6 +14,7 @@ import { toggleNotificationsPanel } from 'calypso/state/ui/actions';
 import { activateNextLayoutFocus, setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import { getSectionName, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import CommandPalette from './command-palette';
 import type { AnalyticsClient } from 'calypso/dashboard/app/analytics';
 import type { AppConfig } from 'calypso/dashboard/app/context';
 
@@ -79,6 +80,7 @@ export default function Omnibar( {
 			reader: true,
 			notifications: true,
 			help: !! loadHelpCenterIcon,
+			commandPalette: true,
 		},
 	};
 
@@ -94,6 +96,7 @@ export default function Omnibar( {
 							sectionName={ sectionName ?? undefined }
 						/>
 					</div>
+					<CommandPalette />
 				</AnalyticsProvider>
 			</QueryClientProvider>
 		</AppProvider>


### PR DESCRIPTION
Fixes p1788156313210679/1788141355.232059-slack-CRWCHQGUB

## Proposed Changes

* Mount a command palette on Calypso pages and stop hiding the admin bar's palette button there.
* The palette reuses the dashboard's navigation command definitions, mapped onto the Calypso routes they correspond to (`/domains/manage`, `/email`, `/me/purchases`, …). Commands with no Calypso equivalent, such as Preferences, are left out.

## Why are these changes being made?

On any Calypso page — My Home, for example — the command palette is missing from the admin bar, and ⌘K does nothing. It only exists in the new dashboard client.

That was deliberate: the palette component is rendered only where the app config declares support for it, which is the dashboard alone, so the omnibar filters the palette node out of the admin bar everywhere else rather than show a button that opens nothing. The legacy masterbar has the same gate on a prop that only the dashboard's interim masterbar passes.

Now that the omnibar is shared between the two clients, the button should work on both sides. Mounting a Calypso-side palette that navigates through the Calypso router makes the button meaningful, so the filter can let it through.

## Considerations

The dashboard's palette navigates with TanStack Router, which does not exist on Calypso pages, and the two clients don't share an information architecture — some dashboard destinations live at different Calypso paths, and one has no Calypso page at all. Rather than generalise the dashboard component, this adds a small Calypso counterpart that reuses the shared command list (labels, icons, search terms) and supplies its own route map and navigation. One source of command definitions, no routing coupling.

This only affects the omnibar. The legacy masterbar still has no palette button; it is disabled in production and being replaced, so it seemed better left alone than given a new toolbar icon.

## Testing Instructions

* Visit `/home/:site` (or any other Calypso page) on a build with the omnibar enabled.
* The search/command icon appears in the admin bar. Click it, or press ⌘K.
* The palette opens; picking a destination navigates there client-side without a full page reload.
* Confirm the palette still behaves as before in the dashboard client.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)