### PR TITLE
E2E: fix site drift in the invite revoke spec

### DIFF
--- a/test/e2e/specs/users/invite__revoke.spec.ts
+++ b/test/e2e/specs/users/invite__revoke.spec.ts
@@ -1,10 +1,7 @@
 import { DataHelper, RestAPIClient, SecretsManager } from '@automattic/calypso-e2e';
 import { expect, skipIfMailosaurLimitReached, tags, test } from '../../lib/pw-base';
 
-// .fixme: muted project-wide since 2026-02-02 and failing every run — the invites endpoint
-// throttles in CI (`unauthorized: API calls to this endpoint have been disabled`). The mute
-// keeps builds green, so running it only wastes CI time. Underlying throttle tracked in TESTOPS-232.
-test.describe.fixme(
+test.describe(
 	DataHelper.createSuiteTitle( 'Invite: Revoke' ),
 	{ tag: [ tags.CALYPSO_PR, tags.CALYPSO_RELEASE, tags.DESKTOP_ONLY ] },
 	() => {
@@ -84,7 +81,6 @@ test.describe.fixme(
 
 		test( 'As a site owner, I can revoke a pending invite so that the invitation link becomes invalid', async ( {
 			page,
-			componentSidebar,
 			clientEmail,
 			pageIncognito,
 			pagePeople,
@@ -120,8 +116,15 @@ test.describe.fixme(
 				await accountDefaultUser.authenticate( page );
 			} );
 
-			await test.step( 'When I navigate to Users > All Users', async function () {
-				await componentSidebar.navigate( 'Users', 'All Users' );
+			// Navigate by URL, not through the sidebar: the sidebar follows the
+			// account's selected site, which has drifted from testSites.primary, so
+			// the invite created above would not be listed. Same fix as TESTOPS-193.
+			await test.step( 'When I navigate to the pending invites', async function () {
+				await page.goto(
+					DataHelper.getCalypsoURL(
+						`/people/pending-invites/${ credentials.testSites?.primary?.url }`
+					)
+				);
 			} );
 
 			await test.step( 'Then I can see the invite is pending', async function () {


### PR DESCRIPTION
Part of TESTOPS-287

## Proposed Changes

* `invite__revoke.spec.ts`: drop `describe.fixme` and navigate straight to `/people/pending-invites/<primary site>` instead of going through the sidebar.
* Remove the comment explaining the `fixme`, which recorded a cause that turns out to be wrong.

TeamCity mute 1408 is removed separately. It is a no-op today — every occurrence it covers is already `ignored` — and it carries neither a reason nor an issue id.

## Why are these changes being made?

The spec was `fixme`'d on the belief that the invites endpoint throttles in CI. It does not.

The `API calls to this endpoint have been disabled.` message comes from `endpoint_allowed_for_site()`, which checks site state — deleted, archived, spam, graylisted — and is not a rate limiter. The throttle infrastructure the comment pointed at covers only `signup`, `domain-suggestions` and `domain-availability`; invites are not in it. TESTOPS-232, cited as the underlying cause, is closed and was never related.

The real failure is site drift. The invite is created over REST against `testSites.primary`, then the sidebar navigates to whichever site the account currently has selected — which has drifted away from `testSites.primary`. The People page then renders "The invites list is empty" and `waitForInvitation` times out. The REST call succeeds every time; nothing is throttled.

This is the same bug, and the same fix, as #111958 for the sibling spec.

## Testing Instructions

```bash
CALYPSO_BASE_URL=https://wpcalypso.wordpress.com \
  yarn workspace wp-e2e-tests exec playwright test \
  --project=chrome specs/users/invite__revoke.spec.ts --repeat-each=5
```

Green with the fix; reverting the navigation back to the sidebar reproduces the timeout.

Two things to keep in mind. The spec is tagged `@calypso-pr`, so it rejoins every PR matrix run — roughly 30s and one Mailosaur message per run. And the People page fetches only the newest 100 invites, while the shared site still carries the pending-invite backlog tracked in TESTOPS-206; newest-first ordering plus `DESKTOP_ONLY` keeps that safe today, but TESTOPS-206 stays open as the standing risk.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
