### PR TITLE
Plans: scope eCommerce-trial sites to the commerce plans grid

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
@@ -27,15 +27,6 @@ const usePlanIntentFromSiteMeta = (): IntentFromSiteMeta => {
 		};
 	}
 
-	// A site on the eCommerce free trial has no `site_intent` (the trial is created
-	// without a plan in the cart), so scope its plans to the commerce-oriented grid.
-	if ( isECommerceTrial ) {
-		return {
-			processing: false,
-			intent: 'plans-business-trial',
-		};
-	}
-
 	const siteIntent = siteIntentResponse.data?.site_intent;
 
 	// ai-site-builder flow is specifically the free trial for big sky
@@ -61,6 +52,15 @@ const usePlanIntentFromSiteMeta = (): IntentFromSiteMeta => {
 		return {
 			processing: false,
 			intent: 'plans-videopress',
+		};
+	}
+
+	// A site on the eCommerce free trial has no `site_intent` (the trial is created
+	// without a plan in the cart), so scope its plans to the commerce-oriented grid.
+	if ( isECommerceTrial ) {
+		return {
+			processing: false,
+			intent: 'plans-business-trial',
 		};
 	}
 

--- a/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-intent-from-site-meta.ts
@@ -1,5 +1,6 @@
 import { useSiteIntent, Onboard } from '@automattic/data-stores';
 import { useSelector } from 'react-redux';
+import isSiteOnECommerceTrial from 'calypso/state/sites/plans/selectors/trials/is-site-on-ecommerce-trial';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import type { PlansIntent } from '@automattic/plans-grid-next';
@@ -14,12 +15,24 @@ interface IntentFromSiteMeta {
 const usePlanIntentFromSiteMeta = (): IntentFromSiteMeta => {
 	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	const isECommerceTrial = useSelector( ( state ) =>
+		isSiteOnECommerceTrial( state, selectedSiteId ?? null )
+	);
 	const siteIntentResponse = useSiteIntent( selectedSiteId );
 
 	if ( siteIntentResponse.isFetching ) {
 		return {
 			processing: true,
 			intent: undefined, // undefined -> we haven't observed any metadata yet
+		};
+	}
+
+	// A site on the eCommerce free trial has no `site_intent` (the trial is created
+	// without a plan in the cart), so scope its plans to the commerce-oriented grid.
+	if ( isECommerceTrial ) {
+		return {
+			processing: false,
+			intent: 'plans-business-trial',
 		};
 	}
 


### PR DESCRIPTION
> [!NOTE]
> Stacked on #113922 (`fix/launch-site-trial-plan-step`). Review/merge that first; this PR's base is set to that branch so the diff shows only the scoping change.

Fixes #

## Proposed Changes

* In the site→plans intent bridge (`usePlanIntentFromSiteMeta`), resolve a site on the eCommerce free trial to the `plans-business-trial` intent, so the plans grid is scoped to the commerce-oriented plans (Business + Commerce) instead of the full WPCOM set.

## Why are these changes being made?

When an eCommerce trial site reaches a plans grid (e.g. the `plans-launch` step of `start/launch-site`), it sees the full list of every supported plan rather than the commerce plans the trial is meant to upgrade into.

Root cause: the eCommerce trial is created via the trial-acknowledge path with no plan in the cart, so `create-site` never sets the `sell` site_intent (it only does so when a commerce plan is purchased). With no meaningful `site_intent`, the intent bridge returned nothing and `PlansFeaturesMain` fell back to the default WPCOM plan set.

This keys off the current plan (`isSiteOnECommerceTrial`) rather than `site_intent`, and returns the existing `plans-business-trial` intent. Because `PlansFeaturesMain` resolves `intentFromProps || intentFromSiteMeta.intent || default`, and the launch-site plan step passes no explicit intent, the scoped intent now applies there (and to other surfaces that render `PlansFeaturesMain` for an eCommerce-trial site). The dedicated `/plans` trial page renders its own component and is unaffected.

## Testing Instructions

1. Use a site on the eCommerce trial plan (`ecommerce-trial-bundle-monthly`).
2. Go to `start/launch-site/launch?siteSlug=<trial-site>`, click Launch, and continue to the plan step.
3. Verify the plan grid shows only the commerce plans (Business + Commerce), not the full plan list.
4. Verify a non-trial site still shows its normal plan grid.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in dark mode?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
