### PR TITLE
Agents Manager: Update the default welcome message

### DIFF
--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -139,7 +139,7 @@ function getEmptyViewHeading(): string {
 	if ( isReaderChatHost() ) {
 		return __( 'Ask me anything about this blog.', __i18n_text_domain__ );
 	}
-	return __( 'Howdy! How can I help you today?', __i18n_text_domain__ );
+	return __( 'What should we work on next?', __i18n_text_domain__ );
 }
 
 function getEmptyViewHelp(): string {


### PR DESCRIPTION
Fixes AM-49

## Proposed Changes

* Replace the WordPress Agent’s default empty-view welcome message “Howdy! How can I help you today?” with “What should we work on next?”.

## Why are these changes being made?

* Requested in AM-49 to update the default greeting shown when opening the WordPress Agent.
* The Reader chat greeting and the host `emptyViewHeading` override are unaffected — only the orchestrator default changes.

## Testing Instructions

### Calypso

1. Run `yarn start`.
2. Open a site and launch the AI assistant from the masterbar.
3. Start a new conversation and verify the empty view shows “What should we work on next?”.

### Simple/Atomic

1. Sandbox `widgets.wp.com`.
2. Run `cd apps/agents-manager && yarn dev --sync`.
3. Visit any Simple or Atomic site (the site itself does not need sandboxing) and open the agent chat.
4. Start a new conversation and verify the empty view shows “What should we work on next?”.

### Regression check

1. Open the Reader chat and verify its greeting still reads “Ask me anything about this blog.”.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
