### PR TITLE
Signup: serve every plan-specific /start flow from Stepper onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -1,12 +1,16 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { OnboardActions, OnboardSelect } from '@automattic/data-stores';
+import { getLanguageSlugs } from '@automattic/i18n-utils';
 import { clearStepPersistedState, ONBOARDING_FLOW, SITE_SETUP_FLOW } from '@automattic/onboarding';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { clearSessionStorageQuery } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
-import { WOO_HOSTING_SOLUTIONS_REF } from 'calypso/landing/stepper/constants';
+import {
+	STEPPER_TRACKS_EVENT_SIGNUP_START,
+	WOO_HOSTING_SOLUTIONS_REF,
+} from 'calypso/landing/stepper/constants';
 import {
 	getLaunchpadPersonalizationDestination,
 	resolveLaunchpadPersonalizationVariation,
@@ -45,7 +49,13 @@ import {
 	requestBuildWowSite,
 } from '../../../utils/build-wow';
 import { goToCheckout } from '../../../utils/checkout';
+import { getCurrentQueryParams } from '../../../utils/get-current-query-params';
 import { getStepFromURL } from '../../../utils/get-flow-from-url';
+import {
+	getPreselectedPlan,
+	getPreselectedStorageAddOn,
+	skipsPlansStep,
+} from '../../../utils/preselected-plan';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import {
 	clearWowFunnelSite,
@@ -270,6 +280,32 @@ const onboarding: FlowV2< typeof initialize > = {
 	isSignupFlow: true,
 	__experimentalUseBuiltinAuth: true,
 	initialize,
+	useTracksEventProps() {
+		const query = useQuery();
+		const preselectedPlan = getPreselectedPlan( query );
+		// Reported raw, as the legacy flows reported their declared query dependencies.
+		const couponParam = preselectedPlan ? query.get( 'coupon' ) : null;
+		const storageParam = preselectedPlan ? query.get( 'storage' ) : null;
+
+		// A new object each render would record a new signup start, so this has to be memoised.
+		return useMemo(
+			() => ( {
+				isLoading: false,
+				// The redirect collapses the plan flows' `flow` values into `onboarding`. This
+				// is how that traffic stays separable.
+				eventsProperties: preselectedPlan
+					? {
+							[ STEPPER_TRACKS_EVENT_SIGNUP_START ]: {
+								preselected_plan: preselectedPlan,
+								...( couponParam ? { coupon: couponParam } : {} ),
+								...( storageParam ? { storage: storageParam } : {} ),
+							},
+					  }
+					: {},
+			} ),
+			[ preselectedPlan, couponParam, storageParam ]
+		);
+	},
 	useStepNavigation( currentStepSlug, navigate ) {
 		const flowName = this.name;
 		// Variant B: the account step doesn't gate; the verification step is met after the free plan
@@ -296,6 +332,7 @@ const onboarding: FlowV2< typeof initialize > = {
 			[]
 		);
 		const queryParams = useQuery();
+		const skipsPlans = skipsPlansStep( queryParams, planCartItem );
 		const coupon = queryParams.get( 'coupon' );
 		const refParameter = queryParams.get( 'ref' );
 		const diyLaunchpad = queryParams.get( 'diy-launchpad' );
@@ -437,6 +474,21 @@ const onboarding: FlowV2< typeof initialize > = {
 			} );
 		};
 
+		/**
+		 * With a plan already in the cart the plans step has nothing left to ask, so the flow
+		 * goes straight to site creation. The free-plan and email-verification branches in the
+		 * plans handler below only apply when no plan was picked, so nothing is skipped here.
+		 */
+		const navigateAfterDomain = () => {
+			if ( ! skipsPlans ) {
+				return navigate( 'plans' );
+			}
+
+			setSignupCompleteFlowName( flowName );
+
+			return navigate( 'create-site', undefined, false );
+		};
+
 		const submit: SubmitHandler< typeof initialize > = async ( submittedStep ) => {
 			const { slug, providedDependencies } = submittedStep;
 			switch ( slug ) {
@@ -462,7 +514,7 @@ const onboarding: FlowV2< typeof initialize > = {
 					setDomainCartItems( providedDependencies.domainCart as MinimalRequestCartProduct[] );
 					setSignupDomainOrigin( providedDependencies.signupDomainOrigin as string );
 
-					return navigate( 'plans' );
+					return navigateAfterDomain();
 				case 'use-my-domain': {
 					if (
 						providedDependencies &&
@@ -484,7 +536,7 @@ const onboarding: FlowV2< typeof initialize > = {
 						setDomainCartItem( providedDependencies.domainCartItem );
 					}
 
-					return navigate( 'plans' );
+					return navigateAfterDomain();
 				}
 				case 'plans': {
 					const cartItems = providedDependencies.cartItems;
@@ -778,7 +830,9 @@ const onboarding: FlowV2< typeof initialize > = {
 	},
 	useSideEffect( currentStepSlug ) {
 		const reduxDispatch = useReduxDispatch();
-		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
+		const { resetOnboardStore, setPlanCartItem, setProductCartItems } = useDispatch(
+			ONBOARD_STORE
+		) as OnboardActions;
 		const isLoggedIn = useSelector( isUserLoggedIn );
 		const user = useSelector( getCurrentUser );
 
@@ -788,7 +842,10 @@ const onboarding: FlowV2< typeof initialize > = {
 		 * starts on a clean slate.
 		 */
 		useEffect( () => {
-			if ( ! currentStepSlug ) {
+			// The route match is the unconstrained `/:flow/:step?/:lang?`, so
+			// `/setup/onboarding/es` arrives with the locale in place of a step. Reading it as
+			// a step would skip the reset.
+			if ( ! currentStepSlug || getLanguageSlugs().includes( currentStepSlug ) ) {
 				resetOnboardStore();
 				reduxDispatch( setSelectedSiteId( null ) );
 				clearStepPersistedState( this.name );
@@ -797,8 +854,27 @@ const onboarding: FlowV2< typeof initialize > = {
 				clearSignupCompleteFlowName();
 				clearSignupCompleteSlug();
 				clearSignupCompleteSiteID();
+
+				// Must follow the reset above, not precede it.
+				const query = getCurrentQueryParams();
+				const preselectedPlan = getPreselectedPlan( query );
+				const storageAddOn = getPreselectedStorageAddOn( query );
+
+				if ( preselectedPlan ) {
+					setPlanCartItem( { product_slug: preselectedPlan } );
+				}
+
+				if ( storageAddOn ) {
+					setProductCartItems( [ storageAddOn ] );
+				}
 			}
-		}, [ currentStepSlug, reduxDispatch, resetOnboardStore ] );
+		}, [
+			currentStepSlug,
+			reduxDispatch,
+			resetOnboardStore,
+			setPlanCartItem,
+			setProductCartItems,
+		] );
 
 		/**
 		 * Load Survicate and set visitor traits on each step navigation.
@@ -814,8 +890,13 @@ const onboarding: FlowV2< typeof initialize > = {
 			}
 		}, [ isLoggedIn, currentStepSlug, user?.email, user?.date, user?.ID ] );
 
-		// Preload the visual split experiment
+		// Skip the preload when this visit skips the plans step: enrolling someone in a
+		// plans-page test they never see only dilutes it.
 		useEffect( () => {
+			if ( getPreselectedPlan( getCurrentQueryParams() ) ) {
+				return;
+			}
+
 			loadExperimentAssignment( 'calypso_plans_page_visual_separation_2025_09_v2' );
 		}, [] );
 

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-post-plan-selection-email-verification.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-post-plan-selection-email-verification.ts
@@ -16,6 +16,13 @@ jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', (
 	clearSessionStorageQuery: jest.fn(),
 } ) );
 
+// The product catalog's feature list pulls @wordpress/components in through this, and that
+// chain needs a real @wordpress/data, which this file mocks. Only JSX uses these.
+jest.mock( '@automattic/components', () => ( {
+	MaterialIcon: () => null,
+	ExternalLink: () => null,
+} ) );
+
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
 		resetOnboardStore: jest.fn(),

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-wow-funnel-resume.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-wow-funnel-resume.ts
@@ -49,6 +49,12 @@ jest.mock( 'calypso/state/selectors/get-current-locale-slug', () => ( {
 jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', () => ( {
 	clearSessionStorageQuery: jest.fn(),
 } ) );
+// The product catalog's feature list pulls @wordpress/components in through this, and that
+// chain needs a real @wordpress/data, which this file mocks. Only JSX uses these.
+jest.mock( '@automattic/components', () => ( {
+	MaterialIcon: () => null,
+	ExternalLink: () => null,
+} ) );
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {} ),
 	useSelect: jest.fn( () => ( {} ) ),

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
@@ -2,15 +2,39 @@
  * @jest-environment jsdom
  */
 import { renderHook } from '@testing-library/react';
+import { useSelect } from '@wordpress/data';
 import { clearSessionStorageQuery } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import onboarding from '../onboarding';
 
 jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', () => ( {
 	clearSessionStorageQuery: jest.fn(),
 } ) );
 
+const mockResetOnboardStore = jest.fn();
+const mockSetPlanCartItem = jest.fn();
+const mockSetProductCartItems = jest.fn();
+
+// The product catalog's feature list pulls @wordpress/components in through this, and that
+// chain needs a real @wordpress/data, which this file mocks. Only JSX uses these.
+jest.mock( '@automattic/components', () => ( {
+	MaterialIcon: () => null,
+	ExternalLink: () => null,
+} ) );
+
 jest.mock( '@wordpress/data', () => ( {
-	useDispatch: () => ( { resetOnboardStore: jest.fn() } ),
+	useDispatch: () => ( {
+		resetOnboardStore: mockResetOnboardStore,
+		setDomain: jest.fn(),
+		setDomainCartItem: jest.fn(),
+		setDomainCartItems: jest.fn(),
+		setHideFreePlan: jest.fn(),
+		setPlanCartItem: mockSetPlanCartItem,
+		setProductCartItems: mockSetProductCartItems,
+		setSignupDomainOrigin: jest.fn(),
+		setSiteUrl: jest.fn(),
+	} ),
 	useSelect: jest.fn( () => ( {} ) ),
 	resolveSelect: jest.fn(),
 } ) );
@@ -46,7 +70,10 @@ jest.mock( 'calypso/landing/stepper/stores', () => ( {
 	SITE_STORE: 'SITE_STORE',
 } ) );
 
-jest.mock( '@automattic/data-stores', () => ( {} ) );
+jest.mock( '@automattic/data-stores', () => ( {
+	// Real add-on constants: the barrel is too heavy for this environment, this file is not.
+	AddOns: jest.requireActual( '@automattic/data-stores/src/add-ons/constants' ),
+} ) );
 
 jest.mock(
 	'calypso/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification',
@@ -147,5 +174,185 @@ describe( 'onboarding flow use-my-domain navigation', () => {
 		const query = new URLSearchParams( queryString );
 		expect( query.get( 'step' ) ).toBe( 'transfer-or-connect' );
 		expect( query.get( 'initialQuery' ) ).toBe( 'example.com' );
+	} );
+} );
+
+describe( 'onboarding flow domains navigation', () => {
+	const submitDomains = ( search: string, cartPlan?: string ) => {
+		( useQuery as jest.Mock ).mockReturnValue( new URLSearchParams( search ) );
+		( useSelect as jest.Mock ).mockReturnValue(
+			cartPlan ? { planCartItem: { product_slug: cartPlan } } : {}
+		);
+
+		const navigate = jest.fn();
+		const { result } = renderHook( () =>
+			// `useStepNavigation` reads `this.name`, so it must be invoked bound to the flow.
+			onboarding.useStepNavigation.call(
+				onboarding,
+				'domains' as Parameters< typeof onboarding.useStepNavigation >[ 0 ],
+				navigate
+			)
+		);
+
+		result.current.submit?.( {
+			slug: 'domains',
+			providedDependencies: { siteUrl: 'example.wordpress.com' },
+		} as Parameters< NonNullable< typeof result.current.submit > >[ 0 ] );
+
+		return navigate;
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	// Without this, redirected traffic is asked to pick a plan it already chose.
+	it( 'skips the plans step when the URL names a plan already in the cart', () => {
+		const navigate = submitDomains( 'plan=personal-bundle', 'personal-bundle' );
+
+		expect( navigate ).toHaveBeenCalledWith( 'create-site', undefined, false );
+	} );
+
+	// A cold step URL never ran the seeding; skipping would hand over a free site.
+	it( 'goes to the plans step when the cart does not hold the named plan', () => {
+		const navigate = submitDomains( 'plan=personal-bundle' );
+
+		expect( navigate ).toHaveBeenCalledWith( 'plans' );
+	} );
+
+	it( 'goes to the plans step when the URL names no plan', () => {
+		const navigate = submitDomains( '' );
+
+		expect( navigate ).toHaveBeenCalledWith( 'plans' );
+	} );
+} );
+
+describe( 'onboarding flow plan preselection', () => {
+	const enterFlowAt = ( search: string, currentStepSlug: string | null ) => {
+		window.history.replaceState( {}, '', `/setup/onboarding${ search }` );
+
+		renderHook(
+			() =>
+				// `useSideEffect` reads `this.name`, so it must be invoked bound to the flow.
+				onboarding.useSideEffect?.call(
+					onboarding,
+					currentStepSlug as Parameters< NonNullable< typeof onboarding.useSideEffect > >[ 0 ],
+					jest.fn()
+				)
+		);
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		sessionStorage.clear();
+	} );
+
+	// Entry resets the store. Seed any earlier and the customer arrives at checkout with no
+	// plan, because navigation still skips the grid.
+	it( 'seeds the cart after the entry reset, not before it', () => {
+		enterFlowAt( '?plan=personal-bundle', null );
+
+		expect( mockResetOnboardStore ).toHaveBeenCalled();
+		expect( mockSetPlanCartItem ).toHaveBeenCalledWith( { product_slug: 'personal-bundle' } );
+		expect( mockResetOnboardStore.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			mockSetPlanCartItem.mock.invocationCallOrder[ 0 ]
+		);
+	} );
+
+	it( 'carries a storage add-on into the cart alongside the plan', () => {
+		enterFlowAt( '?plan=business-bundle&storage=50gb-storage-add-on', null );
+
+		expect( mockSetProductCartItems ).toHaveBeenCalledWith( [
+			expect.objectContaining( { product_slug: 'wordpress_com_1gb_space_addon_yearly' } ),
+		] );
+	} );
+
+	// `/setup/onboarding` is public and the query rides through the redirect untouched, so
+	// this is the only thing stopping a combination that was never purchasable.
+	it( 'refuses a storage add-on on a plan that cannot buy one', () => {
+		enterFlowAt( '?plan=personal-bundle&storage=50gb-storage-add-on', null );
+
+		expect( mockSetPlanCartItem ).toHaveBeenCalledWith( { product_slug: 'personal-bundle' } );
+		expect( mockSetProductCartItems ).not.toHaveBeenCalled();
+	} );
+
+	it( 'leaves the cart alone when no plan is named', () => {
+		enterFlowAt( '', null );
+
+		expect( mockSetPlanCartItem ).not.toHaveBeenCalled();
+	} );
+
+	// The route match is unconstrained, so a localized entry hands over the locale where a
+	// step slug would be. Read as a step, it leaves the cart unseeded.
+	it( 'seeds the cart on a localized entry, where the locale arrives as the step slug', () => {
+		enterFlowAt( '/es?plan=personal-bundle', 'es' );
+
+		expect( mockSetPlanCartItem ).toHaveBeenCalledWith( { product_slug: 'personal-bundle' } );
+	} );
+
+	it( 'leaves the cart alone on a real step, which is not flow entry', () => {
+		enterFlowAt( '/domains?plan=personal-bundle', 'domains' );
+
+		expect( mockSetPlanCartItem ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'onboarding flow tracks event props', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	// The consumer keys its effect on object identity, so a new object each render records
+	// another signup start.
+	it( 'returns a stable object across renders', () => {
+		( useQuery as jest.Mock ).mockReturnValue( new URLSearchParams( 'plan=personal-bundle' ) );
+
+		const { result, rerender } = renderHook(
+			() => onboarding.useTracksEventProps?.call( onboarding )
+		);
+		const first = result.current;
+		rerender();
+
+		expect( result.current ).toBe( first );
+		expect( first?.eventsProperties.calypso_signup_start ).toEqual( {
+			preselected_plan: 'personal-bundle',
+		} );
+	} );
+} );
+
+describe( 'onboarding flow plans-page experiment enrolment', () => {
+	const enterFlowAt = ( search: string ) => {
+		window.history.replaceState( {}, '', `/setup/onboarding${ search }` );
+
+		renderHook(
+			() =>
+				// `useSideEffect` reads `this.name`, so it must be invoked bound to the flow.
+				onboarding.useSideEffect?.call(
+					onboarding,
+					'' as Parameters< NonNullable< typeof onboarding.useSideEffect > >[ 0 ],
+					jest.fn()
+				)
+		);
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		sessionStorage.clear();
+	} );
+
+	// A preselected plan skips the grid, so enrolling puts someone in a plans-page test they
+	// never see and dilutes it for everyone who does.
+	it( 'does not enrol a visit that skips the plans step', () => {
+		enterFlowAt( '?plan=personal-bundle' );
+
+		expect( loadExperimentAssignment ).not.toHaveBeenCalled();
+	} );
+
+	it( 'enrols an ordinary visit', () => {
+		enterFlowAt( '' );
+
+		expect( loadExperimentAssignment ).toHaveBeenCalledWith(
+			'calypso_plans_page_visual_separation_2025_09_v2'
+		);
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -1,3 +1,4 @@
+import { isMonthly } from '@automattic/calypso-products';
 import { HelpCenter } from '@automattic/data-stores';
 import {
 	isAIBuilderFlow,
@@ -146,6 +147,11 @@ const DomainSearchStep: StepType< {
 
 	const storedSiteTitle = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedSiteTitle(),
+		[]
+	);
+
+	const planCartItem = useSelect(
+		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
 		[]
 	);
 
@@ -339,12 +345,18 @@ const DomainSearchStep: StepType< {
 			return ! site || ! siteHasPaidPlan( site );
 		}
 
+		// A plan chosen before this step never reaches the shopping cart, so the cart's own
+		// monthly check cannot see it. Monthly plans do not carry the free first year.
+		if ( planCartItem?.product_slug && isMonthly( planCartItem.product_slug ) ) {
+			return false;
+		}
+
 		if ( site || sourceSlug || isHundredYearPlanFlow( flow ) || isHundredYearDomainFlow( flow ) ) {
 			return false;
 		}
 
 		return true;
-	}, [ flow, isCiab, site, sourceSlug ] );
+	}, [ flow, isCiab, site, sourceSlug, planCartItem ] );
 
 	const slots = useMemo( () => {
 		return {

--- a/client/landing/stepper/utils/preselected-plan.ts
+++ b/client/landing/stepper/utils/preselected-plan.ts
@@ -1,0 +1,75 @@
+import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
+import { AddOns } from '@automattic/data-stores';
+import { getAddOn } from '@automattic/data-stores/src/add-ons/add-ons-list';
+import { isPreselectablePlan, supportsStorageAddOn } from 'calypso/lib/signup/legacy-plan-flows';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+import type { PreselectablePlan } from 'calypso/lib/signup/legacy-plan-flows';
+
+type StorageAddOnSlug = ( typeof AddOns.STORAGE_ADD_ONS )[ number ];
+
+function isStorageAddOnSlug( slug: string ): slug is StorageAddOnSlug {
+	return ( AddOns.STORAGE_ADD_ONS as readonly string[] ).includes( slug );
+}
+
+/**
+ * The plan named by `?plan=`, or null when it is absent or not one the legacy plan flows
+ * preselected. Falling back to null keeps the plans grid as the graceful degradation, which
+ * is what an unrecognised flow name already did on the `/start` side.
+ */
+export function getPreselectedPlan( query: URLSearchParams ): PreselectablePlan | null {
+	const productSlug = query.get( 'plan' );
+
+	return productSlug && isPreselectablePlan( productSlug ) ? productSlug : null;
+}
+
+/**
+ * The storage add-on named by `?storage=`, as a cart product.
+ *
+ * `feature_slug` is pinned to the 50GB add-on for every size, which is what the legacy
+ * storage-addon step sent — the quantity is what distinguishes the tiers. Kept as-is so
+ * carts built here match the ones built before; worth a separate look, not a silent change.
+ */
+export function getPreselectedStorageAddOn(
+	query: URLSearchParams
+): MinimalRequestCartProduct | null {
+	const plan = getPreselectedPlan( query );
+
+	// `/setup/onboarding` is public, and this add-on on any other plan was never purchasable.
+	if ( ! plan || ! supportsStorageAddOn( plan ) ) {
+		return null;
+	}
+
+	const selectedStorage = query.get( 'storage' );
+
+	if ( ! selectedStorage || ! isStorageAddOnSlug( selectedStorage ) ) {
+		return null;
+	}
+
+	const addOn = getAddOn( selectedStorage );
+
+	if ( ! addOn?.quantity ) {
+		return null;
+	}
+
+	return {
+		product_slug: PRODUCT_1GB_SPACE,
+		quantity: addOn.quantity,
+		volume: 1,
+		extra: { feature_slug: AddOns.ADD_ON_50GB_STORAGE },
+	};
+}
+
+/**
+ * Whether this visit passes the plans grid by. Both halves are required: the query is the one
+ * that decides, because `planCartItem` is persisted and a leftover from an old session would
+ * send an ordinary visitor past the grid; the cart then has to agree, because a plan is seeded
+ * on entry alone and a deep link to a later step still has one to ask for.
+ */
+export function skipsPlansStep(
+	query: URLSearchParams,
+	planCartItem: MinimalRequestCartProduct | null | undefined
+): boolean {
+	const plan = getPreselectedPlan( query );
+
+	return !! plan && planCartItem?.product_slug === plan;
+}

--- a/client/lib/signup/legacy-plan-flows.ts
+++ b/client/lib/signup/legacy-plan-flows.ts
@@ -1,0 +1,110 @@
+import {
+	PLAN_BUSINESS,
+	PLAN_BUSINESS_2_YEARS,
+	PLAN_BUSINESS_3_YEARS,
+	PLAN_BUSINESS_MONTHLY,
+	PLAN_PERSONAL,
+	PLAN_PERSONAL_2_YEARS,
+	PLAN_PERSONAL_3_YEARS,
+	PLAN_PERSONAL_MONTHLY,
+	PLAN_PREMIUM,
+	PLAN_PREMIUM_2_YEARS,
+	PLAN_PREMIUM_3_YEARS,
+	PLAN_PREMIUM_MONTHLY,
+} from '@automattic/calypso-products';
+
+/**
+ * The legacy `/start/<plan>` signup flows, which exist only to preselect a plan, and the
+ * data needed to serve them from Stepper's onboarding flow instead.
+ */
+
+/** Flow name as it appears in the wild, mapped to the plan it preselects. */
+export const REDIRECTED_PLAN_FLOWS = {
+	personal: PLAN_PERSONAL,
+	'personal-monthly': PLAN_PERSONAL_MONTHLY,
+	'personal-2y': PLAN_PERSONAL_2_YEARS,
+	'personal-3y': PLAN_PERSONAL_3_YEARS,
+	premium: PLAN_PREMIUM,
+	'premium-monthly': PLAN_PREMIUM_MONTHLY,
+	'premium-2y': PLAN_PREMIUM_2_YEARS,
+	'premium-3y': PLAN_PREMIUM_3_YEARS,
+	business: PLAN_BUSINESS,
+	'business-monthly': PLAN_BUSINESS_MONTHLY,
+	'business-2y': PLAN_BUSINESS_2_YEARS,
+	'business-3y': PLAN_BUSINESS_3_YEARS,
+
+	// Landpack emits these spellings. They never matched a flow name, so they lose their
+	// preselection today; mapping them fixes the pages already cached.
+	'personal-2-years': PLAN_PERSONAL_2_YEARS,
+	'personal-3-years': PLAN_PERSONAL_3_YEARS,
+	'premium-2-years': PLAN_PREMIUM_2_YEARS,
+	'premium-3-years': PLAN_PREMIUM_3_YEARS,
+	'business-2-years': PLAN_BUSINESS_2_YEARS,
+	'business-3-years': PLAN_BUSINESS_3_YEARS,
+} as const;
+
+export type RedirectedPlanFlow = keyof typeof REDIRECTED_PLAN_FLOWS;
+export type PreselectablePlan = ( typeof REDIRECTED_PLAN_FLOWS )[ RedirectedPlanFlow ];
+
+// Plans onboarding will preselect on request. Today exactly what the redirected flows sold;
+// widening it is a deliberate act, because anything here is selectable by typing a URL.
+const PRESELECTABLE_PLANS: ReadonlySet< string > = new Set(
+	Object.values( REDIRECTED_PLAN_FLOWS )
+);
+
+/**
+ * Whether onboarding will preselect a plan on request.
+ *
+ * Deliberately narrower than "is a WordPress.com plan": a plan reached through its own
+ * eligibility gate — the Student plan behind the Education flow's invite check, or an
+ * ecommerce plan whose flow arranges an Atomic transfer — must not become selectable by
+ * hand-writing a query argument. The backend remains the authority; this only decides what
+ * onboarding is willing to preselect.
+ */
+export function isPreselectablePlan( slug: string ): slug is PreselectablePlan {
+	return PRESELECTABLE_PLANS.has( slug );
+}
+
+/**
+ * Whether a plan can buy a storage add-on. Annual Business and annual Commerce are the two
+ * that can; the plans grid holds the canonical list, and only Business is redirected here.
+ */
+export function supportsStorageAddOn( slug: string ): boolean {
+	return slug === REDIRECTED_PLAN_FLOWS.business;
+}
+
+/** Whether a flow should be redirected at all. */
+export function shouldRedirectLegacyPlanFlow( flow: string ): flow is RedirectedPlanFlow {
+	return flow in REDIRECTED_PLAN_FLOWS;
+}
+
+/**
+ * The Stepper URL a legacy plan flow redirects to.
+ * The whole query is carried over. Nothing here is a boundary: `plan` and `storage` are
+ * checked where they are read, which is also the only place that covers someone typing
+ * `/setup/onboarding` directly, and the rest of onboarding's arguments are reachable there
+ * anyway.
+ * @param flow     Flow name from the path.
+ * @param query    Parsed query string of the incoming request.
+ * @param locale   Locale slug to append, when it isn't the default.
+ */
+export function getLegacyPlanFlowRedirect(
+	flow: RedirectedPlanFlow,
+	query: Record< string, unknown > = {},
+	locale = ''
+): string {
+	const forwarded: Record< string, string > = {};
+
+	for ( const [ arg, value ] of Object.entries( query ) ) {
+		if ( typeof value === 'string' && value ) {
+			forwarded[ arg ] = value;
+		}
+	}
+
+	// Last, so a caller cannot name its own plan through a flow that already names one.
+	forwarded.plan = REDIRECTED_PLAN_FLOWS[ flow ];
+
+	const search = new URLSearchParams( forwarded ).toString();
+
+	return `/setup/onboarding${ locale ? `/${ locale }` : '' }?${ search }`;
+}

--- a/client/lib/signup/test/legacy-plan-flows.ts
+++ b/client/lib/signup/test/legacy-plan-flows.ts
@@ -1,0 +1,35 @@
+import { PLAN_BUSINESS, PLAN_PERSONAL } from '@automattic/calypso-products';
+import {
+	getLegacyPlanFlowRedirect,
+	isPreselectablePlan,
+	shouldRedirectLegacyPlanFlow,
+} from '../legacy-plan-flows';
+
+const target = ( ...args: Parameters< typeof getLegacyPlanFlowRedirect > ) =>
+	new URL( getLegacyPlanFlowRedirect( ...args ), 'https://wordpress.com' );
+
+describe( 'legacy plan flows', () => {
+	// The allowlist is what stops a hand-written `?plan=` reaching a plan with its own
+	// eligibility gate, such as the Student plan behind the Education flow's invite check.
+	it( 'preselects only the plans that need no further gate', () => {
+		expect( isPreselectablePlan( PLAN_PERSONAL ) ).toBe( true );
+		expect( isPreselectablePlan( 'wp_bundle_student_yearly' ) ).toBe( false );
+		expect( isPreselectablePlan( 'ecommerce-bundle' ) ).toBe( false );
+	} );
+
+	// The query is handed on whole, but the plan is the flow's to name, not the caller's.
+	it( 'carries the query over and names the plan itself', () => {
+		const url = target( 'business', { ref: 'pricing-lp', plan: 'value_bundle' }, 'es' );
+
+		expect( url.pathname ).toBe( '/setup/onboarding/es' );
+		expect( url.searchParams.get( 'ref' ) ).toBe( 'pricing-lp' );
+		expect( url.searchParams.get( 'plan' ) ).toBe( PLAN_BUSINESS );
+	} );
+
+	// The server route matcher is built from the map, so a flow outside it must fall through
+	// to the legacy signup section rather than redirect.
+	it( 'redirects only the flows it maps', () => {
+		expect( shouldRedirectLegacyPlanFlow( 'business-monthly' ) ).toBe( true );
+		expect( shouldRedirectLegacyPlanFlow( 'free' ) ).toBe( false );
+	} );
+} );

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -45,6 +45,11 @@ import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { shouldSeeCookieBanner } from 'calypso/lib/analytics/utils';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { login } from 'calypso/lib/paths';
+import {
+	REDIRECTED_PLAN_FLOWS,
+	getLegacyPlanFlowRedirect,
+	shouldRedirectLegacyPlanFlow,
+} from 'calypso/lib/signup/legacy-plan-flows';
 import loginRouter, { LOGIN_SECTION_DEFINITION } from 'calypso/login';
 import sections from 'calypso/sections';
 import isSectionEnabled from 'calypso/sections-filter';
@@ -1335,6 +1340,26 @@ export default function pages() {
 				variant.extraMiddleware
 			)
 		);
+	} );
+
+	// Legacy `/start/<plan>` flows are now served by Stepper's onboarding flow with the plan
+	// preselected. This has to be registered ahead of the section loop below, which binds
+	// `/start` for the signup section and would otherwise match first. The `/*` variant covers
+	// step segments — `/start/personal/domains` is a shape real `redirect_to` values use.
+	const legacyPlanFlowRoute = `/start/:flow(${ Object.keys( REDIRECTED_PLAN_FLOWS ).join( '|' ) })`;
+	app.get( [ legacyPlanFlowRoute, `${ legacyPlanFlowRoute }/*` ], ( req, res, next ) => {
+		if ( ! shouldRedirectLegacyPlanFlow( req.params.flow ) ) {
+			return next( 'route' );
+		}
+
+		// Last non-empty segment, so a trailing slash doesn't hide the locale.
+		const lastPathSegment = req.path.split( '/' ).filter( Boolean ).pop() ?? '';
+		const locale =
+			getLanguageSlugs().includes( lastPathSegment ) && ! isDefaultLocale( lastPathSegment )
+				? lastPathSegment
+				: '';
+
+		res.redirect( 302, getLegacyPlanFlowRedirect( req.params.flow, req.query, locale ) );
 	} );
 
 	sections

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -6,6 +6,10 @@ import { createElement } from 'react';
 import store from 'store';
 import { notFound } from 'calypso/controller';
 import { login } from 'calypso/lib/paths';
+import {
+	getLegacyPlanFlowRedirect,
+	shouldRedirectLegacyPlanFlow,
+} from 'calypso/lib/signup/legacy-plan-flows';
 import { addQueryArgs } from 'calypso/lib/url';
 import flows from 'calypso/signup/config/flows';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -101,6 +105,19 @@ export default {
 		}
 
 		next();
+	},
+
+	// The server redirect only sees hard navigations; `/start` is also a client route, so an
+	// in-app link reaches this router instead. Runs before anything touches signup state so
+	// the hand-off to Stepper leaves nothing half-written behind.
+	redirectLegacyPlanFlow( context, next ) {
+		const { flowName, lang } = context.params;
+
+		if ( ! shouldRedirectLegacyPlanFlow( flowName ) ) {
+			return next();
+		}
+
+		window.location.replace( getLegacyPlanFlowRedirect( flowName, context.query, lang ) );
 	},
 
 	async redirectToFlow( context, next ) {

--- a/client/signup/index.web.js
+++ b/client/signup/index.web.js
@@ -13,6 +13,7 @@ export default function () {
 			`/start/:flowName/:stepName/${ lang }`,
 			`/start/:flowName/:stepName/:stepSectionName/${ lang }`,
 		],
+		controller.redirectLegacyPlanFlow,
 		controller.saveInitialContext,
 		controller.redirectWithoutLocaleIfLoggedIn,
 		controller.redirectToFlow,


### PR DESCRIPTION
## Proposed Changes

* All twelve plan-specific `/start` flows (Personal, Premium and Business, in every term) now redirect into `/setup/onboarding` with the plan preselected. The plan lands in the cart on entry and the flow routes past the plans grid, which is what the old flows did with a fulfilled plans step.
* The domain step no longer promises a free first-year domain when a monthly plan is already chosen. Its guard read the shopping cart, which a plan chosen on entry has not reached yet, so this also closes the same gap in the hosting flow.
* The query is carried over whole. `plan` and `storage` are validated where they are read, which is also the only layer covering someone typing `/setup/onboarding` directly.
* This traffic now reports the signup-start ad conversion, which it did not before. These flows have always met that conversion's definition; the previous condition keyed on flow name and was narrower.
* The flow configs stay for now. Their Tracks volume falling to zero is the signal that nothing still reaches them.

## Why are these changes being made?

These flows exist only to preselect a plan; their plans steps never render, and they already share their UI with Stepper. What remains is duplicated configuration and a second framework. All twelve are roughly a third of the remaining `/start` surface, at under 1% of signup starts.

The 2023 decision to build these on the old framework noted that migrating should not be a big deal. Every blocker named then has since cleared: the account step, the domain step and the pricing grid are all Stepper's now.

Known behaviour deltas needing product and experiment-platform acceptance: these visits become eligible for onboarding's live experiments; post-checkout routing follows onboarding rather than landing on the site; abandoning checkout returns to the plans grid; the checkout URL omits `ref`; and a completed paid attempt records signup-start twice. None are introduced here — all are existing onboarding behaviour this traffic had not previously met.

## Testing Instructions

1. Visit `/start/personal`, `/start/business-2y`, and a localized variant such as `/start/premium/es`. Each should land on onboarding with the plan named in the query, skip the plans grid after the domain step, and reach checkout with the plan in the cart.
2. Visit `/start/business?storage=50gb-storage-add-on&coupon=X&utm_source=test`. The add-on and both parameters should survive. Typing `?plan=personal-bundle&storage=50gb-storage-add-on` directly at `/setup/onboarding` should refuse the add-on.
3. Visit `/start/personal-monthly`. It should redirect like the rest, and the domain step should not offer a free first-year domain. Confirm too that an in-app plugin or theme upsell CTA redirects the same way a bookmark does, since `/start` is a client route as well as a server one.
4. Check the shared domain step both ways: `/start/business` should still offer the free first-year domain, and `/setup/new-hosted-site?showDomainStep&plan=business-monthly`, which could already reach that step with a monthly plan before this change, should not.

Worth a second opinion: annual Personal, Premium and Business declare `redirect_to`, and onboarding ignores it, so a redirected request carrying one lands on My Home rather than the destination the link named. I could find no caller, here or in wpcom. If you know of one, say so and they can stay behind until onboarding honours it.

Rollout dependencies. Shared cart writes currently swallow API failures, so a transient failure can produce a site and an empty checkout. That predates this change and affects all onboarding, but it should be fixed in its own PR before or alongside this rolling out. The ad-conversion change should also be confirmed with whoever owns the ad spend, since it alters bidding input.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
