### PR TITLE
Login: never send a successful login back to the login page

### DIFF
--- a/client/lib/login-redirect-safety/index.ts
+++ b/client/lib/login-redirect-safety/index.ts
@@ -1,0 +1,153 @@
+/**
+ * Where the login flow is allowed to send someone.
+ *
+ * Both the logged-in route middleware and the post-login reboot need this, and
+ * they must agree: whichever one is looser would otherwise be a way around the
+ * other.
+ */
+
+const ALLOWED_HOSTNAMES = [ 'wordpress.com', 'subscribe.wordpress.com', 'agencies.automattic.com' ];
+
+// A nested redirect is only unwrapped when it sits on a login page we serve.
+const LOGIN_PATH_PREFIX = '/log-in';
+
+// More hops than any real flow needs. The bound is only here so that a
+// self-referencing redirect cannot spin.
+const MAX_UNWRAP_HOPS = 5;
+
+/**
+ * For this context, we consider external URLs that are NOT:
+ * - Relative paths (`/test`)
+ * - Absolute URLs on https://wordpress.com/*
+ * @param {string} url URL to check
+ * @returns {boolean}
+ */
+export function isExternalUrl( url: string ): boolean {
+	if ( url.startsWith( '/' ) ) {
+		return false;
+	}
+
+	try {
+		const urlObject = new URL( url );
+
+		if ( ALLOWED_HOSTNAMES.includes( urlObject.hostname ) && urlObject.protocol === 'https:' ) {
+			return false;
+		}
+	} catch {
+		return true;
+	}
+
+	return true;
+}
+
+/**
+ * For internal urls check when parsed the origin
+ * @param {string} url URL to check
+ * @returns {boolean}
+ */
+export function isUnsafeInternalUrl( url: string ): boolean {
+	if ( ! url.startsWith( '/' ) ) {
+		return false;
+	}
+
+	try {
+		return new URL( url, window.location.origin ).origin !== window.location.origin;
+	} catch ( e ) {
+		return true;
+	}
+}
+
+/**
+ * Whether the login flow may send someone to this URL.
+ * @param {string} url URL to check
+ * @returns {boolean}
+ */
+export function isSafeLoginRedirect( url: string | null | undefined ): boolean {
+	if ( ! url ) {
+		return false;
+	}
+
+	return ! isUnsafeInternalUrl( url ) && ! isExternalUrl( url );
+}
+
+/**
+ * Whether this URL is one of our own login pages.
+ * @param {URL} parsed Parsed URL.
+ * @returns {boolean}
+ */
+function isOwnLoginPage( parsed: URL ): boolean {
+	if ( ! parsed.pathname.startsWith( LOGIN_PATH_PREFIX ) ) {
+		return false;
+	}
+
+	// Same origin covers production; the explicit hostname keeps this working
+	// when Calypso is served from somewhere else, such as a calypso.live branch.
+	return parsed.origin === window.location.origin || parsed.hostname === 'wordpress.com';
+}
+
+/**
+ * Works out where to send someone whose login has just succeeded.
+ *
+ * Almost always this is the redirect we were handed, returned untouched. The
+ * exception is a redirect that points back at `/log-in`: the login has already
+ * succeeded, so that page is the one place the person must not end up.
+ * Passwordless accounts cannot get past it at all, which turns it into a loop
+ * they never escape (DOTOBRD-359).
+ *
+ * The destination they were originally heading for is usually still there in
+ * the login URL's own `redirect_to`, so prefer it over dropping them on the
+ * dashboard. That nested value has to pass isSafeLoginRedirect() on its own —
+ * the outer URL having been allowed says nothing about what was in its query
+ * string.
+ * @param {string} redirectTo The sanitized redirect handed to us after login.
+ * @returns {string | null} Where to go, or null to fall back to the dashboard.
+ */
+export function resolvePostLoginRedirect( redirectTo: string | null | undefined ): string | null {
+	if ( ! redirectTo ) {
+		return null;
+	}
+
+	let current = redirectTo;
+
+	for ( let hop = 0; hop < MAX_UNWRAP_HOPS; hop++ ) {
+		let parsed;
+		try {
+			parsed = new URL( current, window.location.origin );
+		} catch {
+			return null;
+		}
+
+		if ( ! isOwnLoginPage( parsed ) ) {
+			// An ordinary destination. Hand it back exactly as it came in, so
+			// flows that rely on their own hosts keep working.
+			return current;
+		}
+
+		const nested = parsed.searchParams.get( 'redirect_to' );
+
+		if ( ! isSafeLoginRedirect( nested ) ) {
+			return null;
+		}
+
+		current = nested as string;
+	}
+
+	return null;
+}
+
+/**
+ * Whether the redirect handed to us after login points back at the login page.
+ * @param {string} redirectTo The sanitized redirect handed to us after login.
+ * @returns {boolean}
+ */
+export function pointsAtLoginPage( redirectTo: string | null | undefined ): boolean {
+	if ( ! redirectTo ) {
+		return false;
+	}
+
+	try {
+		return isOwnLoginPage( new URL( redirectTo, window.location.origin ) );
+	} catch {
+		return false;
+	}
+}

--- a/client/lib/login-redirect-safety/test/index.ts
+++ b/client/lib/login-redirect-safety/test/index.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment jsdom
+ */
+import {
+	isSafeLoginRedirect,
+	pointsAtLoginPage,
+	resolvePostLoginRedirect,
+} from 'calypso/lib/login-redirect-safety';
+
+const originalLocation = window.location;
+
+describe( 'login redirect safety', () => {
+	beforeEach( () => {
+		Object.defineProperty( window, 'location', {
+			value: { href: '', origin: 'https://wordpress.com' },
+			writable: true,
+		} );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', originalLocation );
+	} );
+
+	describe( 'resolvePostLoginRedirect', () => {
+		test( 'returns null when there is no redirect', () => {
+			expect( resolvePostLoginRedirect( null ) ).toBeNull();
+			expect( resolvePostLoginRedirect( undefined ) ).toBeNull();
+			expect( resolvePostLoginRedirect( '' ) ).toBeNull();
+		} );
+
+		test( 'leaves an ordinary relative destination alone', () => {
+			expect( resolvePostLoginRedirect( '/home' ) ).toBe( '/home' );
+			expect( resolvePostLoginRedirect( '/sites' ) ).toBe( '/sites' );
+		} );
+
+		test( 'leaves a destination on another host alone', () => {
+			// The OAuth2 authorize hand-off is not on the allowlist and must
+			// still pass through untouched.
+			const authorize =
+				'https://public-api.wordpress.com/oauth2/authorize?client_id=1&response_type=code';
+
+			expect( resolvePostLoginRedirect( authorize ) ).toBe( authorize );
+		} );
+
+		test( 'leaves an Atomic site destination alone', () => {
+			const site = 'https://example.com/wp-login.php?action=jetpack-sso';
+
+			expect( resolvePostLoginRedirect( site ) ).toBe( site );
+		} );
+
+		test( 'unwraps the destination nested in a login page URL', () => {
+			expect( resolvePostLoginRedirect( 'https://wordpress.com/log-in?redirect_to=%2Fhome' ) ).toBe(
+				'/home'
+			);
+		} );
+
+		test( 'unwraps a relative login page URL', () => {
+			expect( resolvePostLoginRedirect( '/log-in/link/use?redirect_to=%2Fsites' ) ).toBe(
+				'/sites'
+			);
+		} );
+
+		test( 'unwraps more than one layer of login page', () => {
+			const doubled =
+				'/log-in?redirect_to=' +
+				encodeURIComponent( '/log-in?redirect_to=' + encodeURIComponent( '/home' ) );
+
+			expect( resolvePostLoginRedirect( doubled ) ).toBe( '/home' );
+		} );
+
+		test( 'gives up on a login page with nothing nested inside', () => {
+			expect( resolvePostLoginRedirect( 'https://wordpress.com/log-in' ) ).toBeNull();
+			expect( resolvePostLoginRedirect( '/log-in?client_id=1' ) ).toBeNull();
+		} );
+
+		test( 'gives up rather than following a nested destination off-site', () => {
+			expect(
+				resolvePostLoginRedirect(
+					'https://wordpress.com/log-in?redirect_to=' +
+						encodeURIComponent( 'https://evil.example/' )
+				)
+			).toBeNull();
+		} );
+
+		test( 'gives up rather than following a nested protocol-relative URL', () => {
+			expect(
+				resolvePostLoginRedirect(
+					'https://wordpress.com/log-in?redirect_to=' + encodeURIComponent( '//evil.example/' )
+				)
+			).toBeNull();
+		} );
+
+		test( 'gives up on a login page that only ever points at itself', () => {
+			const selfReferencing =
+				'https://wordpress.com/log-in?redirect_to=%2Flog-in%3Fredirect_to%3D%252Flog-in';
+
+			expect( resolvePostLoginRedirect( selfReferencing ) ).toBeNull();
+		} );
+
+		test( 'does not treat an unrelated path that starts with log-in as the login page', () => {
+			// Guards against a prefix match swallowing something else later.
+			expect( resolvePostLoginRedirect( '/home?from=/log-in' ) ).toBe( '/home?from=/log-in' );
+		} );
+	} );
+
+	describe( 'pointsAtLoginPage', () => {
+		test( 'is true for our own login page', () => {
+			expect( pointsAtLoginPage( '/log-in' ) ).toBe( true );
+			expect( pointsAtLoginPage( 'https://wordpress.com/log-in/link/use' ) ).toBe( true );
+		} );
+
+		test( 'is false for anything else', () => {
+			expect( pointsAtLoginPage( null ) ).toBe( false );
+			expect( pointsAtLoginPage( '/home' ) ).toBe( false );
+			expect( pointsAtLoginPage( 'https://example.com/log-in' ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'isSafeLoginRedirect', () => {
+		test( 'accepts relative paths and allowlisted hosts', () => {
+			expect( isSafeLoginRedirect( '/home' ) ).toBe( true );
+			expect( isSafeLoginRedirect( 'https://wordpress.com/home' ) ).toBe( true );
+			expect( isSafeLoginRedirect( 'https://subscribe.wordpress.com/' ) ).toBe( true );
+		} );
+
+		test( 'rejects other hosts, other schemes and empty values', () => {
+			expect( isSafeLoginRedirect( 'https://evil.example/' ) ).toBe( false );
+			expect( isSafeLoginRedirect( 'http://wordpress.com/home' ) ).toBe( false );
+			expect( isSafeLoginRedirect( '//evil.example/' ) ).toBe( false );
+			expect( isSafeLoginRedirect( null ) ).toBe( false );
+		} );
+
+		test( 'rejects a WordPress.com subdomain that is not on the allowlist', () => {
+			// Subdomains are user-controlled, so widening this is a security
+			// decision rather than a bug fix.
+			expect( isSafeLoginRedirect( 'https://mysite.wordpress.com/wp-admin/' ) ).toBe( false );
+		} );
+	} );
+} );

--- a/client/login/redirect-logged-in/index.web.js
+++ b/client/login/redirect-logged-in/index.web.js
@@ -1,51 +1,5 @@
+import { isExternalUrl, isUnsafeInternalUrl } from 'calypso/lib/login-redirect-safety';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-
-/**
- * For this context, we consider external URLs that are NOT:
- * - Relative paths (`/test`)
- * - Absolute URLs on https://wordpress.com/*
- * @param {string} url URL to check
- * @returns {boolean}
- */
-function isExternalUrl( url ) {
-	if ( url.startsWith( '/' ) ) {
-		return false;
-	}
-
-	try {
-		const urlObject = new URL( url );
-		const allowedHostname = [
-			'wordpress.com',
-			'subscribe.wordpress.com',
-			'agencies.automattic.com',
-		];
-
-		if ( allowedHostname.includes( urlObject.hostname ) && urlObject.protocol === 'https:' ) {
-			return false;
-		}
-	} catch {
-		return true;
-	}
-
-	return true;
-}
-
-/**
- * For internal urls check when parsed the origin
- * @param {string} url URL to check
- * @returns {boolean}
- */
-function isUnsafeInternalUrl( url ) {
-	if ( ! url.startsWith( '/' ) ) {
-		return false;
-	}
-
-	try {
-		return new URL( url, window.location.origin ).origin !== window.location.origin;
-	} catch ( e ) {
-		return true;
-	}
-}
 
 export default function redirectLoggedIn( context, next ) {
 	const userLoggedIn = isUserLoggedIn( context.store.getState() );

--- a/client/state/login/actions/reboot-after-login.ts
+++ b/client/state/login/actions/reboot-after-login.ts
@@ -1,3 +1,4 @@
+import { pointsAtLoginPage, resolvePostLoginRedirect } from 'calypso/lib/login-redirect-safety';
 import { clearStore, getStoredUserId } from 'calypso/lib/user/store';
 import { recordTracksEventWithClientId as recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getRedirectToSanitized, isTwoFactorEnabled } from 'calypso/state/login/selectors';
@@ -6,15 +7,21 @@ import type { CalypsoDispatch } from 'calypso/state/types';
 export const rebootAfterLogin =
 	( tracksEventArgs: Record< string, unknown > ) =>
 	async ( dispatch: CalypsoDispatch, getState: () => Record< string, unknown > ) => {
+		const redirectTo = getRedirectToSanitized( getState() );
+
+		// The login app's store has no sites state, so the landing resolver can't run here.
+		const url = resolvePostLoginRedirect( redirectTo ) || '/home';
+
 		dispatch(
 			recordTracksEvent( 'calypso_login_success', {
 				two_factor_enabled: isTwoFactorEnabled( getState() ),
+				// How often the redirect we are handed points back at the login
+				// page. Until this fires in production we cannot say how much of
+				// the reported login loop is this and how much is something else.
+				redirect_to_login_page: pointsAtLoginPage( redirectTo ),
 				...tracksEventArgs,
 			} )
 		);
-
-		// The login app's store has no sites state, so the landing resolver can't run here.
-		const url = getRedirectToSanitized( getState() ) || '/home';
 
 		// user ID is persisted in localstorage
 		// therefore we need to reset it before we redirect, otherwise we'll get

--- a/client/state/login/actions/test/reboot-after-login.js
+++ b/client/state/login/actions/test/reboot-after-login.js
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment jsdom
+ */
+import { rebootAfterLogin } from 'calypso/state/login/actions/reboot-after-login';
+import { getRedirectToSanitized } from 'calypso/state/login/selectors';
+
+jest.mock( 'calypso/state/analytics/actions', () => ( {
+	recordTracksEventWithClientId: jest.fn( ( name, props ) => ( {
+		type: 'MOCK_TRACKS',
+		name,
+		props,
+	} ) ),
+} ) );
+
+jest.mock( 'calypso/state/login/selectors', () => ( {
+	getRedirectToSanitized: jest.fn(),
+	isTwoFactorEnabled: jest.fn( () => false ),
+} ) );
+
+jest.mock( 'calypso/lib/user/store', () => ( {
+	clearStore: jest.fn( () => Promise.resolve() ),
+	getStoredUserId: jest.fn( () => null ),
+} ) );
+
+const originalLocation = window.location;
+
+describe( 'rebootAfterLogin', () => {
+	let dispatch;
+	let getState;
+
+	const run = async () => {
+		await rebootAfterLogin( { magic_login: 1 } )( dispatch, getState );
+	};
+
+	const trackedProps = () =>
+		dispatch.mock.calls.map( ( [ action ] ) => action ).find( ( a ) => a?.type === 'MOCK_TRACKS' )
+			?.props;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		dispatch = jest.fn( ( action ) =>
+			typeof action === 'function' ? action( dispatch, getState ) : action
+		);
+		getState = jest.fn( () => ( {} ) );
+
+		Object.defineProperty( window, 'location', {
+			value: { href: '', origin: 'https://wordpress.com' },
+			writable: true,
+		} );
+	} );
+
+	afterEach( () => {
+		Object.defineProperty( window, 'location', originalLocation );
+	} );
+
+	test( 'redirects to /home when there is no redirect', async () => {
+		getRedirectToSanitized.mockReturnValue( null );
+
+		await run();
+
+		expect( window.location.href ).toBe( '/home' );
+	} );
+
+	test( 'redirects to the given destination', async () => {
+		getRedirectToSanitized.mockReturnValue( '/sites' );
+
+		await run();
+
+		expect( window.location.href ).toBe( '/sites' );
+	} );
+
+	test( 'leaves an Atomic site destination untouched', async () => {
+		const site = 'https://example.com/wp-login.php?action=jetpack-sso';
+		getRedirectToSanitized.mockReturnValue( site );
+
+		await run();
+
+		expect( window.location.href ).toBe( site );
+	} );
+
+	test( 'still appends login_flow to the OAuth2 authorize hand-off', async () => {
+		getRedirectToSanitized.mockReturnValue(
+			'https://public-api.wordpress.com/oauth2/authorize?client_id=1'
+		);
+
+		await run();
+
+		expect( window.location.href ).toBe(
+			'https://public-api.wordpress.com/oauth2/authorize?client_id=1&login_flow=true'
+		);
+	} );
+
+	test( 'unwraps a redirect that points back at the login page', async () => {
+		getRedirectToSanitized.mockReturnValue( 'https://wordpress.com/log-in?redirect_to=%2Fsites' );
+
+		await run();
+
+		expect( window.location.href ).toBe( '/sites' );
+	} );
+
+	test( 'falls back to /home when the login page has no usable destination', async () => {
+		getRedirectToSanitized.mockReturnValue( 'https://wordpress.com/log-in' );
+
+		await run();
+
+		expect( window.location.href ).toBe( '/home' );
+	} );
+
+	test( 'never redirects to the login page after a successful login', async () => {
+		getRedirectToSanitized.mockReturnValue(
+			'https://wordpress.com/log-in?redirect_to=' + encodeURIComponent( 'https://evil.example/' )
+		);
+
+		await run();
+
+		expect( window.location.href ).toBe( '/home' );
+	} );
+
+	test( 'reports whether the redirect pointed at the login page', async () => {
+		getRedirectToSanitized.mockReturnValue( 'https://wordpress.com/log-in?redirect_to=%2Fsites' );
+
+		await run();
+
+		expect( trackedProps() ).toMatchObject( { redirect_to_login_page: true, magic_login: 1 } );
+	} );
+
+	test( 'reports a normal redirect as not pointing at the login page', async () => {
+		getRedirectToSanitized.mockReturnValue( '/sites' );
+
+		await run();
+
+		expect( trackedProps() ).toMatchObject( { redirect_to_login_page: false } );
+	} );
+} );


### PR DESCRIPTION
Related to DOTOBRD-359

## Proposed Changes

* `rebootAfterLogin` no longer redirects to `/log-in`. When the sanitized redirect points at the login page, the destination nested in its own `redirect_to` is used instead; `/home` is the fallback when there is nothing usable inside.
* Every other destination passes through byte-for-byte, including the `public-api.wordpress.com/oauth2/authorize` hand-off, which is deliberately not on the login allowlist.
* The allowlist moves from `client/login/redirect-logged-in/index.web.js` to `client/lib/login-redirect-safety` so the route middleware and the post-login reboot share one policy. Its behaviour is unchanged.
* `calypso_login_success` gains a `redirect_to_login_page` boolean.

## Why

A login that has already succeeded should never land on the login page. Passwordless accounts cannot get past that page at all, so for them it is a loop with no way out — the DOTOBRD-359 report, and a desktop-browser repro on CMM-1230.

Two things to be clear about, because the last attempt at this bug foundered on them:

**This is a guard, not a root-cause fix.** [PR #108992](https://github.com/Automattic/wp-calypso/pull/108992) said the magic-login API "returns a sanitized `redirect_to` that wraps the actual destination in a login page URL". I could not confirm that from the server code. `Login_Base_Endpoint::create_response_with_redirect_url()` runs `wp_sanitize_redirect` → `wp_validate_redirect` → the `login_redirect` filter and echoes the client's own value back; the only `login_redirect` filter on wpcom rewrites to `home_url('/')` for private-blog users and nothing else. The client does not nest either — `request-login-email-form.jsx` and `login-form.jsx` both pass `getRedirectToOriginal( state )` straight through. So whatever puts a login URL into `redirect_to` happens before the link is minted and has not been identified.

That is why `redirect_to_login_page` is here. It measures how often the condition actually occurs, which nobody can currently say. The guard is worth having regardless: it holds no matter what the cause turns out to be.

**The `*.wordpress.com` allowlist is untouched, on purpose.** #108992 also proposed treating any `*.wordpress.com` subdomain as internal. That would fix a real second symptom — a magic link clicked while already logged in lands on `/home` rather than the user's site, because `redirectLoggedIn` rejects the site URL as external. But wordpress.com subdomains are user-controlled, so widening the allowlist is an open-redirect decision rather than a bug fix, and it should be yours rather than mine. Flagging it here; happy to add it if you want it.

## Testing instructions

Unit tests:

```
yarn test-client client/lib/login-redirect-safety client/state/login/actions/test/reboot-after-login.js
```

26 tests. The five loop cases in `reboot-after-login.js` fail against current trunk; the pass-through cases (OAuth2 authorize, Atomic site URLs, ordinary paths) pass both before and after, which is the point of them.

Full login area is green: `yarn test-client client/login client/state/login` — 212 tests.

Manual:

- Create a passwordless account, request a magic login link, click it.
- Verify you land on your destination rather than back on `/log-in`.
- Separately confirm the OAuth2 flow is unaffected: log in via an app that sends you through `public-api.wordpress.com/oauth2/authorize` and check `login_flow=true` is still appended.