### PR TITLE
Sidebar v2: Use Badge from @wordpress/ui

### DIFF
--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@automattic/ui';
 import {
 	__experimentalNavigatorButton as NavigatorButton,
 	__experimentalItem as Item,
@@ -6,6 +5,7 @@ import {
 	FlexBlock,
 } from '@wordpress/components';
 import { Icon, chevronRightSmall, external } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
 import clsx from 'clsx';
 import { TranslateResult } from 'i18n-calypso';
 
@@ -78,7 +78,7 @@ export const SidebarNavigatorMenuItem = ( {
 		<li>
 			<NavigatorButton as={ SidebarItem } path={ path }>
 				<div className="sidebar-menu-item__title-with-badge">
-					{ title } { badge && <Badge>{ badge }</Badge> }
+					{ title } { badge && <Badge intent="draft">{ badge }</Badge> }
 				</div>
 			</NavigatorButton>
 		</li>


### PR DESCRIPTION
Part of #113835

Follow-up to #113939, which migrated the Automattic for Agencies screens. This covers the one shared sidebar component left behind, listed there as a known remainder.

## Proposed Changes

* Replace the old `@automattic/ui` Badge with the design system's `@wordpress/ui` Badge in the shared sidebar menu item, mapping the default look to the `draft` intent like the rest of the migration.
* This is the badge behind the "Beta" chips in the Automattic for Agencies main sidebar (Amplify, Reports, and AI and MCP). Until now those chips still showed the old style next to the already-migrated section chips.

Jetpack Cloud shares this component but never passes a badge into it, so it gets no visual change.

## Why are these changes being made?

* The Badge component is being removed from `@automattic/ui` (#113835). This was the last badge usage behind the Automattic for Agencies screens, and one of the files blocking the final removal PR (#111379).

## Testing Instructions

Using this PR's Calypso Live link with the `a8c-for-agencies` environment, sign in as an agency.

1. In the main sidebar, find **Amplify** and **Reports** (and **Resources and tools → AI and MCP** if your agency has it). Each shows a "Beta" chip.
2. The chips should render in the new design-system style, matching the "Beta" chip shown next to the section title after you open Amplify or Reports.
3. With the `jetpack-cloud` environment, confirm the sidebar still renders normally. No badges appear there today, so nothing should look different.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

