### PR TITLE
Onboarding: simplify progress stepper and move it to header

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/index.tsx
@@ -13,8 +13,20 @@ type Props = {
 	isStepSelectDisabled?: boolean;
 };
 
+/**
+ * The onboarding purchase progress rail, as a text rail in the top bar.
+ *
+ * Renders beside the WordPress logo rather than above the page content, so it
+ * costs no vertical space in the content column at all. There are no
+ * indicators: the steps are one word each, separated by a middot, and status
+ * is carried by weight and colour.
+ *
+ * `Stepper.Indicator` is still rendered even though no dot is drawn. It is
+ * what supplies the "Step 2 of 3, completed" text for screen readers, so it is
+ * visually clipped in style.scss rather than dropped from the tree.
+ */
 export function OnboardingProgress( { currentStep, onStepSelect, isStepSelectDisabled }: Props ) {
-	const { __ } = useI18n();
+	const { __, _x } = useI18n();
 
 	const domainsStepStatus = currentStep !== 'domains' ? ( 'completed' as const ) : undefined;
 	const plansStepStatus = currentStep === 'checkout' ? ( 'completed' as const ) : undefined;
@@ -29,7 +41,7 @@ export function OnboardingProgress( { currentStep, onStepSelect, isStepSelectDis
 				}
 			} }
 			aria-label={ __( 'Purchase steps' ) }
-			indicatorVariant="number"
+			indicatorVariant="bullet"
 			linear
 			className="onboarding-progress"
 		>
@@ -41,8 +53,10 @@ export function OnboardingProgress( { currentStep, onStepSelect, isStepSelectDis
 					className="onboarding-progress-step"
 				>
 					<UIStepper.Trigger className="onboarding-progress-trigger">
-						<UIStepper.Indicator />
-						<UIStepper.Title>{ __( 'Select a domain' ) }</UIStepper.Title>
+						<UIStepper.Indicator className="onboarding-progress-indicator" />
+						<UIStepper.Title className="onboarding-progress-title">
+							{ _x( 'Domain', 'onboarding purchase step' ) }
+						</UIStepper.Title>
 					</UIStepper.Trigger>
 				</UIStepper.Step>
 				<UIStepper.Step
@@ -52,14 +66,18 @@ export function OnboardingProgress( { currentStep, onStepSelect, isStepSelectDis
 					className="onboarding-progress-step"
 				>
 					<UIStepper.Trigger className="onboarding-progress-trigger">
-						<UIStepper.Indicator />
-						<UIStepper.Title>{ __( 'Select a plan' ) }</UIStepper.Title>
+						<UIStepper.Indicator className="onboarding-progress-indicator" />
+						<UIStepper.Title className="onboarding-progress-title">
+							{ _x( 'Plan', 'onboarding purchase step' ) }
+						</UIStepper.Title>
 					</UIStepper.Trigger>
 				</UIStepper.Step>
 				<UIStepper.Step value="checkout" className="onboarding-progress-step">
 					<UIStepper.Trigger className="onboarding-progress-trigger">
-						<UIStepper.Indicator />
-						<UIStepper.Title>{ __( 'Complete payment' ) }</UIStepper.Title>
+						<UIStepper.Indicator className="onboarding-progress-indicator" />
+						<UIStepper.Title className="onboarding-progress-title">
+							{ _x( 'Payment', 'onboarding purchase step' ) }
+						</UIStepper.Title>
 					</UIStepper.Trigger>
 				</UIStepper.Step>
 			</UIStepper.List>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/index.tsx
@@ -14,16 +14,17 @@ type Props = {
 };
 
 /**
- * The onboarding purchase progress rail, as a text rail in the top bar.
+ * The onboarding purchase progress rail, as a segmented bar in the top bar.
  *
  * Renders beside the WordPress logo rather than above the page content, so it
- * costs no vertical space in the content column at all. There are no
- * indicators: the steps are one word each, separated by a middot, and status
- * is carried by weight and colour.
+ * costs no vertical space in the content column. Nothing is drawn but three
+ * pills: the steps reached so far are filled, the rest are not.
  *
- * `Stepper.Indicator` is still rendered even though no dot is drawn. It is
- * what supplies the "Step 2 of 3, completed" text for screen readers, so it is
- * visually clipped in style.scss rather than dropped from the tree.
+ * Both the indicator and the title are still rendered even though neither is
+ * drawn as such. `Stepper.Indicator` becomes the pill and carries the
+ * "Step 2 of 3, completed" text; `Stepper.Title` supplies the step name. Both
+ * are what give each segment an accessible name, so the title is clipped in
+ * style.scss rather than dropped from the tree.
  */
 export function OnboardingProgress( { currentStep, onStepSelect, isStepSelectDisabled }: Props ) {
 	const { __, _x } = useI18n();

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/style.scss
@@ -1,29 +1,66 @@
 @import '@wordpress/theme/design-tokens.css';
 
-// The stepper carries its own vertical spacing, so drop the wrapper's
-// top padding to avoid doubling up the space above it.
-.step-container-v2__content-wrapper.axis-vertical:has( .onboarding-progress ) {
-	padding-top: 0;
-}
-
+// A text rail in the top bar: no indicators, no connectors, just the three
+// step names beside the WordPress logo. It costs nothing in the content
+// column, so unlike the previous treatment there is no wrapper padding to
+// compensate for here.
 .onboarding-progress {
 	display: flex;
-	justify-content: center;
-	padding: 8px 0;
-	margin-block-end: 32px;
-	// Ensure the stepper paints above the sticky checkout sidebar, which is positioned
-	// and would otherwise overlap the heading row at the same stacking level.
-	position: relative;
-	z-index: 1;
+	align-items: center;
 
 	.onboarding-progress-step {
 		display: flex;
-		justify-content: center;
+		align-items: center;
+
+		// Separator between steps. A pseudo-element on the step wrapper rather
+		// than a real node inside the tablist, so it stays out of every tab's
+		// accessible name.
+		&:not( :last-child )::after {
+			content: '\00b7';
+			color: var( --wpds-color-stroke-interactive-neutral );
+			padding-inline: var( --wpds-dimension-padding-xs );
+		}
 	}
 
 	.onboarding-progress-trigger {
 		display: flex;
 		align-items: center;
-		padding: 12px 16px;
+		padding: var( --wpds-dimension-padding-xs ) var( --wpds-dimension-padding-xs );
+		min-height: 0;
+	}
+
+	// No dot is drawn in this treatment, but the indicator still carries the
+	// "Step 2 of 3, completed" text that gives each step its accessible name.
+	// Clip it instead of removing it.
+	.onboarding-progress-indicator {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip-path: inset( 50% );
+		white-space: nowrap;
+		border: 0;
+	}
+
+	// The component's own styles set title colours from the step status, so
+	// these selectors are scoped one level deeper to win. Completed and current
+	// keep the component's neutral; only upcoming is pulled back to weak, and
+	// everything drops to 12px for the top bar.
+	.onboarding-progress-step .onboarding-progress-title {
+		font-size: var( --wpds-typography-font-size-sm );
+		line-height: var( --wpds-typography-line-height-xs );
+		white-space: nowrap;
+	}
+
+	.onboarding-progress-step:not( [data-status] ):not( [data-current] ) .onboarding-progress-title {
+		color: var( --wpds-color-foreground-content-neutral-weak );
+	}
+
+	// Completed steps are the only navigable ones, so give the pointer an extra
+	// cue beyond the component's brand hover colour.
+	.onboarding-progress-trigger:hover:not( [aria-disabled='true'] ) .onboarding-progress-title {
+		text-decoration: underline;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/style.scss
@@ -1,9 +1,13 @@
 @import '@wordpress/theme/design-tokens.css';
 
-// A text rail in the top bar: no indicators, no connectors, just the three
-// step names beside the WordPress logo. It costs nothing in the content
-// column, so unlike the previous treatment there is no wrapper padding to
-// compensate for here.
+// A segmented bar in the top bar: one pill per step beside the WordPress logo,
+// filled up to the step you are on. No labels, no numbers, no dots. It costs
+// nothing in the content column, so unlike the previous treatment there is no
+// wrapper padding to compensate for here.
+//
+// The component's own styles are scoped by `[data-indicator-variant]`, which
+// the root always renders. Qualifying selectors with that attribute is what
+// lets these rules win without resorting to !important.
 .onboarding-progress {
 	display: flex;
 	align-items: center;
@@ -11,28 +15,45 @@
 	.onboarding-progress-step {
 		display: flex;
 		align-items: center;
-
-		// Separator between steps. A pseudo-element on the step wrapper rather
-		// than a real node inside the tablist, so it stays out of every tab's
-		// accessible name.
-		&:not( :last-child )::after {
-			content: '\00b7';
-			color: var( --wpds-color-stroke-interactive-neutral );
-			padding-inline: var( --wpds-dimension-padding-xs );
-		}
 	}
 
+	// The visible bar is 4px tall, so the trigger carries the padding that makes
+	// a usable pointer and touch target out of it.
 	.onboarding-progress-trigger {
 		display: flex;
 		align-items: center;
-		padding: var( --wpds-dimension-padding-xs ) var( --wpds-dimension-padding-xs );
+		padding: var( --wpds-dimension-padding-sm ) var( --wpds-dimension-gap-xs );
 		min-height: 0;
 	}
 
-	// No dot is drawn in this treatment, but the indicator still carries the
-	// "Step 2 of 3, completed" text that gives each step its accessible name.
-	// Clip it instead of removing it.
-	.onboarding-progress-indicator {
+	// The indicator IS the pill. Overrides the component's circle geometry.
+	.onboarding-progress-step .onboarding-progress-indicator[data-indicator-variant] {
+		width: var( --wpds-dimension-size-md );
+		height: var( --wpds-dimension-size-5xs );
+		// Half the 4px height, so the ends come out fully round.
+		border-radius: var( --wpds-border-radius-sm );
+		border: 0;
+		background: var( --wpds-color-stroke-surface-neutral );
+	}
+
+	// Steps reached so far are filled. Completed and current read the same on
+	// purpose: together they are the progress, and the boundary between filled
+	// and unfilled is what carries the meaning.
+	.onboarding-progress-step[data-status='completed'] .onboarding-progress-indicator[data-indicator-variant],
+	.onboarding-progress-step[data-current] .onboarding-progress-indicator[data-indicator-variant] {
+		background: var( --wpds-color-background-interactive-neutral-strong );
+	}
+
+	// The check glyph and the current-step dome would otherwise sit inside a 4px
+	// pill. The indicator's visually hidden step text is a sibling and is not
+	// affected by this.
+	.onboarding-progress-indicator svg {
+		display: none;
+	}
+
+	// The step name still gives each segment its accessible name, so it is
+	// clipped rather than removed.
+	.onboarding-progress-title {
 		position: absolute;
 		width: 1px;
 		height: 1px;
@@ -44,23 +65,8 @@
 		border: 0;
 	}
 
-	// The component's own styles set title colours from the step status, so
-	// these selectors are scoped one level deeper to win. Completed and current
-	// keep the component's neutral; only upcoming is pulled back to weak, and
-	// everything drops to 12px for the top bar.
-	.onboarding-progress-step .onboarding-progress-title {
-		font-size: var( --wpds-typography-font-size-sm );
-		line-height: var( --wpds-typography-line-height-xs );
-		white-space: nowrap;
-	}
-
-	.onboarding-progress-step:not( [data-status] ):not( [data-current] ) .onboarding-progress-title {
-		color: var( --wpds-color-foreground-content-neutral-weak );
-	}
-
-	// Completed steps are the only navigable ones, so give the pointer an extra
-	// cue beyond the component's brand hover colour.
-	.onboarding-progress-trigger:hover:not( [aria-disabled='true'] ) .onboarding-progress-title {
-		text-decoration: underline;
+	// Completed steps are the only navigable ones.
+	.onboarding-progress-trigger:hover:not( [aria-disabled='true'] ) .onboarding-progress-indicator[data-indicator-variant] {
+		background: var( --wpds-color-foreground-interactive-brand );
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/onboarding-progress.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/onboarding-progress/test/onboarding-progress.test.tsx
@@ -10,10 +10,10 @@ describe( 'OnboardingProgress', () => {
 		const onStepSelect = jest.fn();
 		render( <OnboardingProgress currentStep="checkout" onStepSelect={ onStepSelect } /> );
 
-		await userEvent.click( screen.getByRole( 'tab', { name: /Select a domain/ } ) );
+		await userEvent.click( screen.getByRole( 'tab', { name: /Domain/ } ) );
 		expect( onStepSelect ).toHaveBeenCalledWith( 'domains' );
 
-		await userEvent.click( screen.getByRole( 'tab', { name: /Select a plan/ } ) );
+		await userEvent.click( screen.getByRole( 'tab', { name: /Plan/ } ) );
 		expect( onStepSelect ).toHaveBeenCalledWith( 'plans' );
 	} );
 
@@ -21,7 +21,7 @@ describe( 'OnboardingProgress', () => {
 		const onStepSelect = jest.fn();
 		render( <OnboardingProgress currentStep="checkout" onStepSelect={ onStepSelect } /> );
 
-		await userEvent.click( screen.getByRole( 'tab', { name: /Complete payment/ } ) );
+		await userEvent.click( screen.getByRole( 'tab', { name: /Payment/ } ) );
 		expect( onStepSelect ).not.toHaveBeenCalled();
 	} );
 
@@ -35,11 +35,22 @@ describe( 'OnboardingProgress', () => {
 			/>
 		);
 
-		const domainsStep = screen.getByRole( 'tab', { name: /Select a domain/ } );
+		const domainsStep = screen.getByRole( 'tab', { name: /Domain/ } );
 		expect( domainsStep ).toHaveAttribute( 'aria-disabled', 'true' );
 
 		await userEvent.click( domainsStep );
-		await userEvent.click( screen.getByRole( 'tab', { name: /Select a plan/ } ) );
+		await userEvent.click( screen.getByRole( 'tab', { name: /Plan/ } ) );
 		expect( onStepSelect ).not.toHaveBeenCalled();
+	} );
+
+	// The text rail draws no dots, but Stepper.Indicator is still rendered
+	// because it supplies the position and status text. It is clipped in CSS,
+	// not removed. This test fails if anyone deletes it from the tree.
+	it( 'keeps step position and status in each accessible name', () => {
+		render( <OnboardingProgress currentStep="plans" /> );
+
+		expect( screen.getByRole( 'tab', { name: 'Step 1 of 3, completed Domain' } ) ).toBeVisible();
+		expect( screen.getByRole( 'tab', { name: 'Step 2 of 3 Plan' } ) ).toBeVisible();
+		expect( screen.getByRole( 'tab', { name: 'Step 3 of 3 Payment' } ) ).toBeVisible();
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domain-search/index.tsx
@@ -480,8 +480,10 @@ const DomainSearchStep: StepType< {
 
 	if ( shouldUseStepContainerV2( flow ) ) {
 		const getTopBarLeftElement = () => {
+			// The progress rail lives in the top bar beside the logo, so it takes
+			// the left slot that would otherwise carry the back button.
 			if ( showProgress ) {
-				return;
+				return <OnboardingProgress currentStep="domains" />;
 			}
 
 			if ( isNewHostedSiteCreationFlow( flow ) ) {
@@ -601,7 +603,6 @@ const DomainSearchStep: StepType< {
 					// high-quality results can fill the limited vertical space.
 					// The empty/initial state keeps the heading on mobile.
 					<>
-						{ showProgress && <OnboardingProgress currentStep="domains" /> }
 						{ ! ( isMobileViewport && query ) && (
 							<Step.Heading text={ headerText } subText={ subHeaderText } />
 						) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/unified-plans/unified-plans-step.tsx
@@ -720,6 +720,18 @@ function UnifiedPlansStep( {
 	if ( useStepContainerV2 && wrapperProps ) {
 		const goBack = wrapperProps.hideBack || showProgress ? undefined : wrapperProps.goBack;
 
+		// The progress rail lives in the top bar beside the logo. It and the back
+		// button share the left slot; `goBack` is already undefined whenever the
+		// rail is showing, so the two can never collide.
+		let topBarLeftElement;
+		if ( showProgress ) {
+			topBarLeftElement = (
+				<OnboardingProgress currentStep="plans" onStepSelect={ () => wrapperProps.goBack?.() } />
+			);
+		} else if ( goBack ) {
+			topBarLeftElement = <Step.BackButton onClick={ goBack }>{ backLabelText }</Step.BackButton>;
+		}
+
 		return (
 			<>
 				{ /*
@@ -742,11 +754,7 @@ function UnifiedPlansStep( {
 						} ) }
 						topBar={
 							<Step.TopBar
-								leftElement={
-									goBack ? (
-										<Step.BackButton onClick={ goBack }>{ backLabelText }</Step.BackButton>
-									) : undefined
-								}
+								leftElement={ topBarLeftElement }
 								rightElement={
 									isOnboardingFlow( flowName ) ? (
 										<>
@@ -766,12 +774,6 @@ function UnifiedPlansStep( {
 						}
 						heading={
 							<>
-								{ showProgress && (
-									<OnboardingProgress
-										currentStep="plans"
-										onStepSelect={ () => wrapperProps.goBack?.() }
-									/>
-								) }
 								{ ( intent === 'plans-website-builder' ||
 									intent === 'plans-wordpress-hosting' ) && (
 									<IntentToggle

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1132,27 +1132,26 @@ export default function CheckoutMainContent( {
 				<Step.TwoColumnLayout
 					firstColumnWidth={ 8 }
 					secondColumnWidth={ 4 }
-					heading={
-						showProgress ? (
-							<OnboardingProgress
-								currentStep="checkout"
-								isStepSelectDisabled={ leaveModalProps.isLeaveDisabled }
-								onStepSelect={ ( step ) =>
-									handleProgressStepSelect( step, {
-										forceCheckoutBackUrlDomains,
-										forceCheckoutBackUrl,
-										clickStepBack: leaveModalProps.clickStepBack,
-										clickClose: leaveModalProps.clickClose,
-									} )
-								}
-							/>
-						) : undefined
-					}
 					topBar={ ( { isLargeViewport } ) => {
 						const topBar = (
 							<Step.TopBar
 								leftElement={
-									showProgress ? undefined : (
+									// The progress rail takes the left slot beside the logo,
+									// standing in for the back button while it is showing.
+									showProgress ? (
+										<OnboardingProgress
+											currentStep="checkout"
+											isStepSelectDisabled={ leaveModalProps.isLeaveDisabled }
+											onStepSelect={ ( step ) =>
+												handleProgressStepSelect( step, {
+													forceCheckoutBackUrlDomains,
+													forceCheckoutBackUrl,
+													clickStepBack: leaveModalProps.clickStepBack,
+													clickClose: leaveModalProps.clickClose,
+												} )
+											}
+										/>
+									) : (
 										<Step.BackButton
 											onClick={ leaveModalProps.clickClose }
 											disabled={ leaveModalProps.isLeaveDisabled }


### PR DESCRIPTION
## Proposed Changes

* Move the onboarding purchase progress out of the content column and into the top bar, beside the WordPress logo.
* Draw it as three pills, filled up to the step you are on. No labels, no numbers, no dots.
* Keep completed steps clickable, so the rail still navigates back to the domain and plan steps.

## Screenshots

Before and after are needed here, at a large viewport on the domain, plan and checkout steps. Núria to add.

| Before | After |
| --- | --- |
| _to add_ | _to add_ |

## Why are these changes being made?

The rail took roughly 92px of vertical height on desktop and pushed the page down. That was the main complaint in design review, and it got worse next to the pricing grid with platform differentiators, where the two together meant scrolling before any plans were visible.

Putting it in the top bar takes that cost to zero, because the bar is already on screen. Reducing it to an unlabelled bar is the least prominent version that still answers "where am I, and how much is left", which is the part worth protecting.

This is a prototype for side by side comparison, not a merge candidate. It is not behind an experiment gate.

## Testing Instructions

Desktop only. Below the large breakpoint the rail is hidden and the existing top bar step counter takes over, so test at a wide window.

1. Start onboarding and go to the domain step. The bar sits to the right of the WordPress logo, with the first segment filled.
2. Continue to plans, then to checkout. One more segment fills each time.
3. From plans or checkout, click a filled segment to the left of the current one. It should take you back to that step.
4. Tab into the top bar. Each segment should take focus in turn and show a focus ring.
5. Shrink the window below the large breakpoint. The bar should disappear and the "2 of 3" counter should appear on the right instead.
6. Try it against the pricing grid variant with platform differentiators, not just the plain grid. That pairing is the problem this is meant to fix.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
