### PR TITLE
Plugins: offer to replace an installed plugin instead of rejecting the upload

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/product-install-error.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/product-install-error.tsx
@@ -1,9 +1,11 @@
 import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import EmptyContent from 'calypso/components/empty-content';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector, useDispatch } from 'calypso/state';
-import { clearPluginUpload } from 'calypso/state/plugins/upload/actions';
+import { clearPluginUpload, uploadPlugin } from 'calypso/state/plugins/upload/actions';
+import getPluginUploadFile from 'calypso/state/selectors/get-plugin-upload-file';
 import { getTheme } from 'calypso/state/themes/selectors';
 import {
 	getSelectedSite,
@@ -32,6 +34,7 @@ export default function ProductInstallErrorView( {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId ) as number;
 	const wpOrgTheme = useSelector( ( state ) => getTheme( state, 'wporg', themeSlug ) );
+	const pluginUploadFile = useSelector( ( state ) => getPluginUploadFile( state, siteId ) );
 
 	// The abandoned attempt is still marked in progress, and the upload page clears that state only
 	// when it isn't — and hides its drop zone meanwhile. Retire it here or the retry lands on a page
@@ -124,6 +127,79 @@ export default function ProductInstallErrorView( {
 					actionURL={ wpAdminUploadURL }
 					actionCallback={ () => recordCtaClick( 'reupload_wp_admin' ) }
 				/>
+			);
+		}
+		case 'plugin-exists': {
+			const versionsMatch =
+				error.installedVersion &&
+				error.uploadedVersion &&
+				error.installedVersion === error.uploadedVersion;
+
+			if ( versionsMatch ) {
+				return (
+					<EmptyContent
+						title={ null }
+						line={ translate( 'This plugin version is already installed on your site.' ) }
+					>
+						<Button
+							primary
+							className="empty-content__action"
+							href={ pluginsPageURL }
+							onClick={ () => recordCtaClick( 'go_to_plugins' ) }
+						>
+							{ translate( 'Go to plugins' ) }
+						</Button>
+						<Button
+							className="empty-content__action"
+							href={ uploadPageURL }
+							onClick={ () => recordCtaClick( 'back' ) }
+						>
+							{ translate( 'Back' ) }
+						</Button>
+					</EmptyContent>
+				);
+			}
+
+			return (
+				<EmptyContent
+					title={ null }
+					line={
+						error.installedVersion && error.uploadedVersion
+							? translate(
+									'Version %(uploadedVersion)s is ready to replace installed version %(installedVersion)s.',
+									{
+										args: {
+											uploadedVersion: error.uploadedVersion,
+											installedVersion: error.installedVersion,
+										},
+									}
+							  )
+							: translate(
+									'This plugin is already installed on your site. Replace it with the uploaded version?'
+							  )
+					}
+				>
+					<Button
+						primary
+						className="empty-content__action"
+						onClick={ () => {
+							if ( ! pluginUploadFile ) {
+								return;
+							}
+							recordCtaClick( 'replace_plugin' );
+							dispatch( uploadPlugin( siteId, pluginUploadFile, error.pluginSlug ) );
+						} }
+					>
+						{ translate( 'Replace installed plugin' ) }
+					</Button>
+					<Button
+						className="empty-content__action"
+						href={ uploadPageURL }
+						onClick={ () => recordCtaClick( 'back' ) }
+					>
+						{ translate( 'Back' ) }
+					</Button>
+				</EmptyContent>
 			);
 		}
 		// Only the plugin transfer flow reaches this state, so the copy can name the plugin.

--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
@@ -143,6 +143,27 @@ const withUploadError = ( uploadError: object ) => ( {
 	plugins: { upload: { uploadError: { [ SITE_ID ]: uploadError } } },
 } );
 
+const withReplaceCandidate = ( uploadError: object ) => ( {
+	ui: { selectedSiteId: SITE_ID },
+	plugins: {
+		upload: {
+			uploadError: { [ SITE_ID ]: uploadError },
+			uploadFile: { [ SITE_ID ]: { name: 'plugin.zip' } },
+		},
+		installed: {
+			plugins: {
+				[ SITE_ID ]: [
+					{
+						slug: 'hello-dolly',
+						version: '1.6',
+						active: false,
+					},
+				],
+			},
+		},
+	},
+} );
+
 describe( 'useProductInstall', () => {
 	describe( 'who activates an uploaded plugin', () => {
 		// The upload step advances on a timer before activation is reached.
@@ -241,6 +262,46 @@ describe( 'useProductInstall', () => {
 				expect( result.current.error ).toEqual( { type: 'rejected-upload', reason } );
 			}
 		);
+
+		it( 'reports a replace candidate when backend slug and file are available', () => {
+			const { result } = renderProductInstall(
+				{},
+				withReplaceCandidate( {
+					error: 'folder_exists',
+					plugin_slug: 'hello-dolly',
+					plugin_version: '2.0',
+				} )
+			);
+
+			expect( result.current.error ).toEqual( {
+				type: 'plugin-exists',
+				pluginSlug: 'hello-dolly',
+				installedVersion: '1.6',
+				uploadedVersion: '2.0',
+			} );
+		} );
+
+		it( 'keeps the existing rejection when the backend slug is missing', () => {
+			const { result } = renderProductInstall(
+				{},
+				withReplaceCandidate( { error: 'folder_exists', plugin_version: '2.0' } )
+			);
+
+			expect( result.current.error ).toEqual( { type: 'rejected-upload', reason: 'exists' } );
+		} );
+
+		it( 'keeps the existing rejection when the retained file is missing', () => {
+			const { result } = renderProductInstall(
+				{},
+				withUploadError( {
+					error: 'folder_exists',
+					plugin_slug: 'hello-dolly',
+					plugin_version: '2.0',
+				} )
+			);
+
+			expect( result.current.error ).toEqual( { type: 'rejected-upload', reason: 'exists' } );
+		} );
 
 		// Upload flow has no route slug; statuses live under the dispatched plugin id.
 		it( 'surfaces a failed activation instead of waiting out the deadline', () => {

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -34,6 +34,7 @@ import { fetchPluginData as wporgFetchPluginData } from 'calypso/state/plugins/w
 import { getPlugin, isFetched } from 'calypso/state/plugins/wporg/selectors';
 import { getCurrentQueryArguments } from 'calypso/state/selectors/get-current-query-arguments';
 import getPluginUploadError from 'calypso/state/selectors/get-plugin-upload-error';
+import getPluginUploadFile from 'calypso/state/selectors/get-plugin-upload-file';
 import getPluginUploadMethod from 'calypso/state/selectors/get-plugin-upload-method';
 import getPluginUploadProgress from 'calypso/state/selectors/get-plugin-upload-progress';
 import getUploadedPluginId from 'calypso/state/selectors/get-uploaded-plugin-id';
@@ -145,6 +146,12 @@ export type ProductInstallError =
 	| { type: 'non-installable-plan' }
 	| { type: 'no-direct-access-upload' }
 	| { type: 'theme-direct-install' }
+	| {
+			type: 'plugin-exists';
+			pluginSlug: string;
+			installedVersion?: string;
+			uploadedVersion?: string;
+	  }
 	| { type: 'rejected-upload'; reason: 'exists' | 'malicious' | 'too-big' }
 	| { type: 'transfer-failed' }
 	| { type: 'timeout' }
@@ -194,6 +201,8 @@ export function useProductInstall( {
 	const uploadedPluginSlug = useSelector( ( state ) =>
 		getUploadedPluginId( state, siteId )
 	) as string;
+	const uploadErrorPluginSlug = pluginUploadError?.plugin_slug;
+	const pluginUploadFile = useSelector( ( state ) => getPluginUploadFile( state, siteId ) );
 	const pluginUploadComplete = useSelector( ( state ) => isPluginUploadComplete( state, siteId ) );
 	// A zip upload that brought the site to Atomic. Its plugin arrives with the transfer rather than
 	// through an install this page dispatched, so the recovery poll is what watches for it — and
@@ -214,6 +223,9 @@ export function useProductInstall( {
 		: marketplacePlugin?.software_slug || marketplacePlugin?.org_slug || pluginSlug;
 	const installedPlugin = useSelector( ( state ) =>
 		getPluginOnSite( state, siteId, installedPluginSlug )
+	);
+	const existingPlugin = useSelector( ( state ) =>
+		uploadErrorPluginSlug ? getPluginOnSite( state, siteId, uploadErrorPluginSlug ) : undefined
 	);
 	const pluginActive = useSelector( ( state ) =>
 		isPluginActive( state, siteId, installedPluginSlug )
@@ -376,6 +388,14 @@ export function useProductInstall( {
 		}
 		if ( themeSlug && noDirectAccessError && ! directInstallationAllowed ) {
 			return { type: 'theme-direct-install' };
+		}
+		if ( isPluginUploadFlow && pluginExists && uploadErrorPluginSlug && pluginUploadFile ) {
+			return {
+				type: 'plugin-exists',
+				pluginSlug: uploadErrorPluginSlug,
+				installedVersion: existingPlugin?.version,
+				uploadedVersion: pluginUploadError?.plugin_version,
+			};
 		}
 		if ( pluginExists ) {
 			return { type: 'rejected-upload', reason: 'exists' };

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-thank-you-redirect.ts
@@ -113,10 +113,10 @@ export function useThankYouRedirect( {
 	// drives, that is only true once the transfer is far enough along and the site is reachable, which
 	// is also when the URL below resolves.
 	useEffect( () => {
-		if ( installedPlugin && pluginActive && pluginsUrlFinal ) {
+		if ( ! halted && installedPlugin && pluginActive && pluginsUrlFinal ) {
 			window.location.href = pluginsUrlFinal;
 		}
-	}, [ installedPlugin, pluginActive, pluginsUrlFinal, siteId, pluginSlug ] );
+	}, [ halted, installedPlugin, pluginActive, pluginsUrlFinal, siteId, pluginSlug ] );
 
 	// Validate theme is already active
 	useEffect( () => {

--- a/client/state/data-layer/wpcom/sites/plugins/new/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/index.js
@@ -14,16 +14,21 @@ import {
 } from 'calypso/state/plugins/upload/actions';
 
 export const uploadPlugin = ( action ) => {
-	const { siteId, file } = action;
+	const { siteId, file, replaceSlug } = action;
 
 	return [
-		recordTracksEvent( 'calypso_plugin_upload' ),
+		recordTracksEvent( 'calypso_plugin_upload', { is_replace: !! replaceSlug } ),
 		http(
 			{
 				method: 'POST',
-				path: `/sites/${ siteId }/plugins/new`,
+				path: replaceSlug ? `/sites/${ siteId }/plugins/replace` : `/sites/${ siteId }/plugins/new`,
 				apiVersion: '1',
-				formData: [ [ 'zip[]', file ] ],
+				formData: replaceSlug
+					? [
+							[ 'zip[]', file ],
+							[ 'slug', replaceSlug ],
+					  ]
+					: [ [ 'zip[]', file ] ],
 			},
 			action
 		),

--- a/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
+++ b/client/state/data-layer/wpcom/sites/plugins/new/test/index.js
@@ -31,10 +31,28 @@ describe( 'uploadPlugin', () => {
 		const action = uploadPlugin( { siteId, file: 'xyz' } );
 		expect( action ).toEqual(
 			expect.arrayContaining( [
+				recordTracksEvent( 'calypso_plugin_upload', { is_replace: false } ),
 				expect.objectContaining( {
 					formData: [ [ 'zip[]', 'xyz' ] ],
 					method: 'POST',
 					path: `/sites/${ siteId }/plugins/new`,
+				} ),
+			] )
+		);
+	} );
+
+	test( 'should return an http request action for replacing an installed plugin', () => {
+		const action = uploadPlugin( { siteId, file: 'xyz', replaceSlug: pluginId } );
+		expect( action ).toEqual(
+			expect.arrayContaining( [
+				recordTracksEvent( 'calypso_plugin_upload', { is_replace: true } ),
+				expect.objectContaining( {
+					formData: [
+						[ 'zip[]', 'xyz' ],
+						[ 'slug', pluginId ],
+					],
+					method: 'POST',
+					path: `/sites/${ siteId }/plugins/replace`,
 				} ),
 			] )
 		);

--- a/client/state/plugins/upload/actions.js
+++ b/client/state/plugins/upload/actions.js
@@ -13,13 +13,15 @@ import 'calypso/state/plugins/init';
  * Upload a plugin to a site.
  * @param {number} siteId site ID
  * @param {window.File} file the plugin zip to upload
+ * @param {string} [replaceSlug] slug of an installed plugin to replace
  * @returns {Object} action object
  */
-export function uploadPlugin( siteId, file ) {
+export function uploadPlugin( siteId, file, replaceSlug ) {
 	return {
 		type: PLUGIN_UPLOAD,
 		siteId,
 		file,
+		replaceSlug,
 	};
 }
 

--- a/client/state/plugins/upload/reducer.js
+++ b/client/state/plugins/upload/reducer.js
@@ -24,6 +24,18 @@ export const uploadMethod = keyedReducer( 'siteId', ( state = null, action ) => 
 	return state;
 } );
 
+export const uploadFile = keyedReducer( 'siteId', ( state = null, action ) => {
+	switch ( action.type ) {
+		case PLUGIN_UPLOAD:
+			return action.file;
+		case PLUGIN_UPLOAD_COMPLETE:
+		case PLUGIN_UPLOAD_CLEAR:
+			return null;
+	}
+
+	return state;
+} );
+
 export const uploadedPluginId = keyedReducer( 'siteId', ( state = {}, action ) => {
 	switch ( action.type ) {
 		case PLUGIN_UPLOAD:
@@ -105,6 +117,7 @@ export const inProgress = keyedReducer( 'siteId', ( state = {}, action ) => {
 
 export default combineReducers( {
 	uploadedPluginId,
+	uploadFile,
 	uploadMethod,
 	uploadError,
 	progressPercent,

--- a/client/state/plugins/upload/test/reducer.js
+++ b/client/state/plugins/upload/test/reducer.js
@@ -12,6 +12,7 @@ import {
 import {
 	inProgress,
 	progressPercent,
+	uploadFile,
 	uploadedPluginId,
 	uploadError,
 	uploadMethod,
@@ -69,6 +70,30 @@ describe( 'uploadMethod', () => {
 		expect( uploadMethod( {}, initiateAutomatedTransferWithPluginZip( siteId ) )[ siteId ] ).toBe(
 			'transfer'
 		);
+	} );
+} );
+
+describe( 'uploadFile', () => {
+	const file = { name: 'plugin.zip' };
+
+	test( 'should contain the file after upload starts', () => {
+		const state = uploadFile( {}, uploadPlugin( siteId, file ) );
+		expect( state[ siteId ] ).toBe( file );
+	} );
+
+	test( 'should retain the file after a failed upload', () => {
+		const state = uploadFile( { [ siteId ]: file }, pluginUploadError( siteId, error ) );
+		expect( state[ siteId ] ).toBe( file );
+	} );
+
+	test( 'should clear the file after a successful upload', () => {
+		const state = uploadFile( { [ siteId ]: file }, completePluginUpload( siteId, pluginId ) );
+		expect( state[ siteId ] ).toBeUndefined();
+	} );
+
+	test( 'should clear the file when the upload is cleared', () => {
+		const state = uploadFile( { [ siteId ]: file }, clearPluginUpload( siteId ) );
+		expect( state[ siteId ] ).toBeUndefined();
 	} );
 } );
 

--- a/client/state/selectors/get-plugin-upload-error.js
+++ b/client/state/selectors/get-plugin-upload-error.js
@@ -5,7 +5,7 @@ import 'calypso/state/plugins/init';
  * null if currently no error.
  * @param {Object} state Global state tree
  * @param {number} siteId the site ID
- * @returns {null|{error?: string, statusCode: number}} Error from upload, if any
+ * @returns {null|{error?: string, message?: string, statusCode?: number, plugin_slug?: string, plugin_version?: string}} Error from upload, if any
  */
 export default function getPluginUploadError( state, siteId ) {
 	return state.plugins.upload.uploadError?.[ siteId ] ?? null;

--- a/client/state/selectors/get-plugin-upload-file.js
+++ b/client/state/selectors/get-plugin-upload-file.js
@@ -1,0 +1,12 @@
+import 'calypso/state/plugins/init';
+
+/**
+ * Returns the zip file from the latest plugin upload, or
+ * null if no upload is available for a site.
+ * @param {Object} state Global state tree
+ * @param {number} siteId the site ID
+ * @returns {?File} zip file from upload, if any
+ */
+export default function getPluginUploadFile( state, siteId ) {
+	return state.plugins.upload.uploadFile?.[ siteId ] ?? null;
+}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18352/uploading-a-newer-zip-of-an-installed-plugin-is-rejected-outright-and

## Proposed Changes

**Uploading a zip for a plugin the site already has now offers to replace it, instead of dead-ending on an error.**

- Sends the upload to `/plugins/replace` when a slug is given, and keeps the zip around so the replace can re-send it.
- The error screen names both versions when the API reports them (“Version 2.0 is ready to replace installed version 1.6”), or says it is already installed when they match.
- Falls back to today’s rejection screen whenever the slug or the retained file is missing.

## Why are these changes being made?

WordPress refuses to unpack a plugin zip over a folder that already exists. Until now that ended the flow: the customer was told the upload failed and pointed at wp-admin to do it by hand.

Most of them were not installing something new — they were updating a plugin they already had. Over five days, 674 sites hit this error 4,223 times, and two thirds of the plugins installed afterwards were ones the site already had ([DOTCOM-18352](https://linear.app/a8c/issue/DOTCOM-18352/uploading-a-newer-zip-of-an-installed-plugin-is-rejected-outright-and)).

## Testing Instructions

1. `yarn start`, open `/plugins/upload/:site` on a Business-plan site and install any plugin zip.
2. Upload the same plugin again, ideally a newer version of it.
3. The screen offers **Replace installed plugin** rather than sending you to wp-admin.
4. Click it: the plugin is replaced in place and the flow continues to the plugins page.
