### PR TITLE
Omnibar: consume free domain upsell experiment

### DIFF
--- a/client/blocks/jitm/index.jsx
+++ b/client/blocks/jitm/index.jsx
@@ -136,6 +136,7 @@ export function JITM( props ) {
 		isJetpack,
 		jitmPlaceholder,
 		template,
+		suppressedMessageIds,
 	} = props;
 
 	const dispatch = useDispatch();
@@ -152,6 +153,8 @@ export function JITM( props ) {
 		jitm.content.icon = '';
 	}
 
+	const isSuppressed = !! jitm && !! suppressedMessageIds?.includes( jitm.id );
+
 	return (
 		<>
 			<QueryJITM
@@ -161,6 +164,7 @@ export function JITM( props ) {
 			/>
 			{ isFetching && jitmPlaceholder }
 			{ jitm &&
+				! isSuppressed &&
 				renderTemplate( jitm.template || template || 'default', {
 					...jitm,
 					...getEventHandlers( props, dispatch ),
@@ -176,6 +180,7 @@ JITM.propTypes = {
 	searchQuery: PropTypes.string,
 	jitmPlaceholder: PropTypes.node,
 	isFetching: PropTypes.bool,
+	suppressedMessageIds: PropTypes.arrayOf( PropTypes.string ),
 };
 
 const mapStateToProps = ( state, { messagePath } ) => {

--- a/client/dashboard/app/omnibar/omnibar.tsx
+++ b/client/dashboard/app/omnibar/omnibar.tsx
@@ -11,12 +11,14 @@ import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 import { dashboardLink, wpcomLink } from '../../utils/link';
 import { getSiteDisplayName } from '../../utils/site-name';
+import { useAnalytics } from '../analytics';
 import { AUTH_QUERY_KEY, initializeCurrentUser } from '../auth';
 import { useAppContext } from '../context';
 import { omnibarEvents } from './events';
 import { OmnibarHomeIcon } from './home';
 import { useAiChatPlugin } from './plugin-ai-chat';
 import { addDashboardNode, useDashboardPlugin } from './plugin-dashboard';
+import { createFreeDomainUpsellNodeBuilder } from './plugin-free-domain-upsell-experiment';
 import { useHelpCenterPlugin } from './plugin-help-center';
 import { useLanguageSwitcherPlugin } from './plugin-language-switcher';
 import { useLaunchSitePlugin } from './plugin-launch-site';
@@ -90,6 +92,7 @@ function ConnectedOmnibar( {
 	sectionName?: string;
 } ) {
 	const { supports } = useAppContext();
+	const { recordTracksEvent } = useAnalytics();
 	const recordNodeClick = useRecordOmnibarNodeClick();
 	const [ hydrated, setHydrated ] = useState( false );
 	useEffect( () => {
@@ -118,14 +121,19 @@ function ConnectedOmnibar( {
 		meta: { persist: false },
 	} );
 
+	// Names the app a node was seen in, for the events builders record. The two
+	// apps mount their own omnibar, so this never changes while one is mounted.
+	const source = sectionName === 'dashboard' ? 'dashboard' : 'calypso';
+
 	const nodeBuilders = useMemo< OmnibarNodeBuilders >(
 		() => ( {
 			'my-wpcom-account': buildWpcomAccountNode,
 			'site-plan-badge': buildSiteBadgeNode,
 			'site-status-badge': buildSiteBadgeNode,
+			'free-domain-upsell': createFreeDomainUpsellNodeBuilder( { source, recordTracksEvent } ),
 			...( authUser ? { logout: createLogoutNodeBuilder( authUser ) } : {} ),
 		} ),
-		[ authUser ]
+		[ authUser, source, recordTracksEvent ]
 	);
 
 	const baseOmnibarNodes = useMemo( () => {

--- a/client/dashboard/app/omnibar/plugin-free-domain-upsell-experiment.scss
+++ b/client/dashboard/app/omnibar/plugin-free-domain-upsell-experiment.scss
@@ -1,0 +1,74 @@
+.omnibar .omnibar__menu.omnibar__free-domain-upsell {
+	--free-domain-upsell-background: color-mix(
+		in srgb,
+		var( --omnibar-highlight-color ) 22%,
+		transparent
+	);
+	--free-domain-upsell-background-hover: color-mix(
+		in srgb,
+		var( --omnibar-highlight-color ) 42%,
+		transparent
+	);
+	--free-domain-upsell-ring: color-mix(
+		in srgb,
+		var( --omnibar-highlight-color ) 45%,
+		transparent
+	);
+	--free-domain-upsell-ring-hover: color-mix(
+		in srgb,
+		var( --omnibar-highlight-color ) 80%,
+		transparent
+	);
+	--free-domain-upsell-text: color-mix( in srgb, var( --omnibar-text-color ) 87%, transparent );
+	--free-domain-upsell-text-hover: var( --omnibar-text-color );
+	--free-domain-upsell-icon: var( --omnibar-highlight-color );
+	--free-domain-upsell-icon-hover: color-mix(
+		in srgb,
+		var( --omnibar-highlight-color ) 70%,
+		var( --omnibar-text-color )
+	);
+
+	padding-inline: 8px;
+
+	&:hover,
+	&:focus-visible,
+	&:active {
+		background-color: transparent;
+	}
+
+	.omnibar__site-action {
+		gap: 4px;
+		height: 24px;
+		padding-inline: 4px 8px;
+		border-radius: 4px;
+		background: var( --free-domain-upsell-background );
+		box-shadow: inset 0 0 0 1px var( --free-domain-upsell-ring );
+		color: var( --free-domain-upsell-text );
+		font-size: 12px;
+		font-weight: 500;
+		line-height: 24px;
+		transition:
+			background 0.12s linear,
+			box-shadow 0.12s linear,
+			color 0.12s linear;
+	}
+
+	svg {
+		width: 16px;
+		height: 16px;
+		color: var( --free-domain-upsell-icon );
+		transition: color 0.12s linear;
+	}
+
+	&:hover .omnibar__site-action,
+	&:focus-visible .omnibar__site-action {
+		background: var( --free-domain-upsell-background-hover );
+		box-shadow: inset 0 0 0 1px var( --free-domain-upsell-ring-hover );
+		color: var( --free-domain-upsell-text-hover );
+	}
+
+	&:hover svg,
+	&:focus-visible svg {
+		color: var( --free-domain-upsell-icon-hover );
+	}
+}

--- a/client/dashboard/app/omnibar/plugin-free-domain-upsell-experiment.tsx
+++ b/client/dashboard/app/omnibar/plugin-free-domain-upsell-experiment.tsx
@@ -1,0 +1,30 @@
+import { Icon } from '@wordpress/components';
+import { upsell } from '../../components/icons';
+import type { AnalyticsClient } from '../analytics';
+import type { AdminBarNode, OmnibarNode } from '@automattic/omnibar';
+
+import './plugin-free-domain-upsell-experiment.scss';
+
+export function createFreeDomainUpsellNodeBuilder( {
+	source,
+	recordTracksEvent,
+}: {
+	source: string;
+	recordTracksEvent: AnalyticsClient[ 'recordTracksEvent' ];
+} ) {
+	return ( adminBarNode: AdminBarNode ): Partial< OmnibarNode > => {
+		const eventProps = {
+			upsell_id: 'omnibar-free-domain',
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			upsell_source: ( adminBarNode.meta as any )?.upsell_source as string | undefined,
+			source,
+		};
+
+		return {
+			icon: <Icon icon={ upsell } size={ 16 } />,
+			className: 'omnibar__free-domain-upsell',
+			onView: () => recordTracksEvent( 'calypso_omnibar_upsell_impression', eventProps ),
+			onClick: () => recordTracksEvent( 'calypso_omnibar_upsell_click', eventProps ),
+		};
+	};
+}

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -1,5 +1,7 @@
+import { queryClient, siteAdminBarQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
 import { getUrlParts } from '@automattic/calypso-url';
+import { useQuery } from '@tanstack/react-query';
 import { localize } from 'i18n-calypso';
 import moment from 'moment';
 import PropTypes from 'prop-types';
@@ -23,6 +25,33 @@ import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 
 const loadJitm = () =>
 	import( /* webpackChunkName: "async-load-calypso-blocks-jitm" */ 'calypso/blocks/jitm' );
+
+const FREE_DOMAIN_UPSELL_NODE_ID = 'free-domain-upsell';
+
+export function SidebarJitm( { siteId } ) {
+	const { data: adminBar, isPending } = useQuery(
+		{ ...siteAdminBarQuery( siteId ), enabled: !! siteId },
+		queryClient
+	);
+
+	if ( siteId && isPending ) {
+		return null;
+	}
+
+	const replacedMessageId = adminBar?.nodes.find(
+		( node ) => node.id === FREE_DOMAIN_UPSELL_NODE_ID
+	)?.meta?.upsell_source;
+
+	return (
+		<AsyncLoad
+			require={ loadJitm }
+			placeholder={ null }
+			messagePath="calypso:sites:sidebar_notice"
+			template="sidebar-banner"
+			suppressedMessageIds={ replacedMessageId ? [ replacedMessageId ] : undefined }
+		/>
+	);
+}
 
 export class SiteNotice extends Component {
 	static propTypes = {
@@ -121,14 +150,7 @@ export class SiteNotice extends Component {
 			<div className="current-site__notices">
 				<QueryActivePromotions />
 				{ siteRedirectNotice }
-				{ showJitms && (
-					<AsyncLoad
-						require={ loadJitm }
-						placeholder={ null }
-						messagePath="calypso:sites:sidebar_notice"
-						template="sidebar-banner"
-					/>
-				) }
+				{ showJitms && <SidebarJitm siteId={ site.ID } /> }
 				<QuerySitePlans siteId={ site.ID } />
 			</div>
 		);

--- a/packages/api-core/src/admin-bar/types.ts
+++ b/packages/api-core/src/admin-bar/types.ts
@@ -6,6 +6,8 @@ export interface AdminBarNode {
 	group: boolean;
 	meta?: {
 		menu_title?: string;
+		title?: string;
+		class?: string;
 	};
 }
 

--- a/packages/omnibar/src/components/omnibar-menu.tsx
+++ b/packages/omnibar/src/components/omnibar-menu.tsx
@@ -1,7 +1,7 @@
 import { privateApis } from '@wordpress/components';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { Button } from '@wordpress/ui';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { OmnibarNodeContent } from './omnibar-node';
 import type { OmnibarNode } from '../types';
 
@@ -13,7 +13,21 @@ const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
 );
 const { Menu } = unlock( privateApis );
 
+function useOnView( onView?: () => void ) {
+	const hasViewed = useRef( false );
+
+	useEffect( () => {
+		if ( hasViewed.current || ! onView ) {
+			return;
+		}
+		hasViewed.current = true;
+		onView();
+	}, [ onView ] );
+}
+
 function OmnibarMenuItem( { node }: { node: OmnibarNode } ) {
+	useOnView( node.onView );
+
 	if ( node.children?.length ) {
 		return (
 			<Menu>
@@ -38,7 +52,7 @@ function OmnibarMenuItem( { node }: { node: OmnibarNode } ) {
 	return (
 		<Menu.Item
 			tabbable
-			render={ node.href ? <a href={ node.href } /> : undefined }
+			render={ node.href ? <a href={ node.href } title={ node.tooltip } /> : undefined }
 			onClick={ node.onClick }
 		>
 			<OmnibarNodeContent node={ node } />
@@ -87,6 +101,8 @@ function OmnibarMenuContent( { nodes }: { nodes: OmnibarNode[] } ) {
 }
 
 export function OmnibarMenu( { node, className }: { node: OmnibarNode; className?: string } ) {
+	useOnView( node.onView );
+
 	const label = node.title || node.label || '';
 	const menuClassName = [ 'omnibar__menu', className, node.className, node.active && 'is-active' ]
 		.filter( Boolean )
@@ -116,6 +132,7 @@ export function OmnibarMenu( { node, className }: { node: OmnibarNode; className
 				disabled={ node.disabled }
 				onClick={ node.onClick }
 				aria-label={ label }
+				title={ node.tooltip }
 			>
 				<OmnibarNodeContent node={ node } />
 			</Button>
@@ -172,6 +189,7 @@ export function OmnibarMenu( { node, className }: { node: OmnibarNode; className
 						variant="unstyled"
 						className={ menuClassName }
 						aria-label={ label }
+						title={ node.tooltip }
 						render={ node.href ? <a href={ node.href } /> : undefined }
 						nativeButton={ ! node.href }
 					>

--- a/packages/omnibar/src/types/admin-bar.ts
+++ b/packages/omnibar/src/types/admin-bar.ts
@@ -6,6 +6,7 @@ export interface AdminBarNode {
 	group: boolean;
 	meta?: {
 		menu_title?: string;
+		title?: string;
 		class?: string;
 	};
 }

--- a/packages/omnibar/src/types/omnibar.ts
+++ b/packages/omnibar/src/types/omnibar.ts
@@ -4,11 +4,13 @@ export interface OmnibarNode {
 	id: string;
 	title?: string;
 	label?: string;
+	tooltip?: string;
 	icon?: React.ReactElement;
 	group?: boolean;
 	variant?: 'secondary';
 	href?: string;
 	onClick?: ( event: React.MouseEvent ) => void;
+	onView?: () => void;
 	disabled?: boolean;
 	active?: boolean;
 	className?: string;

--- a/packages/omnibar/src/utils/admin-bar.tsx
+++ b/packages/omnibar/src/utils/admin-bar.tsx
@@ -20,6 +20,7 @@ export function buildOmnibarNodesFromAdminBarNodes(
 		const omnibarNode: OmnibarNode = {
 			id: node.id,
 			title: node.meta?.menu_title || node.title || '',
+			tooltip: node.meta?.title || undefined,
 			href: node.href && resolveHref ? resolveHref( node.href ) : node.href,
 			group: node.group,
 		};
@@ -127,6 +128,12 @@ export function buildOmnibarNodesFromAdminBarNodes(
 					displayName: doc.querySelector( '.display-name' )?.textContent?.trim(),
 					username: doc.querySelector( '.username' )?.textContent?.trim(),
 				};
+				break;
+			}
+			default: {
+				if ( ! node.parent ) {
+					siteActionNodes.push( omnibarNode );
+				}
 				break;
 			}
 		}


### PR DESCRIPTION
Part of DOTMSD-1529

Reworked from https://github.com/Automattic/wp-calypso/pull/113748

## Proposed Changes

- Consume the new "Free domain" chip from https://github.com/Automattic/jetpack/pull/51815 and add it to the omnibar.
- Hide the corresponding JITM sidebar notices when the upsell is shown in the omnibar.

## Testing Instructions

 WIP