### PR TITLE
Sites - plans: switch to Badge from `@wordpress/ui`

### DIFF
--- a/client/sites/plan/components/current-plan-panel/index.tsx
+++ b/client/sites/plan/components/current-plan-panel/index.tsx
@@ -1,7 +1,7 @@
 import { is100Year } from '@automattic/calypso-products';
 import { LoadingPlaceholder } from '@automattic/components';
-import { Badge } from '@automattic/ui';
 import { Button } from '@wordpress/components';
+import { Badge } from '@wordpress/ui';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { isPartnerPurchase, purchaseType } from 'calypso/lib/purchases';
@@ -86,7 +86,9 @@ export default function CurrentPlanPanel() {
 						) : (
 							<>
 								<h3>{ planName }</h3>
-								{ ! isA4APlan && ! is100YearPlan && <Badge>{ translate( 'Current plan' ) }</Badge> }
+								{ ! isA4APlan && ! is100YearPlan && (
+									<Badge intent="draft">{ translate( 'Current plan' ) }</Badge>
+								) }
 							</>
 						) }
 					</div>


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Pre-requirement for removal of the Badge from `@automattic/ui` as we're now focusing on `@wordpress/ui` [Badge](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge-usage-guidelines--docs).

Part of https://github.com/Automattic/wp-calypso/issues/113835


## Proposed Changes

* Replace `@automattic/ui` `Badge` import with `@wordpress/ui` for "Current plan" in Plan component.


Checked for no overriding styles for the old badge in the styles

https://github.com/Automattic/wp-calypso/blob/7455448a774bc7bcaa4f70af28beec817c1f013a/client/sites/plan/components/current-plan-panel/style.scss#L25-L30

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Badge is being removed from `@automattic/ui`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable `untangling/plans` flag, otherwise you won't see the new plans page, e.g. url `http://calypso.localhost:3000/plans/SITE_SLUG?flags=untangling/plans`

See the grey "Current plan" badge.

### Before
<img width="1070" height="291" alt="Screenshot 2026-09-01 at 16 40 20" src="https://github.com/user-attachments/assets/77800d04-27f6-447b-bed8-77660238a087" />

### After
<img width="1009" height="288" alt="Screenshot 2026-09-01 at 16 40 02" src="https://github.com/user-attachments/assets/d1ab51b6-fdb5-4d0f-8dde-9cd0f11a49da" />




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
