### PR TITLE
Logged-in homepage: let users turn the signed-in WordPress.com homepage on or off

### DIFF
--- a/client/dashboard/me/preferences-defaults/index.tsx
+++ b/client/dashboard/me/preferences-defaults/index.tsx
@@ -27,6 +27,7 @@ type LandingPage = 'primary-site-dashboard' | 'sites' | 'reader';
 
 interface DefaultLandingFormData {
 	defaultLandingPage: LandingPage;
+	showHomepage?: boolean;
 }
 
 interface PrimarySiteFormData {
@@ -36,26 +37,29 @@ interface PrimarySiteFormData {
 function LandingPageCard() {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	const { data: defaultLandingPage } = useSuspenseQuery( {
+	const { data: initialFormData } = useSuspenseQuery( {
 		...rawUserPreferencesQuery(),
-		select: ( preferences ): LandingPage => {
+		select: ( preferences ): DefaultLandingFormData => {
+			let defaultLandingPage: LandingPage = 'primary-site-dashboard';
 			if ( preferences[ 'sites-landing-page' ]?.useSitesAsLandingPage ) {
-				return 'sites';
+				defaultLandingPage = 'sites';
+			} else if ( preferences[ 'reader-landing-page' ]?.useReaderAsLandingPage ) {
+				defaultLandingPage = 'reader';
 			}
-			if ( preferences[ 'reader-landing-page' ]?.useReaderAsLandingPage ) {
-				return 'reader';
-			}
-			return 'primary-site-dashboard';
+			return {
+				defaultLandingPage,
+				showHomepage: preferences[ 'logged-in-homepage' ]?.show,
+			};
 		},
 	} );
 
 	const { mutateAsync: saveUserPreferences, isPending } = useMutation( userPreferencesMutation() );
 
-	const [ formData, setFormData ] = useState< DefaultLandingFormData >( {
-		defaultLandingPage,
-	} );
+	const [ formData, setFormData ] = useState< DefaultLandingFormData >( initialFormData );
 
-	const isDirty = defaultLandingPage !== formData.defaultLandingPage;
+	const isDirty =
+		initialFormData.defaultLandingPage !== formData.defaultLandingPage ||
+		initialFormData.showHomepage !== formData.showHomepage;
 
 	const fields: Field< DefaultLandingFormData >[] = [
 		{
@@ -68,11 +72,17 @@ function LandingPageCard() {
 				{ label: __( 'View posts from sites you follow.' ), value: 'reader' },
 			] satisfies { label: string; value: LandingPage }[],
 		},
+		{
+			id: 'showHomepage',
+			label: __( 'Show the WordPress.com homepage when signed in' ),
+			Edit: 'checkbox',
+			isVisible: () => initialFormData.showHomepage !== undefined,
+		},
 	];
 
 	const form = {
 		layout: { type: 'regular' as const },
-		fields: [ 'defaultLandingPage' ],
+		fields: [ 'defaultLandingPage', 'showHomepage' ],
 	};
 
 	const handleSubmit = ( e: React.FormEvent ) => {
@@ -87,6 +97,12 @@ function LandingPageCard() {
 				useReaderAsLandingPage: formData.defaultLandingPage === 'reader',
 				updatedAt,
 			},
+			...( initialFormData.showHomepage !== undefined && {
+				'logged-in-homepage': {
+					show: !! formData.showHomepage,
+					updatedAt,
+				},
+			} ),
 		} )
 			.then( () => {
 				createSuccessNotice( __( 'Default landing page saved.' ), {

--- a/client/dashboard/me/preferences-defaults/index.tsx
+++ b/client/dashboard/me/preferences-defaults/index.tsx
@@ -6,7 +6,7 @@ import {
 	userSettingsQuery,
 } from '@automattic/api-queries';
 import { useMutation, useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { __experimentalVStack as VStack, Button } from '@wordpress/components';
+import { __experimentalVStack as VStack, Button, CheckboxControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { DataForm, Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
@@ -72,17 +72,11 @@ function LandingPageCard() {
 				{ label: __( 'View posts from sites you follow.' ), value: 'reader' },
 			] satisfies { label: string; value: LandingPage }[],
 		},
-		{
-			id: 'showHomepage',
-			label: __( 'Show the WordPress.com homepage when signed in' ),
-			Edit: 'checkbox',
-			isVisible: () => initialFormData.showHomepage !== undefined,
-		},
 	];
 
 	const form = {
 		layout: { type: 'regular' as const },
-		fields: [ 'defaultLandingPage', 'showHomepage' ],
+		fields: [ 'defaultLandingPage' ],
 	};
 
 	const handleSubmit = ( e: React.FormEvent ) => {
@@ -97,12 +91,13 @@ function LandingPageCard() {
 				useReaderAsLandingPage: formData.defaultLandingPage === 'reader',
 				updatedAt,
 			},
-			...( initialFormData.showHomepage !== undefined && {
-				'logged-in-homepage': {
-					show: !! formData.showHomepage,
-					updatedAt,
-				},
-			} ),
+			...( initialFormData.showHomepage !== undefined &&
+				initialFormData.showHomepage !== formData.showHomepage && {
+					'logged-in-homepage': {
+						show: !! formData.showHomepage,
+						updatedAt,
+					},
+				} ),
 		} )
 			.then( () => {
 				createSuccessNotice( __( 'Default landing page saved.' ), {
@@ -120,21 +115,33 @@ function LandingPageCard() {
 		<Card>
 			<CardBody>
 				<form onSubmit={ handleSubmit } aria-label={ __( 'Landing page' ) }>
-					<VStack spacing={ 4 }>
-						<SectionHeader
-							level={ 3 }
-							title={ __( 'Landing page' ) }
-							description={ __( 'Choose your destination after you log in.' ) }
-						/>
-						<NavigationBlocker shouldBlock={ isDirty } />
-						<DataForm< DefaultLandingFormData >
-							data={ formData }
-							fields={ fields }
-							form={ form }
-							onChange={ ( edits: Partial< DefaultLandingFormData > ) => {
-								setFormData( ( data ) => ( { ...data, ...edits } ) );
-							} }
-						/>
+					<VStack spacing={ 6 }>
+						<VStack spacing={ 4 }>
+							<SectionHeader
+								level={ 3 }
+								title={ __( 'Landing page' ) }
+								description={ __( 'Choose your destination after you log in.' ) }
+							/>
+							<NavigationBlocker shouldBlock={ isDirty } />
+							<DataForm< DefaultLandingFormData >
+								data={ formData }
+								fields={ fields }
+								form={ form }
+								onChange={ ( edits: Partial< DefaultLandingFormData > ) => {
+									setFormData( ( data ) => ( { ...data, ...edits } ) );
+								} }
+							/>
+						</VStack>
+						{ initialFormData.showHomepage !== undefined && (
+							<CheckboxControl
+								__nextHasNoMarginBottom
+								label={ __( 'Show the WordPress.com homepage when signed in' ) }
+								checked={ !! formData.showHomepage }
+								onChange={ ( showHomepage ) => {
+									setFormData( ( data ) => ( { ...data, showHomepage } ) );
+								} }
+							/>
+						) }
 						<ButtonStack>
 							<Button
 								__next40pxDefaultSize

--- a/client/dashboard/me/preferences-defaults/index.tsx
+++ b/client/dashboard/me/preferences-defaults/index.tsx
@@ -12,6 +12,7 @@ import { DataForm, Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState } from 'react';
+import { useAnalytics } from '../../app/analytics';
 import { useAuth } from '../../app/auth';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useAppContext } from '../../app/context';
@@ -36,6 +37,7 @@ interface PrimarySiteFormData {
 
 function LandingPageCard() {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { recordTracksEvent } = useAnalytics();
 
 	const { data: initialFormData } = useSuspenseQuery( {
 		...rawUserPreferencesQuery(),
@@ -100,6 +102,12 @@ function LandingPageCard() {
 				} ),
 		} )
 			.then( () => {
+				if ( initialFormData.showHomepage !== formData.showHomepage ) {
+					recordTracksEvent( 'calypso_dashboard_preferences_defaults_homepage_toggle', {
+						show: !! formData.showHomepage,
+						source: 'account_defaults',
+					} );
+				}
 				createSuccessNotice( __( 'Default landing page saved.' ), {
 					type: 'snackbar',
 				} );

--- a/client/dashboard/me/preferences-defaults/test/index.test.tsx
+++ b/client/dashboard/me/preferences-defaults/test/index.test.tsx
@@ -162,6 +162,77 @@ describe( '<PreferencesDefaults>', () => {
 		} );
 	} );
 
+	describe( 'homepage', () => {
+		const homepageLabel = 'Show the WordPress.com homepage when signed in';
+
+		test( 'is hidden when the user has never decided', async () => {
+			mockPreferences();
+			mockUserSettings();
+			mockSites( [ primarySite, otherSite ] );
+			mockSite( primarySite );
+
+			renderPage();
+
+			await screen.findByRole( 'form', { name: 'Landing page' } );
+			expect( screen.queryByLabelText( homepageLabel ) ).not.toBeInTheDocument();
+		} );
+
+		test( 'reflects a saved preference to show the homepage', async () => {
+			mockPreferences( {
+				'logged-in-homepage': { show: true, updatedAt: 0 },
+			} );
+			mockUserSettings();
+			mockSites( [ primarySite, otherSite ] );
+			mockSite( primarySite );
+
+			renderPage();
+
+			await expect( screen.findByLabelText( homepageLabel ) ).resolves.toBeChecked();
+		} );
+
+		test( 'reflects a saved preference to hide the homepage', async () => {
+			mockPreferences( {
+				'logged-in-homepage': { show: false, updatedAt: 0 },
+			} );
+			mockUserSettings();
+			mockSites( [ primarySite, otherSite ] );
+			mockSite( primarySite );
+
+			renderPage();
+
+			await expect( screen.findByLabelText( homepageLabel ) ).resolves.not.toBeChecked();
+		} );
+
+		test( 'saves the checkbox state alongside the landing page', async () => {
+			const currentUser = userEvent.setup();
+			mockPreferences( {
+				'logged-in-homepage': { show: false, updatedAt: 0 },
+			} );
+			mockUserSettings();
+			mockSites( [ primarySite, otherSite ] );
+			mockSite( primarySite );
+			let savedBody: Record< string, unknown > = {};
+			const saveRequest = nock( 'https://public-api.wordpress.com' )
+				.post( '/rest/v1.1/me/preferences', ( body ) => {
+					savedBody = body;
+					return true;
+				} )
+				.reply( 200, { calypso_preferences: {} } );
+
+			renderPage();
+
+			await currentUser.click( await screen.findByLabelText( homepageLabel ) );
+			await currentUser.click( saveButtonFor( 'Landing page' ) );
+
+			await waitFor( () => expect( saveRequest.isDone() ).toBe( true ) );
+			const savedPreferences = savedBody.calypso_preferences as Record< string, unknown >;
+			expect( savedPreferences[ 'logged-in-homepage' ] ).toMatchObject( { show: true } );
+			expect(
+				typeof ( savedPreferences[ 'logged-in-homepage' ] as { updatedAt: number } ).updatedAt
+			).toBe( 'number' );
+		} );
+	} );
+
 	describe( 'primary site', () => {
 		test( 'shows the saved primary site even when it is absent from the site list', async () => {
 			mockPreferences();

--- a/client/dashboard/me/preferences-defaults/test/index.test.tsx
+++ b/client/dashboard/me/preferences-defaults/test/index.test.tsx
@@ -257,6 +257,50 @@ describe( '<PreferencesDefaults>', () => {
 			const savedPreferences = savedBody.calypso_preferences as Record< string, unknown >;
 			expect( savedPreferences ).not.toHaveProperty( 'logged-in-homepage' );
 		} );
+
+		test( 'records a Tracks event when the checkbox is changed', async () => {
+			const currentUser = userEvent.setup();
+			mockPreferences( {
+				'logged-in-homepage': { show: false, updatedAt: 0 },
+			} );
+			mockUserSettings();
+			mockSites( [ primarySite, otherSite ] );
+			mockSite( primarySite );
+			const saveRequest = mockPreferencesSaved();
+
+			const { recordTracksEvent } = renderPage();
+
+			await currentUser.click( await screen.findByLabelText( homepageLabel ) );
+			await currentUser.click( saveButtonFor( 'Landing page' ) );
+
+			await waitFor( () => expect( saveRequest.isDone() ).toBe( true ) );
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_dashboard_preferences_defaults_homepage_toggle',
+				{ show: true, source: 'account_defaults' }
+			);
+		} );
+
+		test( 'does not record a Tracks event on a radio-only save', async () => {
+			const currentUser = userEvent.setup();
+			mockPreferences( {
+				'logged-in-homepage': { show: false, updatedAt: 0 },
+			} );
+			mockUserSettings();
+			mockSites( [ primarySite, otherSite ] );
+			mockSite( primarySite );
+			const saveRequest = mockPreferencesSaved();
+
+			const { recordTracksEvent } = renderPage();
+
+			await currentUser.click( await screen.findByLabelText( 'See a list of all your sites.' ) );
+			await currentUser.click( saveButtonFor( 'Landing page' ) );
+
+			await waitFor( () => expect( saveRequest.isDone() ).toBe( true ) );
+			expect( recordTracksEvent ).not.toHaveBeenCalledWith(
+				'calypso_dashboard_preferences_defaults_homepage_toggle',
+				expect.anything()
+			);
+		} );
 	} );
 
 	describe( 'primary site', () => {

--- a/client/dashboard/me/preferences-defaults/test/index.test.tsx
+++ b/client/dashboard/me/preferences-defaults/test/index.test.tsx
@@ -231,6 +231,32 @@ describe( '<PreferencesDefaults>', () => {
 				typeof ( savedPreferences[ 'logged-in-homepage' ] as { updatedAt: number } ).updatedAt
 			).toBe( 'number' );
 		} );
+
+		test( 'leaves the homepage preference untouched on a radio-only save', async () => {
+			const currentUser = userEvent.setup();
+			mockPreferences( {
+				'logged-in-homepage': { show: false, updatedAt: 0 },
+			} );
+			mockUserSettings();
+			mockSites( [ primarySite, otherSite ] );
+			mockSite( primarySite );
+			let savedBody: Record< string, unknown > = {};
+			const saveRequest = nock( 'https://public-api.wordpress.com' )
+				.post( '/rest/v1.1/me/preferences', ( body ) => {
+					savedBody = body;
+					return true;
+				} )
+				.reply( 200, { calypso_preferences: {} } );
+
+			renderPage();
+
+			await currentUser.click( await screen.findByLabelText( 'See a list of all your sites.' ) );
+			await currentUser.click( saveButtonFor( 'Landing page' ) );
+
+			await waitFor( () => expect( saveRequest.isDone() ).toBe( true ) );
+			const savedPreferences = savedBody.calypso_preferences as Record< string, unknown >;
+			expect( savedPreferences ).not.toHaveProperty( 'logged-in-homepage' );
+		} );
 	} );
 
 	describe( 'primary site', () => {

--- a/packages/api-core/src/me-preferences/types.ts
+++ b/packages/api-core/src/me-preferences/types.ts
@@ -22,6 +22,11 @@ export interface ReaderLandingPage extends LandingPagePreference {
 	useReaderAsLandingPage: boolean;
 }
 
+export interface LoggedInHomepagePreference {
+	show: boolean;
+	updatedAt: number; // Result of Date.now()
+}
+
 export interface VisitCounter {
 	count: number;
 	lastUpdated: number | null; // Result of Date.now(), or null before the first visit
@@ -45,6 +50,7 @@ export interface UserPreferences {
 	'account-recovery-interstitial-dismiss-count'?: number; // How many times the user has dismissed the account-recovery interstitial; capped so we stop nudging after a few dismissals
 	'reader-landing-page'?: ReaderLandingPage;
 	'sites-landing-page'?: SitesLandingPage;
+	'logged-in-homepage'?: LoggedInHomepagePreference;
 	[ key: `cancel-purchase-survey-completed-${ string | number }` ]: string | undefined;
 	[ key: `cancellation-offer-accepted-notice-dismissed-${ string | number }` ]: string | undefined;
 	'achievements-visibility'?: 'public' | 'private';

--- a/packages/api-queries/src/me-preferences.ts
+++ b/packages/api-queries/src/me-preferences.ts
@@ -21,6 +21,10 @@ const defaultValues: Required< UserPreferences > = {
 		useSitesAsLandingPage: false,
 		updatedAt: 0,
 	},
+	'logged-in-homepage': {
+		show: true,
+		updatedAt: 0,
+	},
 	'achievements-visibility': 'private',
 	'achievements-global-notifications': 'enabled',
 	'reader-profile-posts-visibility': 'public',
@@ -42,6 +46,7 @@ const staticPreferenceStatIds: Record< string, string > = {
 	'account-recovery-interstitial-dismiss-count': 'acrdis',
 	'reader-landing-page': 'rdland',
 	'sites-landing-page': 'stland',
+	'logged-in-homepage': 'lohp',
 	'achievements-visibility': 'achvis',
 	'achievements-global-notifications': 'achnot',
 	'reader-profile-posts-visibility': 'postvis',


### PR DESCRIPTION
Related to [MARTECH-2561](https://linear.app/a8c/issue/MARTECH-2561/logged-in-lohp-make-the-lohp-accessible-to-logged-in-users)

## Proposed Changes

* Add a checkbox to Account defaults so signed-in users can choose whether the WordPress.com homepage opens for them, saved alongside the existing landing-page setting.
* Only show the checkbox to users who've already made a choice about the homepage (e.g. from the on-page banner); no one else sees a new setting.

## Why are these changes being made?

* The signed-in WordPress.com homepage now has an opt-out banner. This setting is the mirror of that choice inside Account defaults, so people can change their mind later without hunting for the banner again.

## Testing Instructions

* Visit `my.wordpress.com/me/preferences/defaults`. If your account has no saved homepage preference yet, the new checkbox is not shown.
* With a saved preference (`logged-in-homepage` in `calypso_preferences`), the checkbox appears under Landing page, reflects the saved value, and Save writes the change alongside the landing-page radios.
* Pairs with the wpcom side, wpcom#238646, which shows the banner and stores the preference; the checkbox only appears once that preference exists.

<img width="480" alt="account-defaults" src="https://github.com/user-attachments/assets/6454af9e-ab43-4ec2-b098-4a196c521040" />


## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
