### PR TITLE
Stats: escape every quote in CSV export labels

### DIFF
--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -196,7 +196,22 @@ describe( 'utils', () => {
 					label: 'Chicken and "Ribs"',
 					value: 10,
 				} )
-			).toEqual( [ [ '"Chicken and ""Ribs""', 10, 'https://example.com/chicken' ] ] );
+			).toEqual( [ [ '"Chicken and ""Ribs"""', 10, 'https://example.com/chicken' ] ] );
+		} );
+
+		test( 'should escape every quote in a label', () => {
+			expect(
+				buildExportArray( {
+					actions: [
+						{
+							type: 'link',
+							data: 'https://example.com/chicken',
+						},
+					],
+					label: 'Chicken "and" "Ribs"',
+					value: 10,
+				} )
+			).toEqual( [ [ '"Chicken ""and"" ""Ribs"""', 10, 'https://example.com/chicken' ] ] );
 		} );
 
 		test( 'should modify each row in csv by a modifier function', () => {

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -130,8 +130,7 @@ export function buildExportArray( data, parent = null, modifierFn = null ) {
 		return [];
 	}
 	const label = parent ? parent + ' > ' + String( data.label ) : String( data.label );
-	// eslint-disable-next-line
-	const escapedLabel = label.replace( /\"/, '""' );
+	const escapedLabel = label.replace( /"/g, '""' );
 	let exportData = [ [ '"' + escapedLabel + '"', data.value ] ];
 
 	// Includes the URL for content data, but not for "Countries" data where it doesn't exist.


### PR DESCRIPTION
Closes STATS-266
Fixes #68737

## Proposed Changes

* `buildExportArray()` doubled only the first `"` in a label (the regex had no `g` flag), so any title with two or more quotes ended its CSV field early and merged into the following rows. Add the `g` flag so every quote is doubled.
* Update the existing escaping test, which encoded the bug, and add a case with several quotes.

## Why are these changes being made?

* Stats CSV downloads with a quoted post title are not valid CSV and Excel refuses to open them (STATS-266, #68737).

## Testing Instructions

* `yarn test-client client/state/stats/lists/test/utils.js`
* On a site with a post titled e.g. `Read "this" now`, get some views, open `/stats/month/posts/:site`, click Download CSV. The row for that post should read `"Read ""this"" now",<views>,<url>` and the file should open in Excel with one row per post.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
