### PR TITLE
Agents Manager: start the chat closed on small viewports

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-setup.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-setup.test.tsx
@@ -49,6 +49,9 @@ jest.mock( '../../hooks/use-agent-config', () => ( {
 jest.mock( '../../hooks/use-open-chat-url-param', () => ( {
 	useOpenChatUrlParam: () => true,
 } ) );
+jest.mock( '../../hooks/use-small-viewport-default-closed', () => ( {
+	useSmallViewportDefaultClosed: () => true,
+} ) );
 jest.mock( '../../utils/load-external-providers', () => ( {
 	loadExternalProviders: async () => ( {
 		providerIds: [],

--- a/packages/agents-manager/src/components/__tests__/agents-manager.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agents-manager.test.tsx
@@ -35,6 +35,9 @@ jest.mock( '../../hooks/use-agent-config', () => ( {} ) );
 jest.mock( '../../hooks/use-open-chat-url-param', () => ( {
 	useOpenChatUrlParam: () => true,
 } ) );
+jest.mock( '../../hooks/use-small-viewport-default-closed', () => ( {
+	useSmallViewportDefaultClosed: () => true,
+} ) );
 jest.mock( '../../utils/load-external-providers', () => ( {} ) );
 jest.mock( '../../hooks/use-empty-view-suggestions', () => ( {} ) );
 jest.mock( '../agent-dock', () => ( { __esModule: true, default: () => null } ) );

--- a/packages/agents-manager/src/components/agents-manager.tsx
+++ b/packages/agents-manager/src/components/agents-manager.tsx
@@ -13,6 +13,7 @@ import { useAgentConfig } from '../hooks/use-agent-config';
 import { useEmptyViewSuggestions } from '../hooks/use-empty-view-suggestions';
 import useHasAiChatEntryButton from '../hooks/use-has-ai-chat-entry-button';
 import { useOpenChatUrlParam } from '../hooks/use-open-chat-url-param';
+import { useSmallViewportDefaultClosed } from '../hooks/use-small-viewport-default-closed';
 import useWebMcpTools from '../hooks/use-webmcp-tools';
 import { AGENTS_MANAGER_STORE } from '../stores';
 import { clearSessionId, getOrCreateSessionId, getSessionId } from '../utils/agent-session';
@@ -106,7 +107,11 @@ export default function AgentsManager( {
 	// the chat first-renders already open in both docked and undocked modes.
 	const isOpenParamHandled = useOpenChatUrlParam();
 
-	if ( ! isStoreReady || ! isOpenParamHandled ) {
+	// On small viewports the floating chat covers the whole screen, so a
+	// persisted-open chat starts closed there; `?ai-open=true` still wins.
+	const isSmallViewportDefaultApplied = useSmallViewportDefaultClosed();
+
+	if ( ! isStoreReady || ! isOpenParamHandled || ! isSmallViewportDefaultApplied ) {
 		return null;
 	}
 

--- a/packages/agents-manager/src/hooks/__tests__/use-small-viewport-default-closed.test.tsx
+++ b/packages/agents-manager/src/hooks/__tests__/use-small-viewport-default-closed.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useSmallViewportDefaultClosed } from '../use-small-viewport-default-closed';
+
+const mockSetIsOpen = jest.fn();
+let mockState: { hasLoaded: boolean; isOpen: boolean };
+
+jest.mock( '../../stores', () => ( {
+	AGENTS_MANAGER_STORE: 'automattic/agents-manager',
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( { setIsOpen: mockSetIsOpen } ),
+	useSelect: () => mockState,
+} ) );
+
+function setViewportIsDesktop( isDesktop: boolean ) {
+	window.matchMedia = jest.fn().mockReturnValue( { matches: isDesktop } );
+}
+
+function setSearch( search: string ) {
+	window.history.replaceState( null, '', `${ window.location.pathname }${ search }` );
+}
+
+describe( 'useSmallViewportDefaultClosed', () => {
+	beforeEach( () => {
+		mockSetIsOpen.mockClear();
+		mockState = { hasLoaded: true, isOpen: true };
+		setSearch( '' );
+	} );
+
+	it( 'closes a persisted-open chat on a small viewport, without saving', () => {
+		setViewportIsDesktop( false );
+
+		const { result, rerender } = renderHook( () => useSmallViewportDefaultClosed() );
+
+		expect( mockSetIsOpen ).toHaveBeenCalledWith( false, false );
+		expect( result.current ).toBe( false );
+
+		// Handled once the store reflects the closed state.
+		mockState = { hasLoaded: true, isOpen: false };
+		rerender();
+		expect( result.current ).toBe( true );
+		expect( mockSetIsOpen ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'waits for the persisted state to load before deciding', () => {
+		setViewportIsDesktop( false );
+		mockState = { hasLoaded: false, isOpen: false };
+
+		const { result, rerender } = renderHook( () => useSmallViewportDefaultClosed() );
+		expect( mockSetIsOpen ).not.toHaveBeenCalled();
+		expect( result.current ).toBe( false );
+
+		mockState = { hasLoaded: true, isOpen: true };
+		rerender();
+		expect( mockSetIsOpen ).toHaveBeenCalledWith( false, false );
+	} );
+
+	it( 'does nothing on a desktop viewport', () => {
+		setViewportIsDesktop( true );
+
+		const { result } = renderHook( () => useSmallViewportDefaultClosed() );
+
+		expect( mockSetIsOpen ).not.toHaveBeenCalled();
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'defers to an explicit ?ai-open=true', () => {
+		setViewportIsDesktop( false );
+		setSearch( '?ai-open=true' );
+
+		const { result } = renderHook( () => useSmallViewportDefaultClosed() );
+
+		expect( mockSetIsOpen ).not.toHaveBeenCalled();
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'leaves a chat that was already closed alone', () => {
+		setViewportIsDesktop( false );
+		mockState = { hasLoaded: true, isOpen: false };
+
+		const { result } = renderHook( () => useSmallViewportDefaultClosed() );
+
+		expect( mockSetIsOpen ).not.toHaveBeenCalled();
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'respects the host-configured desktop media query', () => {
+		const matchMedia = jest.fn().mockReturnValue( { matches: true } );
+		window.matchMedia = matchMedia;
+		window.__agentsManagerActions = {
+			desktopMediaQuery: '(min-width: 960px)',
+		} as unknown as Window[ '__agentsManagerActions' ];
+
+		try {
+			renderHook( () => useSmallViewportDefaultClosed() );
+			expect( matchMedia ).toHaveBeenCalledWith( '(min-width: 960px)' );
+		} finally {
+			delete window.__agentsManagerActions;
+		}
+	} );
+} );

--- a/packages/agents-manager/src/hooks/desktop-media-query.ts
+++ b/packages/agents-manager/src/hooks/desktop-media-query.ts
@@ -1,0 +1,5 @@
+// Viewport gate for docking; also what `useSmallViewportDefaultClosed` treats
+// as the small-viewport threshold. Hosts can override it via
+// `setChatDesktopMediaQuery`. Lives in its own module so consumers can import
+// it without dragging in the layout manager's component dependencies.
+export const DEFAULT_DESKTOP_MEDIA_QUERY = '(min-width: 1200px)';

--- a/packages/agents-manager/src/hooks/desktop-media-query.ts
+++ b/packages/agents-manager/src/hooks/desktop-media-query.ts
@@ -1,3 +1,4 @@
-// Hosts can override this via `setChatDesktopMediaQuery`. Own module so it is
-// importable without the layout manager's component dependencies.
+// Hosts override this by pre-setting `window.__agentsManagerActions.desktopMediaQuery`
+// (the runtime `setChatDesktopMediaQuery` action reaches only the dock). Own
+// module so it is importable without the layout manager's component dependencies.
 export const DEFAULT_DESKTOP_MEDIA_QUERY = '(min-width: 1200px)';

--- a/packages/agents-manager/src/hooks/desktop-media-query.ts
+++ b/packages/agents-manager/src/hooks/desktop-media-query.ts
@@ -1,5 +1,3 @@
-// Viewport gate for docking; also what `useSmallViewportDefaultClosed` treats
-// as the small-viewport threshold. Hosts can override it via
-// `setChatDesktopMediaQuery`. Lives in its own module so consumers can import
-// it without dragging in the layout manager's component dependencies.
+// Hosts can override this via `setChatDesktopMediaQuery`. Own module so it is
+// importable without the layout manager's component dependencies.
 export const DEFAULT_DESKTOP_MEDIA_QUERY = '(min-width: 1200px)';

--- a/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
+++ b/packages/agents-manager/src/hooks/use-agent-layout-manager/index.tsx
@@ -13,6 +13,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { AI } from '../../components/icons';
 import observeEditorCanvasPointerDown from '../../utils/observe-editor-canvas-pointerdown';
+import { DEFAULT_DESKTOP_MEDIA_QUERY } from '../desktop-media-query';
 import { ResponsiveUndockContext } from './responsive-undock-context';
 
 // On Gutenberg editor screens, only dock when fullscreen mode is on —
@@ -90,7 +91,7 @@ export default function useAgentLayoutManager( {
 	isReady = true,
 	defaultDocked = true,
 	defaultOpen = false,
-	desktopMediaQuery = '(min-width: 1200px)',
+	desktopMediaQuery = DEFAULT_DESKTOP_MEDIA_QUERY,
 	onOpenSidebar = () => {},
 	onCloseSidebar = () => {},
 	onDock = () => {},

--- a/packages/agents-manager/src/hooks/use-open-chat-url-param.ts
+++ b/packages/agents-manager/src/hooks/use-open-chat-url-param.ts
@@ -2,14 +2,9 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { AGENTS_MANAGER_STORE } from '../stores';
 import { isReaderChatHost } from '../utils/is-reader-chat-agent';
+import { hasOpenChatUrlParam, OPEN_CHAT_URL_PARAM } from '../utils/open-chat-url-param';
 import { recordBigSkyTracksEvent } from '../utils/tracks';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
-
-const OPEN_CHAT_URL_PARAM = 'ai-open';
-
-export const hasOpenChatUrlParam = () =>
-	typeof window !== 'undefined' &&
-	new URLSearchParams( window.location.search ).get( OPEN_CHAT_URL_PARAM ) === 'true';
 
 /**
  * Opens the chat when the page URL carries `?ai-open=true` (e.g. promo links

--- a/packages/agents-manager/src/hooks/use-open-chat-url-param.ts
+++ b/packages/agents-manager/src/hooks/use-open-chat-url-param.ts
@@ -7,7 +7,7 @@ import type { AgentsManagerSelect } from '@automattic/data-stores';
 
 const OPEN_CHAT_URL_PARAM = 'ai-open';
 
-const hasOpenChatUrlParam = () =>
+export const hasOpenChatUrlParam = () =>
 	typeof window !== 'undefined' &&
 	new URLSearchParams( window.location.search ).get( OPEN_CHAT_URL_PARAM ) === 'true';
 

--- a/packages/agents-manager/src/hooks/use-small-viewport-default-closed.ts
+++ b/packages/agents-manager/src/hooks/use-small-viewport-default-closed.ts
@@ -1,0 +1,66 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { AGENTS_MANAGER_STORE } from '../stores';
+import { DEFAULT_DESKTOP_MEDIA_QUERY } from './desktop-media-query';
+import { hasOpenChatUrlParam } from './use-open-chat-url-param';
+import type { AgentsManagerSelect } from '@automattic/data-stores';
+
+/**
+ * Whether the viewport is below the desktop breakpoint the dock uses. Reads
+ * the host's override when one is set, like `AgentDock` does.
+ */
+function isSmallViewport(): boolean {
+	if ( typeof window === 'undefined' || ! window.matchMedia ) {
+		return false;
+	}
+	const query = window.__agentsManagerActions?.desktopMediaQuery ?? DEFAULT_DESKTOP_MEDIA_QUERY;
+	return ! window.matchMedia( query ).matches;
+}
+
+/**
+ * Starts the chat closed on small viewports, where the floating chat covers
+ * the whole screen: a user landing on a phone with `agents_manager_open`
+ * persisted from an earlier (usually desktop) session would see only the
+ * chat, not the page they navigated to. Closed still leaves the chat one tap
+ * away — the admin-bar entry or the floating button reopens it.
+ *
+ * Deliberately narrow:
+ *
+ * - Applies once, to the persisted state the session starts from. Anything
+ *   the user does afterwards (opening, closing, rotating) is theirs.
+ * - `?ai-open=true` wins: an explicit ask to open is not a stale preference.
+ *   Both this hook and `useOpenChatUrlParam` capture the param on the first
+ *   render, before it is consumed.
+ * - The close is not persisted, so a later desktop session still restores
+ *   the chat the way the user left it.
+ *
+ * Returns `true` once handled. `AgentsManager` gates rendering on it so the
+ * chat never first-paints open on a small viewport; without anything to do it
+ * returns `true` immediately.
+ */
+export function useSmallViewportDefaultClosed(): boolean {
+	const [ shouldApply ] = useState( () => isSmallViewport() && ! hasOpenChatUrlParam() );
+	const [ isHandled, setIsHandled ] = useState( false );
+	const { setIsOpen } = useDispatch( AGENTS_MANAGER_STORE );
+	const { hasLoaded, isOpen } = useSelect( ( select ) => {
+		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
+		return store.getAgentsManagerState();
+	}, [] );
+
+	useEffect( () => {
+		if ( ! shouldApply || isHandled || ! hasLoaded ) {
+			return;
+		}
+
+		if ( isOpen ) {
+			// Close without saving; the effect re-runs via the `isOpen` dep
+			// and reports handled once the store reflects the closed state.
+			setIsOpen( false, false );
+			return;
+		}
+
+		setIsHandled( true );
+	}, [ hasLoaded, isHandled, isOpen, setIsOpen, shouldApply ] );
+
+	return isHandled || ! shouldApply;
+}

--- a/packages/agents-manager/src/hooks/use-small-viewport-default-closed.ts
+++ b/packages/agents-manager/src/hooks/use-small-viewport-default-closed.ts
@@ -5,10 +5,7 @@ import { DEFAULT_DESKTOP_MEDIA_QUERY } from './desktop-media-query';
 import { hasOpenChatUrlParam } from './use-open-chat-url-param';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
 
-/**
- * Whether the viewport is below the desktop breakpoint the dock uses. Reads
- * the host's override when one is set, like `AgentDock` does.
- */
+/** Whether the viewport is below the desktop breakpoint the dock uses. */
 function isSmallViewport(): boolean {
 	if ( typeof window === 'undefined' || ! window.matchMedia ) {
 		return false;

--- a/packages/agents-manager/src/hooks/use-small-viewport-default-closed.ts
+++ b/packages/agents-manager/src/hooks/use-small-viewport-default-closed.ts
@@ -1,8 +1,8 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { AGENTS_MANAGER_STORE } from '../stores';
+import { hasOpenChatUrlParam } from '../utils/open-chat-url-param';
 import { DEFAULT_DESKTOP_MEDIA_QUERY } from './desktop-media-query';
-import { hasOpenChatUrlParam } from './use-open-chat-url-param';
 import type { AgentsManagerSelect } from '@automattic/data-stores';
 
 /** Whether the viewport is below the desktop breakpoint the dock uses. */

--- a/packages/agents-manager/src/hooks/use-small-viewport-default-closed.ts
+++ b/packages/agents-manager/src/hooks/use-small-viewport-default-closed.ts
@@ -36,8 +36,9 @@ function isSmallViewport(): boolean {
  * returns `true` immediately.
  */
 export function useSmallViewportDefaultClosed(): boolean {
-	const [ shouldApply ] = useState( () => isSmallViewport() && ! hasOpenChatUrlParam() );
-	const [ isHandled, setIsHandled ] = useState( false );
+	const [ isHandled, setIsHandled ] = useState(
+		() => ! isSmallViewport() || hasOpenChatUrlParam()
+	);
 	const { setIsOpen } = useDispatch( AGENTS_MANAGER_STORE );
 	const { hasLoaded, isOpen } = useSelect( ( select ) => {
 		const store: AgentsManagerSelect = select( AGENTS_MANAGER_STORE );
@@ -45,7 +46,7 @@ export function useSmallViewportDefaultClosed(): boolean {
 	}, [] );
 
 	useEffect( () => {
-		if ( ! shouldApply || isHandled || ! hasLoaded ) {
+		if ( isHandled || ! hasLoaded ) {
 			return;
 		}
 
@@ -57,7 +58,7 @@ export function useSmallViewportDefaultClosed(): boolean {
 		}
 
 		setIsHandled( true );
-	}, [ hasLoaded, isHandled, isOpen, setIsOpen, shouldApply ] );
+	}, [ hasLoaded, isHandled, isOpen, setIsOpen ] );
 
-	return isHandled || ! shouldApply;
+	return isHandled;
 }

--- a/packages/agents-manager/src/utils/open-chat-url-param.ts
+++ b/packages/agents-manager/src/utils/open-chat-url-param.ts
@@ -1,0 +1,6 @@
+export const OPEN_CHAT_URL_PARAM = 'ai-open';
+
+/** Whether the page URL carries `?ai-open=true`, an explicit ask to open the chat. */
+export const hasOpenChatUrlParam = () =>
+	typeof window !== 'undefined' &&
+	new URLSearchParams( window.location.search ).get( OPEN_CHAT_URL_PARAM ) === 'true';


### PR DESCRIPTION
Part of BIGR-964.

## Proposed Changes

* On viewports below the dock's desktop breakpoint (1200px by default), the chat starts closed instead of restoring a persisted open state. The close happens once, before the dock first renders, so the open chat never flashes.
* The close is not saved: a later desktop session still restores the chat the way the user left it. `?ai-open=true` still opens the chat. The chat stays one tap away via the admin-bar entry or the floating button.

## Why are these changes being made?

* On small screens the floating chat covers the whole viewport. A user who opened the chat on desktop once would land on any wp-admin page on their phone and see only the chat, not the page they came for.
* The site-builder flow hits this hardest: the "your site is ready" notification opens the editor on a phone, and the chat (left open by the builder handoff) hides the brand-new site. Feedback from launch testing asked for the chat to start minimized on small screens.

## Testing Instructions

Calypso (`yarn start`):

1. On a desktop-width window, open the AI chat so the open state is persisted.
2. Narrow the window below 1200px and reload: the chat starts closed, and the entry button or floating button reopens it.
3. Reload with `?ai-open=true` appended on the narrow window: the chat opens.
4. Back on a desktop-width window, reload: the chat is open again (the mobile default did not overwrite the preference).

Sandbox (Simple/Atomic): `cd apps/agents-manager && yarn dev --sync`, sandbox `widgets.wp.com`, then repeat the steps above on any site's wp-admin.

Unit tests: `yarn test-packages packages/agents-manager/src/hooks/__tests__/use-small-viewport-default-closed.test.tsx` (6 tests).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSQLurJvhoU9QuRFqrKyPR
