### PR TITLE
Agents Manager: withhold the block-edit summary while a visual check is being performed

### DIFF
--- a/packages/agents-manager/src/components/orchestrator-chat/index.tsx
+++ b/packages/agents-manager/src/components/orchestrator-chat/index.tsx
@@ -1634,6 +1634,7 @@ export default function OrchestratorChat( {
 			messages: currentMessages,
 			getChatComponent,
 			currentPostId,
+			isProcessing,
 		} );
 
 		const latestAgentMessageId = getLatestAgentMessageId( currentMessages );

--- a/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/convert-tool-messages-to-components.test.ts
@@ -625,6 +625,122 @@ describe( 'convertToolMessagesToComponents', () => {
 		] );
 	} );
 
+	describe( 'pending visual check', () => {
+		const pendingCheckOutcome = ( overrides?: Partial< UIMessage > ) =>
+			createApplyBlockEditsMessage(
+				'tool-call-1',
+				{
+					result: {
+						success: true,
+						message: 'Corrected one misspelling.',
+						outcome: 'updated',
+					},
+					followUpTasks: false,
+					visualCheckPending: true,
+				},
+				{ id: 'applied-outcome', ...overrides }
+			);
+
+		it( 'withholds the summary while the reply is outstanding', () => {
+			const result = convertToolMessagesToComponents( {
+				messages: [ pendingCheckOutcome() ],
+				isProcessing: true,
+			} );
+
+			expect( result ).toEqual( [] );
+		} );
+
+		it( 'restores the summary and keeps the deferred reply once it arrives', () => {
+			const prose = createMessage( {
+				id: 'prose',
+				content: [
+					{ type: 'text', text: 'I looked at the result and the heading is aligned now.' },
+				],
+			} );
+
+			const result = convertToolMessagesToComponents( {
+				messages: [ pendingCheckOutcome(), prose ],
+				isProcessing: true,
+			} );
+
+			expect( result ).toHaveLength( 2 );
+			expect( result[ 0 ].content ).toEqual( [
+				{ type: 'text', text: 'Corrected one misspelling.' },
+			] );
+			expect( result[ 1 ].id ).toBe( 'prose' );
+		} );
+
+		it( 'restores the summary when the turn ends without a reply', () => {
+			const nextTurn = createMessage( {
+				id: 'next-turn',
+				role: 'user',
+				content: [ { type: 'text', text: 'Now change the footer.' } ],
+			} );
+
+			const result = convertToolMessagesToComponents( {
+				messages: [ pendingCheckOutcome(), nextTurn ],
+				isProcessing: true,
+			} );
+
+			expect( result ).toHaveLength( 2 );
+			expect( result[ 0 ].content ).toEqual( [
+				{ type: 'text', text: 'Corrected one misspelling.' },
+			] );
+		} );
+
+		// The flag can promise a check the ability will not run — the per-turn look
+		// budget is invisible to it — so a stopped stream must not swallow the edit.
+		it( 'restores the summary once the stream stops', () => {
+			const result = convertToolMessagesToComponents( {
+				messages: [ pendingCheckOutcome() ],
+				isProcessing: false,
+			} );
+
+			expect( result ).toHaveLength( 1 );
+			expect( result[ 0 ].content ).toEqual( [
+				{ type: 'text', text: 'Corrected one misspelling.' },
+			] );
+		} );
+
+		it( 'keeps waiting across an intervening tool message', () => {
+			const laterTool = createToolMessage(
+				'big_sky__editor_navigate',
+				{ summary: 'Opened the homepage.' },
+				{ id: 'later-tool' }
+			);
+
+			const result = convertToolMessagesToComponents( {
+				messages: [ pendingCheckOutcome(), laterTool ],
+				isProcessing: true,
+			} );
+
+			expect( result ).toHaveLength( 1 );
+			expect( result[ 0 ].id ).toBe( 'later-tool' );
+		} );
+
+		it( 'ignores the flag for a no-change outcome', () => {
+			const noChangeOutcome = createApplyBlockEditsMessage(
+				'tool-call-1',
+				{
+					result: {
+						success: true,
+						message: 'The requested changes were already applied.',
+						outcome: 'no-changes',
+					},
+					visualCheckPending: true,
+				},
+				{ id: 'no-change-outcome' }
+			);
+
+			const result = convertToolMessagesToComponents( {
+				messages: [ noChangeOutcome ],
+				isProcessing: true,
+			} );
+
+			expect( result[ 0 ].content ).toEqual( [ { type: 'text', text: '✓ No changes needed' } ] );
+		} );
+	} );
+
 	it( 'filters out unsuccessful apply-block-edits tool summaries', () => {
 		const message = createToolMessage( 'big_sky__apply_block_edits', {
 			success: false,

--- a/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
+++ b/packages/agents-manager/src/utils/convert-tool-messages-to-components.ts
@@ -12,6 +12,7 @@ import {
 	getDisplayMessageFromToolData,
 	isBlockEditToolId,
 	isDisplayableToolMessageTool,
+	isVisualCheckPending,
 } from './tool-message-utils';
 import type { GetChatComponent } from './load-external-providers';
 import type { ShowComponentType } from '../abilities/show-component';
@@ -52,6 +53,8 @@ interface Options {
 	messages: UIMessage[];
 	getChatComponent?: GetChatComponent;
 	currentPostId?: number | string;
+	/** Whether the agent's turn is still running, so a promised check may still land. */
+	isProcessing?: boolean;
 }
 
 interface MessageWithContextFlags extends UIMessage {
@@ -181,6 +184,38 @@ function hasLaterApplyBlockEditsOutcome(
 	return false;
 }
 
+/**
+ * Whether the deferred reply for a promised visual check is still outstanding.
+ *
+ * The reply is plain agent prose following the tool result, so the wait lasts
+ * only while nothing follows this message. It ends two ways: the prose arrives,
+ * or the turn ends without it. Either way the summary comes back, which is what
+ * a flag that over-promises — the per-turn look budget the ability cannot see —
+ * falls back to, with no timer and no stale state in rehydrated history.
+ */
+function isAwaitingVisualCheckReply( messages: UIMessage[], currentIndex: number ): boolean {
+	for ( const laterMessage of messages.slice( currentIndex + 1 ) ) {
+		if ( laterMessage.role === 'user' ) {
+			return false;
+		}
+
+		const laterText = laterMessage.content?.[ 0 ]?.text?.trim();
+		if ( ! hasAgentRole( laterMessage ) || ! laterText || isContextOnlyMessage( laterMessage ) ) {
+			continue;
+		}
+
+		try {
+			if ( typeof JSON.parse( laterText )?.tool_id === 'string' ) {
+				continue;
+			}
+		} catch ( _error ) {}
+
+		return false;
+	}
+
+	return true;
+}
+
 function followsTerminalApplyBlockEditsOutcome(
 	messages: UIMessage[],
 	currentIndex: number
@@ -202,9 +237,13 @@ function followsTerminalApplyBlockEditsOutcome(
 				continue;
 			}
 
+			// A promised visual check makes the following prose the deferred reply
+			// rather than redundant narration, so it has to survive. Suppressing it
+			// alongside the withheld summary would leave the turn with nothing.
 			return (
 				!! getApplyBlockEditsOutcome( earlierData.tool_id, earlierData.data ) &&
-				earlierData.data?.followUpTasks !== true
+				earlierData.data?.followUpTasks !== true &&
+				! isVisualCheckPending( earlierData.tool_id, earlierData.data )
 			);
 		} catch ( _error ) {
 			return false;
@@ -221,6 +260,7 @@ export default function convertToolMessagesToComponents( {
 	messages,
 	getChatComponent,
 	currentPostId,
+	isProcessing,
 }: Options ): AgentsManagerUIMessage[] {
 	return messages.flatMap( ( message, index, array ) => {
 		if ( isContextOnlyMessage( message ) ) {
@@ -420,6 +460,20 @@ export default function convertToolMessagesToComponents( {
 			if (
 				typeof textData.tool_call_id === 'string' &&
 				hasLaterApplyBlockEditsOutcome( array, index, textData.tool_call_id )
+			) {
+				return [];
+			}
+			// While a promised check is still running, the transient thinking indicator
+			// already reads as the agent working, so the summary is withheld rather than
+			// replaced by a second, static one. `no-changes` is excluded: nothing was
+			// written, so there is nothing to look at. The summary returns as soon as any
+			// of the three ends the wait — the reply lands, the turn ends, or the stream
+			// stops — so a flag that over-promises cannot swallow the edit.
+			if (
+				isProcessing &&
+				blockEditOutcome !== 'no-changes' &&
+				isVisualCheckPending( textData.tool_id, textData.data ) &&
+				isAwaitingVisualCheckReply( array, index )
 			) {
 				return [];
 			}

--- a/packages/agents-manager/src/utils/tool-message-utils.ts
+++ b/packages/agents-manager/src/utils/tool-message-utils.ts
@@ -45,6 +45,23 @@ export function getDisplayMessageFromToolData( data: unknown ): string | undefin
 
 export type ApplyBlockEditsOutcome = 'updated' | 'no-changes';
 
+/**
+ * Whether a visual check of this edit is actually coming.
+ *
+ * The flag is the conjunction, resolved by the plugin: the server sets it when
+ * the filter is on, and the plugin only forwards it once the rasterizer has
+ * produced a capture to check against. A refused or blank capture therefore
+ * looks the same here as no check at all, which is what keeps the summary from
+ * being withheld for a reply that never arrives.
+ */
+export function isVisualCheckPending( toolId: unknown, data: unknown ): boolean {
+	if ( ! isBlockEditToolId( toolId ) || typeof data !== 'object' || data === null ) {
+		return false;
+	}
+
+	return ( data as { visualCheckPending?: unknown } ).visualCheckPending === true;
+}
+
 export function isBlockEditToolId( toolId: unknown ): boolean {
 	return typeof toolId === 'string' && BLOCK_EDIT_TOOL_IDS.has( toolId );
 }


### PR DESCRIPTION
## Proposed Changes

* When the agent edits a block and is going to check its own work by looking at the result, hold the "here's what I changed" summary back instead of showing it straight away. The thinking indicator that already exists covers the wait, so nothing new is drawn.
* Bring the summary back as soon as the wait ends — the agent replies, the turn ends, or the response stops. Whichever happens first.
* Stop hiding the agent's follow-up message in this case. It's normally hidden for repeating what the summary already said, but when a check was promised it is the actual answer.
* Edits that aren't being checked behave exactly as before.

## Why are these changes being made?

Showing the summary first puts the messages in the wrong order. The user reads "I changed the heading", and then the reply that actually matters — what the agent saw when it looked — gets hidden as repetitive narration. Holding the summary until the check is done keeps the conversation reading in the order things actually happen.

The three separate ways the summary can come back are deliberate. The agent only says a check *may* run; sometimes one doesn't. If we waited on the reply alone, a successful edit could end up with nothing shown for it at all. Any of the three ends the wait, so that can't happen.

## Testing Instructions

This is the front-end half only. It stays dormant until the back end sends the flag, so nothing in the chat changes today — the main thing to confirm is that ordinary editing is untouched.

1. Open the site editor, ask the agent to change something on the page, and confirm the summary appears as it always has.
2. Try an edit the agent makes no change for, and confirm you still get "No changes needed".

Once the back-end flag is switched on:

3. Ask for an edit the agent will check. While it's checking you should see the thinking indicator and no summary.
4. When it replies, the summary and the reply both appear, in that order.

Unit tests: `yarn jest -c test/packages/jest.config.js --testPathPattern=agents-manager` — 1068 passing, including 6 new ones covering each way the wait can end.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
