### PR TITLE
Prototype: compact peek-dots onboarding progress rail

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/index.tsx
@@ -13,8 +13,17 @@ type Props = {
 	isStepSelectDisabled?: boolean;
 };
 
+/**
+ * The onboarding purchase progress rail.
+ *
+ * Renders as "peek dots": a compact row of indicators where only the current
+ * step keeps its label on screen. The other labels are still rendered, so they
+ * remain part of each step's accessible name, and they reveal visually on
+ * hover and keyboard focus. See style.scss for how that is done without
+ * reflowing the rail.
+ */
 export function OnboardingProgress( { currentStep, onStepSelect, isStepSelectDisabled }: Props ) {
-	const { __ } = useI18n();
+	const { __, _x } = useI18n();
 
 	const domainsStepStatus = currentStep !== 'domains' ? ( 'completed' as const ) : undefined;
 	const plansStepStatus = currentStep === 'checkout' ? ( 'completed' as const ) : undefined;
@@ -29,7 +38,7 @@ export function OnboardingProgress( { currentStep, onStepSelect, isStepSelectDis
 				}
 			} }
 			aria-label={ __( 'Purchase steps' ) }
-			indicatorVariant="number"
+			indicatorVariant="bullet"
 			linear
 			className="onboarding-progress"
 		>
@@ -42,7 +51,9 @@ export function OnboardingProgress( { currentStep, onStepSelect, isStepSelectDis
 				>
 					<UIStepper.Trigger className="onboarding-progress-trigger">
 						<UIStepper.Indicator />
-						<UIStepper.Title>{ __( 'Select a domain' ) }</UIStepper.Title>
+						<UIStepper.Title className="onboarding-progress-title">
+							{ _x( 'Domain', 'onboarding purchase step' ) }
+						</UIStepper.Title>
 					</UIStepper.Trigger>
 				</UIStepper.Step>
 				<UIStepper.Step
@@ -53,13 +64,17 @@ export function OnboardingProgress( { currentStep, onStepSelect, isStepSelectDis
 				>
 					<UIStepper.Trigger className="onboarding-progress-trigger">
 						<UIStepper.Indicator />
-						<UIStepper.Title>{ __( 'Select a plan' ) }</UIStepper.Title>
+						<UIStepper.Title className="onboarding-progress-title">
+							{ _x( 'Plan', 'onboarding purchase step' ) }
+						</UIStepper.Title>
 					</UIStepper.Trigger>
 				</UIStepper.Step>
 				<UIStepper.Step value="checkout" className="onboarding-progress-step">
 					<UIStepper.Trigger className="onboarding-progress-trigger">
 						<UIStepper.Indicator />
-						<UIStepper.Title>{ __( 'Complete payment' ) }</UIStepper.Title>
+						<UIStepper.Title className="onboarding-progress-title">
+							{ _x( 'Payment', 'onboarding purchase step' ) }
+						</UIStepper.Title>
 					</UIStepper.Trigger>
 				</UIStepper.Step>
 			</UIStepper.List>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/style.scss
@@ -9,8 +9,7 @@
 .onboarding-progress {
 	display: flex;
 	justify-content: center;
-	padding: 8px 0;
-	margin-block-end: 32px;
+	margin-block-end: var( --wpds-dimension-gap-lg );
 	// Ensure the stepper paints above the sticky checkout sidebar, which is positioned
 	// and would otherwise overlap the heading row at the same stacking level.
 	position: relative;
@@ -18,12 +17,70 @@
 
 	.onboarding-progress-step {
 		display: flex;
-		justify-content: center;
+		align-items: center;
+		// Positioning context for the revealed label below.
+		position: relative;
+
+		// Connector from this step to the next one.
+		&:not( :last-child )::after {
+			content: '';
+			flex: none;
+			width: var( --wpds-dimension-gap-xl );
+			height: var( --wpds-border-width-xs );
+			background-color: var( --wpds-color-stroke-surface-neutral );
+		}
 	}
 
 	.onboarding-progress-trigger {
 		display: flex;
 		align-items: center;
-		padding: 12px 16px;
+		padding: var( --wpds-dimension-padding-xs ) var( --wpds-dimension-padding-sm );
+	}
+
+	.onboarding-progress-title {
+		white-space: nowrap;
+		font-size: var( --wpds-typography-font-size-sm );
+		line-height: var( --wpds-typography-line-height-xs );
+	}
+
+	// Peek behaviour.
+	//
+	// Only the current step shows its label inline. Every other label is lifted
+	// out of the flow and parked under its own dot, so revealing it on hover or
+	// focus never reflows the rail and never shifts the page.
+	//
+	// It is hidden with opacity rather than `display: none` or
+	// `visibility: hidden` on purpose: the text has to stay in the
+	// accessibility tree, because it is what gives each step its accessible
+	// name ("Step 2 of 3, completed Domain"). Sighted pointer and keyboard
+	// users get it back on demand; screen reader users never lost it.
+	.onboarding-progress-step:not( [data-current] ) .onboarding-progress-title {
+		position: absolute;
+		top: 100%;
+		// Physical `left` on purpose: paired with a -50% translate this centres
+		// the label under the dot identically in LTR and RTL.
+		left: 50%;
+		transform: translate( -50%, -2px );
+		z-index: 1;
+		opacity: 0;
+		pointer-events: none;
+		padding: 2px var( --wpds-dimension-padding-sm );
+		border: var( --wpds-border-width-xs ) solid var( --wpds-color-stroke-surface-neutral );
+		border-radius: var( --wpds-border-radius-sm );
+		background-color: var( --wpds-color-background-surface-neutral-strong );
+		color: var( --wpds-color-foreground-content-neutral );
+	}
+
+	.onboarding-progress-step:not( [data-current] ) .onboarding-progress-trigger:hover .onboarding-progress-title,
+	.onboarding-progress-step:not( [data-current] ) .onboarding-progress-trigger:focus-visible .onboarding-progress-title {
+		opacity: 1;
+		transform: translate( -50%, 0 );
+	}
+
+	// Only opacity and transform animate, so the reveal stays off the main thread.
+	@media ( prefers-reduced-motion: no-preference ) {
+		.onboarding-progress-step:not( [data-current] ) .onboarding-progress-title {
+			transition: opacity 120ms ease, transform 120ms ease;
+		}
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/onboarding-progress.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/onboarding-progress.test.tsx
@@ -10,10 +10,10 @@ describe( 'OnboardingProgress', () => {
 		const onStepSelect = jest.fn();
 		render( <OnboardingProgress currentStep="checkout" onStepSelect={ onStepSelect } /> );
 
-		await userEvent.click( screen.getByRole( 'tab', { name: /Select a domain/ } ) );
+		await userEvent.click( screen.getByRole( 'tab', { name: /Domain/ } ) );
 		expect( onStepSelect ).toHaveBeenCalledWith( 'domains' );
 
-		await userEvent.click( screen.getByRole( 'tab', { name: /Select a plan/ } ) );
+		await userEvent.click( screen.getByRole( 'tab', { name: /Plan/ } ) );
 		expect( onStepSelect ).toHaveBeenCalledWith( 'plans' );
 	} );
 
@@ -21,7 +21,7 @@ describe( 'OnboardingProgress', () => {
 		const onStepSelect = jest.fn();
 		render( <OnboardingProgress currentStep="checkout" onStepSelect={ onStepSelect } /> );
 
-		await userEvent.click( screen.getByRole( 'tab', { name: /Complete payment/ } ) );
+		await userEvent.click( screen.getByRole( 'tab', { name: /Payment/ } ) );
 		expect( onStepSelect ).not.toHaveBeenCalled();
 	} );
 
@@ -35,11 +35,23 @@ describe( 'OnboardingProgress', () => {
 			/>
 		);
 
-		const domainsStep = screen.getByRole( 'tab', { name: /Select a domain/ } );
+		const domainsStep = screen.getByRole( 'tab', { name: /Domain/ } );
 		expect( domainsStep ).toHaveAttribute( 'aria-disabled', 'true' );
 
 		await userEvent.click( domainsStep );
-		await userEvent.click( screen.getByRole( 'tab', { name: /Select a plan/ } ) );
+		await userEvent.click( screen.getByRole( 'tab', { name: /Plan/ } ) );
 		expect( onStepSelect ).not.toHaveBeenCalled();
+	} );
+
+	// The peek treatment hides non-current labels with opacity, never with
+	// `display: none`, so every step keeps a full accessible name even while
+	// only one label is painted. This is the test that would fail if someone
+	// "optimised" the hidden labels out of the DOM.
+	it( 'keeps every step label in the accessible name, including the hidden ones', () => {
+		render( <OnboardingProgress currentStep="plans" /> );
+
+		expect( screen.getByRole( 'tab', { name: /Domain/ } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'tab', { name: /Plan/ } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'tab', { name: /Payment/ } ) ).toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
## What

A prototype of a more compact treatment for the onboarding purchase progress rail (domain, plan, payment).

Design review feedback was that the rail eats too much vertical height on desktop, pushes content down, and crowds the pricing grid when platform differentiators are showing. This explores the most compact treatment that still tells you where you are and how many steps are left, since that is the part the activation result depends on.

## Changes

All of it lives in the `onboarding-progress` consumer. The shared `@automattic/ui` Stepper is untouched: the treatment is driven entirely by the `data-current` and `data-status` attributes the component already exposes.

- Bullet indicators instead of numbers, with a connector line between steps
- One word per step label (Domain, Plan, Payment), through `_x()` so translators get context. Single words are very hard to translate blind
- Only the current step shows its label. The others reveal on hover and on keyboard focus
- Tighter trigger padding, and the bottom margin drops from 32px to 16px

Vertical footprint goes from roughly 92px to roughly 42px.

## Accessibility

The revealed labels are the part worth reviewing.

- Every label stays in the DOM. Hidden ones use `opacity: 0`, never `display: none` or `visibility: hidden`, so each step keeps its full accessible name ("Step 1 of 3, completed Domain"). Screen reader users lose nothing.
- The reveal is absolutely positioned, so it never reflows the rail or shifts the page under the pointer.
- Hover and `:focus-visible` both trigger it, so keyboard users get it too.
- Only `opacity` and `transform` animate, and the transition sits behind `prefers-reduced-motion`.
- There is a test that fails if anyone removes the hidden labels from the DOM.

I deliberately did not use `Tooltip` from `@wordpress/ui`, although that was the first instinct. `Tooltip.Trigger` renders a button and the step trigger already is one (a `Tabs.Tab` rendered as a `Button`), so it would mean either nesting buttons or a three way `render` fusion. Plain CSS on the existing markup is a lot less machinery for the same result.

## Trade-offs, worth arguing about

- There is no hover on touch, so touch users would see dots plus the current label only. The rail is desktop only today so it is not a live problem, but it is the reason not to port this to mobile as is.
- Overriding the `Text` size from the consumer is a smell. If this direction wins, it should become a size or density prop on the Stepper instead of a consumer override.
- Dots carry less information than numbers at a glance. That is the deliberate bet here, and it is exactly what an experiment should measure.

## Not in this PR

- No experiment gate yet. This needs one before it goes anywhere near production.
- The wider typography pass on the onboarding screen (several sizes and colours for similar elements) is separate work.

## Testing

- `yarn test-client onboarding-progress` passes, 7 tests
- Desktop only, so check at a large viewport across the domain, plan and checkout steps
- Tab through the rail to confirm labels appear on focus, not just on hover
- Worth checking against the pricing grid with platform differentiators, not only the plain grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
