### PR TITLE
Site generation: redirect to the live build's editor URL

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/build-status-poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/build-status-poller.ts
@@ -33,6 +33,10 @@ export type BuildWowUi = {
 export type BuildWowStatusResponse = {
 	build_status?: string;
 	build_phase?: string;
+	// Where a finished build lands. Once the build is live this names the
+	// generated front page on the edit canvas; before that it is the bare
+	// easy-mode URL the site-spec step already captured.
+	site_editor_url?: string;
 	ui?: BuildWowUi;
 };
 
@@ -59,7 +63,7 @@ export function pollForBuildWowStatus( {
 	fetchStatus = fetchBuildWowStatus,
 }: {
 	siteIdentifier: string;
-	onReady: () => void;
+	onReady: ( response: BuildWowStatusResponse ) => void;
 	onFailed: ( status: string, ui?: BuildWowUi ) => void;
 	onUpdate?: ( ui: BuildWowUi ) => void;
 	onRequestError?: ( reason: string ) => void;
@@ -83,7 +87,7 @@ export function pollForBuildWowStatus( {
 			// does not send the ui block yet.
 			const status = typeof response.build_status === 'string' ? response.build_status : undefined;
 			if ( ui?.state === 'ready' || status === BUILD_WOW_LIVE_STATUS ) {
-				onReady();
+				onReady( response );
 				return 'stop';
 			}
 			if ( ui?.state === 'failed' || ( status && isBuildWowFailedStatus( status ) ) ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/editor-url.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/editor-url.ts
@@ -1,3 +1,5 @@
+import { addQueryArgs, getQueryArgs } from '@wordpress/url';
+
 const ALLOWED_HOST_SUFFIXES = [ '.wordpress.com', '.wpcomstaging.com' ];
 
 export function getSafeEditorUrl( rawUrl: string | null ): string | null {
@@ -40,11 +42,8 @@ export function getLiveEditorUrl( capturedUrl: string, liveUrl: unknown ): strin
 		return capturedUrl;
 	}
 
-	const destination = new URL( safeLiveUrl );
-	new URL( capturedUrl ).searchParams.forEach( ( value, key ) => {
-		if ( ! destination.searchParams.has( key ) ) {
-			destination.searchParams.append( key, value );
-		}
+	return addQueryArgs( safeLiveUrl, {
+		...getQueryArgs( capturedUrl ),
+		...getQueryArgs( safeLiveUrl ),
 	} );
-	return destination.href;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/editor-url.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/editor-url.ts
@@ -27,3 +27,24 @@ export function getSafeEditorUrl( rawUrl: string | null ): string | null {
 
 	return isAllowedHost ? parsed.href : null;
 }
+
+// The editor URL the site-spec step captured came from the build's POST
+// response, before the generated front page existed, so it names no route.
+// Once the build is live the status endpoint's site_editor_url points at
+// that page on the edit canvas: prefer it, and carry over the query args the
+// flow added to the captured URL (spec_id, source) that it does not have.
+// Anything unusable falls back to the captured URL.
+export function getLiveEditorUrl( capturedUrl: string, liveUrl: unknown ): string {
+	const safeLiveUrl = getSafeEditorUrl( typeof liveUrl === 'string' ? liveUrl : null );
+	if ( ! safeLiveUrl ) {
+		return capturedUrl;
+	}
+
+	const destination = new URL( safeLiveUrl );
+	new URL( capturedUrl ).searchParams.forEach( ( value, key ) => {
+		if ( ! destination.searchParams.has( key ) ) {
+			destination.searchParams.append( key, value );
+		}
+	} );
+	return destination.href;
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/build-status-poller.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/build-status-poller.ts
@@ -13,11 +13,16 @@ describe( 'pollForBuildWowStatus', () => {
 		jest.useRealTimers();
 	} );
 
-	it( 'calls onReady once the status is live', async () => {
+	it( 'calls onReady with the live response once the status is live', async () => {
+		const liveResponse = {
+			build_status: 'live',
+			site_editor_url:
+				'https://example.wordpress.com/wp-admin/site-editor.php?easy-mode=true&p=%2Fpage%2F12&canvas=edit',
+		};
 		const fetchStatus = jest
 			.fn()
 			.mockResolvedValueOnce( { build_status: 'delivering' } )
-			.mockResolvedValueOnce( { build_status: 'live' } );
+			.mockResolvedValueOnce( liveResponse );
 		const onReady = jest.fn();
 		const onFailed = jest.fn();
 
@@ -34,6 +39,9 @@ describe( 'pollForBuildWowStatus', () => {
 
 		await jest.advanceTimersByTimeAsync( 1000 );
 		expect( onReady ).toHaveBeenCalledTimes( 1 );
+		// The consumer reads site_editor_url off this: the live route is only
+		// known once the build has verified the generated front page.
+		expect( onReady ).toHaveBeenCalledWith( liveResponse );
 		expect( onFailed ).not.toHaveBeenCalled();
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/editor-url.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/editor-url.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { getSafeEditorUrl } from '../editor-url';
+import { getLiveEditorUrl, getSafeEditorUrl } from '../editor-url';
 
 describe( 'getSafeEditorUrl', () => {
 	it( 'returns null for a missing value', () => {
@@ -77,5 +77,43 @@ describe( 'getSafeEditorUrl', () => {
 		expect( getSafeEditorUrl( 'https://evil.example/phishing' ) ).toBeNull();
 		expect( getSafeEditorUrl( 'https://evilwordpress.com/' ) ).toBeNull();
 		expect( getSafeEditorUrl( 'https://wordpress.com.evil.example/' ) ).toBeNull();
+	} );
+} );
+
+describe( 'getLiveEditorUrl', () => {
+	const captured =
+		'https://example.wordpress.com/wp-admin/site-editor.php?easy-mode=true&spec_id=spec-1&source=dashboard';
+	const live =
+		'https://example.wordpress.com/wp-admin/site-editor.php?easy-mode=true&p=%2Fpage%2F12&canvas=edit';
+
+	it( 'prefers the live URL and carries over the query args the flow added', () => {
+		const url = new URL( getLiveEditorUrl( captured, live ) );
+
+		expect( url.origin + url.pathname ).toBe(
+			'https://example.wordpress.com/wp-admin/site-editor.php'
+		);
+		expect( url.searchParams.get( 'p' ) ).toBe( '/page/12' );
+		expect( url.searchParams.get( 'canvas' ) ).toBe( 'edit' );
+		expect( url.searchParams.get( 'easy-mode' ) ).toBe( 'true' );
+		expect( url.searchParams.get( 'spec_id' ) ).toBe( 'spec-1' );
+		expect( url.searchParams.get( 'source' ) ).toBe( 'dashboard' );
+		// Not duplicated: the live URL's own value wins for a shared key.
+		expect( url.searchParams.getAll( 'easy-mode' ) ).toEqual( [ 'true' ] );
+	} );
+
+	it( 'keeps the route encoded the way the site editor documents it', () => {
+		expect( getLiveEditorUrl( captured, live ) ).toContain( 'p=%2Fpage%2F12' );
+	} );
+
+	it( 'falls back to the captured URL when the response carries none', () => {
+		expect( getLiveEditorUrl( captured, undefined ) ).toBe( captured );
+		expect( getLiveEditorUrl( captured, '' ) ).toBe( captured );
+		expect( getLiveEditorUrl( captured, 42 ) ).toBe( captured );
+	} );
+
+	it( 'falls back to the captured URL when the live URL fails the host allowlist', () => {
+		expect( getLiveEditorUrl( captured, 'https://evil.example/wp-admin/site-editor.php' ) ).toBe(
+			captured
+		);
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
@@ -143,10 +143,46 @@ describe( 'useSiteGeneration', () => {
 
 			const { onReady } = statusPollMock.mock.calls[ 0 ][ 0 ];
 			act( () => {
-				onReady();
+				// A live response with no site_editor_url: the captured URL stands.
+				onReady( { build_status: 'live' } );
 			} );
 			expect( window.location.assign ).toHaveBeenCalledWith(
 				'https://example.wordpress.com/wp-admin/site-editor.php'
+			);
+		} finally {
+			Object.defineProperty( window, 'location', {
+				value: originalLocation,
+				configurable: true,
+			} );
+		}
+	} );
+
+	it( 'redirects to the live editor URL, keeping the args the flow added to the captured one', () => {
+		Object.defineProperty( window, 'location', {
+			value: { ...originalLocation, assign: jest.fn() },
+			configurable: true,
+		} );
+
+		try {
+			renderHook( () =>
+				useSiteGeneration( {
+					siteIdentifier: '123',
+					editorUrl:
+						'https://example.wordpress.com/wp-admin/site-editor.php?easy-mode=true&spec_id=spec-1',
+					steps: STEPS,
+				} )
+			);
+
+			const { onReady } = statusPollMock.mock.calls[ 0 ][ 0 ];
+			act( () => {
+				onReady( {
+					build_status: 'live',
+					site_editor_url:
+						'https://example.wordpress.com/wp-admin/site-editor.php?easy-mode=true&p=%2Fpage%2F12&canvas=edit',
+				} );
+			} );
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				'https://example.wordpress.com/wp-admin/site-editor.php?easy-mode=true&p=%2Fpage%2F12&canvas=edit&spec_id=spec-1'
 			);
 		} finally {
 			Object.defineProperty( window, 'location', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/use-site-generation.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/use-site-generation.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { logBuildWowEvent, requestBuildWowSite } from 'calypso/landing/stepper/utils/build-wow';
 import { pollForBuildWowStatus } from './build-status-poller';
+import { getLiveEditorUrl } from './editor-url';
 import type { BuildWowUi } from './build-status-poller';
 import type { BuildWowGraph } from 'calypso/landing/stepper/utils/build-wow';
 
@@ -89,7 +90,8 @@ export function useSiteGeneration( {
 		);
 		const stopStatusPolling = pollForBuildWowStatus( {
 			siteIdentifier,
-			onReady: () => window.location.assign( editorUrl ),
+			onReady: ( response ) =>
+				window.location.assign( getLiveEditorUrl( editorUrl, response.site_editor_url ) ),
 			onFailed: ( status, ui ) => {
 				logBuildWowEvent( 'site_generation_failed', {
 					status,


### PR DESCRIPTION
Part of the build-wow landing fix; the backend half (the status endpoint returning the live editor URL) ships separately.

## Proposed Changes

* The site-generation waiting screen now redirects to the `site_editor_url` returned by the build-wow status endpoint once the build is live, instead of the URL captured from the build's POST response.
* Query args the flow added to the captured URL (`spec_id`, `source`) are carried over. If the live response has no usable URL (missing, or a host outside the allowlist), the captured URL is used as before.
* `pollForBuildWowStatus` now passes the live status response to `onReady`.

## Why are these changes being made?

The captured URL comes from the build's POST response, before the generated front page exists, so it is the bare `site-editor.php?easy-mode=true`. Where that lands depends on the Big Sky plugin's own redirect and on core's default handling of a bare `site-editor.php`. Both have changed recently, and both times testers got stuck on the site editor's design view.

Once the build is live, the status endpoint returns the generated front page on the edit canvas (`site-editor.php?easy-mode=true&p=%2Fpage%2F{id}&canvas=edit`). Using that URL removes the dependency on the redirect.

## Testing Instructions

1. Start an AI site build through the site-spec flow (`/setup/ai-site-builder-spec/site-spec?build_wow=1&siteId=...`).
2. Wait on the generation screen until the build is live.
3. You should land on the generated home page in the site editor's edit canvas, with `p=%2Fpage%2F{id}&canvas=edit&easy-mode=true` and the original `spec_id` in the URL.
4. Against a backend that does not return the new URL yet, the redirect goes to the same URL as before.

Unit tests: `yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/site-generation` (69 passing).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDsDaiEvWPQRhUEwAaYvfD
