### PR TITLE
Checkout: disable gift checkout "Back" until the cart loads

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/index.tsx
@@ -6,9 +6,14 @@ import './style.scss';
 type Props = {
 	currentStep: 'domains' | 'plans' | 'checkout';
 	onStepSelect?: ( step: 'domains' | 'plans' ) => void;
+	/**
+	 * Blocks navigation to the earlier steps while a previous selection is still
+	 * being acted on, so the user can see the click was registered.
+	 */
+	isStepSelectDisabled?: boolean;
 };
 
-export function OnboardingProgress( { currentStep, onStepSelect }: Props ) {
+export function OnboardingProgress( { currentStep, onStepSelect, isStepSelectDisabled }: Props ) {
 	const { __ } = useI18n();
 
 	const domainsStepStatus = currentStep !== 'domains' ? ( 'completed' as const ) : undefined;
@@ -32,6 +37,7 @@ export function OnboardingProgress( { currentStep, onStepSelect }: Props ) {
 				<UIStepper.Step
 					value="domains"
 					status={ domainsStepStatus }
+					disabled={ isStepSelectDisabled }
 					className="onboarding-progress-step"
 				>
 					<UIStepper.Trigger className="onboarding-progress-trigger">
@@ -42,6 +48,7 @@ export function OnboardingProgress( { currentStep, onStepSelect }: Props ) {
 				<UIStepper.Step
 					value="plans"
 					status={ plansStepStatus }
+					disabled={ isStepSelectDisabled }
 					className="onboarding-progress-step"
 				>
 					<UIStepper.Trigger className="onboarding-progress-trigger">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/index.tsx
@@ -7,8 +7,8 @@ type Props = {
 	currentStep: 'domains' | 'plans' | 'checkout';
 	onStepSelect?: ( step: 'domains' | 'plans' ) => void;
 	/**
-	 * Blocks navigation to the earlier steps while a previous selection is still
-	 * being acted on, so the user can see the click was registered.
+	 * Blocks navigation to the earlier steps while the current step is not yet
+	 * ready to act on a selection.
 	 */
 	isStepSelectDisabled?: boolean;
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/onboarding-progress.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/onboarding-progress.test.tsx
@@ -24,4 +24,22 @@ describe( 'OnboardingProgress', () => {
 		await userEvent.click( screen.getByRole( 'tab', { name: /Complete payment/ } ) );
 		expect( onStepSelect ).not.toHaveBeenCalled();
 	} );
+
+	it( 'ignores clicks on the previous steps while step selection is disabled', async () => {
+		const onStepSelect = jest.fn();
+		render(
+			<OnboardingProgress
+				currentStep="checkout"
+				onStepSelect={ onStepSelect }
+				isStepSelectDisabled
+			/>
+		);
+
+		const domainsStep = screen.getByRole( 'tab', { name: /Select a domain/ } );
+		expect( domainsStep ).toHaveAttribute( 'aria-disabled', 'true' );
+
+		await userEvent.click( domainsStep );
+		await userEvent.click( screen.getByRole( 'tab', { name: /Select a plan/ } ) );
+		expect( onStepSelect ).not.toHaveBeenCalled();
+	} );
 } );

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -100,7 +100,7 @@ const CheckoutMasterbar = ( {
 					showCloseButton ? (
 						<Step.BackButton
 							onClick={ leaveModalProps.clickClose }
-							disabled={ leaveModalProps.isLeavePending }
+							disabled={ leaveModalProps.isLeaveDisabled }
 							accessibleWhenDisabled
 						/>
 					) : undefined

--- a/client/layout/masterbar/checkout.tsx
+++ b/client/layout/masterbar/checkout.tsx
@@ -97,7 +97,13 @@ const CheckoutMasterbar = ( {
 		>
 			<Step.TopBar
 				leftElement={
-					showCloseButton ? <Step.BackButton onClick={ leaveModalProps.clickClose } /> : undefined
+					showCloseButton ? (
+						<Step.BackButton
+							onClick={ leaveModalProps.clickClose }
+							disabled={ leaveModalProps.isLeavePending }
+							accessibleWhenDisabled
+						/>
+					) : undefined
 				}
 				rightElement={
 					<>

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1136,6 +1136,7 @@ export default function CheckoutMainContent( {
 						showProgress ? (
 							<OnboardingProgress
 								currentStep="checkout"
+								isStepSelectDisabled={ leaveModalProps.isLeavePending }
 								onStepSelect={ ( step ) =>
 									handleProgressStepSelect( step, {
 										forceCheckoutBackUrlDomains,

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1152,7 +1152,11 @@ export default function CheckoutMainContent( {
 							<Step.TopBar
 								leftElement={
 									showProgress ? undefined : (
-										<Step.BackButton onClick={ leaveModalProps.clickClose } />
+										<Step.BackButton
+											onClick={ leaveModalProps.clickClose }
+											disabled={ leaveModalProps.isLeavePending }
+											accessibleWhenDisabled
+										/>
 									)
 								}
 								rightElement={

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1136,7 +1136,7 @@ export default function CheckoutMainContent( {
 						showProgress ? (
 							<OnboardingProgress
 								currentStep="checkout"
-								isStepSelectDisabled={ leaveModalProps.isLeavePending }
+								isStepSelectDisabled={ leaveModalProps.isLeaveDisabled }
 								onStepSelect={ ( step ) =>
 									handleProgressStepSelect( step, {
 										forceCheckoutBackUrlDomains,
@@ -1155,7 +1155,7 @@ export default function CheckoutMainContent( {
 									showProgress ? undefined : (
 										<Step.BackButton
 											onClick={ leaveModalProps.clickClose }
-											disabled={ leaveModalProps.isLeavePending }
+											disabled={ leaveModalProps.isLeaveDisabled }
 											accessibleWhenDisabled
 										/>
 									)

--- a/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
+++ b/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
@@ -94,6 +94,15 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 	// — acting then confirms nothing and sends the gifter to their own home —
 	// so the click is held until the cart settles.
 	const requestLeave = ( backUrl?: string ) => {
+		// The click already waiting on the cart owns the destination. Registering
+		// a new one restarts the timeout below, so without this a user clicking
+		// repeatedly at a cart that never settles would never be let out.
+		if ( pendingLeave ) {
+			return;
+		}
+		// A plain close must use the default back URL, not a step-back URL left
+		// over from an earlier `clickStepBack` whose modal was dismissed.
+		setStepBackUrl( backUrl );
 		if ( isCartLoading ) {
 			setPendingLeave( { backUrl } );
 			return;
@@ -123,14 +132,10 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 	}, [ pendingLeave, isCartLoading ] );
 
 	const clickClose = () => {
-		// A plain close must use the default back URL, not a step-back URL left
-		// over from an earlier `clickStepBack` whose modal was dismissed.
-		setStepBackUrl( undefined );
 		requestLeave();
 	};
 
 	const clickStepBack = ( destinationUrl: string ) => {
-		setStepBackUrl( destinationUrl );
 		requestLeave( destinationUrl );
 	};
 

--- a/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
+++ b/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
@@ -1,7 +1,7 @@
 import { useShoppingCart, useShoppingCartManagerClient } from '@automattic/shopping-cart';
 import { Button, Modal, __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getPreviousRoute from '../../../../state/selectors/get-previous-route';
@@ -10,9 +10,16 @@ import useValidCheckoutBackUrl from '../hooks/use-valid-checkout-back-url';
 import { getGiftCheckoutBackUrl } from '../lib/get-gift-checkout-back-url';
 import { leaveCheckout } from '../lib/leave-checkout';
 
+// A cart request that never settles must not trap the user in checkout, so a
+// deferred "Back" gives up on the cart after this long and leaves anyway.
+const PENDING_LEAVE_TIMEOUT = 5000;
+
 export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 	const [ stepBackUrl, setStepBackUrl ] = useState< string | undefined >( undefined );
+	const [ pendingLeave, setPendingLeave ] = useState< { backUrl?: string } | undefined >(
+		undefined
+	);
 	const forceCheckoutBackUrl = useValidCheckoutBackUrl( siteUrl );
 	// When a flow supplies a dedicated "back to domains" URL, emptying the cart
 	// sends the user there rather than to the plan-step back URL — the plan they
@@ -25,7 +32,11 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 		'checkoutBackUrlDomains'
 	);
 	const cartKey = useCartKey();
-	const { responseCart, replaceProductsInCart } = useShoppingCart( cartKey );
+	const {
+		responseCart,
+		replaceProductsInCart,
+		isLoading: isCartLoading,
+	} = useShoppingCart( cartKey );
 	const giftBackUrl = getGiftCheckoutBackUrl( {
 		giftDetails: responseCart.gift_details,
 		referrer: document.referrer,
@@ -68,28 +79,59 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 		'/checkout/failed-purchases'
 	);
 
+	const confirmOrLeave = ( backUrl?: string ) => {
+		if ( shouldClearCartWhenLeaving && responseCart.products.length > 0 ) {
+			recordTracksEvent( 'calypso_masterbar_checkout_close_modal_displayed' );
+			setIsModalVisible( true );
+			return;
+		}
+		closeAndLeave( { closedWithoutConfirmation: true, forceBackUrl: backUrl } );
+	};
+
+	// The cart answers both questions "Back" depends on: whether to ask about
+	// saving the cart (does it hold anything?) and, for a gift checkout, where
+	// to go (`gift_details`). Neither is known while the cart is still loading
+	// — acting then confirms nothing and sends the gifter to their own home —
+	// so the click is held until the cart settles.
+	const requestLeave = ( backUrl?: string ) => {
+		if ( isCartLoading ) {
+			setPendingLeave( { backUrl } );
+			return;
+		}
+		confirmOrLeave( backUrl );
+	};
+
+	const confirmOrLeaveRef = useRef( confirmOrLeave );
+	useEffect( () => {
+		confirmOrLeaveRef.current = confirmOrLeave;
+	} );
+
+	useEffect( () => {
+		if ( ! pendingLeave ) {
+			return;
+		}
+		const leaveNow = () => {
+			setPendingLeave( undefined );
+			confirmOrLeaveRef.current( pendingLeave.backUrl );
+		};
+		if ( ! isCartLoading ) {
+			leaveNow();
+			return;
+		}
+		const timeoutId = setTimeout( leaveNow, PENDING_LEAVE_TIMEOUT );
+		return () => clearTimeout( timeoutId );
+	}, [ pendingLeave, isCartLoading ] );
+
 	const clickClose = () => {
 		// A plain close must use the default back URL, not a step-back URL left
 		// over from an earlier `clickStepBack` whose modal was dismissed.
 		setStepBackUrl( undefined );
-		if ( shouldClearCartWhenLeaving && responseCart.products.length > 0 ) {
-			recordTracksEvent( 'calypso_masterbar_checkout_close_modal_displayed' );
-			setIsModalVisible( true );
-			return;
-		}
-		closeAndLeave( {
-			closedWithoutConfirmation: true,
-		} );
+		requestLeave();
 	};
 
 	const clickStepBack = ( destinationUrl: string ) => {
 		setStepBackUrl( destinationUrl );
-		if ( shouldClearCartWhenLeaving && responseCart.products.length > 0 ) {
-			recordTracksEvent( 'calypso_masterbar_checkout_close_modal_displayed' );
-			setIsModalVisible( true );
-			return;
-		}
-		closeAndLeave( { closedWithoutConfirmation: true, forceBackUrl: destinationUrl } );
+		requestLeave( destinationUrl );
 	};
 
 	const clearCartAndLeave = async () => {
@@ -128,6 +170,7 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 	return {
 		isModalVisible,
 		setIsModalVisible,
+		isLeavePending: pendingLeave !== undefined,
 		clickClose,
 		clickStepBack,
 		closeAndLeave,

--- a/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
+++ b/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
@@ -1,7 +1,7 @@
 import { useShoppingCart, useShoppingCartManagerClient } from '@automattic/shopping-cart';
 import { Button, Modal, __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getPreviousRoute from '../../../../state/selectors/get-previous-route';
@@ -10,16 +10,9 @@ import useValidCheckoutBackUrl from '../hooks/use-valid-checkout-back-url';
 import { getGiftCheckoutBackUrl } from '../lib/get-gift-checkout-back-url';
 import { leaveCheckout } from '../lib/leave-checkout';
 
-// A cart request that never settles must not trap the user in checkout, so a
-// deferred "Back" gives up on the cart after this long and leaves anyway.
-const PENDING_LEAVE_TIMEOUT = 5000;
-
 export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 	const [ isModalVisible, setIsModalVisible ] = useState( false );
 	const [ stepBackUrl, setStepBackUrl ] = useState< string | undefined >( undefined );
-	const [ pendingLeave, setPendingLeave ] = useState< { backUrl?: string } | undefined >(
-		undefined
-	);
 	const forceCheckoutBackUrl = useValidCheckoutBackUrl( siteUrl );
 	// When a flow supplies a dedicated "back to domains" URL, emptying the cart
 	// sends the user there rather than to the plan-step back URL — the plan they
@@ -80,6 +73,9 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 	);
 
 	const confirmOrLeave = ( backUrl?: string ) => {
+		// A plain close must use the default back URL, not a step-back URL left
+		// over from an earlier `clickStepBack` whose modal was dismissed.
+		setStepBackUrl( backUrl );
 		if ( shouldClearCartWhenLeaving && responseCart.products.length > 0 ) {
 			recordTracksEvent( 'calypso_masterbar_checkout_close_modal_displayed' );
 			setIsModalVisible( true );
@@ -88,55 +84,12 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 		closeAndLeave( { closedWithoutConfirmation: true, forceBackUrl: backUrl } );
 	};
 
-	// The cart answers both questions "Back" depends on: whether to ask about
-	// saving the cart (does it hold anything?) and, for a gift checkout, where
-	// to go (`gift_details`). Neither is known while the cart is still loading
-	// — acting then confirms nothing and sends the gifter to their own home —
-	// so the click is held until the cart settles.
-	const requestLeave = ( backUrl?: string ) => {
-		// The click already waiting on the cart owns the destination. Registering
-		// a new one restarts the timeout below, so without this a user clicking
-		// repeatedly at a cart that never settles would never be let out.
-		if ( pendingLeave ) {
-			return;
-		}
-		// A plain close must use the default back URL, not a step-back URL left
-		// over from an earlier `clickStepBack` whose modal was dismissed.
-		setStepBackUrl( backUrl );
-		if ( isCartLoading ) {
-			setPendingLeave( { backUrl } );
-			return;
-		}
-		confirmOrLeave( backUrl );
-	};
-
-	const confirmOrLeaveRef = useRef( confirmOrLeave );
-	useEffect( () => {
-		confirmOrLeaveRef.current = confirmOrLeave;
-	} );
-
-	useEffect( () => {
-		if ( ! pendingLeave ) {
-			return;
-		}
-		const leaveNow = () => {
-			setPendingLeave( undefined );
-			confirmOrLeaveRef.current( pendingLeave.backUrl );
-		};
-		if ( ! isCartLoading ) {
-			leaveNow();
-			return;
-		}
-		const timeoutId = setTimeout( leaveNow, PENDING_LEAVE_TIMEOUT );
-		return () => clearTimeout( timeoutId );
-	}, [ pendingLeave, isCartLoading ] );
-
 	const clickClose = () => {
-		requestLeave();
+		confirmOrLeave();
 	};
 
 	const clickStepBack = ( destinationUrl: string ) => {
-		requestLeave( destinationUrl );
+		confirmOrLeave( destinationUrl );
 	};
 
 	const clearCartAndLeave = async () => {
@@ -175,7 +128,11 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 	return {
 		isModalVisible,
 		setIsModalVisible,
-		isLeavePending: pendingLeave !== undefined,
+		// The cart answers both questions "Back" depends on: whether to ask about
+		// saving the cart (does it hold anything?) and, for a gift checkout, where
+		// to go (`gift_details`). Neither is known until the cart arrives, so the
+		// control stays disabled rather than acting on a placeholder.
+		isLeaveDisabled: isCartLoading,
 		clickClose,
 		clickStepBack,
 		closeAndLeave,

--- a/client/my-sites/checkout/src/components/test/leave-checkout-modal.test.tsx
+++ b/client/my-sites/checkout/src/components/test/leave-checkout-modal.test.tsx
@@ -321,6 +321,9 @@ describe( 'useCheckoutLeaveModal.clickStepBack', () => {
 		const { result } = renderHook( () => useCheckoutLeaveModal( { siteUrl: NEW_SITE_SLUG } ), {
 			wrapper: Wrapper,
 		} );
+		await waitFor( () =>
+			expect( client.forCartKey( NEW_SITE_CART_KEY ).getState().isLoading ).toBe( false )
+		);
 
 		await act( async () => {
 			result.current.clickStepBack( 'https://mynewsite.wordpress.com/setup/onboarding/domains' );
@@ -567,5 +570,126 @@ describe( 'useCheckoutLeaveModal gift checkout', () => {
 		expect( leaveCheckout ).toHaveBeenCalledWith(
 			expect.objectContaining( { forceCheckoutBackUrl: undefined } )
 		);
+	} );
+
+	describe( 'when the cart is still loading', () => {
+		/**
+		 * Render the hook against a cart whose fetch is held open, so "Back" can
+		 * be clicked while the cart is still loading. `resolveCart` completes the
+		 * fetch with the given cart contents.
+		 */
+		function renderGiftHookWithPendingCart() {
+			let releaseCart: ( cart: ResponseCart ) => void = () => {};
+			const cartPromise = new Promise< ResponseCart >( ( resolve ) => {
+				releaseCart = resolve;
+			} );
+			const client = createShoppingCartManagerClient( {
+				getCart: () => cartPromise,
+				setCart: async ( cartKey, newCart: RequestCart ) => ( {
+					...getEmptyResponseCart(),
+					cart_key: cartKey,
+					products: newCart.products as ResponseCartProduct[],
+				} ),
+			} );
+			const rendered = renderHook( () => useCheckoutLeaveModal( { siteUrl: '' } ), {
+				wrapper: buildWrapper( client ),
+			} );
+			expect( client.forCartKey( GIFT_CART_KEY ).getState().isLoading ).toBe( true );
+
+			const resolveCart = async ( seed: Partial< ResponseCart > ) => {
+				await act( async () => {
+					releaseCart( {
+						...getEmptyResponseCart(),
+						cart_key: GIFT_CART_KEY,
+						products: [],
+						...seed,
+					} );
+					await cartPromise;
+				} );
+			};
+			return { ...rendered, resolveCart };
+		}
+
+		it( 'holds "Back" until the cart loads, then uses the gifted site', async () => {
+			setReferrer( '' );
+			const { result, resolveCart } = renderGiftHookWithPendingCart();
+
+			await act( async () => {
+				result.current.clickClose();
+			} );
+			expect( leaveCheckout ).not.toHaveBeenCalled();
+			expect( result.current.isLeavePending ).toBe( true );
+
+			await resolveCart( { gift_details: giftDetails, is_gift_purchase: true } );
+
+			await waitFor( () =>
+				expect( leaveCheckout ).toHaveBeenCalledWith(
+					expect.objectContaining( { forceCheckoutBackUrl: 'https://giftedsite.wordpress.com/' } )
+				)
+			);
+			expect( result.current.isLeavePending ).toBe( false );
+		} );
+
+		it( 'holds "Back" until the cart loads, then asks about a cart with products', async () => {
+			setReferrer( '' );
+			const { result, resolveCart } = renderGiftHookWithPendingCart();
+
+			await act( async () => {
+				result.current.clickClose();
+			} );
+			expect( result.current.isModalVisible ).toBe( false );
+
+			await resolveCart( {
+				gift_details: giftDetails,
+				is_gift_purchase: true,
+				products: [ planProduct ],
+			} );
+
+			await waitFor( () => expect( result.current.isModalVisible ).toBe( true ) );
+			expect( leaveCheckout ).not.toHaveBeenCalled();
+		} );
+
+		it( 'holds a step-back destination until the cart loads', async () => {
+			setReferrer( '' );
+			const { result, resolveCart } = renderGiftHookWithPendingCart();
+
+			await act( async () => {
+				result.current.clickStepBack( 'https://wordpress.com/setup/onboarding/domains' );
+			} );
+			expect( leaveCheckout ).not.toHaveBeenCalled();
+
+			await resolveCart( { gift_details: giftDetails, is_gift_purchase: true } );
+
+			await waitFor( () =>
+				expect( leaveCheckout ).toHaveBeenCalledWith(
+					expect.objectContaining( {
+						forceCheckoutBackUrl: 'https://wordpress.com/setup/onboarding/domains',
+					} )
+				)
+			);
+		} );
+
+		it( 'does not trap the user when the cart never loads', async () => {
+			jest.useFakeTimers();
+			try {
+				setReferrer( '' );
+				const { result } = renderGiftHookWithPendingCart();
+
+				act( () => {
+					result.current.clickClose();
+				} );
+				expect( leaveCheckout ).not.toHaveBeenCalled();
+
+				act( () => {
+					jest.advanceTimersByTime( 5000 );
+				} );
+
+				expect( leaveCheckout ).toHaveBeenCalledWith(
+					expect.objectContaining( { forceCheckoutBackUrl: undefined } )
+				);
+			} finally {
+				jest.useRealTimers();
+			}
+		} );
 	} );
 } );

--- a/client/my-sites/checkout/src/components/test/leave-checkout-modal.test.tsx
+++ b/client/my-sites/checkout/src/components/test/leave-checkout-modal.test.tsx
@@ -691,5 +691,51 @@ describe( 'useCheckoutLeaveModal gift checkout', () => {
 				jest.useRealTimers();
 			}
 		} );
+
+		it( 'does not let repeat clicks postpone the escape hatch', async () => {
+			jest.useFakeTimers();
+			try {
+				setReferrer( '' );
+				const { result } = renderGiftHookWithPendingCart();
+
+				act( () => {
+					result.current.clickClose();
+				} );
+				act( () => {
+					jest.advanceTimersByTime( 4000 );
+				} );
+				act( () => {
+					result.current.clickClose();
+				} );
+				act( () => {
+					jest.advanceTimersByTime( 4000 );
+				} );
+
+				expect( leaveCheckout ).toHaveBeenCalledTimes( 1 );
+			} finally {
+				jest.useRealTimers();
+			}
+		} );
+
+		it( 'keeps the first destination when a second click lands before the cart loads', async () => {
+			setReferrer( '' );
+			const { result, resolveCart } = renderGiftHookWithPendingCart();
+
+			await act( async () => {
+				result.current.clickStepBack( 'https://wordpress.com/setup/onboarding/domains' );
+			} );
+			await act( async () => {
+				result.current.clickStepBack( 'https://wordpress.com/setup/onboarding/plans' );
+			} );
+
+			await resolveCart( { gift_details: giftDetails, is_gift_purchase: true } );
+
+			await waitFor( () => expect( leaveCheckout ).toHaveBeenCalledTimes( 1 ) );
+			expect( leaveCheckout ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					forceCheckoutBackUrl: 'https://wordpress.com/setup/onboarding/domains',
+				} )
+			);
+		} );
 	} );
 } );

--- a/client/my-sites/checkout/src/components/test/leave-checkout-modal.test.tsx
+++ b/client/my-sites/checkout/src/components/test/leave-checkout-modal.test.tsx
@@ -574,9 +574,9 @@ describe( 'useCheckoutLeaveModal gift checkout', () => {
 
 	describe( 'when the cart is still loading', () => {
 		/**
-		 * Render the hook against a cart whose fetch is held open, so "Back" can
-		 * be clicked while the cart is still loading. `resolveCart` completes the
-		 * fetch with the given cart contents.
+		 * Render the hook against a cart whose fetch is held open, so the loading
+		 * window can be observed. `resolveCart` completes the fetch with the given
+		 * cart contents.
 		 */
 		function renderGiftHookWithPendingCart() {
 			let releaseCart: ( cart: ResponseCart ) => void = () => {};
@@ -610,131 +610,26 @@ describe( 'useCheckoutLeaveModal gift checkout', () => {
 			return { ...rendered, resolveCart };
 		}
 
-		it( 'holds "Back" until the cart loads, then uses the gifted site', async () => {
+		it( 'keeps "Back" disabled while the cart is loading', () => {
+			setReferrer( '' );
+			const { result } = renderGiftHookWithPendingCart();
+
+			expect( result.current.isLeaveDisabled ).toBe( true );
+		} );
+
+		it( 'enables "Back" once the cart arrives, and then uses the gifted site', async () => {
 			setReferrer( '' );
 			const { result, resolveCart } = renderGiftHookWithPendingCart();
+
+			await resolveCart( { gift_details: giftDetails, is_gift_purchase: true } );
+			await waitFor( () => expect( result.current.isLeaveDisabled ).toBe( false ) );
 
 			await act( async () => {
 				result.current.clickClose();
 			} );
-			expect( leaveCheckout ).not.toHaveBeenCalled();
-			expect( result.current.isLeavePending ).toBe( true );
 
-			await resolveCart( { gift_details: giftDetails, is_gift_purchase: true } );
-
-			await waitFor( () =>
-				expect( leaveCheckout ).toHaveBeenCalledWith(
-					expect.objectContaining( { forceCheckoutBackUrl: 'https://giftedsite.wordpress.com/' } )
-				)
-			);
-			expect( result.current.isLeavePending ).toBe( false );
-		} );
-
-		it( 'holds "Back" until the cart loads, then asks about a cart with products', async () => {
-			setReferrer( '' );
-			const { result, resolveCart } = renderGiftHookWithPendingCart();
-
-			await act( async () => {
-				result.current.clickClose();
-			} );
-			expect( result.current.isModalVisible ).toBe( false );
-
-			await resolveCart( {
-				gift_details: giftDetails,
-				is_gift_purchase: true,
-				products: [ planProduct ],
-			} );
-
-			await waitFor( () => expect( result.current.isModalVisible ).toBe( true ) );
-			expect( leaveCheckout ).not.toHaveBeenCalled();
-		} );
-
-		it( 'holds a step-back destination until the cart loads', async () => {
-			setReferrer( '' );
-			const { result, resolveCart } = renderGiftHookWithPendingCart();
-
-			await act( async () => {
-				result.current.clickStepBack( 'https://wordpress.com/setup/onboarding/domains' );
-			} );
-			expect( leaveCheckout ).not.toHaveBeenCalled();
-
-			await resolveCart( { gift_details: giftDetails, is_gift_purchase: true } );
-
-			await waitFor( () =>
-				expect( leaveCheckout ).toHaveBeenCalledWith(
-					expect.objectContaining( {
-						forceCheckoutBackUrl: 'https://wordpress.com/setup/onboarding/domains',
-					} )
-				)
-			);
-		} );
-
-		it( 'does not trap the user when the cart never loads', async () => {
-			jest.useFakeTimers();
-			try {
-				setReferrer( '' );
-				const { result } = renderGiftHookWithPendingCart();
-
-				act( () => {
-					result.current.clickClose();
-				} );
-				expect( leaveCheckout ).not.toHaveBeenCalled();
-
-				act( () => {
-					jest.advanceTimersByTime( 5000 );
-				} );
-
-				expect( leaveCheckout ).toHaveBeenCalledWith(
-					expect.objectContaining( { forceCheckoutBackUrl: undefined } )
-				);
-			} finally {
-				jest.useRealTimers();
-			}
-		} );
-
-		it( 'does not let repeat clicks postpone the escape hatch', async () => {
-			jest.useFakeTimers();
-			try {
-				setReferrer( '' );
-				const { result } = renderGiftHookWithPendingCart();
-
-				act( () => {
-					result.current.clickClose();
-				} );
-				act( () => {
-					jest.advanceTimersByTime( 4000 );
-				} );
-				act( () => {
-					result.current.clickClose();
-				} );
-				act( () => {
-					jest.advanceTimersByTime( 4000 );
-				} );
-
-				expect( leaveCheckout ).toHaveBeenCalledTimes( 1 );
-			} finally {
-				jest.useRealTimers();
-			}
-		} );
-
-		it( 'keeps the first destination when a second click lands before the cart loads', async () => {
-			setReferrer( '' );
-			const { result, resolveCart } = renderGiftHookWithPendingCart();
-
-			await act( async () => {
-				result.current.clickStepBack( 'https://wordpress.com/setup/onboarding/domains' );
-			} );
-			await act( async () => {
-				result.current.clickStepBack( 'https://wordpress.com/setup/onboarding/plans' );
-			} );
-
-			await resolveCart( { gift_details: giftDetails, is_gift_purchase: true } );
-
-			await waitFor( () => expect( leaveCheckout ).toHaveBeenCalledTimes( 1 ) );
 			expect( leaveCheckout ).toHaveBeenCalledWith(
-				expect.objectContaining( {
-					forceCheckoutBackUrl: 'https://wordpress.com/setup/onboarding/domains',
-				} )
+				expect.objectContaining( { forceCheckoutBackUrl: 'https://giftedsite.wordpress.com/' } )
 			);
 		} );
 	} );


### PR DESCRIPTION
Follow-up to #113879 (DOTOBRD-600)
This is an edge case for the "Back" button during a gift: if we click on it before loading car items, it won't work:

https://github.com/user-attachments/assets/0cbb10ea-e23b-4b2b-841b-216dd42b2086

## Proposed Changes

- Disable checkout's "Back" while the shopping cart is still loading — the masterbar back button, the in-content back button, and the onboarding progress steps. Previously a click during the load window went straight out of checkout with no cart data at all.
- The back buttons use `accessibleWhenDisabled`, so they stay focusable and announced while the cart loads.
- Adds 2 unit tests covering the loading window, plus one for the progress indicator.

## Why are these changes being made?

#113879 sends gift checkout's "Back" to the gifted site, reading `receiver_blog_url` from the cart's `gift_details`. But the cart is fetched asynchronously, and until it arrives `useCheckoutLeaveModal` sees a placeholder cart: no `gift_details` and no products. Clicking "Back" in that window therefore did two wrong things at once — it skipped the "Save your cart for later?" modal (the cart looks empty), and it fell through to the default destination, landing the gifter on `/home` instead of the gifted site.

The cart is the source of truth for both questions "Back" has to answer — *should we confirm?* and *where do we go?* — so the control stays disabled until the cart is there rather than acting on a placeholder.

An earlier revision of this PR instead *held* the click and replayed it once the cart settled. That needed a pending-leave state, a latest-ref, two effects and a 5s wall-clock escape hatch, and it carried two sharp edges of its own: a cart slower than 5s left to the default destination anyway, and `isLoading` goes true again on refetch-on-focus, so a click after tabbing away would have been deferred against a cart that was already known. Since the rest of checkout is already a loading skeleton during this window (`checkoutLoadingConditions` includes "Loading cart"), a greyed-out "Back" is consistent with the rest of the page and costs at most one extra click.

## Testing Instructions

1. On a Simple site with a paid plan, open the site logged out in another browser (or use a plan close to expiry) and click the banner's gift link. You land on `/checkout/<plan>/gift/<id>?cancel_to=/home`.
2. Copy everything after the domain (e.g. `/checkout/personal-bundle-monthly/gift/28968619?cancel_to=/home`) and paste it into your test instance.
3. Throttle the network (DevTools → Network → Slow 3G) so the cart request stays in flight, reload, and try to click "< Back" **immediately**, before the order summary renders.
   * Before: straight to `/home` (logged in) or the login page (logged out), no modal.
   * After: "< Back" is greyed out until the cart arrives; once it does, clicking it shows the "Save your cart for later?" modal, and both "Save cart" and "Empty cart" land on the gifted site.
4. Repeat without throttling to confirm the normal (already-loaded) path is unchanged.
5. Sanity-check a normal non-gift checkout, clicking "Back" both during and after cart load — behaves as before.

Unit tests:

```
yarn test-client client/my-sites/checkout/src/components/test/leave-checkout-modal.test.tsx
yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? The back buttons use `accessibleWhenDisabled`, so they stay focusable and announced while the cart loads.
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? No new strings.
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YM7U6dqF8n1jYfmb4U3gPW
