### PR TITLE
Login: use a generic label for the 2FA verification code field

### DIFF
--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -107,12 +107,11 @@ class VerificationCodeForm extends Component {
 
 		let buttonText = translate( 'Continue' );
 		let helpText = translate( 'Enter the code from your authenticator app.' );
-		let labelText = translate( '6-Digit code' );
+		let labelText = translate( 'Verification code' );
 		let smallPrint;
 
 		if ( twoFactorEmailNonce ) {
 			helpText = translate( 'Enter the code from the email we sent you.' );
-			labelText = translate( '9-Digit code' );
 		}
 
 		if ( twoFactorAuthType === 'sms' ) {


### PR DESCRIPTION
Fixes DOTOBRD-604

## Proposed Changes

* Label the 2FA code field "Verification code" instead of "6-Digit code" / "9-Digit code".

## Why are these changes being made?

Code length depends on the method: 6 digits from an authenticator app, 7 from SMS, 8 for a backup code, 9 for the emailed code sent to a locked account. A customer with SMS 2FA saw the label "6-Digit Code" but received a 7-digit code, which was confusing.

### Screenshots

| Before | After |
| --- | --- |
| <img width="1920" height="1080" alt="Screenshot 2026-09-01 at 19 41 04" src="https://github.com/user-attachments/assets/0cdc78ae-8ff1-4e03-80bf-25d622041fcc" /> | <img width="1920" height="1080" alt="Screenshot 2026-09-01 at 19 35 14" src="https://github.com/user-attachments/assets/66ccc681-e615-4229-a93b-c75f329766b3" /> |

## Testing Instructions

* Log in to an account with SMS two-step authentication enabled.
* On the verification screen, confirm the field label reads "Verification code" and that entering the 7-digit code from the text message works.
* Repeat with an authenticator app account, and with a backup code, and confirm the labels still make sense ("Verification code" and "Backup code" respectively).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?


🤖 Generated with [Claude Code](https://claude.com/claude-code)
