### PR TITLE
Site Launch Modals: set an explicit font-family on the modals

### DIFF
--- a/packages/site-launch-modals/package.json
+++ b/packages/site-launch-modals/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/site-launch-modals",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Presentational modals for the WordPress.com site-launch flow (pre-launch confirmation and post-launch celebration).",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/site-launch-modals/src/celebration-modal/style.scss
+++ b/packages/site-launch-modals/src/celebration-modal/style.scss
@@ -1,11 +1,8 @@
 @import '@wordpress/base-styles/variables';
 
 .celebration-modal {
-	// The modal renders through a portal onto `document.body`, so it inherits the
-	// host document's font. In contexts where that font is not the WordPress admin
-	// sans-serif (e.g. a site preview showing the theme's typography, or wp-admin),
-	// the modal would otherwise pick up the wrong font. Set it explicitly so the
-	// component stays self-contained wherever it is mounted.
+	// Set the font explicitly so the modal doesn't inherit the host page's font
+	// (e.g. a site theme's typography when shown over a site preview).
 	font-family: $default-font;
 
 	.flex-shrink-safe {

--- a/packages/site-launch-modals/src/celebration-modal/style.scss
+++ b/packages/site-launch-modals/src/celebration-modal/style.scss
@@ -1,6 +1,13 @@
 @import '@wordpress/base-styles/variables';
 
 .celebration-modal {
+	// The modal renders through a portal onto `document.body`, so it inherits the
+	// host document's font. In contexts where that font is not the WordPress admin
+	// sans-serif (e.g. a site preview showing the theme's typography, or wp-admin),
+	// the modal would otherwise pick up the wrong font. Set it explicitly so the
+	// component stays self-contained wherever it is mounted.
+	font-family: $default-font;
+
 	.flex-shrink-safe {
 		flex: 1;
 		min-width: 0;

--- a/packages/site-launch-modals/src/pre-launch-modal/style.scss
+++ b/packages/site-launch-modals/src/pre-launch-modal/style.scss
@@ -1,10 +1,7 @@
 @import '@wordpress/base-styles/variables';
 
-// The modal renders through a portal onto `document.body`, so it inherits the
-// host document's font. In contexts where that font is not the WordPress admin
-// sans-serif (e.g. a site preview showing the theme's typography, or wp-admin),
-// the modal would otherwise pick up the wrong font. Set it explicitly so the
-// component stays self-contained wherever it is mounted.
+// Set the font explicitly so the modal doesn't inherit the host page's font
+// (e.g. a site theme's typography when shown over a site preview).
 .site-launch-pre-launch-modal {
 	font-family: $default-font;
 }

--- a/packages/site-launch-modals/src/pre-launch-modal/style.scss
+++ b/packages/site-launch-modals/src/pre-launch-modal/style.scss
@@ -1,5 +1,14 @@
 @import '@wordpress/base-styles/variables';
 
+// The modal renders through a portal onto `document.body`, so it inherits the
+// host document's font. In contexts where that font is not the WordPress admin
+// sans-serif (e.g. a site preview showing the theme's typography, or wp-admin),
+// the modal would otherwise pick up the wrong font. Set it explicitly so the
+// component stays self-contained wherever it is mounted.
+.site-launch-pre-launch-modal {
+	font-family: $default-font;
+}
+
 .site-launch-pre-launch-modal__preview-card {
 	padding: $grid-unit-20 $grid-unit-20;
 	background-color: var( --studio-blue-5 );


### PR DESCRIPTION
## Proposed Changes

* Set an explicit `font-family` (`$default-font`) on the pre-launch and celebration modals in `@automattic/site-launch-modals`.

## Why are these changes being made?

The modals render through a `@wordpress/components` `Modal`, which portals onto `document.body`, outside the app's React root. Neither the package nor the underlying `Modal`/`Text` primitives declare a `font-family`, so the modal inherited whatever font the host document used.

This worked in the classic Calypso dashboard and the new Dashboard because both set a sans-serif font on `body`. But when the pre-launch modal is opened from the masterbar launch button in site-preview mode, the surrounding page is the site's front-end, so the modal inherited the site theme's font (serif in the reported case). The package is intended to be portable to any host (including wp-admin), so it should own its typography rather than rely on inheritance.

## Testing Instructions

* Open a site in preview mode (front-end view) on a site with a serif theme.
* Click the launch button in the masterbar (requires a paid plan and a custom domain so the pre-launch confirmation modal appears).
* Confirm the modal text now renders in the standard sans-serif font instead of the theme's serif font.
* Launch a site and confirm the celebration modal text also renders in sans-serif.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)