### PR TITLE
Customer Home: stop serializing the requests that gate the first render

### DIFF
--- a/client/data/home/test/use-home-layout-query.test.tsx
+++ b/client/data/home/test/use-home-layout-query.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import useHomeLayoutQuery, { getCacheKey, prefetchHomeLayout } from '../use-home-layout-query';
+
+const mockGet = jest.fn();
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: { get: ( ...args: unknown[] ) => mockGet( ...args ) },
+} ) );
+
+jest.mock( '../use-home-layout-query-params', () => ( {
+	useHomeLayoutQueryParams: () => ( {} ),
+	getHomeLayoutQueryParams: () => ( {} ),
+} ) );
+
+const SITE_ID = 1;
+
+describe( 'useHomeLayoutQuery', () => {
+	let queryClient: QueryClient;
+
+	const wrapper = ( { children }: { children: ReactNode } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+
+	beforeEach( () => {
+		mockGet.mockReset().mockResolvedValue( { view_name: 'VIEW_SITE_SETUP' } );
+		queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	} );
+
+	it( 'uses a layout the route already requested instead of asking again', async () => {
+		await prefetchHomeLayout( queryClient, SITE_ID );
+		expect( mockGet ).toHaveBeenCalledTimes( 1 );
+
+		const { result } = renderHook( () => useHomeLayoutQuery( SITE_ID ), { wrapper } );
+
+		// The prefetched layout is available on the first render, with no placeholder.
+		expect( result.current.isLoading ).toBe( false );
+		expect( result.current.data ).toEqual( { view_name: 'VIEW_SITE_SETUP' } );
+
+		await waitFor( () => expect( result.current.isFetching ).toBe( false ) );
+		expect( mockGet ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'requests the layout itself when the route did not', async () => {
+		const { result } = renderHook( () => useHomeLayoutQuery( SITE_ID ), { wrapper } );
+
+		await waitFor( () => expect( result.current.data ).toBeDefined() );
+		expect( mockGet ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'requests a fresh layout per navigation, so the view can change', async () => {
+		await prefetchHomeLayout( queryClient, SITE_ID );
+		renderHook( () => useHomeLayoutQuery( SITE_ID ), { wrapper } );
+
+		// A second navigation prefetches again over a cache entry that never goes stale.
+		await prefetchHomeLayout( queryClient, SITE_ID );
+
+		expect( mockGet ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'recovers when the route request failed', async () => {
+		mockGet.mockRejectedValueOnce( new Error( 'network' ) );
+		await expect( prefetchHomeLayout( queryClient, SITE_ID ) ).rejects.toThrow( 'network' );
+		expect( queryClient.getQueryData( getCacheKey( SITE_ID ) ) ).toBeUndefined();
+
+		const { result } = renderHook( () => useHomeLayoutQuery( SITE_ID ), { wrapper } );
+
+		await waitFor( () => expect( result.current.data ).toBeDefined() );
+	} );
+} );

--- a/client/data/home/use-home-layout-query-params.ts
+++ b/client/data/home/use-home-layout-query-params.ts
@@ -7,11 +7,17 @@ export interface HomeLayoutQueryParams {
 	view?: string;
 }
 
-export function useHomeLayoutQueryParams(): HomeLayoutQueryParams {
-	const { dev, view } = useSelector( getCurrentQueryArguments ) ?? {};
+type QueryArguments = Record< string, string | string[] > | null | undefined;
+
+export function getHomeLayoutQueryParams( queryArguments: QueryArguments ): HomeLayoutQueryParams {
+	const { dev, view } = queryArguments ?? {};
 
 	return {
 		dev: dev === 'true' || ( ! dev && config.isEnabled( 'home/layout-dev' ) ) || undefined,
 		view: view?.toString(),
 	};
+}
+
+export function useHomeLayoutQueryParams(): HomeLayoutQueryParams {
+	return getHomeLayoutQueryParams( useSelector( getCurrentQueryArguments ) );
 }

--- a/client/data/home/use-home-layout-query.ts
+++ b/client/data/home/use-home-layout-query.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryResult, QueryKey } from '@tanstack/react-query';
+import { useQuery, UseQueryResult, QueryKey, QueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { useHomeLayoutQueryParams, HomeLayoutQueryParams } from './use-home-layout-query-params';
 
@@ -21,9 +21,30 @@ const useHomeLayoutQuery = (
 		// so the view doesn't change without some user action.
 		staleTime: Infinity,
 		refetchInterval: false,
-		refetchOnMount: 'always',
+
+		// Navigating to My Home is the user action that earns a new view, and the route
+		// asks for one via `prefetchHomeLayout` before this ever mounts. Refetching on
+		// mount as well would throw that request away and re-request on arrival.
+		refetchOnMount: true,
 	} );
 };
+
+/**
+ * Requests the layout from the route, so it is in flight before My Home renders.
+ *
+ * `fetchQuery` without a `staleTime` always goes to the network, which is what keeps
+ * a new view per navigation working now that the hook no longer refetches on mount.
+ */
+export function prefetchHomeLayout(
+	queryClient: QueryClient,
+	siteId: number | null,
+	query: HomeLayoutQueryParams = {}
+): Promise< unknown > {
+	return queryClient.fetchQuery( {
+		queryKey: getCacheKey( siteId ),
+		queryFn: () => fetchHomeLayout( siteId, query ),
+	} );
+}
 
 export function fetchHomeLayout(
 	siteId: number | null,

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -25,8 +25,8 @@ import {
 import { redirectToLaunchpad } from 'calypso/utils';
 import CustomerHome from './main';
 
-export default async function renderHome( context, next ) {
-	const state = await context.store.getState();
+export default function renderHome( context, next ) {
+	const state = context.store.getState();
 	const site = getSelectedSite( state );
 
 	// Scroll to the top
@@ -120,6 +120,11 @@ export async function maybeRedirect( context, next ) {
 		}
 	}
 
+	// Started before the assignment below is awaited, not after it: nothing renders until
+	// this middleware calls `next()`, and the two requests are independent, so awaiting them
+	// in sequence adds a whole round trip to the time the boot placeholder stays on screen.
+	const launchpadPromise = fetchLaunchpad( slug ).catch( () => null );
+
 	// The no_guidance launchpad-personalization variation gets no guidance surface at all:
 	// keep these sites off My Home, landing them on the plain wp-admin dashboard.
 	const personalizationAssignment = await loadExperimentAssignment(
@@ -140,7 +145,7 @@ export async function maybeRedirect( context, next ) {
 			launchpad_screen: launchpadScreenOption,
 			site_intent: siteIntentOption,
 			checklist: launchpadChecklist,
-		} = await fetchLaunchpad( slug );
+		} = ( await launchpadPromise ) ?? {};
 
 		const shouldShowLaunchpad = ! isRemovedFlow( siteIntentOption );
 

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -2,6 +2,8 @@ import { getAiLaunchpadStatus } from '@automattic/api-core';
 import page from '@automattic/calypso-router';
 import { captureException } from '@automattic/calypso-sentry';
 import { fetchLaunchpad } from '@automattic/data-stores';
+import { prefetchHomeLayout } from 'calypso/data/home/use-home-layout-query';
+import { getHomeLayoutQueryParams } from 'calypso/data/home/use-home-layout-query-params';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
 import { isRemovedFlow } from 'calypso/landing/stepper/utils/flow-redirect-handler';
 import { LAUNCHPAD_PERSONALIZATION_EXPERIMENT, normalizeVariation } from 'calypso/lib/ai-launchpad';
@@ -124,6 +126,15 @@ export async function maybeRedirect( context, next ) {
 	// this middleware calls `next()`, and the two requests are independent, so awaiting them
 	// in sequence adds a whole round trip to the time the boot placeholder stays on screen.
 	const launchpadPromise = fetchLaunchpad( slug ).catch( () => null );
+
+	// My Home renders a placeholder until the card layout arrives. Asking for it here puts
+	// it in flight during the rest of this middleware and the section's chunk load, rather
+	// than only once the cards mount. Deliberately not awaited — nothing here needs it.
+	prefetchHomeLayout(
+		context.queryClient,
+		siteId,
+		getHomeLayoutQueryParams( context.query )
+	).catch( () => {} );
 
 	// The no_guidance launchpad-personalization variation gets no guidance surface at all:
 	// keep these sites off My Home, landing them on the plain wp-admin dashboard.

--- a/client/my-sites/customer-home/test/controller.js
+++ b/client/my-sites/customer-home/test/controller.js
@@ -4,8 +4,10 @@
 
 import page from '@automattic/calypso-router';
 import { fetchLaunchpad } from '@automattic/data-stores';
+import { QueryClient } from '@tanstack/react-query';
 import configureStore from 'redux-mock-store';
 import { thunk } from 'redux-thunk';
+import { prefetchHomeLayout } from 'calypso/data/home/use-home-layout-query';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getLoggedInLandingPage } from 'calypso/lib/landing-page';
 import { canCurrentUserUseCustomerHome } from 'calypso/state/sites/selectors';
@@ -23,6 +25,11 @@ jest.mock( '@automattic/data-stores', () => ( {
 
 jest.mock( 'calypso/lib/explat', () => ( {
 	loadExperimentAssignment: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/data/home/use-home-layout-query', () => ( {
+	...jest.requireActual( 'calypso/data/home/use-home-layout-query' ),
+	prefetchHomeLayout: jest.fn( () => Promise.resolve( { primary: [] } ) ),
 } ) );
 
 jest.mock( '@automattic/api-core', () => ( {
@@ -190,6 +197,7 @@ describe( 'maybeRedirect', () => {
 		path: '/home/test.wordpress.com',
 		pathname: '/home/test.wordpress.com',
 		params: { site: 'test.wordpress.com' },
+		queryClient: new QueryClient(),
 	} );
 
 	beforeEach( () => {
@@ -230,6 +238,30 @@ describe( 'maybeRedirect', () => {
 	it( 'renders the page when the launchpad request fails', async () => {
 		loadExperimentAssignment.mockResolvedValue( { variationName: null } );
 		fetchLaunchpad.mockRejectedValue( new Error( 'network' ) );
+		const next = jest.fn();
+
+		await maybeRedirect( buildSiteContext(), next );
+		await flushPromises();
+
+		expect( next ).toHaveBeenCalled();
+	} );
+
+	it( 'requests the card layout from the route rather than leaving it to the cards', async () => {
+		loadExperimentAssignment.mockResolvedValue( { variationName: null } );
+		fetchLaunchpad.mockResolvedValue( { launchpad_screen: 'off' } );
+		const next = jest.fn();
+
+		await maybeRedirect( buildSiteContext(), next );
+		await flushPromises();
+
+		expect( prefetchHomeLayout ).toHaveBeenCalledWith( expect.anything(), 1, expect.any( Object ) );
+		expect( next ).toHaveBeenCalled();
+	} );
+
+	it( 'still renders the page when the card layout request fails', async () => {
+		loadExperimentAssignment.mockResolvedValue( { variationName: null } );
+		fetchLaunchpad.mockResolvedValue( { launchpad_screen: 'off' } );
+		prefetchHomeLayout.mockRejectedValueOnce( new Error( 'network' ) );
 		const next = jest.fn();
 
 		await maybeRedirect( buildSiteContext(), next );

--- a/client/my-sites/customer-home/test/controller.js
+++ b/client/my-sites/customer-home/test/controller.js
@@ -3,14 +3,55 @@
  */
 
 import page from '@automattic/calypso-router';
+import { fetchLaunchpad } from '@automattic/data-stores';
 import configureStore from 'redux-mock-store';
 import { thunk } from 'redux-thunk';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { getLoggedInLandingPage } from 'calypso/lib/landing-page';
-import { redirectToLandingPage } from '../controller';
+import { canCurrentUserUseCustomerHome } from 'calypso/state/sites/selectors';
+import { maybeRedirect, redirectToLandingPage } from '../controller';
 
 jest.mock( 'calypso/lib/landing-page', () => ( {
 	...jest.requireActual( 'calypso/lib/landing-page' ),
 	getLoggedInLandingPage: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/data-stores', () => ( {
+	...jest.requireActual( '@automattic/data-stores' ),
+	fetchLaunchpad: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/explat', () => ( {
+	loadExperimentAssignment: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/api-core', () => ( {
+	...jest.requireActual( '@automattic/api-core' ),
+	getAiLaunchpadStatus: jest.fn( () => null ),
+} ) );
+
+jest.mock( 'calypso/state/sites/actions', () => ( {
+	requestSite: jest.fn( () => ( { type: 'SITE_REQUEST' } ) ),
+} ) );
+
+jest.mock( 'calypso/state/sites/plans/selectors/is-site-big-sky-trial', () =>
+	jest.fn( () => false )
+);
+
+jest.mock( 'calypso/state/sites/selectors', () => ( {
+	canCurrentUserUseCustomerHome: jest.fn( () => true ),
+	getSiteAdminUrl: jest.fn( () => 'https://example.wordpress.com/wp-admin/index.php' ),
+	getSiteUrl: jest.fn( () => 'https://example.wordpress.com' ),
+} ) );
+
+jest.mock( 'calypso/state/ui/selectors', () => ( {
+	getSelectedSite: jest.fn( () => ( { ID: 1, launch_status: 'launched' } ) ),
+	getSelectedSiteId: jest.fn( () => 1 ),
+	getSelectedSiteSlug: jest.fn( () => 'test.wordpress.com' ),
+} ) );
+
+jest.mock( 'calypso/utils', () => ( {
+	redirectToLaunchpad: jest.fn(),
 } ) );
 
 const mockStore = configureStore( [ thunk ] );
@@ -140,5 +181,75 @@ describe( 'redirectToLandingPage', () => {
 
 		expect( next ).toHaveBeenCalled();
 		expect( redirect ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'maybeRedirect', () => {
+	const buildSiteContext = () => ( {
+		...buildContext(),
+		path: '/home/test.wordpress.com',
+		pathname: '/home/test.wordpress.com',
+		params: { site: 'test.wordpress.com' },
+	} );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		canCurrentUserUseCustomerHome.mockReturnValue( true );
+		jest.spyOn( page, 'redirect' ).mockImplementation( () => {} );
+		jest.spyOn( page, 'replace' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'has the launchpad request in flight while the experiment assignment is still pending', async () => {
+		let resolveAssignment;
+		loadExperimentAssignment.mockReturnValue(
+			new Promise( ( resolve ) => {
+				resolveAssignment = resolve;
+			} )
+		);
+		fetchLaunchpad.mockResolvedValue( { launchpad_screen: 'off' } );
+		const next = jest.fn();
+
+		maybeRedirect( buildSiteContext(), next );
+		await flushPromises();
+
+		// The assignment has not resolved yet, so a serial implementation could not
+		// have issued this request.
+		expect( fetchLaunchpad ).toHaveBeenCalledWith( 'test.wordpress.com' );
+		expect( next ).not.toHaveBeenCalled();
+
+		resolveAssignment( { variationName: null } );
+		await flushPromises();
+
+		expect( next ).toHaveBeenCalled();
+	} );
+
+	it( 'renders the page when the launchpad request fails', async () => {
+		loadExperimentAssignment.mockResolvedValue( { variationName: null } );
+		fetchLaunchpad.mockRejectedValue( new Error( 'network' ) );
+		const next = jest.fn();
+
+		await maybeRedirect( buildSiteContext(), next );
+		await flushPromises();
+
+		expect( next ).toHaveBeenCalled();
+	} );
+
+	it( 'redirects to the launchpad when the checklist is unfinished', async () => {
+		loadExperimentAssignment.mockResolvedValue( { variationName: null } );
+		fetchLaunchpad.mockResolvedValue( {
+			launchpad_screen: 'full',
+			site_intent: 'build',
+			checklist: [ { id: 'a', completed: false } ],
+		} );
+		const next = jest.fn();
+
+		await maybeRedirect( buildSiteContext(), next );
+		await flushPromises();
+
+		expect( next ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

Two independent waits on `/home/:site`, in two commits.

* **The boot placeholder.** Start the launchpad fetch before awaiting the launchpad-personalization experiment assignment, instead of after it. The two requests are independent, so the blocking chain goes from three serial round trips to two.
* **The card placeholder.** Request the card layout from the route, alongside the launchpad fetch, instead of waiting for the cards to mount and request it themselves.
* The layout hook refetched on every mount, which would have thrown that early request away, so it now refetches only when its data is stale.
* Drop an `await` on a synchronous store read.
* Add tests for the route middleware and the layout hook, neither of which had coverage.

## Why are these changes being made?

My Home feels slow to appear in production. There are two placeholders back to back, and each has its own cause.

**First the pulsing logo.** It is server-rendered into the initial HTML and stays until the route middleware calls `next()`, so its lifetime is exactly how long that middleware blocks. It was making three network requests one after another, each awaited before the next began: fetch the site, then the experiment assignment, then the launchpad checklist.

Only the first link in that chain is a real dependency — the launchpad fetch needs the site slug. The assignment needs nothing from either, so it was sitting in the middle purely because of statement order. This costs more than one round trip suggests: ExPlat falls back to a stale or default assignment only after a 10 second fetch timeout, and whenever that path was hit the full stall landed before the launchpad request had even been sent.

**Then the card placeholder.** Once the logo clears, the cards show their own placeholder while the layout endpoint is queried. That query could not start until the middleware had finished, the section chunk had downloaded, and the cards had mounted — none of which it depends on. It only ever needed the site ID, which the route has early.

## Considerations

**Why the experiment assignment was not moved off the critical path entirely.** The first attempt hoisted it above the site request, which would have removed it from the chain altogether. That was rejected: requesting an assignment is what enrols a user in the experiment, and hoisting it moves it above four early-return redirects. Sites that redirect away and never reach My Home would have been enrolled, biasing the experiment. Parallelising the launchpad fetch saves the same round trip with no change to who gets enrolled.

**Why the layout hook stopped refetching on mount.** It previously refetched on every mount, which is what gave a new view each time you arrived at My Home. That would now discard the route's request and immediately re-request. Refetching only when stale is safe here because the hook's data never goes stale on its own, so the route entry is the thing that earns a fresh view — and the route always goes to the network. A mount with no prefetched data, or a failed prefetch, still fetches for itself.

**Wasted requests.** The launchpad and layout requests are issued before the experiment assignment is known, so both are wasted for users in the `no_guidance` variation, as is the layout request for users redirected to the launchpad. Neither carries experiment semantics.

**Not addressed.** Getting the middleware to a single round trip would mean overlapping the launchpad fetch with the site request too. That is possible, since the slug can be read from the URL rather than the store, but it is a real behaviour change and belongs in its own PR.

## Testing Instructions

Verified in a browser against a real account's five sites, on a local dev build of this branch.

**All five sites behaved correctly.** Three render My Home normally; two redirect to the launchpad because their checklists are incomplete (2/5), which is the pre-existing behaviour and confirms the changed launchpad path still works.

| Site | Result |
| --- | --- |
| a `wpcomstaging.com` site | Renders |
| two `wordpress.com` sites | Renders |
| two `wordpress.com` sites with an incomplete checklist | Redirects to the launchpad, as before |

**The layout request now comes from the route.** In the network trace it is issued immediately after the route's launchpad call, and ahead of the requests the cards and sidebar make once they mount (site domains, features, plans, admin menu). Previously it could not start until those had already begun.

**One request per navigation, and the view still rotates.** Across a full load plus a client-side trip to Plans and back, the layout endpoint was hit exactly twice — once per arrival at My Home, each time paired with the route's launchpad call:

```
181  GET .../launchpad          182  GET .../home/layout   <- first load
391  GET .../launchpad          392  GET .../home/layout   <- after returning
```

Two requests, not one, shows a fresh view is still fetched per navigation. Two, not four, shows the cards are no longer re-requesting on mount.

**Console.** No errors attributable to these changes. The only errors are analytics hosts blocked by the sandbox and a pre-existing React `inert` attribute warning.

To reproduce: visit My Home for a site, watch the network panel for `home/layout`, then navigate to Plans and back and confirm a second request is made and the cards re-render.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? <!-- Simple and a wpcomstaging site covered; no self-hosted Jetpack site was available to test. -->
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
