### PR TITLE
Reader: restore the shelf button box in the full-post action bar

### DIFF
--- a/client/blocks/reader-full-post/style.scss
+++ b/client/blocks/reader-full-post/style.scss
@@ -178,7 +178,7 @@ $reader-full-post-desktop-min: $reader-full-post-sidebar-width + $reader-full-po
 	.post-edit-button,
 	.reader-full-post__view-original-button,
 	.reader-full-post__seen-button,
-	.reader-subscribe-with-space__spaces,
+	.reader-subscribe-with-shelf__shelves,
 	.follow-button {
 		margin: 0;
 		padding: 8px 16px;

--- a/client/reader/shelves/subscribe-with-shelf/style.scss
+++ b/client/reader/shelves/subscribe-with-shelf/style.scss
@@ -1,17 +1,5 @@
 @use 'calypso/reader/shelves/colors' as shelf-colors;
 
-// The full-post action bar sizes its controls at 8px/16px padding, but
-// `.components-button.has-icon.is-next-40px-default-size` outranks that shared
-// rule and would pin this to a 40px square, 2px short of its neighbours.
-.reader-subscribe-with-shelf__shelves.components-button.has-icon {
-	width: 58px;
-	height: 42px;
-	padding: 8px 16px;
-	border: 1px solid var( --color-neutral-10 );
-	border-radius: 4px;
-	background: var( --color-surface );
-}
-
 // Fixed-height flex column: static header + feed preview + search, a scrolling
 // list, and a pinned footer — so only the list scrolls, not the whole modal.
 // Mirrors the customize-shelf modal layout.

--- a/client/reader/shelves/subscribe-with-shelf/style.scss
+++ b/client/reader/shelves/subscribe-with-shelf/style.scss
@@ -1,5 +1,17 @@
 @use 'calypso/reader/shelves/colors' as shelf-colors;
 
+// The full-post action bar sizes its controls at 8px/16px padding, but
+// `.components-button.has-icon.is-next-40px-default-size` outranks that shared
+// rule and would pin this to a 40px square, 2px short of its neighbours.
+.reader-subscribe-with-shelf__shelves.components-button.has-icon {
+	width: 58px;
+	height: 42px;
+	padding: 8px 16px;
+	border: 1px solid var( --color-neutral-10 );
+	border-radius: 4px;
+	background: var( --color-surface );
+}
+
 // Fixed-height flex column: static header + feed preview + search, a scrolling
 // list, and a pinned footer — so only the list scrolls, not the whole modal.
 // Mirrors the customize-shelf modal layout.


### PR DESCRIPTION
Closes READ-709


| Before | After |
|--------|--------|
| <img width="1714" height="1816" alt="CleanShot 2026-09-02 at 10 43 57@2x" src="https://github.com/user-attachments/assets/8c7dc092-adf6-4483-96c4-9f9ef5422862" /> | <img width="1712" height="1816" alt="CleanShot 2026-09-02 at 10 41 56@2x" src="https://github.com/user-attachments/assets/5eb2b6dc-00c8-4da0-824f-d725d3d9b249" /> | 

## Proposed Changes

* Point the full-post action bar's shared control styles at `.reader-subscribe-with-shelf__shelves`, so the Shelves button gets the border, background, hover state, dark-theme treatment and icon opacity that every other control in that row already has.

## Why are these changes being made?

In the full-post action bar the Shelves button rendered as a bare icon, with no box around it, while every control next to it sat inside one.

The cause is a stale selector in `client/blocks/reader-full-post/style.scss`: it still carried the button's old class name, so it matched nothing and the shared control styles never reached the button. It was the last orphaned selector of its kind left in `client/`.

That shared rule carries more than the box — the hover border, the `svg` opacity treatment, the transition, and the whole dark-theme block are all keyed off the same selector list. Restoring the match brings the button back in line with its neighbours on every one of those, rather than just repainting a border onto it.

## Testing Instructions

Requires the `reader/shelves` feature flag.

### Scenario 1 - Shelves button in the full post action bar:
- Go to `/reader/feeds/:feed_id/posts/:post_id` for any subscribed feed
- Check if you can see the Shelves icon, next to the Subscribe button, rendered inside a bordered rounded box with a white background
- Check if you can see the Shelves button aligned to the same height as the Comment, Like and Subscribe buttons next to it, with no vertical offset

### Scenario 2 - Hover state:
- Go to `/reader/feeds/:feed_id/posts/:post_id`
- Hover the Shelves button
- Check if you can see its border darken and its icon go to full opacity, matching what the Comment and Like buttons do on hover

### Scenario 3 - Dark mode:
- Go to `/reader/feeds/:feed_id/posts/:post_id` with the Reader in dark mode
- Check if you can see the Shelves button with a transparent background and the same border colour as the Comment, Like and Subscribe buttons
- Hover the Shelves button and check if you can see the border and icon pick up the link colour, like its neighbours

### Scenario 4 - Shelf feed layouts are unchanged:
- Go to a shelf feed using the Standard list or Gallery layout
- Check if you can see the Shelves action in each post row still rendered borderless and compact, exactly as before this change

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
