### PR TITLE
Dashboard: let support sessions access migrating sites

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -167,7 +167,11 @@ export const siteRoute = createRoute( {
 		}
 
 		const migrationUrl = `/sites/${ siteSlug }/migration-overview`;
-		if ( isSiteMigrationInProgress( site ) && ! location.pathname.includes( migrationUrl ) ) {
+		if (
+			isSiteMigrationInProgress( site ) &&
+			! isSupportSession() &&
+			! location.pathname.includes( migrationUrl )
+		) {
 			throw dashboardRedirect( { to: migrationUrl } );
 		}
 

--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -73,7 +73,7 @@ function SiteMenuSidebar( { site }: { site: Site } ) {
 	const siteTypeSupports = getSiteTypeFeatureSupports( site );
 	const isApmEnabled = isEnabled( 'performance/apm' );
 
-	if ( isSiteMigrationInProgress( site ) ) {
+	if ( isSiteMigrationInProgress( site ) && ! isSupportSession() ) {
 		return null;
 	}
 


### PR DESCRIPTION
Fixes DOTMSD-1459

## Proposed Changes

* Skip the redirect to `/sites/:slug/migration-overview` for sites with a migration in progress when the dashboard is being viewed in a support session.
* Render the full site sidebar menu for migrating sites in a support session, instead of hiding every item.

## Why are these changes being made?

In the previous hosting dashboard, Happiness Engineers could access every tab for a site in migration. In the new dashboard, a migrating site is locked to the migration overview page and the sidebar is emptied, so tabs like Settings or Logs are unreachable during a migration. Those tabs are useful while diagnosing migration issues, so support sessions now get the same access they had in v1. Regular users are unaffected.

## Testing Instructions

1. Find or create a site with a migration in progress (the site’s `migration_status` is `migration-in-progress`, or `migration-pending-*` / `migration-started-*`).
2. As a regular user, open `/sites/<slug>/settings`. You should still be redirected to the migration overview page and the sidebar should show no menu items.
3. Start a support session for the site owner and open `/sites/<slug>/settings` again. The settings page should load and the sidebar should show the full site menu.
4. Open `/sites/<slug>/migration-overview` in the support session. It should still load.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01EtbBdKf4M5cTQMrM9ELMk5
