### PR TITLE
Email management: read the raw Purchase instead of the assembled one

### DIFF
--- a/client/my-sites/domains/domain-management/edit/card/renew-button/index.tsx
+++ b/client/my-sites/domains/domain-management/edit/card/renew-button/index.tsx
@@ -2,10 +2,10 @@ import { Button } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
-import { handleRenewNowClick, getRenewalPrice } from 'calypso/lib/purchases';
+import { handleRenewNowClick } from 'calypso/lib/purchases';
 import { useDispatch } from 'calypso/state';
+import type { Purchase } from '@automattic/api-core';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { Purchase } from 'calypso/lib/purchases/types';
 import type { ProductListItem } from 'calypso/state/products-list/selectors/get-products-list';
 
 import './style.scss';
@@ -46,9 +46,9 @@ function RenewButton( {
 	let loading = true;
 
 	if ( purchase && selectedSite.ID ) {
-		const renewalPrice = getRenewalPrice( purchase ) + ( redemptionProduct?.cost ?? 0 );
-		const currencyCode = purchase.currencyCode;
-		formattedPrice = formatCurrency( renewalPrice, currencyCode, { stripZeros: true } );
+		const renewalPrice =
+			( purchase.sale_amount || purchase.amount ) + ( redemptionProduct?.cost ?? 0 );
+		formattedPrice = formatCurrency( renewalPrice, purchase.currency_code, { stripZeros: true } );
 		loading = false;
 	}
 
@@ -69,10 +69,8 @@ function RenewButton( {
 	}
 
 	function handleRenew() {
-		// Temporary bridge (SHILL-2256): this component still receives the
-		// camelCase Purchase. Remove once it takes the raw shape.
 		dispatch(
-			handleRenewNowClick( ( purchase as Purchase ).rawPurchase, selectedSite.slug, {
+			handleRenewNowClick( purchase as Purchase, selectedSite.slug, {
 				tracksProps,
 			} )
 		);

--- a/client/my-sites/domains/domain-management/security/index.jsx
+++ b/client/my-sites/domains/domain-management/security/index.jsx
@@ -106,7 +106,9 @@ class Security extends Component {
 					{ selectedSite.ID && ! purchase && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 					<RenewButton
 						primary
-						purchase={ purchase }
+						// Temporary bridge (SHILL-2256): this page still reads the camelCase
+						// Purchase from Redux. Remove once it reads the raw shape.
+						purchase={ purchase?.rawPurchase ?? null }
 						selectedSite={ selectedSite }
 						subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
 						redemptionProduct={ domain.isRedeemable ? this.props.redemptionProduct : null }

--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -131,7 +131,9 @@ const RegisteredDomainDetails = ( {
 
 		return (
 			<RenewButton
-				purchase={ purchase }
+				// Temporary bridge (SHILL-2256): this card still reads the camelCase
+				// Purchase from Redux. Remove once it reads the raw shape.
+				purchase={ purchase?.rawPurchase ?? null }
 				selectedSite={ selectedSite }
 				subscriptionId={ parseInt( domain.subscriptionId ?? '', 10 ) }
 				tracksProps={ { source: 'registered-domain-status', domain_status: 'active' } }

--- a/client/my-sites/email/email-management/home/email-plan-header.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-header.tsx
@@ -3,19 +3,17 @@ import clsx from 'clsx';
 import { EmailPlanSubscription } from 'calypso/my-sites/email/email-management/home/email-plan-subscription';
 import EmailPlanWarnings from 'calypso/my-sites/email/email-management/home/email-plan-warnings';
 import EmailTypeIcon from 'calypso/my-sites/email/email-management/home/email-type-icon';
+import { useEmailPurchaseByDomain } from 'calypso/my-sites/email/email-management/home/use-email-purchase';
 import { resolveEmailPlanStatus } from 'calypso/my-sites/email/email-management/home/utils';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { EmailAccount } from 'calypso/data/emails/types';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
-import type { Purchase } from 'calypso/lib/purchases/types';
 
 type EmailPlanHeaderProps = {
 	domain: ResponseDomain;
 	emailAccount: EmailAccount;
 	isLoadingEmails: boolean;
 	hasEmailSubscription: boolean;
-	isLoadingPurchase: boolean;
-	purchase?: Purchase;
 	selectedSite: SiteDetails;
 };
 
@@ -24,10 +22,10 @@ export const EmailPlanHeader = ( {
 	emailAccount,
 	hasEmailSubscription,
 	isLoadingEmails,
-	isLoadingPurchase,
-	purchase,
 	selectedSite,
 }: EmailPlanHeaderProps ) => {
+	const { purchase, isLoadingPurchase } = useEmailPurchaseByDomain( domain );
+
 	if ( ! domain ) {
 		return null;
 	}

--- a/client/my-sites/email/email-management/home/email-plan-subscription/index.tsx
+++ b/client/my-sites/email/email-management/home/email-plan-subscription/index.tsx
@@ -3,11 +3,10 @@ import { formatCurrency } from '@automattic/number-formatters';
 import clsx from 'clsx';
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { getRenewalPrice } from 'calypso/lib/purchases';
 import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-toggle';
 import RenewButton from 'calypso/my-sites/domains/domain-management/edit/card/renew-button';
+import type { Purchase } from '@automattic/api-core';
 import type { SiteDetails } from '@automattic/data-stores';
-import type { Purchase } from 'calypso/lib/purchases/types';
 
 import './style.scss';
 
@@ -40,29 +39,29 @@ export const EmailPlanSubscription = ( {
 	}
 
 	const todayTimestamp = new Date().setUTCHours( 0, 0, 0, 0 );
-	const expiryTimestamp = new Date( purchase.expiryDate ).getTime();
+	const expiryTimestamp = new Date( purchase.expiry_date ).getTime();
 	const hasSubscriptionExpired = todayTimestamp > expiryTimestamp;
 
 	const getDescription = () => {
 		const formattedRenewalPrice = formatCurrency(
-			getRenewalPrice( purchase ),
-			purchase.currencyCode,
+			purchase.sale_amount || purchase.amount,
+			purchase.currency_code,
 			{
 				stripZeros: true,
 			}
 		);
-		const expiryDate = moment( purchase.expiryDate ).format( 'LL' );
+		const expiryDate = moment( purchase.expiry_date ).format( 'LL' );
 
 		if ( hasSubscriptionExpired ) {
 			return translate( 'Expired on %(expiryDate)s.', {
 				args: {
-					expiryDate: moment( purchase.expiryDate ).format( 'LL' ),
+					expiryDate: moment( purchase.expiry_date ).format( 'LL' ),
 				},
 				comment: 'Shows the expiry date of the email subscription',
 			} );
 		}
 
-		return purchase.isAutoRenewEnabled
+		return purchase.is_auto_renew_enabled
 			? translate( 'Renews on %(expiryDate)s for %(formattedRenewalPrice)s', {
 					args: {
 						expiryDate,
@@ -72,7 +71,7 @@ export const EmailPlanSubscription = ( {
 			  } )
 			: translate( 'Expires on %(expiryDate)s.', {
 					args: {
-						expiryDate: moment( purchase.expiryDate ).format( 'LL' ),
+						expiryDate: moment( purchase.expiry_date ).format( 'LL' ),
 					},
 					comment: 'Shows the expiry date of the email subscription',
 			  } );
@@ -93,7 +92,7 @@ export const EmailPlanSubscription = ( {
 					purchase={ purchase }
 					primary={ hasSubscriptionExpired }
 					selectedSite={ selectedSite }
-					subscriptionId={ purchase.id }
+					subscriptionId={ Number( purchase.ID ) }
 					tracksProps={ { source: 'email-plan-view' } }
 					customLabel={ translate( 'Renew now' ) }
 				/>
@@ -102,7 +101,7 @@ export const EmailPlanSubscription = ( {
 				<AutoRenewToggle
 					planName={ selectedSite.plan?.product_name_short }
 					siteDomain={ selectedSite.domain }
-					purchase={ purchase.rawPurchase }
+					purchase={ purchase }
 					withTextStatus
 					toggleSource="email-plan-view"
 				/>

--- a/client/my-sites/email/email-management/home/email-plan/index.jsx
+++ b/client/my-sites/email/email-management/home/email-plan/index.jsx
@@ -8,10 +8,10 @@ import { useEffect, useState } from 'react';
 import titleCase from 'to-title-case';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteProducts from 'calypso/components/data/query-site-products';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import HeaderCake from 'calypso/components/header-cake';
 import VerticalNav from 'calypso/components/vertical-nav';
 import VerticalNavItem from 'calypso/components/vertical-nav/item';
+import { isExpiredOrRemoved } from 'calypso/dashboard/utils/purchase';
 import { useIsLoading as useAddEmailForwardMutationIsLoading } from 'calypso/data/emails/use-add-email-forward-mutation';
 import { useGetEmailAccountsQuery } from 'calypso/data/emails/use-get-email-accounts-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -23,7 +23,7 @@ import {
 	getProductType,
 	hasGSuiteWithUs,
 } from 'calypso/lib/gsuite';
-import { handleRenewNowClick, isExpiredOrRemoved } from 'calypso/lib/purchases';
+import { handleRenewNowClick } from 'calypso/lib/purchases';
 import {
 	getTitanProductName,
 	getTitanSubscriptionId,
@@ -34,10 +34,8 @@ import { TITAN_CONTROL_PANEL_CONTEXT_CREATE_EMAIL } from 'calypso/lib/titan/cons
 import { EmailPlanHeader } from 'calypso/my-sites/email/email-management/home/email-plan-header';
 import EmailPlanMailboxesList from 'calypso/my-sites/email/email-management/home/email-plan-mailboxes-list';
 import MailPoetUpsell from 'calypso/my-sites/email/email-management/home/mailpoet-upsell';
-import {
-	getEmailPurchaseByDomain,
-	hasEmailSubscription,
-} from 'calypso/my-sites/email/email-management/home/utils';
+import { useEmailPurchaseByDomain } from 'calypso/my-sites/email/email-management/home/use-email-purchase';
+import { hasEmailSubscription } from 'calypso/my-sites/email/email-management/home/utils';
 import {
 	getEmailManagementPath,
 	getAddEmailForwardsPath,
@@ -51,10 +49,6 @@ import {
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { successNotice } from 'calypso/state/notices/actions';
-import {
-	hasLoadedSitePurchasesFromServer,
-	isFetchingSitePurchases,
-} from 'calypso/state/purchases/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getSiteAvailableProduct } from 'calypso/state/sites/products/selectors';
 
@@ -128,10 +122,7 @@ function EmailPlan( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const purchase = useSelector( ( state ) => getEmailPurchaseByDomain( state, domain ) );
-	const isLoadingPurchase = useSelector(
-		( state ) => isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state )
-	);
+	const { purchase } = useEmailPurchaseByDomain( domain );
 	const currentRoute = useSelector( getCurrentRoute );
 	const canAddMailboxes = canAddMailboxesToEmailSubscription( domain );
 	const hasSubscription = hasEmailSubscription( domain );
@@ -144,9 +135,7 @@ function EmailPlan( {
 		event.preventDefault();
 
 		dispatch(
-			// Temporary bridge (SHILL-2256): this page still reads the camelCase
-			// Purchase from Redux. Remove once it reads the raw shape.
-			handleRenewNowClick( purchase.rawPurchase, selectedSite.slug, {
+			handleRenewNowClick( purchase, selectedSite.slug, {
 				tracksProps: { source: 'email-plan-view' },
 			} )
 		);
@@ -279,7 +268,7 @@ function EmailPlan( {
 
 	function renderViewBillingAndPaymentSettingsNavItem() {
 		const managePurchaseUrl = purchase
-			? getManagePurchaseUrlFor( selectedSite.slug, purchase.id )
+			? getManagePurchaseUrlFor( selectedSite.slug, purchase.ID )
 			: '';
 
 		if ( ! hasSubscription || ! purchase ) {
@@ -366,7 +355,6 @@ function EmailPlan( {
 	return (
 		<>
 			{ selectedSite && <QuerySiteProducts siteId={ selectedSite.ID } /> }
-			{ selectedSite && hasSubscription && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 			<DocumentHead title={ titleCase( getHeaderText() ) } />
 			{ ! hideMailPoetUpsell && <MailPoetUpsell /> }
 			{ ! hideHeaderCake && <HeaderCake onClick={ handleBack }>{ getHeaderText() }</HeaderCake> }
@@ -375,8 +363,6 @@ function EmailPlan( {
 					domain={ domain }
 					hasEmailSubscription={ hasSubscription }
 					isLoadingEmails={ isLoading }
-					isLoadingPurchase={ isLoadingPurchase }
-					purchase={ purchase }
 					selectedSite={ selectedSite }
 					emailAccount={ getAccount( emailAccounts ) }
 				/>

--- a/client/my-sites/email/email-management/home/use-email-purchase.ts
+++ b/client/my-sites/email/email-management/home/use-email-purchase.ts
@@ -1,0 +1,24 @@
+import { purchaseQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { getEmailSubscriptionIdByDomain } from 'calypso/my-sites/email/email-management/home/utils';
+import type { Purchase } from '@automattic/api-core';
+import type { ResponseDomain } from 'calypso/lib/domains/types';
+
+/**
+ * Fetches the email purchase associated with the specified domain.
+ */
+export function useEmailPurchaseByDomain( domain: ResponseDomain ): {
+	purchase: Purchase | undefined;
+	isLoadingPurchase: boolean;
+} {
+	const subscriptionId = getEmailSubscriptionIdByDomain( domain );
+
+	const { data: purchase, isPending } = useQuery( {
+		...purchaseQuery( subscriptionId as number ),
+		enabled: Boolean( subscriptionId ),
+	} );
+
+	// A disabled query stays `pending` forever, so a domain without an email
+	// subscription must not read as perpetually loading.
+	return { purchase, isLoadingPurchase: Boolean( subscriptionId ) && isPending };
+}

--- a/client/my-sites/email/email-management/home/utils.ts
+++ b/client/my-sites/email/email-management/home/utils.ts
@@ -22,10 +22,8 @@ import {
 	getTitanSubscriptionId,
 	hasTitanMailWithUs,
 } from 'calypso/lib/titan';
-import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import type { EmailAccount } from 'calypso/data/emails/types';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
-import type { AppState } from 'calypso/types';
 
 export function getNumberOfMailboxesText( domain: ResponseDomain ) {
 	if ( hasGSuiteWithUs( domain ) ) {
@@ -65,23 +63,11 @@ export function getNumberOfMailboxesText( domain: ResponseDomain ) {
 }
 
 /**
- * Retrieves the email purchase associated to the specified domain.
- * @param state - global Redux state
- * @param domain - domain object
- * @returns the corresponding email purchase, or null if not found
- */
-export function getEmailPurchaseByDomain( state: AppState, domain: ResponseDomain ) {
-	const subscriptionId = getEmailSubscriptionIdByDomain( domain );
-
-	return subscriptionId ? getByPurchaseId( state, subscriptionId ) : null;
-}
-
-/**
  * Retrieves the identifier of the email subscription for the specified domain.
  * @param domain - domain object
  * @returns the corresponding subscription id, or null if not found
  */
-function getEmailSubscriptionIdByDomain( domain: ResponseDomain ) {
+export function getEmailSubscriptionIdByDomain( domain: ResponseDomain ) {
 	let subscriptionId = null;
 
 	if ( hasGSuiteWithUs( domain ) ) {

--- a/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
+++ b/client/my-sites/email/email-management/titan-manage-mailboxes/index.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 import titleCase from 'to-title-case';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
@@ -25,18 +24,11 @@ import {
 } from 'calypso/lib/titan/constants';
 import EmailHeader from 'calypso/my-sites/email/email-header';
 import { EmailPlanHeader } from 'calypso/my-sites/email/email-management/home/email-plan-header';
-import {
-	getEmailPurchaseByDomain,
-	hasEmailSubscription,
-} from 'calypso/my-sites/email/email-management/home/utils';
+import { hasEmailSubscription } from 'calypso/my-sites/email/email-management/home/utils';
 import {
 	getEmailManagementPath,
 	getTitanControlPanelRedirectPath,
 } from 'calypso/my-sites/email/paths';
-import {
-	hasLoadedSitePurchasesFromServer,
-	isFetchingSitePurchases,
-} from 'calypso/state/purchases/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import { getDomainsBySite } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -52,8 +44,6 @@ class TitanManageMailboxes extends Component {
 		currentRoute: PropTypes.string.isRequired,
 		domain: PropTypes.object,
 		hasSubscription: PropTypes.bool.isRequired,
-		isLoadingPurchase: PropTypes.bool.isRequired,
-		purchase: PropTypes.object,
 		selectedSite: PropTypes.object.isRequired,
 
 		// Props injected via localize()
@@ -153,14 +143,11 @@ class TitanManageMailboxes extends Component {
 	};
 
 	render() {
-		const { domain, hasSubscription, isLoadingPurchase, purchase, selectedSite, translate } =
-			this.props;
+		const { domain, hasSubscription, selectedSite, translate } = this.props;
 
 		return (
 			<>
 				{ selectedSite && <QuerySiteDomains siteId={ selectedSite.ID } /> }
-
-				{ selectedSite && hasSubscription && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 
 				<Main wideLayout>
 					<DocumentHead title={ titleCase( translate( 'Manage all mailboxes' ) ) } />
@@ -175,8 +162,6 @@ class TitanManageMailboxes extends Component {
 						domain={ domain }
 						hasEmailSubscription={ hasSubscription }
 						isLoadingEmails={ false }
-						isLoadingPurchase={ isLoadingPurchase }
-						purchase={ purchase }
 						selectedSite={ selectedSite }
 					/>
 
@@ -225,9 +210,6 @@ export default connect( ( state, ownProps ) => {
 		currentRoute: getCurrentRoute( state ),
 		domain,
 		hasSubscription: hasEmailSubscription( domain ),
-		isLoadingPurchase:
-			isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
-		purchase: getEmailPurchaseByDomain( state, domain ),
 		selectedSite,
 	};
 } )( localize( TitanManageMailboxes ) );


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2256

## Proposed changes

Moves the email management pages off the camelCase `Purchase` produced by the data-stores assembler and onto the raw snake_case `Purchase` from `@automattic/api-core`, fetched with TanStack Query instead of Redux. `RenewButton` comes along because the email subscription card feeds it — leaving it camelCase would have relocated a bridge rather than removed one.

* Replace the `getEmailPurchaseByDomain` Redux selector with a new `useEmailPurchaseByDomain( domain )` hook backed by `purchaseQuery`. The domain object already carries the email subscription id, so this fetches the one purchase directly rather than the whole site's purchases.
* Move the purchase fetch into `EmailPlanHeader` and drop its `purchase` / `isLoadingPurchase` props. Both callers only passed the value straight through, and this lets the still-class-based `TitanManageMailboxes` drop purchases from `mapStateToProps` entirely instead of gaining a container component.
* Convert `EmailPlanSubscription`, `EmailPlan` and `RenewButton` to the raw shape (`expiry_date`, `currency_code`, `is_auto_renew_enabled`, `ID`), inlining the renewal price as `sale_amount || amount` and sourcing `isExpiredOrRemoved` from `client/dashboard/utils/purchase`.
* Remove the now-redundant `<QuerySitePurchases />` fetch triggers from both email pages — nothing else under `client/my-sites/email` reads the Redux purchase selectors.
* Delete three `purchase.rawPurchase` bridges (the email renew handler, the `AutoRenewToggle` in the subscription card, and `RenewButton`'s own). `RenewButton`'s two remaining camelCase callers — `registered-domain-details` and the domain `security` page — bridge with `purchase?.rawPurchase ?? null` until the domain settings cluster migrates.

## Why are these changes being made?

The data-stores assembler (`createPurchaseObject`) exists only to rename the API's snake_case purchase fields into camelCase, which means every purchase-rendering surface in Calypso carries a duplicate `Purchase` type and an extra transformation the backend never asked for. SHILL-2256 removes it; the assembler stays alive until the last consumer migrates, so the work is landing page by page.

Email management is a self-contained cluster: a single selector fed three consumers, all of which passed the purchase into the same header component. That made it possible to delete the selector outright and let the component that actually renders the subscription fetch its own data, which removes a layer of prop drilling as a side effect. `RenewButton` was pulled in deliberately rather than bridged — it is the direct child of the email subscription card, so converting only the card would have moved a `createPurchaseObject` call into `client/my-sites/email` instead of deleting one.

The `<QuerySitePurchases />` removals are safe because these pages fetched the entire site's purchase list purely to look up one subscription by id; `purchaseQuery` asks the API for exactly that purchase.

## Testing instructions

No test files exist for any of the touched components, so no new coverage was added. The surrounding suites confirm nothing regressed:

TC:
```
yarn test-client client/my-sites/email client/my-sites/domains/domain-management client/me/purchases
```

Manual testing:

* Use a Simple site with an active Professional Email (Titan) or Google Workspace subscription.
* Go to **Upgrades → Emails** and open the domain. The subscription card should show the correct copy and price: "Renews on {date} for {price}" when auto-renew is on, "Expires on {date}." when it is off, "Expired on {date}." once past expiry.
* Toggle auto-renew off and back on. The card copy should switch between the "Renews on" and "Expires on" variants.
* Click **Renew now** and confirm checkout opens with the correct email subscription in the cart at the right price.
* Click **View billing and payment settings** and confirm it lands on the correct Manage Purchase page for that subscription.
* For a Titan subscription, open **Manage all mailboxes** and confirm the same subscription card renders there.
* Regression check for the shared `RenewButton`: on **Domains → {domain} → Settings**, confirm the renew button shows the correct price and starts a renewal; and on an expired domain's **Security** page (HTTPS disabled notice), confirm the reactivate/renew button still shows the correct price.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
