### PR TITLE
Dashboard: give performance recommendation tables usable column widths

### DIFF
--- a/client/dashboard/sites/performance/performance-insight-table.tsx
+++ b/client/dashboard/sites/performance/performance-insight-table.tsx
@@ -15,6 +15,23 @@ const wrapLongValueStyle = { whiteSpace: 'normal', overflowWrap: 'anywhere' } as
 
 const FLEXIBLE_VALUE_TYPES = [ 'code', 'link', 'source-location', 'text', 'url' ];
 
+type PerformanceMetricAuditDetailsHeading = NonNullable<
+	PerformanceMetricAuditDetails[ 'headings' ]
+>[ number ];
+
+type PerformanceInsightRow = PerformanceMetricAuditDetailsItem & {
+	id: string;
+	__isSubItem?: boolean;
+};
+
+const getCellValue = (
+	heading: PerformanceMetricAuditDetailsHeading,
+	item: PerformanceMetricAuditDetailsItem
+) =>
+	heading.subItemsHeading && item.__isSubItem
+		? item[ heading.subItemsHeading.key ]
+		: item[ heading.key ];
+
 const renderNode = (
 	data: { [ key: string ]: any },
 	fullPageScreenshot: SitePerformanceReport[ 'fullPageScreenshot' ]
@@ -54,10 +71,7 @@ const PerformanceInsightTable = ( {
 		enableSorting: false,
 		enableHiding: false,
 		render: ( { item }: { item: PerformanceMetricAuditDetailsItem } ) => {
-			const value =
-				heading.subItemsHeading && item.__isSubItem
-					? item[ heading.subItemsHeading.key ]
-					: item[ heading.key ];
+			const value = getCellValue( heading, item );
 
 			const valueType =
 				heading.subItemsHeading && item.__isSubItem
@@ -114,10 +128,28 @@ const PerformanceInsightTable = ( {
 		},
 	} ) );
 
+	const rows: PerformanceInsightRow[] = details.isEntityGrouped
+		? items.flatMap( ( item, i ) => [
+				{ ...item, id: `${ i }` },
+				...( item.subItems?.items ?? [] ).map( ( subItem, j ) => ( {
+					...subItem,
+					id: `${ item.entity }- ${ j }`,
+					entity: item.entity,
+					__isSubItem: true,
+				} ) ),
+		  ] )
+		: items.map( ( item, i ) => ( { ...item, id: `${ i }` } ) );
+
 	// Without explicit widths DataViews shrinks every column to its content and hands all the
-	// slack to the last one, which collapses wrapped text columns into a narrow stack.
-	const flexibleHeadings = headings.filter( ( heading ) =>
-		FLEXIBLE_VALUE_TYPES.includes( heading.valueType )
+	// slack to the last one, which collapses wrapped text columns into a narrow stack. Columns
+	// that render nothing are skipped so they can't claim a share of the width.
+	const flexibleHeadings = headings.filter(
+		( heading ) =>
+			FLEXIBLE_VALUE_TYPES.includes( heading.valueType ) &&
+			rows.some( ( row ) => {
+				const value = getCellValue( heading, row );
+				return value !== undefined && value !== null && value !== '';
+			} )
 	);
 	const columnStyles = Object.fromEntries(
 		flexibleHeadings.map( ( heading ) => [
@@ -137,25 +169,8 @@ const PerformanceInsightTable = ( {
 	};
 
 	return (
-		<DataViews< PerformanceMetricAuditDetailsItem & { id: string; __isSubItem?: boolean } >
-			data={
-				details.isEntityGrouped
-					? items
-							.map( ( item, i ) => [
-								{
-									...item,
-									id: `${ i }`,
-								},
-								...( item.subItems?.items ?? [] ).map( ( subItem, j ) => ( {
-									...subItem,
-									id: `${ item.entity }- ${ j }`,
-									entity: item.entity,
-									__isSubItem: true,
-								} ) ),
-							] )
-							.flat()
-					: items.map( ( item, i ) => ( { ...item, id: `${ i }` } ) )
-			}
+		<DataViews< PerformanceInsightRow >
+			data={ rows }
 			fields={ fields }
 			view={ view }
 			defaultLayouts={ { table: {} } }

--- a/client/dashboard/sites/performance/performance-insight-table.tsx
+++ b/client/dashboard/sites/performance/performance-insight-table.tsx
@@ -10,8 +10,10 @@ import type {
 } from '@automattic/api-core';
 
 // DataViews sets white-space: nowrap on the cell wrapper, which suppresses every wrap
-// opportunity; word-break alone has no effect without overriding it.
-const wrapLongValueStyle = { whiteSpace: 'normal', wordBreak: 'break-all' } as const;
+// opportunity; overflow-wrap alone has no effect without overriding it.
+const wrapLongValueStyle = { whiteSpace: 'normal', overflowWrap: 'anywhere' } as const;
+
+const FLEXIBLE_VALUE_TYPES = [ 'code', 'link', 'source-location', 'text', 'url' ];
 
 const renderNode = (
 	data: { [ key: string ]: any },
@@ -112,12 +114,25 @@ const PerformanceInsightTable = ( {
 		},
 	} ) );
 
+	// Without explicit widths DataViews shrinks every column to its content and hands all the
+	// slack to the last one, which collapses wrapped text columns into a narrow stack.
+	const flexibleHeadings = headings.filter( ( heading ) =>
+		FLEXIBLE_VALUE_TYPES.includes( heading.valueType )
+	);
+	const columnStyles = Object.fromEntries(
+		flexibleHeadings.map( ( heading ) => [
+			heading.key,
+			{ width: `${ 100 / flexibleHeadings.length }%` },
+		] )
+	);
+
 	const view = {
 		fields: fields.map( ( field ) => field.id ),
 		type: 'table' as const,
 		groupBy: details.isEntityGrouped ? { field: 'entity', direction: 'asc' as const } : undefined,
 		layout: {
 			enableMoving: false,
+			styles: columnStyles,
 		},
 	};
 


### PR DESCRIPTION
Part of DOTMSD-1541

## Proposed Changes

* Long URLs in the performance recommendations table now wrap across the full width of their column instead of collapsing into a narrow strip.

## Why are these changes being made?

* #113961 made the URLs wrap, but DataViews then shrank the URL column to its minimum and gave all the leftover width to the trailing numeric column.

## Testing Instructions

* Go to a site's performance page and expand a recommendation with a URL or source-location column.
* Check that URLs use the full column width and that the columns fill the panel.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?