### PR TITLE
Signup: brand the create account page as the Jetpack app

### DIFF
--- a/client/lib/oauth2-clients.js
+++ b/client/lib/oauth2-clients.js
@@ -115,8 +115,9 @@ const fullyDecode = ( value ) => {
 	return decoded;
 };
 
-// Reads the app's OAuth2 callback (redirect_uri) out of a login query. It is
-// nested inside redirect_to, but may also appear as a direct query param.
+// Reads the app's OAuth2 callback (redirect_uri) out of a login or signup query.
+// It may appear as a direct query param, nested inside redirect_to (login), or
+// nested inside oauth2_redirect (signup, see getSignupUrl).
 export const getOAuth2RedirectUri = ( query ) => {
 	if ( ! query ) {
 		return null;
@@ -124,11 +125,16 @@ export const getOAuth2RedirectUri = ( query ) => {
 	if ( typeof query.redirect_uri === 'string' ) {
 		return query.redirect_uri;
 	}
-	if ( typeof query.redirect_to !== 'string' ) {
-		return null;
+	for ( const param of [ 'redirect_to', 'oauth2_redirect' ] ) {
+		if ( typeof query[ param ] !== 'string' ) {
+			continue;
+		}
+		const redirectUri = getQueryArg( query[ param ], 'redirect_uri' );
+		if ( typeof redirectUri === 'string' ) {
+			return redirectUri;
+		}
 	}
-	const redirectUri = getQueryArg( query.redirect_to, 'redirect_uri' );
-	return typeof redirectUri === 'string' ? redirectUri : null;
+	return null;
 };
 
 export const isJetpackAppRedirectUri = ( redirectUri ) => {

--- a/client/lib/test/oauth2-clients.js
+++ b/client/lib/test/oauth2-clients.js
@@ -60,6 +60,15 @@ describe( 'oauth2-clients mobile app helpers', () => {
 			expect( getOAuth2RedirectUri( query ) ).toBe( 'jetpack://oauth2-callback' );
 		} );
 
+		test( 'extracts redirect_uri nested inside oauth2_redirect on signup pages', () => {
+			const query = {
+				oauth2_client_id: '11',
+				oauth2_redirect:
+					'https://public-api.wordpress.com/oauth2/authorize?client_id=11&response_type=code&redirect_uri=jetpack%3A%2F%2Foauth2-callback',
+			};
+			expect( getOAuth2RedirectUri( query ) ).toBe( 'jetpack://oauth2-callback' );
+		} );
+
 		test( 'prefers a direct redirect_uri query param when present', () => {
 			const query = { redirect_uri: 'wordpress://oauth2-callback', redirect_to: 'https://x/?y=1' };
 			expect( getOAuth2RedirectUri( query ) ).toBe( 'wordpress://oauth2-callback' );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -28,6 +28,7 @@ import { getPartnerAllowedSocialServices } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
 import LoginContextProvider, { useLoginContext } from 'calypso/login/login-context';
 import OneLoginLayout from 'calypso/login/wp-login/components/one-login-layout';
+import { getMobileAppClientName } from 'calypso/login/wp-login/hooks/get-header-text';
 import getHeadingSubText from 'calypso/login/wp-login/hooks/get-heading-subtext';
 import getNoThanksRedirectUrl from 'calypso/login/wp-login/hooks/get-no-thanks-redirect';
 import flows from 'calypso/signup/config/flows';
@@ -48,6 +49,7 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getIsAkismet from 'calypso/state/selectors/get-is-akismet';
 import getIsBlazePro from 'calypso/state/selectors/get-is-blaze-pro';
+import getIsJetpackApp from 'calypso/state/selectors/get-is-jetpack-app';
 import getIsWoo from 'calypso/state/selectors/get-is-woo';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
@@ -438,7 +440,14 @@ export class UserStep extends Component {
 			isJetpackCloud,
 			isStudioApp,
 			isBlazePro,
+			isJetpackApp,
 		} = this.props;
+
+		const mobileAppClientName = getMobileAppClientName( {
+			oauth2Client,
+			isJetpackApp,
+			translate,
+		} );
 
 		/**
 		 * BEGIN: Unified create account
@@ -453,12 +462,15 @@ export class UserStep extends Component {
 					isA4A ||
 					isBlazePro ||
 					isJetpackCloud ||
-					isStudioApp ) ) ||
+					isStudioApp ||
+					mobileAppClientName ) ) ||
 			isAkismet
 		) {
 			let clientName = oauth2Client?.name;
 
-			if ( isAkismet ) {
+			if ( mobileAppClientName ) {
+				clientName = mobileAppClientName;
+			} else if ( isAkismet ) {
 				clientName = 'Akismet';
 			} else if ( isA4A ) {
 				clientName = 'Automattic for Agencies';
@@ -474,7 +486,15 @@ export class UserStep extends Component {
 				text: 'Sign up for {{span}}%(client)s{{/span}} with WordPress.com',
 				newCopy: translate( 'Sign up for {{span}}%(client)s{{/span}} with WordPress.com', {
 					args: { client: clientName },
-					components: { span: <span className="wp-login__one-login-header-client-name" /> },
+					components: {
+						span: (
+							<span
+								className={ clsx( 'wp-login__one-login-header-client-name', {
+									'is-exact-case': !! mobileAppClientName,
+								} ) }
+							/>
+						),
+					},
 				} ),
 				oldCopy: translate( 'Create your account' ),
 			} );
@@ -716,6 +736,7 @@ const ConnectedUser = connect(
 			isVIPClient,
 			isJetpackCloud,
 			isStudioApp,
+			isJetpackApp: getIsJetpackApp( state ),
 		};
 	},
 	{

--- a/client/state/selectors/test/get-is-jetpack-app.js
+++ b/client/state/selectors/test/get-is-jetpack-app.js
@@ -1,6 +1,6 @@
 import getIsJetpackApp from 'calypso/state/selectors/get-is-jetpack-app';
 
-const buildState = ( { clientId, redirectTo, initialRedirectTo } ) => ( {
+const buildState = ( { clientId, redirectTo, oauth2Redirect, initialRedirectTo } ) => ( {
 	oauth2Clients: {
 		ui: { currentClientId: clientId ?? null },
 		clients: clientId ? { [ clientId ]: { id: clientId } } : {},
@@ -10,6 +10,7 @@ const buildState = ( { clientId, redirectTo, initialRedirectTo } ) => ( {
 			current: {
 				...( clientId ? { client_id: String( clientId ) } : {} ),
 				...( redirectTo ? { redirect_to: redirectTo } : {} ),
+				...( oauth2Redirect ? { oauth2_redirect: oauth2Redirect } : {} ),
 			},
 			...( initialRedirectTo
 				? { initial: { client_id: String( clientId ), redirect_to: initialRedirectTo } }
@@ -78,6 +79,29 @@ describe( 'getIsJetpackApp', () => {
 			} ),
 		} );
 		expect( getIsJetpackApp( state ) ).toBe( true );
+	} );
+
+	test( 'is true on the signup page, where the redirect_uri is nested inside oauth2_redirect', () => {
+		// getSignupUrl sends OAuth2 clients to /start/wpcc?oauth2_client_id=…&oauth2_redirect=<login redirect_to>.
+		const state = buildState( {
+			clientId: 11,
+			oauth2Redirect: authorizeUrl( {
+				clientId: 11,
+				redirectUri: 'jetpack%3A%2F%2Foauth2-callback',
+			} ),
+		} );
+		expect( getIsJetpackApp( state ) ).toBe( true );
+	} );
+
+	test( 'is false on the signup page for the WordPress app', () => {
+		const state = buildState( {
+			clientId: 2697,
+			oauth2Redirect: authorizeUrl( {
+				clientId: 2697,
+				redirectUri: 'wordpress%3A%2F%2Foauth2-callback',
+			} ),
+		} );
+		expect( getIsJetpackApp( state ) ).toBe( false );
 	} );
 
 	test( 'is false when there is no current OAuth2 client', () => {


### PR DESCRIPTION
Fixes CMM-2365

## Proposed Changes

* `getOAuth2RedirectUri` now also reads the app's `redirect_uri` when it is nested inside `oauth2_redirect`, which is how the login page's "Create an account" link passes it to `/start/wpcc`. This makes `getIsJetpackApp` work on the signup page, so the shared `HeadingLogo` shows the Jetpack app icon.
* The signup user step's header now uses `getMobileAppClientName` for the shared mobile app OAuth2 clients, so the title reads "Sign up for Jetpack for iOS with WordPress.com" (or WordPress / Android) instead of the raw client title from the API. The mobile app name opts out of the header's `text-transform: capitalize` via the existing `is-exact-case` class, as on the login page.
* Unit tests for the new `oauth2_redirect` handling in `getOAuth2RedirectUri` and `getIsJetpackApp`.

## Why are these changes being made?

#112392, #112439 and #112448 branded the login and 2FA screens for the Jetpack app by detecting its `jetpack://` redirect URI in `redirect_uri` or `redirect_to`. The signup page reached from the login page's "Create an account" link carries that URI inside `oauth2_redirect` instead, so detection failed there and the page fell back to the WordPress app name and icon.

## Testing Instructions

Prefix each path with your dev host. The client ID is shared by both apps; only the `redirect_uri` scheme inside `oauth2_redirect` differs.

Jetpack iOS: expect "Sign up for Jetpack for iOS with WordPress.com" and the Jetpack app icon.

```
/start/wpcc?oauth2_client_id=11&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D11%26response_type%3Dcode%26scope%3Dglobal%26redirect_uri%3Djetpack%253A%252F%252Foauth2-callback
```

WordPress iOS: expect "Sign up for WordPress for iOS with WordPress.com" and the WordPress app icon.

```
/start/wpcc?oauth2_client_id=11&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D11%26response_type%3Dcode%26scope%3Dglobal%26redirect_uri%3Dwordpress%253A%252F%252Foauth2-callback
```

For Android, use `oauth2_client_id=2697` and `client_id%3D2697`; expect "Jetpack for Android" / "WordPress for Android".

Full path as the app does it: open the login page below, then tap "Create an account". It should land on the Jetpack iOS URL above.

```
/log-in?client_id=11&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D11%26response_type%3Dcode%26scope%3Dglobal%26redirect_uri%3Djetpack%253A%252F%252Foauth2-callback
```

On trunk, all signup variants show the WordPress icon and the API's stored client title.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
