### PR TITLE
Dashboard DNS: fix the busy state on the email records restore button

### DIFF
--- a/client/dashboard/domains/domain-dns/index.tsx
+++ b/client/dashboard/domains/domain-dns/index.tsx
@@ -386,7 +386,7 @@ export default function DomainDns() {
 			<RestoreDefaultEmailRecords
 				onConfirm={ handleRestoreDefaultEmailRecords }
 				onCancel={ () => setIsRestoreDefaultEmailRecordsDialogOpen( false ) }
-				isBusy={ updateDnsMutation.isPending }
+				isBusy={ restoreDefaultEmailRecordsMutation.isPending }
 				isOpen={ isRestoreDefaultEmailRecordsDialogOpen }
 			/>
 			{ isImportDialogOpen && (


### PR DESCRIPTION
Attempts to fix DOMENG-1115

## Proposed Changes

* Point the "Restore email records" modal's `isBusy` at the mutation its own confirm handler triggers, so the Restore button shows its loading state while the request is in flight.

## Why are these changes being made?

`client/dashboard/domains/domain-dns/index.tsx` passed `isBusy={ updateDnsMutation.isPending }` to `<RestoreDefaultEmailRecords />`, but the confirm handler (`handleRestoreDefaultEmailRecords`) triggers `restoreDefaultEmailRecordsMutation`. The button was reading a mutation that its own click never starts, so `isPending` stayed `false` for the whole request and the button gave no indication that anything was happening.

This makes the email modal consistent with the A-records modal, which already reads the mutation its own handler fires.

`isBusy` in `@wordpress/components` is purely visual and does not disable the button, so this changes feedback only — it has no bearing on repeated clicks or double submission.

## Testing Instructions

1. Run the dashboard dev server and open a domain's DNS records screen at `/domains/<domain>/dns`. The domain must not already have the default email records, since the menu item is disabled while they are present.
2. Throttle the network (DevTools → Network → Slow) so the request stays in flight long enough to observe.
3. Open **DNS actions → Restore default email records → Restore**.
4. The Restore button now shows its loading animation for the duration of the request. Before this change it stayed idle for the whole request.

Verified locally on the dashboard dev server.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

