### PR TITLE
Omnibar: build the Help menu and Ask AI button from the admin bar payload

### DIFF
--- a/client/dashboard/app/omnibar/admin-bar-icon.tsx
+++ b/client/dashboard/app/omnibar/admin-bar-icon.tsx
@@ -1,34 +1,47 @@
+import { Icon, backup, comment, page, rss, video } from '@wordpress/icons';
 import { Path, SVG } from '@wordpress/primitives';
-import type { SVGAttributes } from 'react';
+import type { ReactElement } from 'react';
 
-type SvgRule = SVGAttributes< SVGPathElement >[ 'fillRule' ];
+// Glyphs `@wordpress/icons` does not carry.
+const help = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z"
+		/>
+	</SVG>
+);
 
-const attribute = ( element: Element, name: string ) => element.getAttribute( name ) ?? undefined;
+const askAi = (
+	<SVG viewBox="-45 -45 490 490" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M391.528 188.061L309.455 159.75C276.997 148.597 251.403 123.003 240.25 90.5451L211.939 8.47185C208.079 -2.82395 191.921 -2.82395 188.061 8.47185L159.75 90.5451C148.597 123.003 123.003 148.597 90.5451 159.75L8.47185 188.061C-2.82395 191.921 -2.82395 208.079 8.47185 211.939L90.5451 240.25C123.003 251.403 148.597 276.997 159.75 309.455L188.061 391.528C191.921 402.824 208.079 402.824 211.939 391.528L240.25 309.455C251.403 276.997 276.997 251.403 309.455 240.25L391.528 211.939C402.824 208.079 402.824 191.921 391.528 188.061ZM295.728 206.077L254.692 220.232C238.391 225.809 225.666 238.677 220.089 254.835L205.934 295.871C203.932 301.591 195.925 301.591 193.923 295.871L179.768 254.835C174.191 238.534 161.323 225.809 145.165 220.232L104.129 206.077C98.4093 204.075 98.4093 196.068 104.129 194.066L145.165 179.911C161.466 174.334 174.191 161.466 179.768 145.308L193.923 104.272C195.925 98.5523 203.932 98.5523 205.934 104.272L220.089 145.308C225.666 161.609 238.534 174.334 254.692 179.911L295.728 194.066C301.448 196.068 301.448 204.075 295.728 206.077Z" />
+	</SVG>
+);
 
-// Site-generated markup is rebuilt, never injected: only the `<svg>` and its `<path>` children survive.
-export function adminBarIcon( className: string, markup: string | undefined ) {
-	const svg = markup
-		? new DOMParser().parseFromString( markup, 'text/html' ).querySelector( 'svg' )
-		: null;
-	const paths = svg ? Array.from( svg.querySelectorAll( 'path' ) ) : [];
+const ICONS: Record< string, ReactElement > = {
+	comment,
+	backup,
+	page,
+	video,
+	rss,
+	help,
+	'ask-ai': askAi,
+};
 
-	if ( ! svg || ! paths.length ) {
+export function adminBarIcon(
+	name: string | undefined,
+	className: string
+): ReactElement | undefined {
+	const icon = name && Object.hasOwn( ICONS, name ) ? ICONS[ name ] : undefined;
+
+	if ( ! icon ) {
 		return undefined;
 	}
 
 	return (
 		<span className={ className }>
-			<SVG viewBox={ attribute( svg, 'viewBox' ) } xmlns="http://www.w3.org/2000/svg">
-				{ paths.map( ( path, index ) => (
-					<Path
-						key={ index }
-						d={ attribute( path, 'd' ) }
-						fill={ attribute( path, 'fill' ) }
-						fillRule={ attribute( path, 'fill-rule' ) as SvgRule }
-						clipRule={ attribute( path, 'clip-rule' ) as SvgRule }
-					/>
-				) ) }
-			</SVG>
+			<Icon icon={ icon } />
 		</span>
 	);
 }

--- a/client/dashboard/app/omnibar/admin-bar-icon.tsx
+++ b/client/dashboard/app/omnibar/admin-bar-icon.tsx
@@ -1,0 +1,34 @@
+import { Path, SVG } from '@wordpress/primitives';
+import type { SVGAttributes } from 'react';
+
+type SvgRule = SVGAttributes< SVGPathElement >[ 'fillRule' ];
+
+const attribute = ( element: Element, name: string ) => element.getAttribute( name ) ?? undefined;
+
+// Site-generated markup is rebuilt, never injected: only the `<svg>` and its `<path>` children survive.
+export function adminBarIcon( className: string, markup: string | undefined ) {
+	const svg = markup
+		? new DOMParser().parseFromString( markup, 'text/html' ).querySelector( 'svg' )
+		: null;
+	const paths = svg ? Array.from( svg.querySelectorAll( 'path' ) ) : [];
+
+	if ( ! svg || ! paths.length ) {
+		return undefined;
+	}
+
+	return (
+		<span className={ className }>
+			<SVG viewBox={ attribute( svg, 'viewBox' ) } xmlns="http://www.w3.org/2000/svg">
+				{ paths.map( ( path, index ) => (
+					<Path
+						key={ index }
+						d={ attribute( path, 'd' ) }
+						fill={ attribute( path, 'fill' ) }
+						fillRule={ attribute( path, 'fill-rule' ) as SvgRule }
+						clipRule={ attribute( path, 'clip-rule' ) as SvgRule }
+					/>
+				) ) }
+			</SVG>
+		</span>
+	);
+}

--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -128,10 +128,14 @@ function ConnectedOmnibar( {
 		[ authUser ]
 	);
 
+	const adminBarNodes = useMemo(
+		() => siteNodes ?? dashboardNodes ?? [],
+		[ siteNodes, dashboardNodes ]
+	);
+
 	const baseOmnibarNodes = useMemo( () => {
-		const nodes = siteNodes ?? dashboardNodes ?? [];
 		const result = buildOmnibarNodesFromAdminBarNodes(
-			removeUnsupportedNodes( nodes, supports ),
+			removeUnsupportedNodes( adminBarNodes, supports ),
 			nodeBuilders,
 			createHrefResolver( siteNodes ? site?.options?.admin_url : undefined )
 		);
@@ -159,11 +163,11 @@ function ConnectedOmnibar( {
 		}
 
 		return result;
-	}, [ dashboardNodes, siteNodes, site, supports, nodeBuilders ] );
+	}, [ adminBarNodes, siteNodes, site, supports, nodeBuilders ] );
 
 	const readerPluginNode = useReaderPlugin( { sectionGroup } );
-	const helpCenterPluginNode = useHelpCenterPlugin( { sectionName } );
-	const aiChatPluginNode = useAiChatPlugin( { sectionName } );
+	const helpCenterPluginNode = useHelpCenterPlugin( { sectionName, adminBarNodes } );
+	const aiChatPluginNode = useAiChatPlugin( { sectionName, adminBarNodes } );
 	const notificationsPluginNode = useNotificationsPlugin( { user } );
 	const { node: languageSwitcherNode, panel: languageSwitcherPanel } = useLanguageSwitcherPlugin( {
 		user,

--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -15,7 +15,7 @@ import { AUTH_QUERY_KEY, initializeCurrentUser } from '../auth';
 import { useAppContext } from '../context';
 import { omnibarEvents } from './events';
 import { OmnibarHomeIcon } from './home';
-import { useAiChatPlugin } from './plugin-ai-chat';
+import { createAiChatNodeBuilder } from './plugin-ai-chat';
 import { addDashboardNode, useDashboardPlugin } from './plugin-dashboard';
 import { useHelpCenterPlugin } from './plugin-help-center';
 import { useLanguageSwitcherPlugin } from './plugin-language-switcher';
@@ -123,9 +123,12 @@ function ConnectedOmnibar( {
 			'my-wpcom-account': buildWpcomAccountNode,
 			'site-plan-badge': buildSiteBadgeNode,
 			'site-status-badge': buildSiteBadgeNode,
+			...( supports.help
+				? { 'agents-manager-ai-chat': createAiChatNodeBuilder( sectionName ) }
+				: {} ),
 			...( authUser ? { logout: createLogoutNodeBuilder( authUser ) } : {} ),
 		} ),
-		[ authUser ]
+		[ authUser, sectionName, supports.help ]
 	);
 
 	const adminBarNodes = useMemo(
@@ -167,7 +170,6 @@ function ConnectedOmnibar( {
 
 	const readerPluginNode = useReaderPlugin( { sectionGroup } );
 	const helpCenterPluginNode = useHelpCenterPlugin( { sectionName, adminBarNodes } );
-	const aiChatPluginNode = useAiChatPlugin( { sectionName, adminBarNodes } );
 	const notificationsPluginNode = useNotificationsPlugin( { user } );
 	const { node: languageSwitcherNode, panel: languageSwitcherPanel } = useLanguageSwitcherPlugin( {
 		user,
@@ -189,7 +191,8 @@ function ConnectedOmnibar( {
 				...( shoppingCartNode ? [ shoppingCartNode ] : [] ),
 				...( supports.reader ? [ readerPluginNode ] : [] ),
 				...( supports.help ? [ helpCenterPluginNode ] : [] ),
-				...( supports.help && aiChatPluginNode ? [ aiChatPluginNode ] : [] ),
+				// Ask AI, plus any other node a builder claimed above.
+				...( baseOmnibarNodes.plugins ?? [] ),
 				...( supports.notifications ? [ notificationsPluginNode ] : [] ),
 		  ]
 		: [];

--- a/client/dashboard/app/omnibar/plugin-ai-chat.scss
+++ b/client/dashboard/app/omnibar/plugin-ai-chat.scss
@@ -1,11 +1,15 @@
-.omnibar .omnibar__menu svg.omnibar__ai-chat-icon {
-	width: 30px;
-	height: 30px;
+.omnibar .omnibar__menu .omnibar__ai-chat-icon {
+	display: flex;
 
-	@media ( min-width: 782px ) {
-		width: 22px;
-		height: 22px;
-		margin-inline-start: 2px;
-		margin-inline-end: 3px;
+	svg {
+		width: 30px;
+		height: 30px;
+
+		@media ( min-width: 782px ) {
+			width: 22px;
+			height: 22px;
+			margin-inline-start: 2px;
+			margin-inline-end: 3px;
+		}
 	}
 }

--- a/client/dashboard/app/omnibar/plugin-ai-chat.tsx
+++ b/client/dashboard/app/omnibar/plugin-ai-chat.tsx
@@ -3,9 +3,7 @@ import {
 	isAgentsManagerChatVisible,
 	openAgentsManagerChat,
 	recordAgentsManagerTracksEvent,
-	useShouldUseUnifiedAgent,
 } from '@automattic/agents-manager';
-import { useMemo } from 'react';
 import { adminBarIcon } from './admin-bar-icon';
 import type { AdminBarNode, OmnibarNode } from '@automattic/omnibar';
 
@@ -20,14 +18,9 @@ export function useAiChatPlugin( {
 	sectionName?: string;
 	adminBarNodes: AdminBarNode[];
 } ): OmnibarNode | undefined {
-	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 	const aiChatNode = adminBarNodes.find( ( node ) => node.id === AI_CHAT_NODE_ID );
-	const icon = useMemo(
-		() => adminBarIcon( 'omnibar__ai-chat-icon', aiChatNode?.meta?.icon ),
-		[ aiChatNode?.meta?.icon ]
-	);
-
-	if ( ! shouldUseUnifiedAgent || ! aiChatNode ) {
+	// The backend only sends this node to eligible users, so its presence is the gate.
+	if ( ! aiChatNode ) {
 		return undefined;
 	}
 
@@ -50,7 +43,7 @@ export function useAiChatPlugin( {
 	return {
 		id: aiChatNode.id,
 		label: aiChatNode.meta?.menu_title,
-		icon,
+		icon: adminBarIcon( aiChatNode.meta?.icon, 'omnibar__ai-chat-icon' ),
 		tooltip: aiChatNode.meta?.menu_title,
 		className: 'masterbar__item-agents-manager-ai-chat',
 		onClick: handleClick,

--- a/client/dashboard/app/omnibar/plugin-ai-chat.tsx
+++ b/client/dashboard/app/omnibar/plugin-ai-chat.tsx
@@ -9,43 +9,27 @@ import type { AdminBarNode, OmnibarNode } from '@automattic/omnibar';
 
 import './plugin-ai-chat.scss';
 
-const AI_CHAT_NODE_ID = 'agents-manager-ai-chat';
-
-export function useAiChatPlugin( {
-	sectionName,
-	adminBarNodes,
-}: {
-	sectionName?: string;
-	adminBarNodes: AdminBarNode[];
-} ): OmnibarNode | undefined {
-	const aiChatNode = adminBarNodes.find( ( node ) => node.id === AI_CHAT_NODE_ID );
-	// The backend only sends this node to eligible users, so its presence is the gate.
-	if ( ! aiChatNode ) {
-		return undefined;
-	}
-
-	const handleClick = () => {
-		const isChatVisible = isAgentsManagerChatVisible();
-
-		recordAgentsManagerTracksEvent( 'calypso_agents_manager_ai_chat_clicked', {
-			surface: 'masterbar',
-			section: sectionName || 'unknown',
-			action: isChatVisible ? 'close' : 'open',
-		} );
-
-		if ( isChatVisible ) {
-			closeAgentsManagerChat();
-		} else {
-			openAgentsManagerChat();
-		}
-	};
-
-	return {
-		id: aiChatNode.id,
-		label: aiChatNode.meta?.menu_title,
-		icon: adminBarIcon( aiChatNode.meta?.icon, 'omnibar__ai-chat-icon' ),
-		tooltip: aiChatNode.meta?.menu_title,
+export function createAiChatNodeBuilder( sectionName?: string ) {
+	return ( adminBarNode: AdminBarNode ): Partial< OmnibarNode > => ( {
+		title: undefined,
+		label: adminBarNode.meta?.menu_title,
+		icon: adminBarIcon( adminBarNode.meta?.icon, 'omnibar__ai-chat-icon' ),
+		tooltip: adminBarNode.meta?.menu_title,
 		className: 'masterbar__item-agents-manager-ai-chat',
-		onClick: handleClick,
-	};
+		onClick: () => {
+			const isChatVisible = isAgentsManagerChatVisible();
+
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_ai_chat_clicked', {
+				surface: 'masterbar',
+				section: sectionName || 'unknown',
+				action: isChatVisible ? 'close' : 'open',
+			} );
+
+			if ( isChatVisible ) {
+				closeAgentsManagerChat();
+			} else {
+				openAgentsManagerChat();
+			}
+		},
+	} );
 }

--- a/client/dashboard/app/omnibar/plugin-ai-chat.tsx
+++ b/client/dashboard/app/omnibar/plugin-ai-chat.tsx
@@ -5,33 +5,29 @@ import {
 	recordAgentsManagerTracksEvent,
 	useShouldUseUnifiedAgent,
 } from '@automattic/agents-manager';
-import { __ } from '@wordpress/i18n';
-import type { OmnibarNode } from '@automattic/omnibar';
+import { useMemo } from 'react';
+import { adminBarIcon } from './admin-bar-icon';
+import type { AdminBarNode, OmnibarNode } from '@automattic/omnibar';
 
 import './plugin-ai-chat.scss';
 
-function BigSkyIcon() {
-	return (
-		<svg
-			className="omnibar__ai-chat-icon"
-			width="24"
-			height="24"
-			viewBox="-45 -45 490 490"
-			xmlns="http://www.w3.org/2000/svg"
-		>
-			<path d="M391.528 188.061L309.455 159.75C276.997 148.597 251.403 123.003 240.25 90.5451L211.939 8.47185C208.079 -2.82395 191.921 -2.82395 188.061 8.47185L159.75 90.5451C148.597 123.003 123.003 148.597 90.5451 159.75L8.47185 188.061C-2.82395 191.921 -2.82395 208.079 8.47185 211.939L90.5451 240.25C123.003 251.403 148.597 276.997 159.75 309.455L188.061 391.528C191.921 402.824 208.079 402.824 211.939 391.528L240.25 309.455C251.403 276.997 276.997 251.403 309.455 240.25L391.528 211.939C402.824 208.079 402.824 191.921 391.528 188.061ZM295.728 206.077L254.692 220.232C238.391 225.809 225.666 238.677 220.089 254.835L205.934 295.871C203.932 301.591 195.925 301.591 193.923 295.871L179.768 254.835C174.191 238.534 161.323 225.809 145.165 220.232L104.129 206.077C98.4093 204.075 98.4093 196.068 104.129 194.066L145.165 179.911C161.466 174.334 174.191 161.466 179.768 145.308L193.923 104.272C195.925 98.5523 203.932 98.5523 205.934 104.272L220.089 145.308C225.666 161.609 238.534 174.334 254.692 179.911L295.728 194.066C301.448 196.068 301.448 204.075 295.728 206.077Z" />
-		</svg>
-	);
-}
+const AI_CHAT_NODE_ID = 'agents-manager-ai-chat';
 
 export function useAiChatPlugin( {
 	sectionName,
+	adminBarNodes,
 }: {
 	sectionName?: string;
+	adminBarNodes: AdminBarNode[];
 } ): OmnibarNode | undefined {
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
+	const aiChatNode = adminBarNodes.find( ( node ) => node.id === AI_CHAT_NODE_ID );
+	const icon = useMemo(
+		() => adminBarIcon( 'omnibar__ai-chat-icon', aiChatNode?.meta?.icon ),
+		[ aiChatNode?.meta?.icon ]
+	);
 
-	if ( ! shouldUseUnifiedAgent ) {
+	if ( ! shouldUseUnifiedAgent || ! aiChatNode ) {
 		return undefined;
 	}
 
@@ -52,9 +48,10 @@ export function useAiChatPlugin( {
 	};
 
 	return {
-		id: 'ai-chat',
-		label: __( 'Ask AI' ),
-		icon: <BigSkyIcon />,
+		id: aiChatNode.id,
+		label: aiChatNode.meta?.menu_title,
+		icon,
+		tooltip: aiChatNode.meta?.menu_title,
 		className: 'masterbar__item-agents-manager-ai-chat',
 		onClick: handleClick,
 	};

--- a/client/dashboard/app/omnibar/plugin-help-center.scss
+++ b/client/dashboard/app/omnibar/plugin-help-center.scss
@@ -1,11 +1,15 @@
-.omnibar .omnibar__menu svg.omnibar__help-icon {
-	width: 30px;
-	height: 30px;
+.omnibar .omnibar__menu .omnibar__help-icon {
+	display: flex;
 
-	@media ( min-width: 782px ) {
-		width: 22px;
-		height: 22px;
-		margin-inline: 3px;
+	svg {
+		width: 30px;
+		height: 30px;
+
+		@media ( min-width: 782px ) {
+			width: 22px;
+			height: 22px;
+			margin-inline: 3px;
+		}
 	}
 }
 

--- a/client/dashboard/app/omnibar/plugin-help-center.tsx
+++ b/client/dashboard/app/omnibar/plugin-help-center.tsx
@@ -3,7 +3,6 @@ import {
 	getAgentsManagerChatRoute,
 	isAgentsManagerChatVisible,
 	openAgentsManagerChat,
-	useShouldUseUnifiedAgent,
 } from '@automattic/agents-manager';
 import { omnibarSiteIdQuery } from '@automattic/api-queries';
 // eslint-disable-next-line no-restricted-imports -- Help Center host events need explicit site attribution.
@@ -11,7 +10,6 @@ import { withSiteContext } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
-import { useMemo } from 'react';
 import { useAnalytics } from '../analytics';
 import { useHelpCenter } from '../help-center';
 import { adminBarIcon } from './admin-bar-icon';
@@ -24,20 +22,6 @@ type RecordTracksEvent = AnalyticsClient[ 'recordTracksEvent' ];
 
 const AGENTS_MANAGER_NODE_ID = 'agents-manager';
 const SECONDARY_GROUP_NODE_ID = 'agents-manager-menu-panel-links';
-
-function HelpIcon() {
-	return (
-		<span className="omnibar__help-icon">
-			<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-				<path
-					fillRule="evenodd"
-					clipRule="evenodd"
-					d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z"
-				/>
-			</svg>
-		</span>
-	);
-}
 
 function handleMenuClick(
 	recordTracksEvent: RecordTracksEvent,
@@ -118,7 +102,7 @@ function buildAgentsManagerMenuNodes(
 						return {
 							id: node.id,
 							title: node.meta?.menu_title,
-							icon: adminBarIcon( 'omnibar__help-menu-icon', node.meta?.icon ),
+							icon: adminBarIcon( node.meta?.icon, 'omnibar__help-menu-icon' ),
 							onClick: () =>
 								handleMenuClick(
 									recordTracksEvent,
@@ -140,29 +124,25 @@ export function useHelpCenterPlugin( {
 	sectionName?: string;
 	adminBarNodes: AdminBarNode[];
 } ): OmnibarNode {
-	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 	const { isShown: isHelpCenterShown, setShowHelpCenter } = useHelpCenter();
 	const { recordTracksEvent } = useAnalytics();
 	const { data: omnibarSiteId } = useQuery( omnibarSiteIdQuery() );
 
 	const helpNode = adminBarNodes.find( ( node ) => node.id === AGENTS_MANAGER_NODE_ID );
 
-	// Building the menu parses an SVG per node, and this runs on every omnibar render.
-	const children = useMemo(
-		() =>
-			buildAgentsManagerMenuNodes( adminBarNodes, recordTracksEvent, omnibarSiteId, sectionName ),
-		[ adminBarNodes, recordTracksEvent, omnibarSiteId, sectionName ]
-	);
-	const icon = useMemo(
-		() => adminBarIcon( 'omnibar__help-icon', helpNode?.meta?.icon ),
-		[ helpNode?.meta?.icon ]
-	);
+	// The backend only sends these nodes to eligible users, so their presence is the gate.
+	if ( helpNode ) {
+		const children = buildAgentsManagerMenuNodes(
+			adminBarNodes,
+			recordTracksEvent,
+			omnibarSiteId,
+			sectionName
+		);
 
-	if ( shouldUseUnifiedAgent && helpNode ) {
 		return {
 			id: helpNode.id,
 			label: helpNode.meta?.menu_title,
-			icon,
+			icon: adminBarIcon( helpNode.meta?.icon, 'omnibar__help-icon' ),
 			tooltip: helpNode.meta?.menu_title,
 			// Disconnected sites get a link instead of a dropdown, opened in a new tab as in wp-admin.
 			...( children.length
@@ -174,7 +154,7 @@ export function useHelpCenterPlugin( {
 	return {
 		id: 'help-center',
 		label: __( 'Help' ),
-		icon: <HelpIcon />,
+		icon: adminBarIcon( 'help', 'omnibar__help-icon' ),
 		onClick: () => setShowHelpCenter( ! isHelpCenterShown ),
 	};
 }

--- a/client/dashboard/app/omnibar/plugin-help-center.tsx
+++ b/client/dashboard/app/omnibar/plugin-help-center.tsx
@@ -11,38 +11,30 @@ import { withSiteContext } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
-import { Icon, backup, comment, page, rss, video } from '@wordpress/icons';
+import { useMemo } from 'react';
 import { useAnalytics } from '../analytics';
 import { useHelpCenter } from '../help-center';
+import { adminBarIcon } from './admin-bar-icon';
 import type { AnalyticsClient } from '../analytics';
-import type { OmnibarNode } from '@automattic/omnibar';
+import type { AdminBarNode, OmnibarNode } from '@automattic/omnibar';
 
 import './plugin-help-center.scss';
 
 type RecordTracksEvent = AnalyticsClient[ 'recordTracksEvent' ];
 
+const AGENTS_MANAGER_NODE_ID = 'agents-manager';
+const SECONDARY_GROUP_NODE_ID = 'agents-manager-menu-panel-links';
+
 function HelpIcon() {
 	return (
-		<svg
-			className="omnibar__help-icon"
-			width="24"
-			height="24"
-			viewBox="0 0 24 24"
-			xmlns="http://www.w3.org/2000/svg"
-		>
-			<path
-				fillRule="evenodd"
-				clipRule="evenodd"
-				d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z"
-			/>
-		</svg>
-	);
-}
-
-function menuIcon( icon: JSX.Element ) {
-	return (
-		<span className="omnibar__help-menu-icon">
-			<Icon icon={ icon } />
+		<span className="omnibar__help-icon">
+			<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+				<path
+					fillRule="evenodd"
+					clipRule="evenodd"
+					d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 16v-2h2v2h-2zm2-3v-1.141A3.991 3.991 0 0016 10a4 4 0 00-8 0h2c0-1.103.897-2 2-2s2 .897 2 2-.897 2-2 2a1 1 0 00-1 1v2h2z"
+				/>
+			</svg>
 		</span>
 	);
 }
@@ -103,86 +95,79 @@ function handleMenuClick(
 	);
 }
 
-function getAgentsManagerMenuNodes(
+function buildAgentsManagerMenuNodes(
+	adminBarNodes: AdminBarNode[],
 	recordTracksEvent: RecordTracksEvent,
 	omnibarSiteId: number | null | undefined,
 	sectionName: string | undefined
 ): OmnibarNode[] {
-	return [
-		{
-			id: 'help-chat',
-			group: true,
-			children: [
-				{
-					id: 'chat-support',
-					title: __( 'Chat support' ),
-					icon: menuIcon( comment ),
-					onClick: () => handleMenuClick( recordTracksEvent, '/chat', omnibarSiteId, sectionName ),
-				},
-				{
-					id: 'chat-history',
-					title: __( 'Chat history' ),
-					icon: menuIcon( backup ),
-					onClick: () =>
-						handleMenuClick( recordTracksEvent, '/history', omnibarSiteId, sectionName ),
-				},
-			],
-		},
-		{
-			id: 'help-resources',
-			group: true,
-			variant: 'secondary',
-			children: [
-				{
-					id: 'support-guides',
-					title: __( 'Support guides' ),
-					icon: menuIcon( page ),
-					onClick: () =>
-						handleMenuClick( recordTracksEvent, '/support-guides', omnibarSiteId, sectionName ),
-				},
-				{
-					id: 'courses',
-					title: __( 'Courses' ),
-					icon: menuIcon( video ),
-					onClick: () =>
-						handleMenuClick(
-							recordTracksEvent,
-							localizeUrl( 'https://wordpress.com/support/courses/' ),
-							omnibarSiteId,
-							sectionName,
-							true
-						),
-				},
-				{
-					id: 'product-updates',
-					title: __( 'Product updates' ),
-					icon: menuIcon( rss ),
-					onClick: () =>
-						handleMenuClick(
-							recordTracksEvent,
-							localizeUrl( 'https://wordpress.com/blog/category/product-features/' ),
-							omnibarSiteId,
-							sectionName,
-							true
-						),
-				},
-			],
-		},
-	];
+	return adminBarNodes
+		.filter( ( node ) => node.group && node.parent === AGENTS_MANAGER_NODE_ID )
+		.map(
+			( group ): OmnibarNode => ( {
+				id: group.id,
+				group: true,
+				// Not keyed on `ab-sub-secondary`: wp-admin marks both groups with it, Calypso shades one.
+				...( group.id === SECONDARY_GROUP_NODE_ID ? { variant: 'secondary' as const } : {} ),
+				children: adminBarNodes
+					.filter( ( node ) => node.parent === group.id && ( node.meta?.route || node.href ) )
+					.map( ( node ): OmnibarNode => {
+						const route = node.meta?.route;
+						const destination = route ?? localizeUrl( node.href );
+
+						return {
+							id: node.id,
+							title: node.meta?.menu_title,
+							icon: adminBarIcon( 'omnibar__help-menu-icon', node.meta?.icon ),
+							onClick: () =>
+								handleMenuClick(
+									recordTracksEvent,
+									destination,
+									omnibarSiteId,
+									sectionName,
+									! route
+								),
+						};
+					} ),
+			} )
+		);
 }
 
-export function useHelpCenterPlugin( { sectionName }: { sectionName?: string } ): OmnibarNode {
+export function useHelpCenterPlugin( {
+	sectionName,
+	adminBarNodes,
+}: {
+	sectionName?: string;
+	adminBarNodes: AdminBarNode[];
+} ): OmnibarNode {
 	const shouldUseUnifiedAgent = useShouldUseUnifiedAgent();
 	const { isShown: isHelpCenterShown, setShowHelpCenter } = useHelpCenter();
 	const { recordTracksEvent } = useAnalytics();
 	const { data: omnibarSiteId } = useQuery( omnibarSiteIdQuery() );
 
-	if ( shouldUseUnifiedAgent ) {
+	const helpNode = adminBarNodes.find( ( node ) => node.id === AGENTS_MANAGER_NODE_ID );
+
+	// Building the menu parses an SVG per node, and this runs on every omnibar render.
+	const children = useMemo(
+		() =>
+			buildAgentsManagerMenuNodes( adminBarNodes, recordTracksEvent, omnibarSiteId, sectionName ),
+		[ adminBarNodes, recordTracksEvent, omnibarSiteId, sectionName ]
+	);
+	const icon = useMemo(
+		() => adminBarIcon( 'omnibar__help-icon', helpNode?.meta?.icon ),
+		[ helpNode?.meta?.icon ]
+	);
+
+	if ( shouldUseUnifiedAgent && helpNode ) {
 		return {
-			id: 'help-center',
-			label: __( 'Help' ),
-			icon: <HelpIcon />,
-			children: getAgentsManagerMenuNodes( recordTracksEvent, omnibarSiteId, sectionName ),
+			id: helpNode.id,
+			label: helpNode.meta?.menu_title,
+			icon,
+			tooltip: helpNode.meta?.menu_title,
+			// Disconnected sites get a link instead of a dropdown, opened in a new tab as in wp-admin.
+			...( children.length
+				? { children }
+				: { href: helpNode.href, target: helpNode.meta?.target, rel: helpNode.meta?.rel } ),
 		};
 	}
 

--- a/client/dashboard/app/omnibar/test/admin-bar-icon.test.tsx
+++ b/client/dashboard/app/omnibar/test/admin-bar-icon.test.tsx
@@ -4,24 +4,22 @@
 import { render } from '@testing-library/react';
 import { adminBarIcon } from '../admin-bar-icon';
 
-const ICON =
-	'<svg class="ab-icon" viewBox="0 0 24 24"><path d="M1 2z" fill-rule="evenodd" /></svg>';
-
 describe( 'adminBarIcon', () => {
-	it( 'rebuilds the glyph and keeps the wrapper class', () => {
-		const { container } = render(
-			adminBarIcon( 'omnibar__help-icon', ICON ) as React.ReactElement
-		);
+	it.each( [ 'comment', 'backup', 'page', 'video', 'rss', 'help', 'ask-ai' ] )(
+		'resolves the %s glyph',
+		( name ) => {
+			const { container } = render(
+				adminBarIcon( name, 'omnibar__help-icon' ) as React.ReactElement
+			);
 
-		expect( container.querySelector( '.omnibar__help-icon' ) ).toBeVisible();
-		expect( container.querySelector( 'svg' ) ).toHaveAttribute( 'viewBox', '0 0 24 24' );
-		expect( container.querySelector( 'path' ) ).toHaveAttribute( 'd', 'M1 2z' );
-		expect( container.querySelector( 'path' ) ).toHaveAttribute( 'fill-rule', 'evenodd' );
-	} );
+			expect( container.querySelector( '.omnibar__help-icon > svg' ) ).toBeVisible();
+			expect( container.querySelector( 'path' ) ).toHaveAttribute( 'd' );
+		}
+	);
 
 	it( 'hides the decorative glyph from assistive tech', () => {
 		const { container } = render(
-			adminBarIcon( 'omnibar__help-icon', ICON ) as React.ReactElement
+			adminBarIcon( 'help', 'omnibar__help-icon' ) as React.ReactElement
 		);
 		const svg = container.querySelector( 'svg' );
 
@@ -29,27 +27,13 @@ describe( 'adminBarIcon', () => {
 		expect( svg ).toHaveAttribute( 'focusable', 'false' );
 	} );
 
-	it( 'drops everything outside the svg and path allowlist', () => {
-		const hostile =
-			'<svg viewBox="0 0 24 24" onload="pwned()"><path d="M1 2z" /><img src="x" onerror="pwned()" /><script>pwned()</script></svg>';
-
-		const { container } = render(
-			adminBarIcon( 'omnibar__help-icon', hostile ) as React.ReactElement
-		);
-
-		expect( container.querySelector( 'img' ) ).toBeNull();
-		expect( container.querySelector( 'script' ) ).toBeNull();
-		expect( container.innerHTML ).not.toContain( 'onerror' );
-		expect( container.innerHTML ).not.toContain( 'onload' );
-		expect( container.querySelector( 'path' ) ).toHaveAttribute( 'd', 'M1 2z' );
-	} );
-
 	it.each( [
-		[ 'nothing to render', undefined ],
-		[ 'an empty string', '' ],
-		[ 'markup with no svg', '<span>Help</span>' ],
-		[ 'an svg with no paths', '<svg viewBox="0 0 24 24"><circle r="4" /></svg>' ],
-	] )( 'renders no icon given %s', ( _label, markup ) => {
-		expect( adminBarIcon( 'omnibar__help-icon', markup ) ).toBeUndefined();
+		[ 'no name', undefined ],
+		[ 'an empty name', '' ],
+		[ 'an unknown name', 'not-a-real-icon' ],
+		[ 'an inherited object key', 'constructor' ],
+		[ 'another inherited key', 'toString' ],
+	] )( 'renders no icon given %s', ( _label, name ) => {
+		expect( adminBarIcon( name, 'omnibar__help-icon' ) ).toBeUndefined();
 	} );
 } );

--- a/client/dashboard/app/omnibar/test/admin-bar-icon.test.tsx
+++ b/client/dashboard/app/omnibar/test/admin-bar-icon.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import { adminBarIcon } from '../admin-bar-icon';
+
+const ICON =
+	'<svg class="ab-icon" viewBox="0 0 24 24"><path d="M1 2z" fill-rule="evenodd" /></svg>';
+
+describe( 'adminBarIcon', () => {
+	it( 'rebuilds the glyph and keeps the wrapper class', () => {
+		const { container } = render(
+			adminBarIcon( 'omnibar__help-icon', ICON ) as React.ReactElement
+		);
+
+		expect( container.querySelector( '.omnibar__help-icon' ) ).toBeVisible();
+		expect( container.querySelector( 'svg' ) ).toHaveAttribute( 'viewBox', '0 0 24 24' );
+		expect( container.querySelector( 'path' ) ).toHaveAttribute( 'd', 'M1 2z' );
+		expect( container.querySelector( 'path' ) ).toHaveAttribute( 'fill-rule', 'evenodd' );
+	} );
+
+	it( 'hides the decorative glyph from assistive tech', () => {
+		const { container } = render(
+			adminBarIcon( 'omnibar__help-icon', ICON ) as React.ReactElement
+		);
+		const svg = container.querySelector( 'svg' );
+
+		expect( svg ).toHaveAttribute( 'aria-hidden', 'true' );
+		expect( svg ).toHaveAttribute( 'focusable', 'false' );
+	} );
+
+	it( 'drops everything outside the svg and path allowlist', () => {
+		const hostile =
+			'<svg viewBox="0 0 24 24" onload="pwned()"><path d="M1 2z" /><img src="x" onerror="pwned()" /><script>pwned()</script></svg>';
+
+		const { container } = render(
+			adminBarIcon( 'omnibar__help-icon', hostile ) as React.ReactElement
+		);
+
+		expect( container.querySelector( 'img' ) ).toBeNull();
+		expect( container.querySelector( 'script' ) ).toBeNull();
+		expect( container.innerHTML ).not.toContain( 'onerror' );
+		expect( container.innerHTML ).not.toContain( 'onload' );
+		expect( container.querySelector( 'path' ) ).toHaveAttribute( 'd', 'M1 2z' );
+	} );
+
+	it.each( [
+		[ 'nothing to render', undefined ],
+		[ 'an empty string', '' ],
+		[ 'markup with no svg', '<span>Help</span>' ],
+		[ 'an svg with no paths', '<svg viewBox="0 0 24 24"><circle r="4" /></svg>' ],
+	] )( 'renders no icon given %s', ( _label, markup ) => {
+		expect( adminBarIcon( 'omnibar__help-icon', markup ) ).toBeUndefined();
+	} );
+} );

--- a/client/dashboard/app/omnibar/test/plugin-ai-chat.test.tsx
+++ b/client/dashboard/app/omnibar/test/plugin-ai-chat.test.tsx
@@ -8,8 +8,9 @@ import {
 	recordAgentsManagerTracksEvent,
 	useShouldUseUnifiedAgent,
 } from '@automattic/agents-manager';
-import { renderHook } from '@testing-library/react';
+import { render, renderHook } from '@testing-library/react';
 import { useAiChatPlugin } from '../plugin-ai-chat';
+import type { AdminBarNode } from '@automattic/omnibar';
 
 jest.mock( '@automattic/agents-manager', () => ( {
 	closeAgentsManagerChat: jest.fn(),
@@ -26,6 +27,20 @@ const mockUseShouldUseUnifiedAgent = useShouldUseUnifiedAgent as jest.MockedFunc
 	typeof useShouldUseUnifiedAgent
 >;
 
+const AI_CHAT_NODE = {
+	id: 'agents-manager-ai-chat',
+	title: '<span>Ask AI</span>',
+	parent: 'top-secondary',
+	href: '',
+	group: false,
+	meta: {
+		menu_title: 'Ask AI',
+		icon: '<svg class="ab-icon" viewBox="0 0 24 24"><path d="M1 2z" /></svg>',
+	},
+} as AdminBarNode;
+
+const adminBarNodes = [ AI_CHAT_NODE ];
+
 describe( 'useAiChatPlugin', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -36,19 +51,46 @@ describe( 'useAiChatPlugin', () => {
 	it( 'returns no node when the unified agent is unavailable', () => {
 		mockUseShouldUseUnifiedAgent.mockReturnValue( false );
 
-		const { result } = renderHook( () => useAiChatPlugin( { sectionName: 'sites' } ) );
+		const { result } = renderHook( () =>
+			useAiChatPlugin( { sectionName: 'sites', adminBarNodes } )
+		);
 
 		expect( result.current ).toBeUndefined();
 	} );
 
+	it( 'returns no node when the admin bar has no AI chat node', () => {
+		const { result } = renderHook( () =>
+			useAiChatPlugin( { sectionName: 'sites', adminBarNodes: [] } )
+		);
+
+		expect( result.current ).toBeUndefined();
+	} );
+
+	it( 'takes its label, tooltip and icon from the admin bar node', () => {
+		const { result } = renderHook( () =>
+			useAiChatPlugin( { sectionName: 'sites', adminBarNodes } )
+		);
+
+		const { container } = render( result.current?.icon as React.ReactElement );
+
+		expect( result.current?.label ).toBe( 'Ask AI' );
+		expect( result.current?.tooltip ).toBe( 'Ask AI' );
+		expect( container.querySelector( 'svg' ) ).toHaveAttribute( 'viewBox', '0 0 24 24' );
+		expect( container.querySelector( 'path' ) ).toHaveAttribute( 'd', 'M1 2z' );
+	} );
+
 	it( 'carries the class that marks it as the chat entry button', () => {
-		const { result } = renderHook( () => useAiChatPlugin( { sectionName: 'sites' } ) );
+		const { result } = renderHook( () =>
+			useAiChatPlugin( { sectionName: 'sites', adminBarNodes } )
+		);
 
 		expect( result.current?.className ).toBe( 'masterbar__item-agents-manager-ai-chat' );
 	} );
 
 	it( 'records the masterbar event with the section and opens the chat on click', () => {
-		const { result } = renderHook( () => useAiChatPlugin( { sectionName: 'sites' } ) );
+		const { result } = renderHook( () =>
+			useAiChatPlugin( { sectionName: 'sites', adminBarNodes } )
+		);
 		result.current?.onClick?.( {} as React.MouseEvent );
 
 		expect( recordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
@@ -62,7 +104,7 @@ describe( 'useAiChatPlugin', () => {
 	it( 'records an unknown section and closes a visible chat on click', () => {
 		mockIsChatVisible.mockReturnValue( true );
 
-		const { result } = renderHook( () => useAiChatPlugin( {} ) );
+		const { result } = renderHook( () => useAiChatPlugin( { adminBarNodes } ) );
 		result.current?.onClick?.( {} as React.MouseEvent );
 
 		expect( recordAgentsManagerTracksEvent ).toHaveBeenCalledWith(

--- a/client/dashboard/app/omnibar/test/plugin-ai-chat.test.tsx
+++ b/client/dashboard/app/omnibar/test/plugin-ai-chat.test.tsx
@@ -7,8 +7,8 @@ import {
 	openAgentsManagerChat,
 	recordAgentsManagerTracksEvent,
 } from '@automattic/agents-manager';
-import { render, renderHook } from '@testing-library/react';
-import { useAiChatPlugin } from '../plugin-ai-chat';
+import { render } from '@testing-library/react';
+import { createAiChatNodeBuilder } from '../plugin-ai-chat';
 import type { AdminBarNode } from '@automattic/omnibar';
 
 jest.mock( '@automattic/agents-manager', () => ( {
@@ -34,47 +34,34 @@ const AI_CHAT_NODE: AdminBarNode = {
 	},
 };
 
-const adminBarNodes = [ AI_CHAT_NODE ];
+const buildAiChatNode = ( sectionName?: string ) =>
+	createAiChatNodeBuilder( sectionName )( AI_CHAT_NODE );
 
-describe( 'useAiChatPlugin', () => {
+describe( 'createAiChatNodeBuilder', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockIsChatVisible.mockReturnValue( false );
 	} );
 
-	it( 'returns no node when the admin bar has no AI chat node', () => {
-		const { result } = renderHook( () =>
-			useAiChatPlugin( { sectionName: 'sites', adminBarNodes: [] } )
-		);
-
-		expect( result.current ).toBeUndefined();
-	} );
-
 	it( 'takes its label, tooltip and icon from the admin bar node', () => {
-		const { result } = renderHook( () =>
-			useAiChatPlugin( { sectionName: 'sites', adminBarNodes } )
-		);
+		const node = buildAiChatNode( 'sites' );
+		const { container } = render( node.icon as React.ReactElement );
 
-		const { container } = render( result.current?.icon as React.ReactElement );
-
-		expect( result.current?.label ).toBe( 'Ask AI' );
-		expect( result.current?.tooltip ).toBe( 'Ask AI' );
+		expect( node.label ).toBe( 'Ask AI' );
+		expect( node.tooltip ).toBe( 'Ask AI' );
 		expect( container.querySelector( '.omnibar__ai-chat-icon > svg' ) ).toBeVisible();
 	} );
 
-	it( 'carries the class that marks it as the chat entry button', () => {
-		const { result } = renderHook( () =>
-			useAiChatPlugin( { sectionName: 'sites', adminBarNodes } )
-		);
+	it( 'drops the title so the button renders as an icon', () => {
+		expect( buildAiChatNode( 'sites' ).title ).toBeUndefined();
+	} );
 
-		expect( result.current?.className ).toBe( 'masterbar__item-agents-manager-ai-chat' );
+	it( 'carries the class that marks it as the chat entry button', () => {
+		expect( buildAiChatNode( 'sites' ).className ).toBe( 'masterbar__item-agents-manager-ai-chat' );
 	} );
 
 	it( 'records the masterbar event with the section and opens the chat on click', () => {
-		const { result } = renderHook( () =>
-			useAiChatPlugin( { sectionName: 'sites', adminBarNodes } )
-		);
-		result.current?.onClick?.( {} as React.MouseEvent );
+		buildAiChatNode( 'sites' ).onClick?.( {} as React.MouseEvent );
 
 		expect( recordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
 			'calypso_agents_manager_ai_chat_clicked',
@@ -87,8 +74,7 @@ describe( 'useAiChatPlugin', () => {
 	it( 'records an unknown section and closes a visible chat on click', () => {
 		mockIsChatVisible.mockReturnValue( true );
 
-		const { result } = renderHook( () => useAiChatPlugin( { adminBarNodes } ) );
-		result.current?.onClick?.( {} as React.MouseEvent );
+		buildAiChatNode().onClick?.( {} as React.MouseEvent );
 
 		expect( recordAgentsManagerTracksEvent ).toHaveBeenCalledWith(
 			'calypso_agents_manager_ai_chat_clicked',

--- a/client/dashboard/app/omnibar/test/plugin-ai-chat.test.tsx
+++ b/client/dashboard/app/omnibar/test/plugin-ai-chat.test.tsx
@@ -6,7 +6,6 @@ import {
 	isAgentsManagerChatVisible,
 	openAgentsManagerChat,
 	recordAgentsManagerTracksEvent,
-	useShouldUseUnifiedAgent,
 } from '@automattic/agents-manager';
 import { render, renderHook } from '@testing-library/react';
 import { useAiChatPlugin } from '../plugin-ai-chat';
@@ -17,17 +16,13 @@ jest.mock( '@automattic/agents-manager', () => ( {
 	isAgentsManagerChatVisible: jest.fn( () => false ),
 	openAgentsManagerChat: jest.fn(),
 	recordAgentsManagerTracksEvent: jest.fn(),
-	useShouldUseUnifiedAgent: jest.fn( () => true ),
 } ) );
 
 const mockIsChatVisible = isAgentsManagerChatVisible as jest.MockedFunction<
 	typeof isAgentsManagerChatVisible
 >;
-const mockUseShouldUseUnifiedAgent = useShouldUseUnifiedAgent as jest.MockedFunction<
-	typeof useShouldUseUnifiedAgent
->;
 
-const AI_CHAT_NODE = {
+const AI_CHAT_NODE: AdminBarNode = {
 	id: 'agents-manager-ai-chat',
 	title: '<span>Ask AI</span>',
 	parent: 'top-secondary',
@@ -35,9 +30,9 @@ const AI_CHAT_NODE = {
 	group: false,
 	meta: {
 		menu_title: 'Ask AI',
-		icon: '<svg class="ab-icon" viewBox="0 0 24 24"><path d="M1 2z" /></svg>',
+		icon: 'ask-ai',
 	},
-} as AdminBarNode;
+};
 
 const adminBarNodes = [ AI_CHAT_NODE ];
 
@@ -45,17 +40,6 @@ describe( 'useAiChatPlugin', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockIsChatVisible.mockReturnValue( false );
-		mockUseShouldUseUnifiedAgent.mockReturnValue( true );
-	} );
-
-	it( 'returns no node when the unified agent is unavailable', () => {
-		mockUseShouldUseUnifiedAgent.mockReturnValue( false );
-
-		const { result } = renderHook( () =>
-			useAiChatPlugin( { sectionName: 'sites', adminBarNodes } )
-		);
-
-		expect( result.current ).toBeUndefined();
 	} );
 
 	it( 'returns no node when the admin bar has no AI chat node', () => {
@@ -75,8 +59,7 @@ describe( 'useAiChatPlugin', () => {
 
 		expect( result.current?.label ).toBe( 'Ask AI' );
 		expect( result.current?.tooltip ).toBe( 'Ask AI' );
-		expect( container.querySelector( 'svg' ) ).toHaveAttribute( 'viewBox', '0 0 24 24' );
-		expect( container.querySelector( 'path' ) ).toHaveAttribute( 'd', 'M1 2z' );
+		expect( container.querySelector( '.omnibar__ai-chat-icon > svg' ) ).toBeVisible();
 	} );
 
 	it( 'carries the class that marks it as the chat entry button', () => {

--- a/client/dashboard/app/omnibar/test/plugin-help-center.test.tsx
+++ b/client/dashboard/app/omnibar/test/plugin-help-center.test.tsx
@@ -6,7 +6,6 @@ import {
 	getAgentsManagerChatRoute,
 	isAgentsManagerChatVisible,
 	openAgentsManagerChat,
-	useShouldUseUnifiedAgent,
 } from '@automattic/agents-manager';
 import { render, renderHook } from '@testing-library/react';
 import { useHelpCenter } from '../../help-center';
@@ -18,7 +17,6 @@ jest.mock( '@automattic/agents-manager', () => ( {
 	getAgentsManagerChatRoute: jest.fn( () => undefined ),
 	isAgentsManagerChatVisible: jest.fn( () => false ),
 	openAgentsManagerChat: jest.fn(),
-	useShouldUseUnifiedAgent: jest.fn( () => true ),
 } ) );
 jest.mock( '@automattic/api-queries', () => ( { omnibarSiteIdQuery: jest.fn( () => ( {} ) ) } ) );
 jest.mock( '@automattic/calypso-analytics', () => ( {
@@ -35,9 +33,6 @@ jest.mock( '../../help-center', () => ( {
 	useHelpCenter: jest.fn( () => ( { isShown: false, setShowHelpCenter: jest.fn() } ) ),
 } ) );
 
-const mockUseShouldUseUnifiedAgent = useShouldUseUnifiedAgent as jest.MockedFunction<
-	typeof useShouldUseUnifiedAgent
->;
 const mockIsChatVisible = isAgentsManagerChatVisible as jest.MockedFunction<
 	typeof isAgentsManagerChatVisible
 >;
@@ -47,17 +42,16 @@ const mockGetChatRoute = getAgentsManagerChatRoute as jest.MockedFunction<
 const mockUseHelpCenter = useHelpCenter as jest.MockedFunction< typeof useHelpCenter >;
 const setShowHelpCenter = jest.fn();
 
-const ICON = '<svg viewBox="0 0 24 24"><path d="M1 2z" /></svg>';
+const ICON = 'help';
 
-const node = ( id: string, extra: Partial< AdminBarNode > = {} ): AdminBarNode =>
-	( {
-		id,
-		title: `<span>${ id }</span>`,
-		parent: 'agents-manager',
-		href: '',
-		group: false,
-		...extra,
-	} ) as AdminBarNode;
+const node = ( id: string, extra: Partial< AdminBarNode > = {} ): AdminBarNode => ( {
+	id,
+	title: `<span>${ id }</span>`,
+	parent: 'agents-manager',
+	href: '',
+	group: false,
+	...extra,
+} );
 
 const HELP_NODES: AdminBarNode[] = [
 	node( 'agents-manager', {
@@ -96,7 +90,6 @@ const childrenOf = ( n: OmnibarNode | undefined, id: string ) =>
 describe( 'useHelpCenterPlugin', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockUseShouldUseUnifiedAgent.mockReturnValue( true );
 		mockIsChatVisible.mockReturnValue( false );
 		mockGetChatRoute.mockReturnValue( undefined );
 		mockUseHelpCenter.mockReturnValue( {
@@ -112,8 +105,10 @@ describe( 'useHelpCenterPlugin', () => {
 		expect( result.label ).toBe( 'Help Center' );
 		expect( result.tooltip ).toBe( 'Help Center' );
 		expect(
-			render( result.icon as React.ReactElement ).container.querySelector( 'path' )
-		).toHaveAttribute( 'd', 'M1 2z' );
+			render( result.icon as React.ReactElement ).container.querySelector(
+				'.omnibar__help-icon > svg'
+			)
+		).toBeVisible();
 	} );
 
 	it( 'builds the groups in payload order, shading only the resources group', () => {
@@ -147,6 +142,20 @@ describe( 'useHelpCenterPlugin', () => {
 		item?.onClick?.( {} as React.MouseEvent );
 
 		expect( openAgentsManagerChat ).toHaveBeenCalledWith( expected );
+	} );
+
+	it( 'skips items that have neither a route nor a link', () => {
+		const result = renderPlugin( [
+			...HELP_NODES,
+			node( 'agents-manager-mystery', {
+				parent: 'agents-manager-menu-panel-chat',
+				meta: { menu_title: 'Mystery', icon: ICON },
+			} ),
+		] );
+
+		expect(
+			childrenOf( result, 'agents-manager-menu-panel-chat' ).map( ( item ) => item.id )
+		).toEqual( [ 'agents-manager-chat-support', 'agents-manager-chat-history' ] );
 	} );
 
 	it( 'closes the chat when the active route is clicked again', () => {
@@ -198,13 +207,8 @@ describe( 'useHelpCenterPlugin', () => {
 		expect( result.children ).toBeUndefined();
 	} );
 
-	it.each( [
-		[ 'the unified agent is unavailable', HELP_NODES, false ],
-		[ 'the payload has no agents manager node', [], true ],
-	] )( 'falls back to the legacy Help Center when %s', ( _label, nodes, unified ) => {
-		mockUseShouldUseUnifiedAgent.mockReturnValue( unified as boolean );
-
-		const result = renderPlugin( nodes as AdminBarNode[] );
+	it( 'falls back to the legacy Help Center when the payload has no agents manager node', () => {
+		const result = renderPlugin( [] );
 
 		const { container } = render( result.icon as React.ReactElement );
 

--- a/client/dashboard/app/omnibar/test/plugin-help-center.test.tsx
+++ b/client/dashboard/app/omnibar/test/plugin-help-center.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	closeAgentsManagerChat,
+	getAgentsManagerChatRoute,
+	isAgentsManagerChatVisible,
+	openAgentsManagerChat,
+	useShouldUseUnifiedAgent,
+} from '@automattic/agents-manager';
+import { render, renderHook } from '@testing-library/react';
+import { useHelpCenter } from '../../help-center';
+import { useHelpCenterPlugin } from '../plugin-help-center';
+import type { AdminBarNode, OmnibarNode } from '@automattic/omnibar';
+
+jest.mock( '@automattic/agents-manager', () => ( {
+	closeAgentsManagerChat: jest.fn(),
+	getAgentsManagerChatRoute: jest.fn( () => undefined ),
+	isAgentsManagerChatVisible: jest.fn( () => false ),
+	openAgentsManagerChat: jest.fn(),
+	useShouldUseUnifiedAgent: jest.fn( () => true ),
+} ) );
+jest.mock( '@automattic/api-queries', () => ( { omnibarSiteIdQuery: jest.fn( () => ( {} ) ) } ) );
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	withSiteContext: jest.fn( ( props ) => props ),
+} ) );
+jest.mock( '@automattic/i18n-utils', () => ( {
+	localizeUrl: jest.fn( ( url ) => `${ url }?l=fr` ),
+} ) );
+jest.mock( '@tanstack/react-query', () => ( { useQuery: jest.fn( () => ( { data: 7 } ) ) } ) );
+jest.mock( '../../analytics', () => ( {
+	useAnalytics: jest.fn( () => ( { recordTracksEvent: jest.fn() } ) ),
+} ) );
+jest.mock( '../../help-center', () => ( {
+	useHelpCenter: jest.fn( () => ( { isShown: false, setShowHelpCenter: jest.fn() } ) ),
+} ) );
+
+const mockUseShouldUseUnifiedAgent = useShouldUseUnifiedAgent as jest.MockedFunction<
+	typeof useShouldUseUnifiedAgent
+>;
+const mockIsChatVisible = isAgentsManagerChatVisible as jest.MockedFunction<
+	typeof isAgentsManagerChatVisible
+>;
+const mockGetChatRoute = getAgentsManagerChatRoute as jest.MockedFunction<
+	typeof getAgentsManagerChatRoute
+>;
+const mockUseHelpCenter = useHelpCenter as jest.MockedFunction< typeof useHelpCenter >;
+const setShowHelpCenter = jest.fn();
+
+const ICON = '<svg viewBox="0 0 24 24"><path d="M1 2z" /></svg>';
+
+const node = ( id: string, extra: Partial< AdminBarNode > = {} ): AdminBarNode =>
+	( {
+		id,
+		title: `<span>${ id }</span>`,
+		parent: 'agents-manager',
+		href: '',
+		group: false,
+		...extra,
+	} ) as AdminBarNode;
+
+const HELP_NODES: AdminBarNode[] = [
+	node( 'agents-manager', {
+		parent: 'top-secondary',
+		meta: { menu_title: 'Help Center', icon: ICON, class: 'menupop' },
+	} ),
+	node( 'agents-manager-menu-panel-chat', {
+		group: true,
+		meta: { class: 'ab-sub-secondary' },
+	} ),
+	node( 'agents-manager-chat-support', {
+		parent: 'agents-manager-menu-panel-chat',
+		meta: { menu_title: 'Chat support', icon: ICON, route: '/chat' },
+	} ),
+	node( 'agents-manager-chat-history', {
+		parent: 'agents-manager-menu-panel-chat',
+		meta: { menu_title: 'Chat history', icon: ICON, route: '/history' },
+	} ),
+	node( 'agents-manager-menu-panel-links', {
+		group: true,
+		meta: { class: 'ab-sub-secondary' },
+	} ),
+	node( 'agents-manager-courses', {
+		parent: 'agents-manager-menu-panel-links',
+		href: 'https://wordpress.com/support/courses/',
+		meta: { menu_title: 'Courses', icon: ICON, target: '_blank', rel: 'noopener noreferrer' },
+	} ),
+];
+
+const renderPlugin = ( adminBarNodes: AdminBarNode[] ) =>
+	renderHook( () => useHelpCenterPlugin( { sectionName: 'sites', adminBarNodes } ) ).result.current;
+
+const childrenOf = ( n: OmnibarNode | undefined, id: string ) =>
+	n?.children?.find( ( group ) => group.id === id )?.children ?? [];
+
+describe( 'useHelpCenterPlugin', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockUseShouldUseUnifiedAgent.mockReturnValue( true );
+		mockIsChatVisible.mockReturnValue( false );
+		mockGetChatRoute.mockReturnValue( undefined );
+		mockUseHelpCenter.mockReturnValue( {
+			isShown: false,
+			setShowHelpCenter,
+		} as unknown as ReturnType< typeof useHelpCenter > );
+	} );
+
+	it( 'takes its id, label and tooltip from the admin bar node', () => {
+		const result = renderPlugin( HELP_NODES );
+
+		expect( result.id ).toBe( 'agents-manager' );
+		expect( result.label ).toBe( 'Help Center' );
+		expect( result.tooltip ).toBe( 'Help Center' );
+		expect(
+			render( result.icon as React.ReactElement ).container.querySelector( 'path' )
+		).toHaveAttribute( 'd', 'M1 2z' );
+	} );
+
+	it( 'builds the groups in payload order, shading only the resources group', () => {
+		const result = renderPlugin( HELP_NODES );
+
+		expect( result.children?.map( ( group ) => group.id ) ).toEqual( [
+			'agents-manager-menu-panel-chat',
+			'agents-manager-menu-panel-links',
+		] );
+		expect( result.children?.[ 0 ].variant ).toBeUndefined();
+		expect( result.children?.[ 1 ].variant ).toBe( 'secondary' );
+	} );
+
+	it( 'labels each item from the payload', () => {
+		const result = renderPlugin( HELP_NODES );
+
+		expect(
+			childrenOf( result, 'agents-manager-menu-panel-chat' ).map( ( item ) => item.title )
+		).toEqual( [ 'Chat support', 'Chat history' ] );
+	} );
+
+	it.each( [
+		[ 'agents-manager-chat-support', undefined ],
+		[ 'agents-manager-chat-history', '/history' ],
+	] )( 'opens the chat for %s', ( id, expected ) => {
+		const result = renderPlugin( HELP_NODES );
+		const item = childrenOf( result, 'agents-manager-menu-panel-chat' ).find(
+			( child ) => child.id === id
+		);
+
+		item?.onClick?.( {} as React.MouseEvent );
+
+		expect( openAgentsManagerChat ).toHaveBeenCalledWith( expected );
+	} );
+
+	it( 'closes the chat when the active route is clicked again', () => {
+		mockIsChatVisible.mockReturnValue( true );
+		mockGetChatRoute.mockReturnValue( '/history' );
+
+		const result = renderPlugin( HELP_NODES );
+		childrenOf( result, 'agents-manager-menu-panel-chat' )
+			.find( ( child ) => child.id === 'agents-manager-chat-history' )
+			?.onClick?.( {} as React.MouseEvent );
+
+		expect( closeAgentsManagerChat ).toHaveBeenCalled();
+		expect( openAgentsManagerChat ).not.toHaveBeenCalled();
+	} );
+
+	it( 'opens external items in a new tab, localized', () => {
+		const open = jest.spyOn( window, 'open' ).mockImplementation( () => null );
+
+		const result = renderPlugin( HELP_NODES );
+		childrenOf( result, 'agents-manager-menu-panel-links' )[ 0 ]?.onClick?.(
+			{} as React.MouseEvent
+		);
+
+		expect( open ).toHaveBeenCalledWith(
+			'https://wordpress.com/support/courses/?l=fr',
+			'_blank',
+			'noopener,noreferrer'
+		);
+		expect( openAgentsManagerChat ).not.toHaveBeenCalled();
+	} );
+
+	it( 'links out instead of opening a dropdown when there is no menu panel', () => {
+		const result = renderPlugin( [
+			node( 'agents-manager', {
+				parent: 'top-secondary',
+				href: 'https://wordpress.com/help',
+				meta: {
+					menu_title: 'Help Center',
+					icon: ICON,
+					target: '_blank',
+					rel: 'noopener noreferrer',
+				},
+			} ),
+		] );
+
+		expect( result.href ).toBe( 'https://wordpress.com/help' );
+		expect( result.target ).toBe( '_blank' );
+		expect( result.rel ).toBe( 'noopener noreferrer' );
+		expect( result.children ).toBeUndefined();
+	} );
+
+	it.each( [
+		[ 'the unified agent is unavailable', HELP_NODES, false ],
+		[ 'the payload has no agents manager node', [], true ],
+	] )( 'falls back to the legacy Help Center when %s', ( _label, nodes, unified ) => {
+		mockUseShouldUseUnifiedAgent.mockReturnValue( unified as boolean );
+
+		const result = renderPlugin( nodes as AdminBarNode[] );
+
+		const { container } = render( result.icon as React.ReactElement );
+
+		expect( result.id ).toBe( 'help-center' );
+		expect( result.label ).toBe( 'Help' );
+		expect( result.children ).toBeUndefined();
+
+		// The icon must keep the wrapper the stylesheet sizes through.
+		expect( container.querySelector( '.omnibar__help-icon > svg' ) ).toBeVisible();
+
+		result.onClick?.( {} as React.MouseEvent );
+		expect( setShowHelpCenter ).toHaveBeenCalledWith( true );
+	} );
+} );

--- a/packages/api-core/src/admin-bar/types.ts
+++ b/packages/api-core/src/admin-bar/types.ts
@@ -6,6 +6,11 @@ export interface AdminBarNode {
 	group: boolean;
 	meta?: {
 		menu_title?: string;
+		class?: string;
+		icon?: string;
+		route?: string;
+		target?: string;
+		rel?: string;
 	};
 }
 

--- a/packages/omnibar/src/components/omnibar-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-menu.tsx
@@ -38,7 +38,9 @@ function OmnibarMenuItem( { node }: { node: OmnibarNode } ) {
 	return (
 		<Menu.Item
 			tabbable
-			render={ node.href ? <a href={ node.href } /> : undefined }
+			render={
+				node.href ? <a href={ node.href } target={ node.target } rel={ node.rel } /> : undefined
+			}
 			onClick={ node.onClick }
 		>
 			<OmnibarNodeContent node={ node } />
@@ -111,11 +113,14 @@ export function OmnibarMenu( { node, className }: { node: OmnibarNode; className
 			<Button
 				variant="unstyled"
 				className={ menuClassName }
-				render={ isLink ? <a href={ node.href } /> : undefined }
+				render={
+					isLink ? <a href={ node.href } target={ node.target } rel={ node.rel } /> : undefined
+				}
 				nativeButton={ ! isLink }
 				disabled={ node.disabled }
 				onClick={ node.onClick }
 				aria-label={ label }
+				title={ node.tooltip }
 			>
 				<OmnibarNodeContent node={ node } />
 			</Button>
@@ -172,7 +177,12 @@ export function OmnibarMenu( { node, className }: { node: OmnibarNode; className
 						variant="unstyled"
 						className={ menuClassName }
 						aria-label={ label }
-						render={ node.href ? <a href={ node.href } /> : undefined }
+						title={ node.tooltip }
+						render={
+							node.href ? (
+								<a href={ node.href } target={ node.target } rel={ node.rel } />
+							) : undefined
+						}
 						nativeButton={ ! node.href }
 					>
 						<OmnibarNodeContent node={ node } />

--- a/packages/omnibar/src/types/admin-bar.ts
+++ b/packages/omnibar/src/types/admin-bar.ts
@@ -7,5 +7,9 @@ export interface AdminBarNode {
 	meta?: {
 		menu_title?: string;
 		class?: string;
+		icon?: string;
+		route?: string;
+		target?: string;
+		rel?: string;
 	};
 }

--- a/packages/omnibar/src/types/omnibar.ts
+++ b/packages/omnibar/src/types/omnibar.ts
@@ -4,10 +4,13 @@ export interface OmnibarNode {
 	id: string;
 	title?: string;
 	label?: string;
+	tooltip?: string;
 	icon?: React.ReactElement;
 	group?: boolean;
 	variant?: 'secondary';
 	href?: string;
+	target?: string;
+	rel?: string;
 	onClick?: ( event: React.MouseEvent ) => void;
 	disabled?: boolean;
 	active?: boolean;

--- a/packages/omnibar/src/utils/admin-bar.tsx
+++ b/packages/omnibar/src/utils/admin-bar.tsx
@@ -14,6 +14,7 @@ export function buildOmnibarNodesFromAdminBarNodes(
 ): OmnibarNodes {
 	const omnibarNodes: OmnibarNodes = {};
 	const siteActionNodes: OmnibarNode[] = [];
+	const pluginNodes: OmnibarNode[] = [];
 
 	const nodeMap = new Map< string, OmnibarNode >();
 	for ( const node of adminBarNodes ) {
@@ -134,6 +135,11 @@ export function buildOmnibarNodesFromAdminBarNodes(
 		const builder = builders?.[ node.id ];
 		if ( builder ) {
 			Object.assign( omnibarNode, builder( node ) );
+
+			// The tree walk skips `top-secondary`, so a builder is what surfaces those nodes.
+			if ( node.parent === 'top-secondary' ) {
+				pluginNodes.push( omnibarNode );
+			}
 		}
 
 		nodeMap.set( node.id, omnibarNode );
@@ -141,6 +147,10 @@ export function buildOmnibarNodesFromAdminBarNodes(
 
 	if ( siteActionNodes.length > 0 ) {
 		omnibarNodes.siteActions = siteActionNodes;
+	}
+
+	if ( pluginNodes.length > 0 ) {
+		omnibarNodes.plugins = pluginNodes;
 	}
 
 	for ( const node of adminBarNodes ) {


### PR DESCRIPTION
Part of AM-34

## Proposed Changes

Build the Help Center submenu and the Ask AI button from the admin bar payload instead of restating them in Calypso, and delete the duplicates (`getAgentsManagerMenuNodes()`, `BigSkyIcon`, the `@wordpress/icons` menu icons).

Both entry points now read from the same source wp-admin renders, so they cannot drift:

| | Calypso reads | wp-admin renders |
| -- | -- | -- |
| Label | `meta.menu_title` | same string |
| Icon | `meta.icon` (a name) | same name, same `get_icon()` glyph |
| Tooltip | `meta.menu_title` | same `title` text |
| Chat / history / guides | `meta.route` | same routes |
| Courses / product updates | `href` | same URLs |
| Disconnected Help | `href` + `meta.target` / `meta.rel` | same link, same new tab |
| Grouping and order | `parent`, `group` | same tree |
| Eligibility | node presence | same guard |

Nothing changes visually — the glyphs are identical to the ones Calypso drew before. The Help button now reads "Help Center", and node ids match wp-admin, which moves `node_id` on `calypso_omnibar_node_click` for 9 nodes. Every other Tracks event is unchanged, and click behaviour stays client-side: the re-click-to-close check, both Tracks events, `window.open`, and `localizeUrl()` over the two un-localized URLs.

Ask AI is registered as a **node builder** — the omnibar's existing extension point (`buildWpcomAccountNode`, `createLogoutNodeBuilder`) — per review. `buildOmnibarNodesFromAdminBarNodes` now fills the `plugins` slot it already exposed and rendered but never populated; a `top-secondary` node lands there only when a builder is registered for its id, so every other node behaves exactly as before.

Help keeps its hook. It is the only node with children, and the tree walk *appends* payload children to whatever a builder returns, so routing it through the same extension point renders the submenu twice. Review scoped it out of this PR.

`meta.icon` carries an icon **name**, not markup, so nothing from the payload reaches the DOM as HTML. Five names resolve from `@wordpress/icons`; `help` and `ask-ai` are not in that package, so those two glyphs stay defined client-side.

`OmnibarNode` gained three fields: `tooltip` (named that way because `title` there already means visible text) and `target` / `rel`, so the disconnected Help link opens in a new tab rather than stealing the dashboard tab.

Covered by 28 unit tests across three suites — the payload-to-node mapping, both click paths, the legacy Help Center fallback, and icon resolution including unknown and inherited-key names.

## Why are these changes being made?

The eligibility logic and submenu nodes were duplicated between Calypso and wp-admin, with no signal when they drifted. The admin bar endpoint now returns this data, so Calypso consumes it. Eligibility comes from the payload alone — the backend registers these nodes only for eligible users, so the client-side `useShouldUseUnifiedAgent()` check was removed rather than kept as a second gate that could drift from it.

Both backend prerequisites have shipped: Automattic/jetpack#51657 (the nodes) and Automattic/jetpack#51883 (icon names) are merged and live, and the site-less `dashboard/admin-bar` endpoint now returns the Agents Manager nodes.

## Overlaps with #114048

Both PRs rewrite `client/dashboard/app/omnibar/plugin-ai-chat.tsx` and its test, so **whichever merges first, the other needs updating** — the hunks will not apply cleanly.

* **If this merges first**, #114048 re-applies its `render` prop and `AiChatEntryLabel` to `createAiChatNodeBuilder()`; `useAiChatPlugin()` no longer exists.
* **If #114048 merges first**, this PR carries that `render` prop and label into the builder.

Beyond the textual conflict: this PR sources the label from `meta.menu_title` ("Ask AI") instead of a hardcoded string, so #114048's "Agent" label has to come from the backend or be overridden in the builder.

## Testing Instructions

1. Sandbox `public-api.wordpress.com`.
2. Open the dashboard on a site you administer, with the unified experience enabled.

Everything should look and work exactly as on trunk, apart from the Help button reading "Help Center":

* Help "?" and Ask AI icons at the same size, narrow and wide, each with a hover tooltip.
* Dropdown lists Chat support, Chat history, Support guides, Courses, Product updates — same icons, same order, shaded background on the second group only.
* Chat support / Chat history / Support guides open the chat at their route; clicking the current one again closes it.
* Courses and Product updates open in a new tab, localized.
* No new console or TypeScript errors.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes (PCYsg-S3g-p2)?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label (p4TIVU-aUh-p2)?
