### PR TITLE
A4A: Link to partner directories in onboarding tour

### DIFF
--- a/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
+++ b/client/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour-sections.tsx
@@ -348,7 +348,35 @@ export default function useOnboardingTourSections() {
 					title: translate( 'Get leads from multiple agency directories' ),
 					descriptions: [
 						translate(
-							"By partnering with us, you're eligible to be listed on up to four agency directories across our Woo, Pressable, WordPress.com, and Jetpack sites."
+							"By partnering with us, you're eligible to be listed on up to four agency directories across our {{woo}}Woo{{/woo}}, {{pressable}}Pressable{{/pressable}}, {{wpcom}}WordPress.com{{/wpcom}}, and {{jetpack}}Jetpack{{/jetpack}} sites.",
+							{
+								components: {
+									woo: (
+										<ExternalLink
+											href="https://woocommerce.com/development-services/"
+											children={ null }
+										/>
+									),
+									pressable: (
+										<ExternalLink
+											href="https://pressable.com/development-services/"
+											children={ null }
+										/>
+									),
+									wpcom: (
+										<ExternalLink
+											href="https://wordpress.com/development-services/"
+											children={ null }
+										/>
+									),
+									jetpack: (
+										<ExternalLink
+											href="https://jetpack.com/development-services/"
+											children={ null }
+										/>
+									),
+								},
+							}
 						),
 						translate(
 							'To get listed on these directories, you have to qualify for our Agency Partner tier and demonstrate expertise with each of the brands that you would like to be listed with.'


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes https://linear.app/a8c/issue/A4A-3304/partner-directory-link-the-brand-names-woo-pressable-jetpack

## Proposed Changes

Adds external links to the actual partner directories into the onboarding tour of A4A, so agencies can actually see where they'll be listed when joining the directory.

## Testing Instructions

* View the onboarding tour and go to the Partner Directory section. Ensure that there are links for WordPress.com, Woo, Pressable, and Jetpack. Make sure they all open new windows to the appropriate directories.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
