### PR TITLE
Plans: use is_instant_downgrade_available for the downgrade flow

### DIFF
--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -813,18 +813,14 @@ export function hasAmountAvailableToRefund( purchase: Purchase ) {
 }
 
 /**
- * Returns true if the plan is eligible for an instant, self-serve downgrade: the
- * plan has a refundable receipt and has neither expired nor entered its
- * post-expiry grace period.
+ * Returns true if the plan is eligible for an instant, self-serve downgrade,
+ * performed now via the cancel endpoint rather than scheduled for renewal.
  *
- * `is_refundable` covers any refundable receipt, so it holds both for an initial
- * purchase and for a renewal that is still within its own refund window — both
- * cases where an instant downgrade costs neither side money.
- *
- * Note: this intentionally does NOT require a refundable amount. A refundable
- * receipt worth nothing generally means the purchase was free (or fully paid
- * with credits), which is still a valid instant downgrade — it just issues no
- * refund, and the confirmation modal drops its refund line accordingly.
+ * The server answers this directly through `is_instant_downgrade_available`,
+ * which already accounts for expiry and for receipts worth nothing (a comped
+ * plan or a 100%-off coupon downgrades instantly and simply issues no refund).
+ * Do not reintroduce a `is_refundable` check here: that asks a different
+ * question and gave the wrong answer for zero-cost purchases.
  *
  * This is distinct from {@link isExpiredAndInGracePeriod}, which gates the
  * downgrade-to-checkout flow for plans whose expiry date has already passed.
@@ -833,8 +829,7 @@ export function isWithinRefundWindowDowngradeEligible( purchase: Purchase ): boo
 	return (
 		purchase.is_plan_type_downgradable &&
 		purchase.is_plan &&
-		purchase.is_refundable &&
-		! isExpiredOrRemoved( purchase )
+		purchase.is_instant_downgrade_available
 	);
 }
 

--- a/client/dashboard/utils/test/purchase.ts
+++ b/client/dashboard/utils/test/purchase.ts
@@ -27,6 +27,7 @@ function makePurchase( overrides: Partial< Purchase > = {} ): Purchase {
 	return {
 		is_auto_renew_enabled: true,
 		is_refundable: false,
+		is_instant_downgrade_available: false,
 		refund_amount: 0,
 		expiry_status: 'auto-renewing',
 		subscription_status: 'active',
@@ -484,13 +485,13 @@ describe( 'isPurchaseDowngradeEligible', () => {
 		).toBe( true );
 	} );
 
-	test( 'is true for a downgradable plan inside its refund window', () => {
+	test( 'is true for a downgradable plan the server will downgrade instantly', () => {
 		expect(
 			isPurchaseDowngradeEligible(
 				makePurchase( {
 					is_plan: true,
 					is_plan_type_downgradable: true,
-					is_refundable: true,
+					is_instant_downgrade_available: true,
 				} )
 			)
 		).toBe( true );
@@ -501,35 +502,41 @@ describe( 'isWithinRefundWindowDowngradeEligible', () => {
 	const downgradablePlan = ( overrides: Partial< Purchase > = {} ) =>
 		makePurchase( { is_plan: true, is_plan_type_downgradable: true, ...overrides } );
 
-	test( 'is true for a refundable plan', () => {
-		expect(
-			isWithinRefundWindowDowngradeEligible( downgradablePlan( { is_refundable: true } ) )
-		).toBe( true );
-	} );
-
-	test( 'is true for a refundable renewal outside the initial refund window', () => {
+	test( 'is true when the server reports an instant downgrade is available', () => {
 		expect(
 			isWithinRefundWindowDowngradeEligible(
-				downgradablePlan( { is_within_initial_refund_window: false, is_refundable: true } )
+				downgradablePlan( { is_instant_downgrade_available: true } )
 			)
 		).toBe( true );
 	} );
 
-	test( 'is false once no receipt is refundable, even inside the initial refund window', () => {
+	test( 'is true for a zero-cost purchase, which has no refundable receipt', () => {
 		expect(
 			isWithinRefundWindowDowngradeEligible(
-				downgradablePlan( { is_within_initial_refund_window: true, is_refundable: false } )
+				downgradablePlan( {
+					is_instant_downgrade_available: true,
+					is_refundable: false,
+					refund_amount: 0,
+				} )
+			)
+		).toBe( true );
+	} );
+
+	test( 'is false when the server says so, even for a refundable plan', () => {
+		expect(
+			isWithinRefundWindowDowngradeEligible(
+				downgradablePlan( { is_instant_downgrade_available: false, is_refundable: true } )
 			)
 		).toBe( false );
 	} );
 
-	test( 'is false for a plan in its post-expiry grace period even when refundable', () => {
+	test( 'is false for a plan with nothing below it', () => {
 		expect(
 			isWithinRefundWindowDowngradeEligible(
-				downgradablePlan( {
-					is_refundable: true,
-					expiry_status: 'expired',
-					subscription_status: 'active',
+				makePurchase( {
+					is_plan: true,
+					is_plan_type_downgradable: false,
+					is_instant_downgrade_available: true,
 				} )
 			)
 		).toBe( false );
@@ -538,7 +545,11 @@ describe( 'isWithinRefundWindowDowngradeEligible', () => {
 	test( 'is false for a non-plan product', () => {
 		expect(
 			isWithinRefundWindowDowngradeEligible(
-				makePurchase( { is_plan: false, is_plan_type_downgradable: true, is_refundable: true } )
+				makePurchase( {
+					is_plan: false,
+					is_plan_type_downgradable: true,
+					is_instant_downgrade_available: true,
+				} )
 			)
 		).toBe( false );
 	} );

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -825,29 +825,6 @@ export function hasAmountAvailableToRefund( purchase: Purchase ): boolean {
 }
 
 /**
- * Returns true if the plan is eligible for an instant, self-serve downgrade: the
- * plan has a refundable receipt and has neither expired nor entered its
- * post-expiry grace period.
- *
- * `isRefundable` covers any refundable receipt, so it holds both for an initial
- * purchase and for a renewal that is still within its own refund window — both
- * cases where an instant downgrade costs neither side money.
- *
- * Note: this intentionally does NOT require a refundable amount. A refundable
- * receipt worth nothing generally means the purchase was free (or fully paid
- * with credits), which is still a valid instant downgrade — it just issues no
- * refund, and the confirmation modal drops its refund line accordingly.
- *
- * The caller is responsible for confirming the purchase is a plan (see `isPlan`
- * from `@automattic/calypso-products`). This is distinct from
- * `isExpiredAndInGracePeriod`, which gates the downgrade-to-checkout flow for
- * plans whose expiry date has already passed.
- */
-export function isWithinRefundWindowDowngradeEligible( purchase: Purchase ): boolean {
-	return purchase.isRefundable && ! isExpiredOrRemoved( purchase );
-}
-
-/**
  * Checks whether the specified purchase can be removed from a user account.
  * @param {Object} purchase - the purchase with which we are concerned
  * @returns {boolean} true if the purchase can be removed, false otherwise

--- a/client/me/purchases/lib/raw-purchase-helpers.ts
+++ b/client/me/purchases/lib/raw-purchase-helpers.ts
@@ -400,7 +400,7 @@ export function getDowngradePlanFromPurchase( purchase: Purchase ) {
 }
 
 export function isWithinRefundWindowDowngradeEligible( purchase: Purchase ): boolean {
-	return purchase.is_refundable && ! isExpiredOrRemoved( purchase );
+	return purchase.is_instant_downgrade_available;
 }
 
 export function getDisplayName( purchase: Purchase ): TranslateResult {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -297,11 +297,11 @@ const PlansFeaturesMain = ( {
 	);
 	const isPlanExpired = !! sitePlansData?.find( ( p ) => p.currentPlan )?.expired;
 
-	// Refund-window instant downgrade: when the current plan has a refundable
-	// receipt — its initial purchase or, after a renewal, the renewal's — a
-	// downgrade is performed instantly via the cancel endpoint instead of routing
-	// the user to checkout. This applies regardless of whether any money would be
-	// refunded (e.g. plans paid with credits or free).
+	// Refund-window instant downgrade: when the server reports the plan can be
+	// downgraded instantly, the downgrade is performed via the cancel endpoint
+	// instead of routing the user to checkout. This applies regardless of whether
+	// any money would be refunded (e.g. comped plans, 100%-off coupons, or plans
+	// paid entirely with credits).
 	const reduxDispatch = useReduxDispatch();
 	const queryClient = useQueryClient();
 	const cancelAndRefundMutation = useMutation( cancelAndRefundPurchaseMutation() );
@@ -319,14 +319,14 @@ const PlansFeaturesMain = ( {
 		...purchaseQuery( currentPlanPurchaseId ?? 0 ),
 		enabled: !! currentPlanPurchaseId,
 	} );
-	const isWithinRefundWindow =
-		!! currentPurchase && currentPurchase.is_refundable && ! currentPurchase.is_past_expiry_date;
+	const isInstantDowngradeAvailable =
+		!! currentPurchase && currentPurchase.is_instant_downgrade_available;
 	// Three downgrade modes:
-	//   'instant'  — within refund window: cancel+refund via the cancel endpoint
+	//   'instant'  — server allows it now: cancel+refund via the cancel endpoint
 	//   'checkout' — expired plan: route to checkout to purchase the new plan
-	//   'delayed'  — active plan, not in refund window: schedule downgrade at renewal
+	//   'delayed'  — active plan, no instant downgrade: schedule downgrade at renewal
 	let downgradeMode: 'instant' | 'checkout' | 'delayed';
-	if ( isWithinRefundWindow ) {
+	if ( isInstantDowngradeAvailable ) {
 		downgradeMode = 'instant';
 	} else if ( ! isPlanExpired ) {
 		downgradeMode = 'delayed';
@@ -745,11 +745,11 @@ const PlansFeaturesMain = ( {
 			return true;
 		}
 
-		// For plans still within their refund window, intercept paid-plan downgrades
-		// to show a confirmation modal that performs the downgrade instantly (paid out
-		// of the refund) instead of routing to checkout.
+		// For plans the server will downgrade instantly, intercept paid-plan
+		// downgrades to show a confirmation modal that performs the downgrade now
+		// (paid out of the refund, if any) instead of routing to checkout.
 		if (
-			isWithinRefundWindow &&
+			isInstantDowngradeAvailable &&
 			! isFreePlan( planSlug ) &&
 			sitePlansData?.find( ( p ) => p.productSlug === planSlug )?.availableForDowngrade
 		) {
@@ -757,11 +757,11 @@ const PlansFeaturesMain = ( {
 			return true;
 		}
 
-		// For active paid plans (not expired, not in refund window), intercept
-		// paid-plan downgrades to schedule the downgrade at end-of-term instead.
+		// For active paid plans (not expired, no instant downgrade available),
+		// intercept paid-plan downgrades to schedule the downgrade at end-of-term.
 		if (
 			! isPlanExpired &&
-			! isWithinRefundWindow &&
+			! isInstantDowngradeAvailable &&
 			currentPurchase?.is_plan_type_downgradable &&
 			! isFreePlan( planSlug ) &&
 			sitePlansData?.find( ( p ) => p.productSlug === planSlug )?.availableForDowngrade

--- a/packages/api-core/src/upgrades/types.ts
+++ b/packages/api-core/src/upgrades/types.ts
@@ -605,6 +605,26 @@ export interface Purchase {
 	is_plan_term_downgradable: boolean;
 
 	/**
+	 * True if this subscription's plan can be downgraded instantly, right now,
+	 * rather than having the change scheduled for its next renewal.
+	 *
+	 * When this is true, `POST /wpcom/v2/upgrades/$purchase_id/cancel` with
+	 * `{ type: 'downgrade', to_product_id }` will be accepted and will provision
+	 * the lower plan immediately.
+	 *
+	 * This is not the same question as `is_refundable`, and must not be derived
+	 * from it. In particular it is true for a refundable receipt worth nothing
+	 * (a comped plan, a 100%-off coupon, or a purchase paid entirely with
+	 * credits) — the instant downgrade is still valid, it just issues no refund.
+	 * For whether any money would come back, check `total_refund_amount`.
+	 *
+	 * It is also true for a renewal that is still within its own refund window,
+	 * not only for an initial purchase, so it is unrelated to
+	 * `is_within_initial_refund_window`.
+	 */
+	is_instant_downgrade_available: boolean;
+
+	/**
 	 * True if deactivating this subscription will cause the site to be reverted
 	 * from an Atomic site to a Simple site. This is only true if the site is
 	 * currently on the Atomic architecture and removing this subscription would


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2489

## Proposed Changes

Switches both plans clients from inferring instant-downgrade eligibility out of `is_refundable` to reading the new server-provided `is_instant_downgrade_available` field. Requires the backend PR adding that field to the `/upgrades` responses to be deployed first.

* Add `is_instant_downgrade_available` to the `Purchase` type in `@automattic/api-core`.
* Read it in the plans grid's downgrade mode selection, dropping the client-side `! is_past_expiry_date` guard now that the server owns expiry.
* Reduce `isWithinRefundWindowDowngradeEligible()` in the Dashboard to the new field.
* Update the same helper in `client/me/purchases/lib/raw-purchase-helpers.ts`.
* Delete the unused camelCase copy in `client/lib/purchases`, rather than extend the assembler that SHILL-2256 is removing.
* Rename the local `isWithinRefundWindow` to `isInstantDowngradeAvailable` in the plans grid, since it no longer holds a refund-window answer.

Depends on: 238411-ghe-Automattic/wpcom

## Why are these changes being made?

`is_refundable` was standing in for a question it does not answer. The client needs to know whether the cancel endpoint will accept a `type: downgrade` call right now; `is_refundable` reports whether a refundable receipt exists, and the API returns false for a receipt worth nothing.

That gap is invisible for ordinary paid plans and wrong for every zero-cost one. A plan added via store admin, bought with a 100%-off coupon, or purchased by the user at $0 reports `is_refundable: false` alongside `is_within_initial_refund_window: true` minutes after purchase, so both clients fell through to the delayed flow and scheduled the change for the next renewal. That flow may not even be completable for these purchases, since its confirm button requires a rechargeable payment method they do not have.

Rather than widen `is_refundable` — which has ~40 consumers, many of which treat it as "show refund messaging" and would start rendering "You will be refunded $0" — the server now states the downgrade answer it already owns, and the clients read it.

## Testing Instructions

TC:

```
yarn test-client client/dashboard/utils/test/purchase.ts
yarn test-client client/my-sites/plans-features-main
```

The Dashboard suite adds a regression test for a zero-cost purchase: one with `is_refundable: false` and `refund_amount: 0` that the server marks instantly downgradable is now eligible.

Manual testing (needs the backend field deployed to the sandbox):

* Add a plan to a test site at $0 — via store admin, a 100%-off coupon, or a user-initiated $0 purchase.
* Go to `/plans/<site-slug>` and click the downgrade button on a lower plan.
* Confirm the instant downgrade modal appears, with no refund line, and that confirming provisions the lower plan immediately.
* Repeat on an ordinary paid plan inside its refund window and confirm the instant flow still shows its refund amount.
* Repeat on a plan past its refund window and confirm it still gets the delayed flow.
