### PR TITLE
Help Center: match video embeds to the text width

### DIFF
--- a/packages/support-articles/src/components/help-center-article/help-center-article-content.tsx
+++ b/packages/support-articles/src/components/help-center-article/help-center-article-content.tsx
@@ -28,11 +28,7 @@ const ArticleContent = ( {
 					<SupportArticleHeader post={ post } isLoading={ false } />
 					<EmbedContainer>
 						<div
-							className={
-								post.lesson_navigation
-									? 'help-center-article-content__main help-center-article-content__main--with-lesson-navigation'
-									: 'help-center-article-content__main'
-							}
+							className="help-center-article-content__main"
 							// eslint-disable-next-line react/no-danger
 							dangerouslySetInnerHTML={ { __html: post.content } }
 							ref={ articleContentRef }

--- a/packages/support-articles/src/components/help-center-article/help-center-article.scss
+++ b/packages/support-articles/src/components/help-center-article/help-center-article.scss
@@ -537,11 +537,10 @@
 				}
 			}
 
-			// Videos span the full width of the Help Center, bleeding past the
-			// article's horizontal padding.
+			// Drop the browser's default <figure> side margins so videos match
+			// the text width.
 			.wp-block-embed.is-type-video {
-				margin-inline: -16px;
-				inline-size: calc( 100% + 32px );
+				margin-inline: 0;
 				max-inline-size: none;
 			}
 

--- a/packages/support-articles/src/components/help-center-article/help-center-article.scss
+++ b/packages/support-articles/src/components/help-center-article/help-center-article.scss
@@ -537,15 +537,12 @@
 				}
 			}
 
-			&.help-center-article-content__main--with-lesson-navigation {
-				// Course lesson videos span the full width of the Help Center,
-				// bleeding past the article's horizontal padding.
-				.wp-block-embed.is-type-video {
-					margin-left: -16px;
-					margin-right: -16px;
-					max-width: none;
-					width: calc( 100% + 32px );
-				}
+			// Videos span the full width of the Help Center, bleeding past the
+			// article's horizontal padding.
+			.wp-block-embed.is-type-video {
+				margin-inline: -16px;
+				inline-size: calc( 100% + 32px );
+				max-inline-size: none;
 			}
 
 			.wp-block-wpsupport3-update-plan-cta {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18468/full-width-video-embeds-in-the-help-center

## Proposed Changes

**Video embeds in Help Center articles now span the full text column instead of sitting inside the browser's default 40px figure margins.**

- Zeroes the side margins on `.wp-block-embed.is-type-video` for every article.
- Drops the course-lesson-only `--with-lesson-navigation` modifier; lessons get the same text-width treatment.

## Why are these changes being made?

Videos in Help Center guides showed with a wide margin on each side, so they looked small and easy to skip ([DOTCOM-18468](https://linear.app/a8c/issue/DOTCOM-18468/full-width-video-embeds-in-the-help-center)). The margin came from the browser's default `<figure>` styling, which nothing in the article stylesheet reset.

## Testing Instructions

1. `yarn start`, open the Help Center on any site.
2. Open a guide that contains a video embed, e.g. “Transfer a domain to WordPress.com”.
3. The video's left and right edges line up with the text above it.
