### PR TITLE
Blaze: move the "Learn more" link into the page description

### DIFF
--- a/client/my-sites/promote-post-i2/components/blaze-page/index.tsx
+++ b/client/my-sites/promote-post-i2/components/blaze-page/index.tsx
@@ -2,8 +2,12 @@ import config from '@automattic/calypso-config';
 import { Page } from '@wordpress/admin-ui';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import JetpackFooter from 'calypso/components/jetpack/jetpack-footer';
 import JetpackLogo from 'calypso/components/jetpack-logo';
+import { useSelector } from 'calypso/state';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const isBlazePlugin = config.isEnabled( 'is_running_in_blaze_plugin' );
 
@@ -29,13 +33,30 @@ export function BlazeFooter() {
  */
 export default function BlazePage( { actions, children }: Props ) {
 	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const isSelfHosted = useSelector( ( state ) =>
+		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+	);
 
 	return (
 		<Page
 			className="promote-post-i2__page"
 			visual={ isBlazePlugin ? undefined : <JetpackLogo size={ 24 } monochrome={ false } /> }
 			title="Blaze Ads"
-			subTitle={ translate( 'Promote your posts and pages across WordPress.com and Tumblr.' ) }
+			subTitle={ translate(
+				'Promote your posts and pages across WordPress.com and Tumblr. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+				{
+					components: {
+						learnMoreLink: (
+							<InlineSupportLink
+								supportContext="advertising"
+								showIcon={ false }
+								showSupportModal={ ! isSelfHosted }
+							/>
+						),
+					},
+				}
+			) }
 			showSidebarToggle={ false }
 			actions={ actions }
 		>

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -8,7 +8,6 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import EmptyContent from 'calypso/components/empty-content';
-import InlineSupportLink from 'calypso/components/inline-support-link';
 import Notice from 'calypso/components/notice';
 import {
 	BlazablePost,
@@ -42,7 +41,6 @@ import {
 	getPagedBlazeSearchData,
 } from 'calypso/my-sites/promote-post-i2/utils';
 import { useSelector } from 'calypso/state';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import BlazePage from './components/blaze-page';
 import BlazePageViewTracker from './components/blaze-page-view-tracker';
@@ -100,9 +98,6 @@ export default function PromotedPosts( { tab, receiptId }: Props ) {
 		keyValue: 'post-0', // post 0 means to open post selector in widget
 		entrypoint: 'promoted_posts-header',
 	} );
-	const isSelfHosted = useSelector( ( state ) =>
-		isJetpackSite( state, selectedSiteId, { treatAtomicAsJetpackSite: false } )
-	);
 
 	/* query for campaigns */
 	const [ campaignsSearchOptions, setCampaignsSearchOptions ] = useState< SearchOptions >( {} );
@@ -270,20 +265,13 @@ export default function PromotedPosts( { tab, receiptId }: Props ) {
 
 			<BlazePage
 				actions={
-					<>
-						<InlineSupportLink
-							supportContext="advertising"
-							showIcon={ false }
-							showSupportModal={ ! isSelfHosted }
-						/>
-						<Button
-							variant="primary"
-							onClick={ onClickPromote }
-							disabled={ isLoadingBillingSummary || paymentBlocked }
-						>
-							{ translate( 'Promote' ) }
-						</Button>
-					</>
+					<Button
+						variant="primary"
+						onClick={ onClickPromote }
+						disabled={ isLoadingBillingSummary || paymentBlocked }
+					>
+						{ translate( 'Promote' ) }
+					</Button>
 				}
 			>
 				<div className="promote-post-i2__page-body">


### PR DESCRIPTION
Fixes MARMON-38

## Proposed Changes

* Move the "Learn more" link out of the header's button area and into the header description, so it now reads: *Promote your posts and pages across WordPress.com and Tumblr. Learn more.*
* The button area is now just the "Promote" button.
* The description is one sentence with the link inside it, so it's a new string for translation.

**The final translated string looks like:**
```
Promote your posts and pages across WordPress.com and Tumblr. {{learnMoreLink}}Learn more{{/learnMoreLink}}.
```
<img width="1489" height="809" alt="Screenshot 2026-09-01 at 2 30 38 PM" src="https://github.com/user-attachments/assets/9822a631-4942-42e4-9042-a6df590c93d5" />

## Why are these changes being made?

Sitting next to "Promote", the link looked like a second button and was easy to skip past, so the help doc behind it wasn't getting found. Putting it at the end of the sentence that already explains what Blaze does makes it much easier to notice.

## Testing Instructions

1. Open Advertising for a site — `/advertising/:site` on WordPress.com, or Jetpack → Blaze Ads in wp-admin.
2. "Learn more" should appear at the end of the description under the page title, and should no longer be next to the "Promote" button.
3. Click it. It opens the "Promote a post" support doc — in the Help Center on WordPress.com and Atomic, in a new tab on self-hosted Jetpack.
4. The same header is used by the Blaze setup page (the one shown when a site can't run campaigns yet), so the link appears there too.

In wp-admin this arrives with the next blaze-dashboard deploy.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
