### PR TITLE
Agenttic: add getDispatchableTools

### DIFF
--- a/packages/agenttic-client/README.md
+++ b/packages/agenttic-client/README.md
@@ -566,15 +566,20 @@ model-chosen call is dispatched only against this list.
 `getDispatchableTools()` covers the other direction. Tools it returns are
 **never advertised to the agent**, but the client will still execute them
 (through the same `executeTool`) when the **backend** dispatches them in an
-`input-required` handoff. Use it for backend-driven steps the model must not
-be able to invoke on its own — a confirmation step, for example.
+`input-required` handoff. Use it for backend-driven steps the agent has no
+reason to choose for itself — a confirmation step, for example.
 
-The gate is per message: when none of an `input-required` message's tool
-calls match either list (or a registered ability), nothing is executed —
-the update stays final and a debug log line explains which tool ids went
-unhandled. When at least one call matches, every call in that message is
-dispatched through `executeTool`, matched or not, so a provider's
-`executeTool` should be prepared to reject tool ids it does not recognize.
+Keeping a tool off the advertisement list is not an authorization boundary.
+`input-required` is also the path model-chosen calls take to `executeTool`,
+so a call naming a dispatchable id still runs if the backend relays one.
+Anything that must not run on the model's say-so needs the backend to reject
+unadvertised tool names, or a confirmation inside `executeTool` itself.
+
+Matching is per tool call: each call in an `input-required` message is
+dispatched only if its own id is in one of the lists (or is a registered
+ability). Calls with no handler are skipped and named in a debug log line;
+when no call in the message matches, nothing runs and the update stays
+final.
 
 ## Development
 

--- a/packages/agenttic-client/README.md
+++ b/packages/agenttic-client/README.md
@@ -552,9 +552,29 @@ type AuthProvider = () => Promise< Record< string, string > >;
 type ContextProvider = { getClientContext: () => any };
 type ToolProvider = {
 	getAvailableTools: () => Promise< Tool[] >;
+	getDispatchableTools?: () => Promise< Tool[] >;
 	executeTool: ( toolId: string, args: any ) => Promise< any >;
 };
 ```
+
+### Advertised vs dispatchable tools
+
+`getAvailableTools()` is the advertisement list: every tool it returns is
+offered to the agent as callable, and a `running`-state echo of a
+model-chosen call is dispatched only against this list.
+
+`getDispatchableTools()` covers the other direction. Tools it returns are
+**never advertised to the agent**, but the client will still execute them
+(through the same `executeTool`) when the **backend** dispatches them in an
+`input-required` handoff. Use it for backend-driven steps the model must not
+be able to invoke on its own — a confirmation step, for example.
+
+The gate is per message: when none of an `input-required` message's tool
+calls match either list (or a registered ability), nothing is executed —
+the update stays final and a debug log line explains which tool ids went
+unhandled. When at least one call matches, every call in that message is
+dispatched through `executeTool`, matched or not, so a provider's
+`executeTool` should be prepared to reject tool ids it does not recognize.
 
 ## Development
 

--- a/packages/agenttic-client/README.md
+++ b/packages/agenttic-client/README.md
@@ -577,9 +577,10 @@ unadvertised tool names, or a confirmation inside `executeTool` itself.
 
 Matching is per tool call: each call in an `input-required` message is
 dispatched only if its own id is in one of the lists (or is a registered
-ability). Calls with no handler are skipped and named in a debug log line;
-when no call in the message matches, nothing runs and the update stays
-final.
+ability). A call with no handler is never dispatched; it is answered with an
+error result — so the agent learns the step failed rather than waiting on a
+result that never arrives — and named in a debug log line. When no call in the
+message matches, nothing runs and the update stays final.
 
 ## Development
 

--- a/packages/agenttic-client/src/client/index.test.ts
+++ b/packages/agenttic-client/src/client/index.test.ts
@@ -1188,6 +1188,216 @@ describe( 'Client', () => {
 		} );
 	} );
 
+	describe( 'Dispatchable (non-advertised) tools', () => {
+		const dispatchableTool = {
+			id: 'spec_confirm',
+			name: 'Spec Confirm',
+			description: 'Backend-dispatched confirmation step',
+			input_schema: {
+				type: 'object' as const,
+				properties: {},
+			},
+		};
+
+		const inputRequiredEventFor = ( toolId: string ) =>
+			JSON.stringify( {
+				jsonrpc: '2.0',
+				id: 'req-dispatchable',
+				result: {
+					type: 'TaskStatusUpdateEvent',
+					taskId: 'task-dispatchable',
+					status: {
+						state: 'input-required',
+						message: {
+							messageId: 'resp-dispatchable',
+							role: 'agent',
+							kind: 'message',
+							parts: [
+								{
+									type: 'data',
+									data: {
+										toolCallId: 'call-dispatchable',
+										toolId,
+										arguments: { confirmed: true },
+									},
+								},
+							],
+						},
+						final: true,
+					},
+					sessionId: 'session-dispatchable',
+				},
+			} );
+
+		const completionEvent = JSON.stringify( {
+			jsonrpc: '2.0',
+			id: 'req-dispatchable-complete',
+			result: {
+				type: 'TaskStatusUpdateEvent',
+				taskId: 'task-dispatchable',
+				status: {
+					state: 'completed',
+					message: {
+						role: 'agent',
+						kind: 'message',
+						parts: [ { type: 'text', text: 'Confirmed.' } ],
+					},
+					final: true,
+				},
+				sessionId: 'session-dispatchable',
+			},
+		} );
+
+		const mockSSEResponse = ( payload: string ) => ( {
+			ok: true,
+			status: 200,
+			headers: new Headers( { 'content-type': 'text/event-stream' } ),
+			body: new ReadableStream( {
+				start( controller ) {
+					controller.enqueue( new TextEncoder().encode( `data: ${ payload }\n\n` ) );
+					controller.close();
+				},
+			} ),
+		} );
+
+		it( 'executes a backend-dispatched tool that is listed only in getDispatchableTools', async () => {
+			// The input-required caller is the backend, not the model, so a
+			// tool can be executable without ever being advertised to the
+			// agent (BSKY-2024).
+			let executedToolId: string | undefined;
+			const mockToolProvider: ToolProvider = {
+				async getAvailableTools() {
+					return [];
+				},
+				async getDispatchableTools() {
+					return [ dispatchableTool ];
+				},
+				async executeTool( toolId: string ) {
+					executedToolId = toolId;
+					return {
+						result: { ok: true },
+						returnToAgent: true,
+					};
+				},
+			};
+
+			mockFetch.mockResolvedValueOnce( mockSSEResponse( inputRequiredEventFor( 'spec_confirm' ) ) );
+			mockFetch.mockResolvedValueOnce( mockSSEResponse( completionEvent ) );
+
+			const client = createClient( {
+				agentId: 'test-agent',
+				toolProvider: mockToolProvider,
+			} );
+
+			const result = await sendMessageAndWait( client, {
+				message: createTextMessage( 'Confirm the spec' ),
+			} );
+
+			expect( executedToolId ).toBe( 'spec_confirm' );
+			expect( mockFetch ).toHaveBeenCalledTimes( 2 );
+			expect( result.final ).toBe( true );
+			expect( result.text ).toBe( 'Confirmed.' );
+		} );
+
+		it( 'does not execute a dispatchable-only tool from a running status echo', async () => {
+			// Dispatchable tools are backend-dispatched only. A running echo
+			// reports a model-chosen call, and the model can only choose
+			// advertised tools, so a dispatchable match here would mean the
+			// agent invoked a tool it was never offered.
+			const executedTools: string[] = [];
+			const mockToolProvider: ToolProvider = {
+				async getAvailableTools() {
+					return [];
+				},
+				async getDispatchableTools() {
+					return [ dispatchableTool ];
+				},
+				async executeTool( toolId: string ) {
+					executedTools.push( toolId );
+					return { result: { ok: true }, returnToAgent: true };
+				},
+			};
+
+			const runningEvent = JSON.stringify( {
+				jsonrpc: '2.0',
+				id: 'req-running-dispatchable',
+				result: {
+					type: 'TaskStatusUpdateEvent',
+					taskId: 'task-running-dispatchable',
+					status: {
+						state: 'running',
+						message: {
+							messageId: 'running-dispatchable',
+							role: 'agent',
+							kind: 'message',
+							parts: [
+								{
+									type: 'data',
+									data: {
+										toolCallId: 'call-running',
+										toolId: 'spec_confirm',
+										arguments: { confirmed: true },
+									},
+								},
+							],
+						},
+						final: true,
+					},
+				},
+			} );
+
+			mockFetch.mockResolvedValueOnce( mockSSEResponse( runningEvent ) );
+
+			const client = createClient( {
+				agentId: 'test-agent',
+				toolProvider: mockToolProvider,
+			} );
+
+			const updates = [];
+			for await ( const update of client.sendMessageStream( {
+				message: createTextMessage( 'Test message' ),
+			} ) ) {
+				updates.push( update );
+			}
+
+			expect( executedTools ).toHaveLength( 0 );
+			expect( updates ).toHaveLength( 1 );
+			expect( updates[ 0 ].status.state ).toBe( 'running' );
+		} );
+
+		it( 'leaves an input-required update final when the tool matches no list', async () => {
+			// Without a matching advertised or dispatchable tool the handoff
+			// cannot run; the update must pass through as final instead of
+			// hanging the stream on a continuation that will never come.
+			const mockToolProvider: ToolProvider = {
+				async getAvailableTools() {
+					return [];
+				},
+				async getDispatchableTools() {
+					return [ dispatchableTool ];
+				},
+				async executeTool() {
+					throw new Error( 'Should not execute' );
+				},
+			};
+
+			mockFetch.mockResolvedValueOnce( mockSSEResponse( inputRequiredEventFor( 'unknown_tool' ) ) );
+
+			const client = createClient( {
+				agentId: 'test-agent',
+				toolProvider: mockToolProvider,
+			} );
+
+			const result = await sendMessageAndWait( client, {
+				message: createTextMessage( 'Confirm the spec' ),
+			} );
+
+			expect( mockFetch ).toHaveBeenCalledTimes( 1 );
+			expect( result.final ).toBe( true );
+			expect( result.status.state ).toBe( 'input-required' );
+		} );
+	} );
+
 	describe( 'File part preservation in conversation history', () => {
 		it( 'should preserve file parts in conversation history when continuing after tool execution', async () => {
 			// Arrange: Create a mock tool provider with a tool that returns to agent

--- a/packages/agenttic-client/src/client/index.test.ts
+++ b/packages/agenttic-client/src/client/index.test.ts
@@ -1396,6 +1396,77 @@ describe( 'Client', () => {
 			expect( result.final ).toBe( true );
 			expect( result.status.state ).toBe( 'input-required' );
 		} );
+
+		it( 'executes only the matching call when an unhandled call rides along', async () => {
+			// Matching is per call, not per message: one dispatchable match
+			// must not carry an unrelated tool id into executeTool with it.
+			const executedTools: string[] = [];
+			const mockToolProvider: ToolProvider = {
+				async getAvailableTools() {
+					return [];
+				},
+				async getDispatchableTools() {
+					return [ dispatchableTool ];
+				},
+				async executeTool( toolId: string ) {
+					executedTools.push( toolId );
+					return { result: { ok: true }, returnToAgent: true };
+				},
+			};
+
+			const mixedEvent = JSON.stringify( {
+				jsonrpc: '2.0',
+				id: 'req-mixed',
+				result: {
+					type: 'TaskStatusUpdateEvent',
+					taskId: 'task-mixed',
+					status: {
+						state: 'input-required',
+						message: {
+							messageId: 'resp-mixed',
+							role: 'agent',
+							kind: 'message',
+							parts: [
+								{
+									type: 'data',
+									data: {
+										toolCallId: 'call-known',
+										toolId: 'spec_confirm',
+										arguments: { confirmed: true },
+									},
+								},
+								{
+									type: 'data',
+									data: {
+										toolCallId: 'call-unknown',
+										toolId: 'some_unknown_tool',
+										arguments: {},
+									},
+								},
+							],
+						},
+						final: true,
+					},
+					sessionId: 'session-mixed',
+				},
+			} );
+
+			mockFetch.mockResolvedValueOnce( mockSSEResponse( mixedEvent ) );
+			mockFetch.mockResolvedValueOnce( mockSSEResponse( completionEvent ) );
+
+			const client = createClient( {
+				agentId: 'test-agent',
+				toolProvider: mockToolProvider,
+			} );
+
+			const result = await sendMessageAndWait( client, {
+				message: createTextMessage( 'Confirm the spec' ),
+			} );
+
+			expect( executedTools ).toEqual( [ 'spec_confirm' ] );
+			expect( result.final ).toBe( true );
+			expect( result.text ).toBe( 'Confirmed.' );
+		} );
 	} );
 
 	describe( 'File part preservation in conversation history', () => {

--- a/packages/agenttic-client/src/client/index.test.ts
+++ b/packages/agenttic-client/src/client/index.test.ts
@@ -1466,6 +1466,109 @@ describe( 'Client', () => {
 			expect( executedTools ).toEqual( [ 'spec_confirm' ] );
 			expect( result.final ).toBe( true );
 			expect( result.text ).toBe( 'Confirmed.' );
+
+			// The continuation replays the agent message with both calls, so
+			// the unhandled one still needs a result of its own — an error,
+			// since nothing here could run it.
+			const continuationBody = JSON.parse( mockFetch.mock.calls[ 1 ][ 1 ].body );
+			const unknownResult = continuationBody.params.message.parts.find(
+				( part: any ) =>
+					part.type === 'data' &&
+					part.data?.toolCallId === 'call-unknown' &&
+					// The replayed agent message carries the original call for
+					// the same id; the result part is the one without arguments.
+					! ( 'arguments' in part.data )
+			);
+
+			expect( unknownResult ).toBeDefined();
+			expect( unknownResult.data.toolId ).toBe( 'some_unknown_tool' );
+			expect( unknownResult.metadata.error ).toBe( 'No handler found for tool: some_unknown_tool' );
+		} );
+
+		it( 'matches abilities and dispatchable tools from the same provider', async () => {
+			// The Agents Manager merges several providers into one, so a single
+			// provider can expose both kinds at once. Matching is per call, so
+			// neither kind may shadow the other.
+			const executed: string[] = [];
+			const ability = {
+				name: 'big-sky/apply-block-edits',
+				label: 'Apply Block Edits',
+				description: 'Applies block edits to the canvas',
+				category: 'big-sky',
+				callback: async () => {
+					executed.push( 'ability' );
+					return { result: { success: true }, returnToAgent: true };
+				},
+			};
+
+			const mockToolProvider: ToolProvider = {
+				async getAvailableTools() {
+					return [];
+				},
+				async getDispatchableTools() {
+					return [ dispatchableTool ];
+				},
+				async getAbilities() {
+					return [ ability ];
+				},
+				async executeTool( toolId: string ) {
+					executed.push( toolId );
+					return { result: { ok: true }, returnToAgent: true };
+				},
+			};
+
+			const mixedEvent = JSON.stringify( {
+				jsonrpc: '2.0',
+				id: 'req-ability-mixed',
+				result: {
+					type: 'TaskStatusUpdateEvent',
+					taskId: 'task-ability-mixed',
+					status: {
+						state: 'input-required',
+						message: {
+							messageId: 'resp-ability-mixed',
+							role: 'agent',
+							kind: 'message',
+							parts: [
+								{
+									type: 'data',
+									data: {
+										toolCallId: 'call-dispatchable',
+										toolId: 'spec_confirm',
+										arguments: { confirmed: true },
+									},
+								},
+								{
+									type: 'data',
+									data: {
+										toolCallId: 'call-ability',
+										toolId: 'big_sky__apply_block_edits',
+										arguments: {},
+									},
+								},
+							],
+						},
+						final: true,
+					},
+					sessionId: 'session-ability-mixed',
+				},
+			} );
+
+			mockFetch.mockResolvedValueOnce( mockSSEResponse( mixedEvent ) );
+			mockFetch.mockResolvedValueOnce( mockSSEResponse( completionEvent ) );
+
+			const client = createClient( {
+				agentId: 'test-agent',
+				toolProvider: mockToolProvider,
+			} );
+
+			const result = await sendMessageAndWait( client, {
+				message: createTextMessage( 'Confirm the spec' ),
+			} );
+
+			expect( executed ).toEqual( [ 'spec_confirm', 'ability' ] );
+			expect( result.final ).toBe( true );
+			expect( result.text ).toBe( 'Confirmed.' );
 		} );
 	} );
 

--- a/packages/agenttic-client/src/client/index.ts
+++ b/packages/agenttic-client/src/client/index.ts
@@ -164,33 +164,41 @@ interface MatchingToolCallbacksOptions {
 	 * Dispatchable tools are backend-dispatched only: they are never
 	 * advertised to the agent, so they must never match for `running`-state
 	 * echoes of model-chosen calls. Only the `input-required` handoff, where
-	 * the backend is the caller, may count them.
+	 * the backend is the caller, may count them. Note that this narrows what
+	 * the agent is offered, not what it can ultimately reach — see
+	 * `ToolProvider.getDispatchableTools`.
 	 */
 	includeDispatchable?: boolean;
 }
 
 /**
- * Check if any tool calls in a message have matching callbacks
+ * Narrow a message's tool calls to the ones this provider can actually run.
+ *
+ * Callers dispatch exactly what comes back, so a call the provider has no
+ * handler for is dropped rather than forwarded to `executeTool` on the
+ * strength of some *other* call in the same message matching.
  * @param toolProvider                - The tool provider to check
  * @param message                     - The message containing tool calls
  * @param options                     - Which handler kinds count as a match
  * @param options.includeAbilities    - Whether a registered ability counts as a match
  * @param options.includeDispatchable - Whether a tool from getDispatchableTools counts as a match
- * @returns Promise resolving to boolean indicating if any tools can be executed
+ * @returns Promise resolving to the executable subset of the message's tool calls, in message order
  */
-async function hasMatchingToolCallbacks(
+async function getMatchingToolCalls(
 	toolProvider: any,
 	message: Message,
 	{ includeAbilities = true, includeDispatchable = true }: MatchingToolCallbacksOptions = {}
-): Promise< boolean > {
+): Promise< ToolCallDataPart[] > {
 	if ( ! toolProvider || ! message ) {
-		return false;
+		return [];
 	}
 
 	const toolCalls = extractToolCallsFromMessage( message );
 	if ( toolCalls.length === 0 ) {
-		return false;
+		return [];
 	}
+
+	const executableIds = new Set< string >();
 
 	// Advertised and dispatchable tools match by id and execute through the
 	// same executeTool; only which getter supplies the list differs.
@@ -205,11 +213,8 @@ async function hasMatchingToolCallbacks(
 			}
 			try {
 				const tools = await getTools.call( toolProvider );
-				const hasMatchingTool = toolCalls.some( ( toolCall ) =>
-					tools.some( ( tool: any ) => tool.id === toolCall.data.toolId )
-				);
-				if ( hasMatchingTool ) {
-					return true;
+				for ( const tool of tools ) {
+					executableIds.add( tool.id );
 				}
 			} catch {
 				// Continue checking the other handler kinds when tool discovery fails.
@@ -220,21 +225,18 @@ async function hasMatchingToolCallbacks(
 	if ( includeAbilities && toolProvider.getAbilities ) {
 		try {
 			const abilities = await toolProvider.getAbilities();
-
-			return toolCalls.some( ( toolCall ) =>
-				abilities.some(
-					( ability: any ) =>
-						( ability.callback || toolProvider.executeAbility ) &&
-						( ability.name === toolCall.data.toolId ||
-							sanitizeAbilityName( ability.name ) === toolCall.data.toolId )
-				)
-			);
+			for ( const ability of abilities ) {
+				if ( ability.callback || toolProvider.executeAbility ) {
+					executableIds.add( ability.name );
+					executableIds.add( sanitizeAbilityName( ability.name ) );
+				}
+			}
 		} catch {
-			return false;
+			// Keep whatever the tool getters matched when ability discovery fails.
 		}
 	}
 
-	return false;
+	return toolCalls.filter( ( toolCall ) => executableIds.has( toolCall.data.toolId as string ) );
 }
 
 /**
@@ -565,20 +567,26 @@ async function* processAgentResponseStream(
 		const inputRequiredCalls = inputRequiredMessage
 			? extractToolCallsFromMessage( inputRequiredMessage )
 			: [];
-		const hasInputRequiredToolCalls = inputRequiredMessage
-			? await hasMatchingToolCallbacks( toolProvider, inputRequiredMessage )
-			: false;
-		const inputRequiredToolCalls = hasInputRequiredToolCalls ? inputRequiredCalls : [];
+		// Only the calls this provider has a handler for. An unhandled call
+		// riding along in the same message is dropped rather than pushed at
+		// executeTool because a sibling call matched.
+		const inputRequiredToolCalls = inputRequiredMessage
+			? await getMatchingToolCalls( toolProvider, inputRequiredMessage )
+			: [];
+		const hasInputRequiredToolCalls = inputRequiredToolCalls.length > 0;
 
 		// A dropped handoff otherwise fails silently: the update passes
 		// through as final and the stream just ends, with nothing to say the
 		// backend asked for a tool nobody here can run.
-		if ( ! hasInputRequiredToolCalls && inputRequiredCalls.length > 0 ) {
+		const unhandledInputRequiredCalls = inputRequiredCalls.filter(
+			( toolCall ) => ! inputRequiredToolCalls.includes( toolCall )
+		);
+		if ( unhandledInputRequiredCalls.length > 0 ) {
 			logger(
-				'No handler for input-required tool calls %o; the update stays final. ' +
+				'No handler for input-required tool calls %o; they are skipped. ' +
 					'Advertise the tool via getAvailableTools, or list it in ' +
 					'getDispatchableTools if the agent must not call it.',
-				inputRequiredCalls.map( ( toolCall ) => toolCall.data.toolId )
+				unhandledInputRequiredCalls.map( ( toolCall ) => toolCall.data.toolId )
 			);
 		}
 
@@ -606,29 +614,21 @@ async function* processAgentResponseStream(
 		// dispatching registered abilities from it runs them twice per call,
 		// the first time on an unvalidated payload, and discards the result so
 		// the agent never learns the call failed.
-		if (
-			update.status.state === 'running' &&
-			update.status.message &&
-			toolProvider &&
-			( await hasMatchingToolCallbacks( toolProvider, update.status.message, {
-				includeAbilities: false,
-				includeDispatchable: false,
-			} ) )
-		) {
-			// A provider can expose both advertised tools and abilities (the
-			// Agents Manager merges several providers into one). The gate above
-			// only proves *some* call in this message is an advertised tool, so
-			// narrow to those before dispatching — otherwise an ability riding
-			// along in the same message is executed anyway.
-			const advertisedTools = toolProvider.getAvailableTools
-				? await toolProvider.getAvailableTools().catch( () => [] )
+		const runningToolCalls =
+			update.status.state === 'running' && update.status.message && toolProvider
+				? // A provider can expose advertised tools, dispatchable tools and
+				  // abilities at once (the Agents Manager merges several providers
+				  // into one). Narrow to advertised tools only, so neither an
+				  // ability nor a backend-dispatched tool riding along in the same
+				  // message is executed from this branch.
+				  await getMatchingToolCalls( toolProvider, update.status.message, {
+						includeAbilities: false,
+						includeDispatchable: false,
+				  } )
 				: [];
-			const toolCalls = extractToolCallsFromMessage( update.status.message ).filter( ( toolCall ) =>
-				advertisedTools.some( ( tool: any ) => tool.id === toolCall.data.toolId )
-			);
-
+		if ( runningToolCalls.length > 0 ) {
 			// Execute tools async without blocking the stream
-			for ( const toolCall of toolCalls ) {
+			for ( const toolCall of runningToolCalls ) {
 				const { toolCallId, toolId, arguments: args } = toolCall.data;
 
 				// Execute tool async (fire and forget)
@@ -652,7 +652,7 @@ async function* processAgentResponseStream(
 					message: {
 						role: 'agent' as const,
 						kind: 'message' as const,
-						parts: toolCalls,
+						parts: runningToolCalls,
 						messageId: generateMessageId(),
 					},
 				},

--- a/packages/agenttic-client/src/client/index.ts
+++ b/packages/agenttic-client/src/client/index.ts
@@ -157,20 +157,31 @@ interface MatchingToolCallbacksOptions {
 	 * state branch in `processAgentResponseStream`.
 	 */
 	includeAbilities?: boolean;
+	/**
+	 * Whether a tool from `getDispatchableTools` counts as a match. Defaults
+	 * to true.
+	 *
+	 * Dispatchable tools are backend-dispatched only: they are never
+	 * advertised to the agent, so they must never match for `running`-state
+	 * echoes of model-chosen calls. Only the `input-required` handoff, where
+	 * the backend is the caller, may count them.
+	 */
+	includeDispatchable?: boolean;
 }
 
 /**
  * Check if any tool calls in a message have matching callbacks
- * @param toolProvider             - The tool provider to check
- * @param message                  - The message containing tool calls
- * @param options                  - Which handler kinds count as a match
- * @param options.includeAbilities - Whether a registered ability counts as a match
+ * @param toolProvider                - The tool provider to check
+ * @param message                     - The message containing tool calls
+ * @param options                     - Which handler kinds count as a match
+ * @param options.includeAbilities    - Whether a registered ability counts as a match
+ * @param options.includeDispatchable - Whether a tool from getDispatchableTools counts as a match
  * @returns Promise resolving to boolean indicating if any tools can be executed
  */
 async function hasMatchingToolCallbacks(
 	toolProvider: any,
 	message: Message,
-	{ includeAbilities = true }: MatchingToolCallbacksOptions = {}
+	{ includeAbilities = true, includeDispatchable = true }: MatchingToolCallbacksOptions = {}
 ): Promise< boolean > {
 	if ( ! toolProvider || ! message ) {
 		return false;
@@ -181,20 +192,28 @@ async function hasMatchingToolCallbacks(
 		return false;
 	}
 
-	if ( toolProvider.getAvailableTools ) {
-		try {
-			const availableTools = await toolProvider.getAvailableTools();
-
-			const hasMatchingTool =
-				!! toolProvider.executeTool &&
-				toolCalls.some( ( toolCall ) =>
-					availableTools.some( ( tool: any ) => tool.id === toolCall.data.toolId )
-				);
-			if ( hasMatchingTool ) {
-				return true;
+	// Advertised and dispatchable tools match by id and execute through the
+	// same executeTool; only which getter supplies the list differs.
+	const toolListGetters = [
+		toolProvider.getAvailableTools,
+		includeDispatchable ? toolProvider.getDispatchableTools : undefined,
+	];
+	if ( toolProvider.executeTool ) {
+		for ( const getTools of toolListGetters ) {
+			if ( ! getTools ) {
+				continue;
 			}
-		} catch {
-			// Continue checking abilities when tool discovery fails.
+			try {
+				const tools = await getTools.call( toolProvider );
+				const hasMatchingTool = toolCalls.some( ( toolCall ) =>
+					tools.some( ( tool: any ) => tool.id === toolCall.data.toolId )
+				);
+				if ( hasMatchingTool ) {
+					return true;
+				}
+			} catch {
+				// Continue checking the other handler kinds when tool discovery fails.
+			}
 		}
 	}
 
@@ -543,13 +562,25 @@ async function* processAgentResponseStream(
 			update.status.state === 'input-required' && update.status.message && toolProvider
 				? update.status.message
 				: undefined;
+		const inputRequiredCalls = inputRequiredMessage
+			? extractToolCallsFromMessage( inputRequiredMessage )
+			: [];
 		const hasInputRequiredToolCalls = inputRequiredMessage
 			? await hasMatchingToolCallbacks( toolProvider, inputRequiredMessage )
 			: false;
-		const inputRequiredToolCalls =
-			hasInputRequiredToolCalls && inputRequiredMessage
-				? extractToolCallsFromMessage( inputRequiredMessage )
-				: [];
+		const inputRequiredToolCalls = hasInputRequiredToolCalls ? inputRequiredCalls : [];
+
+		// A dropped handoff otherwise fails silently: the update passes
+		// through as final and the stream just ends, with nothing to say the
+		// backend asked for a tool nobody here can run.
+		if ( ! hasInputRequiredToolCalls && inputRequiredCalls.length > 0 ) {
+			logger(
+				'No handler for input-required tool calls %o; the update stays final. ' +
+					'Advertise the tool via getAvailableTools, or list it in ' +
+					'getDispatchableTools if the agent must not call it.',
+				inputRequiredCalls.map( ( toolCall ) => toolCall.data.toolId )
+			);
+		}
 
 		// Capture sessionId from server response for fresh chats
 		// This ensures continuations use the sessionId assigned by the server
@@ -581,6 +612,7 @@ async function* processAgentResponseStream(
 			toolProvider &&
 			( await hasMatchingToolCallbacks( toolProvider, update.status.message, {
 				includeAbilities: false,
+				includeDispatchable: false,
 			} ) )
 		) {
 			// A provider can expose both advertised tools and abilities (the

--- a/packages/agenttic-client/src/client/index.ts
+++ b/packages/agenttic-client/src/client/index.ts
@@ -148,7 +148,7 @@ async function executeToolOrAbility(
  */
 const toolResultPromises = new Map< string, { promise: Promise< any >; resolvedValue: any } >();
 
-interface MatchingToolCallbacksOptions {
+interface MatchingToolCallsOptions {
 	/**
 	 * Whether a registered ability counts as a match. Defaults to true.
 	 *
@@ -172,33 +172,52 @@ interface MatchingToolCallbacksOptions {
 }
 
 /**
- * Narrow a message's tool calls to the ones this provider can actually run.
+ * A message's tool calls, split by whether this provider can run them.
+ */
+interface MatchingToolCalls {
+	/** Calls with a handler, in message order. */
+	matched: ToolCallDataPart[];
+	/** Calls with no handler, in message order. */
+	unmatched: ToolCallDataPart[];
+}
+
+const NO_MATCHING_TOOL_CALLS: MatchingToolCalls = Object.freeze( {
+	matched: [],
+	unmatched: [],
+} );
+
+/**
+ * Split a message's tool calls by whether this provider can actually run them.
  *
- * Callers dispatch exactly what comes back, so a call the provider has no
- * handler for is dropped rather than forwarded to `executeTool` on the
- * strength of some *other* call in the same message matching.
+ * Callers dispatch exactly what `matched` holds, so a call the provider has no
+ * handler for is never forwarded to `executeTool` on the strength of some
+ * *other* call in the same message matching. `unmatched` is returned rather
+ * than discarded because a dispatched call still owes the agent a result — see
+ * the `input-required` branch in `processAgentResponseStream`.
  * @param toolProvider                - The tool provider to check
  * @param message                     - The message containing tool calls
  * @param options                     - Which handler kinds count as a match
  * @param options.includeAbilities    - Whether a registered ability counts as a match
  * @param options.includeDispatchable - Whether a tool from getDispatchableTools counts as a match
- * @returns Promise resolving to the executable subset of the message's tool calls, in message order
+ * @returns Promise resolving to the message's tool calls split into matched and unmatched
  */
 async function getMatchingToolCalls(
 	toolProvider: any,
 	message: Message,
-	{ includeAbilities = true, includeDispatchable = true }: MatchingToolCallbacksOptions = {}
-): Promise< ToolCallDataPart[] > {
+	{ includeAbilities = true, includeDispatchable = true }: MatchingToolCallsOptions = {}
+): Promise< MatchingToolCalls > {
 	if ( ! toolProvider || ! message ) {
-		return [];
+		return NO_MATCHING_TOOL_CALLS;
 	}
 
 	const toolCalls = extractToolCallsFromMessage( message );
 	if ( toolCalls.length === 0 ) {
-		return [];
+		return NO_MATCHING_TOOL_CALLS;
 	}
 
 	const executableIds = new Set< string >();
+	const isExecutable = ( toolCall: ToolCallDataPart ) =>
+		executableIds.has( toolCall.data.toolId as string );
 
 	// Advertised and dispatchable tools match by id and execute through the
 	// same executeTool; only which getter supplies the list differs.
@@ -222,7 +241,11 @@ async function getMatchingToolCalls(
 		}
 	}
 
-	if ( includeAbilities && toolProvider.getAbilities ) {
+	// Ability discovery can be a round trip, so skip it once every call in this
+	// message is already accounted for. A partial match still needs it: an
+	// ability riding along with an advertised tool has to resolve too, because
+	// matching is per call.
+	if ( includeAbilities && toolProvider.getAbilities && ! toolCalls.every( isExecutable ) ) {
 		try {
 			const abilities = await toolProvider.getAbilities();
 			for ( const ability of abilities ) {
@@ -236,7 +259,13 @@ async function getMatchingToolCalls(
 		}
 	}
 
-	return toolCalls.filter( ( toolCall ) => executableIds.has( toolCall.data.toolId as string ) );
+	const matched: ToolCallDataPart[] = [];
+	const unmatched: ToolCallDataPart[] = [];
+	for ( const toolCall of toolCalls ) {
+		( isExecutable( toolCall ) ? matched : unmatched ).push( toolCall );
+	}
+
+	return { matched, unmatched };
 }
 
 /**
@@ -564,26 +593,22 @@ async function* processAgentResponseStream(
 			update.status.state === 'input-required' && update.status.message && toolProvider
 				? update.status.message
 				: undefined;
-		const inputRequiredCalls = inputRequiredMessage
-			? extractToolCallsFromMessage( inputRequiredMessage )
-			: [];
-		// Only the calls this provider has a handler for. An unhandled call
-		// riding along in the same message is dropped rather than pushed at
-		// executeTool because a sibling call matched.
-		const inputRequiredToolCalls = inputRequiredMessage
-			? await getMatchingToolCalls( toolProvider, inputRequiredMessage )
-			: [];
+		// Only the calls this provider has a handler for are dispatched. An
+		// unhandled call riding along in the same message is not pushed at
+		// executeTool because a sibling call matched; it is answered with an
+		// error result below instead.
+		const { matched: inputRequiredToolCalls, unmatched: unhandledInputRequiredCalls } =
+			inputRequiredMessage
+				? await getMatchingToolCalls( toolProvider, inputRequiredMessage )
+				: NO_MATCHING_TOOL_CALLS;
 		const hasInputRequiredToolCalls = inputRequiredToolCalls.length > 0;
 
-		// A dropped handoff otherwise fails silently: the update passes
+		// An unhandled handoff otherwise fails silently: the update passes
 		// through as final and the stream just ends, with nothing to say the
 		// backend asked for a tool nobody here can run.
-		const unhandledInputRequiredCalls = inputRequiredCalls.filter(
-			( toolCall ) => ! inputRequiredToolCalls.includes( toolCall )
-		);
 		if ( unhandledInputRequiredCalls.length > 0 ) {
 			logger(
-				'No handler for input-required tool calls %o; they are skipped. ' +
+				'No handler for input-required tool calls %o. ' +
 					'Advertise the tool via getAvailableTools, or list it in ' +
 					'getDispatchableTools if the agent must not call it.',
 				unhandledInputRequiredCalls.map( ( toolCall ) => toolCall.data.toolId )
@@ -614,7 +639,7 @@ async function* processAgentResponseStream(
 		// dispatching registered abilities from it runs them twice per call,
 		// the first time on an unvalidated payload, and discards the result so
 		// the agent never learns the call failed.
-		const runningToolCalls =
+		const { matched: runningToolCalls } =
 			update.status.state === 'running' && update.status.message && toolProvider
 				? // A provider can expose advertised tools, dispatchable tools and
 				  // abilities at once (the Agents Manager merges several providers
@@ -625,7 +650,7 @@ async function* processAgentResponseStream(
 						includeAbilities: false,
 						includeDispatchable: false,
 				  } )
-				: [];
+				: NO_MATCHING_TOOL_CALLS;
 		if ( runningToolCalls.length > 0 ) {
 			// Execute tools async without blocking the stream
 			for ( const toolCall of runningToolCalls ) {
@@ -671,6 +696,23 @@ async function* processAgentResponseStream(
 
 				// Track tool calls and results for message enhancement
 				const toolParts: ( ToolCallDataPart | ToolResultDataPart )[] = [];
+
+				// Answer the calls nothing here can run with an error result
+				// rather than dropping them. The continuation replays the agent
+				// message with every call the backend dispatched, so a call left
+				// without a matching result is an error on the next turn, not a
+				// no-op — and the error tells the agent the step failed.
+				for ( const toolCall of unhandledInputRequiredCalls ) {
+					const toolResult = createToolResultDataPart(
+						toolCall.data.toolCallId as string,
+						toolCall.data.toolId as string,
+						undefined,
+						`No handler found for tool: ${ toolCall.data.toolId }`
+					);
+
+					toolResults.push( toolResult );
+					toolParts.push( toolResult );
+				}
 
 				// Track agent messages from tool executions
 				const agentMessages: Message[] = [];

--- a/packages/agenttic-client/src/client/types/index.ts
+++ b/packages/agenttic-client/src/client/types/index.ts
@@ -375,6 +375,16 @@ export interface ToolExecutionResult {
 
 export interface ToolProvider {
 	getAvailableTools?: () => Promise< Tool[] >;
+	/**
+	 * Tools the client executes when the backend dispatches them in an
+	 * `input-required` handoff, WITHOUT advertising them to the agent as
+	 * callable. Use this for backend-driven handoffs the model must not be
+	 * able to invoke on its own (a confirmation step, for example). Tools
+	 * listed here are executed through `executeTool`, exactly like
+	 * advertised tools; they are ignored for `running`-state echoes, which
+	 * only ever dispatch advertised tools.
+	 */
+	getDispatchableTools?: () => Promise< Tool[] >;
 	executeTool?: (
 		toolId: string,
 		args: any,

--- a/packages/agenttic-client/src/client/types/index.ts
+++ b/packages/agenttic-client/src/client/types/index.ts
@@ -378,11 +378,18 @@ export interface ToolProvider {
 	/**
 	 * Tools the client executes when the backend dispatches them in an
 	 * `input-required` handoff, WITHOUT advertising them to the agent as
-	 * callable. Use this for backend-driven handoffs the model must not be
-	 * able to invoke on its own (a confirmation step, for example). Tools
-	 * listed here are executed through `executeTool`, exactly like
-	 * advertised tools; they are ignored for `running`-state echoes, which
-	 * only ever dispatch advertised tools.
+	 * callable. Use this for backend-driven handoffs the agent has no reason
+	 * to choose for itself (a confirmation step, for example). Tools listed
+	 * here are executed through `executeTool`, exactly like advertised tools;
+	 * they are ignored for `running`-state echoes, which only ever dispatch
+	 * advertised tools.
+	 *
+	 * This keeps the tool out of the agent's tool list — it is not an
+	 * authorization boundary. `input-required` is also how model-chosen calls
+	 * reach `executeTool`, so a call naming a dispatchable id still runs if
+	 * the backend relays one. Anything that must not run on the model's say-so
+	 * needs the backend to reject unadvertised tool names, or a confirmation
+	 * inside `executeTool` itself.
 	 */
 	getDispatchableTools?: () => Promise< Tool[] >;
 	executeTool?: (


### PR DESCRIPTION
As described in BSKY-2024, an update to the Agenttic library broke Site Spec, and so Site Spec is pinned to the last working version.

This PR is based on Miguel's work in 426-ghe-Automattic/agenttic that was done just before the move to the Calypso repo. It takes the original PR and adjusts things to fit Calypso's rules.

## Testing Instructions

The changes here are only manually testable by Site Spec. You can use 336-ghe-Automattic/site-spec to test it from there.

In terms of testing that the changes don't affect existing usage:

- Confirm agents manager continues to work

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?