### PR TITLE
A4A: Show the Pressable Q3 offers on the revamped Overview

### DIFF
--- a/client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx
@@ -1,6 +1,8 @@
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { CONTACT_URL_HASH_FRAGMENT } from 'calypso/a8c-for-agencies/components/a4a-contact-support-widget';
+import useIsEligibleForExpansionOffer from 'calypso/a8c-for-agencies/components/a4a-pressable-offer/hooks/use-is-eligible-for-expansion-offer';
+import usePressableOfferEligibility from 'calypso/a8c-for-agencies/components/a4a-pressable-offer/hooks/use-pressable-offer-eligibility';
 import { ONBOARDING_TOUR_HASH } from 'calypso/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour';
 import {
 	A4A_AGENCY_TIER_LINK,
@@ -17,10 +19,15 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
-export default function DashboardOverviewBody() {
+function DashboardOverviewBodyContent( {
+	isEligibleForPressableExpansionOffer,
+}: {
+	isEligibleForPressableExpansionOffer: boolean;
+} ) {
 	const dispatch = useDispatch();
 	const agency = useSelector( getActiveAgency );
 	const approvalStatus = agency?.approval_status;
+	const { isEligibleForIntroductoryOffer } = usePressableOfferEligibility();
 	const hasPartnerDirectoryListing =
 		!! agency?.profile?.partner_directory_application?.directories.some(
 			( { status } ) => status === 'approved'
@@ -51,6 +58,8 @@ export default function DashboardOverviewBody() {
 			approvalStatus={ approvalStatus }
 			capabilities={ agency.user?.capabilities }
 			hasPartnerDirectoryListing={ hasPartnerDirectoryListing }
+			isEligibleForPressableIntroOffer={ isEligibleForIntroductoryOffer }
+			isEligibleForPressableExpansionOffer={ isEligibleForPressableExpansionOffer }
 			links={ {
 				tiers: A4A_AGENCY_TIER_LINK,
 				sites: A4A_SITES_LINK,
@@ -85,4 +94,26 @@ export default function DashboardOverviewBody() {
 			recordTracksEvent={ handleRecordTracksEvent }
 		/>
 	);
+}
+
+function ContentWithExpansionOfferCheck() {
+	const isEligibleForExpansionOffer = useIsEligibleForExpansionOffer();
+
+	return (
+		<DashboardOverviewBodyContent
+			isEligibleForPressableExpansionOffer={ isEligibleForExpansionOffer }
+		/>
+	);
+}
+
+export default function DashboardOverviewBody() {
+	const { mayBeEligibleForExpansionOffer } = usePressableOfferEligibility();
+
+	// Gate before rendering so the license fetch behind the expansion offer
+	// check only runs for agencies that own a Pressable plan through A4A.
+	if ( mayBeEligibleForExpansionOffer ) {
+		return <ContentWithExpansionOfferCheck />;
+	}
+
+	return <DashboardOverviewBodyContent isEligibleForPressableExpansionOffer={ false } />;
 }

--- a/client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx
@@ -13,7 +13,10 @@ import {
 	A4A_WOOPAYMENTS_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import useScheduleCall from 'calypso/a8c-for-agencies/hooks/use-schedule-call';
-import { PROGRAM_INCENTIVES_URL } from 'calypso/dashboard/agency/overview/constants';
+import {
+	PRESSABLE_Q3_2026_OFFER_ENDS_AT,
+	PROGRAM_INCENTIVES_URL,
+} from 'calypso/dashboard/agency/overview/constants';
 import AgencyOverviewContent from 'calypso/dashboard/agency/overview/overview-content';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
@@ -108,10 +111,13 @@ function ContentWithExpansionOfferCheck() {
 
 export default function DashboardOverviewBody() {
 	const { mayBeEligibleForExpansionOffer } = usePressableOfferEligibility();
+	// Once the offer ends the card can never render, so don't pay for the
+	// license fetch either.
+	const isOfferActive = new Date() < new Date( PRESSABLE_Q3_2026_OFFER_ENDS_AT );
 
 	// Gate before rendering so the license fetch behind the expansion offer
 	// check only runs for agencies that own a Pressable plan through A4A.
-	if ( mayBeEligibleForExpansionOffer ) {
+	if ( isOfferActive && mayBeEligibleForExpansionOffer ) {
 		return <ContentWithExpansionOfferCheck />;
 	}
 

--- a/client/dashboard/agency/overview/constants.ts
+++ b/client/dashboard/agency/overview/constants.ts
@@ -6,6 +6,18 @@ export const PARTNER_PROGRAM_GUIDE_URL =
 
 export const PROGRAM_INCENTIVES_URL = 'https://automattic.com/for-agencies/program-incentives/';
 
+// Inlined from client/a8c-for-agencies/components/a4a-pressable-offer/constants
+// so the dashboard has no dependency on the classic A4A app.
+export const PRESSABLE_Q3_2026_OFFER_START_DATE = '2026-08-11';
+export const PRESSABLE_INTRODUCTORY_OFFER_TERMS_URL =
+	'https://pressable.com/legal/late-summer-promotion-terms-and-conditions/';
+export const PRESSABLE_EXPANSION_OFFER_TERMS_URL =
+	'https://pressable.com/legal/summer-2026-expansion-incentive-terms-and-conditions/';
+
+// Resolves in the classic A4A marketplace until a dashboard Pressable hosting
+// page exists, like the links in agency/marketplace/exclusive-offers.
+export const MARKETPLACE_HOSTING_PRESSABLE_PATH = '/marketplace/hosting/pressable';
+
 interface TierOverviewContent {
 	description: string;
 	hasPartnerManager: boolean;

--- a/client/dashboard/agency/overview/constants.ts
+++ b/client/dashboard/agency/overview/constants.ts
@@ -9,6 +9,9 @@ export const PROGRAM_INCENTIVES_URL = 'https://automattic.com/for-agencies/progr
 // Inlined from client/a8c-for-agencies/components/a4a-pressable-offer/constants
 // so the dashboard has no dependency on the classic A4A app.
 export const PRESSABLE_Q3_2026_OFFER_START_DATE = '2026-08-11';
+/** The day after the offer ends: the promo cards and the license fetch behind
+ * the expansion offer both stop at this date. */
+export const PRESSABLE_Q3_2026_OFFER_ENDS_AT = '2026-10-01';
 export const PRESSABLE_INTRODUCTORY_OFFER_TERMS_URL =
 	'https://pressable.com/legal/late-summer-promotion-terms-and-conditions/';
 export const PRESSABLE_EXPANSION_OFFER_TERMS_URL =

--- a/client/dashboard/agency/overview/event-card.tsx
+++ b/client/dashboard/agency/overview/event-card.tsx
@@ -56,7 +56,7 @@ function SingleEventCard( {
 							</Text>
 						) ) }
 					</VStack>
-					<ButtonStack justify="flex-start">
+					<ButtonStack justify="flex-start" wrap>
 						{ ctas.map( ( cta ) => (
 							<Button
 								key={ cta.id }

--- a/client/dashboard/agency/overview/event-card.tsx
+++ b/client/dashboard/agency/overview/event-card.tsx
@@ -7,20 +7,29 @@ import {
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { Text } from '../../components/text';
-import { FEATURED_EVENT } from './events';
+import {
+	FEATURED_EVENT,
+	PRESSABLE_EXPANSION_OFFER_EVENT,
+	PRESSABLE_INTRO_OFFER_EVENT,
+} from './events';
 import NewTabLabel from './new-tab-label';
+import type { FeaturedEvent } from './events';
 import type { RecordTracksEvent } from '../tiers/types';
 
 interface EventCardProps {
+	isEligibleForPressableIntroOffer?: boolean;
+	isEligibleForPressableExpansionOffer?: boolean;
 	recordTracksEvent?: RecordTracksEvent;
 }
 
-export default function EventCard( { recordTracksEvent }: EventCardProps ) {
-	if ( ! FEATURED_EVENT || new Date() >= new Date( FEATURED_EVENT.endsAt ) ) {
-		return null;
-	}
-
-	const { id, logo, logoAlt, when, title, subtitle, description, ctaLabel, url } = FEATURED_EVENT;
+function SingleEventCard( {
+	event,
+	recordTracksEvent,
+}: {
+	event: FeaturedEvent;
+	recordTracksEvent?: RecordTracksEvent;
+} ) {
+	const { id, logo, logoAlt, when, title, subtitle, description, ctas } = event;
 
 	return (
 		<Card>
@@ -48,23 +57,52 @@ export default function EventCard( { recordTracksEvent }: EventCardProps ) {
 						) ) }
 					</VStack>
 					<ButtonStack justify="flex-start">
-						<Button
-							size="compact"
-							variant="secondary"
-							href={ url }
-							target="_blank"
-							rel="noreferrer"
-							onClick={ () =>
-								recordTracksEvent?.( 'calypso_a4a_overview_event_register_click', {
-									event_id: id,
-								} )
-							}
-						>
-							<NewTabLabel>{ ctaLabel }</NewTabLabel>
-						</Button>
+						{ ctas.map( ( cta ) => (
+							<Button
+								key={ cta.id }
+								size="compact"
+								variant={ cta.variant ?? 'secondary' }
+								href={ cta.url }
+								target={ cta.isExternal ? '_blank' : undefined }
+								rel={ cta.isExternal ? 'noreferrer' : undefined }
+								onClick={ () =>
+									recordTracksEvent?.( 'calypso_a4a_overview_event_cta_click', {
+										event_id: id,
+										cta_id: cta.id,
+									} )
+								}
+							>
+								{ cta.isExternal ? <NewTabLabel>{ cta.label }</NewTabLabel> : cta.label }
+							</Button>
+						) ) }
 					</ButtonStack>
 				</VStack>
 			</CardBody>
 		</Card>
+	);
+}
+
+export default function EventCard( {
+	isEligibleForPressableIntroOffer,
+	isEligibleForPressableExpansionOffer,
+	recordTracksEvent,
+}: EventCardProps ) {
+	const now = new Date();
+	const events = [
+		FEATURED_EVENT,
+		isEligibleForPressableIntroOffer ? PRESSABLE_INTRO_OFFER_EVENT : null,
+		isEligibleForPressableExpansionOffer ? PRESSABLE_EXPANSION_OFFER_EVENT : null,
+	].filter( ( event ): event is FeaturedEvent => !! event && now < new Date( event.endsAt ) );
+
+	if ( ! events.length ) {
+		return null;
+	}
+
+	return (
+		<>
+			{ events.map( ( event ) => (
+				<SingleEventCard key={ event.id } event={ event } recordTracksEvent={ recordTracksEvent } />
+			) ) }
+		</>
 	);
 }

--- a/client/dashboard/agency/overview/event-card.tsx
+++ b/client/dashboard/agency/overview/event-card.tsx
@@ -65,12 +65,15 @@ function SingleEventCard( {
 								href={ cta.url }
 								target={ cta.isExternal ? '_blank' : undefined }
 								rel={ cta.isExternal ? 'noreferrer' : undefined }
-								onClick={ () =>
+								onClick={ () => {
 									recordTracksEvent?.( 'calypso_a4a_overview_event_cta_click', {
 										event_id: id,
 										cta_id: cta.id,
-									} )
-								}
+									} );
+									if ( cta.legacyTrackEventName ) {
+										recordTracksEvent?.( cta.legacyTrackEventName );
+									}
+								} }
 							>
 								{ cta.isExternal ? <NewTabLabel>{ cta.label }</NewTabLabel> : cta.label }
 							</Button>

--- a/client/dashboard/agency/overview/event-card.tsx
+++ b/client/dashboard/agency/overview/event-card.tsx
@@ -4,6 +4,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { useViewportMatch } from '@wordpress/compose';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { Text } from '../../components/text';
@@ -30,6 +31,7 @@ function SingleEventCard( {
 	recordTracksEvent?: RecordTracksEvent;
 } ) {
 	const { id, logo, logoAlt, when, title, subtitle, description, ctas } = event;
+	const isMobileViewport = useViewportMatch( 'mobile', '<' );
 
 	return (
 		<Card>
@@ -62,6 +64,7 @@ function SingleEventCard( {
 								key={ cta.id }
 								size="compact"
 								variant={ cta.variant ?? 'secondary' }
+								style={ isMobileViewport ? { width: '100%', justifyContent: 'center' } : undefined }
 								href={ cta.url }
 								target={ cta.isExternal ? '_blank' : undefined }
 								rel={ cta.isExternal ? 'noreferrer' : undefined }

--- a/client/dashboard/agency/overview/events.ts
+++ b/client/dashboard/agency/overview/events.ts
@@ -4,6 +4,7 @@ import {
 	MARKETPLACE_HOSTING_PRESSABLE_PATH,
 	PRESSABLE_EXPANSION_OFFER_TERMS_URL,
 	PRESSABLE_INTRODUCTORY_OFFER_TERMS_URL,
+	PRESSABLE_Q3_2026_OFFER_ENDS_AT,
 } from './constants';
 
 export interface FeaturedEventCta {
@@ -14,6 +15,11 @@ export interface FeaturedEventCta {
 	variant?: 'primary' | 'secondary';
 	/** Opens the link in a new tab, with the new-tab arrow on the label. */
 	isExternal?: boolean;
+	/**
+	 * Also fired on click: the per-CTA event name the classic News and updates
+	 * section fires, so funnels keyed on it keep working across the transition.
+	 */
+	legacyTrackEventName?: string;
 }
 
 export interface FeaturedEvent {
@@ -93,15 +99,19 @@ export const PRESSABLE_INTRO_OFFER_EVENT: FeaturedEvent = {
 			label: __( 'View promo details' ),
 			url: MARKETPLACE_HOSTING_PRESSABLE_PATH,
 			variant: 'primary',
+			legacyTrackEventName:
+				'calypso_a4a_overview_events_a4a_pressable_promo_offer_q3_2026_view_promo_details_click',
 		},
 		{
 			id: 'see-full-terms',
 			label: __( 'See full terms' ),
 			url: PRESSABLE_INTRODUCTORY_OFFER_TERMS_URL,
 			isExternal: true,
+			legacyTrackEventName:
+				'calypso_a4a_overview_events_a4a_pressable_promo_offer_q3_2026_see_full_terms_click',
 		},
 	],
-	endsAt: '2026-10-01',
+	endsAt: PRESSABLE_Q3_2026_OFFER_ENDS_AT,
 };
 
 export const PRESSABLE_EXPANSION_OFFER_EVENT: FeaturedEvent = {
@@ -126,12 +136,16 @@ export const PRESSABLE_EXPANSION_OFFER_EVENT: FeaturedEvent = {
 			url: PRESSABLE_EXPANSION_OFFER_TERMS_URL,
 			variant: 'primary',
 			isExternal: true,
+			legacyTrackEventName:
+				'calypso_a4a_overview_events_a4a_pressable_expansion_offer_view_promo_details_click',
 		},
 		{
 			id: 'see-pressable-plans',
 			label: __( 'See Pressable plans' ),
 			url: MARKETPLACE_HOSTING_PRESSABLE_PATH,
+			legacyTrackEventName:
+				'calypso_a4a_overview_events_a4a_pressable_expansion_offer_see_pressable_plans_click',
 		},
 	],
-	endsAt: '2026-10-01',
+	endsAt: PRESSABLE_Q3_2026_OFFER_ENDS_AT,
 };

--- a/client/dashboard/agency/overview/events.ts
+++ b/client/dashboard/agency/overview/events.ts
@@ -1,4 +1,20 @@
 import { __ } from '@wordpress/i18n';
+import PressableLogo from 'calypso/assets/images/a8c-for-agencies/events/pressable-logo.svg';
+import {
+	MARKETPLACE_HOSTING_PRESSABLE_PATH,
+	PRESSABLE_EXPANSION_OFFER_TERMS_URL,
+	PRESSABLE_INTRODUCTORY_OFFER_TERMS_URL,
+} from './constants';
+
+export interface FeaturedEventCta {
+	/** Used as the `cta_id` tracks property, so keep it stable per CTA. */
+	id: string;
+	label: string;
+	url: string;
+	variant?: 'primary' | 'secondary';
+	/** Opens the link in a new tab, with the new-tab arrow on the label. */
+	isExternal?: boolean;
+}
 
 export interface FeaturedEvent {
 	/** Used as the `event_id` tracks property, so keep it stable per event. */
@@ -14,8 +30,7 @@ export interface FeaturedEvent {
 	subtitle: string;
 	/** One entry per paragraph. */
 	description: string[];
-	ctaLabel: string;
-	url: string;
+	ctas: FeaturedEventCta[];
 	/** ISO date the card stops showing itself, typically the day after the event. */
 	endsAt: string;
 }
@@ -42,7 +57,81 @@ export const FEATURED_EVENT: FeaturedEvent | null = {
 			'Come talk shop with our partner managers, get answers in person, and grab a pin while they last.'
 		),
 	],
-	ctaLabel: __( 'Get your spot!' ),
-	url: 'https://us.wordcamp.org/2026/',
+	ctas: [
+		{
+			id: 'register',
+			label: __( 'Get your spot!' ),
+			url: 'https://us.wordcamp.org/2026/',
+			isExternal: true,
+		},
+	],
 	endsAt: '2026-08-20',
+};
+
+/**
+ * The Q3 2026 Pressable promos, shown to eligible agencies alongside the
+ * featured event. Which one an agency sees is decided by the shells through
+ * the eligibility props on AgencyOverviewContent: the introductory offer
+ * targets agencies without a Pressable plan through A4A, the expansion offer
+ * agencies with one that missed the introductory offer.
+ */
+export const PRESSABLE_INTRO_OFFER_EVENT: FeaturedEvent = {
+	id: 'a4a-pressable-promo-offer-2026-q3',
+	logo: PressableLogo,
+	logoAlt: __( 'Pressable' ),
+	when: __( 'Limited time offer · Until September 30, 2026' ),
+	title: __( 'Get up to 6 months of free Pressable hosting on new plans!' ),
+	subtitle: __( 'Automattic for Agencies & Pressable' ),
+	description: [
+		__(
+			'Enjoy up to 6 months free on Pressable Signature and Premium Plans with Automattic for Agencies. Choose annual billing for 6 months free or monthly billing for 3 months free, while still earning revenue share and reseller incentives.'
+		),
+	],
+	ctas: [
+		{
+			id: 'view-promo-details',
+			label: __( 'View promo details' ),
+			url: MARKETPLACE_HOSTING_PRESSABLE_PATH,
+			variant: 'primary',
+		},
+		{
+			id: 'see-full-terms',
+			label: __( 'See full terms' ),
+			url: PRESSABLE_INTRODUCTORY_OFFER_TERMS_URL,
+			isExternal: true,
+		},
+	],
+	endsAt: '2026-10-01',
+};
+
+export const PRESSABLE_EXPANSION_OFFER_EVENT: FeaturedEvent = {
+	id: 'a4a-pressable-expansion-offer-2026-q3',
+	logo: PressableLogo,
+	logoAlt: __( 'Pressable' ),
+	when: __( 'Limited time offer · Until September 30, 2026' ),
+	title: __( 'Upgrade your Pressable plan and get up to 6 months of the upgrade free' ),
+	subtitle: __( 'Automattic for Agencies & Pressable' ),
+	description: [
+		__(
+			'Move up a Pressable plan tier and we’ll cover part of the increase: 6 months’ worth on annual upgrades, 3 months’ worth on monthly.'
+		),
+		__(
+			'For example, an annual upgrade from $10,000 to $13,250/yr is a $3,250 increase, so you’d save $1,625. The discount is calculated on that increase. Migrating 50+ sites? You may qualify for a custom incentive, up to $25,000.'
+		),
+	],
+	ctas: [
+		{
+			id: 'view-promo-details',
+			label: __( 'View promo details' ),
+			url: PRESSABLE_EXPANSION_OFFER_TERMS_URL,
+			variant: 'primary',
+			isExternal: true,
+		},
+		{
+			id: 'see-pressable-plans',
+			label: __( 'See Pressable plans' ),
+			url: MARKETPLACE_HOSTING_PRESSABLE_PATH,
+		},
+	],
+	endsAt: '2026-10-01',
 };

--- a/client/dashboard/agency/overview/index.tsx
+++ b/client/dashboard/agency/overview/index.tsx
@@ -10,6 +10,7 @@ import { useScheduleCall } from '../tiers/use-schedule-call';
 import { PROGRAM_INCENTIVES_URL } from './constants';
 import AgencyOverviewContent from './overview-content';
 import AgencyOverviewHeader from './overview-header';
+import usePressableOfferEligibility from './use-pressable-offer-eligibility';
 
 // TODO: the MSD dashboard has no contact-support entry point yet. This matches the
 // '#contact-support' placeholder in agency/tiers/constants.ts — wire both up together.
@@ -30,6 +31,8 @@ export default function AgencyOverview() {
 			( { status } ) => status === 'approved'
 		);
 	const { scheduleCall, isLoading: isSchedulingCall } = useScheduleCall( agency?.id );
+	const { isEligibleForPressableIntroOffer, isEligibleForPressableExpansionOffer } =
+		usePressableOfferEligibility( agency );
 
 	if ( ! agency ) {
 		return <PageLayout header={ <PageHeader title={ __( 'Overview' ) } /> } />;
@@ -58,6 +61,8 @@ export default function AgencyOverview() {
 				approvalStatus={ approvalStatus }
 				capabilities={ agency.user?.capabilities }
 				hasPartnerDirectoryListing={ hasPartnerDirectoryListing }
+				isEligibleForPressableIntroOffer={ isEligibleForPressableIntroOffer }
+				isEligibleForPressableExpansionOffer={ isEligibleForPressableExpansionOffer }
 				links={ {
 					tiers: '/agency/tiers',
 					sites: '/sites',

--- a/client/dashboard/agency/overview/overview-content.tsx
+++ b/client/dashboard/agency/overview/overview-content.tsx
@@ -129,12 +129,12 @@ export default function AgencyOverviewContent( {
 				/>
 			</VStack>
 			<VStack spacing={ spacing } justify="flex-start">
+				<HelpfulLinksCard links={ links.helpful } recordTracksEvent={ recordTracksEvent } />
 				<EventCard
 					isEligibleForPressableIntroOffer={ isEligibleForPressableIntroOffer }
 					isEligibleForPressableExpansionOffer={ isEligibleForPressableExpansionOffer }
 					recordTracksEvent={ recordTracksEvent }
 				/>
-				<HelpfulLinksCard links={ links.helpful } recordTracksEvent={ recordTracksEvent } />
 			</VStack>
 		</Grid>
 	);

--- a/client/dashboard/agency/overview/overview-content.tsx
+++ b/client/dashboard/agency/overview/overview-content.tsx
@@ -37,6 +37,10 @@ export interface AgencyOverviewContentProps {
 	capabilities?: string[];
 	/** Whether the agency already has an approved Partner Directory listing. */
 	hasPartnerDirectoryListing?: boolean;
+	/** Shows the Pressable introductory offer in the news column. */
+	isEligibleForPressableIntroOffer?: boolean;
+	/** Shows the Pressable expansion offer in the news column. */
+	isEligibleForPressableExpansionOffer?: boolean;
 	links: AgencyOverviewLinks;
 	shouldUseRouterLink?: boolean;
 	onScheduleCall?: () => void;
@@ -57,6 +61,8 @@ export default function AgencyOverviewContent( {
 	approvalStatus,
 	capabilities,
 	hasPartnerDirectoryListing,
+	isEligibleForPressableIntroOffer,
+	isEligibleForPressableExpansionOffer,
 	links,
 	shouldUseRouterLink,
 	onScheduleCall,
@@ -123,7 +129,11 @@ export default function AgencyOverviewContent( {
 				/>
 			</VStack>
 			<VStack spacing={ spacing } justify="flex-start">
-				<EventCard recordTracksEvent={ recordTracksEvent } />
+				<EventCard
+					isEligibleForPressableIntroOffer={ isEligibleForPressableIntroOffer }
+					isEligibleForPressableExpansionOffer={ isEligibleForPressableExpansionOffer }
+					recordTracksEvent={ recordTracksEvent }
+				/>
 				<HelpfulLinksCard links={ links.helpful } recordTracksEvent={ recordTracksEvent } />
 			</VStack>
 		</Grid>

--- a/client/dashboard/agency/overview/test/use-pressable-offer-eligibility.ts
+++ b/client/dashboard/agency/overview/test/use-pressable-offer-eligibility.ts
@@ -1,0 +1,68 @@
+import {
+	getAgencyPlanLicenses,
+	hasBenefitedFromIntroductoryOffer,
+	hasPlanEligibleForExpansionOffer,
+} from '../use-pressable-offer-eligibility';
+import type { JetpackLicense } from '@automattic/api-core';
+
+function license( overrides: Partial< JetpackLicense > ): JetpackLicense {
+	return {
+		license_key: 'pressable-signature-1_abc',
+		issued_at: '2026-01-15 10:00:00',
+		referral: null,
+		...overrides,
+	} as JetpackLicense;
+}
+
+describe( 'getAgencyPlanLicenses', () => {
+	it( 'keeps Pressable plan licenses the agency bought for itself', () => {
+		const licenses = [ license( { license_key: 'pressable-signature-1_abc' } ) ];
+
+		expect( getAgencyPlanLicenses( licenses ) ).toEqual( licenses );
+	} );
+
+	it( 'drops addon, referral, and non-Pressable licenses', () => {
+		const licenses = [
+			license( { license_key: 'pressable-addon-storage_abc' } ),
+			license( { referral: { id: 1 } } ),
+			license( { license_key: 'jetpack-backup_abc' } ),
+		];
+
+		expect( getAgencyPlanLicenses( licenses ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'hasBenefitedFromIntroductoryOffer', () => {
+	it( 'returns null when the agency has no plan license', () => {
+		expect( hasBenefitedFromIntroductoryOffer( [] ) ).toBeNull();
+	} );
+
+	it( 'returns false when the earliest plan license predates the offer', () => {
+		const licenses = [
+			license( { issued_at: '2026-01-15 10:00:00' } ),
+			license( { issued_at: '2026-08-20 10:00:00' } ),
+		];
+
+		expect( hasBenefitedFromIntroductoryOffer( licenses ) ).toBe( false );
+	} );
+
+	it( 'returns true when the earliest plan license was issued within the offer window', () => {
+		const licenses = [ license( { issued_at: '2026-08-12 10:00:00' } ) ];
+
+		expect( hasBenefitedFromIntroductoryOffer( licenses ) ).toBe( true );
+	} );
+} );
+
+describe( 'hasPlanEligibleForExpansionOffer', () => {
+	it( 'accepts Signature and Premium tier plans', () => {
+		expect(
+			hasPlanEligibleForExpansionOffer( [ license( { license_key: 'pressable-premium-2_abc' } ) ] )
+		).toBe( true );
+	} );
+
+	it( 'rejects legacy plans with no upgrade path in the offer', () => {
+		expect(
+			hasPlanEligibleForExpansionOffer( [ license( { license_key: 'pressable-premium_abc' } ) ] )
+		).toBe( false );
+	} );
+} );

--- a/client/dashboard/agency/overview/test/use-pressable-offer-eligibility.ts
+++ b/client/dashboard/agency/overview/test/use-pressable-offer-eligibility.ts
@@ -51,6 +51,12 @@ describe( 'hasBenefitedFromIntroductoryOffer', () => {
 
 		expect( hasBenefitedFromIntroductoryOffer( licenses ) ).toBe( true );
 	} );
+
+	it( 'counts a license issued exactly on the offer start date as benefited', () => {
+		const licenses = [ license( { issued_at: '2026-08-11 00:00:00' } ) ];
+
+		expect( hasBenefitedFromIntroductoryOffer( licenses ) ).toBe( true );
+	} );
 } );
 
 describe( 'hasPlanEligibleForExpansionOffer', () => {

--- a/client/dashboard/agency/overview/use-pressable-offer-eligibility.ts
+++ b/client/dashboard/agency/overview/use-pressable-offer-eligibility.ts
@@ -1,0 +1,88 @@
+import {
+	JetpackLicenseFilter,
+	JetpackLicenseSortDirection,
+	JetpackLicenseSortField,
+} from '@automattic/api-core';
+import { jetpackAgencyLicensesQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { PRESSABLE_Q3_2026_OFFER_START_DATE } from './constants';
+import type { Agency, JetpackLicense } from '@automattic/api-core';
+
+// The offer only covers moves up within the Signature and Premium tiers, the
+// same plans the checkout coupon is built from. The trailing hyphen keeps the
+// legacy bare 'pressable-premium' plan out.
+const EXPANSION_OFFER_PLAN_PREFIXES = [ 'pressable-signature-', 'pressable-premium-' ];
+
+export function getAgencyPlanLicenses( licenses: JetpackLicense[] = [] ): JetpackLicense[] {
+	return licenses.filter(
+		( license ) =>
+			( license.license_key.startsWith( 'pressable-' ) ||
+				license.license_key.startsWith( 'jetpack-pressable' ) ) &&
+			! license.license_key.startsWith( 'pressable-addon' ) &&
+			! license.referral
+	);
+}
+
+// The introductory offer applies automatically to plans purchased after its
+// start date, so an agency whose earliest plan license was issued on or after
+// that date has benefited from it (or is a new customer who bought outside the
+// offer window). Returns null when no plan license is found.
+export function hasBenefitedFromIntroductoryOffer( licenses: JetpackLicense[] ): boolean | null {
+	const planLicenses = getAgencyPlanLicenses( licenses );
+
+	if ( ! planLicenses.length ) {
+		return null;
+	}
+
+	const earliestLicense = planLicenses.reduce( ( earliest, license ) =>
+		license.issued_at < earliest.issued_at ? license : earliest
+	);
+
+	return earliestLicense.issued_at.slice( 0, 10 ) >= PRESSABLE_Q3_2026_OFFER_START_DATE;
+}
+
+// An agency on a legacy plan has no upgrade path the offer applies to, so the
+// discount would never materialize at checkout.
+export function hasPlanEligibleForExpansionOffer( licenses: JetpackLicense[] ): boolean {
+	return getAgencyPlanLicenses( licenses ).some( ( license ) =>
+		EXPANSION_OFFER_PLAN_PREFIXES.some( ( prefix ) => license.license_key.startsWith( prefix ) )
+	);
+}
+
+/**
+ * The dashboard's port of the classic app's Pressable Q3 2026 offer
+ * eligibility (client/a8c-for-agencies/components/a4a-pressable-offer): the
+ * introductory offer targets agencies without a Pressable plan through the A4A
+ * marketplace, the expansion offer agencies with one that did not benefit from
+ * the introductory offer. The license check behind the expansion offer only
+ * fires for agencies that pass the cheaper plan-ownership check.
+ */
+export default function usePressableOfferEligibility( agency: Agency | null | undefined ) {
+	const pressable = agency?.third_party?.pressable;
+	// A regular Pressable plan (not bought through the A4A marketplace) has a null A4A id.
+	const ownsPressableThroughA4A = !! pressable?.pressable_id && pressable?.a4a_id !== null;
+	const isBillingDragonAgency = agency?.billing_system === 'billingdragon';
+	const mayBeEligibleForExpansionOffer = isBillingDragonAgency && ownsPressableThroughA4A;
+
+	const { data: licenses, isFetched } = useQuery( {
+		...jetpackAgencyLicensesQuery( agency?.id ?? 0, {
+			filter: JetpackLicenseFilter.NotRevoked,
+			search: 'pressable',
+			sortField: JetpackLicenseSortField.IssuedAt,
+			sortDirection: JetpackLicenseSortDirection.Ascending,
+		} ),
+		enabled: !! agency?.id && mayBeEligibleForExpansionOffer,
+		refetchOnWindowFocus: false,
+	} );
+
+	return {
+		isEligibleForPressableIntroOffer: isBillingDragonAgency && ! ownsPressableThroughA4A,
+		// Unknown history (query pending, or no plan license found) counts as
+		// ineligible so the offer stays hidden.
+		isEligibleForPressableExpansionOffer:
+			mayBeEligibleForExpansionOffer &&
+			isFetched &&
+			hasPlanEligibleForExpansionOffer( licenses ?? [] ) &&
+			hasBenefitedFromIntroductoryOffer( licenses ?? [] ) === false,
+	};
+}

--- a/client/dashboard/agency/overview/use-pressable-offer-eligibility.ts
+++ b/client/dashboard/agency/overview/use-pressable-offer-eligibility.ts
@@ -5,7 +5,7 @@ import {
 } from '@automattic/api-core';
 import { jetpackAgencyLicensesQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { PRESSABLE_Q3_2026_OFFER_START_DATE } from './constants';
+import { PRESSABLE_Q3_2026_OFFER_ENDS_AT, PRESSABLE_Q3_2026_OFFER_START_DATE } from './constants';
 import type { Agency, JetpackLicense } from '@automattic/api-core';
 
 // The offer only covers moves up within the Signature and Premium tiers, the
@@ -62,7 +62,11 @@ export default function usePressableOfferEligibility( agency: Agency | null | un
 	// A regular Pressable plan (not bought through the A4A marketplace) has a null A4A id.
 	const ownsPressableThroughA4A = !! pressable?.pressable_id && pressable?.a4a_id !== null;
 	const isBillingDragonAgency = agency?.billing_system === 'billingdragon';
-	const mayBeEligibleForExpansionOffer = isBillingDragonAgency && ownsPressableThroughA4A;
+	// Once the offer ends the cards can never render, so don't pay for the
+	// license fetch either.
+	const isOfferActive = new Date() < new Date( PRESSABLE_Q3_2026_OFFER_ENDS_AT );
+	const mayBeEligibleForExpansionOffer =
+		isOfferActive && isBillingDragonAgency && ownsPressableThroughA4A;
 
 	const { data: licenses, isFetched } = useQuery( {
 		...jetpackAgencyLicensesQuery( agency?.id ?? 0, {

--- a/packages/api-core/src/agency/types.ts
+++ b/packages/api-core/src/agency/types.ts
@@ -164,6 +164,9 @@ export interface Agency {
 	};
 	third_party?: null | {
 		pressable?: null | {
+			pressable_id?: number;
+			/** Null for a regular Pressable plan not bought through the A4A marketplace. */
+			a4a_id?: string | null;
 			usage?: null | {
 				start_date?: string;
 				end_date?: string;


### PR DESCRIPTION
Part of A4A-3164. Follow-up to #113374, addressing CFT feedback that the revamped Overview was missing the "News and updates" content — most importantly the Pressable promo currently running.

## Proposed Changes

* Bring the two Q3 2026 Pressable offers from the classic Overview's "News and updates" section to the revamped Overview. They render in the news column, where the WordCamp US promo sat (that card expired on August 20th, which is why the column went empty).
* Per design feedback, the promo/event cards now sit **below "Helpful links"** rather than above them, so promotional content doesn't lead the column.
* Refactor the featured-event card so it renders **every active entry** (featured event plus whichever Pressable offer the agency is eligible for) instead of a single hand-curated event, and so each entry supports **multiple CTAs** with per-CTA styling, new-tab behavior, and tracking.
* Port the offer eligibility rules to both shells that render the shared Overview content:
  * **Classic app** (`a8c-for-agencies`, behind `a4a-overview-revamp`) reuses the existing `a4a-pressable-offer` hooks, including the gate that only fires the license fetch for agencies that own a Pressable plan through A4A.
  * **New dashboard** gets a new `usePressableOfferEligibility` hook built on `@automattic/api-queries` (`activeAgencyQuery` + `jetpackAgencyLicensesQuery`) that mirrors the classic rules 1:1. The pure helpers (`getAgencyPlanLicenses`, `hasBenefitedFromIntroductoryOffer`, `hasPlanEligibleForExpansionOffer`) are unit-tested.
* Model `third_party.pressable.pressable_id` / `a4a_id` on the `Agency` type in `@automattic/api-core` (the API already returns them; only consumed fields are typed).
* Each CTA fires `calypso_a4a_overview_event_cta_click` with `event_id` and `cta_id` properties (replacing the single-CTA `calypso_a4a_overview_event_register_click`, which no live event fires — the only featured event expired before launch). The promo CTAs **also fire the per-CTA event names the classic "News and updates" section fires**, so existing funnels keyed on those events keep reporting when agencies move to the revamped page.
* The license fetch behind the expansion-offer check is additionally gated on the offer end date, so from October 1st the Overview stops paying for a fetch whose card can never render.

### Eligibility rules (unchanged from the classic "News and updates" section)

| Offer | Shown when |
|---|---|
| **Introductory** | Agency is on the BillingDragon billing system **and** has no Pressable plan bought through A4A |
| **Expansion** | Agency is on BillingDragon, owns an A4A Pressable **Signature/Premium** plan, and its earliest plan license was issued **before** the offer started (August 11th) — i.e. it did not already benefit from the introductory offer |

An agency sees at most one of the two (the ownership conditions are mutually exclusive). Both cards hide themselves after September 30th.

### Cards, CTAs, and links

| Card | CTA | Variant | Destination | New tab | `cta_id` |
|---|---|---|---|---|---|
| Get up to 6 months of free Pressable hosting on new plans! | View promo details | primary | `/marketplace/hosting/pressable` | No | `view-promo-details` |
| | See full terms | secondary | [Late-summer promotion terms](https://pressable.com/legal/late-summer-promotion-terms-and-conditions/) | Yes | `see-full-terms` |
| Upgrade your Pressable plan and get up to 6 months of the upgrade free | View promo details | primary | [Expansion incentive terms](https://pressable.com/legal/summer-2026-expansion-incentive-terms-and-conditions/) | Yes | `view-promo-details` |
| | See Pressable plans | secondary | `/marketplace/hosting/pressable` | No | `see-pressable-plans` |

Both CTAs on both cards fire `calypso_a4a_overview_event_cta_click` with `{ event_id, cta_id }`; the `event_id` values are the same stable ids the classic section used (`a4a-pressable-promo-offer-2026-q3`, `a4a-pressable-expansion-offer-2026-q3`).

Each promo CTA also fires its classic per-CTA event, keeping the existing funnels intact:

* `calypso_a4a_overview_events_a4a_pressable_promo_offer_q3_2026_view_promo_details_click`
* `calypso_a4a_overview_events_a4a_pressable_promo_offer_q3_2026_see_full_terms_click`
* `calypso_a4a_overview_events_a4a_pressable_expansion_offer_view_promo_details_click`
* `calypso_a4a_overview_events_a4a_pressable_expansion_offer_see_pressable_plans_click`

On the new dashboard, `/marketplace/hosting/pressable` resolves in the classic A4A marketplace via a plain link — the same approach `agency/marketplace/exclusive-offers` already uses until a dashboard Pressable page exists.

## Why are these changes being made?

* The Pressable promo drives real engagement on the current Overview, and the offer runs until September 30th, so the revamped page shouldn't launch without it. The growth-call prompt — the other item raised during CFT — is already covered by the tier card's schedule-a-call callout.
* Porting the eligibility logic (rather than showing the promo to everyone) keeps the promise accurate: agencies that already own a Pressable plan through A4A see the upgrade offer instead of an introductory offer that doesn't apply to them, and legacy-billing agencies see neither — matching the classic page exactly.

## Testing Instructions

Using this PR's Calypso Live link with the `a8c-for-agencies` environment, sign in as an agency and open the Overview with `?flags=a4a-overview-revamp`.

Real-data scenarios (the promo an agency sees depends on its billing system and Pressable ownership):

* **BillingDragon agency without an A4A Pressable plan** — the introductory offer card appears in the right column, below "Helpful links". "View promo details" opens the Pressable hosting marketplace page in the same tab; "See full terms" opens the terms page in a new tab.
* **BillingDragon agency with an A4A Signature/Premium plan issued before August 11th** — the expansion offer card appears instead. "View promo details" opens the expansion terms in a new tab; "See Pressable plans" opens the Pressable hosting marketplace page.
* **Legacy-billing agency (any Pressable ownership)** — no promo card renders; the right column shows only "Helpful links". This matches what the classic "News and updates" section shows the same agency.
* Each CTA click fires `calypso_a4a_overview_event_cta_click` with the `event_id`/`cta_id` from the table above.

For quick visual QA without an eligible agency, force the flags where the shells pass them into `AgencyOverviewContent`:

* Classic app: `client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx`
* New dashboard: `client/dashboard/agency/overview/index.tsx`

set `isEligibleForPressableIntroOffer` / `isEligibleForPressableExpansionOffer` to `true` (one at a time — real agencies never see both).

Unit tests: `yarn test-client client/dashboard/agency/overview` (7 tests covering the eligibility helpers).

## Screenshots

**Introductory offer**

<img width="1352" height="705" alt="The revamped Overview with the Pressable introductory offer card below the Helpful links card" src="https://github.com/user-attachments/assets/c19eadc3-3126-4715-92a2-5f536f94eea9" />

**Expansion offer**

<img width="1352" height="705" alt="The revamped Overview with the Pressable expansion offer card below the Helpful links card" src="https://github.com/user-attachments/assets/21cfa5a7-525d-457c-9036-76d0e4901789" />

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
