### PR TITLE
Site generation: mark the editor handoff URL

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
@@ -146,7 +146,7 @@ describe( 'useSiteGeneration', () => {
 				onReady();
 			} );
 			expect( window.location.assign ).toHaveBeenCalledWith(
-				'https://example.wordpress.com/wp-admin/site-editor.php'
+				'https://example.wordpress.com/wp-admin/site-editor.php?from=site-generation'
 			);
 		} finally {
 			Object.defineProperty( window, 'location', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
@@ -136,7 +136,10 @@ describe( 'useSiteGeneration', () => {
 			renderHook( () =>
 				useSiteGeneration( {
 					siteIdentifier: '123',
-					editorUrl: 'https://example.wordpress.com/wp-admin/site-editor.php',
+					// The production editor URL already carries query args
+					// (page, spec_id): the marker must merge, not clobber.
+					editorUrl:
+						'https://example.wordpress.com/wp-admin/admin.php?page=easy-site-editor&spec_id=abc',
 					steps: STEPS,
 				} )
 			);
@@ -146,7 +149,7 @@ describe( 'useSiteGeneration', () => {
 				onReady();
 			} );
 			expect( window.location.assign ).toHaveBeenCalledWith(
-				'https://example.wordpress.com/wp-admin/site-editor.php?from=site-generation'
+				'https://example.wordpress.com/wp-admin/admin.php?page=easy-site-editor&spec_id=abc&from=site-generation'
 			);
 		} finally {
 			Object.defineProperty( window, 'location', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/use-site-generation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/use-site-generation.ts
@@ -90,7 +90,8 @@ export function useSiteGeneration( {
 		);
 		const stopStatusPolling = pollForBuildWowStatus( {
 			siteIdentifier,
-			// The marker lets the editor greet a freshly generated site.
+			// The marker tells the editor this is a fresh handoff, so it
+			// welcomes the user instead of showing canned suggestions.
 			onReady: () =>
 				window.location.assign( addQueryArgs( editorUrl, { from: 'site-generation' } ) ),
 			onFailed: ( status, ui ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/use-site-generation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/use-site-generation.ts
@@ -1,3 +1,4 @@
+import { addQueryArgs } from '@wordpress/url';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { logBuildWowEvent, requestBuildWowSite } from 'calypso/landing/stepper/utils/build-wow';
 import { pollForBuildWowStatus } from './build-status-poller';
@@ -89,7 +90,9 @@ export function useSiteGeneration( {
 		);
 		const stopStatusPolling = pollForBuildWowStatus( {
 			siteIdentifier,
-			onReady: () => window.location.assign( editorUrl ),
+			// The marker lets the editor greet a freshly generated site.
+			onReady: () =>
+				window.location.assign( addQueryArgs( editorUrl, { from: 'site-generation' } ) ),
 			onFailed: ( status, ui ) => {
 				logBuildWowEvent( 'site_generation_failed', {
 					status,


### PR DESCRIPTION
## Proposed Changes

When a finished AI site build redirects to the editor, append `from=site-generation` to the editor URL. The editor uses the marker to greet a freshly generated site (see https://github.com/Automattic/big-sky-plugin/pull/6361).

## Why are these changes being made?

The editor cannot tell a first visit after generation apart from any other visit, so it cannot welcome the user at the right moment. The redirect is the one place that knows.

## Testing Instructions

- Run a site build through the AI site builder flow.
- When the build finishes, the browser should land on the editor with `from=site-generation` in the URL.
- Unit: `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/site-generation` (64 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gpp2v7YLiwh5qPPYmfhCQW
