### PR TITLE
Agents Manager: add shared-component rules and refresh docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,12 +22,14 @@
 
 ## Packages
 
+- **Agents Manager** (`packages/agents-manager`) — shared component library for WordPress.com's unified AI agent experience, running in Calypso, Simple, Atomic, and CIAB sites. Also deployed via `apps/agents-manager/` to `widgets.wp.com`. See its `AGENTS.md` for architecture and conventions.
 - **Help Center** (`packages/help-center`) — shared component library for WordPress.com support. Also deployed via `apps/help-center/` to `widgets.wp.com`.
 - **Image Studio** (`packages/image-studio`) — AI-powered image editing and generation
 - **Calypso Products** (`packages/calypso-products`) — ⚠️ **Avoid.** Deprecated/frozen: a bloated client-side duplicate of product data the backend already owns. Don't add to it; prefer backend-driven data (e.g. `@automattic/api-queries`). See `packages/calypso-products/AGENTS.md`.
 
 ## Apps
 
+- **Agents Manager** (`apps/agents-manager`) — build/deploy layer that bundles `packages/agents-manager` into webpack entry points served from `widgets.wp.com`.
 - **Help Center** (`apps/help-center`) — build/deploy layer that bundles `packages/help-center` into webpack entry points served from `widgets.wp.com`.
 
 ## Development

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 
 ## Packages
 
-- **Agents Manager** (`packages/agents-manager`) — shared component library for WordPress.com's unified AI agent experience, running in Calypso, Simple, Atomic, and CIAB sites. Also deployed via `apps/agents-manager/` to `widgets.wp.com`. See its `AGENTS.md` for architecture and conventions.
+- **Agents Manager** (`packages/agents-manager`) — shared component library for WordPress.com's unified AI agent experience, running in Calypso, Simple, and Atomic sites. Also deployed via `apps/agents-manager/` to `widgets.wp.com`. See its `AGENTS.md` for architecture and conventions.
 - **Help Center** (`packages/help-center`) — shared component library for WordPress.com support. Also deployed via `apps/help-center/` to `widgets.wp.com`.
 - **Image Studio** (`packages/image-studio`) — AI-powered image editing and generation
 - **Calypso Products** (`packages/calypso-products`) — ⚠️ **Avoid.** Deprecated/frozen: a bloated client-side duplicate of product data the backend already owns. Don't add to it; prefer backend-driven data (e.g. `@automattic/api-queries`). See `packages/calypso-products/AGENTS.md`.

--- a/apps/agents-manager/AGENTS.md
+++ b/apps/agents-manager/AGENTS.md
@@ -2,7 +2,7 @@
 
 Build and deployment layer for the Agents Manager. Most code lives in `packages/agents-manager/` — see its `AGENTS.md` for architecture and conventions.
 
-This app bundles the package into 9 webpack entry points deployed to `widgets.wp.com/agents-manager/`. They are separate compilations sharing one `dist/`, so each entry's chunk filenames and chunk-loading global must stay entry-unique. Jetpack enqueues these on Simple, Atomic, and CIAB sites.
+This app bundles the package into 9 webpack entry points deployed to `widgets.wp.com/agents-manager/`. They are separate compilations sharing one `dist/`, so each entry's chunk filenames and chunk-loading global must stay entry-unique. Jetpack enqueues these on Simple and Atomic sites.
 
 ## Build & Sync
 
@@ -21,7 +21,7 @@ The `--sync` flag syncs bundles to `widgets.wp.com/agents-manager/` on your sand
 
 1. Sandbox `widgets.wp.com` (the sites themselves do not need sandboxing).
 2. Run `yarn dev --sync` from this directory.
-3. Visit any Simple, Atomic, or CIAB site.
+3. Visit any Simple or Atomic site.
 4. Open the Agents Manager and verify your changes.
 
 ## Pitfalls

--- a/apps/agents-manager/README.md
+++ b/apps/agents-manager/README.md
@@ -13,11 +13,9 @@ The Agents Manager runs in multiple different environments:
 3. In Atomic sites
    - as a plugin to Gutenberg editor.
    - as a wpadminbar menu item.
-4. In CIAB (Commerce in a Box)
-   - as a Next Admin SPA integration.
-5. In the WooCommerce AI admin
+4. In the WooCommerce AI admin
    - as a standalone chat container.
-6. On public blog frontends
+5. On public blog frontends
    - as Reader Chat for logged-out visitors.
 
 ### How to develop the Agents Manager

--- a/packages/agents-manager/AGENTS.md
+++ b/packages/agents-manager/AGENTS.md
@@ -24,6 +24,7 @@ cd apps/agents-manager && yarn dev --sync
 
 ## Conventions
 
+- **`@wordpress/*` for React APIs, UI elements, and icons**: import React APIs from `@wordpress/element` (keep bare `react` imports type-only), UI elements from `@wordpress/components`, and icons from `@wordpress/icons`. This matches the existing code and the script externals WordPress registers on wp-admin/editor surfaces — a different source ships a duplicate copy.
 - **i18n**: Use `@wordpress/i18n` with the `__i18n_text_domain__` text domain placeholder — passed unquoted as it is a global constant, not a string literal. The webpack `DefinePlugin` replaces it with `'default'` at build time.
 - **Curly quotes**: Preserve `""` `''` exactly as they appear. Do not convert to unicode escapes or ASCII equivalents.
 

--- a/packages/agents-manager/AGENTS.md
+++ b/packages/agents-manager/AGENTS.md
@@ -27,6 +27,23 @@ cd apps/agents-manager && yarn dev --sync
 - **i18n**: Use `@wordpress/i18n` with the `__i18n_text_domain__` text domain placeholder — passed unquoted as it is a global constant, not a string literal. The webpack `DefinePlugin` replaces it with `'default'` at build time.
 - **Curly quotes**: Preserve `""` `''` exactly as they appear. Do not convert to unicode escapes or ASCII equivalents.
 
+## Working in Heavily Shared Components
+
+A heavily shared component is one rendered by multiple agent chats or surfaces — `components/orchestrator-chat` (the largest), `components/agent-chat`, `components/agent-dock`. They accrete cross-cutting logic fast, making changes — AI-generated ones most of all — hard to read and review. Target shape: a thin composition layer — hooks at the top, minimal glue, render at the bottom.
+
+These rules are MUSTs, not suggestions. They apply to every change that adds or modifies state, effects, handlers, or behavior in such a component:
+
+1. **One mechanism, one hook.** All state, refs, effects, and callbacks implementing a single behavior MUST live together in one custom hook under `src/hooks/`, named after the behavior (`use-image-upload`, `use-navigation-continuation` are the pattern). A mechanism's pieces MUST NOT be spread across the component body.
+2. **New cross-cutting logic starts as a hook, not inline.** A change that adds a `useState` + `useEffect` + handler cluster to one of these components MUST extract it into a hook in the same PR. If a hook already owns that behavior, it MUST be extended — a parallel hook MUST NOT be added.
+3. **Pure logic goes to `utils/`.** New logic with no React state — parsing, formatting, list transforms — MUST be a pure function with explicit inputs and outputs. When adding a stage to a multi-stage derivation (e.g. a large `useMemo` shaping the transcript), the stage MUST be a named pure function, so the derivation stays an ordered pipeline.
+4. **Keep hook APIs narrow.** A hook MUST take explicit inputs and return only what callers use. When two mechanisms share state, it MUST be passed explicitly between them — never coupled through the component closure.
+5. **One gate per surface difference.** Surface- or provider-specific behavior MUST be gated in a single place — a prop, a capability flag, the provider contract (`extension-types.ts`), or one derived value (as `isReaderChat` is) — and MUST NOT be re-tested with scattered ad-hoc conditionals through the body. Behavior owned by a provider MUST come through the contract, not be hardcoded in shared code.
+6. **Changing existing behavior needs a blast-radius check.** A shared component's props, events, and observable behavior are a contract with every surface. Before changing or removing any, you MUST find all consumers — every chat entry, the `-disconnected` variants, and external providers if `extension-types.ts` is involved (see Pitfalls) — and confirm each still behaves as intended.
+7. **Docblock the why.** Every hook MUST have a docblock stating which mechanism it implements and why it exists — the race, product behavior, or platform quirk. That context is what keeps grouped logic safe to move later.
+8. **Shared weight is universal weight.** Any import added to shared code ships to every surface — you MUST check the Performance section before importing anything heavy.
+
+Before finishing a change to one of these components, check the diff against each rule above.
+
 ## Performance
 
 One source ships to every surface, so weight one surface needs is weight they all carry — `reader-chat` most of all, since it bundles its dependencies instead of externalizing them.

--- a/packages/agents-manager/AGENTS.md
+++ b/packages/agents-manager/AGENTS.md
@@ -26,7 +26,7 @@ cd apps/agents-manager && yarn dev --sync
 
 - **`@wordpress/*` for React APIs, UI elements, and icons**: import React APIs from `@wordpress/element` (keep bare `react` imports type-only), UI elements from `@wordpress/components`, and icons from `@wordpress/icons`. This matches the existing code and the script externals WordPress registers on wp-admin/editor surfaces — a different source ships a duplicate copy.
 - **i18n**: Use `@wordpress/i18n` with the `__i18n_text_domain__` text domain placeholder — passed unquoted as it is a global constant, not a string literal. The webpack `DefinePlugin` replaces it with `'default'` at build time.
-- **Curly quotes**: Preserve `""` `''` exactly as they appear. Do not convert to unicode escapes or ASCII equivalents.
+- **Curly quotes**: Preserve `“”` `‘’` exactly as they appear. Do not convert to unicode escapes or ASCII equivalents.
 
 ## Working in Heavily Shared Components
 

--- a/packages/agents-manager/AGENTS.md
+++ b/packages/agents-manager/AGENTS.md
@@ -24,7 +24,7 @@ cd apps/agents-manager && yarn dev --sync
 
 ## Conventions
 
-- **`@wordpress/*` for React APIs, UI elements, and icons**: import React APIs from `@wordpress/element` (keep bare `react` imports type-only), UI elements from `@wordpress/components`, and icons from `@wordpress/icons`. This matches the existing code and the script externals WordPress registers on wp-admin/editor surfaces — a different source ships a duplicate copy.
+- **`@wordpress/*` for React APIs, generic UI, and icons**: in new code, import React APIs from `@wordpress/element` (keep bare `react` imports type-only), generic UI primitives from `@wordpress/components`, and icons from `@wordpress/icons` — matching the script externals WordPress registers on wp-admin/editor surfaces, where a different source ships a duplicate copy. Chat UI comes from `@automattic/agenttic-ui` (the chat runtime above); this rule is not a license to replace it or to churn existing compliant imports.
 - **i18n**: Use `@wordpress/i18n` with the `__i18n_text_domain__` text domain placeholder — passed unquoted as it is a global constant, not a string literal. The webpack `DefinePlugin` replaces it with `'default'` at build time.
 - **Curly quotes**: Preserve `“”` `‘’` exactly as they appear. Do not convert to unicode escapes or ASCII equivalents.
 

--- a/packages/agents-manager/AGENTS.md
+++ b/packages/agents-manager/AGENTS.md
@@ -1,6 +1,6 @@
 # Agents Manager Package
 
-`@automattic/agents-manager` is the shared component library for WordPress.com's unified AI agent experience. It runs in Calypso, Simple sites, Atomic sites, and CIAB — all from the same source.
+`@automattic/agents-manager` is the shared component library for WordPress.com's unified AI agent experience. It runs in Calypso, Simple sites, and Atomic sites — all from the same source.
 
 ## Cross-Repo Boundaries
 
@@ -15,7 +15,7 @@
 # Unit tests (from repo root)
 yarn jest -c test/packages/jest.config.js --testPathPattern=agents-manager
 
-# Sandbox testing (Simple/Atomic/CIAB)
+# Sandbox testing (Simple/Atomic)
 cd apps/agents-manager && yarn dev --sync
 # Then visit any site — only widgets.wp.com needs sandboxing, not the site itself
 ```
@@ -69,7 +69,7 @@ AM ability registration (`registerAmAbilities()`) is called wherever the chat mo
 
 ## Pitfalls
 
-- **Two deployment targets**: Every change must work in both Calypso (SPA) and Simple/Atomic/CIAB (via `widgets.wp.com` bundles). They use different bootstrap paths.
+- **Two deployment targets**: Every change must work in both Calypso (SPA) and Simple/Atomic (via `widgets.wp.com` bundles). They use different bootstrap paths.
 - **Async chunks resolve from the entry script's URL** (webpack `publicPath: "auto"`): the abilities chunk and any new lazy seam must be verified on both targets plus the inlined `reader-chat` bundle — a chunk that 404s fails silently as a missing feature, not an error page. All entries share `dist/`, so chunk filenames and the chunk-loading global are entry-unique (`output-chunk-filename` + `chunkLoadingGlobal` per config) — a same-named chunk from another entry's build would overwrite it.
 - **asset.json sync gap**: Adding/removing `@wordpress/*` dependencies changes `.asset.json` files, which Jetpack fetches from production — not your sandbox. Dependency changes require a deploy to take effect on Atomic.
 - **Unregistered script handles**: `@wordpress/*` packages WordPress doesn't register as scripts (e.g. `@wordpress/abilities`, `@wordpress/ui`) must stay force-bundled in `apps/agents-manager/webpack.config.js` — an externalized unregistered dependency makes `WP_Scripts` silently drop the whole bundle.

--- a/packages/agents-manager/AGENTS.md
+++ b/packages/agents-manager/AGENTS.md
@@ -48,8 +48,8 @@ Before finishing a change to one of these components, check the diff against eac
 
 One source ships to every surface, so weight one surface needs is weight they all carry — `reader-chat` most of all, since it bundles its dependencies instead of externalizing them.
 
-- **Load heavy, surface-specific code on demand.** Components go through `lazyComponent()` (`utils/lazy-component.ts`); other modules take a gated dynamic `import()`, as `abilities/index.ts` does. One static import of `@wordpress/block-editor`, `blocks`, `core-data`, or `media-utils` anywhere in the shared chat path pulls that tree into every entry.
-- **Measure before and after** — `webpack-bundle-analyzer`, or the per-entry sizes from `yarn build` in `apps/agents-manager`. Import chains are easy to misjudge by reading.
+- **Heavy, surface-specific code MUST load on demand.** Components go through `lazyComponent()` (`utils/lazy-component.ts`); other modules take a gated dynamic `import()`, as `abilities/index.ts` does. A static import of `@wordpress/block-editor`, `blocks`, `core-data`, or `media-utils` MUST NOT be added anywhere in the shared chat path — it pulls that tree into every entry.
+- **Changes that add a dependency or touch a lazy-loading seam MUST be measured before and after** — `webpack-bundle-analyzer`, or the per-entry sizes from `yarn build` in `apps/agents-manager`. Import chains are easy to misjudge by reading.
 
 ## Ability Scoping
 

--- a/packages/agents-manager/README.md
+++ b/packages/agents-manager/README.md
@@ -105,7 +105,7 @@ function MyComponent() {
 }
 ```
 
-Feedback utilities are also exported: `useFeedbackAction`, `submitFeedback`, `rateMessage`, and the `FeedbackInput` component.
+Feedback utilities are also exported: `useFeedbackAction`, `submitFeedback`, `rateMessage`, and the `FeedbackInput` component. Chat UI actions (`openAgentsManagerChat`, `closeAgentsManagerChat`, `isAgentsManagerChatVisible`, `getAgentsManagerChatRoute`) and `recordAgentsManagerTracksEvent` are exported as well.
 
 ### Exported Types
 
@@ -135,27 +135,10 @@ interface ToolProvider {
 
 ### Ability Interface
 
-Based on the WordPress Abilities API:
+`Ability` is re-exported from `@wordpress/abilities`, which owns the authoritative shape (`name`, `label`, `description`, `category`, schemas, callbacks, and `meta`):
 
 ```tsx
-interface Ability {
-	name: string;
-	label: string;
-	description: string;
-	category: string;
-	input_schema?: Record< string, any >;
-	output_schema?: Record< string, any >;
-	callback?: ( input: any ) => any | Promise< any >;
-	permissionCallback?: ( input?: any ) => boolean | Promise< boolean >;
-	meta?: {
-		annotations?: {
-			readonly?: boolean | null;
-			destructive?: boolean | null;
-			idempotent?: boolean | null;
-		};
-		[ key: string ]: any;
-	};
-}
+import type { Ability } from '@automattic/agents-manager';
 ```
 
 ### ContextProvider Interface
@@ -169,7 +152,14 @@ interface ClientContextType {
 	url: string;
 	pathname: string;
 	search: string;
-	environment: 'wp-admin' | 'ciab-admin' | 'calypso' | string;
+	environment:
+		| 'wp-admin'
+		| 'ciab-admin'
+		| 'calypso'
+		| 'wp-admin-disconnected'
+		| 'gutenberg-disconnected'
+		| 'ciab-disconnected'
+		| string;
 	contextEntries?: ContextEntry[];
 	[ key: string ]: any;
 }

--- a/packages/agents-manager/README.md
+++ b/packages/agents-manager/README.md
@@ -152,14 +152,7 @@ interface ClientContextType {
 	url: string;
 	pathname: string;
 	search: string;
-	environment:
-		| 'wp-admin'
-		| 'ciab-admin'
-		| 'calypso'
-		| 'wp-admin-disconnected'
-		| 'gutenberg-disconnected'
-		| 'ciab-disconnected'
-		| string;
+	environment: 'wp-admin' | 'calypso' | string; // full union in `src/extension-types.ts`
 	contextEntries?: ContextEntry[];
 	[ key: string ]: any;
 }


### PR DESCRIPTION
Part of AM-19

## Proposed Changes

* Add a `Working in Heavily Shared Components` section to `packages/agents-manager/AGENTS.md`: eight MUST rules for keeping cross-cutting logic grouped into hooks/utils when changing heavily shared components (`orchestrator-chat`, `agent-chat`, `agent-dock`), plus a closing diff self-check.
* Make the existing Performance section's rules normative to match (on-demand loading and bundle measurement as MUSTs), since the new section defers to it for import weight.
* Add the Agents Manager package and app to the root `AGENTS.md` lists, which predated them.
* Remove a discontinued surface from the Agents Manager docs; it is no longer listed as supported.
* Add a Conventions bullet codifying the existing `@wordpress/*` practice: React APIs from `@wordpress/element` (bare `react` imports type-only), UI elements from `@wordpress/components`, icons from `@wordpress/icons`.
* Refresh the package `README.md` where it had drifted from the source: the `Ability` section now points at `@wordpress/abilities` (which owns the type) instead of a stale copy, the `ClientContextType` snippet defers the full `environment` union to `extension-types.ts`, and the exported chat-action/Tracks utilities are listed.

## Why are these changes being made?

* Heavily shared components accrete cross-cutting logic fast and become hard to read and review — `orchestrator-chat` is now ~2000 lines. The new rules keep related logic grouped going forward and give AI tools (which load `AGENTS.md` automatically) explicit, checkable constraints, so generated changes stay reviewable. This is doc-only groundwork for the AM-19 reorganization.
* The remaining changes bring the surrounding docs up to date: the root `AGENTS.md` did not mention the Agents Manager at all, and the docs still listed a discontinued surface.

## Testing Instructions

* Doc-only change — no runtime or build impact. Review the rendered Markdown files and confirm the rules read clearly and the referenced paths/symbols exist (`src/hooks/use-image-upload.ts`, `src/hooks/use-navigation-continuation.ts`, `src/extension-types.ts`).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?



