### PR TITLE
Launch site: send Back to the page the launch actually started from

### DIFF
--- a/client/dashboard/app/interim-omnibar/omnibar-launch-button.tsx
+++ b/client/dashboard/app/interim-omnibar/omnibar-launch-button.tsx
@@ -27,7 +27,9 @@ export function OmnibarLaunchButton( { site }: { site: Site } ) {
 	const { isLoading, isExperimentLoading, isHidden, isDisabled, isBusy, href, onClick, modal } =
 		useSiteLaunch( site, {
 			tracksContext: 'interim_omnibar',
-			backTo: siteOverviewUrl,
+			// The omnibar rides along on every screen, so Back belongs on the page the user left
+			// (the `backTo` default); only the post-launch landing is the site overview.
+			flowDestination: siteOverviewUrl,
 			postLaunchUrl: dashboardLinkWithBackport( siteOverviewUrl ),
 			recordTracksEvent,
 			onLaunchError: () => {

--- a/client/dashboard/app/omnibar/plugin-launch-site.tsx
+++ b/client/dashboard/app/omnibar/plugin-launch-site.tsx
@@ -41,7 +41,9 @@ export function useLaunchSitePlugin( { site }: { site?: Site } ): {
 	const { isLoading, isExperimentLoading, isDisabled, isBusy, href, onClick, modal } =
 		useSiteLaunch( launchSite, {
 			tracksContext: 'omnibar',
-			backTo: siteOverviewUrl,
+			// The omnibar rides along on every screen, so Back belongs on the page the user left
+			// (the `backTo` default); only the post-launch landing is the site overview.
+			flowDestination: siteOverviewUrl,
 			postLaunchUrl: dashboardLinkWithBackport( siteOverviewUrl ),
 			domainsOptions: { ...queries.domainsQuery(), enabled: isLaunchable },
 			recordTracksEvent,

--- a/client/dashboard/app/omnibar/test/plugin-launch-site.test.tsx
+++ b/client/dashboard/app/omnibar/test/plugin-launch-site.test.tsx
@@ -49,6 +49,11 @@ function LaunchHarness( { site }: { site: Site } ) {
 					{ node.title }
 				</button>
 			) }
+			{ node?.href && (
+				<a href={ node.href } data-testid="launch-href">
+					launch link
+				</a>
+			) }
 			{ panel }
 		</>
 	);
@@ -75,5 +80,23 @@ describe( 'useLaunchSitePlugin', () => {
 		expect(
 			await screen.findByRole( 'dialog', { name: 'Launching makes your site public' } )
 		).toBeVisible();
+	} );
+
+	test( 'sends Back to the page the launch started from, not the site overview', async () => {
+		const settingsPath = '/sites/kaonashi.wordpress.com/settings/site-visibility';
+		window.history.replaceState( {}, '', settingsPath );
+		mockDomainsApi( [ createMockDomain( 'kaonashi.wordpress.com', false ) ] );
+
+		render( <LaunchHarness site={ createMockSite() } /> );
+
+		const link = await screen.findByTestId( 'launch-href' );
+		const params = new URL( link.getAttribute( 'href' ) as string, window.location.origin )
+			.searchParams;
+
+		// Back returns to the settings screen the omnibar was clicked from…
+		expect( params.get( 'back_to' ) ).toContain( settingsPath );
+		// …while the post-launch landing stays on the site overview.
+		expect( params.get( 'redirect_to' ) ).toContain( '/sites/kaonashi.wordpress.com' );
+		expect( params.get( 'redirect_to' ) ).not.toContain( '/settings/site-visibility' );
 	} );
 } );

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -127,8 +127,10 @@ function getSignupDestination( { siteSlug, redirect_to, localeSlug, flowName } )
 /**
  * The wp-admin page the launch flow was started from, for launches that started in wp-admin.
  *
- * The `ref` query arg carries that page as a site-relative path, so the URL is always pinned to the
- * site's own host.
+ * The `ref` query arg carries that page as a site-relative path, and the slug supplies the host, so
+ * callers must pass a slug they trust. Anything that would move the URL off that host — credentials
+ * in the slug, a path, a slug that isn't a hostname at all — resolves to null rather than to
+ * somewhere the caller didn't intend.
  * @param {Object} dependencies the signup dependency store
  * @returns {?string} the wp-admin URL, or null when the launch did not start in wp-admin
  */
@@ -139,7 +141,15 @@ export function getWpAdminLaunchReturnUrl( dependencies ) {
 		return null;
 	}
 
-	return `https://${ dependencies.siteSlug }/${ ref }`;
+	const siteSlug = dependencies.siteSlug?.trim() ?? '';
+
+	try {
+		const url = new URL( `/${ ref }`, `https://${ siteSlug }` );
+
+		return url.host === siteSlug.toLowerCase() ? url.href : null;
+	} catch {
+		return null;
+	}
 }
 
 function getLaunchReturnTarget( dependencies ) {

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -124,18 +124,35 @@ function getSignupDestination( { siteSlug, redirect_to, localeSlug, flowName } )
 	return redirectTo;
 }
 
+/**
+ * The wp-admin page the launch flow was started from, for launches that started in wp-admin.
+ *
+ * The `ref` query arg carries that page as a site-relative path, so the URL is always pinned to the
+ * site's own host.
+ * @param {Object} dependencies the signup dependency store
+ * @returns {?string} the wp-admin URL, or null when the launch did not start in wp-admin
+ */
+export function getWpAdminLaunchReturnUrl( dependencies ) {
+	const ref = dependencies.refParameter?.trim() ?? '';
+
+	if ( ref !== 'wp-admin' && ! ref.startsWith( 'wp-admin/' ) ) {
+		return null;
+	}
+
+	return `https://${ dependencies.siteSlug }/${ ref }`;
+}
+
 function getLaunchReturnTarget( dependencies ) {
 	// If a back_to parameter is provided, use it as the destination
 	if ( dependencies.back_to ) {
 		return { url: dependencies.back_to, celebrateArgs: { celebrateLaunch: 'true' } };
 	}
 
-	const ref = dependencies.refParameter?.trim() ?? '';
-	const isWpAdminPath = ref === 'wp-admin' || ref.startsWith( 'wp-admin/' );
+	const wpAdminUrl = getWpAdminLaunchReturnUrl( dependencies );
 
-	if ( isWpAdminPath ) {
+	if ( wpAdminUrl ) {
 		return {
-			url: `https://${ dependencies.siteSlug }/${ ref }`,
+			url: wpAdminUrl,
 			celebrateArgs: { 'celebrate-launch': 'true' },
 		};
 	}

--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -393,11 +393,13 @@ const DomainSearchUI = (
 				dashboardOrigins().some( ( origin ) => backTo?.startsWith( origin ) );
 
 			// A launch started from wp-admin has no `back_to`; `ref` carries the page it started
-			// from, so Back returns there instead of leaving the user in the sites list.
+			// from, so Back returns there instead of leaving the user in the sites list. The host
+			// comes from the site the flow loaded rather than from `siteSlug`, which is raw query
+			// input and would otherwise point Back at any host an attacker cared to name.
 			const wpAdminBackUrl =
 				'launch-site' === flowName
 					? getWpAdminLaunchReturnUrl( {
-							siteSlug: queryObject.siteSlug,
+							siteSlug: site?.slug,
 							refParameter: queryObject.ref,
 					  } )
 					: null;
@@ -422,7 +424,7 @@ const DomainSearchUI = (
 		previousStepName,
 		goBack,
 		userSiteCount,
-		queryObject.siteSlug,
+		site?.slug,
 		queryObject.ref,
 		__,
 	] );

--- a/client/signup/steps/domains/index.tsx
+++ b/client/signup/steps/domains/index.tsx
@@ -27,6 +27,7 @@ import {
 	domainManagementTransferIn,
 	domainManagementTransferToOtherSite,
 } from 'calypso/my-sites/domains/paths';
+import { getWpAdminLaunchReturnUrl } from 'calypso/signup/config/flows';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getNextStepName, getStepUrl } from 'calypso/signup/utils';
 import { useSelector } from 'calypso/state';
@@ -391,8 +392,21 @@ const DomainSearchUI = (
 				isRelativeUrl( backTo ) ||
 				dashboardOrigins().some( ( origin ) => backTo?.startsWith( origin ) );
 
+			// A launch started from wp-admin has no `back_to`; `ref` carries the page it started
+			// from, so Back returns there instead of leaving the user in the sites list.
+			const wpAdminBackUrl =
+				'launch-site' === flowName
+					? getWpAdminLaunchReturnUrl( {
+							siteSlug: queryObject.siteSlug,
+							refParameter: queryObject.ref,
+					  } )
+					: null;
+
 			if ( isSafeBackTo ) {
 				backUrl = backTo;
+				backLabelText = __( 'Back' );
+			} else if ( wpAdminBackUrl ) {
+				backUrl = wpAdminBackUrl;
 				backLabelText = __( 'Back' );
 			}
 		}
@@ -402,7 +416,16 @@ const DomainSearchUI = (
 			backUrl,
 			backLabelText,
 		};
-	}, [ dashboardOptIn, flowName, previousStepName, goBack, userSiteCount, __ ] );
+	}, [
+		dashboardOptIn,
+		flowName,
+		previousStepName,
+		goBack,
+		userSiteCount,
+		queryObject.siteSlug,
+		queryObject.ref,
+		__,
+	] );
 
 	const getUseDomainIOwnLink = () => {
 		if ( ! query || ! config.allowsUsingOwnDomain ) {

--- a/client/signup/steps/domains/test/index.tsx
+++ b/client/signup/steps/domains/test/index.tsx
@@ -2,9 +2,8 @@
  * @jest-environment jsdom
  */
 
-jest.mock(
-	'calypso/signup/step-wrapper',
-	() => ( props: { stepContent?: React.ReactNode } ) => props.stepContent ?? null
+jest.mock( 'calypso/signup/step-wrapper', () =>
+	jest.fn( ( props: { stepContent?: React.ReactNode } ) => props.stepContent ?? null )
 );
 jest.mock( 'calypso/components/domains/wpcom-domain-search', () => ( {
 	WPCOMDomainSearch: jest.fn().mockReturnValue( null ),
@@ -15,10 +14,12 @@ jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', (
 
 import React from 'react';
 import { WPCOMDomainSearch } from 'calypso/components/domains/wpcom-domain-search';
+import StepWrapper from 'calypso/signup/step-wrapper';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import DomainSearchStep from '../';
 
 const mockWPCOMDomainSearch = WPCOMDomainSearch as jest.Mock;
+const mockStepWrapper = StepWrapper as unknown as jest.Mock;
 
 const domainItem = { meta: 'example.com', product_slug: 'domain_reg' };
 
@@ -38,6 +39,12 @@ function renderStep( props = baseProps, options = {} ) {
 	mockWPCOMDomainSearch.mockClear();
 	renderWithProvider( <DomainSearchStep { ...props } />, options );
 	return mockWPCOMDomainSearch.mock.calls[ 0 ][ 0 ].events;
+}
+
+function renderStepForNavigation( props: typeof baseProps, options = {} ) {
+	mockStepWrapper.mockClear();
+	renderWithProvider( <DomainSearchStep { ...props } />, options );
+	return mockStepWrapper.mock.calls.at( -1 )?.[ 0 ];
 }
 
 const LOGGED_IN_STATE = { currentUser: { id: 12345 } };
@@ -135,5 +142,58 @@ describe( 'DomainSearchStep — domain-only checkout simplification', () => {
 			} )
 		);
 		expect( goToNextStep ).toHaveBeenCalledTimes( 1 );
+	} );
+} );
+
+describe( 'DomainSearchStep — launch-site Back button', () => {
+	const launchProps = {
+		...baseProps,
+		flowName: 'launch-site',
+		stepName: 'domains-launch',
+	};
+
+	// The site the signup controller loaded and selected for the flow.
+	const withSelectedSite = ( selectedSiteId: number | null ) => ( {
+		initialState: {
+			currentUser: { id: 12345 },
+			sites: { items: { 77: { ID: 77, URL: 'https://real-site.wordpress.com' } } },
+		},
+		reducers: { ui: () => ( { selectedSiteId } ) },
+	} );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockWPCOMDomainSearch.mockReturnValue( null );
+	} );
+
+	it( 'returns to the wp-admin page the launch started from', () => {
+		const props = renderStepForNavigation(
+			{ ...launchProps, queryObject: { ref: 'wp-admin/admin.php?page=stats' } },
+			withSelectedSite( 77 )
+		);
+
+		expect( props?.backUrl ).toBe(
+			'https://real-site.wordpress.com/wp-admin/admin.php?page=stats'
+		);
+		expect( props?.backLabelText ).toBe( 'Back' );
+	} );
+
+	it( 'takes the host from the loaded site, not from the siteSlug query arg', () => {
+		const props = renderStepForNavigation(
+			{ ...launchProps, queryObject: { ref: 'wp-admin', siteSlug: 'evil.example' } },
+			withSelectedSite( 77 )
+		);
+
+		expect( props?.backUrl ).toBe( 'https://real-site.wordpress.com/wp-admin' );
+	} );
+
+	it( 'falls back to the sites list when no site was loaded for the flow', () => {
+		const props = renderStepForNavigation(
+			{ ...launchProps, queryObject: { ref: 'wp-admin', siteSlug: 'evil.example' } },
+			withSelectedSite( null )
+		);
+
+		expect( props?.backUrl ).not.toContain( 'evil.example' );
+		expect( props?.backLabelText ).toBe( 'Back to sites' );
 	} );
 } );

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -134,13 +134,33 @@ describe( 'Signup Flows Configuration', () => {
 			expect( getWpAdminLaunchReturnUrl( { siteSlug: 'test-site.wordpress.com' } ) ).toBeNull();
 		} );
 
-		test( 'keeps the URL on the site host for a ref that only looks like a wp-admin path', () => {
+		test( 'returns null for a ref that only looks like a wp-admin path', () => {
 			expect(
 				getWpAdminLaunchReturnUrl( {
 					siteSlug: 'test-site.wordpress.com',
 					refParameter: 'wp-admin.evil.com',
 				} )
 			).toBeNull();
+		} );
+
+		test( 'returns null for a slug that would move the URL off the site host', () => {
+			expect(
+				getWpAdminLaunchReturnUrl( {
+					siteSlug: 'test-site.wordpress.com@evil.com',
+					refParameter: 'wp-admin',
+				} )
+			).toBeNull();
+			expect(
+				getWpAdminLaunchReturnUrl( {
+					siteSlug: 'test-site.wordpress.com/../..',
+					refParameter: 'wp-admin',
+				} )
+			).toBeNull();
+		} );
+
+		test( 'returns null when there is no site to return to', () => {
+			expect( getWpAdminLaunchReturnUrl( { refParameter: 'wp-admin' } ) ).toBeNull();
+			expect( getWpAdminLaunchReturnUrl( { siteSlug: '', refParameter: 'wp-admin' } ) ).toBeNull();
 		} );
 	} );
 

--- a/client/signup/test/flows.js
+++ b/client/signup/test/flows.js
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import flows from 'calypso/signup/config/flows';
+import flows, { getWpAdminLaunchReturnUrl } from 'calypso/signup/config/flows';
 import { generateFlows } from 'calypso/signup/config/flows-pure';
 import mockedFlows from './fixtures/flows';
 
@@ -91,6 +91,56 @@ describe( 'Signup Flows Configuration', () => {
 					redirect_to: null,
 				} )
 			).toBe( '/sites/test-site/settings/site-visibility?celebrateLaunch=true' );
+		} );
+
+		test( 'returns the user to the wp-admin page the launch started from', () => {
+			expect(
+				getDestination( {
+					siteSlug: 'test-site.wordpress.com',
+					refParameter: 'wp-admin/admin.php?page=stats',
+				} )
+			).toBe(
+				'https://test-site.wordpress.com/wp-admin/admin.php?page=stats&celebrate-launch=true'
+			);
+		} );
+	} );
+
+	describe( 'getWpAdminLaunchReturnUrl', () => {
+		test( 'resolves a bare wp-admin ref', () => {
+			expect(
+				getWpAdminLaunchReturnUrl( {
+					siteSlug: 'test-site.wordpress.com',
+					refParameter: 'wp-admin',
+				} )
+			).toBe( 'https://test-site.wordpress.com/wp-admin' );
+		} );
+
+		test( 'resolves a ref pointing at a specific wp-admin page', () => {
+			expect(
+				getWpAdminLaunchReturnUrl( {
+					siteSlug: 'test-site.wordpress.com',
+					refParameter: 'wp-admin/admin.php?page=stats',
+				} )
+			).toBe( 'https://test-site.wordpress.com/wp-admin/admin.php?page=stats' );
+		} );
+
+		test( 'returns null for launches that did not start in wp-admin', () => {
+			expect(
+				getWpAdminLaunchReturnUrl( {
+					siteSlug: 'test-site.wordpress.com',
+					refParameter: 'calypso',
+				} )
+			).toBeNull();
+			expect( getWpAdminLaunchReturnUrl( { siteSlug: 'test-site.wordpress.com' } ) ).toBeNull();
+		} );
+
+		test( 'keeps the URL on the site host for a ref that only looks like a wp-admin path', () => {
+			expect(
+				getWpAdminLaunchReturnUrl( {
+					siteSlug: 'test-site.wordpress.com',
+					refParameter: 'wp-admin.evil.com',
+				} )
+			).toBeNull();
 		} );
 	} );
 


### PR DESCRIPTION
Follow-up for DOTOBRD-606

## Proposed Changes

Two separate entry points into the launch flow lost track of where the user came from.

**From wp-admin** (`client/signup/steps/domains/index.tsx`)

* The admin bar's button passes `ref=wp-admin…` and no `back_to`. The domains step only ever consulted `back_to`, so it fell through to its default and rendered "Back to sites" pointing at the sites list.
* `getLaunchReturnTarget()` already knew how to resolve a wp-admin `ref`; that logic is extracted as `getWpAdminLaunchReturnUrl()` and the step's Back button now reuses it.

**From the dashboard** (`plugin-launch-site.tsx`, `interim-omnibar/omnibar-launch-button.tsx`)

* Both omnibar buttons hardcoded `backTo` to the site overview. The omnibar rides along on every screen, so launching from Settings → Site visibility sent Back to the overview instead of back to Settings.
* `backTo` is dropped so it defaults to the current page, and the site overview moves to `flowDestination` — which is what `redirect_to` is for. The post-launch landing is unchanged.

## Why are these changes being made?

`back_to` means "where Back returns to" (see #113953, which separated it from `redirect_to`). Both call sites broke that contract in different ways: wp-admin never set it, and the omnibar set it to a fixed page rather than the current one.

Reproduced live in both cases before fixing:

* From `SIMPLE_SITE_DOMAIN/wp-admin/admin.php?page=stats`, Back read "Back to sites" and navigated to `my.wordpress.com/sites`.
* From `my.wordpress.com/sites/<site>/settings/site-visibility`, the launch URL carried `back_to=https://my.wordpress.com/sites/<site>` and Back landed on the site overview.

The wp-admin half only reaches the exact screen once the companion Jetpack PR ships a more specific `ref`; with today's `ref=wp-admin` this change already fixes the label and returns the user to wp-admin instead of the sites list.

Companion Jetpack PR: Automattic/jetpack#51850

Note the `ref` → URL resolution is pinned to `https://{siteSlug}/`, so a crafted `ref` cannot redirect off-site; `back_to` keeps its existing `isSafeBackTo` allowlist and is unchanged.

## Testing Instructions

**wp-admin**

* On an unlaunched Simple site, go to `/wp-admin/admin.php?page=stats` and click "Launch site" in the admin bar.
* The flow's Back button should read "Back" and return you to wp-admin, not "Back to sites" → the sites list.

**Dashboard omnibar**

* Go to `/sites/<site>/settings/site-visibility` for an unlaunched site and click "Launch site" in the omnibar.
* Back should return you to Settings → Site visibility, not the site overview.
* Complete a launch and confirm you still land on the site overview afterwards (that behaviour is deliberately unchanged).

**Regression check**

* Launching from the Site visibility page's own button should still work as before — it passes its own `back_to`.

Unit tests: `yarn test-client client/signup/test/flows.js client/dashboard/app/omnibar/test/plugin-launch-site.test.tsx client/dashboard/sites/site-launch-button client/signup/steps/launch-site client/signup/steps/domains` (39 passing).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
