### PR TITLE
Dashboard DNS: name CNAME records in the restore success toast

### DIFF
--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -74,6 +74,13 @@ export default function DomainDns() {
 			error: { source: 'server' },
 		} )
 	);
+	const restoreDefaultCnameRecordMutation = useMutation(
+		withSnackbar( domainDnsMutation( domainName ), {
+			/* translators: %s is the domain name */
+			success: sprintf( __( 'Default CNAME record restored for %s.' ), domainName ),
+			error: { source: 'server' },
+		} )
+	);
 	const restoreDefaultEmailRecordsMutation = useMutation(
 		withSnackbar( domainDnsEmailMutation( domainName ), {
 			/* translators: %s is the domain name */
@@ -166,7 +173,7 @@ export default function DomainDns() {
 			domain: domainName,
 		} );
 
-		updateDnsMutation.mutate(
+		restoreDefaultCnameRecordMutation.mutate(
 			{
 				recordsToRemove,
 				recordsToAdd: recordsToAdd as DnsRecord[],
@@ -380,7 +387,7 @@ export default function DomainDns() {
 			<RestoreDefaultCnameRecord
 				onConfirm={ handleRestoreDefaultCnameRecord }
 				onCancel={ () => setIsRestoreDefaultCnameRecordDialogOpen( false ) }
-				isBusy={ updateDnsMutation.isPending }
+				isBusy={ restoreDefaultCnameRecordMutation.isPending }
 				isOpen={ isRestoreDefaultCnameRecordDialogOpen }
 			/>
 			<RestoreDefaultEmailRecords


### PR DESCRIPTION
Attempts to fix DOMENG-1114

## Proposed Changes

* Give the "restore default CNAME record" action on the dashboard DNS screen its own mutation, so its success toast names CNAME records rather than A records.

## Why are these changes being made?

Restoring the default CNAME record showed `Default A records restored for <domain>.` The restore itself worked correctly — only the confirmation copy named the wrong record type, telling the user something untrue about what had just happened.

Both restore handlers in `client/dashboard/domains/domain-dns/index.tsx` shared a single `updateDnsMutation`, and `withSnackbar()` writes the success string into the mutation's `meta` at creation time. A single instance can therefore only ever carry one message, so the CNAME path inherited the A-records copy.

Splitting the mutation is the smallest change that lets each action carry its own message. It mirrors the existing email-restore mutation in the same file, and `add.tsx`, `edit.tsx`, `dns-import-dialog.tsx` and `actions.tsx` each construct their own instance the same way.

The wording is singular: the action adds exactly one `www` CNAME, the menu item reads "Restore default CNAME record", the modal title is "Restore CNAME record", and the classic Calypso DNS page already says "Default CNAME record restored" — the dashboard now agrees with it instead of contradicting it.

The request payload, the `meta.statId` failure stat and the Tracks events are all unchanged, so this is a copy-only change in behavior. The CNAME modal's `isBusy` now follows the new mutation, which is not user-visible since only one restore dialog is open at a time.

## Testing Instructions

1. Run the dashboard dev server and open a domain's DNS screen at `/domains/<domain>/dns`.
2. The "Restore default CNAME record" action is disabled while the default `www` CNAME record exists, so delete or edit that record first to enable it.
3. Open **DNS actions → Restore default CNAME record → Restore**.
4. The success toast should read **`Default CNAME record restored for <domain>.`** Before this change it read `Default A records restored for <domain>.`
5. Confirm the **Restore default A records** action still shows `Default A records restored for <domain>.`

Verified locally against a real domain on the dashboard dev server. No new unit test was added.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
