### PR TITLE
Help Center: run the Zendesk connectivity check on demand

### DIFF
--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -44,9 +44,8 @@ const HelpCenter: React.FC< Container > = ( {
 		! isLoadingOpenInteractions && supportInteractionsOpen
 			? supportInteractionsOpen?.length > 0
 			: false;
-	// The connectivity check costs a network request per page load, so only run it once
-	// its answer can change something: the Help Center is open, or Smooch may need to
-	// mount for unread notifications.
+	// Only check connectivity when the answer can matter: the panel is open, or Smooch
+	// may need to mount for unread notifications.
 	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging(
 		!! currentUser?.ID && ( isHelpCenterShown || hasOpenZendeskConversations ),
 		site?.ID

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -38,16 +38,19 @@ const HelpCenter: React.FC< Container > = ( {
 	}, [] );
 	const { currentUser, site } = useHelpCenterContext();
 	const { setCurrentUser } = useDispatch( HELP_CENTER_STORE );
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging(
-		!! currentUser?.ID,
-		site?.ID
-	);
 	const { data: supportInteractionsOpen, isLoading: isLoadingOpenInteractions } =
 		useGetSupportInteractions( 'zendesk' );
 	const hasOpenZendeskConversations =
 		! isLoadingOpenInteractions && supportInteractionsOpen
 			? supportInteractionsOpen?.length > 0
 			: false;
+	// The connectivity check costs a network request per page load, so only run it once
+	// its answer can change something: the Help Center is open, or Smooch may need to
+	// mount for unread notifications.
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging(
+		!! currentUser?.ID && ( isHelpCenterShown || hasOpenZendeskConversations ),
+		site?.ID
+	);
 
 	useEffect( () => {
 		if ( currentUser ) {

--- a/packages/help-center/src/hooks/use-get-support-interactions.ts
+++ b/packages/help-center/src/hooks/use-get-support-interactions.ts
@@ -18,19 +18,23 @@ export const useGetSupportInteractions = (
 	// No auth cookie yet (e.g. right after in-stepper signup) means these authed requests
 	// would 401 and leave the panel stuck loading; skip them and render the logged-out home.
 	const isAuthed = !! currentUser?.ID && ! isCookieAuthMissing();
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( isAuthed, site?.ID );
+	// Subscribe without fetching: the interactions endpoint is a WordPress.com API and
+	// works regardless of Zendesk connectivity. Whoever needs the connectivity answer
+	// (e.g. the Help Center root, to mount Smooch) triggers the check; here it only
+	// hides Zendesk conversations once the user is known to be unable to open them.
+	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( false, site?.ID );
 
-	let shouldFetch = enabled && isAuthed;
-	// Only fetch Zendesk interactions if the user can connect to Zendesk.
-	if ( ( provider === 'zendesk' || provider === 'zendesk-staging' ) && ! canConnectToZendesk ) {
-		shouldFetch = false;
-	}
+	const isZendeskProvider = provider === 'zendesk' || provider === 'zendesk-staging';
+	const shouldFetch = enabled && isAuthed;
 
 	return useQuery( {
 		queryKey: [ 'support-interactions', 'get-interactions', isTestMode ],
 		queryFn: () => handleSupportInteractionsFetch( 'GET', '?per_page=100&page=1', isTestMode ),
 		select: ( response ) => {
 			if ( provider ) {
+				if ( isZendeskProvider && canConnectToZendesk === false ) {
+					return [];
+				}
 				return response.filter( ( interaction ) =>
 					interaction.events.some( ( event ) => event.event_source === provider )
 				);

--- a/packages/help-center/src/hooks/use-get-support-interactions.ts
+++ b/packages/help-center/src/hooks/use-get-support-interactions.ts
@@ -18,9 +18,7 @@ export const useGetSupportInteractions = (
 	// No auth cookie yet (e.g. right after in-stepper signup) means these authed requests
 	// would 401 and leave the panel stuck loading; skip them and render the logged-out home.
 	const isAuthed = !! currentUser?.ID && ! isCookieAuthMissing();
-	// Subscribe without fetching: the interactions endpoint is a WordPress.com API and
-	// works regardless of Zendesk connectivity. Whoever needs the connectivity answer
-	// (e.g. the Help Center root, to mount Smooch) triggers the check; here it only
+	// Subscribe without fetching: the Help Center root triggers the check; here it only
 	// hides Zendesk conversations once the user is known to be unable to open them.
 	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( false, site?.ID );
 

--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -1,4 +1,9 @@
-import { getValidBlogId, recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
+import {
+	getValidBlogId,
+	NO_SITE_CONTEXT,
+	recordTracksEvent,
+	withSiteContext,
+} from '@automattic/calypso-analytics';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useEffect } from '@wordpress/element';
 import type { Query } from '@tanstack/react-query';
@@ -10,8 +15,10 @@ const QUERY_KEY = [ 'canConnectToZendesk' ];
  * ones. Version 2 reports once per settled query instead of once per observer per state.
  * Version 3 attaches the support site as `blog_id` when a consumer knows it; only the
  * request event gained anything in v3, the error event merely shares the counter.
+ * Version 4 declares `site_context_source: 'none'` when no consumer supplied a site,
+ * instead of omitting the property.
  */
-const REPORTING_VERSION = 3;
+const REPORTING_VERSION = 4;
 
 type ReportingState = {
 	lastResolutionKey?: string;
@@ -51,8 +58,7 @@ function fetchZendeskConfig() {
  *
  * `siteId` is the support site the caller knows, if any. The connectivity check is shared
  * across all consumers, so the reported event attaches the last valid site any of them
- * supplied; when none did, the properties stay site-less rather than asserting that no
- * site exists.
+ * supplied; when none did, it reports `site_context_source: 'none'`.
  */
 export function useCanConnectToZendeskMessaging( enabled = true, siteId?: number | string ) {
 	const queryClient = useQueryClient();
@@ -135,9 +141,11 @@ export function useCanConnectToZendeskMessaging( enabled = true, siteId?: number
 		};
 		recordTracksEvent(
 			'calypso_helpcenter_zendesk_config_request',
-			reportingState.blogId
-				? withSiteContext( requestProperties, 'help_center_context', reportingState.blogId )
-				: requestProperties
+			withSiteContext(
+				requestProperties,
+				reportingState.blogId ? 'help_center_context' : NO_SITE_CONTEXT,
+				reportingState.blogId
+			)
 		);
 		// The two timestamps look redundant next to `fetchStatus`, which already cycles on
 		// every network refetch. They are what re-runs this for a resolution that leaves

--- a/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
+++ b/packages/zendesk-client/src/use-can-connect-to-zendesk-messaging.ts
@@ -15,8 +15,8 @@ const QUERY_KEY = [ 'canConnectToZendesk' ];
  * ones. Version 2 reports once per settled query instead of once per observer per state.
  * Version 3 attaches the support site as `blog_id` when a consumer knows it; only the
  * request event gained anything in v3, the error event merely shares the counter.
- * Version 4 declares `site_context_source: 'none'` when no consumer supplied a site,
- * instead of omitting the property.
+ * Version 4 declares `site_context_source: 'none'` instead of omitting it when no
+ * consumer supplied a site.
  */
 const REPORTING_VERSION = 4;
 

--- a/packages/zendesk-client/test/use-can-connect-to-zendesk-messaging.test.tsx
+++ b/packages/zendesk-client/test/use-can-connect-to-zendesk-messaging.test.tsx
@@ -15,7 +15,7 @@ jest.mock( '@automattic/calypso-analytics', () => ( {
 
 const REQUEST_EVENT = 'calypso_helpcenter_zendesk_config_request';
 const ERROR_EVENT = 'calypso_helpcenter_zendesk_config_error';
-const REPORTING_VERSION = 3;
+const REPORTING_VERSION = 4;
 const fetchMock = jest.fn();
 const originalFetch = globalThis.fetch;
 
@@ -67,6 +67,7 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 			status_text: undefined,
 			failure_count: 0,
 			reporting_version: REPORTING_VERSION,
+			site_context_source: 'none',
 		} );
 	} );
 
@@ -102,7 +103,7 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 		} );
 	} );
 
-	it( 'keeps the properties site-less for an invalid site id', async () => {
+	it( 'declares no site context for an invalid site id', async () => {
 		const queryClient = makeQueryClient();
 		const { result } = renderHook( () => useCanConnectToZendeskMessaging( true, 0 ), {
 			wrapper: makeWrapper( queryClient ),
@@ -115,6 +116,7 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 			status_text: undefined,
 			failure_count: 0,
 			reporting_version: REPORTING_VERSION,
+			site_context_source: 'none',
 		} );
 	} );
 
@@ -137,6 +139,7 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 			status_text: undefined,
 			failure_count: 0,
 			reporting_version: REPORTING_VERSION,
+			site_context_source: 'none',
 		} );
 	} );
 
@@ -220,6 +223,7 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 			status_text: 'Zendesk unavailable',
 			failure_count: 4,
 			reporting_version: REPORTING_VERSION,
+			site_context_source: 'none',
 		} );
 	} );
 
@@ -242,6 +246,7 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 			status_text: undefined,
 			failure_count: 2,
 			reporting_version: REPORTING_VERSION,
+			site_context_source: 'none',
 		} );
 	} );
 
@@ -295,6 +300,7 @@ describe( 'useCanConnectToZendeskMessaging', () => {
 			status_text: undefined,
 			failure_count: 2,
 			reporting_version: REPORTING_VERSION,
+			site_context_source: 'none',
 		} );
 	} );
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTSUP-553/help-center-record-zendesk-config-request-once-per-query-resolution
Fixes https://linear.app/a8c/issue/DOTSUP-554/help-center-emit-no-site-context-sentinel-on-site-context-source-when

## Proposed Changes

**The Zendesk connectivity check now runs only when its answer can change something, instead of on every page load for every logged-in user.**

- The Help Center enables the check only when the panel is open or the user has open Zendesk conversations; the support-interactions request no longer triggers it, since that endpoint works regardless of Zendesk connectivity.
- `calypso_helpcenter_zendesk_config_request` now reports `site_context_source: 'none'` when no caller supplied a site, and bumps `reporting_version` to 4.

## Why are these changes being made?

The check fires a network request and a Tracks event about 11 times per user per day (~1M events/day), but the result is only used when the Help Center opens or chat needs to connect ([DOTSUP-553](https://linear.app/a8c/issue/DOTSUP-553/help-center-record-zendesk-config-request-once-per-query-resolution)). Separately, when the event carried no site there was no way to tell “no site was involved” apart from “a call site forgot to pass one” — the new `none` value declares the first case explicitly ([DOTSUP-554](https://linear.app/a8c/issue/DOTSUP-554/help-center-emit-no-site-context-sentinel-on-site-context-source-when)).

## Testing Instructions

### Calypso

1. `yarn start`, log in, browse a few pages without opening the Help Center: no request to Zendesk config in the Network tab, no `calypso_helpcenter_zendesk_config_request` Tracks event.
2. Open the Help Center: the config request fires once and the event carries `reporting_version: 4` and a `site_context_source`.
3. If you have an open Zendesk conversation, reload without opening the panel: the request still fires (Smooch needs it for unread notifications).

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`, run `cd apps/help-center && yarn dev --sync`.
2. Visit a Simple or Atomic site’s wp-admin and repeat the checks above.
