### PR TITLE
Prioritise release jobs ahead of feature builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,6 +7,7 @@ steps:
   # The desktop build is resource-intensive and this repo runs many builds,
   # so keep it scoped to the same branch families the CircleCI workflow used.
   - label: ":desktop_computer: Build desktop (mac)"
+    priority: 1
     key: desktop-build-mac
     branches: trunk release/* desktop/* desktop-v*
     notify:
@@ -34,6 +35,7 @@ steps:
       - desktop/test/e2e/results/screenshot.png
 
   - label: ":desktop_computer: Build desktop (linux, unsigned)"
+    priority: 1
     key: desktop-build-linux
     branches: release/* desktop/* desktop-v*
     notify:
@@ -59,6 +61,7 @@ steps:
       - desktop/test/e2e/results/screenshot.png
 
   - label: ":windows: Build desktop (windows store, unsigned)"
+    priority: 1
     key: desktop-build-windows-store
     branches: release/* desktop/* desktop-v*
     notify:
@@ -73,6 +76,7 @@ steps:
   # Signed NSIS direct-download installer — the auto-update path (electron-
   # updater stays enabled). Signs via Azure Artifact Signing.
   - label: ":windows: Build desktop (windows nsis, signed)"
+    priority: 1
     key: desktop-build-windows-nsis
     branches: release/* desktop/* desktop-v*
     notify:
@@ -89,6 +93,7 @@ steps:
       - desktop/release/latest.yml
 
   - label: ":desktop_computer: Desktop publish"
+    priority: 1
     branches: desktop-v*
     depends_on:
       - desktop-build-mac


### PR DESCRIPTION
<!-- blue -->
> [!NOTE]  
> Actually, I'm going to close this PR. It was open by an agent sweeping for release builds to prioritize, but I don't think the rationale applies here. The steps  that have been set to `priority: 1` are not necessarily steps that are part of a release. As such, I think prioritizing them is not necessary.
>
> Eventually, we'll update the automation of this repo to have dedicated release CI pipelines etc. At that point, those dedicated pipelines will have `priority: 1`

---

Adds `priority: 1` to the five desktop build and publish steps so a desktop release jumps the queue ahead of feature builds.

Closes [AINFRA-3054](https://linear.app/a8c/issue/AINFRA-3054).

<details>
<summary>AI-generated details.</summary>

## Description

These steps share their queues with every calypso PR build, so a desktop release waits behind queued feature work.

Applied per step rather than pipeline-wide, to keep the key beside the branch gate it belongs to. One tradeoff worth knowing: the mac build also runs on `trunk`, so continuous desktop builds there gain priority too. Prioritising only `Desktop publish` would avoid that but leave the four builds it depends on still queued.

Part of [AINFRA-3038](https://linear.app/a8c/issue/AINFRA-3038); audit in [AINFRA-3032](https://linear.app/a8c/issue/AINFRA-3032).

## Testing instructions

Verified locally that the file parses and all five steps resolve to priority `1`.

Real confirmation is the next `desktop-v*` tag: the jobs should show **Priority** `1` in Buildkite, against `0` for a PR build.

</details>
