### PR TITLE
Checkout: keep gift checkout "Back" disabled until the gift details arrive

### DIFF
--- a/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
+++ b/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
@@ -29,6 +29,8 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 		responseCart,
 		replaceProductsInCart,
 		isLoading: isCartLoading,
+		isPendingUpdate: isCartPendingUpdate,
+		loadingError: cartLoadingError,
 	} = useShoppingCart( cartKey );
 	const giftBackUrl = getGiftCheckoutBackUrl( {
 		giftDetails: responseCart.gift_details,
@@ -132,7 +134,16 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 		// saving the cart (does it hold anything?) and, for a gift checkout, where
 		// to go (`gift_details`). Neither is known until the cart arrives, so the
 		// control stays disabled rather than acting on a placeholder.
-		isLeaveDisabled: isCartLoading,
+		//
+		// `isLoading` alone is not enough: it only covers the initial fetch, and
+		// the products this URL asks for are added afterwards, in a second
+		// round-trip. The gap is widest for the siteless carts a gift checkout
+		// uses, because a 'no-user' cart never fetches — it resolves its initial
+		// cart locally and empty — so the control would go live while the gifted
+		// plan (and with it `gift_details`) is still on its way to the server.
+		// `isPendingUpdate` covers that window. A cart that failed to load stops
+		// waiting, so a broken cart can't trap the user in checkout.
+		isLeaveDisabled: ( isCartLoading || isCartPendingUpdate ) && ! cartLoadingError,
 		clickClose,
 		clickStepBack,
 		closeAndLeave,

--- a/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
+++ b/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
@@ -32,6 +32,7 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 		isPendingUpdate: isCartPendingUpdate,
 		loadingError: cartLoadingError,
 	} = useShoppingCart( cartKey );
+	const hasCartFailed = Boolean( cartLoadingError );
 	const giftBackUrl = getGiftCheckoutBackUrl( {
 		giftDetails: responseCart.gift_details,
 		referrer: document.referrer,
@@ -141,9 +142,12 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 		// uses, because a 'no-user' cart never fetches — it resolves its initial
 		// cart locally and empty — so the control would go live while the gifted
 		// plan (and with it `gift_details`) is still on its way to the server.
-		// `isPendingUpdate` covers that window. A cart that failed to load stops
-		// waiting, so a broken cart can't trap the user in checkout.
-		isLeaveDisabled: ( isCartLoading || isCartPendingUpdate ) && ! cartLoadingError,
+		// `isPendingUpdate` covers that window.
+		//
+		// A failed cart is the exception: it reports itself as forever pending
+		// (its cache status never returns to valid), so waiting on it would trap
+		// the user in checkout. Let them leave instead.
+		isLeaveDisabled: ! hasCartFailed && ( isCartLoading || isCartPendingUpdate ),
 		clickClose,
 		clickStepBack,
 		closeAndLeave,

--- a/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
+++ b/client/my-sites/checkout/src/components/leave-checkout-modal.tsx
@@ -28,7 +28,6 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 	const {
 		responseCart,
 		replaceProductsInCart,
-		isLoading: isCartLoading,
 		isPendingUpdate: isCartPendingUpdate,
 		loadingError: cartLoadingError,
 	} = useShoppingCart( cartKey );
@@ -37,6 +36,8 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 		giftDetails: responseCart.gift_details,
 		referrer: document.referrer,
 	} );
+	const isGiftCheckout = window.location.pathname.includes( '/gift/' );
+	const isAwaitingGiftDetails = isGiftCheckout && ! responseCart.gift_details;
 	// Used to lazily clear the siteless 'no-site'/'no-user' carts used by
 	// signup steps before a site exists. /start/domain/domain-only adds the
 	// domain to 'no-site' (logged-in) or 'no-user' (logged-out); if the user
@@ -131,23 +132,27 @@ export const useCheckoutLeaveModal = ( { siteUrl }: { siteUrl: string } ) => {
 	return {
 		isModalVisible,
 		setIsModalVisible,
-		// The cart answers both questions "Back" depends on: whether to ask about
-		// saving the cart (does it hold anything?) and, for a gift checkout, where
-		// to go (`gift_details`). Neither is known until the cart arrives, so the
-		// control stays disabled rather than acting on a placeholder.
+		// "Back" asks the cart two questions, and waits on each only until that
+		// answer is trustworthy.
 		//
-		// `isLoading` alone is not enough: it only covers the initial fetch, and
-		// the products this URL asks for are added afterwards, in a second
-		// round-trip. The gap is widest for the siteless carts a gift checkout
-		// uses, because a 'no-user' cart never fetches — it resolves its initial
-		// cart locally and empty — so the control would go live while the gifted
-		// plan (and with it `gift_details`) is still on its way to the server.
-		// `isPendingUpdate` covers that window.
+		// "Does it hold anything?" decides whether to offer to save the cart. An
+		// empty cart is ambiguous mid-update, because the products a checkout URL
+		// asks for arrive after the initial fetch, in a second round-trip. A cart
+		// that already holds products answers regardless, so later updates — a
+		// coupon, a tax recalculation — leave the control alone.
 		//
-		// A failed cart is the exception: it reports itself as forever pending
-		// (its cache status never returns to valid), so waiting on it would trap
-		// the user in checkout. Let them leave instead.
-		isLeaveDisabled: ! hasCartFailed && ( isCartLoading || isCartPendingUpdate ),
+		// "Where does a gift go?" is answered by `gift_details`, so gift checkouts
+		// wait on that datum rather than on the cart settling: a 'no-user' cart
+		// never fetches and settles locally empty while the gifted plan is still
+		// in flight, and a 'no-site' cart may settle holding a leftover item from
+		// an earlier signup. Both look answerable before they are.
+		//
+		// A failed cart answers neither, but waiting on it would trap the user, so
+		// let them leave — without `gift_details` a gift falls back to `cancel_to`.
+		// The escape is not permanent: a later reload clears the error.
+		isLeaveDisabled:
+			! hasCartFailed &&
+			( isAwaitingGiftDetails || ( isCartPendingUpdate && responseCart.products.length === 0 ) ),
 		clickClose,
 		clickStepBack,
 		closeAndLeave,

--- a/client/my-sites/checkout/src/components/test/leave-checkout-modal.test.tsx
+++ b/client/my-sites/checkout/src/components/test/leave-checkout-modal.test.tsx
@@ -633,4 +633,102 @@ describe( 'useCheckoutLeaveModal gift checkout', () => {
 			);
 		} );
 	} );
+
+	describe( 'when the gifted plan has not reached the server yet', () => {
+		/**
+		 * Reproduce the logged-out gift checkout: a 'no-user' cart never fetches,
+		 * so its initial cart resolves locally and empty, and the gifted plan only
+		 * exists on the cart once checkout has sent it to the server. `releaseCart`
+		 * completes that round-trip.
+		 */
+		async function renderGiftHookWithPendingProducts() {
+			let releaseCart: () => void = () => {};
+			let isCartSyncing = false;
+			const cartSync = new Promise< void >( ( resolve ) => {
+				releaseCart = resolve;
+			} );
+			const client = createShoppingCartManagerClient( {
+				getCart: async () => ( {
+					...getEmptyResponseCart(),
+					cart_key: GIFT_CART_KEY,
+					products: [],
+				} ),
+				setCart: async ( cartKey ) => {
+					isCartSyncing = true;
+					await cartSync;
+					return {
+						...getEmptyResponseCart(),
+						cart_key: cartKey,
+						products: [ planProduct ],
+						gift_details: giftDetails,
+						is_gift_purchase: true,
+					};
+				},
+			} );
+			const rendered = renderHook( () => useCheckoutLeaveModal( { siteUrl: '' } ), {
+				wrapper: buildWrapper( client ),
+			} );
+			await waitFor( () =>
+				expect( client.forCartKey( GIFT_CART_KEY ).getState().isLoading ).toBe( false )
+			);
+
+			// Checkout adds the products named by the URL; the hook lives in the
+			// masterbar, which shares the cart but never adds to it itself.
+			await act( async () => {
+				client
+					.forCartKey( GIFT_CART_KEY )
+					.actions.addProductsToCart( [
+						{ product_slug: planProduct.product_slug, product_id: planProduct.product_id },
+					] )
+					.catch( () => {} );
+			} );
+
+			await waitFor( () => expect( isCartSyncing ).toBe( true ) );
+
+			return {
+				...rendered,
+				releaseCart: async () => {
+					await act( async () => {
+						releaseCart();
+						await cartSync;
+					} );
+				},
+			};
+		}
+
+		it( 'keeps "Back" disabled until the cart comes back with the gift', async () => {
+			setReferrer( '' );
+			const { result, releaseCart } = await renderGiftHookWithPendingProducts();
+
+			expect( result.current.isLeaveDisabled ).toBe( true );
+
+			await releaseCart();
+			await waitFor( () => expect( result.current.isLeaveDisabled ).toBe( false ) );
+
+			await act( async () => {
+				result.current.closeAndLeave();
+			} );
+
+			expect( leaveCheckout ).toHaveBeenCalledWith(
+				expect.objectContaining( { forceCheckoutBackUrl: 'https://giftedsite.wordpress.com/' } )
+			);
+		} );
+	} );
+
+	it( 'enables "Back" when the cart fails to load so checkout is never a dead end', async () => {
+		setReferrer( '' );
+		const client = createShoppingCartManagerClient( {
+			getCart: async () => {
+				throw new Error( 'network down' );
+			},
+			setCart: async () => {
+				throw new Error( 'network down' );
+			},
+		} );
+		const { result } = renderHook( () => useCheckoutLeaveModal( { siteUrl: '' } ), {
+			wrapper: buildWrapper( client ),
+		} );
+
+		await waitFor( () => expect( result.current.isLeaveDisabled ).toBe( false ) );
+	} );
 } );

--- a/client/my-sites/checkout/src/components/test/leave-checkout-modal.test.tsx
+++ b/client/my-sites/checkout/src/components/test/leave-checkout-modal.test.tsx
@@ -445,11 +445,15 @@ describe( 'useCheckoutLeaveModal gift checkout', () => {
 		( leaveCheckout as jest.Mock ).mockReset();
 		( useCartKey as jest.Mock ).mockReturnValue( GIFT_CART_KEY );
 		( useValidCheckoutBackUrl as jest.Mock ).mockReturnValue( undefined );
+		// The hook reads the gift checkout route off the path, the way
+		// `getProductSlugFromContext` does.
+		window.history.replaceState( {}, '', '/checkout/personal-bundle/gift/123' );
 	} );
 
 	afterEach( () => {
 		// Remove the own property so the jsdom prototype getter is visible again.
 		delete ( document as { referrer?: string } ).referrer;
+		window.history.replaceState( {}, '', '/' );
 	} );
 
 	async function renderGiftHook( seed: Partial< ResponseCart > ) {
@@ -715,6 +719,16 @@ describe( 'useCheckoutLeaveModal gift checkout', () => {
 		} );
 	} );
 
+	it( 'keeps "Back" disabled when a settled cart holds a leftover item but no gift yet', async () => {
+		// A logged-in gifter's 'no-site' cart can still hold an item from an
+		// earlier signup. It settles non-empty and looks answerable, but the
+		// gifted site's URL has not arrived, so "Back" must keep waiting.
+		setReferrer( '' );
+		const { result } = await renderGiftHook( { products: [ domainProduct ] } );
+
+		expect( result.current.isLeaveDisabled ).toBe( true );
+	} );
+
 	it( 'enables "Back" when the cart fails to load so checkout is never a dead end', async () => {
 		setReferrer( '' );
 		const client = createShoppingCartManagerClient( {
@@ -729,6 +743,96 @@ describe( 'useCheckoutLeaveModal gift checkout', () => {
 			wrapper: buildWrapper( client ),
 		} );
 
+		expect( result.current.isLeaveDisabled ).toBe( true );
+
 		await waitFor( () => expect( result.current.isLeaveDisabled ).toBe( false ) );
+	} );
+} );
+
+describe( 'useCheckoutLeaveModal isLeaveDisabled outside a gift checkout', () => {
+	const CART_KEY: CartKey = 'no-site';
+
+	beforeEach( () => {
+		( useCartKey as jest.Mock ).mockReset();
+		( useValidCheckoutBackUrl as jest.Mock ).mockReset();
+		( useCartKey as jest.Mock ).mockReturnValue( CART_KEY );
+		( useValidCheckoutBackUrl as jest.Mock ).mockReturnValue( undefined );
+		window.history.replaceState( {}, '', '/checkout/mysite.wordpress.com' );
+	} );
+
+	afterEach( () => {
+		window.history.replaceState( {}, '', '/' );
+	} );
+
+	/**
+	 * Render the hook against a cart seeded with `initialProducts` whose next
+	 * update is held open, so the window while an update is in flight can be
+	 * observed. `releaseUpdate` completes that round-trip.
+	 */
+	async function renderHookWithPendingUpdate( initialProducts: ResponseCartProduct[] ) {
+		let releaseUpdate: () => void = () => {};
+		const cartSync = new Promise< void >( ( resolve ) => {
+			releaseUpdate = resolve;
+		} );
+		const client = createShoppingCartManagerClient( {
+			getCart: async () => ( {
+				...getEmptyResponseCart(),
+				cart_key: CART_KEY,
+				products: initialProducts,
+			} ),
+			setCart: async ( cartKey, newCart: RequestCart ) => {
+				await cartSync;
+				return {
+					...getEmptyResponseCart(),
+					cart_key: cartKey,
+					products: newCart.products as ResponseCartProduct[],
+				};
+			},
+		} );
+		const rendered = renderHook( () => useCheckoutLeaveModal( { siteUrl: '' } ), {
+			wrapper: buildWrapper( client ),
+		} );
+		await waitFor( () =>
+			expect( client.forCartKey( CART_KEY ).getState().isLoading ).toBe( false )
+		);
+
+		await act( async () => {
+			client
+				.forCartKey( CART_KEY )
+				.actions.addProductsToCart( [
+					{ product_slug: planProduct.product_slug, product_id: planProduct.product_id },
+				] )
+				.catch( () => {} );
+		} );
+
+		return {
+			...rendered,
+			releaseUpdate: async () => {
+				await act( async () => {
+					releaseUpdate();
+					await cartSync;
+				} );
+			},
+		};
+	}
+
+	it( 'keeps "Back" disabled while an empty cart is still receiving the products from the URL', async () => {
+		const { result, releaseUpdate } = await renderHookWithPendingUpdate( [] );
+
+		expect( result.current.isLeaveDisabled ).toBe( true );
+
+		await releaseUpdate();
+		await waitFor( () => expect( result.current.isLeaveDisabled ).toBe( false ) );
+	} );
+
+	it( 'keeps "Back" enabled while a cart that already holds products is updating', async () => {
+		// Applying a coupon or recalculating tax leaves the cart pending, but it
+		// still answers the only question "Back" asks here: it holds something,
+		// so the save-cart prompt is correct either way.
+		const { result, releaseUpdate } = await renderHookWithPendingUpdate( [ planProduct ] );
+
+		expect( result.current.isLeaveDisabled ).toBe( false );
+
+		await releaseUpdate();
 	} );
 } );

--- a/test/e2e/specs/plans/plans__gift-checkout-back.spec.ts
+++ b/test/e2e/specs/plans/plans__gift-checkout-back.spec.ts
@@ -37,6 +37,13 @@ async function openGiftCheckoutFromSite( page: Page, siteUrl: string ): Promise<
 	await expect( page ).toHaveURL( /\/checkout\/[^/]+\/gift\// );
 }
 
+function backButton( page: Page ) {
+	return page
+		.getByRole( 'button', { name: 'Back', exact: true } )
+		.filter( { visible: true } )
+		.first();
+}
+
 async function goBackFromCheckout( page: Page, choice: BackChoice ): Promise< void > {
 	// The gifted site is read from the cart's gift_details, so Back must not be
 	// clicked until the cart has loaded. Building a gift cart takes the store
@@ -44,11 +51,7 @@ async function goBackFromCheckout( page: Page, choice: BackChoice ): Promise< vo
 	await expect( page.locator( '.checkout-line-item[data-e2e-product-slug]' ).first() ).toBeVisible(
 		{ timeout: 30_000 }
 	);
-	await page
-		.getByRole( 'button', { name: 'Back', exact: true } )
-		.filter( { visible: true } )
-		.first()
-		.click();
+	await backButton( page ).click();
 	await page.getByRole( 'button', { name: choice, exact: true } ).click();
 }
 
@@ -108,6 +111,32 @@ test.describe( 'Plans: Gift checkout Back navigation', { tag: [ tags.CALYPSO_REL
 	} );
 
 	test.describe( 'Logged-out visitor', () => {
+		test( 'As a logged-out visitor, I can go back from gift checkout as soon as Back is available', async ( {
+			pageIncognito,
+		} ) => {
+			const page = pageIncognito.getPage();
+
+			await test.step( 'When I click Gift in the banner on the site', async function () {
+				await openGiftCheckoutFromSite( page, siteUrl );
+			} );
+
+			await test.step( 'And I click Back the moment it becomes available', async function () {
+				// Back stays disabled until the cart has been round-tripped to the
+				// server, because the gifted site's URL only arrives with it. The
+				// earliest a visitor can act on the control is therefore the earliest
+				// it is safe to, no matter how fast they click.
+				await expect( backButton( page ) ).toBeEnabled( { timeout: 30_000 } );
+				await backButton( page ).click();
+				await page.getByRole( 'button', { name: 'Save cart', exact: true } ).click();
+			} );
+
+			await test.step( 'Then I land on the gifted site', async function () {
+				await expect( page ).toHaveURL(
+					( url ) => url.origin === siteOrigin && url.pathname === '/'
+				);
+			} );
+		} );
+
 		for ( const choice of BACK_CHOICES ) {
 			test( `As a logged-out visitor, I can go back from gift checkout to the gifted site after choosing "${ choice }"`, async ( {
 				pageIncognito,


### PR DESCRIPTION
Part of DOTOBRD-600

Follow-up to #113879, fixing a case where, in 20% of cases, we could still see `/home` if clicking the " Back " button too fast.

## Proposed Changes

"Back" asks the cart two questions, and it now waits on each only until that answer is trustworthy:

- **"Where does a gift go?"** — `gift_details` carries the gifted site's URL, so a gift checkout keeps "Back" disabled until that datum is on the cart, rather than until the cart merely stops updating.
- **"Does the cart hold anything?"** — this decides whether to offer to save the cart. Any checkout keeps "Back" disabled while the cart is *empty* and an update is in flight, because the products a checkout URL asks for arrive in a second round-trip.
- A cart that already holds products answers the second question whatever else is in flight, so later updates — applying a coupon, recalculating tax on the contact step — no longer disable "Back" or lock the progress-step navigation.
- A cart that failed to load stops waiting, so a broken cart can never trap someone in checkout.

```js
isLeaveDisabled:
	! hasCartFailed &&
	( isAwaitingGiftDetails || ( isCartPendingUpdate && responseCart.products.length === 0 ) ),
```

## Why are these changes being made?

At second 13, we can see it's still possible to go to /home from the Gift checkout sometimes:

https://github.com/user-attachments/assets/9034fc27-15cf-4b61-b982-6d875621a4ea


A gift checkout runs on a siteless cart, and waiting for that cart to *settle* is not enough on either of the two it can use:

- **`no-user`** (logged out) is in `cartKeysThatDoNotAllowFetch` — `getServerCart()` resolves locally with an empty cart and never touches the network, so the cart reports itself settled while the gifted plan is still on its way to the server.
- **`no-site`** (a logged-in gifter) can settle holding a leftover item from an earlier signup. That cart looks answerable — it is not loading, not updating, and not empty — but it still has no `gift_details`.

Instrumented trace of a gift checkout page load on production:

| time | event |
| --- | --- |
| 727ms | the masterbar's cart provider mounts, "Back" renders |
| 757ms | initial cart resolves — `isLoading: false`, `isPendingUpdate: false`, cart empty |
| 768ms | checkout dispatches `CART_PRODUCTS_ADD` for the gifted plan |
| 775ms | `POST /me/shopping-cart/no-user` sent |
| 1183ms | response arrives — this is when `gift_details` first exists |

"Back" was live for that whole ~425ms window. Clicking inside it meant `getGiftCheckoutBackUrl()` returned `undefined` and the cart still held 0 products, so the "Save your cart for later?" prompt was skipped entirely and `leaveCheckout` fell through to `cancel_to`, landing the visitor on WordPress.com (or the login page) instead of the gifted site.

Gating on `gift_details` itself closes both carts, including the commit at 757ms where the cart has settled but the products it is about to receive have not been dispatched yet. Gating the save-cart prompt on "empty *and* updating" keeps the same protection for non-gift checkouts without disabling the control for cart updates that cannot change the answer.

## Testing Instructions

Reproducing the bug (before):

1. Open https://testingtheaibuilderagain.wordpress.com in a logged-out browser.
2. Click "Gift" in the banner.
3. Click "Back" the instant it appears — before the page finishes loading.
4. Roughly one attempt in five ends on the WordPress.com home/login page instead of the site. Retry a few times.

Verifying the fix (after), against a local instance with this branch:

1. `yarn start`, then open `/checkout/personal-bundle-monthly/gift/28968619?cancel_to=/home` on your instance, logged out.
2. Click "Back" as early as you can. It stays disabled until the gifted plan has been round-tripped to the server, so the earliest possible click is also the earliest safe one.
3. Choose "Save cart" — you land back on the gifted site. Repeat with "Empty cart"; same result.
4. Sanity-check a normal (non-gift) checkout: "Back" is briefly disabled while the initial cart is empty and filling, then stays enabled — including while a coupon is applied or tax is recalculated on the contact step.

Automated version of steps 1-3: a headless script that clicks "Back" on every animation frame from the moment the page starts rendering, with a fresh browser context — and so a fresh `no-user` cart — each run. That is a far more impatient visitor than a human can be.

| build | result |
| --- | --- |
| this branch | **10/10** runs landed on the gifted site, after 20-77 clicks were absorbed by the disabled control |
| `isLeaveDisabled` reverted to the pre-#113879 gate | **0/3** runs — every one ended on `/log-in?redirect_to=%2Fhome` |

The control matters: it lands on the same login URL quoted in the original report, so the script is exercising the race rather than passing vacuously.

Unit tests:

`yarn test-client client/my-sites/checkout/src/components/test/leave-checkout-modal.test.tsx`

E2E test:

`yarn workspace wp-e2e-tests test specs/plans/plans__gift-checkout-back.spec.ts`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
