### PR TITLE
Domain and Plan flow: fix connecting a domain landing on an empty checkout

### DIFF
--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -13,8 +13,7 @@ import { getCurrentDashboard } from '../../app/routing';
 import { Callout } from '../../components/callout';
 import { TextBlur } from '../../components/text-blur';
 import UpsellCTAButton from '../../components/upsell-cta-button';
-import { getDomainConnectionSetupTemplateUrl } from '../../utils/domain-url';
-import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
+import { dashboardLink, redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import { DomainUpsellIllustraction } from './upsell-illustration';
 import type { Site } from '@automattic/api-core';
 
@@ -103,7 +102,10 @@ const DomainUpsellCardContent = ( {
 		getDomainAndPlanUpsellUrl( {
 			siteSlug: site.slug,
 			backUrl,
-			domainConnectionSetupUrl: getDomainConnectionSetupTemplateUrl(),
+			// The literal template rather than getDomainConnectionSetupTemplateUrl():
+			// reading the route's fullPath drags the whole dashboard router into any
+			// test that renders this card. Same path as my-sites/domains/controller.jsx.
+			domainConnectionSetupUrl: dashboardLink( '/domains/%s/domain-connection-setup' ),
 		} )
 	);
 

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -13,6 +13,7 @@ import { getCurrentDashboard } from '../../app/routing';
 import { Callout } from '../../components/callout';
 import { TextBlur } from '../../components/text-blur';
 import UpsellCTAButton from '../../components/upsell-cta-button';
+import { getDomainConnectionSetupTemplateUrl } from '../../utils/domain-url';
 import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import { DomainUpsellIllustraction } from './upsell-illustration';
 import type { Site } from '@automattic/api-core';
@@ -102,6 +103,7 @@ const DomainUpsellCardContent = ( {
 		getDomainAndPlanUpsellUrl( {
 			siteSlug: site.slug,
 			backUrl,
+			domainConnectionSetupUrl: getDomainConnectionSetupTemplateUrl(),
 		} )
 	);
 

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -102,9 +102,7 @@ const DomainUpsellCardContent = ( {
 		getDomainAndPlanUpsellUrl( {
 			siteSlug: site.slug,
 			backUrl,
-			// The literal template rather than getDomainConnectionSetupTemplateUrl():
-			// reading the route's fullPath drags the whole dashboard router into any
-			// test that renders this card. Same path as my-sites/domains/controller.jsx.
+			// Literal template to avoid pulling the dashboard router into tests.
 			domainConnectionSetupUrl: dashboardLink( '/domains/%s/domain-connection-setup' ),
 		} )
 	);

--- a/client/dashboard/sites/overview-domain-upsell-card/test/index.test.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/test/index.test.tsx
@@ -43,13 +43,6 @@ jest.mock( 'calypso/lib/domains', () => ( {
 	getDomainAndPlanUpsellUrl: () => '/upsell-url',
 } ) );
 
-// Reading the real template URL pulls the dashboard router, and with it the command
-// palette, into this test.
-jest.mock( '../../../utils/domain-url', () => ( {
-	getDomainConnectionSetupTemplateUrl: () =>
-		'https://my.wordpress.com/domains/%s/domain-connection-setup',
-} ) );
-
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
 		createErrorNotice: mockCreateErrorNotice,

--- a/client/dashboard/sites/overview-domain-upsell-card/test/index.test.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/test/index.test.tsx
@@ -43,6 +43,13 @@ jest.mock( 'calypso/lib/domains', () => ( {
 	getDomainAndPlanUpsellUrl: () => '/upsell-url',
 } ) );
 
+// Reading the real template URL pulls the dashboard router, and with it the command
+// palette, into this test.
+jest.mock( '../../../utils/domain-url', () => ( {
+	getDomainConnectionSetupTemplateUrl: () =>
+		'https://my.wordpress.com/domains/%s/domain-connection-setup',
+} ) );
+
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
 		createErrorNotice: mockCreateErrorNotice,

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -16,7 +16,8 @@ export function hasPlanFeature(
 		return false;
 	}
 
-	return site.plan.features.active.includes( feature );
+	// `features` is required by the type but can be absent in real API responses.
+	return site.plan.features?.active?.includes( feature ) ?? false;
 }
 
 // Returns whether the plan supports a specific "hosting feature",

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
@@ -9,7 +9,8 @@ import { addProductsToCart, DOMAIN_AND_PLAN_FLOW } from '@automattic/onboarding'
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import { useEffect, useRef } from 'react';
-import { hasPlanFeature } from 'calypso/dashboard/utils/site-features';
+import { dashboardOrigins } from 'calypso/dashboard/utils/link';
+import { isRelativeUrl } from 'calypso/dashboard/utils/url';
 import wpcom from 'calypso/lib/wp';
 import { domainMappingSetup } from 'calypso/my-sites/domains/paths';
 import { SIGNUP_DOMAIN_ORIGIN } from '../../../../../lib/analytics/signup';
@@ -40,11 +41,23 @@ const domainUpsell: Flow = {
 		const hasQualifyingPlan =
 			!! site?.plan && ! site.plan.is_free && site.plan.billing_period !== 'Monthly';
 		// Connecting a domain is bundled with every paid plan, so there is nothing left to buy.
+		// `features` can be missing at runtime even though the type says otherwise, so this
+		// deliberately does not use `hasPlanFeature()`, which would throw during render.
 		const mappingIsIncludedInPlan =
-			!! site &&
-			( ( !! site.plan && ! site.plan.is_free ) ||
-				hasPlanFeature( site, DotcomFeatures.DOMAIN_MAPPING ) );
-		const domainConnectionSetupUrl = useQuery().get( 'domainConnectionSetupUrl' );
+			( !! site?.plan && ! site.plan.is_free ) ||
+			!! site?.plan?.features?.active?.includes( DotcomFeatures.DOMAIN_MAPPING );
+
+		const domainConnectionSetupUrlParam = useQuery().get( 'domainConnectionSetupUrl' );
+		// The template is attacker-controllable through the URL and is handed to
+		// `window.location.assign()`, so only accept relative paths and dashboard origins.
+		const domainConnectionSetupUrl =
+			domainConnectionSetupUrlParam &&
+			( isRelativeUrl( domainConnectionSetupUrlParam ) ||
+				dashboardOrigins().some( ( origin ) =>
+					domainConnectionSetupUrlParam.startsWith( origin )
+				) )
+				? domainConnectionSetupUrlParam
+				: null;
 		const { getDomainCartItems, getPlanCartItem } = useSelect(
 			( select ) => ( {
 				getDomainCartItems: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItems,
@@ -186,12 +199,12 @@ const domainUpsell: Flow = {
 						);
 					}
 
+					submittedDomains.current = true;
+
 					// The domain can only be connected once the user has bought a plan.
 					if ( 'skipToPlan' in providedDependencies ) {
 						return navigate( STEPS.PLANS.slug );
 					}
-
-					submittedDomains.current = true;
 
 					const domainCartItem = providedDependencies.domainCartItem as
 						| MinimalRequestCartProduct
@@ -201,26 +214,29 @@ const domainUpsell: Flow = {
 						return navigate( STEPS.PLANS.slug );
 					}
 
+					setDomainCartItem( domainCartItem );
+					setDomainCartItems( [ domainCartItem ] );
+
+					const domain = domainCartItem.meta;
+
 					// Nothing to charge for: connect the domain right away and send the user to the
 					// setup instructions rather than through an empty checkout.
 					if (
 						site &&
+						domain &&
 						mappingIsIncludedInPlan &&
 						domainCartItem.product_slug === DomainProductSlugs.DOMAIN_MAPPING
 					) {
-						const domain = domainCartItem.meta as string;
-
 						try {
 							await wpcom.req.post( `/sites/${ site.ID }/add-domain-mapping`, { domain } );
 
 							return window.location.assign( getDomainConnectionSetupUrl( domain ) );
 						} catch {
-							// Fall through to checkout, which can process the mapping as well.
+							// The plan already covers the connection, so let checkout retry it. Falling
+							// through to the plans step would ask a paying customer to buy a plan twice.
+							return addToCartAndRedirectToCheckout( { includePlan: false } );
 						}
 					}
-
-					setDomainCartItem( domainCartItem );
-					setDomainCartItems( [ domainCartItem ] );
 
 					if ( hasQualifyingPlan ) {
 						return addToCartAndRedirectToCheckout( { includePlan: false } );

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
@@ -68,13 +68,31 @@ const domainUpsell: Flow = {
 				: domainMappingSetup( siteSlug, domain, '', false, true );
 		}
 
+		function getPostCheckoutUrl( domainCartItems: MinimalRequestCartProduct[] ) {
+			// A connected domain still has to be pointed at the site once it is paid for, so
+			// finish on the setup instructions rather than wherever the user came from. More
+			// than one domain in the cart makes the destination ambiguous, so leave it alone.
+			if ( domainCartItems.length !== 1 ) {
+				return returnUrl;
+			}
+
+			const [ domainCartItem ] = domainCartItems;
+			const domain = domainCartItem.meta;
+
+			if ( domainCartItem.product_slug !== DomainProductSlugs.DOMAIN_MAPPING || ! domain ) {
+				return returnUrl;
+			}
+
+			return getDomainConnectionSetupUrl( domain );
+		}
+
 		async function addToCartAndRedirectToCheckout( { includePlan = true } = {} ) {
 			const planCartItem = getPlanCartItem();
-			const domainCartItems = getDomainCartItems();
+			const domainCartItems = getDomainCartItems() ?? [];
 
 			const cartItems = [
 				...( includePlan && planCartItem ? [ planCartItem ] : [] ),
-				...( domainCartItems && domainCartItems.length > 0 ? domainCartItems : [] ),
+				...domainCartItems,
 			];
 
 			if ( cartItems.length > 0 ) {
@@ -82,7 +100,9 @@ const domainUpsell: Flow = {
 			}
 
 			return window.location.assign(
-				`/checkout/${ siteSlug }?redirect_to=${ encodeURIComponent( returnUrl ) }`
+				`/checkout/${ siteSlug }?redirect_to=${ encodeURIComponent(
+					getPostCheckoutUrl( domainCartItems )
+				) }`
 			);
 		}
 

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
@@ -1,3 +1,4 @@
+import { DomainProductSlugs, DotcomFeatures } from '@automattic/api-core';
 import {
 	OnboardActions,
 	OnboardSelect,
@@ -8,6 +9,9 @@ import { addProductsToCart, DOMAIN_AND_PLAN_FLOW } from '@automattic/onboarding'
 import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import { useEffect, useRef } from 'react';
+import { hasPlanFeature } from 'calypso/dashboard/utils/site-features';
+import wpcom from 'calypso/lib/wp';
+import { domainMappingSetup } from 'calypso/my-sites/domains/paths';
 import { SIGNUP_DOMAIN_ORIGIN } from '../../../../../lib/analytics/signup';
 import { useQuery } from '../../../hooks/use-query';
 import { useSite } from '../../../hooks/use-site';
@@ -35,6 +39,12 @@ const domainUpsell: Flow = {
 		const site = useSite();
 		const hasQualifyingPlan =
 			!! site?.plan && ! site.plan.is_free && site.plan.billing_period !== 'Monthly';
+		// Connecting a domain is bundled with every paid plan, so there is nothing left to buy.
+		const mappingIsIncludedInPlan =
+			!! site &&
+			( ( !! site.plan && ! site.plan.is_free ) ||
+				hasPlanFeature( site, DotcomFeatures.DOMAIN_MAPPING ) );
+		const domainConnectionSetupUrl = useQuery().get( 'domainConnectionSetupUrl' );
 		const { getDomainCartItems, getPlanCartItem } = useSelect(
 			( select ) => ( {
 				getDomainCartItems: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItems,
@@ -51,6 +61,12 @@ const domainUpsell: Flow = {
 			launchpadScreenOption === 'skipped' || ! backTo ? `/home/${ siteSlug }` : backTo;
 
 		const submittedDomains = useRef( false );
+
+		function getDomainConnectionSetupUrl( domain: string ) {
+			return domainConnectionSetupUrl
+				? domainConnectionSetupUrl.replace( '%s', domain )
+				: domainMappingSetup( siteSlug, domain, '', false, true );
+		}
 
 		async function addToCartAndRedirectToCheckout( { includePlan = true } = {} ) {
 			const planCartItem = getPlanCartItem();
@@ -137,7 +153,54 @@ const domainUpsell: Flow = {
 						return navigate( destination as typeof currentStep );
 					}
 
+					// The step verified domain ownership and created the mapping itself, so all
+					// that is left is to walk the user through pointing the domain at the site.
+					if (
+						'ownershipVerificationCompleted' in providedDependencies &&
+						providedDependencies.domain
+					) {
+						submittedDomains.current = true;
+
+						return window.location.assign(
+							getDomainConnectionSetupUrl( providedDependencies.domain as string )
+						);
+					}
+
+					// The domain can only be connected once the user has bought a plan.
+					if ( 'skipToPlan' in providedDependencies ) {
+						return navigate( STEPS.PLANS.slug );
+					}
+
 					submittedDomains.current = true;
+
+					const domainCartItem = providedDependencies.domainCartItem as
+						| MinimalRequestCartProduct
+						| undefined;
+
+					if ( ! domainCartItem ) {
+						return navigate( STEPS.PLANS.slug );
+					}
+
+					// Nothing to charge for: connect the domain right away and send the user to the
+					// setup instructions rather than through an empty checkout.
+					if (
+						site &&
+						mappingIsIncludedInPlan &&
+						domainCartItem.product_slug === DomainProductSlugs.DOMAIN_MAPPING
+					) {
+						const domain = domainCartItem.meta as string;
+
+						try {
+							await wpcom.req.post( `/sites/${ site.ID }/add-domain-mapping`, { domain } );
+
+							return window.location.assign( getDomainConnectionSetupUrl( domain ) );
+						} catch {
+							// Fall through to checkout, which can process the mapping as well.
+						}
+					}
+
+					setDomainCartItem( domainCartItem );
+					setDomainCartItems( [ domainCartItem ] );
 
 					if ( hasQualifyingPlan ) {
 						return addToCartAndRedirectToCheckout( { includePlan: false } );

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/domain-and-plan.ts
@@ -10,7 +10,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArgs } from '@wordpress/url';
 import { useEffect, useRef } from 'react';
 import { dashboardOrigins } from 'calypso/dashboard/utils/link';
-import { isRelativeUrl } from 'calypso/dashboard/utils/url';
+import { hasPlanFeature } from 'calypso/dashboard/utils/site-features';
 import wpcom from 'calypso/lib/wp';
 import { domainMappingSetup } from 'calypso/my-sites/domains/paths';
 import { SIGNUP_DOMAIN_ORIGIN } from '../../../../../lib/analytics/signup';
@@ -24,6 +24,43 @@ import type { Flow } from '../../internals/types';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 const DOMAIN_UPSELL_STEPS = [ STEPS.DOMAIN_SEARCH, STEPS.USE_MY_DOMAIN, STEPS.PLANS ];
+
+/**
+ * The `domainConnectionSetupUrl` template arrives via the query string and ends up in
+ * `window.location.replace()`, so resolve it the way the browser will and accept only
+ * this origin and the dashboard's. Substring checks are bypassable
+ * (`https://my.wordpress.com.evil.example`, `/\evil.example`), hence parsed origins.
+ */
+function isSafeDomainConnectionSetupUrl( value: string ) {
+	try {
+		const resolvedOrigin = new URL( value, window.location.origin ).origin;
+
+		return (
+			resolvedOrigin === window.location.origin || dashboardOrigins().includes( resolvedOrigin )
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * The name of the domain being connected, when the cart holds exactly that and
+ * nothing else. Shared by the direct-connect branch and the post-checkout
+ * destination so the two paths cannot drift apart.
+ */
+function getSingleMappingDomain( domainCartItems: MinimalRequestCartProduct[] ) {
+	if ( domainCartItems.length !== 1 ) {
+		return null;
+	}
+
+	const [ domainCartItem ] = domainCartItems;
+
+	if ( domainCartItem.product_slug !== DomainProductSlugs.DOMAIN_MAPPING ) {
+		return null;
+	}
+
+	return domainCartItem.meta ?? null;
+}
 
 const domainUpsell: Flow = {
 	name: DOMAIN_AND_PLAN_FLOW,
@@ -41,21 +78,14 @@ const domainUpsell: Flow = {
 		const hasQualifyingPlan =
 			!! site?.plan && ! site.plan.is_free && site.plan.billing_period !== 'Monthly';
 		// Connecting a domain is bundled with every paid plan, so there is nothing left to buy.
-		// `features` can be missing at runtime even though the type says otherwise, so this
-		// deliberately does not use `hasPlanFeature()`, which would throw during render.
 		const mappingIsIncludedInPlan =
 			( !! site?.plan && ! site.plan.is_free ) ||
-			!! site?.plan?.features?.active?.includes( DotcomFeatures.DOMAIN_MAPPING );
+			( !! site && hasPlanFeature( site, DotcomFeatures.DOMAIN_MAPPING ) );
 
 		const domainConnectionSetupUrlParam = useQuery().get( 'domainConnectionSetupUrl' );
-		// The template is attacker-controllable through the URL and is handed to
-		// `window.location.assign()`, so only accept relative paths and dashboard origins.
 		const domainConnectionSetupUrl =
 			domainConnectionSetupUrlParam &&
-			( isRelativeUrl( domainConnectionSetupUrlParam ) ||
-				dashboardOrigins().some( ( origin ) =>
-					domainConnectionSetupUrlParam.startsWith( origin )
-				) )
+			isSafeDomainConnectionSetupUrl( domainConnectionSetupUrlParam )
 				? domainConnectionSetupUrlParam
 				: null;
 		const { getDomainCartItems, getPlanCartItem } = useSelect(
@@ -83,20 +113,10 @@ const domainUpsell: Flow = {
 
 		function getPostCheckoutUrl( domainCartItems: MinimalRequestCartProduct[] ) {
 			// A connected domain still has to be pointed at the site once it is paid for, so
-			// finish on the setup instructions rather than wherever the user came from. More
-			// than one domain in the cart makes the destination ambiguous, so leave it alone.
-			if ( domainCartItems.length !== 1 ) {
-				return returnUrl;
-			}
+			// finish on the setup instructions rather than wherever the user came from.
+			const domain = getSingleMappingDomain( domainCartItems );
 
-			const [ domainCartItem ] = domainCartItems;
-			const domain = domainCartItem.meta;
-
-			if ( domainCartItem.product_slug !== DomainProductSlugs.DOMAIN_MAPPING || ! domain ) {
-				return returnUrl;
-			}
-
-			return getDomainConnectionSetupUrl( domain );
+			return domain ? getDomainConnectionSetupUrl( domain ) : returnUrl;
 		}
 
 		async function addToCartAndRedirectToCheckout( { includePlan = true } = {} ) {
@@ -194,7 +214,9 @@ const domainUpsell: Flow = {
 					) {
 						submittedDomains.current = true;
 
-						return window.location.assign(
+						// replace() rather than assign(): Back must not land on a submit step
+						// for a mapping that already exists.
+						return window.location.replace(
 							getDomainConnectionSetupUrl( providedDependencies.domain as string )
 						);
 					}
@@ -217,20 +239,17 @@ const domainUpsell: Flow = {
 					setDomainCartItem( domainCartItem );
 					setDomainCartItems( [ domainCartItem ] );
 
-					const domain = domainCartItem.meta;
+					const domain = getSingleMappingDomain( [ domainCartItem ] );
 
 					// Nothing to charge for: connect the domain right away and send the user to the
 					// setup instructions rather than through an empty checkout.
-					if (
-						site &&
-						domain &&
-						mappingIsIncludedInPlan &&
-						domainCartItem.product_slug === DomainProductSlugs.DOMAIN_MAPPING
-					) {
+					if ( site && domain && mappingIsIncludedInPlan ) {
 						try {
 							await wpcom.req.post( `/sites/${ site.ID }/add-domain-mapping`, { domain } );
 
-							return window.location.assign( getDomainConnectionSetupUrl( domain ) );
+							// replace() rather than assign(): Back must not land on a submit step
+							// for a mapping that already exists.
+							return window.location.replace( getDomainConnectionSetupUrl( domain ) );
 						} catch {
 							// The plan already covers the connection, so let checkout retry it. Falling
 							// through to the plans step would ask a paying customer to buy a plan twice.

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/test/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/test/domain-and-plan.ts
@@ -11,7 +11,7 @@ import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 const mockSetDomainCartItem = jest.fn();
 const mockSetDomainCartItems = jest.fn();
 const mockGetDomainCartItems = jest.fn( (): MinimalRequestCartProduct[] => [] );
-const mockGetPlanCartItem = jest.fn( () => null );
+const mockGetPlanCartItem = jest.fn( (): MinimalRequestCartProduct | null => null );
 
 jest.mock( '@wordpress/data', () => ( {
 	useDispatch: () => ( {
@@ -44,8 +44,10 @@ jest.mock( 'calypso/lib/wp', () => ( {
 	req: { post: jest.fn( () => Promise.resolve( {} ) ) },
 } ) );
 
+let mockQueryArgs = '';
+
 jest.mock( 'calypso/landing/stepper/hooks/use-query', () => ( {
-	useQuery: () => new URLSearchParams( '' ),
+	useQuery: () => new URLSearchParams( mockQueryArgs ),
 } ) );
 
 jest.mock( 'calypso/landing/stepper/hooks/use-site-slug', () => ( {
@@ -82,6 +84,26 @@ const FREE_SITE = {
 
 const MAPPING_CART_ITEM = { product_slug: 'domain_map', meta: 'example.com' };
 const TRANSFER_CART_ITEM = { product_slug: 'domain_transfer', meta: 'example.com' };
+const PLAN_CART_ITEM = { product_slug: 'value_bundle' };
+
+const submitStep = async ( step: string, providedDependencies: Record< string, unknown > = {} ) => {
+	const navigate = jest.fn();
+	const { result } = renderHook( () =>
+		// `useStepNavigation` reads `this.name`, so it must be invoked bound to the flow.
+		domainAndPlan.useStepNavigation.call(
+			domainAndPlan,
+			step as Parameters< typeof domainAndPlan.useStepNavigation >[ 0 ],
+			navigate
+		)
+	);
+
+	await result.current.submit?.( providedDependencies );
+
+	return { navigate };
+};
+
+const submitUseMyDomain = ( providedDependencies: Record< string, unknown > ) =>
+	submitStep( 'use-my-domain', providedDependencies );
 
 describe( 'domain-and-plan flow use-my-domain navigation', () => {
 	const originalLocation = window.location;
@@ -108,25 +130,10 @@ describe( 'domain-and-plan flow use-my-domain navigation', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockQueryArgs = '';
 		mockGetDomainCartItems.mockReturnValue( [] );
 		mockGetPlanCartItem.mockReturnValue( null );
 	} );
-
-	const submitUseMyDomain = async ( providedDependencies: Record< string, unknown > ) => {
-		const navigate = jest.fn();
-		const { result } = renderHook( () =>
-			// `useStepNavigation` reads `this.name`, so it must be invoked bound to the flow.
-			domainAndPlan.useStepNavigation.call(
-				domainAndPlan,
-				'use-my-domain' as Parameters< typeof domainAndPlan.useStepNavigation >[ 0 ],
-				navigate
-			)
-		);
-
-		await result.current.submit?.( providedDependencies );
-
-		return { navigate };
-	};
 
 	it( 'connects the domain directly and lands on the connection setup page when mapping is included in the plan', async () => {
 		( useSite as jest.Mock ).mockReturnValue( PAID_ANNUAL_SITE );
@@ -175,7 +182,9 @@ describe( 'domain-and-plan flow use-my-domain navigation', () => {
 			TRANSFER_CART_ITEM,
 		] );
 		expect( window.location.assign ).toHaveBeenCalledWith(
-			expect.stringContaining( '/checkout/example.wordpress.com' )
+			`/checkout/example.wordpress.com?redirect_to=${ encodeURIComponent(
+				'/home/example.wordpress.com'
+			) }`
 		);
 	} );
 
@@ -186,5 +195,90 @@ describe( 'domain-and-plan flow use-my-domain navigation', () => {
 
 		expect( navigate ).toHaveBeenCalledWith( 'plans' );
 		expect( window.location.assign ).not.toHaveBeenCalled();
+	} );
+
+	it( 'uses the connection setup URL supplied by the entry point when there is one', async () => {
+		mockQueryArgs =
+			'domainConnectionSetupUrl=https%3A%2F%2Fmy.wordpress.com%2Fdomains%2F%25s%2Fdomain-connection-setup';
+		( useSite as jest.Mock ).mockReturnValue( PAID_ANNUAL_SITE );
+
+		await submitUseMyDomain( { domainCartItem: MAPPING_CART_ITEM } );
+
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			'https://my.wordpress.com/domains/example.com/domain-connection-setup'
+		);
+	} );
+} );
+
+describe( 'domain-and-plan flow post-checkout destination', () => {
+	const originalLocation = window.location;
+
+	beforeAll( () => {
+		Object.defineProperty( window, 'location', {
+			value: {
+				...originalLocation,
+				assign: jest.fn(),
+				href: 'https://wordpress.com/setup/domain-and-plan/plans',
+			},
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	afterAll( () => {
+		Object.defineProperty( window, 'location', {
+			value: originalLocation,
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockQueryArgs = '';
+		( useSite as jest.Mock ).mockReturnValue( FREE_SITE );
+		mockGetDomainCartItems.mockReturnValue( [] );
+		mockGetPlanCartItem.mockReturnValue( PLAN_CART_ITEM );
+	} );
+
+	it( 'finishes on the connection setup page after the plan that unlocks the connection is paid for', async () => {
+		mockGetDomainCartItems.mockReturnValue( [ MAPPING_CART_ITEM ] );
+
+		await submitStep( 'plans', { goToCheckout: true } );
+
+		expect( addProductsToCart ).toHaveBeenCalledWith( 'example.wordpress.com', 'domain-and-plan', [
+			PLAN_CART_ITEM,
+			MAPPING_CART_ITEM,
+		] );
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			`/checkout/example.wordpress.com?redirect_to=${ encodeURIComponent(
+				'/domains/mapping/example.wordpress.com/setup/example.com?firstVisit=true'
+			) }`
+		);
+	} );
+
+	it( 'keeps the default destination when the cart holds more than one domain', async () => {
+		mockGetDomainCartItems.mockReturnValue( [
+			MAPPING_CART_ITEM,
+			{ product_slug: 'domain_map', meta: 'second.com' },
+		] );
+
+		await submitStep( 'plans', { goToCheckout: true } );
+
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			`/checkout/example.wordpress.com?redirect_to=${ encodeURIComponent(
+				'/home/example.wordpress.com'
+			) }`
+		);
+	} );
+
+	it( 'keeps the default destination when no domain is being connected', async () => {
+		await submitStep( 'plans', { goToCheckout: true } );
+
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			`/checkout/example.wordpress.com?redirect_to=${ encodeURIComponent(
+				'/home/example.wordpress.com'
+			) }`
+		);
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/test/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/test/domain-and-plan.ts
@@ -1,0 +1,190 @@
+/**
+ * @jest-environment jsdom
+ */
+import { addProductsToCart } from '@automattic/onboarding';
+import { renderHook } from '@testing-library/react';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import wpcom from 'calypso/lib/wp';
+import domainAndPlan from '../domain-and-plan';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+
+const mockSetDomainCartItem = jest.fn();
+const mockSetDomainCartItems = jest.fn();
+const mockGetDomainCartItems = jest.fn( (): MinimalRequestCartProduct[] => [] );
+const mockGetPlanCartItem = jest.fn( () => null );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		setDomainCartItem: mockSetDomainCartItem,
+		setDomainCartItems: mockSetDomainCartItems,
+		setSignupDomainOrigin: jest.fn(),
+		setHideFreePlan: jest.fn(),
+	} ),
+	useSelect: () => ( {
+		getDomainCartItems: mockGetDomainCartItems,
+		getPlanCartItem: mockGetPlanCartItem,
+	} ),
+} ) );
+
+jest.mock( '@automattic/data-stores', () => ( {
+	updateLaunchpadSettings: jest.fn(),
+	useLaunchpad: () => ( { data: {} } ),
+} ) );
+
+jest.mock( '@automattic/onboarding', () => ( {
+	DOMAIN_AND_PLAN_FLOW: 'domain-and-plan',
+	addProductsToCart: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/signup', () => ( {
+	SIGNUP_DOMAIN_ORIGIN: { USE_YOUR_DOMAIN: 'use-your-domain' },
+} ) );
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: { post: jest.fn( () => Promise.resolve( {} ) ) },
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-query', () => ( {
+	useQuery: () => new URLSearchParams( '' ),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site-slug', () => ( {
+	useSiteSlug: () => 'example.wordpress.com',
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site', () => ( {
+	useSite: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/stores', () => ( {
+	ONBOARD_STORE: 'ONBOARD_STORE',
+} ) );
+
+const PAID_ANNUAL_SITE = {
+	ID: 123,
+	plan: {
+		product_slug: 'value_bundle',
+		is_free: false,
+		billing_period: 'Annually',
+		features: { active: [ 'domain-mapping' ] },
+	},
+};
+
+const FREE_SITE = {
+	ID: 123,
+	plan: {
+		product_slug: 'free_plan',
+		is_free: true,
+		billing_period: '',
+		features: { active: [] },
+	},
+};
+
+const MAPPING_CART_ITEM = { product_slug: 'domain_map', meta: 'example.com' };
+const TRANSFER_CART_ITEM = { product_slug: 'domain_transfer', meta: 'example.com' };
+
+describe( 'domain-and-plan flow use-my-domain navigation', () => {
+	const originalLocation = window.location;
+
+	beforeAll( () => {
+		Object.defineProperty( window, 'location', {
+			value: {
+				...originalLocation,
+				assign: jest.fn(),
+				href: 'https://wordpress.com/setup/domain-and-plan/use-my-domain',
+			},
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	afterAll( () => {
+		Object.defineProperty( window, 'location', {
+			value: originalLocation,
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockGetDomainCartItems.mockReturnValue( [] );
+		mockGetPlanCartItem.mockReturnValue( null );
+	} );
+
+	const submitUseMyDomain = async ( providedDependencies: Record< string, unknown > ) => {
+		const navigate = jest.fn();
+		const { result } = renderHook( () =>
+			// `useStepNavigation` reads `this.name`, so it must be invoked bound to the flow.
+			domainAndPlan.useStepNavigation.call(
+				domainAndPlan,
+				'use-my-domain' as Parameters< typeof domainAndPlan.useStepNavigation >[ 0 ],
+				navigate
+			)
+		);
+
+		await result.current.submit?.( providedDependencies );
+
+		return { navigate };
+	};
+
+	it( 'connects the domain directly and lands on the connection setup page when mapping is included in the plan', async () => {
+		( useSite as jest.Mock ).mockReturnValue( PAID_ANNUAL_SITE );
+
+		const { navigate } = await submitUseMyDomain( { domainCartItem: MAPPING_CART_ITEM } );
+
+		expect( wpcom.req.post ).toHaveBeenCalledWith( '/sites/123/add-domain-mapping', {
+			domain: 'example.com',
+		} );
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			'/domains/mapping/example.wordpress.com/setup/example.com?firstVisit=true'
+		);
+		expect( navigate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'lands on the connection setup page when the step already created the mapping after ownership verification', async () => {
+		( useSite as jest.Mock ).mockReturnValue( PAID_ANNUAL_SITE );
+
+		await submitUseMyDomain( { ownershipVerificationCompleted: true, domain: 'example.com' } );
+
+		expect( wpcom.req.post ).not.toHaveBeenCalled();
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			'/domains/mapping/example.wordpress.com/setup/example.com?firstVisit=true'
+		);
+	} );
+
+	it( 'stores the domain and goes to the plans step when the site has no qualifying plan', async () => {
+		( useSite as jest.Mock ).mockReturnValue( FREE_SITE );
+
+		const { navigate } = await submitUseMyDomain( { domainCartItem: MAPPING_CART_ITEM } );
+
+		expect( mockSetDomainCartItem ).toHaveBeenCalledWith( MAPPING_CART_ITEM );
+		expect( mockSetDomainCartItems ).toHaveBeenCalledWith( [ MAPPING_CART_ITEM ] );
+		expect( navigate ).toHaveBeenCalledWith( 'plans' );
+		expect( window.location.assign ).not.toHaveBeenCalled();
+	} );
+
+	it( 'adds a domain transfer to the cart before redirecting to checkout', async () => {
+		( useSite as jest.Mock ).mockReturnValue( PAID_ANNUAL_SITE );
+		mockGetDomainCartItems.mockReturnValue( [ TRANSFER_CART_ITEM ] );
+
+		await submitUseMyDomain( { domainCartItem: TRANSFER_CART_ITEM } );
+
+		expect( mockSetDomainCartItem ).toHaveBeenCalledWith( TRANSFER_CART_ITEM );
+		expect( addProductsToCart ).toHaveBeenCalledWith( 'example.wordpress.com', 'domain-and-plan', [
+			TRANSFER_CART_ITEM,
+		] );
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			expect.stringContaining( '/checkout/example.wordpress.com' )
+		);
+	} );
+
+	it( 'goes to the plans step when the user must buy a plan before connecting', async () => {
+		( useSite as jest.Mock ).mockReturnValue( FREE_SITE );
+
+		const { navigate } = await submitUseMyDomain( { skipToPlan: true } );
+
+		expect( navigate ).toHaveBeenCalledWith( 'plans' );
+		expect( window.location.assign ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/test/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/test/domain-and-plan.ts
@@ -154,7 +154,9 @@ describe( 'domain-and-plan flow use-my-domain navigation', () => {
 			value: {
 				...originalLocation,
 				assign: jest.fn(),
+				replace: jest.fn(),
 				href: 'https://wordpress.com/setup/domain-and-plan/use-my-domain',
+				origin: 'https://wordpress.com',
 			},
 			writable: true,
 			configurable: true,
@@ -184,7 +186,7 @@ describe( 'domain-and-plan flow use-my-domain navigation', () => {
 		expect( wpcom.req.post ).toHaveBeenCalledWith( '/sites/123/add-domain-mapping', {
 			domain: 'example.com',
 		} );
-		expect( window.location.assign ).toHaveBeenCalledWith(
+		expect( window.location.replace ).toHaveBeenCalledWith(
 			'/domains/mapping/example.wordpress.com/setup/example.com?firstVisit=true'
 		);
 		expect( navigate ).not.toHaveBeenCalled();
@@ -196,7 +198,7 @@ describe( 'domain-and-plan flow use-my-domain navigation', () => {
 		await submitUseMyDomain( { ownershipVerificationCompleted: true, domain: 'example.com' } );
 
 		expect( wpcom.req.post ).not.toHaveBeenCalled();
-		expect( window.location.assign ).toHaveBeenCalledWith(
+		expect( window.location.replace ).toHaveBeenCalledWith(
 			'/domains/mapping/example.wordpress.com/setup/example.com?firstVisit=true'
 		);
 	} );
@@ -271,13 +273,18 @@ describe( 'domain-and-plan flow use-my-domain navigation', () => {
 		expect( navigate ).toHaveBeenCalledWith( 'plans' );
 	} );
 
-	it( 'ignores an off-site connection setup URL', async () => {
-		mockQueryArgs = 'domainConnectionSetupUrl=https%3A%2F%2Fevil.example%2F%25s';
+	it.each( [
+		[ 'off-site URL', 'https://evil.example/%s' ],
+		[ 'origin-extension host', 'https://my.wordpress.com.evil.example/%s' ],
+		[ 'userinfo trick', 'https://my.wordpress.com@evil.example/%s' ],
+		[ 'backslash protocol-relative', '/\\evil.example/%s' ],
+	] )( 'ignores a malicious connection setup URL (%s)', async ( _label, template ) => {
+		mockQueryArgs = `domainConnectionSetupUrl=${ encodeURIComponent( template ) }`;
 		( useSite as jest.Mock ).mockReturnValue( PAID_ANNUAL_SITE );
 
 		await submitUseMyDomain( { domainCartItem: MAPPING_CART_ITEM } );
 
-		expect( window.location.assign ).toHaveBeenCalledWith(
+		expect( window.location.replace ).toHaveBeenCalledWith(
 			'/domains/mapping/example.wordpress.com/setup/example.com?firstVisit=true'
 		);
 	} );
@@ -289,7 +296,7 @@ describe( 'domain-and-plan flow use-my-domain navigation', () => {
 
 		await submitUseMyDomain( { domainCartItem: MAPPING_CART_ITEM } );
 
-		expect( window.location.assign ).toHaveBeenCalledWith(
+		expect( window.location.replace ).toHaveBeenCalledWith(
 			'https://my.wordpress.com/domains/example.com/domain-connection-setup'
 		);
 	} );
@@ -303,7 +310,9 @@ describe( 'domain-and-plan flow post-checkout destination', () => {
 			value: {
 				...originalLocation,
 				assign: jest.fn(),
+				replace: jest.fn(),
 				href: 'https://wordpress.com/setup/domain-and-plan/plans',
+				origin: 'https://wordpress.com',
 			},
 			writable: true,
 			configurable: true,

--- a/client/landing/stepper/declarative-flow/flows/domain-and-plan/test/domain-and-plan.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain-and-plan/test/domain-and-plan.ts
@@ -84,6 +84,22 @@ const FREE_SITE = {
 
 const MAPPING_CART_ITEM = { product_slug: 'domain_map', meta: 'example.com' };
 const TRANSFER_CART_ITEM = { product_slug: 'domain_transfer', meta: 'example.com' };
+const PAID_MONTHLY_SITE = {
+	ID: 123,
+	plan: {
+		product_slug: 'value_bundle_monthly',
+		is_free: false,
+		billing_period: 'Monthly',
+		features: { active: [ 'domain-mapping' ] },
+	},
+};
+
+// `features` is required by the type but can be absent in real API responses.
+const SITE_WITHOUT_PLAN_FEATURES = {
+	ID: 123,
+	plan: { product_slug: 'free_plan', is_free: true, billing_period: '' },
+};
+
 const PLAN_CART_ITEM = { product_slug: 'value_bundle' };
 
 const submitStep = async ( step: string, providedDependencies: Record< string, unknown > = {} ) => {
@@ -104,6 +120,31 @@ const submitStep = async ( step: string, providedDependencies: Record< string, u
 
 const submitUseMyDomain = ( providedDependencies: Record< string, unknown > ) =>
 	submitStep( 'use-my-domain', providedDependencies );
+
+/**
+ * `submittedDomains` is a ref on the hook instance, so the submit and the later
+ * goBack have to share one render to observe it.
+ */
+const submitUseMyDomainThenGoBack = async ( providedDependencies: Record< string, unknown > ) => {
+	const navigate = jest.fn();
+	let currentStep = 'use-my-domain';
+
+	const { result, rerender } = renderHook( () =>
+		domainAndPlan.useStepNavigation.call(
+			domainAndPlan,
+			currentStep as Parameters< typeof domainAndPlan.useStepNavigation >[ 0 ],
+			navigate
+		)
+	);
+
+	await result.current.submit?.( providedDependencies );
+
+	currentStep = 'plans';
+	rerender();
+	result.current.goBack?.();
+
+	return { goBackFromPlans: navigate };
+};
 
 describe( 'domain-and-plan flow use-my-domain navigation', () => {
 	const originalLocation = window.location;
@@ -195,6 +236,50 @@ describe( 'domain-and-plan flow use-my-domain navigation', () => {
 
 		expect( navigate ).toHaveBeenCalledWith( 'plans' );
 		expect( window.location.assign ).not.toHaveBeenCalled();
+	} );
+
+	it( 'sends a paying customer to checkout, not the plans step, when the mapping request fails', async () => {
+		( useSite as jest.Mock ).mockReturnValue( PAID_MONTHLY_SITE );
+		( wpcom.req.post as jest.Mock ).mockRejectedValueOnce( new Error( 'nope' ) );
+		mockGetDomainCartItems.mockReturnValue( [ MAPPING_CART_ITEM ] );
+
+		const { navigate } = await submitUseMyDomain( { domainCartItem: MAPPING_CART_ITEM } );
+
+		expect( navigate ).not.toHaveBeenCalled();
+		expect( addProductsToCart ).toHaveBeenCalledWith( 'example.wordpress.com', 'domain-and-plan', [
+			MAPPING_CART_ITEM,
+		] );
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			expect.stringContaining( '/checkout/example.wordpress.com' )
+		);
+	} );
+
+	it( 'keeps the plans-step back button pointed at domain search after skipping to plans', async () => {
+		( useSite as jest.Mock ).mockReturnValue( FREE_SITE );
+
+		const { goBackFromPlans } = await submitUseMyDomainThenGoBack( { skipToPlan: true } );
+
+		expect( goBackFromPlans ).toHaveBeenCalledWith( 'domains' );
+		expect( window.location.assign ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not throw when the plan is missing its features list', async () => {
+		( useSite as jest.Mock ).mockReturnValue( SITE_WITHOUT_PLAN_FEATURES );
+
+		const { navigate } = await submitUseMyDomain( { domainCartItem: MAPPING_CART_ITEM } );
+
+		expect( navigate ).toHaveBeenCalledWith( 'plans' );
+	} );
+
+	it( 'ignores an off-site connection setup URL', async () => {
+		mockQueryArgs = 'domainConnectionSetupUrl=https%3A%2F%2Fevil.example%2F%25s';
+		( useSite as jest.Mock ).mockReturnValue( PAID_ANNUAL_SITE );
+
+		await submitUseMyDomain( { domainCartItem: MAPPING_CART_ITEM } );
+
+		expect( window.location.assign ).toHaveBeenCalledWith(
+			'/domains/mapping/example.wordpress.com/setup/example.com?firstVisit=true'
+		);
 	} );
 
 	it( 'uses the connection setup URL supplied by the entry point when there is one', async () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -134,9 +134,7 @@ const UseMyDomain: StepType< {
 					clearQueryParams();
 					submit( { ownershipVerificationCompleted: true, domain } );
 
-					// The mapping now exists. Without this the handler falls through and
-					// submits a second time with a domainCartItem, which makes the flow
-					// re-map an already-mapped domain.
+					// Early return: the default handler below would re-submit a domainCartItem.
 					return;
 				} catch ( error ) {
 					// Validation failed - call onDone to display error and stay on current step

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/use-my-domain/index.tsx
@@ -131,7 +131,13 @@ const UseMyDomain: StepType< {
 						domain,
 						...verificationData,
 					} );
+					clearQueryParams();
 					submit( { ownershipVerificationCompleted: true, domain } );
+
+					// The mapping now exists. Without this the handler falls through and
+					// submits a second time with a domainCartItem, which makes the flow
+					// re-map an already-mapped domain.
+					return;
 				} catch ( error ) {
 					// Validation failed - call onDone to display error and stay on current step
 					if ( onDone ) {

--- a/client/lib/domains/get-domain-and-plan-upsell-url.ts
+++ b/client/lib/domains/get-domain-and-plan-upsell-url.ts
@@ -5,6 +5,13 @@ interface GetDomainUpsellUrlParams {
 	step?: 'domains' | 'plans';
 	suggestion?: string;
 	backUrl?: string;
+	/**
+	 * Template URL for the domain connection setup page, with `%s` standing in for the
+	 * domain name. Callers rendered by the dashboard should pass
+	 * `getDomainConnectionSetupTemplateUrl()` so that connecting a domain finishes on the
+	 * dashboard's own setup page; without it the flow falls back to classic Calypso.
+	 */
+	domainConnectionSetupUrl?: string;
 }
 
 export const getDomainAndPlanUpsellUrl = ( {
@@ -12,17 +19,20 @@ export const getDomainAndPlanUpsellUrl = ( {
 	backUrl,
 	step = 'domains',
 	suggestion,
+	domainConnectionSetupUrl,
 }: GetDomainUpsellUrlParams ) => {
 	if ( step === 'domains' ) {
 		return addQueryArgs( '/setup/domain-and-plan', {
 			siteSlug,
 			back_to: backUrl,
 			new: suggestion,
+			domainConnectionSetupUrl,
 		} );
 	}
 
 	return addQueryArgs( '/setup/domain-and-plan/plans', {
 		siteSlug,
 		back_to: backUrl,
+		domainConnectionSetupUrl,
 	} );
 };


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/A4A-3241/add-a-descripdomain-connection-page-bug-in-wordpresscom-checkout

## Proposed Changes

Choosing "Use a domain I own" in `/setup/domain-and-plan` loses the domain: the step submits it as `domainCartItem`, but the flow never reads it. Users on a paid annual plan land on checkout with an empty cart ("You have no items in your cart"). Free-plan users get a checkout with only the plan, and the connection is silently dropped. Every other flow that renders this step stores the item; this one didn't.

The fix:

* Store the submitted domain in the cart store. This is the actual bug fix.
* If the plan already includes domain mapping (any paid plan), skip checkout entirely: create the mapping and send the user to the domain connection setup page.
* When checkout is still needed (free plan buying a plan + connection), redirect to the connection setup page after payment instead of `/home`.
* Handle the step's other submits (`ownershipVerificationCompleted`, `skipToPlan`) that also dead-ended on the empty checkout.
* One-line fix in the shared `use-my-domain` step: a missing `return` made it submit twice on auth-code TLDs, so the flow re-mapped an already-mapped domain.
* The dashboard's domain upsell card now passes `domainConnectionSetupUrl`, so dashboard users finish on the dashboard's setup page. This mirrors what `getAddSiteDomainUrl` already does for `/setup/domain`.
* The setup URL coming from the query string is validated by parsed origin before we redirect to it.

16 unit tests added; 12 of them fail without the fixes.

## Testing Instructions

Main repro (the reported bug):

1. Use a site on a paid annual plan.
2. Go to `/setup/domain-and-plan?siteSlug=<site>`.
3. Choose "Use a domain I own", enter a domain you control, then "Connect your domain".
4. Before: empty checkout. After: the mapping is created and you land on the domain connection setup page.

Free plan:

1. Same steps on a free-plan site. You get the plans step.
2. Pick a plan. Checkout now contains the plan and the domain connection (the connection was missing before).
3. After paying, you land on the connection setup page.

Transfer: choose "Transfer your domain" instead. Checkout contains the transfer product, unchanged behavior (transfers are paid).

## Notes for reviewers

Three judgment calls worth a look:

1. Monthly paid plans also skip checkout now. Mapping is included there too, so there is nothing to charge, but it changes where those users land.
2. After checkout, the setup page wins over `back_to`. That param is a back-button target, not a completion target, and nothing passes `redirect_to` to this flow.
3. Transfers keep their old post-checkout destination: there is no classic transfer-setup page to send people to.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ZYcULHmFYd59aM4JW38bD
