### PR TITLE
Help Center: topic drill-down starter suggestions for the Support Assistant (prototype)

### DIFF
--- a/packages/odie-client/src/components/chat-footer/index.tsx
+++ b/packages/odie-client/src/components/chat-footer/index.tsx
@@ -1,5 +1,6 @@
 import { Notice, animations, ChatInput, AgentUIProvider } from '@automattic/agenttic-ui';
 import { motion } from 'framer-motion';
+import { IntroSuggestions } from '../message/intro-suggestions';
 import './style.scss';
 import type { Transition } from 'framer-motion';
 import type { ComponentProps } from 'react';
@@ -13,6 +14,7 @@ type AgentUIFooterProps = ComponentProps< typeof ChatInput > & {
 export function AgentUIFooter( props: AgentUIFooterProps ) {
 	return (
 		<AgentUIProvider value={ {} as any }>
+			<IntroSuggestions />
 			<motion.div
 				data-slot="chat-footer"
 				className="agenttic--chat-footer-container"

--- a/packages/odie-client/src/components/message/intro-suggestions.scss
+++ b/packages/odie-client/src/components/message/intro-suggestions.scss
@@ -1,0 +1,45 @@
+/* Pin agenttic-ui Suggestions (vertical layout) in normal flow. The library's
+   base container class is position:absolute at the same specificity as the
+   vertical layout's position:static, so stylesheet order decides — this rule
+   out-specifies both deterministically. data-slot is the library's stable hook. */
+.odie-intro-suggestions[data-slot='suggestions'] {
+	position: static;
+	margin-bottom: 8px;
+	/* The component is a framer-motion div that floats itself up via an inline
+	   translateY transform even in vertical layout; !important is required to
+	   beat the inline style. Paired with translateY={0} on the component. */
+	transform: none !important;
+
+	/* Follow-up mode: compact horizontal pill row above the composer. The
+	   library's base container provides the row + horizontal scroll; drop its
+	   inset padding so pills align with the composer edges, size the pills
+	   down to reference proportions, and fade the right edge so a clipped
+	   pill reads as "scrolls" rather than "broken". */
+	&.odie-intro-suggestions--followups {
+		/* The library container is overflow-y: hidden — zero padding clips the
+		   pills' top borders. Keep a few px vertical, keep left flush with the
+		   composer, and leave right room so the last pill can scroll clear of
+		   the fade. */
+		padding: 3px 24px 3px 0;
+		mask-image: linear-gradient( to right, #000 calc( 100% - 24px ), transparent );
+
+		button {
+			height: auto;
+			padding: 8px 14px;
+			/* 16px is the largest radius on the stylelint scale; at this chip
+			   height it renders as a full pill, and every chip in a horizontal
+			   row shares it. */
+			border-radius: 16px;
+			font-size: 13px;
+			line-height: 1.3;
+			white-space: nowrap;
+			flex-shrink: 0;
+		}
+
+		/* rtlcss flips the padding shorthand but not gradient directions, so
+		   the fade needs its own RTL override to stay on the scroll edge. */
+		[dir='rtl'] & {
+			mask-image: linear-gradient( to left, #000 calc( 100% - 24px ), transparent );
+		}
+	}
+}

--- a/packages/odie-client/src/components/message/intro-suggestions.scss
+++ b/packages/odie-client/src/components/message/intro-suggestions.scss
@@ -26,9 +26,8 @@
 		button {
 			height: auto;
 			padding: 8px 14px;
-			/* 16px is the largest radius on the stylelint scale; at this chip
-			   height it renders as a full pill, and every chip in a horizontal
-			   row shares it. */
+			/* On-scale radius that renders as a full pill at this chip height;
+			   every chip in a horizontal row shares it. */
 			border-radius: 16px;
 			font-size: 13px;
 			line-height: 1.3;

--- a/packages/odie-client/src/components/message/intro-suggestions.tsx
+++ b/packages/odie-client/src/components/message/intro-suggestions.tsx
@@ -1,0 +1,281 @@
+import { Suggestions } from '@automattic/agenttic-ui';
+import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
+import { useState } from 'react';
+import { isAskAiPrototypeEnabled } from '../../constants';
+import { useOdieAssistantContext } from '../../context';
+import { useSendChatMessage } from '../../hooks';
+import type { Message } from '../../types';
+import type { Suggestion } from '@automattic/agenttic-ui';
+import './intro-suggestions.scss';
+
+/**
+ * Topic-first starter suggestions for the Support Assistant (design
+ * prototype, gated by the shared localStorage knob). Fresh chats get a
+ * vertical card of the top LANDING_TOPIC_COUNT topics; tapping one surfaces
+ * its questions plus a back item. Once the conversation starts, suggestions
+ * move to a horizontal follow-up row that stays on the active topic until
+ * its questions run out. Topic and back items only switch the local view —
+ * their `action` returns false, which Suggestions treats as "do not
+ * submit"; only question items carry a real `prompt`.
+ */
+
+type TopicQuestion = {
+	id: string;
+	label: string;
+};
+
+type SupportTopic = {
+	id: string;
+	label: string;
+	questions: TopicQuestion[];
+};
+
+// The fresh-chat landing card shows this many topics, like the Help Center
+// home's recommended guides; the rest stay reachable from the follow-up row.
+const LANDING_TOPIC_COUNT = 5;
+
+// Built as a function so the strings are translated at render time, after
+// the locale has loaded. Array order is the landing order.
+const getSupportTopics = (): SupportTopic[] => [
+	{
+		id: 'domains',
+		label: __( 'Domains', __i18n_text_domain__ ),
+		questions: [
+			{
+				id: 'custom-domain',
+				label: __( 'How do I connect a custom domain?', __i18n_text_domain__ ),
+			},
+			{
+				id: 'domain-dns',
+				label: __( 'How do I manage DNS records for my domain?', __i18n_text_domain__ ),
+			},
+			{
+				id: 'domain-ssl',
+				label: __( 'When does SSL activate on my domain?', __i18n_text_domain__ ),
+			},
+		],
+	},
+	{
+		id: 'email',
+		label: __( 'Email', __i18n_text_domain__ ),
+		questions: [
+			{
+				id: 'pro-email',
+				label: __( 'How do I set up a professional email address?', __i18n_text_domain__ ),
+			},
+			{
+				id: 'email-mailboxes',
+				label: __( 'How do I rename or remove a mailbox?', __i18n_text_domain__ ),
+			},
+			{
+				id: 'email-forwarding',
+				label: __( 'Can I forward email from my custom domain?', __i18n_text_domain__ ),
+			},
+		],
+	},
+	{
+		id: 'themes',
+		label: __( 'Themes & design', __i18n_text_domain__ ),
+		questions: [
+			{
+				id: 'change-theme',
+				label: __( "How do I change my site's theme?", __i18n_text_domain__ ),
+			},
+			{
+				id: 'theme-styles',
+				label: __( 'Can I change fonts and colors in the Site Editor?', __i18n_text_domain__ ),
+			},
+			{
+				id: 'theme-switch-safe',
+				label: __( 'Will switching themes delete my content or menus?', __i18n_text_domain__ ),
+			},
+		],
+	},
+	{
+		id: 'seo',
+		label: __( 'Traffic & SEO', __i18n_text_domain__ ),
+		questions: [
+			{
+				id: 'google-visibility',
+				label: __( "Why isn't my site showing up on Google?", __i18n_text_domain__ ),
+			},
+			{
+				id: 'seo-sitemap',
+				label: __( 'How do I submit my sitemap to Google?', __i18n_text_domain__ ),
+			},
+			{
+				id: 'seo-basics',
+				label: __( 'How do I improve my SEO on WordPress.com?', __i18n_text_domain__ ),
+			},
+		],
+	},
+	{
+		id: 'backups',
+		label: __( 'Backups', __i18n_text_domain__ ),
+		questions: [
+			{
+				id: 'backup-site',
+				label: __( 'How do I backup my site?', __i18n_text_domain__ ),
+			},
+			{
+				id: 'backup-restore',
+				label: __( 'How do I restore my site from a backup?', __i18n_text_domain__ ),
+			},
+			{
+				id: 'backup-export',
+				label: __( 'How do I export my content?', __i18n_text_domain__ ),
+			},
+		],
+	},
+	{
+		id: 'plans',
+		label: __( 'Plans & billing', __i18n_text_domain__ ),
+		questions: [
+			{
+				id: 'manage-plan',
+				label: __( 'How do I upgrade or cancel my plan?', __i18n_text_domain__ ),
+			},
+			{
+				id: 'plan-refund',
+				label: __( 'Can I get a refund on my plan?', __i18n_text_domain__ ),
+			},
+			{
+				id: 'plan-after-cancel',
+				label: __( 'What happens to my site if I cancel my plan?', __i18n_text_domain__ ),
+			},
+		],
+	},
+	{
+		id: 'users',
+		label: __( 'Users', __i18n_text_domain__ ),
+		questions: [
+			{
+				id: 'add-user',
+				label: __( 'How do I add another user to my site?', __i18n_text_domain__ ),
+			},
+			{
+				id: 'user-roles',
+				label: __( 'What can each user role do on my site?', __i18n_text_domain__ ),
+			},
+			{
+				id: 'user-remove',
+				label: __( 'How do I remove a user or change their role?', __i18n_text_domain__ ),
+			},
+		],
+	},
+];
+
+export const IntroSuggestions = () => {
+	const { chat, trackEvent } = useOdieAssistantContext();
+	const { sendMessage } = useSendChatMessage();
+	const [ askedIds, setAskedIds ] = useState< string[] >( [] );
+	const [ activeTopicId, setActiveTopicId ] = useState< string | null >( null );
+
+	if ( ! isAskAiPrototypeEnabled() ) {
+		return null;
+	}
+
+	// Mirrors the intro-card gate in messages-container: these are bot-starter
+	// prompts, so never render them over a live human (Zendesk) conversation,
+	// and not while history is still loading on panel (re)mount.
+	if ( chat.provider === 'zendesk' || chat.status === 'loading' ) {
+		return null;
+	}
+
+	const topics = getSupportTopics();
+	// The introduction message is rendered separately and never stored in
+	// chat.messages, so any stored message means the conversation started.
+	const conversationStarted = ( chat.messages?.length ?? 0 ) > 0 || askedIds.length > 0;
+	// The composer disables itself while the bot is busy; question submits
+	// mirror that. Browsing topics stays allowed — it sends nothing.
+	const isBusy = !! chat.status && chat.status !== 'loaded';
+
+	// A question counts as asked if clicked this session OR already present in
+	// the conversation history — history survives panel close/reopen, local
+	// state doesn't.
+	const askedInHistory = ( label: string ): boolean =>
+		!! chat.messages?.some( ( m ) => m.role === 'user' && String( m.content ).trim() === label );
+	const isAsked = ( question: TopicQuestion ): boolean =>
+		askedIds.includes( question.id ) || askedInHistory( question.label );
+	const remainingIn = ( topic: SupportTopic ): TopicQuestion[] =>
+		topic.questions.filter( ( question ) => ! isAsked( question ) );
+
+	// A drained topic silently stops being "active" so the render falls back
+	// to the topic list — derived per render, no effect needed.
+	const activeTopic =
+		topics.find( ( t ) => t.id === activeTopicId && remainingIn( t ).length > 0 ) ?? null;
+
+	let items: Suggestion[];
+	if ( activeTopic ) {
+		items = [
+			{
+				id: 'intro-topics-back',
+				/* translators: compact button returning from a topic's questions to the full topic list */
+				label: __( '‹ All topics', __i18n_text_domain__ ),
+				action: () => {
+					trackEvent( 'chat_intro_topic_back_click', { topic: activeTopic.id } );
+					setActiveTopicId( null );
+					return false;
+				},
+			},
+			...remainingIn( activeTopic ).map( ( question ) => ( {
+				id: question.id,
+				label: question.label,
+				prompt: question.label,
+			} ) ),
+		];
+	} else {
+		const topicsWithQuestions = topics.filter( ( t ) => remainingIn( t ).length > 0 );
+		const visibleTopics = conversationStarted
+			? topicsWithQuestions
+			: topicsWithQuestions.slice( 0, LANDING_TOPIC_COUNT );
+		items = visibleTopics.map( ( topic ) => ( {
+			id: `topic-${ topic.id }`,
+			label: topic.label,
+			action: () => {
+				trackEvent( 'chat_intro_topic_click', { topic: topic.id } );
+				setActiveTopicId( topic.id );
+				return false;
+			},
+		} ) );
+	}
+
+	if ( items.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<Suggestions
+			className={ clsx(
+				'odie-intro-suggestions',
+				conversationStarted && 'odie-intro-suggestions--followups'
+			) }
+			layout={ conversationStarted ? 'horizontal' : 'vertical' }
+			translateY={ 0 }
+			suggestions={ items }
+			onSubmit={ ( selected ) => {
+				if ( isBusy ) {
+					return;
+				}
+				trackEvent( 'chat_intro_suggestion_click', {
+					suggestion: selected.id,
+					topic: activeTopic?.id,
+				} );
+				setAskedIds( [ ...askedIds, selected.id ] );
+				const messageObj = {
+					content: selected.prompt ?? selected.label,
+					role: 'user',
+					type: 'message',
+				} as Message;
+				// Aborted sends put the chip back so the question can be retried,
+				// mirroring how the composer restores its input on abort.
+				sendMessage( messageObj ).catch( ( error: { type?: string } ) => {
+					if ( error?.type === 'abort' ) {
+						setAskedIds( ( ids ) => ids.filter( ( id ) => id !== selected.id ) );
+					}
+				} );
+			} }
+		/>
+	);
+};

--- a/packages/odie-client/src/components/message/intro-suggestions.tsx
+++ b/packages/odie-client/src/components/message/intro-suggestions.tsx
@@ -172,14 +172,27 @@ export const IntroSuggestions = () => {
 	const [ askedIds, setAskedIds ] = useState< string[] >( [] );
 	const [ activeTopicId, setActiveTopicId ] = useState< string | null >( null );
 
+	// "New chat" clears chat.messages without unmounting this component, so
+	// local state has to reset with it or the fresh conversation inherits the
+	// old one's asked questions and drill-down position.
+	const messageCount = chat.messages?.length ?? 0;
+	const [ prevMessageCount, setPrevMessageCount ] = useState( messageCount );
+	if ( messageCount !== prevMessageCount ) {
+		setPrevMessageCount( messageCount );
+		if ( messageCount === 0 ) {
+			setAskedIds( [] );
+			setActiveTopicId( null );
+		}
+	}
+
 	if ( ! isAskAiPrototypeEnabled() ) {
 		return null;
 	}
 
 	// Mirrors the intro-card gate in messages-container: these are bot-starter
 	// prompts, so never render them over a live human (Zendesk) conversation,
-	// and not while history is still loading on panel (re)mount.
-	if ( chat.provider === 'zendesk' || chat.status === 'loading' ) {
+	// mid-escalation, or while history is still loading on panel (re)mount.
+	if ( chat.provider === 'zendesk' || chat.status === 'loading' || chat.status === 'transfer' ) {
 		return null;
 	}
 
@@ -258,23 +271,27 @@ export const IntroSuggestions = () => {
 				if ( isBusy ) {
 					return;
 				}
+				const content = selected.prompt ?? selected.label;
 				trackEvent( 'chat_intro_suggestion_click', {
 					suggestion: selected.id,
 					topic: activeTopic?.id,
 				} );
+				// Same funnel event as every composer send, so suggestion-driven
+				// messages stay visible to existing send metrics.
+				trackEvent( 'chat_message_action_send', {
+					message_length: content.length,
+					provider: chat.provider,
+					context: 'intro_suggestion',
+				} );
 				setAskedIds( [ ...askedIds, selected.id ] );
 				const messageObj = {
-					content: selected.prompt ?? selected.label,
+					content,
 					role: 'user',
 					type: 'message',
 				} as Message;
-				// Aborted sends put the chip back so the question can be retried,
-				// mirroring how the composer restores its input on abort.
-				sendMessage( messageObj ).catch( ( error: { type?: string } ) => {
-					if ( error?.type === 'abort' ) {
-						setAskedIds( ( ids ) => ids.filter( ( id ) => id !== selected.id ) );
-					}
-				} );
+				// Failures surface through the mutation's own error UI; the
+				// optimistic user message stays in history either way.
+				sendMessage( messageObj ).catch( () => {} );
 			} }
 		/>
 	);

--- a/packages/odie-client/src/components/message/test/intro-suggestions.test.tsx
+++ b/packages/odie-client/src/components/message/test/intro-suggestions.test.tsx
@@ -1,0 +1,231 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { IntroSuggestions } from '../intro-suggestions';
+import type { Message } from '../../../types';
+
+/**
+ * Mutable state backing the mocked dependencies. Each test mutates these and
+ * re-renders to drive the component through the scenario under test. Note the
+ * introduction message is rendered separately in production and never stored
+ * in chat.messages — seeds here must not include it.
+ */
+let mockMessages: Message[];
+let mockStatus: string;
+let mockProvider: string;
+const mockTrackEvent = jest.fn();
+const mockSendMessage = jest.fn();
+
+jest.mock( '../../../context', () => ( {
+	useOdieAssistantContext: () => ( {
+		chat: { messages: mockMessages, status: mockStatus, provider: mockProvider },
+		trackEvent: mockTrackEvent,
+	} ),
+} ) );
+
+jest.mock( '../../../hooks', () => ( {
+	useSendChatMessage: () => ( { sendMessage: mockSendMessage } ),
+} ) );
+
+jest.mock( '../intro-suggestions.scss', () => ( {} ) );
+
+// Minimal stand-in that mirrors the library's submit contract exactly:
+// `action` may veto by returning false, and `onSubmit` only fires for
+// suggestions that carry a `prompt`.
+jest.mock(
+	'@automattic/agenttic-ui',
+	() => {
+		const { createElement } = jest.requireActual< typeof import('react') >( 'react' );
+		return {
+			Suggestions: ( {
+				suggestions,
+				onSubmit,
+				layout,
+			}: {
+				suggestions: Array< {
+					id: string;
+					label: string;
+					prompt?: string;
+					action?: () => boolean | Promise< boolean >;
+				} >;
+				onSubmit?: ( selected: unknown, all: unknown ) => void;
+				layout: string;
+			} ) =>
+				createElement(
+					'div',
+					{ 'data-testid': 'suggestions', 'data-layout': layout },
+					suggestions.map( ( suggestion ) =>
+						createElement(
+							'button',
+							{
+								key: suggestion.id,
+								onClick: async () => {
+									let shouldSubmit = true;
+									if ( suggestion.action ) {
+										shouldSubmit = await suggestion.action();
+									}
+									if ( shouldSubmit && onSubmit && suggestion.prompt ) {
+										onSubmit( suggestion, suggestions );
+									}
+								},
+							},
+							suggestion.label
+						)
+					)
+				),
+		};
+	},
+	{ virtual: true }
+);
+
+const userMessage = ( content: string ): Message =>
+	( { content, role: 'user', type: 'message' } ) as Message;
+
+describe( 'IntroSuggestions', () => {
+	beforeEach( () => {
+		mockMessages = [];
+		mockStatus = 'loaded';
+		mockProvider = 'odie';
+		mockTrackEvent.mockClear();
+		mockSendMessage.mockReset();
+		mockSendMessage.mockResolvedValue( undefined );
+		window.localStorage.removeItem( 'agentsManagerAskAi' );
+	} );
+
+	it( 'shows the top five topics vertically on a fresh chat', () => {
+		render( <IntroSuggestions /> );
+
+		expect( screen.getByTestId( 'suggestions' ) ).toHaveAttribute( 'data-layout', 'vertical' );
+		[ 'Domains', 'Email', 'Themes & design', 'Traffic & SEO', 'Backups' ].forEach( ( label ) =>
+			expect( screen.getByText( label ) ).toBeInTheDocument()
+		);
+		expect( screen.queryByText( 'Plans & billing' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Users' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'drills into a topic and tracks the click', async () => {
+		render( <IntroSuggestions /> );
+
+		fireEvent.click( screen.getByText( 'Domains' ) );
+
+		expect( await screen.findByText( 'How do I connect a custom domain?' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'When does SSL activate on my domain?' ) ).toBeInTheDocument();
+		expect( screen.getByText( '‹ All topics' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Email' ) ).not.toBeInTheDocument();
+		expect( mockTrackEvent ).toHaveBeenCalledWith( 'chat_intro_topic_click', {
+			topic: 'domains',
+		} );
+	} );
+
+	it( 'returns to the topic list from the back item without sending anything', async () => {
+		render( <IntroSuggestions /> );
+
+		fireEvent.click( screen.getByText( 'Domains' ) );
+		fireEvent.click( await screen.findByText( '‹ All topics' ) );
+
+		expect( await screen.findByText( 'Email' ) ).toBeInTheDocument();
+		expect( mockSendMessage ).not.toHaveBeenCalled();
+		expect( mockTrackEvent ).toHaveBeenCalledWith( 'chat_intro_topic_back_click', {
+			topic: 'domains',
+		} );
+	} );
+
+	it( 'sends a question as a prompt and keeps the remaining topic questions up', async () => {
+		render( <IntroSuggestions /> );
+
+		fireEvent.click( screen.getByText( 'Domains' ) );
+		fireEvent.click( await screen.findByText( 'How do I connect a custom domain?' ) );
+
+		await waitFor( () =>
+			expect( mockSendMessage ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					content: 'How do I connect a custom domain?',
+					role: 'user',
+				} )
+			)
+		);
+		expect( mockTrackEvent ).toHaveBeenCalledWith( 'chat_intro_suggestion_click', {
+			suggestion: 'custom-domain',
+			topic: 'domains',
+		} );
+		// Asked question drops out; the rest of the topic stays, now horizontal.
+		expect( screen.queryByText( 'How do I connect a custom domain?' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'When does SSL activate on my domain?' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'suggestions' ) ).toHaveAttribute( 'data-layout', 'horizontal' );
+	} );
+
+	it( 'switches to the horizontal row with every remaining topic after the first stored message', () => {
+		mockMessages = [ userMessage( 'hello' ) ];
+		render( <IntroSuggestions /> );
+
+		expect( screen.getByTestId( 'suggestions' ) ).toHaveAttribute( 'data-layout', 'horizontal' );
+		expect( screen.getByText( 'Plans & billing' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Users' ) ).toBeInTheDocument();
+	} );
+
+	it( 'treats questions already in the conversation history as asked', async () => {
+		mockMessages = [ userMessage( 'How do I connect a custom domain?' ) ];
+		render( <IntroSuggestions /> );
+
+		fireEvent.click( screen.getByText( 'Domains' ) );
+
+		expect( await screen.findByText( 'When does SSL activate on my domain?' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'How do I connect a custom domain?' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides a topic whose questions are all asked', () => {
+		mockMessages = [
+			userMessage( 'How do I connect a custom domain?' ),
+			userMessage( 'How do I manage DNS records for my domain?' ),
+			userMessage( 'When does SSL activate on my domain?' ),
+		];
+		render( <IntroSuggestions /> );
+
+		expect( screen.queryByText( 'Domains' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'Email' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not send while the bot is busy', async () => {
+		mockStatus = 'sending';
+		render( <IntroSuggestions /> );
+
+		fireEvent.click( screen.getByText( 'Domains' ) );
+		fireEvent.click( await screen.findByText( 'How do I connect a custom domain?' ) );
+
+		await waitFor( () => expect( mockTrackEvent ).toHaveBeenCalled() );
+		expect( mockSendMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'restores the question chip when the send is aborted', async () => {
+		mockSendMessage.mockRejectedValue( { type: 'abort' } );
+		render( <IntroSuggestions /> );
+
+		fireEvent.click( screen.getByText( 'Domains' ) );
+		fireEvent.click( await screen.findByText( 'How do I connect a custom domain?' ) );
+
+		expect( await screen.findByText( 'How do I connect a custom domain?' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing during a live human (Zendesk) conversation', () => {
+		mockProvider = 'zendesk';
+		mockMessages = [ userMessage( 'hello' ) ];
+		render( <IntroSuggestions /> );
+
+		expect( screen.queryByTestId( 'suggestions' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders nothing while conversation history is loading', () => {
+		mockStatus = 'loading';
+		render( <IntroSuggestions /> );
+
+		expect( screen.queryByTestId( 'suggestions' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders nothing when the prototype knob is off', () => {
+		window.localStorage.setItem( 'agentsManagerAskAi', '0' );
+		render( <IntroSuggestions /> );
+
+		expect( screen.queryByTestId( 'suggestions' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/packages/odie-client/src/components/message/test/intro-suggestions.test.tsx
+++ b/packages/odie-client/src/components/message/test/intro-suggestions.test.tsx
@@ -90,7 +90,7 @@ describe( 'IntroSuggestions', () => {
 		mockTrackEvent.mockClear();
 		mockSendMessage.mockReset();
 		mockSendMessage.mockResolvedValue( undefined );
-		window.localStorage.removeItem( 'agentsManagerAskAi' );
+		window.localStorage.setItem( 'agentsManagerAskAi', '1' );
 	} );
 
 	it( 'shows the top five topics vertically on a fresh chat', () => {
@@ -149,6 +149,11 @@ describe( 'IntroSuggestions', () => {
 			suggestion: 'custom-domain',
 			topic: 'domains',
 		} );
+		expect( mockTrackEvent ).toHaveBeenCalledWith( 'chat_message_action_send', {
+			message_length: 'How do I connect a custom domain?'.length,
+			provider: 'odie',
+			context: 'intro_suggestion',
+		} );
 		// Asked question drops out; the rest of the topic stays, now horizontal.
 		expect( screen.queryByText( 'How do I connect a custom domain?' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'When does SSL activate on my domain?' ) ).toBeInTheDocument();
@@ -197,14 +202,27 @@ describe( 'IntroSuggestions', () => {
 		expect( mockSendMessage ).not.toHaveBeenCalled();
 	} );
 
-	it( 'restores the question chip when the send is aborted', async () => {
-		mockSendMessage.mockRejectedValue( { type: 'abort' } );
+	it( 'resets asked questions and drill-down when the conversation is cleared', async () => {
+		mockMessages = [ userMessage( 'How do I connect a custom domain?' ) ];
+		const { rerender } = render( <IntroSuggestions /> );
+		fireEvent.click( screen.getByText( 'Domains' ) );
+		expect( await screen.findByText( '‹ All topics' ) ).toBeInTheDocument();
+
+		// "New chat" empties chat.messages without unmounting the component.
+		mockMessages = [];
+		rerender( <IntroSuggestions /> );
+
+		expect( screen.getByTestId( 'suggestions' ) ).toHaveAttribute( 'data-layout', 'vertical' );
+		expect( screen.queryByText( '‹ All topics' ) ).not.toBeInTheDocument();
+		fireEvent.click( screen.getByText( 'Domains' ) );
+		expect( await screen.findByText( 'How do I connect a custom domain?' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders nothing while the chat is escalating to a human', () => {
+		mockStatus = 'transfer';
 		render( <IntroSuggestions /> );
 
-		fireEvent.click( screen.getByText( 'Domains' ) );
-		fireEvent.click( await screen.findByText( 'How do I connect a custom domain?' ) );
-
-		expect( await screen.findByText( 'How do I connect a custom domain?' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'suggestions' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders nothing during a live human (Zendesk) conversation', () => {
@@ -224,6 +242,13 @@ describe( 'IntroSuggestions', () => {
 
 	it( 'renders nothing when the prototype knob is off', () => {
 		window.localStorage.setItem( 'agentsManagerAskAi', '0' );
+		render( <IntroSuggestions /> );
+
+		expect( screen.queryByTestId( 'suggestions' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders nothing when the knob is unset — the shipping default', () => {
+		window.localStorage.removeItem( 'agentsManagerAskAi' );
 		render( <IntroSuggestions /> );
 
 		expect( screen.queryByTestId( 'suggestions' ) ).not.toBeInTheDocument();

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -263,6 +263,16 @@ const getOdieInitialPromptContext = ( botNameSlug: OdieAllowedBots ): Context | 
 	}
 };
 
+// DESIGN PROTOTYPE knob, shared with components/message/intro-suggestions.
+// Unset means on; set localStorage.agentsManagerAskAi to '0' to disable.
+export const isAskAiPrototypeEnabled = (): boolean => {
+	try {
+		return window.localStorage?.getItem( 'agentsManagerAskAi' ) !== '0';
+	} catch {
+		return false;
+	}
+};
+
 export const getOdieInitialMessage = (
 	botNameSlug: OdieAllowedBots,
 	displayName: string,
@@ -282,6 +292,15 @@ export const getOdieInitialMessage = (
 				__i18n_text_domain__
 		  );
 
+	// DESIGN PROTOTYPE: fold the human-handoff hint into the greeting — the
+	// topic suggestions below it are all support questions in this variant.
+	const effectiveIntroMessage = isAskAiPrototypeEnabled()
+		? __(
+				"I'm your Support Assistant. You can ask for a human at any time, just type “Human”.",
+				__i18n_text_domain__
+		  )
+		: introMessage;
+
 	return {
 		content: `**${ sprintf(
 			/* translators: %(name)s: the user's display name */
@@ -290,7 +309,7 @@ export const getOdieInitialMessage = (
 				/* translators: fallback used when the user's display name isn't available */
 				name: displayName || __( 'there', __i18n_text_domain__ ),
 			}
-		).trim() } 👋** \n\n ${ introMessage }`,
+		).trim() } 👋** \n\n ${ effectiveIntroMessage }`,
 		role: 'bot',
 		type: 'introduction',
 		context: getOdieInitialPromptContext( botNameSlug ),

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -264,10 +264,11 @@ const getOdieInitialPromptContext = ( botNameSlug: OdieAllowedBots ): Context | 
 };
 
 // DESIGN PROTOTYPE knob, shared with components/message/intro-suggestions.
-// Unset means on; set localStorage.agentsManagerAskAi to '0' to disable.
+// Opt-in so an accidental merge ships nothing: off unless
+// localStorage.agentsManagerAskAi is '1'.
 export const isAskAiPrototypeEnabled = (): boolean => {
 	try {
-		return window.localStorage?.getItem( 'agentsManagerAskAi' ) !== '0';
+		return window.localStorage?.getItem( 'agentsManagerAskAi' ) === '1';
 	} catch {
 		return false;
 	}

--- a/packages/odie-client/src/constants.tsx
+++ b/packages/odie-client/src/constants.tsx
@@ -293,13 +293,9 @@ export const getOdieInitialMessage = (
 				__i18n_text_domain__
 		  );
 
-	// DESIGN PROTOTYPE: fold the human-handoff hint into the greeting — the
-	// topic suggestions below it are all support questions in this variant.
+	// DESIGN PROTOTYPE greeting for the topic-suggestions variant.
 	const effectiveIntroMessage = isAskAiPrototypeEnabled()
-		? __(
-				"I'm your Support Assistant. You can ask for a human at any time, just type “Human”.",
-				__i18n_text_domain__
-		  )
+		? __( "I'm your Support Assistant. What can I help you with?", __i18n_text_domain__ )
 		: introMessage;
 
 	return {


### PR DESCRIPTION
Part of an ongoing Help Center suggestions design exploration. Draft / prototype — not intended to merge as-is.

Related: #113713 explores presales-surface starter chips on the pricing page. This PR is the wp-admin Support Assistant variant and deliberately stands alone; if both directions proceed, this component needs gating off the presales surface (a working version of that gate exists and is a small follow-up).

## Proposed Changes

* Topic-first starter suggestions for the Support Assistant. A fresh chat shows a vertical card of the top five support topics (mirroring the Help Center home's recommended guides); tapping a topic surfaces its questions plus a back item; once the conversation starts, suggestions move to a horizontal follow-up row that stays on the active topic until its questions run out. Built on `@automattic/agenttic-ui`'s `Suggestions` component, using its `action → false` contract for view-switching items so only real questions submit prompts.
* Greeting override for this variant: "I'm your Support Assistant. What can I help you with?" — knob-gated prototype copy. Typed human escalation still works; the greeting just no longer advertises it, per the project's human-support messaging principle.
* Suggestion sends emit the standard `chat_message_action_send` funnel event (with `context: 'intro_suggestion'`) so existing send metrics count them.
* `calypso_odie_chat_intro_topic_click` / `…_topic_back_click` / `…_suggestion_click` Tracks events.
* 14 component tests covering the drill-down, history dedupe, busy handling, New-chat state reset, and the render gates.
* Safety gates: never renders during live human (Zendesk) conversations, mid-escalation, or while history is loading. Local state resets when a new chat clears the conversation.

## Why are these changes being made?

* Internal experiment data on raising Help Center exposure showed users shifting from guides into chat, with a corresponding rise in human support escalations — chat acted as a terminus rather than a bridge back to self-serve content. Structuring the suggestions as the guide taxonomy (topics → questions) is the client-side half of making chat route people toward guides; answers that hand back to guides are the service side and out of scope here.
* A clickable interaction replica used to iterate on this design externally validated the drill-down flow before this implementation.

## Testing Instructions

* The prototype knob is opt-in so an accidental merge ships nothing: set `localStorage.agentsManagerAskAi = '1'` and reload to enable; remove it (or `'0'`) for stock.
* Open the Help Center assistant on a fresh chat → vertical card of five topics under the greeting. Tap a topic → its questions + "‹ All topics". Ask one → real bot answer; the remaining topic questions stay up as a horizontal row. Exhaust a topic → the row falls back to the other topics.
* Ask for a human and complete the transfer → suggestions disappear for the live conversation.
* Close/reopen the panel mid-conversation → no landing-card flash; already-asked questions stay hidden.
* `yarn test-packages packages/odie-client` — all passing.

Open questions for review: per-surface topic sets, replacing the knob with a real feature flag, Tracks event naming, and taxonomy ownership. Known upstream issue: `Suggestions` drops keyboard focus to `<body>` when the list re-renders on view switches — worth an agenttic-ui issue.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
