### PR TITLE
Omnibar: hide on marketplace plugin install page as before

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/style.scss
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/style.scss
@@ -4,9 +4,11 @@ body.is-section-marketplace.theme-default.color-scheme {
 
 // The layout mounts its own masterbar behind this page's. An opaque fill on the one below used to
 // hide it; with the header transparent it would show through, so retire it while this page is up.
-body.is-section-marketplace:has( .marketplace-plugin-install__masterbar )
-	.masterbar:not( .marketplace-plugin-install__masterbar ) {
-	display: none;
+body.is-section-marketplace:has( .marketplace-plugin-install__masterbar ) {
+	.masterbar:not( .marketplace-plugin-install__masterbar ),
+	#wpcom-omnibar {
+		display: none;
+	}
 }
 
 .marketplace-plugin-install__masterbar {


### PR DESCRIPTION
Fixes DOTCOM-18358

## Testing Instructions

1. Prepare an Atomic site.
2. Go to Settings -> General, switch Admin Interface Style to Default.
3. Go to Plugins -> Add Plugin
4. Install a plugin
5. Verify you don't see the top omnibar.

| Before | After |
| - | - | 
|  <img width="606" height="339" alt="image" src="https://github.com/user-attachments/assets/a91ade49-62b4-4242-9cd6-49f2e268ed43" /> | <img width="1728" height="997" alt="image" src="https://github.com/user-attachments/assets/35f432f9-6eeb-455c-b04b-dddc8b482e57" />
