### PR TITLE
Help Center: hide Zendesk interactions when the connectivity check errors

### DIFF
--- a/packages/help-center/src/hooks/use-get-support-interactions.ts
+++ b/packages/help-center/src/hooks/use-get-support-interactions.ts
@@ -20,7 +20,10 @@ export const useGetSupportInteractions = (
 	const isAuthed = !! currentUser?.ID && ! isCookieAuthMissing();
 	// Subscribe without fetching: the Help Center root triggers the check; here it only
 	// hides Zendesk conversations once the user is known to be unable to open them.
-	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging( false, site?.ID );
+	const { data: canConnectToZendesk, isError: canConnectErrored } = useCanConnectToZendeskMessaging(
+		false,
+		site?.ID
+	);
 
 	const isZendeskProvider = provider === 'zendesk' || provider === 'zendesk-staging';
 	const shouldFetch = enabled && isAuthed;
@@ -30,7 +33,7 @@ export const useGetSupportInteractions = (
 		queryFn: () => handleSupportInteractionsFetch( 'GET', '?per_page=100&page=1', isTestMode ),
 		select: ( response ) => {
 			if ( provider ) {
-				if ( isZendeskProvider && canConnectToZendesk === false ) {
+				if ( isZendeskProvider && ( canConnectToZendesk === false || canConnectErrored ) ) {
 					return [];
 				}
 				return response.filter( ( interaction ) =>


### PR DESCRIPTION
## Proposed Changes

**When the Zendesk connectivity check fails, the Help Center now hides Zendesk conversations instead of listing chats the user can’t open.**

- The hook that lists support conversations treats an errored check the same as a “cannot connect” answer; while the check hasn’t run yet, conversations still show as before.

## Why are these changes being made?

Follow-up to #113981, which made the connectivity check run on demand. A failed check reports “no answer” rather than “no”, so the new guard fell through and Zendesk conversations stayed visible for users who can’t reach Zendesk. Before #113981 they were hidden.

## Testing Instructions

### Calypso

1. `yarn start`, block Zendesk (e.g. devtools request blocking), log in as a user with past Zendesk chats.
2. Open the Help Center: no Zendesk conversations listed once the connectivity check fails.
3. Unblock and reload: conversations appear again.

### Simple/Atomic/CIAB

1. Sandbox `widgets.wp.com`, run `cd apps/help-center && yarn dev --sync`.
2. Repeat the checks in a Simple or Atomic site’s wp-admin.
