### PR TITLE
Dashboard: improve Sentry reporting for browser-translation crashes

### DIFF
--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -41,8 +41,6 @@ function boot( config: AppConfig ) {
 		throw new Error( 'No root element found' );
 	}
 	const root = createRoot( rootElement, {
-		// Report commit-phase crashes that bypass every error boundary (e.g.
-		// browser-translation DOM interference). See DOTMSD-1514.
 		onUncaughtError: handleUncaughtError,
 	} );
 

--- a/client/dashboard/app/boot.tsx
+++ b/client/dashboard/app/boot.tsx
@@ -11,6 +11,7 @@ import { AUTH_QUERY_KEY, initializeCurrentUser } from './auth';
 import { handleOAuthCallback } from './auth/oauth-callback';
 import { loadPreferencesHelper } from './dev-tools/preferences';
 import Layout from './layout';
+import { handleUncaughtError } from './logger';
 import { omnibarEvents } from './omnibar/events';
 import limitTotalSnackbars from './snackbars/limit-total-snackbars';
 import type { AppConfig } from './context';
@@ -39,7 +40,11 @@ function boot( config: AppConfig ) {
 	if ( rootElement === null ) {
 		throw new Error( 'No root element found' );
 	}
-	const root = createRoot( rootElement );
+	const root = createRoot( rootElement, {
+		// Report commit-phase crashes that bypass every error boundary (e.g.
+		// browser-translation DOM interference). See DOTMSD-1514.
+		onUncaughtError: handleUncaughtError,
+	} );
 
 	if ( isEnabled( 'dashboard/omnibar-radical' ) ) {
 		import( './omnibar' ).then( ( m ) => m.default( config ) ).catch( captureException );

--- a/client/dashboard/app/logger/component-stack.ts
+++ b/client/dashboard/app/logger/component-stack.ts
@@ -1,0 +1,50 @@
+// The exception stacktrace for translation-induced commit crashes is ~50 frames
+// of react-dom internals, identical for every crash site, so Sentry groups them
+// all into one issue (CALYPSO-3G00). Shaping the React component stack as a
+// synthetic error's `.stack` and chaining it via `cause` gives Sentry
+// symbolicable, in-app `client/dashboard/…` frames to group on instead, splitting
+// the mega-issue per failing component. The default LinkedErrors integration
+// (@sentry/react v7, key `cause`) turns the chained error into a grouped
+// exception. See DOTMSD-1514.
+
+// Trim to the innermost frames: full chains drag in shared router/layout ancestry
+// and distort grouping.
+const MAX_COMPONENT_STACK_FRAMES = 8;
+
+/**
+ * Attach a React component stack to an error as a chained `cause` exception so
+ * Sentry symbolicates and groups by the failing component.
+ */
+export function attachComponentStackAsCause( error: Error, componentStack?: string | null ) {
+	if ( ! componentStack ) {
+		return;
+	}
+
+	// Don't clobber an existing cause chain.
+	if ( ( error as { cause?: unknown } ).cause != null ) {
+		return;
+	}
+
+	const frames = componentStack
+		.split( '\n' )
+		.map( ( line ) => line.trim() )
+		.filter( ( line ) => line.startsWith( 'at ' ) )
+		.slice( 0, MAX_COMPONENT_STACK_FRAMES );
+
+	if ( frames.length === 0 ) {
+		return;
+	}
+
+	const cause = new Error( 'React was rendering this component tree when the error was thrown' );
+	cause.name = 'ReactComponentStack';
+	cause.stack = [
+		`${ cause.name }: ${ cause.message }`,
+		...frames.map( ( frame ) => `    ${ frame }` ),
+	].join( '\n' );
+
+	try {
+		( error as { cause?: unknown } ).cause = cause;
+	} catch {
+		// Some exotic error objects expose a read-only `cause`; leave them as-is.
+	}
+}

--- a/client/dashboard/app/logger/component-stack.ts
+++ b/client/dashboard/app/logger/component-stack.ts
@@ -1,46 +1,48 @@
 // The exception stacktrace for translation-induced commit crashes is ~50 frames
 // of react-dom internals, identical for every crash site, so Sentry groups them
-// all into one issue. Shaping the React component stack as a synthetic error's
-// `.stack` and chaining it via `cause` gives Sentry symbolicable, in-app
-// `client/dashboard/…` frames to group on instead, splitting the mega-issue per
-// failing component.
+// all into one issue. Appending the innermost React components to the Sentry
+// fingerprint splits that mega-issue per failing component, without touching
+// `exception.values` — Sentry's Dedupe and InboundFilters integrations both key
+// exclusively on `values[0]`, so injecting a synthetic frame there would drop
+// distinct errors and stop `denyUrls` filtering extension noise.
 
-const MAX_COMPONENT_STACK_FRAMES = 8;
+const MAX_FINGERPRINT_COMPONENTS = 3;
 
 /**
- * Attach a React component stack to an error as a chained `cause` exception so
- * Sentry symbolicates and groups by the failing component.
+ * React derives component-stack frame shape from the host engine: V8 emits
+ * `at Name (url)`, SpiderMonkey and JavaScriptCore emit `Name@url`, and some
+ * engines emit a bare `Name`. Host elements (`div`, `span`) come through
+ * lowercase and are identical across crash sites, so only capitalised React
+ * component names are kept.
  */
-export function attachComponentStackAsCause( error: Error, componentStack?: string | null ) {
+function parseComponentNames( componentStack: string ): string[] {
+	const names: string[] = [];
+
+	for ( const line of componentStack.split( '\n' ) ) {
+		const name = line.trim().match( /^(?:at\s+)?([A-Za-z0-9_$.]+)/ )?.[ 1 ];
+		if ( name && /^[A-Z]/.test( name ) ) {
+			names.push( name );
+		}
+	}
+
+	return names;
+}
+
+/**
+ * Build a Sentry fingerprint that keeps the default grouping but splits it by
+ * the innermost React components on the stack.
+ */
+export function getComponentStackFingerprint(
+	componentStack?: string | null
+): string[] | undefined {
 	if ( ! componentStack ) {
-		return;
+		return undefined;
 	}
 
-	// Don't clobber existing cause chain.
-	if ( ( error as { cause?: unknown } ).cause != null ) {
-		return;
+	const names = parseComponentNames( componentStack ).slice( 0, MAX_FINGERPRINT_COMPONENTS );
+	if ( names.length === 0 ) {
+		return undefined;
 	}
 
-	const frames = componentStack
-		.split( '\n' )
-		.map( ( line ) => line.trim() )
-		.filter( ( line ) => line.startsWith( 'at ' ) )
-		.slice( 0, MAX_COMPONENT_STACK_FRAMES );
-
-	if ( frames.length === 0 ) {
-		return;
-	}
-
-	const cause = new Error( 'React was rendering this component tree when the error was thrown' );
-	cause.name = 'ReactComponentStack';
-	cause.stack = [
-		`${ cause.name }: ${ cause.message }`,
-		...frames.map( ( frame ) => `    ${ frame }` ),
-	].join( '\n' );
-
-	try {
-		( error as { cause?: unknown } ).cause = cause;
-	} catch {
-		// Some exotic error objects expose a read-only `cause`; leave them as-is.
-	}
+	return [ '{{ default }}', ...names ];
 }

--- a/client/dashboard/app/logger/component-stack.ts
+++ b/client/dashboard/app/logger/component-stack.ts
@@ -1,14 +1,10 @@
 // The exception stacktrace for translation-induced commit crashes is ~50 frames
 // of react-dom internals, identical for every crash site, so Sentry groups them
-// all into one issue (CALYPSO-3G00). Shaping the React component stack as a
-// synthetic error's `.stack` and chaining it via `cause` gives Sentry
-// symbolicable, in-app `client/dashboard/…` frames to group on instead, splitting
-// the mega-issue per failing component. The default LinkedErrors integration
-// (@sentry/react v7, key `cause`) turns the chained error into a grouped
-// exception. See DOTMSD-1514.
+// all into one issue. Shaping the React component stack as a synthetic error's
+// `.stack` and chaining it via `cause` gives Sentry symbolicable, in-app
+// `client/dashboard/…` frames to group on instead, splitting the mega-issue per
+// failing component.
 
-// Trim to the innermost frames: full chains drag in shared router/layout ancestry
-// and distort grouping.
 const MAX_COMPONENT_STACK_FRAMES = 8;
 
 /**
@@ -20,7 +16,7 @@ export function attachComponentStackAsCause( error: Error, componentStack?: stri
 		return;
 	}
 
-	// Don't clobber an existing cause chain.
+	// Don't clobber existing cause chain.
 	if ( ( error as { cause?: unknown } ).cause != null ) {
 		return;
 	}

--- a/client/dashboard/app/logger/dom-interference.ts
+++ b/client/dashboard/app/logger/dom-interference.ts
@@ -5,8 +5,6 @@
  * commit phase. Run only when an error is being reported.
  */
 
-const MAX_CUSTOM_ELEMENTS = 50;
-
 export interface DomInterferenceReport {
 	// Faceted in Sentry, so string-valued.
 	tags: Record< string, string >;
@@ -51,16 +49,15 @@ export function getDomInterferenceReport(): DomInterferenceReport {
 
 		tags.dom_doc_lang = html.lang || '';
 
+		// Every probe above keys on a DOM artefact only Chromium and extension
+		// translators leave behind. Safari and Firefox translate text nodes in
+		// place with no marker, so a `false` there means "undetectable", not
+		// "not translated".
+		tags.dom_probe_coverage = /Chrome|Chromium|Edg\//.test( navigator.userAgent )
+			? 'full'
+			: 'partial';
+
 		context.fontCount = document.querySelectorAll< Element >( 'font' ).length;
-		context.navigatorLanguages = Array.from( navigator.languages ?? [] );
-		// Custom-element tag names catch unknown extensions injecting web components.
-		context.customElements = Array.from(
-			new Set(
-				Array.from( document.querySelectorAll( '*' ) )
-					.map( ( element ) => element.tagName.toLowerCase() )
-					.filter( ( name ) => name.includes( '-' ) )
-			)
-		).slice( 0, MAX_CUSTOM_ELEMENTS );
 	} catch {
 		// Diagnostics must never throw while an error is already being reported.
 	}

--- a/client/dashboard/app/logger/dom-interference.ts
+++ b/client/dashboard/app/logger/dom-interference.ts
@@ -2,10 +2,9 @@
  * Cheap, one-off DOM probes that fingerprint page-mutating agents (browser
  * translation, extensions) which reparent React-managed text nodes and cause
  * `NotFoundError: Failed to execute 'insertBefore' on 'Node'` crashes in React's
- * commit phase. Run only when an error is being reported. See DOTMSD-1514.
+ * commit phase. Run only when an error is being reported.
  */
 
-const MAX_ATTR_VALUE_LENGTH = 100;
 const MAX_CUSTOM_ELEMENTS = 50;
 
 export interface DomInterferenceReport {
@@ -13,18 +12,6 @@ export interface DomInterferenceReport {
 	tags: Record< string, string >;
 	// Richer detail, attached as a Sentry context and to logstash.
 	context: Record< string, unknown >;
-}
-
-function dumpAttributes( element: Element | null | undefined ): Record< string, string > {
-	const dump: Record< string, string > = {};
-	if ( ! element ) {
-		return dump;
-	}
-	for ( const attribute of Array.from( element.attributes ) ) {
-		// Attribute values can, in rare cases, hold user content; cap length as PII mitigation.
-		dump[ attribute.name ] = attribute.value.slice( 0, MAX_ATTR_VALUE_LENGTH );
-	}
-	return dump;
 }
 
 /**
@@ -64,8 +51,6 @@ export function getDomInterferenceReport(): DomInterferenceReport {
 
 		tags.dom_doc_lang = html.lang || '';
 
-		context.documentElementAttributes = dumpAttributes( html );
-		context.bodyAttributes = dumpAttributes( document.body );
 		context.fontCount = document.querySelectorAll< Element >( 'font' ).length;
 		context.navigatorLanguages = Array.from( navigator.languages ?? [] );
 		// Custom-element tag names catch unknown extensions injecting web components.

--- a/client/dashboard/app/logger/dom-interference.ts
+++ b/client/dashboard/app/logger/dom-interference.ts
@@ -1,0 +1,84 @@
+/**
+ * Cheap, one-off DOM probes that fingerprint page-mutating agents (browser
+ * translation, extensions) which reparent React-managed text nodes and cause
+ * `NotFoundError: Failed to execute 'insertBefore' on 'Node'` crashes in React's
+ * commit phase. Run only when an error is being reported. See DOTMSD-1514.
+ */
+
+const MAX_ATTR_VALUE_LENGTH = 100;
+const MAX_CUSTOM_ELEMENTS = 50;
+
+export interface DomInterferenceReport {
+	// Faceted in Sentry, so string-valued.
+	tags: Record< string, string >;
+	// Richer detail, attached as a Sentry context and to logstash.
+	context: Record< string, unknown >;
+}
+
+function dumpAttributes( element: Element | null | undefined ): Record< string, string > {
+	const dump: Record< string, string > = {};
+	if ( ! element ) {
+		return dump;
+	}
+	for ( const attribute of Array.from( element.attributes ) ) {
+		// Attribute values can, in rare cases, hold user content; cap length as PII mitigation.
+		dump[ attribute.name ] = attribute.value.slice( 0, MAX_ATTR_VALUE_LENGTH );
+	}
+	return dump;
+}
+
+/**
+ * Collect a fingerprint of DOM-mutating agents active on the page at error time.
+ */
+export function getDomInterferenceReport(): DomInterferenceReport {
+	const tags: Record< string, string > = {};
+	const context: Record< string, unknown > = {};
+
+	try {
+		const html = document.documentElement;
+
+		// Google Translate: toggles translated-ltr/rtl on <html> and wraps text in <font>.
+		tags.dom_google_translate = String(
+			html.classList.contains( 'translated-ltr' ) ||
+				html.classList.contains( 'translated-rtl' ) ||
+				document.querySelector( 'font[style*="vertical-align"]' ) !== null
+		);
+
+		// Edge built-in translate: stamps _msttexthash attributes on translated nodes.
+		tags.dom_ms_translate = String( document.querySelector( '[_msttexthash]' ) !== null );
+
+		// Immersive Translate extension.
+		tags.dom_immersive_translate = String(
+			document.querySelector( '[class*="immersive-translate"]' ) !== null
+		);
+
+		// Grammarly.
+		tags.dom_grammarly = String(
+			document.querySelector(
+				'[data-gr-ext-installed], grammarly-extension, grammarly-desktop-integration'
+			) !== null
+		);
+
+		// Dark Reader.
+		tags.dom_dark_reader = String( document.querySelector( 'style.darkreader' ) !== null );
+
+		tags.dom_doc_lang = html.lang || '';
+
+		context.documentElementAttributes = dumpAttributes( html );
+		context.bodyAttributes = dumpAttributes( document.body );
+		context.fontCount = document.querySelectorAll< Element >( 'font' ).length;
+		context.navigatorLanguages = Array.from( navigator.languages ?? [] );
+		// Custom-element tag names catch unknown extensions injecting web components.
+		context.customElements = Array.from(
+			new Set(
+				Array.from( document.querySelectorAll( '*' ) )
+					.map( ( element ) => element.tagName.toLowerCase() )
+					.filter( ( name ) => name.includes( '-' ) )
+			)
+		).slice( 0, MAX_CUSTOM_ELEMENTS );
+	} catch {
+		// Diagnostics must never throw while an error is already being reported.
+	}
+
+	return { tags, context };
+}

--- a/client/dashboard/app/logger/index.tsx
+++ b/client/dashboard/app/logger/index.tsx
@@ -4,6 +4,8 @@ import { captureException } from '@automattic/calypso-sentry';
 import { camelToSnakeCase } from '@automattic/js-utils';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { maybeReloadForChunkError } from '../chunk-load-recovery';
+import { attachComponentStackAsCause } from './component-stack';
+import { getDomInterferenceReport } from './dom-interference';
 import type { AnyRouter } from '@tanstack/react-router';
 import type { ErrorInfo } from 'react';
 
@@ -39,15 +41,24 @@ function isBenignError( error: Error ) {
 	return false;
 }
 
-export function handleOnCatch(
+interface ReportOptions {
+	severity: 'error' | 'debug';
+	dashboard_backport?: boolean;
+	calypso_section?: string;
+	routeParams?: Record< string, unknown >;
+	previousPath?: string;
+}
+
+/**
+ * Shared reporting path for dashboard errors, whether caught by a router/error
+ * boundary or by React's root `onUncaughtError` handler. Enriches every report
+ * with a DOM-interference fingerprint and a chained, symbolicable component
+ * stack. See DOTMSD-1514.
+ */
+function reportDashboardError(
 	error: Error,
-	errorInfo: ErrorInfo,
-	router: AnyRouter,
-	options: {
-		severity: 'error' | 'debug';
-		dashboard_backport?: boolean;
-		calypso_section?: string;
-	}
+	componentStack: string | null | undefined,
+	options: ReportOptions
 ) {
 	// A failed chunk load is usually a stale deploy, not a real error. Reload
 	// once to fetch fresh chunks instead of logging and showing an error page.
@@ -59,15 +70,7 @@ export function handleOnCatch(
 		return;
 	}
 
-	const lastMatch = router.state.matches[ router.state.matches.length - 1 ];
-	const routeParams = Object.fromEntries(
-		Object.entries( lastMatch.params ?? {} ).map( ( [ key, value ] ) => [
-			camelToSnakeCase( key ),
-			value,
-		] )
-	);
-
-	const previousPath = previousPaths.get( router );
+	const domInterference = getDomInterferenceReport();
 
 	logToLogstash( {
 		feature: 'calypso_client',
@@ -78,21 +81,83 @@ export function handleOnCatch(
 			dashboard_backport: options.dashboard_backport,
 			env_id: calypsoConfig( 'env_id' ),
 			message: error.message,
-			stack: errorInfo.componentStack,
+			stack: componentStack,
 			path: window.location.href,
-			previous_path: previousPath,
-			params: routeParams,
+			previous_path: options.previousPath,
+			params: options.routeParams,
+			...domInterference.tags,
+			dom_interference: domInterference.context,
 		},
 	} );
 
 	// Dashboard backport has its mechanism to send error log to sentry.
-	if ( ! options.dashboard_backport ) {
-		captureException( error, {
-			tags: {
-				calypso_section: options.calypso_section,
-				...routeParams,
-			},
-			extra: { previous_path: previousPath },
-		} );
+	if ( options.dashboard_backport ) {
+		return;
 	}
+
+	attachComponentStackAsCause( error, componentStack );
+
+	captureException( error, {
+		tags: {
+			calypso_section: options.calypso_section,
+			...options.routeParams,
+			...domInterference.tags,
+		},
+		...( options.previousPath ? { extra: { previous_path: options.previousPath } } : {} ),
+		contexts: {
+			'dom-interference': domInterference.context,
+			...( componentStack ? { react: { componentStack } } : {} ),
+		},
+	} );
+}
+
+export function handleOnCatch(
+	error: Error,
+	errorInfo: ErrorInfo,
+	router: AnyRouter,
+	options: {
+		severity: 'error' | 'debug';
+		dashboard_backport?: boolean;
+		calypso_section?: string;
+	}
+) {
+	const lastMatch = router.state.matches[ router.state.matches.length - 1 ];
+	const routeParams = Object.fromEntries(
+		Object.entries( lastMatch?.params ?? {} ).map( ( [ key, value ] ) => [
+			camelToSnakeCase( key ),
+			value,
+		] )
+	);
+
+	reportDashboardError( error, errorInfo.componentStack, {
+		severity: options.severity,
+		dashboard_backport: options.dashboard_backport,
+		calypso_section: options.calypso_section,
+		routeParams,
+		previousPath: previousPaths.get( router ),
+	} );
+}
+
+/**
+ * Handler for React 19's root `onUncaughtError`. Captures commit-phase crashes
+ * that bypass every error boundary (the `handled:no` subset in Sentry), which
+ * otherwise arrive as bare `window.onerror` events with no component or route
+ * context. React no longer rethrows to `window.onerror` once this is provided,
+ * so this is the only reporting path for those errors.
+ */
+export function handleUncaughtError( error: unknown, errorInfo: { componentStack?: string } ) {
+	try {
+		const normalizedError = error instanceof Error ? error : new Error( String( error ) );
+		reportDashboardError( normalizedError, errorInfo.componentStack, {
+			severity: calypsoConfig( 'env_id' ) === 'dashboard-production' ? 'error' : 'debug',
+			calypso_section: 'dashboard',
+		} );
+	} catch {
+		// A throwing error handler would replace the original crash with a less
+		// useful one. Swallow.
+	}
+
+	// Preserve React's default console reporting for uncaught errors.
+	// eslint-disable-next-line no-console
+	console.error( error );
 }

--- a/client/dashboard/app/logger/index.tsx
+++ b/client/dashboard/app/logger/index.tsx
@@ -50,12 +50,11 @@ interface ReportOptions {
 }
 
 /**
- * Shared reporting path for dashboard errors, whether caught by a router/error
- * boundary or by React's root `onUncaughtError` handler. Enriches every report
- * with a DOM-interference fingerprint and a chained, symbolicable component
- * stack. See DOTMSD-1514.
+ * Shared entry point for dashboard errors, whether caught by a router/error
+ * boundary or by React's root `onUncaughtError` handler. Decides whether an
+ * error is worth reporting, then delegates to `reportDashboardError`.
  */
-function reportDashboardError(
+function handleDashboardError(
 	error: Error,
 	componentStack: string | null | undefined,
 	options: ReportOptions
@@ -70,6 +69,18 @@ function reportDashboardError(
 		return;
 	}
 
+	reportDashboardError( error, componentStack, options );
+}
+
+/**
+ * Enriches every report with a DOM-interference fingerprint and a chained,
+ * symbolicable component stack.
+ */
+function reportDashboardError(
+	error: Error,
+	componentStack: string | null | undefined,
+	options: ReportOptions
+) {
 	const domInterference = getDomInterferenceReport();
 
 	logToLogstash( {
@@ -129,7 +140,7 @@ export function handleOnCatch(
 		] )
 	);
 
-	reportDashboardError( error, errorInfo.componentStack, {
+	handleDashboardError( error, errorInfo.componentStack, {
 		severity: options.severity,
 		dashboard_backport: options.dashboard_backport,
 		calypso_section: options.calypso_section,
@@ -148,7 +159,7 @@ export function handleOnCatch(
 export function handleUncaughtError( error: unknown, errorInfo: { componentStack?: string } ) {
 	try {
 		const normalizedError = error instanceof Error ? error : new Error( String( error ) );
-		reportDashboardError( normalizedError, errorInfo.componentStack, {
+		handleDashboardError( normalizedError, errorInfo.componentStack, {
 			severity: calypsoConfig( 'env_id' ) === 'dashboard-production' ? 'error' : 'debug',
 			calypso_section: 'dashboard',
 		} );

--- a/client/dashboard/app/logger/index.tsx
+++ b/client/dashboard/app/logger/index.tsx
@@ -4,7 +4,7 @@ import { captureException } from '@automattic/calypso-sentry';
 import { camelToSnakeCase } from '@automattic/js-utils';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { maybeReloadForChunkError } from '../chunk-load-recovery';
-import { attachComponentStackAsCause } from './component-stack';
+import { getComponentStackFingerprint } from './component-stack';
 import { getDomInterferenceReport } from './dom-interference';
 import type { AnyRouter } from '@tanstack/react-router';
 import type { ErrorInfo } from 'react';
@@ -47,6 +47,7 @@ interface ReportOptions {
 	calypso_section?: string;
 	routeParams?: Record< string, unknown >;
 	previousPath?: string;
+	mechanism?: { type: string; handled: boolean };
 }
 
 /**
@@ -73,8 +74,8 @@ function handleDashboardError(
 }
 
 /**
- * Enriches every report with a DOM-interference fingerprint and a chained,
- * symbolicable component stack.
+ * Enriches every report with a DOM-interference fingerprint and a Sentry
+ * fingerprint derived from the failing React component.
  */
 function reportDashboardError(
 	error: Error,
@@ -106,19 +107,23 @@ function reportDashboardError(
 		return;
 	}
 
-	attachComponentStackAsCause( error, componentStack );
+	const fingerprint = getComponentStackFingerprint( componentStack );
 
 	captureException( error, {
-		tags: {
-			calypso_section: options.calypso_section,
-			...options.routeParams,
-			...domInterference.tags,
+		captureContext: {
+			tags: {
+				calypso_section: options.calypso_section,
+				...options.routeParams,
+				...domInterference.tags,
+			},
+			...( options.previousPath ? { extra: { previous_path: options.previousPath } } : {} ),
+			contexts: {
+				'dom-interference': domInterference.context,
+				...( componentStack ? { react: { componentStack } } : {} ),
+			},
+			...( fingerprint ? { fingerprint } : {} ),
 		},
-		...( options.previousPath ? { extra: { previous_path: options.previousPath } } : {} ),
-		contexts: {
-			'dom-interference': domInterference.context,
-			...( componentStack ? { react: { componentStack } } : {} ),
-		},
+		...( options.mechanism ? { mechanism: options.mechanism } : {} ),
 	} );
 }
 
@@ -154,7 +159,10 @@ export function handleOnCatch(
  * that bypass every error boundary (the `handled:no` subset in Sentry), which
  * otherwise arrive as bare `window.onerror` events with no component or route
  * context. React no longer rethrows to `window.onerror` once this is provided,
- * so this is the only reporting path for those errors.
+ * so this is the only reporting path for those errors — and the mechanism has to
+ * be set explicitly, since `captureException` would otherwise stamp them
+ * `handled: true` and drop them out of the `handled:no` facet and out of
+ * crash-free-session rate.
  */
 export function handleUncaughtError( error: unknown, errorInfo: { componentStack?: string } ) {
 	try {
@@ -162,6 +170,7 @@ export function handleUncaughtError( error: unknown, errorInfo: { componentStack
 		handleDashboardError( normalizedError, errorInfo.componentStack, {
 			severity: calypsoConfig( 'env_id' ) === 'dashboard-production' ? 'error' : 'debug',
 			calypso_section: 'dashboard',
+			mechanism: { type: 'react.onUncaughtError', handled: false },
 		} );
 	} catch {
 		// A throwing error handler would replace the original crash with a less

--- a/client/dashboard/app/logger/test/component-stack.test.ts
+++ b/client/dashboard/app/logger/test/component-stack.test.ts
@@ -1,51 +1,54 @@
-import { attachComponentStackAsCause } from '../component-stack';
+import { getComponentStackFingerprint } from '../component-stack';
 
-describe( 'attachComponentStackAsCause', () => {
-	it( 'attaches a synthetic cause whose stack holds the component frames', () => {
-		const error = new Error( 'Boom' );
-		attachComponentStackAsCause(
-			error,
-			'\n    at Text (https://example.com/chunk.js:1:2)\n    at Callout (https://example.com/chunk.js:3:4)'
-		);
-
-		const cause = ( error as { cause?: Error } ).cause;
-		expect( cause ).toBeInstanceOf( Error );
-		expect( cause?.name ).toBe( 'ReactComponentStack' );
-		expect( cause?.stack ).toContain( 'at Text (https://example.com/chunk.js:1:2)' );
-		expect( cause?.stack ).toContain( 'at Callout (https://example.com/chunk.js:3:4)' );
+describe( 'getComponentStackFingerprint', () => {
+	it( 'splits the default grouping by the innermost components (Chromium frames)', () => {
+		expect(
+			getComponentStackFingerprint(
+				'\n    at Text (https://example.com/chunk.js:1:2)\n    at Callout (https://example.com/chunk.js:3:4)'
+			)
+		).toEqual( [ '{{ default }}', 'Text', 'Callout' ] );
 	} );
 
-	it( 'trims the stack to the innermost frames', () => {
-		const frames = Array.from(
+	it( 'parses Firefox and Safari frames', () => {
+		expect(
+			getComponentStackFingerprint( '\nText@https://example.com/chunk.js:1:2\nCallout@unknown:0:0' )
+		).toEqual( [ '{{ default }}', 'Text', 'Callout' ] );
+	} );
+
+	it( 'parses bare component names', () => {
+		expect( getComponentStackFingerprint( '\nText\nCallout' ) ).toEqual( [
+			'{{ default }}',
+			'Text',
+			'Callout',
+		] );
+	} );
+
+	it( 'skips host elements, which are identical across crash sites', () => {
+		expect(
+			getComponentStackFingerprint(
+				'\n    at div (<anonymous>)\n    at span (<anonymous>)\n    at Callout (https://example.com/chunk.js:3:4)'
+			)
+		).toEqual( [ '{{ default }}', 'Callout' ] );
+	} );
+
+	it( 'trims to the innermost components', () => {
+		const stack = Array.from(
 			{ length: 20 },
 			( _, i ) => `    at Component${ i } (https://example.com/chunk.js:${ i }:0)`
 		).join( '\n' );
 
-		const error = new Error( 'Boom' );
-		attachComponentStackAsCause( error, frames );
-
-		const stack = ( error as { cause?: Error } ).cause?.stack ?? '';
-		expect( stack ).toContain( 'at Component0 ' );
-		expect( stack ).toContain( 'at Component7 ' );
-		expect( stack ).not.toContain( 'at Component8 ' );
+		expect( getComponentStackFingerprint( stack ) ).toEqual( [
+			'{{ default }}',
+			'Component0',
+			'Component1',
+			'Component2',
+		] );
 	} );
 
-	it( 'does not clobber an existing cause', () => {
-		const original = new Error( 'original cause' );
-		const error = new Error( 'Boom' );
-		( error as { cause?: unknown } ).cause = original;
-
-		attachComponentStackAsCause( error, '    at Text (https://example.com/chunk.js:1:2)' );
-
-		expect( ( error as { cause?: unknown } ).cause ).toBe( original );
-	} );
-
-	it( 'does nothing for an empty or frameless stack', () => {
-		const error = new Error( 'Boom' );
-		attachComponentStackAsCause( error, '' );
-		expect( ( error as { cause?: unknown } ).cause ).toBeUndefined();
-
-		attachComponentStackAsCause( error, 'no frames here' );
-		expect( ( error as { cause?: unknown } ).cause ).toBeUndefined();
+	it( 'returns undefined when there is nothing to group on', () => {
+		expect( getComponentStackFingerprint( '' ) ).toBeUndefined();
+		expect( getComponentStackFingerprint( null ) ).toBeUndefined();
+		expect( getComponentStackFingerprint( undefined ) ).toBeUndefined();
+		expect( getComponentStackFingerprint( '    at div (<anonymous>)' ) ).toBeUndefined();
 	} );
 } );

--- a/client/dashboard/app/logger/test/component-stack.test.ts
+++ b/client/dashboard/app/logger/test/component-stack.test.ts
@@ -1,0 +1,51 @@
+import { attachComponentStackAsCause } from '../component-stack';
+
+describe( 'attachComponentStackAsCause', () => {
+	it( 'attaches a synthetic cause whose stack holds the component frames', () => {
+		const error = new Error( 'Boom' );
+		attachComponentStackAsCause(
+			error,
+			'\n    at Text (https://example.com/chunk.js:1:2)\n    at Callout (https://example.com/chunk.js:3:4)'
+		);
+
+		const cause = ( error as { cause?: Error } ).cause;
+		expect( cause ).toBeInstanceOf( Error );
+		expect( cause?.name ).toBe( 'ReactComponentStack' );
+		expect( cause?.stack ).toContain( 'at Text (https://example.com/chunk.js:1:2)' );
+		expect( cause?.stack ).toContain( 'at Callout (https://example.com/chunk.js:3:4)' );
+	} );
+
+	it( 'trims the stack to the innermost frames', () => {
+		const frames = Array.from(
+			{ length: 20 },
+			( _, i ) => `    at Component${ i } (https://example.com/chunk.js:${ i }:0)`
+		).join( '\n' );
+
+		const error = new Error( 'Boom' );
+		attachComponentStackAsCause( error, frames );
+
+		const stack = ( error as { cause?: Error } ).cause?.stack ?? '';
+		expect( stack ).toContain( 'at Component0 ' );
+		expect( stack ).toContain( 'at Component7 ' );
+		expect( stack ).not.toContain( 'at Component8 ' );
+	} );
+
+	it( 'does not clobber an existing cause', () => {
+		const original = new Error( 'original cause' );
+		const error = new Error( 'Boom' );
+		( error as { cause?: unknown } ).cause = original;
+
+		attachComponentStackAsCause( error, '    at Text (https://example.com/chunk.js:1:2)' );
+
+		expect( ( error as { cause?: unknown } ).cause ).toBe( original );
+	} );
+
+	it( 'does nothing for an empty or frameless stack', () => {
+		const error = new Error( 'Boom' );
+		attachComponentStackAsCause( error, '' );
+		expect( ( error as { cause?: unknown } ).cause ).toBeUndefined();
+
+		attachComponentStackAsCause( error, 'no frames here' );
+		expect( ( error as { cause?: unknown } ).cause ).toBeUndefined();
+	} );
+} );

--- a/client/dashboard/app/logger/test/dom-interference.test.ts
+++ b/client/dashboard/app/logger/test/dom-interference.test.ts
@@ -50,8 +50,7 @@ describe( 'getDomInterferenceReport', () => {
 		expect( context.fontCount ).toBe( 2 );
 	} );
 
-	it( 'collects deduped custom-element tag names and caps attribute value length', () => {
-		document.documentElement.setAttribute( 'data-long', 'x'.repeat( 200 ) );
+	it( 'collects deduped custom-element tag names', () => {
 		document.body.innerHTML = '<my-widget></my-widget><my-widget></my-widget><other-el></other-el>';
 
 		const { context } = getDomInterferenceReport();
@@ -62,8 +61,5 @@ describe( 'getDomInterferenceReport', () => {
 		expect(
 			( context.customElements as string[] ).filter( ( n ) => n === 'my-widget' )
 		).toHaveLength( 1 );
-		expect(
-			( context.documentElementAttributes as Record< string, string > )[ 'data-long' ]
-		).toHaveLength( 100 );
 	} );
 } );

--- a/client/dashboard/app/logger/test/dom-interference.test.ts
+++ b/client/dashboard/app/logger/test/dom-interference.test.ts
@@ -50,16 +50,22 @@ describe( 'getDomInterferenceReport', () => {
 		expect( context.fontCount ).toBe( 2 );
 	} );
 
-	it( 'collects deduped custom-element tag names', () => {
-		document.body.innerHTML = '<my-widget></my-widget><my-widget></my-widget><other-el></other-el>';
+	it( 'flags partial probe coverage on engines with undetectable built-in translation', () => {
+		const userAgent = jest.spyOn( navigator, 'userAgent', 'get' );
 
-		const { context } = getDomInterferenceReport();
-
-		expect( context.customElements ).toEqual(
-			expect.arrayContaining( [ 'my-widget', 'other-el' ] )
+		userAgent.mockReturnValue(
+			'Mozilla/5.0 (Macintosh) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36'
 		);
-		expect(
-			( context.customElements as string[] ).filter( ( n ) => n === 'my-widget' )
-		).toHaveLength( 1 );
+		expect( getDomInterferenceReport().tags.dom_probe_coverage ).toBe( 'full' );
+
+		userAgent.mockReturnValue( 'Mozilla/5.0 (Macintosh; rv:130.0) Gecko/20100101 Firefox/130.0' );
+		expect( getDomInterferenceReport().tags.dom_probe_coverage ).toBe( 'partial' );
+
+		userAgent.mockReturnValue(
+			'Mozilla/5.0 (Macintosh) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15'
+		);
+		expect( getDomInterferenceReport().tags.dom_probe_coverage ).toBe( 'partial' );
+
+		userAgent.mockRestore();
 	} );
 } );

--- a/client/dashboard/app/logger/test/dom-interference.test.ts
+++ b/client/dashboard/app/logger/test/dom-interference.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { getDomInterferenceReport } from '../dom-interference';
+
+afterEach( () => {
+	document.documentElement.className = '';
+	document.documentElement.removeAttribute( 'lang' );
+	document.body.innerHTML = '';
+	document.body.removeAttribute( 'data-gr-ext-installed' );
+} );
+
+describe( 'getDomInterferenceReport', () => {
+	it( 'reports no interference on a clean document', () => {
+		const { tags } = getDomInterferenceReport();
+
+		expect( tags.dom_google_translate ).toBe( 'false' );
+		expect( tags.dom_ms_translate ).toBe( 'false' );
+		expect( tags.dom_immersive_translate ).toBe( 'false' );
+		expect( tags.dom_grammarly ).toBe( 'false' );
+		expect( tags.dom_dark_reader ).toBe( 'false' );
+	} );
+
+	it( 'detects Google Translate via the html class', () => {
+		document.documentElement.classList.add( 'translated-ltr' );
+
+		expect( getDomInterferenceReport().tags.dom_google_translate ).toBe( 'true' );
+	} );
+
+	it( 'detects Edge translate via _msttexthash attributes', () => {
+		document.body.innerHTML = '<span _msttexthash="123">Hello</span>';
+
+		expect( getDomInterferenceReport().tags.dom_ms_translate ).toBe( 'true' );
+	} );
+
+	it( 'detects Grammarly', () => {
+		document.body.setAttribute( 'data-gr-ext-installed', '' );
+
+		expect( getDomInterferenceReport().tags.dom_grammarly ).toBe( 'true' );
+	} );
+
+	it( 'reports the document language and font count in the context', () => {
+		document.documentElement.setAttribute( 'lang', 'es' );
+		document.body.innerHTML = '<font>a</font><font>b</font>';
+
+		const { tags, context } = getDomInterferenceReport();
+
+		expect( tags.dom_doc_lang ).toBe( 'es' );
+		expect( context.fontCount ).toBe( 2 );
+	} );
+
+	it( 'collects deduped custom-element tag names and caps attribute value length', () => {
+		document.documentElement.setAttribute( 'data-long', 'x'.repeat( 200 ) );
+		document.body.innerHTML = '<my-widget></my-widget><my-widget></my-widget><other-el></other-el>';
+
+		const { context } = getDomInterferenceReport();
+
+		expect( context.customElements ).toEqual(
+			expect.arrayContaining( [ 'my-widget', 'other-el' ] )
+		);
+		expect(
+			( context.customElements as string[] ).filter( ( n ) => n === 'my-widget' )
+		).toHaveLength( 1 );
+		expect(
+			( context.documentElementAttributes as Record< string, string > )[ 'data-long' ]
+		).toHaveLength( 100 );
+	} );
+} );

--- a/client/dashboard/app/logger/test/index.test.ts
+++ b/client/dashboard/app/logger/test/index.test.ts
@@ -125,7 +125,6 @@ describe( 'handleOnCatch', () => {
 		} );
 
 		expect( mockedCaptureException ).toHaveBeenCalledTimes( 1 );
-		expect( mockedCaptureException ).toHaveBeenCalledTimes( 1 );
 		expect( mockedCaptureException ).toHaveBeenCalledWith( error, {
 			captureContext: {
 				tags: {

--- a/client/dashboard/app/logger/test/index.test.ts
+++ b/client/dashboard/app/logger/test/index.test.ts
@@ -125,24 +125,25 @@ describe( 'handleOnCatch', () => {
 		} );
 
 		expect( mockedCaptureException ).toHaveBeenCalledTimes( 1 );
+		expect( mockedCaptureException ).toHaveBeenCalledTimes( 1 );
 		expect( mockedCaptureException ).toHaveBeenCalledWith( error, {
-			tags: {
-				calypso_section: 'dashboard',
-				site_slug: 'my-site',
-				some_id: '123',
-				dom_google_translate: 'true',
+			captureContext: {
+				tags: {
+					calypso_section: 'dashboard',
+					site_slug: 'my-site',
+					some_id: '123',
+					dom_google_translate: 'true',
+				},
+				contexts: {
+					'dom-interference': { fontCount: 3 },
+					react: { componentStack: 'at SitePage' },
+				},
+				extra: { previous_path: '/sites/my-site' },
+				// Splits the react-dom mega-issue by the failing component without
+				// touching `exception.values`.
+				fingerprint: [ '{{ default }}', 'SitePage' ],
 			},
-			contexts: {
-				'dom-interference': { fontCount: 3 },
-				react: { componentStack: 'at SitePage' },
-			},
-			extra: { previous_path: '/sites/my-site' },
 		} );
-
-		// The component stack is chained as `cause` so Sentry can symbolicate and
-		// group by the failing component.
-		expect( ( error as { cause?: Error } ).cause ).toBeInstanceOf( Error );
-		expect( ( error as { cause?: Error } ).cause?.stack ).toContain( 'at SitePage' );
 	} );
 
 	it( 'reports no previous path when the error happens on a fresh page load', () => {
@@ -215,14 +216,20 @@ describe( 'handleUncaughtError', () => {
 
 		expect( mockedLogToLogstash ).toHaveBeenCalledTimes( 1 );
 		expect( mockedCaptureException ).toHaveBeenCalledWith( error, {
-			tags: {
-				calypso_section: 'dashboard',
-				dom_google_translate: 'true',
+			captureContext: {
+				tags: {
+					calypso_section: 'dashboard',
+					dom_google_translate: 'true',
+				},
+				contexts: {
+					'dom-interference': { fontCount: 3 },
+					react: { componentStack: 'at DomainUpsellCardContent' },
+				},
+				fingerprint: [ '{{ default }}', 'DomainUpsellCardContent' ],
 			},
-			contexts: {
-				'dom-interference': { fontCount: 3 },
-				react: { componentStack: 'at DomainUpsellCardContent' },
-			},
+			// Without this React's own `reportGlobalError` path is bypassed and
+			// Sentry would default the event to `handled: true`.
+			mechanism: { type: 'react.onUncaughtError', handled: false },
 		} );
 		expect( consoleError ).toHaveBeenCalledWith( error );
 	} );

--- a/client/dashboard/app/logger/test/index.test.ts
+++ b/client/dashboard/app/logger/test/index.test.ts
@@ -5,7 +5,8 @@
 import { captureException } from '@automattic/calypso-sentry';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { maybeReloadForChunkError } from '../../chunk-load-recovery';
-import { handleOnCatch, initLogger } from '../index';
+import { getDomInterferenceReport } from '../dom-interference';
+import { handleOnCatch, handleUncaughtError, initLogger } from '../index';
 import type { AnyRouter } from '@tanstack/react-router';
 import type { ErrorInfo } from 'react';
 
@@ -19,6 +20,12 @@ jest.mock( 'calypso/lib/logstash', () => ( {
 jest.mock( '../../chunk-load-recovery', () => ( {
 	maybeReloadForChunkError: jest.fn(),
 } ) );
+jest.mock( '../dom-interference', () => ( {
+	getDomInterferenceReport: jest.fn( () => ( {
+		tags: { dom_google_translate: 'true' },
+		context: { fontCount: 3 },
+	} ) ),
+} ) );
 
 const mockedLogToLogstash = jest.mocked( logToLogstash );
 const mockedCaptureException = jest.mocked( captureException );
@@ -27,6 +34,10 @@ const mockedMaybeReloadForChunkError = jest.mocked( maybeReloadForChunkError );
 beforeEach( () => {
 	jest.clearAllMocks();
 	mockedMaybeReloadForChunkError.mockReturnValue( false );
+	jest.mocked( getDomInterferenceReport ).mockReturnValue( {
+		tags: { dom_google_translate: 'true' },
+		context: { fontCount: 3 },
+	} );
 } );
 
 type ResolvedListener = ( event: { fromLocation?: { href: string } } ) => void;
@@ -76,7 +87,7 @@ describe( 'handleOnCatch', () => {
 		expect( mockedCaptureException ).not.toHaveBeenCalled();
 	} );
 
-	it( 'logs and captures a non-benign error', () => {
+	it( 'logs and captures a non-benign error with DOM fingerprint and component stack', () => {
 		const error = new Error( 'Boom' );
 		const errorInfo = createErrorInfo( 'at SitePage' );
 		const router = createRouter( { siteSlug: 'my-site', someId: '123' } );
@@ -108,6 +119,8 @@ describe( 'handleOnCatch', () => {
 					site_slug: 'my-site',
 					some_id: '123',
 				},
+				dom_google_translate: 'true',
+				dom_interference: { fontCount: 3 },
 			},
 		} );
 
@@ -117,9 +130,19 @@ describe( 'handleOnCatch', () => {
 				calypso_section: 'dashboard',
 				site_slug: 'my-site',
 				some_id: '123',
+				dom_google_translate: 'true',
+			},
+			contexts: {
+				'dom-interference': { fontCount: 3 },
+				react: { componentStack: 'at SitePage' },
 			},
 			extra: { previous_path: '/sites/my-site' },
 		} );
+
+		// The component stack is chained as `cause` so Sentry can symbolicate and
+		// group by the failing component.
+		expect( ( error as { cause?: Error } ).cause ).toBeInstanceOf( Error );
+		expect( ( error as { cause?: Error } ).cause?.stack ).toContain( 'at SitePage' );
 	} );
 
 	it( 'reports no previous path when the error happens on a fresh page load', () => {
@@ -171,5 +194,45 @@ describe( 'handleOnCatch', () => {
 
 		expect( mockedLogToLogstash ).toHaveBeenCalledTimes( 1 );
 		expect( mockedCaptureException ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'handleUncaughtError', () => {
+	let consoleError: jest.SpyInstance;
+
+	beforeEach( () => {
+		consoleError = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		consoleError.mockRestore();
+	} );
+
+	it( 'reports an uncaught error with fingerprint and component stack, and still console.errors', () => {
+		const error = new Error( 'Uncaught boom' );
+
+		handleUncaughtError( error, { componentStack: 'at DomainUpsellCardContent' } );
+
+		expect( mockedLogToLogstash ).toHaveBeenCalledTimes( 1 );
+		expect( mockedCaptureException ).toHaveBeenCalledWith( error, {
+			tags: {
+				calypso_section: 'dashboard',
+				dom_google_translate: 'true',
+			},
+			contexts: {
+				'dom-interference': { fontCount: 3 },
+				react: { componentStack: 'at DomainUpsellCardContent' },
+			},
+		} );
+		expect( consoleError ).toHaveBeenCalledWith( error );
+	} );
+
+	it( 'normalizes a non-Error value before reporting', () => {
+		handleUncaughtError( 'just a string', {} );
+
+		expect( mockedCaptureException ).toHaveBeenCalledTimes( 1 );
+		const reported = mockedCaptureException.mock.calls[ 0 ][ 0 ] as Error;
+		expect( reported ).toBeInstanceOf( Error );
+		expect( reported.message ).toBe( 'just a string' );
 	} );
 } );

--- a/client/dashboard/app/performance-tracking.ts
+++ b/client/dashboard/app/performance-tracking.ts
@@ -51,7 +51,7 @@ function buildCollector( siteSlug?: string ): Collector {
  * TanStack Router routeIds have a trailing slash (e.g. "/plugins/manage/")
  * but we want a canonical form without one for metrics.
  */
-function normalizeRouteId( routeId?: string ): string {
+export function normalizeRouteId( routeId?: string ): string {
 	return routeId?.replace( /\/$/, '' ) ?? '';
 }
 

--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -141,9 +141,6 @@ export const getRouter = ( config: AppConfig ) => {
 	} );
 
 	// Give Sentry navigation breadcrumbs and a route_id tag on the dashboard.
-	// `beforeBreadcrumb` drops navigation breadcrumbs lacking `should_capture`,
-	// and the route_id tag makes every event — including boundary-bypassing and
-	// non-React errors — facetable by page. See DOTMSD-1514.
 	router.subscribe( 'onResolved', ( { fromLocation, toLocation } ) => {
 		const routeId = router.state.matches.at( -1 )?.routeId;
 		if ( routeId ) {

--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -1,4 +1,5 @@
 import calypsoConfig from '@automattic/calypso-config';
+import { addBreadcrumb, setTag } from '@automattic/calypso-sentry';
 import { createRouter, createRoute } from '@tanstack/react-router';
 import NotFound from '../404';
 import UnknownError from '../500';
@@ -137,6 +138,25 @@ export const getRouter = ( config: AppConfig ) => {
 		if ( routeId ) {
 			startPerformanceTracking( routeId );
 		}
+	} );
+
+	// Give Sentry navigation breadcrumbs and a route_id tag on the dashboard.
+	// `beforeBreadcrumb` drops navigation breadcrumbs lacking `should_capture`,
+	// and the route_id tag makes every event — including boundary-bypassing and
+	// non-React errors — facetable by page. See DOTMSD-1514.
+	router.subscribe( 'onResolved', ( { fromLocation, toLocation } ) => {
+		const routeId = router.state.matches.at( -1 )?.routeId;
+		if ( routeId ) {
+			setTag( 'route_id', String( routeId ) );
+		}
+		addBreadcrumb( {
+			category: 'navigation',
+			data: {
+				should_capture: true,
+				from: fromLocation?.href,
+				to: toLocation?.href,
+			},
+		} );
 	} );
 
 	return router;

--- a/client/dashboard/app/router/index.tsx
+++ b/client/dashboard/app/router/index.tsx
@@ -4,7 +4,7 @@ import { createRouter, createRoute } from '@tanstack/react-router';
 import NotFound from '../404';
 import UnknownError from '../500';
 import { handleOnCatch, initLogger } from '../logger';
-import { startPerformanceTracking } from '../performance-tracking';
+import { normalizeRouteId, startPerformanceTracking } from '../performance-tracking';
 import { createAgencyRoutes } from './agency';
 import { createAgencyClientRoutes } from './agency-client';
 import { createDomainsRoutes } from './domains';
@@ -133,27 +133,37 @@ export const getRouter = ( config: AppConfig ) => {
 
 	initLogger( router );
 
+	// `onResolved` is emitted from a layout effect, i.e. after React commits. A
+	// commit-phase crash aborts before that, so the route is recorded here
+	// instead — otherwise the tag names the route the user came from, or is
+	// absent entirely on a cold load of the crashing URL.
+	let previousRouteId: string | undefined;
 	router.subscribe( 'onBeforeLoad', () => {
 		const routeId = router.state.pendingMatches?.at( -1 )?.routeId;
-		if ( routeId ) {
-			startPerformanceTracking( routeId );
+		if ( ! routeId ) {
+			return;
 		}
-	} );
 
-	// Give Sentry navigation breadcrumbs and a route_id tag on the dashboard.
-	router.subscribe( 'onResolved', ( { fromLocation, toLocation } ) => {
-		const routeId = router.state.matches.at( -1 )?.routeId;
-		if ( routeId ) {
-			setTag( 'route_id', String( routeId ) );
-		}
+		startPerformanceTracking( routeId );
+
+		// Route patterns rather than hrefs: Sentry's own navigation breadcrumbs are
+		// dropped in favour of these (see `beforeBreadcrumb` in calypso-sentry), and
+		// hrefs would carry site slugs and query strings — `/me/agent` alone accepts
+		// `pair_token`, `token` and `telegram_id`. The specific site is already on
+		// the event as the `site_slug` tag. Normalized so the value joins against
+		// the same route id in RUM and Tracks, which both strip the trailing slash
+		// TanStack leaves on index routes.
+		const normalizedRouteId = normalizeRouteId( routeId );
+		setTag( 'route_id', normalizedRouteId );
 		addBreadcrumb( {
 			category: 'navigation',
 			data: {
 				should_capture: true,
-				from: fromLocation?.href,
-				to: toLocation?.href,
+				from: previousRouteId,
+				to: normalizedRouteId,
 			},
 		} );
+		previousRouteId = normalizedRouteId;
 	} );
 
 	return router;

--- a/packages/calypso-sentry/CHANGELOG.md
+++ b/packages/calypso-sentry/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0
+
+- Add `setTag` for setting a single scope-level tag. Prefer it over `configureScope`, which is now deprecated (Sentry removed it in @sentry/react v8).
+
 ## 1.0.1
 
 - Declare React 19 compatibility for package consumers (#111721).

--- a/packages/calypso-sentry/package.json
+++ b/packages/calypso-sentry/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-sentry",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "A wrapper of the sentry for Calypso.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/calypso-sentry/src/index.ts
+++ b/packages/calypso-sentry/src/index.ts
@@ -25,6 +25,7 @@ type SupportedMethods =
 	| 'captureMessage'
 	| 'configureScope'
 	| 'withScope'
+	| 'setTag'
 	| 'setUser';
 
 interface QueueDataMethod< Method extends SupportedMethods > {
@@ -81,11 +82,19 @@ export function captureException( ...args: Parameters< typeof SentryApi.captureE
 export function captureMessage( ...args: Parameters< typeof SentryApi.captureMessage > ) {
 	dispatchSentryMethodCall( 'captureMessage', args );
 }
+/**
+ * @deprecated Sentry deprecated `configureScope` (removed in @sentry/react v8).
+ * To set a tag use `setTag`; for anything else use the top-level scope helpers
+ * directly once the SDK is loaded.
+ */
 export function configureScope( ...args: Parameters< typeof SentryApi.configureScope > ) {
 	dispatchSentryMethodCall( 'configureScope', args );
 }
 export function withScope( ...args: Parameters< typeof SentryApi.withScope > ) {
 	dispatchSentryMethodCall( 'withScope', args );
+}
+export function setTag( ...args: Parameters< typeof SentryApi.setTag > ) {
+	dispatchSentryMethodCall( 'setTag', args );
 }
 export function setUser( ...args: Parameters< typeof SentryApi.setUser > ) {
 	dispatchSentryMethodCall( 'setUser', args );


### PR DESCRIPTION
Part of DOTMSD-1514

## Proposed Changes

* Register React 19's root `onUncaughtError` so crashes that bypass every error boundary are reported through the dashboard's own logging path, with route and component context.
* Append the innermost React component names to the Sentry fingerprint, so the single ~50-frame react-dom mega-issue (CALYPSO-3G00) splits per crash site, and attach the raw component stack as a `react` context.
  * E.g. the fingerprint looks like `['{{ default }}', 'strong', 'ComponentA', 'ComponentB']`. That way errors that happen at the same part of the component tree are grouped together.
* Probe the DOM for page-mutating agents (Google/Edge/Immersive translate, Grammarly, Dark Reader) and report the fingerprint as Sentry tags and context.
* Tag events with the route ID and add navigation breadcrumbs, so non-React errors are facetable by page too.
* Add `setTag` to `@automattic/calypso-sentry` and deprecate `configureScope`.

## Why are these changes being made?

Browser translation extensions rewrite text nodes underneath React, which then crashes with `insertBefore`/`removeChild` errors. These happen during React's commit phase, so they bypass every error boundary and arrive as bare `window.onerror` events — no component, no route, no way to tell which screen broke.

Worse, their stacktraces are ~50 frames of identical react-dom internals. Sentry groups on that shared prefix, so every crash site in the dashboard collapses into one giant issue (CALYPSO-3G00) that can't be triaged or assigned. We know translation is a top crasher but not *where* it hurts.

These changes don't stop the crashes — they make them attributable, so the actual component-level fixes can be prioritised.

## Testing Instructions

I tested this by manually creating the crashes locally and then observing the additional fields sent to Sentry. Sentry however filters out events from localhost addresses, so I can't know for a fact the fingerprinting will work in Sentry until events start arriving.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?



