### PR TITLE
A4A: Use Badge from @wordpress/ui

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/amplify.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/amplify.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
-import { Badge } from '@automattic/ui';
 import { __ } from '@wordpress/i18n';
 import { chevronLeft } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import Sidebar from '../sidebar';
 import useAmplifyMenuItems from './hooks/use-amplify-menu-items';
 import { A4A_AMPLIFY_LINK, A4A_OVERVIEW_LINK } from './lib/constants';
@@ -19,7 +19,7 @@ export default function AmplifySidebar( { path }: Props ) {
 			title={
 				<div className="sidebar-menu-item__title-with-badge">
 					<span>{ __( 'Amplify' ) }</span>
-					<Badge>{ __( 'Beta' ) }</Badge>
+					<Badge intent="draft">{ __( 'Beta' ) }</Badge>
 				</div>
 			}
 			backButtonProps={ {

--- a/client/a8c-for-agencies/components/sidebar-menu/reports.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/reports.tsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
-import { Badge } from '@automattic/ui';
 import { chevronLeft } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import { A4A_REPORTS_LINK } from 'calypso/a8c-for-agencies/sections/reports/constants';
 import Sidebar from '../sidebar';
@@ -21,7 +21,7 @@ export default function ReportsSidebar( { path }: Props ) {
 			title={
 				<div className="sidebar-menu-item__title-with-badge">
 					<span>{ translate( 'Reports' ) }</span>
-					<Badge>{ translate( 'Beta' ) }</Badge>
+					<Badge intent="draft">{ translate( 'Beta' ) }</Badge>
 				</div>
 			}
 			backButtonProps={ {

--- a/client/a8c-for-agencies/sections/agency-tier/progress-card/index.tsx
+++ b/client/a8c-for-agencies/sections/agency-tier/progress-card/index.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@automattic/ui';
 import {
 	Card,
 	CardBody,
@@ -9,6 +8,7 @@ import {
 	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { A4A_AGENCY_TIER_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import getCurrentAgencyTier from 'calypso/dashboard/agency/tiers/get-current-agency-tier';
 import { ButtonStack } from 'calypso/dashboard/components/button-stack';
@@ -65,18 +65,14 @@ export default function AgencyTierProgressCard( {
 						</Heading>
 						<VStack spacing={ 1 }>
 							{ tierStatus === 'early_access' && (
-								<Badge
-									style={ { width: 'fit-content', marginBottom: '4px' } }
-									intent="default"
-									children={ __( 'Early access' ) }
-								/>
+								<Badge style={ { width: 'fit-content', marginBottom: '4px' } } intent="draft">
+									{ __( 'Early access' ) }
+								</Badge>
 							) }
 							{ tierStatus === 'tier_protected' && (
-								<Badge
-									style={ { width: 'fit-content', marginBottom: '4px' } }
-									intent="default"
-									children={ __( 'Tier-level protected' ) }
-								/>
+								<Badge style={ { width: 'fit-content', marginBottom: '4px' } } intent="draft">
+									{ __( 'Tier-level protected' ) }
+								</Badge>
 							) }
 							<Heading level={ 3 } weight={ 500 }>
 								{ currentTier.name }

--- a/client/a8c-for-agencies/sections/amplify/primary/overview/sections/score-card.tsx
+++ b/client/a8c-for-agencies/sections/amplify/primary/overview/sections/score-card.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@automattic/ui';
 import {
 	Card,
 	CardBody,
@@ -9,6 +8,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useState } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -135,7 +135,7 @@ export default function AmplifyScoreCard() {
 						<Text as="code" variant="muted" size={ 12 }>
 							{ SAMPLE_URL }
 						</Text>
-						<Badge intent="success">{ __( 'Audit complete' ) }</Badge>
+						<Badge intent="stable">{ __( 'Audit complete' ) }</Badge>
 					</HStack>
 
 					<ToggleGroupControl

--- a/client/a8c-for-agencies/sections/amplify/primary/reports/reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/primary/reports/reports-content.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@automattic/ui';
 import { useBreakpoint } from '@automattic/viewport-react';
 import {
 	Button,
@@ -10,6 +9,7 @@ import {
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __, sprintf } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import { useMemo, useState } from 'react';
 import {
 	DATAVIEWS_TABLE,
@@ -55,13 +55,13 @@ function ScoreBadge( { score, label }: { score: number | null; label: string } )
 	if ( score === null ) {
 		return null;
 	}
-	let intent: 'success' | 'warning' | 'error';
+	let intent: 'stable' | 'medium' | 'high';
 	if ( score >= 80 ) {
-		intent = 'success';
+		intent = 'stable';
 	} else if ( score >= 50 ) {
-		intent = 'warning';
+		intent = 'medium';
 	} else {
-		intent = 'error';
+		intent = 'high';
 	}
 	return (
 		<Badge intent={ intent }>
@@ -123,7 +123,7 @@ export default function AmplifyReportsContent() {
 				label: __( 'Analysis type' ),
 				getValue: ( { item }: { item: AmplifyReportRow } ) => modeLabel( item.mode ),
 				render: ( { item }: { item: AmplifyReportRow } ): ReactNode => (
-					<Badge>{ modeLabel( item.mode ) }</Badge>
+					<Badge intent="draft">{ modeLabel( item.mode ) }</Badge>
 				),
 				enableHiding: true,
 				enableSorting: true,
@@ -176,7 +176,7 @@ export default function AmplifyReportsContent() {
 				render: ( { item }: { item: AmplifyReportRow } ): ReactNode => {
 					if ( item.rowStatus === 'failed' ) {
 						return (
-							<Badge intent="error" title={ item.failureReason }>
+							<Badge intent="high" title={ item.failureReason }>
 								{ __( 'Analysis failed' ) }
 							</Badge>
 						);

--- a/client/a8c-for-agencies/sections/amplify/primary/reports/reports-content.tsx
+++ b/client/a8c-for-agencies/sections/amplify/primary/reports/reports-content.tsx
@@ -27,7 +27,7 @@ import ArchiveReportConfirmationDialog from './archive-report-confirmation-dialo
 import useAmplifyReportRows, { AmplifyReportRow } from './use-report-rows';
 import type { Action, Field } from '@wordpress/dataviews';
 import type { AmplifyMode } from 'calypso/a8c-for-agencies/data/amplify/types';
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 
 function modeLabel( mode: AmplifyMode ): string {
 	switch ( mode ) {
@@ -55,7 +55,7 @@ function ScoreBadge( { score, label }: { score: number | null; label: string } )
 	if ( score === null ) {
 		return null;
 	}
-	let intent: 'stable' | 'medium' | 'high';
+	let intent: NonNullable< ComponentProps< typeof Badge >[ 'intent' ] >;
 	if ( score >= 80 ) {
 		intent = 'stable';
 	} else if ( score >= 50 ) {

--- a/client/a8c-for-agencies/sections/client/lib/get-subscription-status.tsx
+++ b/client/a8c-for-agencies/sections/client/lib/get-subscription-status.tsx
@@ -3,28 +3,28 @@ export const getSubscriptionStatus = (
 	translate: ( key: string ) => string
 ): {
 	children: string | undefined;
-	type: 'default' | 'success' | 'warning' | 'info' | 'error' | undefined;
+	type: 'draft' | 'stable' | 'medium' | 'informational' | 'high' | undefined;
 } => {
 	switch ( status ) {
 		case 'pending':
 			return {
 				children: translate( 'Pending' ),
-				type: 'warning',
+				type: 'medium',
 			};
 		case 'active':
 			return {
 				children: translate( 'Active' ),
-				type: 'success',
+				type: 'stable',
 			};
 		case 'error':
 			return {
 				children: translate( 'Error' ),
-				type: 'error',
+				type: 'high',
 			};
 		case 'canceled':
 			return {
 				children: translate( 'Canceled' ),
-				type: 'default',
+				type: 'draft',
 			};
 		default:
 			return {

--- a/client/a8c-for-agencies/sections/client/lib/get-subscription-status.tsx
+++ b/client/a8c-for-agencies/sections/client/lib/get-subscription-status.tsx
@@ -1,9 +1,12 @@
+import type { Badge } from '@wordpress/ui';
+import type { ComponentProps } from 'react';
+
 export const getSubscriptionStatus = (
 	status: string,
 	translate: ( key: string ) => string
 ): {
 	children: string | undefined;
-	type: 'draft' | 'stable' | 'medium' | 'informational' | 'high' | undefined;
+	type: ComponentProps< typeof Badge >[ 'intent' ];
 } => {
 	switch ( status ) {
 		case 'pending':

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/field-content.tsx
@@ -1,6 +1,6 @@
 import { formatCurrency } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 import { Button } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import { EXTERNAL_PRESSABLE_AUTH_URL } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';

--- a/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/style.scss
+++ b/client/a8c-for-agencies/sections/client/primary/subscriptions-list/mobile-view/style.scss
@@ -34,6 +34,7 @@
 	}
 
 	.step-section-item__status {
+		display: inline-block;
 		margin-block-start: 8px;
 	}
 

--- a/client/a8c-for-agencies/sections/dev-tools/primary/dev-tools-overview/dev-tool-section.tsx
+++ b/client/a8c-for-agencies/sections/dev-tools/primary/dev-tools-overview/dev-tool-section.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@automattic/ui';
 import {
 	Button,
 	__experimentalHeading as Heading,
@@ -6,6 +5,7 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 import PageSectionColumns from 'calypso/a8c-for-agencies/components/page-section-columns';
 import SimpleList from 'calypso/a8c-for-agencies/components/simple-list';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -49,7 +49,7 @@ export default function DevToolSection( {
 					<>
 						<HStack alignment="left">
 							<Heading level={ 3 }>{ name }</Heading>
-							<Badge>{ badge }</Badge>
+							<Badge intent="draft">{ badge }</Badge>
 						</HStack>
 						<Text className="dev-tools-overview__tagline" weight={ 500 }>
 							{ tagline }

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-usage-section/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/premier-agency-hosting/pressable-usage-section/index.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@automattic/ui';
+import { Badge } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import PageSection from 'calypso/a8c-for-agencies/components/page-section';
 import PressableUsageDetails from 'calypso/a8c-for-agencies/components/pressable-usage-details';
@@ -20,7 +20,7 @@ export default function PressableUsageSection( { existingPlan }: Props ) {
 		>
 			<div className="pressable-usage-card">
 				<div className="pressable-usage-card__heading">
-					{ existingPlan.name } <Badge>{ translate( 'Plan' ) }</Badge>
+					{ existingPlan.name } <Badge intent="draft">{ translate( 'Plan' ) }</Badge>
 				</div>
 				<PressableUsageDetails existingPlan={ existingPlan } />
 			</div>

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/style.scss
@@ -60,6 +60,7 @@
 }
 
 .wpcom-plan-selector__owned-plan {
+	display: inline-block;
 	margin-block-end: 8px;
 }
 

--- a/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hosting-overview/hosting-content/standard-agency-hosting/wpcom-plan-section/wpcom-plan-selector.tsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { formatCurrency } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 import { Button } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -129,7 +129,7 @@ export default function WPCOMPlanSelector( {
 		>
 			<div className="wpcom-plan-selector__top">
 				{ ownedPlans > 0 && (
-					<Badge className="wpcom-plan-selector__owned-plan">
+					<Badge className="wpcom-plan-selector__owned-plan" intent="draft">
 						{ translate( 'You own %(count)s site', 'You own %(count)s sites', {
 							args: {
 								count: ownedPlans,

--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-badges/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-badges/index.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@automattic/ui';
+import { Badge } from '@wordpress/ui';
 import { useProductCategories } from '../../hooks/use-product-categories';
 import type { APIProductFamilyProduct } from 'calypso/a8c-for-agencies/types/products';
 
@@ -14,7 +14,9 @@ export default function ProductBadges( { product }: Props ) {
 	return (
 		<div className="product-badges">
 			{ badges.map( ( badge: string ) => (
-				<Badge key={ badge }>{ badge }</Badge>
+				<Badge key={ badge } intent="draft">
+					{ badge }
+				</Badge>
 			) ) }
 		</div>
 	);

--- a/client/a8c-for-agencies/sections/overview/body/hosting/pressable-offering.tsx
+++ b/client/a8c-for-agencies/sections/overview/body/hosting/pressable-offering.tsx
@@ -1,8 +1,8 @@
 import page from '@automattic/calypso-router';
 import { Button, FoldableCard, Gridicon } from '@automattic/components';
 import { formatNumber } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 import { __experimentalHStack as HStack } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -53,7 +53,7 @@ const PressableOffering = () => {
 				<HStack spacing={ 3 }>
 					<span>{ translate( 'Pressable' ) }</span>
 					{ isPressableRegular && (
-						<Badge intent="success">{ translate( "You're signed up!" ) }</Badge>
+						<Badge intent="stable">{ translate( "You're signed up!" ) }</Badge>
 					) }
 				</HStack>
 			</h3>

--- a/client/a8c-for-agencies/sections/overview/sidebar/featured-woopayments/featured-card.tsx
+++ b/client/a8c-for-agencies/sections/overview/sidebar/featured-woopayments/featured-card.tsx
@@ -1,7 +1,7 @@
 import { Card } from '@automattic/components';
-import { Badge } from '@automattic/ui';
 import { Button } from '@wordpress/components';
 import { close } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import { A4A_WOOPAYMENTS_OVERVIEW_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import WooPaymentsLogo from 'calypso/assets/images/a8c-for-agencies/product-logos/woopayments.svg';
@@ -17,7 +17,7 @@ const WooPaymentsFeaturedCard = ( { onDismiss, onClick }: Props ) => {
 	return (
 		<Card className="overview__featured-woopayments">
 			<div className="overview__featured-woopayments-top">
-				<Badge>{ translate( 'Featured' ) }</Badge>
+				<Badge intent="draft">{ translate( 'Featured' ) }</Badge>
 
 				<Button
 					className="overview__featured-dismiss-button"

--- a/client/a8c-for-agencies/sections/partner-directory/lead-matching/index.tsx
+++ b/client/a8c-for-agencies/sections/partner-directory/lead-matching/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
-import { Badge } from '@automattic/ui';
 import { Card, CardBody, ToggleControl, Button } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Form from 'calypso/a8c-for-agencies/components/form';
@@ -513,7 +513,7 @@ const LeadMatchingForm = ( { initialFormData, profile }: Props ) => {
 					<CardBody className="partner-directory-lead-matching__status-content">
 						{ eligibilityState === 'eligible' && (
 							<>
-								<Badge intent="success">{ __( 'Eligible for leads' ) }</Badge>
+								<Badge intent="stable">{ __( 'Eligible for leads' ) }</Badge>
 								<span className="partner-directory-lead-matching__status-text">
 									{ __( 'Your preferences are saved. You can update them anytime.' ) }
 								</span>
@@ -521,7 +521,7 @@ const LeadMatchingForm = ( { initialFormData, profile }: Props ) => {
 						) }
 						{ eligibilityState === 'not-accepting' && (
 							<>
-								<Badge intent="warning">{ __( 'Not eligible' ) }</Badge>
+								<Badge intent="medium">{ __( 'Not eligible' ) }</Badge>
 								<span className="partner-directory-lead-matching__status-text">
 									{ __(
 										'Turn on Accepting new clients to be included in lead matching and receive leads.'
@@ -531,7 +531,7 @@ const LeadMatchingForm = ( { initialFormData, profile }: Props ) => {
 						) }
 						{ eligibilityState === 'ready' && (
 							<>
-								<Badge intent="info">{ __( '1 step left' ) }</Badge>
+								<Badge intent="informational">{ __( '1 step left' ) }</Badge>
 								<span className="partner-directory-lead-matching__status-text">
 									{ __(
 										'All questions answered — click Update preferences to start receiving leads'

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-card/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-card/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
+import { Badge } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import { memo, ComponentProps } from 'react';
 import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
@@ -18,32 +18,32 @@ function InvoicesListCard( { id, number, dueDate, status, total, currency, pdfUr
 	const dueDateMoment = moment( dueDate );
 	const payInvoice = usePayInvoiceMutation();
 
-	let badgeIntent: ComponentProps< typeof Badge >[ 'intent' ] = 'default';
+	let badgeIntent: ComponentProps< typeof Badge >[ 'intent' ] = 'draft';
 	let badgeLabel = translate( 'Draft' );
 
 	switch ( status ) {
 		case 'open':
-			badgeIntent = 'info';
+			badgeIntent = 'informational';
 			badgeLabel = translate( 'Open' );
 
 			if ( dueDateMoment.isBefore( moment() ) ) {
-				badgeIntent = 'warning';
+				badgeIntent = 'medium';
 				badgeLabel = translate( 'Past due' );
 			}
 			break;
 
 		case 'paid':
-			badgeIntent = 'success';
+			badgeIntent = 'stable';
 			badgeLabel = translate( 'Paid' );
 			break;
 
 		case 'uncollectible':
-			badgeIntent = 'error';
+			badgeIntent = 'high';
 			badgeLabel = translate( 'Uncollectible' );
 			break;
 
 		case 'void':
-			badgeIntent = 'default';
+			badgeIntent = 'draft';
 			badgeLabel = translate( 'Void' );
 			break;
 	}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-details/index.tsx
@@ -1,5 +1,5 @@
 import { Card, Gridicon } from '@automattic/components';
-import { Badge } from '@automattic/ui';
+import { Badge } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
@@ -198,7 +198,7 @@ export default function LicenseDetails( {
 				<div className="license-details__subscription-row">
 					{ subscriptionBadgeLabel && (
 						<Badge
-							intent={ subscription?.status === 'inactive' ? 'success' : 'info' }
+							intent={ subscription?.status === 'inactive' ? 'stable' : 'informational' }
 							className="license-details__subscription-badge"
 						>
 							{ subscriptionBadgeLabel }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -1,8 +1,8 @@
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { Button, Gridicon } from '@automattic/components';
-import { Badge } from '@automattic/ui';
 import { ExternalLink } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
@@ -185,7 +185,7 @@ export default function LicensePreview( {
 	const isSiteAtomic = site?.is_wpcom_atomic;
 
 	const bundleCountContent = quantity && (
-		<Badge className="license-preview__license-count">
+		<Badge className="license-preview__license-count" intent="draft">
 			{ translate( '%(quantity)d License Bundle', {
 				context: 'bundle license count',
 				args: {
@@ -219,7 +219,7 @@ export default function LicensePreview( {
 				ref={ wrapperRef }
 				onActivate={ () => setShowPopover( true ) }
 			>
-				<Badge className="license-preview__migration-badge" intent="success">
+				<Badge className="license-preview__migration-badge" intent="stable">
 					{ translate( 'Transferred' ) }
 				</Badge>
 				{ showPopover && (
@@ -288,7 +288,9 @@ export default function LicensePreview( {
 						<div className="license-preview__product-title">
 							{ productTitle }
 							{ referral && (
-								<Badge className="license-preview__client-badge">{ translate( 'Referral' ) }</Badge>
+								<Badge className="license-preview__client-badge" intent="draft">
+									{ translate( 'Referral' ) }
+								</Badge>
 							) }
 						</div>
 						{ referral && (
@@ -315,7 +317,7 @@ export default function LicensePreview( {
 							) }
 							{ ! domain && licenseState === LicenseState.Detached && ! isPressableAddonLicense && (
 								<span className="license-preview__unassigned">
-									<Badge intent="warning">{ translate( 'Unassigned' ) }</Badge>
+									<Badge intent="medium">{ translate( 'Unassigned' ) }</Badge>
 									{ licenseType === LicenseType.Partner && ! isPressableAddonLicense && (
 										<Button
 											className="license-preview__assign-button"
@@ -330,7 +332,7 @@ export default function LicensePreview( {
 							) }
 							{ revokedAt && (
 								<span>
-									<Badge intent="error">{ translate( 'Revoked' ) }</Badge>
+									<Badge intent="high">{ translate( 'Revoked' ) }</Badge>
 								</span>
 							) }
 						</>
@@ -378,7 +380,7 @@ export default function LicensePreview( {
 				<div className="license-preview__badge-container-wrapper">
 					<div className="license-preview__badge-container">
 						{ !! isParentLicense && bundleCountContent }
-						{ isDevelopmentSite && <Badge>{ translate( 'Development' ) }</Badge> }
+						{ isDevelopmentSite && <Badge intent="draft">{ translate( 'Development' ) }</Badge> }
 						{ shouldShowTransferredBadge() && <TransferredBadge /> }
 					</div>
 				</div>

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -19,6 +19,7 @@ import LayoutHeader, {
 } from 'calypso/layout/hosting-dashboard/header';
 import useGetTipaltiIFrameURL from '../../hooks/use-get-tipalti-iframe-url';
 import useGetTipaltiPayee from '../../hooks/use-get-tipalti-payee';
+import type { ComponentProps } from 'react';
 
 import './style.scss';
 
@@ -68,7 +69,7 @@ function PaymentStatusBadge( {
 	tooltip,
 	children,
 }: {
-	intent: 'stable' | 'medium' | 'high';
+	intent: NonNullable< ComponentProps< typeof Badge >[ 'intent' ] >;
 	tooltip?: string;
 	children?: string;
 } ) {

--- a/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/bank-details/index.tsx
@@ -1,6 +1,6 @@
-import { Badge } from '@automattic/ui';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { Tooltip } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import { LayoutWithGuidedTour as Layout } from 'calypso/a8c-for-agencies/components/layout/layout-with-guided-tour';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/layout-with-payment-notification';
@@ -68,7 +68,7 @@ function PaymentStatusBadge( {
 	tooltip,
 	children,
 }: {
-	intent: 'success' | 'warning' | 'error';
+	intent: 'stable' | 'medium' | 'high';
 	tooltip?: string;
 	children?: string;
 } ) {
@@ -114,7 +114,7 @@ export default function ReferralsBankDetails( { type }: { type?: 'migrations' | 
 									components: {
 										badge: (
 											<PaymentStatusBadge
-												intent={ accountStatus.statusType }
+												intent={ accountStatus.badgeIntent }
 												tooltip={ accountStatus.statusReason }
 											/>
 										),

--- a/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
+++ b/client/a8c-for-agencies/sections/referrals/primary/referrals-overview/layout-body-content.tsx
@@ -1,9 +1,9 @@
 import { Button, WordPressLogo } from '@automattic/components';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { formatNumber } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 import { ExternalLink, Tooltip } from '@wordpress/components';
 import { chevronRight, reusableBlock } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useState, useEffect } from 'react';
 import {
@@ -79,7 +79,7 @@ export default function LayoutBodyContent( {
 		if ( ! accountStatus ) {
 			return undefined;
 		}
-		const badge = <Badge intent={ accountStatus.statusType }>{ accountStatus.status }</Badge>;
+		const badge = <Badge intent={ accountStatus.badgeIntent }>{ accountStatus.status }</Badge>;
 		return accountStatus.statusReason ? (
 			<Tooltip text={ accountStatus.statusReason }>{ badge }</Tooltip>
 		) : (

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -4,7 +4,7 @@ import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { ExternalLink, Tooltip } from '@wordpress/components';
 import { Badge } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, ComponentProps } from 'react';
 import InfoModal from 'calypso/a8c-for-agencies/components/a4a-info-modal';
 import A4APopover from 'calypso/a8c-for-agencies/components/a4a-popover';
 import A4APopoverTrigger from 'calypso/a8c-for-agencies/components/a4a-popover/trigger';
@@ -22,7 +22,7 @@ type Props = {
 	data?: APIProductFamilyProduct[];
 };
 
-type BadgeIntent = 'draft' | 'informational' | 'stable' | 'medium' | 'high';
+type BadgeIntent = NonNullable< ComponentProps< typeof Badge >[ 'intent' ] >;
 
 function getPurchaseStatus(
 	purchase: ReferralPurchase,

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -141,11 +141,8 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 	return (
 		<div className="badge-assigned-to">
 			{ tooltip ? (
-				// Badge does not forward refs, so Tooltip needs a DOM element to anchor to.
 				<Tooltip text={ tooltip }>
-					<span style={ { display: 'inline-flex' } }>
-						<Badge intent={ statusType }>{ statusText }</Badge>
-					</span>
+					<Badge intent={ statusType }>{ statusText }</Badge>
 				</Tooltip>
 			) : (
 				<Badge intent={ statusType }>{ statusText }</Badge>

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/assigned-to.tsx
@@ -1,8 +1,8 @@
 import { Button, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Badge } from '@automattic/ui';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { ExternalLink, Tooltip } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useEffect } from 'react';
 import InfoModal from 'calypso/a8c-for-agencies/components/a4a-info-modal';
@@ -22,7 +22,7 @@ type Props = {
 	data?: APIProductFamilyProduct[];
 };
 
-type BadgeIntent = 'default' | 'info' | 'success' | 'warning' | 'error';
+type BadgeIntent = 'draft' | 'informational' | 'stable' | 'medium' | 'high';
 
 function getPurchaseStatus(
 	purchase: ReferralPurchase,
@@ -30,20 +30,20 @@ function getPurchaseStatus(
 ): [ BadgeIntent, string ] {
 	if ( purchase.status === 'active' ) {
 		if ( purchase.site_assigned ) {
-			return [ 'success', translate( 'Assigned' ) ];
+			return [ 'stable', translate( 'Assigned' ) ];
 		}
-		return [ 'warning', translate( 'Unassigned' ) ];
+		return [ 'medium', translate( 'Unassigned' ) ];
 	}
 
 	if ( purchase.status === 'canceled' ) {
-		return [ 'info', translate( 'Canceled' ) ];
+		return [ 'informational', translate( 'Canceled' ) ];
 	}
 
 	if ( purchase.status === 'error' ) {
-		return [ 'error', translate( 'Error' ) ];
+		return [ 'high', translate( 'Error' ) ];
 	}
 
-	return [ 'warning', translate( 'Awaiting payment' ) ];
+	return [ 'medium', translate( 'Awaiting payment' ) ];
 }
 
 const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props ) => {
@@ -75,7 +75,7 @@ const AssignedTo = ( { purchase, handleAssignToSite, data, isFetching }: Props )
 
 	if ( purchase.site_assigned ) {
 		return isPressable ? (
-			<Badge intent="success">{ translate( 'Pressable' ) }</Badge>
+			<Badge intent="stable">{ translate( 'Pressable' ) }</Badge>
 		) : (
 			<Button
 				className="referrals-purchases__assign-button"

--- a/client/a8c-for-agencies/sections/referrals/referral-details/components/referral-status.tsx
+++ b/client/a8c-for-agencies/sections/referrals/referral-details/components/referral-status.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@automattic/ui';
+import { Badge } from '@wordpress/ui';
 import { ReactNode } from 'react';
 import { getReferralStatus } from 'calypso/dashboard/agency/earn/referrals/lib/get-referral-status';
 

--- a/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
+++ b/client/a8c-for-agencies/sections/reports/primary/dashboard/report-columns.tsx
@@ -1,6 +1,6 @@
 import { Tooltip } from '@automattic/components';
-import { Badge } from '@automattic/ui';
 import { Button } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import EmptyValueIndicator from 'calypso/a8c-for-agencies/components/empty-value-indicator';
@@ -29,10 +29,10 @@ export const ReportStatusColumn = ( { status }: { status: ReportStatus } ) => {
 	const translate = useTranslate();
 
 	const statusConfig = {
-		pending: { intent: 'info' as const, text: translate( 'Preparing' ) },
-		processed: { intent: 'success' as const, text: translate( 'Ready to send' ) },
-		sent: { intent: 'success' as const, text: translate( 'Sent' ) },
-		error: { intent: 'error' as const, text: translate( 'Error' ) },
+		pending: { intent: 'informational' as const, text: translate( 'Preparing' ) },
+		processed: { intent: 'stable' as const, text: translate( 'Ready to send' ) },
+		sent: { intent: 'stable' as const, text: translate( 'Sent' ) },
+		error: { intent: 'high' as const, text: translate( 'Error' ) },
 	};
 
 	const config = statusConfig[ status ];

--- a/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
+++ b/client/a8c-for-agencies/sections/sites/sites-dashboard/sites-dataviews-style.scss
@@ -38,6 +38,7 @@
 	margin-inline-end: 16px;
 
 	.sites-dataviews__site-development-badge {
+		display: inline-block;
 		margin-block-start: 4px;
 	}
 }

--- a/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-dataviews/site-data-field.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/components';
-import { Badge } from '@automattic/ui';
+import { Badge } from '@wordpress/ui';
 import { translate } from 'i18n-calypso';
 import SiteFavicon from 'calypso/blocks/site-favicon';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
@@ -44,10 +44,10 @@ const SiteDataField = ( {
 				<div>{ site.blogname }</div>
 				{ ! migrationInProgress && <div className="sites-dataviews__site-url">{ site.url }</div> }
 				{ migrationInProgress && (
-					<Badge intent="info">{ translate( 'Migration in progress' ) }</Badge>
+					<Badge intent="informational">{ translate( 'Migration in progress' ) }</Badge>
 				) }
 				{ isDevSite && (
-					<Badge className="sites-dataviews__site-development-badge">
+					<Badge className="sites-dataviews__site-development-badge" intent="draft">
 						{ translate( 'Development' ) }
 					</Badge>
 				) }

--- a/client/dashboard/agency/earn/migrations/commissions-list/commission-columns.tsx
+++ b/client/dashboard/agency/earn/migrations/commissions-list/commission-columns.tsx
@@ -8,7 +8,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
 import { Badge } from '@wordpress/ui';
-import { useState } from 'react';
+import { useState, ComponentProps } from 'react';
 import { formatDate } from '../../../../utils/datetime';
 import { urlToSlug } from '../../../../utils/url';
 
@@ -46,7 +46,7 @@ export const ReviewStatusColumn = ( {
 
 	const getStatusProps = (): {
 		statusText: string;
-		intent: 'stable' | 'informational' | 'medium';
+		intent: NonNullable< ComponentProps< typeof Badge >[ 'intent' ] >;
 	} | null => {
 		switch ( reviewStatus ) {
 			case 'paid':

--- a/client/dashboard/agency/earn/migrations/commissions-list/commission-columns.tsx
+++ b/client/dashboard/agency/earn/migrations/commissions-list/commission-columns.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@automattic/ui';
 import {
 	Button,
 	Popover,
@@ -8,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import { useState } from 'react';
 import { formatDate } from '../../../../utils/datetime';
 import { urlToSlug } from '../../../../utils/url';
@@ -46,21 +46,21 @@ export const ReviewStatusColumn = ( {
 
 	const getStatusProps = (): {
 		statusText: string;
-		intent: 'success' | 'info' | 'warning';
+		intent: 'stable' | 'informational' | 'medium';
 	} | null => {
 		switch ( reviewStatus ) {
 			case 'paid':
-				return { statusText: __( 'Paid' ), intent: 'success' };
+				return { statusText: __( 'Paid' ), intent: 'stable' };
 			case 'verified':
-				return { statusText: __( 'Confirmed' ), intent: 'success' };
+				return { statusText: __( 'Confirmed' ), intent: 'stable' };
 			case 'rejected':
-				return { statusText: __( 'Ineligible' ), intent: 'info' };
+				return { statusText: __( 'Ineligible' ), intent: 'informational' };
 			case 'ineligible':
-				return { statusText: __( 'Ineligible' ), intent: 'info' };
+				return { statusText: __( 'Ineligible' ), intent: 'informational' };
 			case 'reverification':
-				return { statusText: __( 'Pending re-verification' ), intent: 'info' };
+				return { statusText: __( 'Pending re-verification' ), intent: 'informational' };
 			case 'pending':
-				return { statusText: __( 'Pending' ), intent: 'warning' };
+				return { statusText: __( 'Pending' ), intent: 'medium' };
 			default:
 				// Unknown status - don't show a badge
 				return null;

--- a/client/dashboard/agency/earn/payout-settings/get-account-status.ts
+++ b/client/dashboard/agency/earn/payout-settings/get-account-status.ts
@@ -14,7 +14,7 @@ export function getAccountStatus( data: TipaltiPayee | null | undefined ): Accou
 		return null;
 	}
 	const { Status, IsPayable, PayableReason } = data;
-	let statusMeta = null;
+	let statusMeta: Pick< AccountStatus, 'statusType' | 'status' | 'statusReason' > | null = null;
 	switch ( Status ) {
 		case 'Active':
 			if ( ! IsPayable ) {
@@ -66,7 +66,7 @@ export function getAccountStatus( data: TipaltiPayee | null | undefined ): Accou
 		return null;
 	}
 
-	const badgeIntents: Record< string, AccountStatus[ 'badgeIntent' ] > = {
+	const badgeIntents: Record< AccountStatus[ 'statusType' ], AccountStatus[ 'badgeIntent' ] > = {
 		success: 'stable',
 		warning: 'medium',
 		error: 'high',
@@ -76,5 +76,5 @@ export function getAccountStatus( data: TipaltiPayee | null | undefined ): Accou
 		...statusMeta,
 		badgeIntent: badgeIntents[ statusMeta.statusType ],
 		actionRequired: [ 'warning', 'error' ].includes( statusMeta.statusType ),
-	} as AccountStatus;
+	};
 }

--- a/client/dashboard/agency/earn/payout-settings/get-account-status.ts
+++ b/client/dashboard/agency/earn/payout-settings/get-account-status.ts
@@ -3,6 +3,7 @@ import type { TipaltiPayee } from '@automattic/api-core';
 
 interface AccountStatus {
 	statusType: 'success' | 'warning' | 'error';
+	badgeIntent: 'stable' | 'medium' | 'high';
 	status: string;
 	statusReason?: string;
 	actionRequired: boolean;
@@ -65,8 +66,15 @@ export function getAccountStatus( data: TipaltiPayee | null | undefined ): Accou
 		return null;
 	}
 
+	const badgeIntents: Record< string, AccountStatus[ 'badgeIntent' ] > = {
+		success: 'stable',
+		warning: 'medium',
+		error: 'high',
+	};
+
 	return {
 		...statusMeta,
+		badgeIntent: badgeIntents[ statusMeta.statusType ],
 		actionRequired: [ 'warning', 'error' ].includes( statusMeta.statusType ),
 	} as AccountStatus;
 }

--- a/client/dashboard/agency/earn/payout-settings/get-account-status.ts
+++ b/client/dashboard/agency/earn/payout-settings/get-account-status.ts
@@ -1,9 +1,11 @@
 import { __ } from '@wordpress/i18n';
 import type { TipaltiPayee } from '@automattic/api-core';
+import type { Badge } from '@wordpress/ui';
+import type { ComponentProps } from 'react';
 
 interface AccountStatus {
 	statusType: 'success' | 'warning' | 'error';
-	badgeIntent: 'stable' | 'medium' | 'high';
+	badgeIntent: NonNullable< ComponentProps< typeof Badge >[ 'intent' ] >;
 	status: string;
 	statusReason?: string;
 	actionRequired: boolean;

--- a/client/dashboard/agency/earn/payout-settings/index.tsx
+++ b/client/dashboard/agency/earn/payout-settings/index.tsx
@@ -3,10 +3,10 @@ import {
 	tipaltiIFrameUrlQuery,
 	tipaltiPayeeQuery,
 } from '@automattic/api-queries';
-import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalHStack as HStack, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { PageHeader } from '../../../components/page-header';
 import PageLayout from '../../../components/page-layout';
 import { Text } from '../../../components/text';
@@ -21,7 +21,7 @@ function PaymentStatusBadge( { agencyId }: { agencyId: number } ) {
 		return null;
 	}
 
-	const badge = <Badge intent={ accountStatus.statusType }>{ accountStatus.status }</Badge>;
+	const badge = <Badge intent={ accountStatus.badgeIntent }>{ accountStatus.status }</Badge>;
 
 	return (
 		<HStack spacing={ 2 } justify="flex-start" expanded={ false }>

--- a/client/dashboard/agency/earn/referrals/empty-state.tsx
+++ b/client/dashboard/agency/earn/referrals/empty-state.tsx
@@ -1,11 +1,11 @@
 import { tipaltiPayeeQuery } from '@automattic/api-queries';
 import { formatNumber } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalHStack as HStack, ExternalLink, Icon } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { reusableBlock } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import EmptyState from '../../../components/empty-state';
 import InlineSupportLink from '../../../components/inline-support-link';
 import RouterLinkButton from '../../../components/router-link-button';
@@ -73,7 +73,7 @@ export default function ReferralsEmptyState( { agencyId }: { agencyId: number } 
 								<HStack as="span" spacing={ 2 } justify="flex-start" expanded={ false }>
 									<span>{ __( 'Prepare to get paid' ) }</span>
 									{ accountStatus && (
-										<Badge intent={ accountStatus.statusType }>{ accountStatus.status }</Badge>
+										<Badge intent={ accountStatus.badgeIntent }>{ accountStatus.status }</Badge>
 									) }
 								</HStack>
 							}

--- a/client/dashboard/agency/earn/referrals/lib/get-purchase-status.ts
+++ b/client/dashboard/agency/earn/referrals/lib/get-purchase-status.ts
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import type { ReferralPurchase } from '@automattic/api-core';
 
-export type PurchaseStatusBadgeIntent = 'default' | 'info' | 'success' | 'warning' | 'error';
+export type PurchaseStatusBadgeIntent = 'draft' | 'informational' | 'stable' | 'medium' | 'high';
 
 /**
  * A purchase reports its own status rather than its referral order's, so an
@@ -13,14 +13,14 @@ export function getPurchaseStatus( purchase: ReferralPurchase ): {
 } {
 	if ( purchase.status === 'active' ) {
 		return purchase.site_assigned
-			? { status: __( 'Assigned' ), type: 'success' }
-			: { status: __( 'Unassigned' ), type: 'warning' };
+			? { status: __( 'Assigned' ), type: 'stable' }
+			: { status: __( 'Unassigned' ), type: 'medium' };
 	}
 	if ( purchase.status === 'canceled' ) {
-		return { status: __( 'Canceled' ), type: 'info' };
+		return { status: __( 'Canceled' ), type: 'informational' };
 	}
 	if ( purchase.status === 'error' ) {
-		return { status: __( 'Error' ), type: 'error' };
+		return { status: __( 'Error' ), type: 'high' };
 	}
-	return { status: __( 'Awaiting payment' ), type: 'warning' };
+	return { status: __( 'Awaiting payment' ), type: 'medium' };
 }

--- a/client/dashboard/agency/earn/referrals/lib/get-purchase-status.ts
+++ b/client/dashboard/agency/earn/referrals/lib/get-purchase-status.ts
@@ -1,7 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import type { ReferralPurchase } from '@automattic/api-core';
+import type { Badge } from '@wordpress/ui';
+import type { ComponentProps } from 'react';
 
-export type PurchaseStatusBadgeIntent = 'draft' | 'informational' | 'stable' | 'medium' | 'high';
+export type PurchaseStatusBadgeIntent = NonNullable< ComponentProps< typeof Badge >[ 'intent' ] >;
 
 /**
  * A purchase reports its own status rather than its referral order's, so an

--- a/client/dashboard/agency/earn/referrals/lib/get-referral-status.ts
+++ b/client/dashboard/agency/earn/referrals/lib/get-referral-status.ts
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 
-export type ReferralStatusBadgeIntent = 'default' | 'info' | 'success' | 'warning' | 'error';
+export type ReferralStatusBadgeIntent = 'draft' | 'informational' | 'stable' | 'medium' | 'high';
 
 export function getReferralStatus( status: string ): {
 	status: string;
@@ -10,32 +10,32 @@ export function getReferralStatus( status: string ): {
 		case 'active':
 			return {
 				status: __( 'Active' ),
-				type: 'success',
+				type: 'stable',
 			};
 		case 'pending':
 			return {
 				status: __( 'Pending' ),
-				type: 'warning',
+				type: 'medium',
 			};
 		case 'canceled':
 			return {
 				status: __( 'Canceled' ),
-				type: 'info',
+				type: 'informational',
 			};
 		case 'error':
 			return {
 				status: __( 'Error' ),
-				type: 'error',
+				type: 'high',
 			};
 		case 'archived':
 			return {
 				status: __( 'Archived' ),
-				type: 'default',
+				type: 'draft',
 			};
 		default:
 			return {
 				status: __( 'Mixed' ),
-				type: 'warning',
+				type: 'medium',
 			};
 	}
 }

--- a/client/dashboard/agency/earn/referrals/lib/get-referral-status.ts
+++ b/client/dashboard/agency/earn/referrals/lib/get-referral-status.ts
@@ -1,6 +1,8 @@
 import { __ } from '@wordpress/i18n';
+import type { Badge } from '@wordpress/ui';
+import type { ComponentProps } from 'react';
 
-export type ReferralStatusBadgeIntent = 'draft' | 'informational' | 'stable' | 'medium' | 'high';
+export type ReferralStatusBadgeIntent = NonNullable< ComponentProps< typeof Badge >[ 'intent' ] >;
 
 export function getReferralStatus( status: string ): {
 	status: string;

--- a/client/dashboard/agency/earn/referrals/referral/overview.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/overview.tsx
@@ -1,9 +1,9 @@
 import { agencyProductsQuery, referralCommissionPayoutQuery } from '@automattic/api-queries';
-import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalGrid as Grid, __experimentalHStack as HStack } from '@wordpress/components';
 import { DataViews } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { useAnalytics } from '../../../../app/analytics';
 import { useLocale } from '../../../../app/locale';

--- a/client/dashboard/agency/earn/referrals/referral/purchase-site-details.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/purchase-site-details.tsx
@@ -47,10 +47,5 @@ export default function PurchaseSiteDetails( {
 		? __( 'When your client pays, you can initiate this site.' )
 		: __( 'When your client pays, you can assign this product to a site.' );
 
-	// Badge does not forward refs, so Tooltip needs a DOM element to anchor to.
-	return (
-		<Tooltip text={ tooltip }>
-			<span style={ { display: 'inline-flex' } }>{ badge }</span>
-		</Tooltip>
-	);
+	return <Tooltip text={ tooltip }>{ badge }</Tooltip>;
 }

--- a/client/dashboard/agency/earn/referrals/referral/purchase-site-details.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/purchase-site-details.tsx
@@ -1,6 +1,6 @@
-import { Badge } from '@automattic/ui';
 import { ExternalLink, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import RouterLinkButton from '../../../../components/router-link-button';
 import { urlToSlug } from '../../../../utils/url';
 import { findAgencyProduct } from '../lib/get-product-name';
@@ -25,7 +25,7 @@ export default function PurchaseSiteDetails( {
 	if ( purchase.site_assigned ) {
 		const product = findAgencyProduct( purchase.product_id, products );
 		if ( product?.slug.startsWith( 'pressable' ) ) {
-			return <Badge intent="success">{ __( 'Pressable' ) }</Badge>;
+			return <Badge intent="stable">{ __( 'Pressable' ) }</Badge>;
 		}
 
 		const siteSlug = urlToSlug( purchase.site_assigned );

--- a/client/dashboard/agency/earn/referrals/referral/referrals-tab.tsx
+++ b/client/dashboard/agency/earn/referrals/referral/referrals-tab.tsx
@@ -3,7 +3,6 @@ import {
 	archiveReferralMutation,
 	resendReferralEmailMutation,
 } from '@automattic/api-queries';
-import { Badge } from '@automattic/ui';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import {
 	__experimentalHStack as HStack,
@@ -14,6 +13,7 @@ import { useDispatch } from '@wordpress/data';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+import { Badge } from '@wordpress/ui';
 import { useMemo, useState } from 'react';
 import { useAnalytics } from '../../../../app/analytics';
 import { DataViews, DataViewsCard } from '../../../../components/dataviews';

--- a/client/dashboard/agency/earn/referrals/subscription-status.tsx
+++ b/client/dashboard/agency/earn/referrals/subscription-status.tsx
@@ -1,6 +1,6 @@
-import { Badge } from '@automattic/ui';
 import { Tooltip } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { getReferralStatus } from './lib/get-referral-status';
 import type { Referral } from '@automattic/api-core';
 

--- a/client/dashboard/agency/earn/referrals/subscription-status.tsx
+++ b/client/dashboard/agency/earn/referrals/subscription-status.tsx
@@ -58,10 +58,5 @@ export default function SubscriptionStatus( { item }: { item: Referral } ) {
 		.filter( Boolean )
 		.join( ', ' );
 
-	// Badge does not forward refs, so Tooltip needs a DOM element to anchor to.
-	return (
-		<Tooltip text={ tooltipText }>
-			<span style={ { display: 'inline-flex' } }>{ badge }</span>
-		</Tooltip>
-	);
+	return <Tooltip text={ tooltipText }>{ badge }</Tooltip>;
 }

--- a/client/dashboard/agency/earn/woopayments/site-columns.tsx
+++ b/client/dashboard/agency/earn/woopayments/site-columns.tsx
@@ -10,7 +10,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
 import { Badge } from '@wordpress/ui';
-import { memo, useState } from 'react';
+import { memo, useState, ComponentProps } from 'react';
 import { urlToSlug } from '../../../utils/url';
 import type { RecordTracksEvent } from './types';
 import type { WooPaymentsData } from '@automattic/api-core';
@@ -117,7 +117,10 @@ export const WooPaymentsStatusColumn = ( {
 		);
 	}
 
-	const getStatusProps = (): { statusText: string; statusType: 'stable' | 'high' } | null => {
+	const getStatusProps = (): {
+		statusText: string;
+		statusType: NonNullable< ComponentProps< typeof Badge >[ 'intent' ] >;
+	} | null => {
 		switch ( state ) {
 			case 'active':
 				return {

--- a/client/dashboard/agency/earn/woopayments/site-columns.tsx
+++ b/client/dashboard/agency/earn/woopayments/site-columns.tsx
@@ -1,6 +1,5 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { formatCurrency } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
@@ -10,6 +9,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import { memo, useState } from 'react';
 import { urlToSlug } from '../../../utils/url';
 import type { RecordTracksEvent } from './types';
@@ -117,17 +117,17 @@ export const WooPaymentsStatusColumn = ( {
 		);
 	}
 
-	const getStatusProps = (): { statusText: string; statusType: 'success' | 'error' } | null => {
+	const getStatusProps = (): { statusText: string; statusType: 'stable' | 'high' } | null => {
 		switch ( state ) {
 			case 'active':
 				return {
 					statusText: __( 'Active' ),
-					statusType: 'success',
+					statusType: 'stable',
 				};
 			case 'disconnected':
 				return {
 					statusText: __( 'Disconnected' ),
-					statusType: 'error',
+					statusType: 'high',
 				};
 			default:
 				return null;
@@ -171,13 +171,13 @@ export const CommissionEligibilityColumn = ( {
 	const statusProps = isCommissionEligible
 		? {
 				statusText: __( 'Eligible' ),
-				statusType: 'success' as const,
+				statusType: 'stable' as const,
 				showInfoIcon: false,
 				ineligibleReason: undefined,
 		  }
 		: {
 				statusText: __( 'Not eligible' ),
-				statusType: 'error' as const,
+				statusType: 'high' as const,
 				showInfoIcon: true,
 				ineligibleReason: ineligibleSite?.ineligible_reason,
 		  };

--- a/client/dashboard/agency/marketplace/exclusive-offers/partner-offers.tsx
+++ b/client/dashboard/agency/marketplace/exclusive-offers/partner-offers.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@automattic/ui';
 import {
 	Button,
 	__experimentalGrid as Grid,
@@ -9,6 +8,7 @@ import {
 } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { useState, useMemo } from 'react';
 import { ButtonStack } from '../../../components/button-stack';
 import { Card, CardBody } from '../../../components/card';
@@ -63,7 +63,7 @@ function PartnerOfferCard( {
 						>
 							{ item.logo }
 						</HStack>
-						{ offerType?.label && <Badge>{ offerType.label }</Badge> }
+						{ offerType?.label && <Badge intent="draft">{ offerType.label }</Badge> }
 					</HStack>
 					<VStack spacing={ 1 }>
 						<Text size={ 13 } weight={ 500 }>

--- a/client/dashboard/agency/overview/referral-earnings-card.tsx
+++ b/client/dashboard/agency/overview/referral-earnings-card.tsx
@@ -1,6 +1,5 @@
 import { referralCommissionPayoutQuery, referralsQuery } from '@automattic/api-queries';
 import { formatCurrency, formatNumber } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
 import {
 	__experimentalHeading as Heading,
@@ -8,6 +7,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { Text } from '../../components/text';
@@ -51,7 +51,7 @@ function ReferralEarningsEmptyState( {
 			</Text>
 			{ lockedNote && (
 				<HStack justify="flex-start" expanded={ false }>
-					<Badge>{ lockedNote }</Badge>
+					<Badge intent="draft">{ lockedNote }</Badge>
 				</HStack>
 			) }
 			{ ! locked && (

--- a/client/dashboard/agency/overview/woopayments-revenue-card.tsx
+++ b/client/dashboard/agency/overview/woopayments-revenue-card.tsx
@@ -1,6 +1,5 @@
 import { agencyWooPaymentsDataQuery } from '@automattic/api-queries';
 import { formatCurrency, formatNumber } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 import { useQuery } from '@tanstack/react-query';
 import {
 	__experimentalHeading as Heading,
@@ -8,6 +7,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { ButtonStack } from '../../components/button-stack';
 import { Callout } from '../../components/callout';
 import { Card, CardBody } from '../../components/card';
@@ -56,7 +56,7 @@ function WooPaymentsEmptyState( {
 					</Text>
 					{ lockedNote && (
 						<HStack justify="flex-start" expanded={ false }>
-							<Badge>{ lockedNote }</Badge>
+							<Badge intent="draft">{ lockedNote }</Badge>
 						</HStack>
 					) }
 				</VStack>

--- a/client/dashboard/agency/partner-directory/lib.ts
+++ b/client/dashboard/agency/partner-directory/lib.ts
@@ -6,7 +6,7 @@ import type {
 	AgencyPartnerDirectorySlug,
 	AgencyProfile,
 } from '@automattic/api-core';
-import type { Badge } from '@automattic/ui';
+import type { Badge } from '@wordpress/ui';
 import type { ComponentProps } from 'react';
 
 export type StatusBadgeIntent = ComponentProps< typeof Badge >[ 'intent' ];
@@ -30,15 +30,15 @@ export function getDirectoryStatusBadge(
 ): DirectoryStatusBadge {
 	switch ( status ) {
 		case 'pending':
-			return { key: 'pending', label: __( 'Pending' ), intent: 'warning' };
+			return { key: 'pending', label: __( 'Pending' ), intent: 'medium' };
 		case 'approved':
-			return { key: 'approved', label: __( 'Approved' ), intent: 'success' };
+			return { key: 'approved', label: __( 'Approved' ), intent: 'stable' };
 		case 'rejected':
-			return { key: 'rejected', label: __( 'Not approved' ), intent: 'error' };
+			return { key: 'rejected', label: __( 'Not approved' ), intent: 'high' };
 		case 'closed':
-			return { key: 'closed', label: __( 'Closed' ), intent: 'default' };
+			return { key: 'closed', label: __( 'Closed' ), intent: 'draft' };
 		default:
-			return { key: 'unknown', label: '-', intent: 'default' };
+			return { key: 'unknown', label: '-', intent: 'draft' };
 	}
 }
 

--- a/client/dashboard/agency/partner-directory/status-badge.tsx
+++ b/client/dashboard/agency/partner-directory/status-badge.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@automattic/ui';
+import { Badge } from '@wordpress/ui';
 import NotApprovedPopover from './not-approved-popover';
 import type { DirectoryStatusBadge } from './lib';
 

--- a/client/dashboard/agency/team/dataviews/fields.tsx
+++ b/client/dashboard/agency/team/dataviews/fields.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@automattic/ui';
 import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
@@ -6,6 +5,7 @@ import {
 } from '@wordpress/components';
 import { dateI18n } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { OWNER_ROLE } from '../constants';
 import type { TeamMember, TeamMemberStatus } from '@automattic/api-core';
 import type { Field, Operator } from '@wordpress/dataviews';
@@ -27,15 +27,15 @@ function getStatusLabel( status: TeamMemberStatus ): string {
 	}
 }
 
-function getStatusIntent( status: TeamMemberStatus ): 'success' | 'warning' | 'error' {
+function getStatusIntent( status: TeamMemberStatus ): 'stable' | 'medium' | 'high' {
 	switch ( status ) {
 		case 'active':
-			return 'success';
+			return 'stable';
 		case 'expired':
-			return 'error';
+			return 'high';
 		case 'pending':
 		default:
-			return 'warning';
+			return 'medium';
 	}
 }
 

--- a/client/dashboard/agency/team/dataviews/fields.tsx
+++ b/client/dashboard/agency/team/dataviews/fields.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@wordpress/ui';
 import { OWNER_ROLE } from '../constants';
 import type { TeamMember, TeamMemberStatus } from '@automattic/api-core';
 import type { Field, Operator } from '@wordpress/dataviews';
+import type { ComponentProps } from 'react';
 
 function getRoleLabel( role?: string ): string {
 	// Currently there are only two roles: owner and member. More may come later.
@@ -27,7 +28,9 @@ function getStatusLabel( status: TeamMemberStatus ): string {
 	}
 }
 
-function getStatusIntent( status: TeamMemberStatus ): 'stable' | 'medium' | 'high' {
+function getStatusIntent(
+	status: TeamMemberStatus
+): NonNullable< ComponentProps< typeof Badge >[ 'intent' ] > {
 	switch ( status ) {
 		case 'active':
 			return 'stable';

--- a/client/dashboard/agency/tiers/tier-benefits.tsx
+++ b/client/dashboard/agency/tiers/tier-benefits.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@automattic/ui';
 import {
 	Button,
 	Icon,
@@ -8,6 +7,7 @@ import {
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { Fragment } from 'react';
 import { Card, CardBody, CardDivider, CardHeader } from '../../components/card';
 import { SectionHeader } from '../../components/section-header';
@@ -130,7 +130,7 @@ function BenefitRow( {
 					<Text weight={ 500 } variant={ isLocked ? 'muted' : undefined }>
 						{ benefit.title }
 					</Text>
-					{ benefit.status && <Badge intent="default" children={ benefit.status } /> }
+					{ benefit.status && <Badge intent="draft" children={ benefit.status } /> }
 				</HStack>
 				<Text size={ 12 } variant="muted">
 					{ benefit.description }

--- a/client/dashboard/agency/tiers/tier-cards.tsx
+++ b/client/dashboard/agency/tiers/tier-cards.tsx
@@ -1,5 +1,4 @@
 import { formatCurrency } from '@automattic/number-formatters';
-import { Badge } from '@automattic/ui';
 import {
 	Button,
 	Modal,
@@ -10,6 +9,7 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useState, useEffect, useRef } from 'react';
 import { ButtonStack } from '../../components/button-stack';
@@ -127,7 +127,7 @@ export default function TierCards( {
 								{ isCurrentTier && ! isEarlyAccess && (
 									<Badge
 										style={ { minWidth: 'fit-content' } }
-										intent="default"
+										intent="draft"
 										children={ __( 'Your tier' ) }
 									/>
 								) }
@@ -135,7 +135,7 @@ export default function TierCards( {
 							{ isCurrentTier && isEarlyAccess && (
 								<Badge
 									style={ { width: 'fit-content' } }
-									intent="default"
+									intent="draft"
 									children={ __( 'Your tier — Early access' ) }
 								/>
 							) }


### PR DESCRIPTION
Part of #113835

Includes the changes from #111376, and covers every remaining badge in the Automattic for Agencies screens, in both the classic app and the new dashboard.

## Proposed Changes

* Replace the old `@automattic/ui` Badge with the design system's `@wordpress/ui` Badge everywhere in the Automattic for Agencies screens.
* Map the old badge colors to the closest design-system intents, following the mapping used in the other migration PRs: default → draft, info → informational, success → stable, warning → medium, error → high.
* The payout account status helper now returns a badge intent alongside its existing status values. The existing values stay untouched because the classic sidebar notification dots and the "account confirmed" notice logic still rely on them.

No labels, copy, or behavior change — this is a visual-only swap of the badge component.

## Why are these changes being made?

* The Badge component is being removed from `@automattic/ui` in favor of the design system's Badge (#113835). These were the last remaining usages in the Automattic for Agencies screens, and the final removal PR (#111379) would break the build while they are still there.

## Known remainders for follow-ups

* The "Beta" chips in the main sidebar menu (Reports, Amplify, and the Learn items) still use the old badge. They render through the shared sidebar menu item component, which is also used by Jetpack Cloud, so it is left for a follow-up PR. Until then the main menu chips and the section chips show the two badge styles side by side, and the final removal PR (#111379) stays blocked on that file.
* "Canceled" is gray in the client subscriptions list but blue in the referral screens. That mismatch existed before this change and is ported as is; unifying the color is follow-up material.

## Testing Instructions

Using this PR's Calypso Live link with the `a8c-for-agencies` environment, sign in as an agency. Badges should render with the new design-system styling everywhere; every label should read exactly as before.

Classic app:

1. **Sidebar** — open **Reports** and **Amplify**; each shows a "Beta" badge next to the menu title.
2. **Overview** — the Pressable hosting row shows "You're signed up!" when applicable, and the featured WooPayments card in the sidebar shows "Featured".
3. **Marketplace** — product listing badges, the Pressable plan badge, and the "You own N sites" badge on the WordPress.com plan selector.
4. **Purchases → Licenses** — "Unassigned", "Revoked", "Referral", "Development", license bundle, and "Transferred" badges; open a license's details to see the "Refundable" badge. **Purchases → Invoices** — invoice status badges ("Paid", "Open", "Past due", "Void").
5. **Referrals** — the payment status badge in the header ("Confirmed" / "Not Payable"), and in a referral's details the status badges ("Assigned", "Unassigned", "Canceled", "Awaiting payment", "Pressable").
6. **Reports dashboard** — report status badges ("Preparing", "Ready to send", "Sent", "Error"). **Amplify** — the "Audit complete" badge, score badges, and analysis type badges.
7. **Partner Directory → Lead matching** — the eligibility badge ("Eligible for leads" / "Not eligible" / "1 step left"). Directory application statuses ("Pending", "Approved", "Not approved") also use the new badge.
8. **Agency Tier** — "Early access" / "Tier-level protected" badges on the progress card. **Dev Tools** — the section badges.
9. **Sites** — a development site shows a "Development" badge; a migrating site shows "Migration in progress".

New dashboard screens (these also power the corresponding classic screens):

1. **Earn** — referral statuses, subscription statuses, WooPayments site statuses ("Active", "Disconnected", "Eligible", "Not eligible"), migration commission statuses ("Paid", "Confirmed", "Pending"), and the payout settings payment status badge.
2. **Team** — member status badges ("Active", "Invite pending", "Invite expired").
3. **Agency tier** — "Your tier" badges on the tier cards and benefit status badges.
4. **Marketplace → Exclusive offers** — the offer type badge on partner offer cards.
5. **Overview** — the locked-state note badges on the referral earnings and WooPayments revenue cards.

Since the new badge follows the design system, also glance at one of the new dashboard screens in dark mode.

## Screenshots

Badges after the swap, with the same labels as before. Personal details are blurred.

### Team member statuses

<img width="1352" height="705" alt="team-statuses" src="https://github.com/user-attachments/assets/40ab5927-6180-4234-bc78-a1d59753d818" />

### Referrals — subscription statuses

<img width="1352" height="705" alt="referral-statuses" src="https://github.com/user-attachments/assets/be79e85b-8aeb-4b8d-998c-7a302209884a" />

### Invoices

<img width="1352" height="705" alt="invoice-statuses" src="https://github.com/user-attachments/assets/4f7d7c15-a82f-4e0d-9f79-4aac4f609fe1" />

### Agency tier

<img width="1352" height="705" alt="agency-tier" src="https://github.com/user-attachments/assets/9f805cad-039d-499d-8902-6bf9966691c6" />

### Marketplace product badges

<img width="1512" height="788" alt="marketplace-products" src="https://github.com/user-attachments/assets/cc43b788-d3b1-4191-8a91-637af367d2b8" />


### All badge states

Captured on a local dev server, with states forced in code where the test account could not reach them naturally. Personal details are blurred.

**Invoices: Draft, Open, Past due, Paid, Uncollectible, Void**

<img width="1512" height="788" alt="invoices-all-states" src="https://github.com/user-attachments/assets/21382349-1828-4894-87b2-f931fac4ba19" />

**Licenses: Unassigned, Development, Transferred**

<img width="1512" height="788" alt="licenses-unassigned-dev-transferred" src="https://github.com/user-attachments/assets/4c3f0d09-6a0c-4010-bf15-c5b2a428c9d3" />

**Licenses: Revoked**

<img width="1512" height="788" alt="licenses-revoked" src="https://github.com/user-attachments/assets/350ca7b1-0733-4cec-823e-9e6f172aeb95" />

**Payout settings: payment status badge**

<img width="1512" height="788" alt="payout-confirmed" src="https://github.com/user-attachments/assets/76c40403-2af9-45d0-a140-2259e25e1cac" />

**Amplify: sidebar Beta badge and Audit complete**

<img width="1512" height="788" alt="amplify-overview" src="https://github.com/user-attachments/assets/c1c00f21-0f25-4191-830c-140e60ee177c" />

**Amplify reports: score badges and Analysis failed**

<img width="1512" height="788" alt="amplify-reports" src="https://github.com/user-attachments/assets/9002e4f5-7590-48bb-81bc-e0afcd9c04ae" />

**Lead matching: Eligible for leads**

<img width="1512" height="788" alt="lead-matching-eligible" src="https://github.com/user-attachments/assets/37a7f67e-2ed1-4afb-89b9-61e27036d828" />

**Lead matching: Not eligible**

<img width="1512" height="788" alt="lead-matching-not-eligible" src="https://github.com/user-attachments/assets/f8c13446-bb32-4455-a27a-4c91dee2183b" />

**Lead matching: 1 step left**

<img width="1512" height="788" alt="lead-matching-one-step-left" src="https://github.com/user-attachments/assets/997c278a-2ea2-421d-9d8b-06814b472c20" />

**Partner Directories: Approved, Pending, Not approved, Closed**

<img width="1512" height="788" alt="partner-directory-statuses" src="https://github.com/user-attachments/assets/fbc4ac73-82e5-4ebc-88b9-5fb528fda85d" />

**Overview: Pressable signed-up badge and tier Early access**

<img width="1512" height="788" alt="overview-pressable-tier" src="https://github.com/user-attachments/assets/dd0bdbc4-e3d5-4a15-9a08-414e048d2a4b" />

**Marketplace hosting: Pressable Plan badge**

<img width="1512" height="788" alt="hosting-pressable-plan2" src="https://github.com/user-attachments/assets/3659178c-bcaf-43d9-bf6f-d9ef19db5a36" />

**Marketplace hosting: owned sites badge**

<img width="1352" height="705" alt="hosting-owned-plans" src="https://github.com/user-attachments/assets/6de83364-3749-4768-b9fa-9d0706f551ce" />

**WooPayments sites: Active, Disconnected, Eligible, Not eligible**

<img width="1512" height="788" alt="woopayments-site-statuses" src="https://github.com/user-attachments/assets/deeac248-b9bc-42c9-bbb8-6913e67068ca" />

**Migration commissions: Paid, Confirmed, Ineligible, Pending re-verification, Pending**

<img width="1512" height="788" alt="migration-commission-statuses" src="https://github.com/user-attachments/assets/ac019101-68da-429f-8e2e-c7e0bac4bd0d" />

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


