### PR TITLE
Onboarding: resume the unpaid wow-funnel site instead of starting a new run

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -27,6 +27,7 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useSelector, useDispatch as useReduxDispatch } from 'calypso/state';
 import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { State } from '../../../../../../packages/data-stores/src/plans/reducer';
 import { isPlanProductFree } from '../../../../../../packages/data-stores/src/plans/selectors';
@@ -43,6 +44,8 @@ import {
 	logBuildWowEvent,
 	requestBuildWowSite,
 } from '../../../utils/build-wow';
+import { goToCheckout } from '../../../utils/checkout';
+import { getStepFromURL } from '../../../utils/get-flow-from-url';
 import { stepsWithRequiredLogin } from '../../../utils/steps-with-required-login';
 import {
 	clearWowFunnelSite,
@@ -55,7 +58,13 @@ import {
 	logWowFunnelEvent,
 	wowFunnelSiteIsPaid,
 } from '../../../utils/wow-funnel';
-import { forgetWowFunnelRun, startWowFunnelSite } from '../../../utils/wow-funnel-site';
+import {
+	adoptWowFunnelSite,
+	fetchPendingWowFunnelSite,
+	forgetWowFunnelRun,
+	startWowFunnelSite,
+	wowFunnelSiteHasCartItems,
+} from '../../../utils/wow-funnel-site';
 import { getOnboardingPostCheckoutDestination } from '../../helpers/get-onboarding-post-checkout-destination';
 import { withLocale } from '../../helpers/with-locale';
 import { usePurchasePlanNotification } from '../../internals/hooks/use-purchase-plan-notification';
@@ -65,8 +74,181 @@ import { ProcessingResult } from '../../internals/steps-repository/processing-st
 import { type FlowV2, type ProvidedDependencies, type SubmitHandler } from '../../internals/types';
 import { getOnboardingStepperPosition } from './step-counter-config';
 import type { DomainSuggestion } from '@automattic/api-core';
+import type { Store } from 'redux';
 
-function initialize() {
+/**
+ * Where a funnel run lands once it is paid for.
+ *
+ * Shared by the ordinary run — where it becomes checkout's `redirect_to` — and by a resumed one,
+ * which hands the same URL to checkout itself. The two must not drift: a resumed purchase that
+ * lost this would end up on My Home rather than on the site the funnel just built.
+ * @param options               Options.
+ * @param options.funnelSlug    The funnel being run.
+ * @param options.dest          Where the CTA asked to land.
+ * @param options.siteSlug      The funnel site's slug.
+ * @param options.siteId        The funnel site's blog ID.
+ * @param options.blueprintSlug Blueprint being built, for the site-spec hand-off.
+ * @param options.ref           Referrer to carry through.
+ * @param options.locale        Flow locale.
+ * @returns The URL to land on after checkout.
+ */
+function getWowFunnelPostCheckoutDestination( {
+	funnelSlug,
+	dest,
+	siteSlug,
+	siteId,
+	blueprintSlug,
+	ref,
+	locale,
+}: {
+	funnelSlug: string;
+	dest: WowFunnelDest;
+	siteSlug: string;
+	siteId: number;
+	blueprintSlug?: string | null;
+	ref?: string | null;
+	locale: string;
+} ): string {
+	const { interstitials } = getWowFunnelConfig( funnelSlug );
+
+	// site-spec: the funnel's follow-up (e.g. the blueprint import) is already running
+	// server-side, so site-spec only waits on it and hands over. It must not start one — see the
+	// funnel guard on its kickoff effect.
+	if ( interstitials.includes( 'site-spec' ) ) {
+		return getBlueprintArchiveSiteSpecUrl( {
+			siteSlug,
+			siteId,
+			blueprintSlug: blueprintSlug ?? '',
+			ref,
+			wowFunnel: funnelSlug,
+		} );
+	}
+
+	// Hand off through the funnel's own post-checkout page rather than pointing checkout straight
+	// at the built site: the readiness wait has to be on a page the customer reaches after paying.
+	return addQueryArgs(
+		withLocale( `/setup/${ ONBOARDING_FLOW }/${ STEPS.WOW_FUNNEL_HANDOFF.slug }`, locale ),
+		{
+			wow_funnel: funnelSlug,
+			dest,
+			siteSlug,
+			// Skip siteId when it's 0/falsy: "0" in the URL poisons the site lookup.
+			...( siteId ? { siteId } : {} ),
+		}
+	);
+}
+
+/**
+ * Put a customer who already has an unpaid funnel site back where they stopped.
+ *
+ * Runs in initialize, which is awaited before the flow renders anything, so a resumed customer
+ * never sees a step flash past on the way to their cart. Returning true means a redirect is under
+ * way and the flow must not start.
+ *
+ * Only the bare flow URL is a resume: a CTA click arrives with no step in the path, while working
+ * through the run — or refreshing inside it — always carries one, and bouncing those would throw
+ * the customer out of the step they are on.
+ * @param reduxStore The Calypso store, for the logged-in check and the locale.
+ * @returns True when the customer is being redirected and the flow should not render.
+ */
+async function resumeWowFunnelRun( reduxStore: Store ): Promise< boolean > {
+	if ( getStepFromURL() ) {
+		return false;
+	}
+
+	const queryParams = new URLSearchParams( window.location.search );
+	const funnelSlug = getWowFunnelSlug( queryParams );
+	if ( ! isKnownWowFunnel( funnelSlug ) || ! isUserLoggedIn( reduxStore.getState() ) ) {
+		return false;
+	}
+
+	const funnelArgs = getWowFunnelArgs( queryParams );
+
+	// Ask the server, not this browser. sessionStorage remembers the run only in the tab that
+	// started it, and it is the customer coming back that this exists to catch. The server drops
+	// its pointer as it reads it, so a site since paid for or reverted answers "none" here and a
+	// fresh run begins.
+	const pending = await fetchPendingWowFunnelSite();
+	if ( ! pending ) {
+		return false;
+	}
+
+	// Adopt before redirecting, so create-site consumes this site rather than asking for one the
+	// server will refuse. When the adoption cannot be stored there is nowhere to record that the
+	// resume happened, and every entry would resume all over again — so let the flow start and let
+	// create-site's own throttle fallback reach the same site.
+	if ( ! adoptWowFunnelSite( pending, funnelSlug, funnelArgs ) ) {
+		logWowFunnelEvent( 'resume_not_remembered', {
+			funnel: funnelSlug,
+			blog_id: pending.blogId,
+		} );
+		return false;
+	}
+
+	if ( pending.funnelSlug !== funnelSlug ) {
+		// A different CTA. The throttle holds regardless of which one, so the unpaid site still
+		// wins — worth seeing, since what gets resumed is not what this CTA asked to build.
+		logWowFunnelEvent( 'resumed_across_funnels', {
+			funnel: funnelSlug,
+			pending_funnel: pending.funnelSlug,
+			blog_id: pending.blogId,
+		} );
+	}
+
+	const locale = getCurrentLocaleSlug( reduxStore.getState() ) || '';
+	const [ , plansUrl ] = getOnboardingPostCheckoutDestination( {
+		flowName: ONBOARDING_FLOW,
+		locale,
+		siteSlug: pending.siteSlug,
+	} );
+
+	// Something in the cart means they reached checkout and did not pay, so show them exactly
+	// that. An empty one means they never picked a plan.
+	if ( await wowFunnelSiteHasCartItems( pending.blogId ) ) {
+		logWowFunnelEvent( 'resumed_at_checkout', {
+			funnel: funnelSlug,
+			blog_id: pending.blogId,
+		} );
+
+		// goToCheckout persists the post-checkout destination, which flow entry clears on its way
+		// in — without it a resumed purchase would land on My Home instead of the site the funnel
+		// built.
+		goToCheckout( {
+			flowName: ONBOARDING_FLOW,
+			stepName: 'plans',
+			siteSlug: pending.siteSlug,
+			destination: getWowFunnelPostCheckoutDestination( {
+				funnelSlug,
+				dest: getWowFunnelDest( queryParams, funnelSlug ),
+				siteSlug: pending.siteSlug,
+				siteId: pending.blogId,
+				blueprintSlug: queryParams.get( 'blueprint' ),
+				ref: queryParams.get( 'ref' ),
+				locale,
+			} ),
+		} );
+		return true;
+	}
+
+	logWowFunnelEvent( 'resumed_at_plans', {
+		funnel: funnelSlug,
+		blog_id: pending.blogId,
+	} );
+
+	// Carry the entry URL's own params, so the resumed run stays a funnel run: wow_funnel, dest
+	// and the funnel args all still have work to do downstream.
+	window.location.assign( addQueryArgs( plansUrl, getQueryArgs( window.location.href ) ) );
+
+	return true;
+}
+
+async function initialize( reduxStore: Store ) {
+	// Before anything renders: a customer with an unpaid funnel site is sent back to it, and the
+	// flow is killed rather than started behind the redirect.
+	if ( await resumeWowFunnelRun( reduxStore ) ) {
+		return false as const;
+	}
+
 	const steps = [
 		STEPS.DOMAIN_SEARCH,
 		STEPS.USE_MY_DOMAIN,
@@ -145,55 +327,28 @@ const onboarding: FlowV2< typeof initialize > = {
 			if ( isKnownWowFunnel( wowFunnelSlug ) ) {
 				const siteSlug = providedDependencies.siteSlug as string;
 				const siteId = providedDependencies.siteId as number;
-				const { interstitials } = getWowFunnelConfig( wowFunnelSlug );
 
 				// The run is over. Without this the remembered site outlives it for the whole
 				// browser session, and the next CTA click resumes this site instead of building
 				// a new one — offering a renewal of the plan just bought for it.
 				clearWowFunnelSite();
 
-				// site-spec: the funnel's follow-up (e.g. the blueprint import) is already running
-				// server-side, so site-spec only waits on it and hands over. It must not start
-				// one — see the funnel guard on its kickoff effect.
-				if ( interstitials.includes( 'site-spec' ) ) {
-					const blueprintSlug = queryParams.get( 'blueprint' ) ?? '';
-					logWowFunnelEvent( 'post_checkout_site_spec', {
-						funnel: wowFunnelSlug,
-						blog_id: siteId,
-					} );
-					return [
-						getBlueprintArchiveSiteSpecUrl( {
-							siteSlug,
-							siteId,
-							blueprintSlug,
-							ref: refParameter,
-							wowFunnel: wowFunnelSlug,
-						} ),
-						null,
-						null,
-					];
-				}
-
-				// Hand off through the funnel's own post-checkout page rather than pointing
-				// checkout straight at the built site. This function runs BEFORE checkout — its
-				// result becomes checkout's redirect_to — so the readiness wait cannot live
-				// here; it has to be on a page the customer reaches after paying.
 				logWowFunnelEvent( 'post_checkout_handoff', {
 					funnel: wowFunnelSlug,
 					blog_id: siteId,
 					dest: wowFunnelDest,
 				} );
+
 				return [
-					addQueryArgs(
-						withLocale( `/setup/${ ONBOARDING_FLOW }/${ STEPS.WOW_FUNNEL_HANDOFF.slug }`, locale ),
-						{
-							wow_funnel: wowFunnelSlug,
-							dest: wowFunnelDest,
-							siteSlug,
-							// Skip siteId when it's 0/falsy: "0" in the URL poisons the site lookup.
-							...( siteId ? { siteId } : {} ),
-						}
-					),
+					getWowFunnelPostCheckoutDestination( {
+						funnelSlug: wowFunnelSlug,
+						dest: wowFunnelDest,
+						siteSlug,
+						siteId,
+						blueprintSlug: queryParams.get( 'blueprint' ),
+						ref: refParameter,
+						locale,
+					} ),
 					null,
 					null,
 				];

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -73,6 +73,7 @@ import { useIsPostPlanSelectionEmailVerification } from '../../internals/steps-r
 import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
 import { type FlowV2, type ProvidedDependencies, type SubmitHandler } from '../../internals/types';
 import { getOnboardingStepperPosition } from './step-counter-config';
+import type { WowFunnelDest } from '../../../utils/wow-funnel';
 import type { DomainSuggestion } from '@automattic/api-core';
 import type { Store } from 'redux';
 

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-wow-funnel-resume.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-wow-funnel-resume.ts
@@ -1,0 +1,195 @@
+/**
+ * @jest-environment jsdom
+ */
+import onboarding from '../onboarding';
+
+const mockFetchPending = jest.fn();
+const mockHasCartItems = jest.fn();
+const mockAdopt = jest.fn();
+const mockGoToCheckout = jest.fn();
+const mockAssign = jest.fn();
+let mockLoggedIn = true;
+
+jest.mock( 'calypso/landing/stepper/utils/wow-funnel-site', () => ( {
+	fetchPendingWowFunnelSite: ( ...args: unknown[] ) => mockFetchPending( ...args ),
+	wowFunnelSiteHasCartItems: ( ...args: unknown[] ) => mockHasCartItems( ...args ),
+	adoptWowFunnelSite: ( ...args: unknown[] ) => mockAdopt( ...args ),
+	startWowFunnelSite: jest.fn(),
+	forgetWowFunnelRun: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/utils/wow-funnel', () => ( {
+	getWowFunnelSlug: ( params: URLSearchParams ) => params.get( 'wow_funnel' ),
+	getWowFunnelArgs: () => ( {} ),
+	getWowFunnelDest: () => 'editor',
+	getWowFunnelConfig: () => ( { interstitials: [] } ),
+	isKnownWowFunnel: ( slug: string | null ) => Boolean( slug ),
+	getRememberedWowFunnelSite: () => null,
+	clearWowFunnelSite: jest.fn(),
+	wowFunnelSiteIsPaid: () => false,
+	logWowFunnelEvent: jest.fn(),
+	waitForWowFunnelReady: jest.fn(),
+	getWowFunnelHandoffUrl: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/utils/checkout', () => ( {
+	goToCheckout: ( ...args: unknown[] ) => mockGoToCheckout( ...args ),
+} ) );
+
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	isUserLoggedIn: () => mockLoggedIn,
+	getCurrentUser: () => null,
+} ) );
+
+jest.mock( 'calypso/state/selectors/get-current-locale-slug', () => ( {
+	__esModule: true,
+	default: () => 'en',
+} ) );
+
+jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', () => ( {
+	clearSessionStorageQuery: jest.fn(),
+} ) );
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {} ),
+	useSelect: jest.fn( () => ( {} ) ),
+	resolveSelect: jest.fn(),
+} ) );
+jest.mock( 'calypso/landing/stepper/hooks/use-query', () => ( {
+	useQuery: jest.fn( () => new URLSearchParams( '' ) ),
+} ) );
+jest.mock( 'calypso/landing/stepper/hooks/use-flow-locale', () => ( {
+	useFlowLocale: jest.fn( () => 'en' ),
+} ) );
+jest.mock( 'calypso/state', () => ( {
+	useSelector: jest.fn(),
+	useDispatch: () => jest.fn(),
+} ) );
+jest.mock( 'calypso/lib/analytics/survicate', () => ( { addSurvicate: jest.fn() } ) );
+jest.mock( 'calypso/lib/analytics/signup', () => ( { SIGNUP_DOMAIN_ORIGIN: {} } ) );
+jest.mock( 'calypso/lib/explat', () => ( {
+	loadExperimentAssignment: jest.fn(),
+	useExperiment: jest.fn( () => [ false, null ] ),
+} ) );
+jest.mock( 'calypso/landing/stepper/stores', () => ( {
+	ONBOARD_STORE: 'ONBOARD_STORE',
+	SITE_STORE: 'SITE_STORE',
+} ) );
+jest.mock( '@automattic/data-stores', () => ( {} ) );
+jest.mock( '@automattic/onboarding', () => ( {
+	ONBOARDING_FLOW: 'onboarding',
+	SITE_SETUP_FLOW: 'site-setup',
+	clearStepPersistedState: jest.fn(),
+	isOnboardingFlow: ( flow: string ) => flow === 'onboarding',
+} ) );
+jest.mock(
+	'calypso/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification',
+	() => ( {
+		usePurchasePlanNotification: jest.fn( () => ( { setShouldShowNotification: jest.fn() } ) ),
+	} )
+);
+jest.mock( 'calypso/signup/storageUtils', () => ( {
+	persistSignupDestination: jest.fn(),
+	setSignupCompleteFlowName: jest.fn(),
+	setSignupCompleteSlug: jest.fn(),
+	clearSignupCompleteSlug: jest.fn(),
+	clearSignupCompleteFlowName: jest.fn(),
+	clearSignupDestinationCookie: jest.fn(),
+	clearSignupCompleteSiteID: jest.fn(),
+} ) );
+
+const PENDING = {
+	blogId: 111,
+	siteSlug: 'site-111.wordpress.com',
+	funnelSlug: 'default',
+	funnelArgs: {},
+};
+
+const store = { getState: () => ( {} ) } as never;
+
+function enterAt( pathname: string ) {
+	delete ( window as unknown as { location?: unknown } ).location;
+	( window as unknown as { location: unknown } ).location = {
+		pathname,
+		search: '?wow_funnel=default',
+		href: `http://calypso.localhost:3000${ pathname }?wow_funnel=default`,
+		assign: mockAssign,
+	};
+}
+
+/**
+ * A customer who left an unpaid funnel site behind is put back where they stopped. This runs in
+ * initialize, which the Stepper awaits before rendering, so the decision is made before any step
+ * is on screen. `false` is initialize's contract for "a redirect is under way, do not start the
+ * flow".
+ */
+describe( 'wow funnel resume', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockLoggedIn = true;
+		mockAdopt.mockReturnValue( { blogId: PENDING.blogId } );
+		enterAt( '/setup/onboarding' );
+	} );
+
+	it( 'sends the customer back to checkout when the abandoned cart still holds their plan', async () => {
+		mockFetchPending.mockResolvedValue( PENDING );
+		mockHasCartItems.mockResolvedValue( true );
+
+		await expect( onboarding.initialize( store ) ).resolves.toBe( false );
+		expect( mockGoToCheckout.mock.calls[ 0 ][ 0 ] ).toMatchObject( {
+			siteSlug: PENDING.siteSlug,
+		} );
+	} );
+
+	/**
+	 * A resumed purchase must still land on the site the funnel built. Flow entry clears the
+	 * destination cookie, so checkout is handed the destination explicitly.
+	 */
+	it( 'gives the resumed checkout the funnel hand-off as its destination', async () => {
+		mockFetchPending.mockResolvedValue( PENDING );
+		mockHasCartItems.mockResolvedValue( true );
+
+		await onboarding.initialize( store );
+
+		expect( mockGoToCheckout.mock.calls[ 0 ][ 0 ].destination ).toContain( 'wow-funnel-handoff' );
+	} );
+
+	it( 'sends the customer to plans when the site is standing but nothing was ever chosen', async () => {
+		mockFetchPending.mockResolvedValue( PENDING );
+		mockHasCartItems.mockResolvedValue( false );
+
+		await expect( onboarding.initialize( store ) ).resolves.toBe( false );
+		expect( mockAssign.mock.calls[ 0 ][ 0 ] ).toContain( '/setup/onboarding/plans' );
+		expect( mockGoToCheckout ).not.toHaveBeenCalled();
+	} );
+
+	it( 'starts the flow normally when the customer has no site standing', async () => {
+		mockFetchPending.mockResolvedValue( null );
+
+		await expect( onboarding.initialize( store ) ).resolves.not.toBe( false );
+		expect( mockGoToCheckout ).not.toHaveBeenCalled();
+		expect( mockAssign ).not.toHaveBeenCalled();
+	} );
+
+	/**
+	 * A step in the path means the customer is inside the run. Resuming there would throw them out
+	 * of the step they are on — a refresh on the domain step would jump to plans.
+	 */
+	it( 'never resumes once a step is in the path', async () => {
+		enterAt( '/setup/onboarding/domains' );
+		mockFetchPending.mockResolvedValue( PENDING );
+		mockHasCartItems.mockResolvedValue( true );
+
+		await expect( onboarding.initialize( store ) ).resolves.not.toBe( false );
+		expect( mockFetchPending ).not.toHaveBeenCalled();
+		expect( mockGoToCheckout ).not.toHaveBeenCalled();
+		expect( mockAssign ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not ask the server about a logged-out visitor', async () => {
+		mockLoggedIn = false;
+		mockFetchPending.mockResolvedValue( PENDING );
+
+		await expect( onboarding.initialize( store ) ).resolves.not.toBe( false );
+		expect( mockFetchPending ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/landing/stepper/utils/test/wow-funnel-site.ts
+++ b/client/landing/stepper/utils/test/wow-funnel-site.ts
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	adoptWowFunnelSite,
+	fetchPendingWowFunnelSite,
+	wowFunnelSiteHasCartItems,
+} from '../wow-funnel-site';
+
+const mockGet = jest.fn();
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	__esModule: true,
+	default: { req: { get: ( ...args: unknown[] ) => mockGet( ...args ) } },
+} ) );
+
+// The barrels this module pulls in for site creation are irrelevant to the throttle helpers, and
+// loading them for real drags i18n-calypso into the test.
+jest.mock( '@automattic/onboarding', () => ( {
+	ONBOARDING_FLOW: 'onboarding',
+	createSite: jest.fn(),
+} ) );
+jest.mock( '@automattic/data-stores/src/site/types', () => ( {
+	Visibility: { PublicNotIndexed: 0 },
+} ) );
+
+describe( 'fetchPendingWowFunnelSite', () => {
+	beforeEach( () => {
+		mockGet.mockReset();
+	} );
+
+	it( 'reports the unpaid site the customer left standing', async () => {
+		mockGet.mockResolvedValue( {
+			pending: true,
+			blog_id: 111,
+			site_slug: 'site-111.wordpress.com',
+			funnel_slug: 'blueprint',
+			funnel_args: { blueprint_slug: 'coachava' },
+		} );
+
+		await expect( fetchPendingWowFunnelSite() ).resolves.toEqual( {
+			blogId: 111,
+			siteSlug: 'site-111.wordpress.com',
+			funnelSlug: 'blueprint',
+			funnelArgs: { blueprint_slug: 'coachava' },
+		} );
+	} );
+
+	/**
+	 * The server drops its own pointer as it reads it, so a site since paid for or reverted
+	 * answers "none" — which is what lets a fresh run begin.
+	 */
+	it( 'reports nothing when the previous run has ended', async () => {
+		mockGet.mockResolvedValue( { pending: false } );
+
+		await expect( fetchPendingWowFunnelSite() ).resolves.toBeNull();
+	} );
+
+	it( 'treats a failed lookup as nothing pending, leaving /sites/new the final say', async () => {
+		mockGet.mockRejectedValue( new Error( 'network' ) );
+
+		await expect( fetchPendingWowFunnelSite() ).resolves.toBeNull();
+	} );
+} );
+
+describe( 'wowFunnelSiteHasCartItems', () => {
+	beforeEach( () => {
+		mockGet.mockReset();
+	} );
+
+	/**
+	 * This is what separates the two ways of resuming: a cart with something in it means the
+	 * customer reached checkout and did not pay, so they go back there rather than to plans.
+	 */
+	it( 'is true when the abandoned cart still holds products', async () => {
+		mockGet.mockResolvedValue( { products: [ { product_slug: 'business-bundle' } ] } );
+
+		await expect( wowFunnelSiteHasCartItems( 111 ) ).resolves.toBe( true );
+	} );
+
+	it( 'is false for an empty cart', async () => {
+		mockGet.mockResolvedValue( { products: [] } );
+
+		await expect( wowFunnelSiteHasCartItems( 111 ) ).resolves.toBe( false );
+	} );
+
+	it( 'is false when the cart cannot be read, so the customer lands on plans', async () => {
+		mockGet.mockRejectedValue( new Error( 'network' ) );
+
+		await expect( wowFunnelSiteHasCartItems( 111 ) ).resolves.toBe( false );
+	} );
+} );
+
+describe( 'adoptWowFunnelSite', () => {
+	beforeEach( () => {
+		window.sessionStorage.clear();
+	} );
+
+	/**
+	 * One unpaid site is allowed at a time, so a different CTA cannot build its own. Remembering
+	 * the pending site under the run being entered is what stops create-site from asking for a
+	 * second site the server will refuse.
+	 */
+	it( 'remembers the pending site under the run being entered, not the one that built it', () => {
+		const adopted = adoptWowFunnelSite(
+			{
+				blogId: 111,
+				siteSlug: 'site-111.wordpress.com',
+				funnelSlug: 'blueprint',
+				funnelArgs: { blueprint_slug: 'coachava' },
+			},
+			'blueprint',
+			{ blueprint_slug: 'other' }
+		);
+
+		expect( adopted ).toMatchObject( { blogId: 111, funnelSlug: 'blueprint' } );
+		expect(
+			JSON.parse( window.sessionStorage.getItem( 'wow-funnel-created-site' ) ?? '{}' )
+		).toMatchObject( { blogId: 111 } );
+	} );
+} );

--- a/client/landing/stepper/utils/wow-funnel-site.ts
+++ b/client/landing/stepper/utils/wow-funnel-site.ts
@@ -1,5 +1,6 @@
 import { Visibility } from '@automattic/data-stores/src/site/types';
 import { ONBOARDING_FLOW, createSite } from '@automattic/onboarding';
+import wpcom from 'calypso/lib/wp';
 import {
 	clearWowFunnelSite,
 	getRememberedWowFunnelSite,
@@ -44,6 +45,187 @@ export function forgetWowFunnelRun(
 }
 
 /**
+ * The unpaid funnel site the customer already has in flight, as the server reports it.
+ *
+ * The funnel builds an Atomic site before anyone pays for it, so a customer who leaves before
+ * checkout leaves one standing. The server allows exactly one at a time and refuses to build a
+ * second, so this is what a funnel entry has to consult before it tries to start a run.
+ */
+export type PendingWowFunnelSite = {
+	blogId: number;
+	siteSlug: string;
+	/** The run that built it, which is not necessarily the run being entered now. */
+	funnelSlug: string;
+	funnelArgs: Record< string, string >;
+};
+
+/**
+ * Ask the server whether this customer already has an unpaid funnel site.
+ *
+ * The server drops its own pointer as it reads it, so an empty answer means the previous site is
+ * genuinely gone — paid for, or reverted — not merely forgotten by this browser.
+ * @returns The pending site, or null when the customer has none (and on any lookup failure, where
+ *          treating it as absent lets /sites/new have the final say).
+ */
+export async function fetchPendingWowFunnelSite(): Promise< PendingWowFunnelSite | null > {
+	try {
+		const response = ( await wpcom.req.get( {
+			path: '/wow-funnel/pending',
+			apiNamespace: 'wpcom/v2',
+		} ) ) as {
+			pending?: boolean;
+			blog_id?: number;
+			site_slug?: string;
+			funnel_slug?: string;
+			funnel_args?: Record< string, string >;
+		};
+
+		if ( ! response?.pending || ! response.blog_id || ! response.site_slug ) {
+			return null;
+		}
+
+		return {
+			blogId: Number( response.blog_id ),
+			siteSlug: String( response.site_slug ),
+			funnelSlug: String( response.funnel_slug ?? '' ),
+			funnelArgs: response.funnel_args ?? {},
+		};
+	} catch ( error ) {
+		logWowFunnelEvent( 'pending_lookup_error', {
+			error: error instanceof Error ? error.message : String( error ),
+		} );
+		return null;
+	}
+}
+
+/**
+ * Does the pending site's cart still hold what the customer picked before they left?
+ *
+ * This is the difference between the two ways of resuming: a cart with something in it means they
+ * got as far as checkout and did not pay, so put them back there; an empty one means they never
+ * chose a plan, so send them to pick one.
+ * @param blogId The pending site's blog ID.
+ * @returns True when the site's persisted cart has products in it.
+ */
+export async function wowFunnelSiteHasCartItems( blogId: number ): Promise< boolean > {
+	try {
+		const cart = ( await wpcom.req.get( `/me/shopping-cart/${ blogId }` ) ) as {
+			products?: unknown[];
+		};
+		return Array.isArray( cart?.products ) && cart.products.length > 0;
+	} catch ( error ) {
+		// An unreadable cart is indistinguishable from an empty one here, and plans is the safe
+		// place to land: the customer can still reach checkout from there.
+		logWowFunnelEvent( 'cart_lookup_error', {
+			blog_id: blogId,
+			error: error instanceof Error ? error.message : String( error ),
+		} );
+		return false;
+	}
+}
+
+/**
+ * Take the pending site over as this run's site.
+ *
+ * Remembered under the run being entered now, not the run that built it: with one unpaid site
+ * allowed at a time, a different CTA cannot build its own anyway, and keying it any other way
+ * would leave create-site asking for a second site the server will refuse.
+ * @param pending    The pending site.
+ * @param funnelSlug The slug of the run being entered.
+ * @param funnelArgs Args of the run being entered.
+ * @returns The remembered site, or null when sessionStorage would not hold it — in which case
+ *          nothing must be built on the assumption that a later page load will remember this.
+ */
+export function adoptWowFunnelSite(
+	pending: PendingWowFunnelSite,
+	funnelSlug: string,
+	funnelArgs: Record< string, string > = {}
+): RememberedWowFunnelSite | null {
+	const site: RememberedWowFunnelSite = {
+		funnelSlug,
+		funnelKey: getWowFunnelKey( funnelSlug, funnelArgs ),
+		blogId: pending.blogId,
+		siteSlug: pending.siteSlug,
+	};
+
+	return rememberWowFunnelSite( site ) ? site : null;
+}
+
+/**
+ * Create the funnel's site, or take over the one the throttle refused to duplicate.
+ *
+ * /sites/new allows one unpaid funnel site per customer, so a create can legitimately fail
+ * because the customer already has one — a second tab, or a session whose memory of the run was
+ * lost. Failing the flow there would strand them; adopting the site the server is holding is what
+ * they were going to get anyway.
+ * @param options            Options.
+ * @param options.funnelSlug The funnel slug.
+ * @param options.funnelArgs Args from the entry URL.
+ * @param options.siteTitle  Optional site title.
+ * @returns The created or adopted site.
+ */
+async function createSiteOrAdoptPending( {
+	funnelSlug,
+	funnelArgs,
+	siteTitle,
+}: {
+	funnelSlug: string;
+	funnelArgs?: Record< string, string >;
+	siteTitle?: string;
+} ): Promise< { siteId: number; siteSlug: string } > {
+	let creationError: unknown;
+	let site;
+
+	try {
+		site = await createSite(
+			ONBOARDING_FLOW,
+			'', // themeSlugWithRepo — default theme.
+			Visibility.PublicNotIndexed, // coming soon.
+			siteTitle ?? '',
+			'#113AF5', // accent — backend requires a value.
+			false, // useThemeHeadstart.
+			// username: only ever a last-resort blog_name seed, and the server generates the
+			// funnel's arbitrary subdomain regardless — see /sites/new's wow-funnel block.
+			'',
+			null, // partnerBundle.
+			undefined, // storedSiteUrl — empty so the server generates an arbitrary subdomain.
+			undefined, // domainItem.
+			undefined, // sourceSlug.
+			undefined, // siteIntent.
+			undefined, // siteGoals.
+			null, // gardenName.
+			null, // gardenPartnerName.
+			undefined, // specId.
+			undefined, // ref.
+			undefined, // provisionTarget.
+			undefined, // aiLaunchpadEnabled.
+			funnelSlug,
+			funnelArgs
+		);
+	} catch ( error ) {
+		creationError = error;
+	}
+
+	if ( site ) {
+		return site;
+	}
+
+	const pending = await fetchPendingWowFunnelSite();
+	if ( pending ) {
+		logWowFunnelEvent( 'start_site_adopted_pending', {
+			funnel: funnelSlug,
+			blog_id: pending.blogId,
+			pending_funnel: pending.funnelSlug,
+		} );
+		return { siteId: pending.blogId, siteSlug: pending.siteSlug };
+	}
+
+	throw creationError instanceof Error
+		? creationError
+		: new Error( 'Failed to create WoW funnel site' );
+}
+
+/**
  * Create the funnel's Simple site (which the server immediately fast-provisions to Atomic), once.
  *
  * Single-flight: concurrent callers for the same funnel share one request, and a site already
@@ -75,35 +257,7 @@ export function startWowFunnelSite( {
 	const request = ( async () => {
 		logWowFunnelEvent( 'start_site_creation', { funnel: funnelSlug } );
 
-		const site = await createSite(
-			ONBOARDING_FLOW,
-			'', // themeSlugWithRepo — default theme.
-			Visibility.PublicNotIndexed, // coming soon.
-			siteTitle ?? '',
-			'#113AF5', // accent — backend requires a value.
-			false, // useThemeHeadstart.
-			// username: only ever a last-resort blog_name seed, and the server generates the
-			// funnel's arbitrary subdomain regardless — see /sites/new's wow-funnel block.
-			'',
-			null, // partnerBundle.
-			undefined, // storedSiteUrl — empty so the server generates an arbitrary subdomain.
-			undefined, // domainItem.
-			undefined, // sourceSlug.
-			undefined, // siteIntent.
-			undefined, // siteGoals.
-			null, // gardenName.
-			null, // gardenPartnerName.
-			undefined, // specId.
-			undefined, // ref.
-			undefined, // provisionTarget.
-			undefined, // aiLaunchpadEnabled.
-			funnelSlug,
-			funnelArgs
-		);
-
-		if ( ! site ) {
-			throw new Error( 'Failed to create WoW funnel site' );
-		}
+		const site = await createSiteOrAdoptPending( { funnelSlug, funnelArgs, siteTitle } );
 
 		const result: RememberedWowFunnelSite = {
 			funnelSlug,

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -225,12 +225,14 @@ export function getRememberedWowFunnelSite(
 	return remembered && remembered.funnelKey === key ? remembered : null;
 }
 
-export function rememberWowFunnelSite( site: RememberedWowFunnelSite ): void {
+export function rememberWowFunnelSite( site: RememberedWowFunnelSite ): boolean {
 	try {
 		window.sessionStorage.setItem( SESSION_KEY, JSON.stringify( site ) );
+		return true;
 	} catch {
 		// sessionStorage unavailable — the module-level in-flight cache still de-dupes within the
 		// session, and create-site falls back to creating the site itself.
+		return false;
 	}
 }
 

--- a/packages/wp-babel-makepot/test/parallel-output/test-examples-private-fields.js.pot
+++ b/packages/wp-babel-makepot/test/parallel-output/test-examples-private-fields.js.pot
@@ -1,0 +1,10 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=utf-8\n"
+
+#: test/examples/private-fields.js:2
+msgid "Private property"
+msgstr ""
+
+#: test/examples/private-fields.js:4
+msgid "Private method"
+msgstr ""

--- a/packages/wp-babel-makepot/test/parallel-output/test-examples-react-1.jsx.pot
+++ b/packages/wp-babel-makepot/test/parallel-output/test-examples-react-1.jsx.pot
@@ -1,0 +1,14 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=utf-8\n"
+
+#: test/examples/react-1.jsx:10
+msgid "Prop string"
+msgstr ""
+
+#: test/examples/react-1.jsx:13
+#. Extract from leading
+msgctxt "react"
+msgid "Child string"
+msgid_plural "Child string plural"
+msgstr[0] ""
+msgstr[1] ""

--- a/packages/wp-babel-makepot/test/parallel-output/test-examples-react-2.jsx.pot
+++ b/packages/wp-babel-makepot/test/parallel-output/test-examples-react-2.jsx.pot
@@ -1,0 +1,14 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=utf-8\n"
+
+#: test/examples/react-2.jsx:5
+msgid "Prop string"
+msgstr ""
+
+#: test/examples/react-2.jsx:8
+#. Extract from leading
+msgctxt "react"
+msgid "Child string"
+msgid_plural "Child string plural"
+msgstr[0] ""
+msgstr[1] ""

--- a/packages/wp-babel-makepot/test/parallel-output/test-examples-translate-1.js.pot
+++ b/packages/wp-babel-makepot/test/parallel-output/test-examples-translate-1.js.pot
@@ -1,0 +1,28 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=utf-8\n"
+
+#: test/examples/translate-1.js:2
+msgid "Simple string"
+msgstr ""
+
+#: test/examples/translate-1.js:4
+msgid "Singular"
+msgid_plural "Plural"
+msgstr[0] ""
+msgstr[1] ""
+
+#: test/examples/translate-1.js:14
+#: test/examples/translate-1.js:18
+#. String comment
+msgid "String with comment"
+msgid_plural "Plural with comment"
+msgstr[0] ""
+msgstr[1] ""
+
+#: test/examples/translate-1.js:6
+#: test/examples/translate-1.js:10
+msgctxt "simple context"
+msgid "String with context"
+msgid_plural "Plural with context"
+msgstr[0] ""
+msgstr[1] ""

--- a/packages/wp-babel-makepot/test/parallel-output/test-examples-translate-2.js.pot
+++ b/packages/wp-babel-makepot/test/parallel-output/test-examples-translate-2.js.pot
@@ -1,0 +1,27 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=utf-8\n"
+
+#: test/examples/translate-2.js:4
+#. Second occurrence of `Simple string` should also be extracted.
+msgid "Simple string"
+msgstr ""
+
+#: test/examples/translate-2.js:8
+#: test/examples/translate-2.js:9
+#. First comment
+#. Second comment
+msgid "Stack comments"
+msgstr ""
+
+#: test/examples/translate-2.js:12
+#: test/examples/translate-2.js:15
+#. Extract from leading comment first
+#. Extract from leading comment second
+msgid "Extract from leading comment"
+msgstr ""
+
+#: test/examples/translate-2.js:17
+msgid "Exrract _x as alias for translate"
+msgid_plural "Second param should be extracted as plural instead of context"
+msgstr[0] ""
+msgstr[1] ""

--- a/packages/wp-babel-makepot/test/parallel-output/test-examples-typescript-react.tsx.pot
+++ b/packages/wp-babel-makepot/test/parallel-output/test-examples-typescript-react.tsx.pot
@@ -1,0 +1,6 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=utf-8\n"
+
+#: test/examples/typescript-react.tsx:8
+msgid "Typescript react component string"
+msgstr ""

--- a/packages/wp-babel-makepot/test/parallel-output/test-examples-wordpress-i18n.js.pot
+++ b/packages/wp-babel-makepot/test/parallel-output/test-examples-wordpress-i18n.js.pot
@@ -1,0 +1,28 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=utf-8\n"
+
+#: test/examples/wordpress-i18n.js:2
+msgid "Simple string"
+msgstr ""
+
+#: test/examples/wordpress-i18n.js:4
+msgid "Singular"
+msgid_plural "Plural"
+msgstr[0] ""
+msgstr[1] ""
+
+#: test/examples/wordpress-i18n.js:11
+#: test/examples/wordpress-i18n.js:14
+#. String comment
+msgid "String with comment"
+msgid_plural "Plural with comment"
+msgstr[0] ""
+msgstr[1] ""
+
+#: test/examples/wordpress-i18n.js:6
+#: test/examples/wordpress-i18n.js:8
+msgctxt "simple context"
+msgid "String with context"
+msgid_plural "Plural with context"
+msgstr[0] ""
+msgstr[1] ""


### PR DESCRIPTION
## Proposed Changes

* A customer who already has an unpaid funnel site is put back where they stopped instead of starting a new run: to checkout when the abandoned cart still holds what they picked, and to the plans step when it does not.
* The decision is made in `initialize`, which the Stepper awaits before mounting anything, and returning `false` kills the flow — so nothing paints before the redirect.
* Only the bare flow URL resumes. `currentStepRoute` comes straight off the route params, so a CTA click arrives with no step in the path while working through the run — or refreshing inside it — always carries one.
* The pending site is adopted into the run before redirecting, so `create-site` consumes it rather than asking for a second site the server will refuse. When `sessionStorage` will not hold the adoption, the flow starts normally rather than redirecting in a loop.
* `startWowFunnelSite()` falls back to adopting the pending site when creation is refused, so a second tab does not dead-end the flow.
* The post-checkout destination is now built by one helper shared between the ordinary path and a resumed checkout, so the two cannot drift.

## Why are these changes being made?

The server now allows one unpaid funnel site per customer (`238076-ghe-Automattic/wpcom`). The funnel builds an Atomic site before anyone pays for it, so a customer who left before checkout was building another one on every CTA click, each holding Atomic resources until its abandonment revert ran.

Once `/sites/new` refuses that second site, the refusal has to become a resume or the funnel is broken for anyone who left before paying. The client cannot find the site on its own — the enrollment lives on the blog — hence the server lookup.

A resumed checkout carries its post-checkout destination explicitly, because flow entry clears the destination cookie on its way in. Without it a resumed purchase lands on My Home instead of the funnel hand-off.

The throttle helpers live in `wow-funnel-site.ts` rather than `wow-funnel.ts`, following the seam that file documents: they concern the customer's existing site and need the wpcom client, which the hand-off side deliberately does without.

## Testing Instructions

Needs a sandboxed `public-api.wordpress.com` and an Automattician account — the funnel is internal-only and the server ignores it for anyone else. `GET /wpcom/v2/wow-funnel/pending` only exists with `238076-ghe-Automattic/wpcom` applied; against production it 404s and the lookup treats that as "nothing pending", so the funnel behaves exactly as it does today.

* Open `/setup/onboarding?wow_funnel=default`, go through domain and plan selection to checkout, then leave without paying.
* Click the same CTA again. You land on checkout for the site you already had, cart intact — no domain step in between, and no new site in your site list.
* Repeat in a fresh tab or private window, so `sessionStorage` is empty. Same result: the resume comes from the server, not this browser.
* Start a run, stop before choosing a plan, then re-enter. You land on the plans step for the existing site rather than a new one.
* Refresh while on the domain step mid-run. You stay on the domain step — this is the case that must not be bounced to plans.
* Finish a purchase, then click the CTA again. A new run starts normally: the server drops its pointer once the site is paid for.
* Abandon at checkout, re-enter, and complete the purchase. You land on the funnel hand-off and end up on the built site, not My Home.

## Related to

* `238076-ghe-Automattic/wpcom` — the server-side throttle and the `/wpcom/v2/wow-funnel/pending` lookup this consumes.
* #113860 — closed; its changes reached trunk through the funnel PRs that landed after it.
