### PR TITLE
Me - MCP settings: update Badge component to `@wordpress/ui`

### DIFF
--- a/client/dashboard/me/mcp/wordpress-agent-slack.tsx
+++ b/client/dashboard/me/mcp/wordpress-agent-slack.tsx
@@ -4,11 +4,11 @@ import {
 	wordpressAgentSlackOauthMutation,
 	wordpressAgentSlackPairMutation,
 } from '@automattic/api-queries';
-import { Badge } from '@automattic/ui';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Button, Notice, Spinner, __experimentalVStack as VStack } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { Badge } from '@wordpress/ui';
 import { useState } from 'react';
 import SlackMark from 'calypso/assets/images/logos/slack-mark.svg';
 import { useAnalytics } from '../../app/analytics';
@@ -117,7 +117,7 @@ export default function WordPressAgentSlack( {
 						title={ connection.team_name }
 						actions={
 							connection.installed && connection.is_owner ? (
-								<Badge intent="info">{ __( 'Integration owner' ) }</Badge>
+								<Badge intent="informational">{ __( 'Integration owner' ) }</Badge>
 							) : undefined
 						}
 						description={


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Pre-requirement for removal of the Badge from `@automattic/ui` as we're now focusing on `@wordpress/ui` [Badge](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge-usage-guidelines--docs).

Part of https://github.com/Automattic/wp-calypso/issues/113835


## Proposed Changes

* Replace `@automattic/ui` `Badge` import with `@wordpress/ui` in WP Agent page.


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Badge is being removed from `@automattic/ui`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Badge should be similar blue badge as before at _Me → WordPress Agent._

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
