### PR TITLE
Omnibar: fix misaligned items on <480px width

### DIFF
--- a/client/dashboard/app/omnibar/plugin-reader.scss
+++ b/client/dashboard/app/omnibar/plugin-reader.scss
@@ -8,7 +8,7 @@ $omnibar-reader-active-radius: 4px;
 	);
 }
 
-.omnibar .omnibar__reader {
+.omnibar .omnibar__menu.omnibar__reader {
 	@media ( max-width: 360px ) {
 		display: none;
 	}

--- a/packages/omnibar/src/components/omnibar.scss
+++ b/packages/omnibar/src/components/omnibar.scss
@@ -146,7 +146,7 @@ body:has( .omnibar ) {
 
 			svg {
 				position: relative;
-				inset-inline-start: -1px;
+				inset-inline-start: 1px;
 			}
 		}
 
@@ -159,12 +159,11 @@ body:has( .omnibar ) {
 		@media ( max-width: 480px ) {
 			.dashicons-before::before {
 				width: 46px;
-				inset-inline-start: 3px;
 			}
 
 			.omnibar__site-icon {
 				position: relative;
-				inset-inline-start: 3px;
+				inset-inline-start: 0.5px;
 			}
 		}
 


### PR DESCRIPTION
Part of DOTCOM-18357

## Proposed Changes

Mirror changes from https://github.com/Automattic/jetpack/pull/51765.

Additionally, fix the specificity loss that prevents Reader from being hidden on Classic Calypso screens on <= 360px width.
