### PR TITLE
Blueprint funnel: wait on the import from the processing screen

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder-spec/ai-site-builder-spec.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder-spec/ai-site-builder-spec.ts
@@ -6,6 +6,7 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { STEPS } from '../../internals/steps';
+import { ProcessingResult } from '../../internals/steps-repository/processing-step/constants';
 import { FlowV2 } from '../../internals/types';
 
 function initialize() {
@@ -22,6 +23,7 @@ function initialize() {
 	const shouldEarlyProvisionSite = queryParams.get( 'early_provision_site' ) === '1';
 	const shouldProvisionAtomicSite = queryParams.get( 'provision_target' ) === 'wpcom-atomic';
 	const shouldBuildWow = queryParams.get( 'build_wow' ) === '1';
+	const shouldImportBlueprint = queryParams.get( 'blueprint_archive_import' ) === '1';
 
 	if ( specId && ! shouldEarlyProvisionSite && ! shouldProvisionAtomicSite && ! shouldBuildWow ) {
 		// Redirect to main ai-site-builder flow preserving query parameters
@@ -29,7 +31,18 @@ function initialize() {
 		return [];
 	}
 
-	return shouldBuildWow ? [ STEPS.SITE_SPEC, STEPS.SITE_GENERATION ] : [ STEPS.SITE_SPEC ];
+	if ( shouldBuildWow ) {
+		return [ STEPS.SITE_SPEC, STEPS.SITE_GENERATION ];
+	}
+
+	// A blueprint-archive run still has minutes of work to wait on once the spec is confirmed —
+	// the Atomic transfer and the archive restore. That wait belongs on the standard processing
+	// screen, not behind a spec page the customer has already finished with.
+	if ( shouldImportBlueprint ) {
+		return [ STEPS.SITE_SPEC, STEPS.PROCESSING, STEPS.ERROR ];
+	}
+
+	return [ STEPS.SITE_SPEC ];
 }
 
 const aiSiteBuilderSpec: FlowV2< typeof initialize > = {
@@ -54,8 +67,31 @@ const aiSiteBuilderSpec: FlowV2< typeof initialize > = {
 			}
 		}, [ source, currentUser ] );
 	},
-	useStepNavigation: () => {
-		return { submit: () => {} };
+	useStepNavigation: ( currentStepSlug, navigate ) => {
+		return {
+			submit: ( submittedStep ) => {
+				switch ( submittedStep.slug ) {
+					case 'site-spec':
+						// Replaced, not pushed: the spec is confirmed and its only action taken, so
+						// Back belongs to whatever sent the customer here.
+						return navigate( 'processing', undefined, true );
+
+					case 'processing': {
+						const result = submittedStep.providedDependencies;
+						if ( ProcessingResult.SUCCESS === result.processingResult && result.redirectTo ) {
+							// The hand-off leaves Calypso for the built site, so it is a location
+							// change rather than a step navigation.
+							window.location.assign( result.redirectTo );
+							return;
+						}
+
+						// The pending action reports a failed or timed-out build by throwing, and
+						// the processing step has already stashed its message for the error step.
+						return navigate( 'error', undefined, true );
+					}
+				}
+			},
+		};
 	},
 };
 

--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder-spec/test/ai-site-builder-spec.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder-spec/test/ai-site-builder-spec.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { STEPS } from '../../../internals/steps';
+import { ProcessingResult } from '../../../internals/steps-repository/processing-step/constants';
 import aiSiteBuilderSpec from '../ai-site-builder-spec';
 
 jest.mock( '@automattic/calypso-config', () => ( {
@@ -34,5 +35,72 @@ describe( 'ai-site-builder-spec flow', () => {
 		window.history.replaceState( {}, '', '/setup/ai-site-builder-spec/site-spec?build_wow=1' );
 
 		expect( aiSiteBuilderSpec.initialize() ).toEqual( [ STEPS.SITE_SPEC, STEPS.SITE_GENERATION ] );
+	} );
+
+	it( 'gives a blueprint-archive run somewhere to wait', () => {
+		window.history.replaceState(
+			{},
+			'',
+			'/setup/ai-site-builder-spec/site-spec?blueprint_archive_import=1&blueprint_slug=961&wow_funnel=blueprint'
+		);
+
+		expect( aiSiteBuilderSpec.initialize() ).toEqual( [
+			STEPS.SITE_SPEC,
+			STEPS.PROCESSING,
+			STEPS.ERROR,
+		] );
+	} );
+
+	describe( 'navigation', () => {
+		const originalLocation = window.location;
+		const navigate = jest.fn();
+		const submitFrom = ( slug: string, providedDependencies: Record< string, unknown > = {} ) =>
+			aiSiteBuilderSpec
+				.useStepNavigation( slug as never, navigate )
+				.submit( { slug, providedDependencies } as never );
+
+		beforeEach( () => {
+			jest.clearAllMocks();
+		} );
+
+		afterEach( () => {
+			Object.defineProperty( window, 'location', {
+				value: originalLocation,
+				writable: true,
+				configurable: true,
+			} );
+		} );
+
+		it( 'sends a confirmed spec straight to the waiting screen', () => {
+			submitFrom( 'site-spec' );
+
+			// Replacing rather than pushing keeps Back off the spec the customer just confirmed.
+			expect( navigate ).toHaveBeenCalledWith( 'processing', undefined, true );
+		} );
+
+		it( 'hands off to the built site once the wait resolves', () => {
+			const assign = jest.fn();
+			Object.defineProperty( window, 'location', {
+				value: { assign },
+				writable: true,
+				configurable: true,
+			} );
+
+			submitFrom( 'processing', {
+				processingResult: ProcessingResult.SUCCESS,
+				redirectTo: 'https://example.wordpress.com/wp-admin/site-editor.php',
+			} );
+
+			expect( assign ).toHaveBeenCalledWith(
+				'https://example.wordpress.com/wp-admin/site-editor.php'
+			);
+			expect( navigate ).not.toHaveBeenCalled();
+		} );
+
+		it( 'shows the error step when the wait fails', () => {
+			submitFrom( 'processing', { processingResult: ProcessingResult.FAILURE } );
+
+			expect( navigate ).toHaveBeenCalledWith( 'error', undefined, true );
+		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -2,11 +2,13 @@ import { isAutomatticianQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { getSessionId as getPostHogSessionId } from '@automattic/posthog';
 import { useQuery as useReactQuery } from '@tanstack/react-query';
+import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import {
 	applyBlueprintSpec,
 	getBlueprintArchiveSiteIdentifier,
@@ -125,7 +127,7 @@ function logEarlyProvisionEvent(
 	} ).catch( () => {} );
 }
 
-const SiteSpec: StepType = function SiteSpec() {
+const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 	const translate = useTranslate();
 	const queryParams = useQuery();
 	const querySource = queryParams.get( 'source' );
@@ -166,6 +168,12 @@ const SiteSpec: StepType = function SiteSpec() {
 	const messageCountRef = useRef( 0 );
 	const isSubmittingRef = useRef( false );
 	const blueprintImportStartedRef = useRef( false );
+	const { setPendingAction } = useDispatch( ONBOARD_STORE );
+	// Held in a ref so the spec-confirm callback stays referentially stable: the flow hands
+	// down a fresh submit() on every render, and useSiteSpec re-initialises the widget
+	// whenever its handlers change identity.
+	const submitRef = useRef( navigation.submit );
+	submitRef.current = navigation.submit;
 
 	const handleCiabMessage = useCallback( () => {
 		messageCountRef.current += 1;
@@ -381,11 +389,12 @@ const SiteSpec: StepType = function SiteSpec() {
 	] );
 
 	// Blueprint archive import: the transfer-to-Atomic + archive restore runs in
-	// the background (kicked off on mount below). On spec confirm we poll the
-	// canonical Atomic transfer endpoint, then the import status, and finally hand
-	// the user off to the Atomic Site Editor.
+	// the background (kicked off on mount below, or before checkout for a funnel
+	// run). Confirming the spec is the end of this page's job, so the wait moves off
+	// it: the customer goes straight to the flow's processing step — Calypso's
+	// standard waiting screen — and the poll runs there as its pending action.
 	const handleBlueprintArchiveSpecConfirm = useCallback(
-		async ( specData: unknown ) => {
+		( specData: unknown ) => {
 			if ( isSubmittingRef.current ) {
 				return;
 			}
@@ -398,65 +407,83 @@ const SiteSpec: StepType = function SiteSpec() {
 
 			isSubmittingRef.current = true;
 
-			try {
-				logBlueprintArchiveEvent( 'spec_confirm_poll_start', {
-					site_identifier: blueprintArchiveSiteIdentifier,
-				} );
+			// Read here, not inside the pending action: the confirmed spec arrives with this
+			// page's message and the wait only needs the id it carries.
+			const specId = getSpecId( specData );
 
-				// As a funnel interstitial this step owns the funnel's readiness wait, so it
-				// goes through the shared helper — one definition of "ready" per funnel, and one
-				// timeout. Outside a funnel this is a plain blueprint-archive run, which keeps
-				// its own unbounded waits.
-				if ( wowFunnelSlug ) {
-					await waitForWowFunnelReady( {
-						funnelSlug: wowFunnelSlug,
-						siteIdentifier: blueprintArchiveSiteIdentifier,
+			setPendingAction( async () => {
+				try {
+					logBlueprintArchiveEvent( 'spec_confirm_poll_start', {
+						site_identifier: blueprintArchiveSiteIdentifier,
 					} );
-				} else {
-					await waitForAtomicTransferComplete( blueprintArchiveSiteIdentifier );
-					await waitForBlueprintImportComplete( blueprintArchiveSiteIdentifier );
-				}
 
-				// Only once the restore is done: it replaces the site's options
-				// wholesale, so a spec applied earlier would be overwritten.
-				// Never blocks the hand-off — applyBlueprintSpec() resolves either way.
-				const specId = getSpecId( specData );
-				const applied = await applyBlueprintSpec(
-					blueprintArchiveSiteIdentifier,
-					specId,
-					blueprintArchiveSlug
-				);
-				logBlueprintArchiveEvent( 'apply_spec_done', {
-					site_identifier: blueprintArchiveSiteIdentifier,
-					applied,
-					has_spec_id: Boolean( specId ),
-				} );
-
-				// Resolved after the wait either way, so the URL names the site that now exists.
-				const siteEditorUrl = wowFunnelSlug
-					? await getWowFunnelHandoffUrl( {
-							dest: wowFunnelDest,
+					// As a funnel interstitial this step owns the funnel's readiness wait, so it
+					// goes through the shared helper — one definition of "ready" per funnel, and one
+					// timeout. Outside a funnel this is a plain blueprint-archive run, which keeps
+					// its own unbounded waits.
+					if ( wowFunnelSlug ) {
+						await waitForWowFunnelReady( {
+							funnelSlug: wowFunnelSlug,
 							siteIdentifier: blueprintArchiveSiteIdentifier,
-					  } )
-					: getSiteEditorUrl( await getSiteAdminUrl( blueprintArchiveSiteIdentifier ), {
-							canvasEdit: applied,
-					  } );
+						} );
+					} else {
+						await waitForAtomicTransferComplete( blueprintArchiveSiteIdentifier );
+						await waitForBlueprintImportComplete( blueprintArchiveSiteIdentifier );
+					}
 
-				logBlueprintArchiveEvent( 'redirect_site_editor', {
-					site_identifier: blueprintArchiveSiteIdentifier,
-				} );
-				window.location.href = siteEditorUrl;
-			} catch ( error ) {
-				logBlueprintArchiveEvent( 'spec_confirm_error', {
-					site_identifier: blueprintArchiveSiteIdentifier,
-					error: error instanceof Error ? error.message : String( error ),
-				} );
-				// eslint-disable-next-line no-console
-				console.error( 'Failed to finish blueprint import:', error );
-				isSubmittingRef.current = false;
-			}
+					// Only once the restore is done: it replaces the site's options
+					// wholesale, so a spec applied earlier would be overwritten.
+					// Never blocks the hand-off — applyBlueprintSpec() resolves either way.
+					const applied = await applyBlueprintSpec(
+						blueprintArchiveSiteIdentifier,
+						specId,
+						blueprintArchiveSlug
+					);
+					logBlueprintArchiveEvent( 'apply_spec_done', {
+						site_identifier: blueprintArchiveSiteIdentifier,
+						applied,
+						has_spec_id: Boolean( specId ),
+					} );
+
+					// Resolved after the wait either way, so the URL names the site that now exists.
+					const siteEditorUrl = wowFunnelSlug
+						? await getWowFunnelHandoffUrl( {
+								dest: wowFunnelDest,
+								siteIdentifier: blueprintArchiveSiteIdentifier,
+						  } )
+						: getSiteEditorUrl( await getSiteAdminUrl( blueprintArchiveSiteIdentifier ), {
+								canvasEdit: applied,
+						  } );
+
+					logBlueprintArchiveEvent( 'redirect_site_editor', {
+						site_identifier: blueprintArchiveSiteIdentifier,
+					} );
+
+					// Handed back rather than navigated to here, so the loading screen stays up
+					// until the browser actually leaves — the flow performs the redirect.
+					return { redirectTo: siteEditorUrl };
+				} catch ( error ) {
+					logBlueprintArchiveEvent( 'spec_confirm_error', {
+						site_identifier: blueprintArchiveSiteIdentifier,
+						error: error instanceof Error ? error.message : String( error ),
+					} );
+					// eslint-disable-next-line no-console
+					console.error( 'Failed to finish blueprint import:', error );
+					// Rethrown for the processing step to report: retrying here is no longer an
+					// option once the spec widget has been navigated away from.
+					throw error;
+				}
+			} );
+
+			submitRef.current?.();
 		},
-		[ blueprintArchiveSiteIdentifier, blueprintArchiveSlug, wowFunnelSlug, wowFunnelDest ]
+		[
+			blueprintArchiveSiteIdentifier,
+			blueprintArchiveSlug,
+			wowFunnelSlug,
+			wowFunnelDest,
+			setPendingAction,
+		]
 	);
 
 	// Kick off the background transfer + blueprint-archive import as soon as the

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
@@ -3,6 +3,12 @@
  */
 import { useQuery as useReactQuery } from '@tanstack/react-query';
 import { act, render } from '@testing-library/react';
+import {
+	applyBlueprintSpec,
+	startBlueprintArchiveImport,
+	waitForAtomicTransferComplete,
+	waitForBlueprintImportComplete,
+} from 'calypso/landing/stepper/utils/blueprint-archive-import';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { useSiteSpec } from 'calypso/lib/site-spec';
 import wpcom from 'calypso/lib/wp';
@@ -62,9 +68,36 @@ jest.mock( 'calypso/lib/logstash', () => ( {
 } ) );
 
 jest.mock( 'calypso/lib/site-spec/utils', () => ( {
+	getBlueprintSiteSpecConfig: jest.fn( () => ( { agentId: 'blueprint-site-spec' } ) ),
 	getBuildWowSiteSpecConfig: jest.fn( () => ( { agentId: 'build-wow-site-spec' } ) ),
 	getCiabSiteSpecConfig: jest.fn( () => ( { agentId: 'ciab-site-spec' } ) ),
 	getEarlyProvisionSiteSpecConfig: jest.fn( () => ( { agentId: 'early-provision-site-spec' } ) ),
+} ) );
+
+const mockSetPendingAction = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( { setPendingAction: mockSetPendingAction } ),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/stores', () => ( {
+	ONBOARD_STORE: 'automattic/onboard',
+} ) );
+
+// The wow-funnel helpers stay real so the funnel's readiness rules are exercised; only the
+// requests they make are stubbed.
+jest.mock( 'calypso/landing/stepper/utils/blueprint-archive-import', () => ( {
+	applyBlueprintSpec: jest.fn( () => Promise.resolve( true ) ),
+	getBlueprintArchiveSiteIdentifier: jest.fn(
+		( { siteSlug, siteId }: { siteSlug?: string | null; siteId?: string | null } ) =>
+			siteSlug || ( siteId && String( siteId ) !== '0' ? String( siteId ) : null )
+	),
+	getSiteAdminUrl: jest.fn( () => Promise.resolve( 'https://example.wordpress.com/wp-admin/' ) ),
+	getSiteEditorUrl: jest.fn( () => 'https://example.wordpress.com/wp-admin/site-editor.php' ),
+	logBlueprintArchiveEvent: jest.fn(),
+	startBlueprintArchiveImport: jest.fn( () => Promise.resolve() ),
+	waitForAtomicTransferComplete: jest.fn( () => Promise.resolve() ),
+	waitForBlueprintImportComplete: jest.fn( () => Promise.resolve() ),
 } ) );
 
 jest.mock( 'calypso/lib/wp', () => ( {
@@ -215,5 +248,78 @@ describe( 'SiteSpec early provisioning step', () => {
 		expect( siteSpecOptions.siteSpecConfig ).toBeUndefined();
 		expect( siteSpecOptions.onSpecConfirm ).toBeUndefined();
 		expect( wpcomPostMock ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'SiteSpec blueprint archive import', () => {
+	const mockUseSiteSpec = useSiteSpec as jest.Mock;
+	const navigation = { submit: jest.fn() };
+
+	const renderSiteSpec = () =>
+		render(
+			<SiteSpec navigation={ navigation } stepName="site-spec" flow="ai-site-builder-spec" />
+		);
+
+	const confirmSpec = async () => {
+		renderSiteSpec();
+
+		const siteSpecOptions = mockUseSiteSpec.mock.calls[ 0 ][ 0 ];
+		await act( async () => {
+			await siteSpecOptions.onSpecConfirm( { spec_id: 'spec-789' } );
+		} );
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockQueryParams = new URLSearchParams(
+			'blueprint_archive_import=1&blueprint_slug=961&siteSlug=example.wordpress.com&wow_funnel=blueprint'
+		);
+	} );
+
+	it( 'leaves the spec page for the waiting screen without waiting on the import first', async () => {
+		await confirmSpec();
+
+		expect( navigation.submit ).toHaveBeenCalled();
+		expect( mockSetPendingAction ).toHaveBeenCalledTimes( 1 );
+		// The poll belongs to the processing step now, so nothing has been asked for yet.
+		expect( waitForAtomicTransferComplete ).not.toHaveBeenCalled();
+		expect( waitForBlueprintImportComplete ).not.toHaveBeenCalled();
+	} );
+
+	it( 'polls the import from the waiting screen and hands back the site editor URL', async () => {
+		await confirmSpec();
+
+		const pendingAction = mockSetPendingAction.mock.calls[ 0 ][ 0 ];
+
+		await expect( pendingAction() ).resolves.toEqual( {
+			redirectTo: 'https://example.wordpress.com/wp-admin/site-editor.php',
+		} );
+
+		expect( waitForAtomicTransferComplete ).toHaveBeenCalledWith( 'example.wordpress.com', {
+			initialDelayMs: 0,
+		} );
+		expect( waitForBlueprintImportComplete ).toHaveBeenCalledWith( 'example.wordpress.com', {
+			initialDelayMs: 0,
+		} );
+		// Applied only after the restore, which replaces the site's options wholesale.
+		expect( applyBlueprintSpec ).toHaveBeenCalledWith( 'example.wordpress.com', 'spec-789', '961' );
+	} );
+
+	it( 'reports a failed import to the waiting screen rather than swallowing it', async () => {
+		( waitForBlueprintImportComplete as jest.Mock ).mockRejectedValueOnce(
+			new Error( 'Import failed' )
+		);
+
+		await confirmSpec();
+
+		const pendingAction = mockSetPendingAction.mock.calls[ 0 ][ 0 ];
+
+		await expect( pendingAction() ).rejects.toThrow();
+	} );
+
+	it( 'never starts a second import for a funnel run', async () => {
+		await confirmSpec();
+
+		expect( startBlueprintArchiveImport ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

* Confirming the site spec in a blueprint-archive run now hands the customer to the flow's processing step straight away, rather than holding them on the spec page while the Atomic transfer and the archive restore finish.
* The readiness wait, the spec apply, and the hand-off URL resolution move into an `ONBOARD_STORE` pending action, so the import is polled from the standard processing screen.
* `ai-site-builder-spec` gains `processing` and `error` steps — for a blueprint-archive run only — and a real `useStepNavigation` that routes `site-spec` → `processing`, then either to the built site or to `error`.
* A failed or timed-out build now lands on the error step with its message. Previously it only reached `console.error`.

## Why are these changes being made?

The spec page was doing double duty. Once the customer confirmed, its only interactive element was spent — but they stayed on it for as long as the import ran, which for a `wow_funnel=blueprint` run is minutes, since the archive restore is genuinely long. No progress, no way to tell a slow import from a stuck page.

Calypso already has a screen for exactly this wait. Moving to it also puts the failure path somewhere a customer can see: the readiness wait throws on failure and on its 900s timeout, and that message was being swallowed into the console while the customer sat looking at a spec they had already confirmed.

## Testing Instructions

Live branch: https://calypso.live/?branch=claude/wow-funnel-blueprint-polling — append `?flags=site-spec` if you are on a config where the flag is off (it is on in `development`, `stage`, and `wpcalypso`).

* Start a blueprint funnel at `/setup/onboarding?wow_funnel=blueprint&blueprint=<id>&dest=editor`, pick a domain, and complete checkout. You land on the site-spec page as before.
* Confirm the spec. The URL should change to `/setup/ai-site-builder-spec/processing` immediately and show the standard loading screen with its rotating messages — before this change the spec page stayed put for the whole import.
* Wait it out. When the import finishes you are handed to the Site Editor on the built Atomic site, the same destination as before.
* Press Back from the processing screen. It goes to whatever preceded the spec page, not back onto the spec you just confirmed.
* Failure path: block `GET /rest/v1.1/sites/<id>/imports` in devtools before confirming. You should land on the error step with a transfer-failure message rather than getting a silent console error and a stuck spec page.
* Standalone blueprint-archive run (no `wow_funnel`, reached via `build_dest=wow`) gets the same processing screen, and the import it kicks off on mount still fires exactly once.
* Unchanged paths worth a glance: `?build_wow=1` still goes to `site-generation` on confirm, and `?early_provision_site=1` / `?source=ciab-*` still redirect as they did.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
