### PR TITLE
A4A: switch a8c-components Badge to wp-ui

### DIFF
--- a/client/a8c-for-agencies/components/agency-site-tag/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tag/index.tsx
@@ -1,5 +1,6 @@
-import { Badge } from '@wordpress/ui';
 import { Icon, closeSmall } from '@wordpress/icons';
+import { Badge } from '@wordpress/ui';
+
 import './style.scss';
 
 interface Props {
@@ -10,8 +11,8 @@ interface Props {
 
 export default function AgencySiteTag( { tag, onRemoveTag, isRemovable = true }: Props ) {
 	return (
-		<Badge className="agency-site-tag" intent="informational">
-			<span className="agency-site-tag__text">{ tag }</span>
+		<span className="agency-site-tag">
+			<Badge intent="informational">{ tag }</Badge>
 			{ isRemovable && (
 				<Icon
 					className="agency-site-tag__close"
@@ -19,6 +20,6 @@ export default function AgencySiteTag( { tag, onRemoveTag, isRemovable = true }:
 					icon={ closeSmall }
 				/>
 			) }
-		</Badge>
+		</span>
 	);
 }

--- a/client/a8c-for-agencies/components/agency-site-tag/index.tsx
+++ b/client/a8c-for-agencies/components/agency-site-tag/index.tsx
@@ -1,4 +1,4 @@
-import { Badge } from '@automattic/components';
+import { Badge } from '@wordpress/ui';
 import { Icon, closeSmall } from '@wordpress/icons';
 import './style.scss';
 
@@ -10,7 +10,7 @@ interface Props {
 
 export default function AgencySiteTag( { tag, onRemoveTag, isRemovable = true }: Props ) {
 	return (
-		<Badge className="agency-site-tag" type="info">
+		<Badge className="agency-site-tag" intent="informational">
 			<span className="agency-site-tag__text">{ tag }</span>
 			{ isRemovable && (
 				<Icon

--- a/client/a8c-for-agencies/components/agency-site-tag/style.scss
+++ b/client/a8c-for-agencies/components/agency-site-tag/style.scss
@@ -1,25 +1,9 @@
-@import "@wordpress/base-styles/variables";
-@import "@wordpress/base-styles/mixins";
-
-.agency-site-tag.badge {
-	background: var(--studio-gray-5);
-	border-radius: 4px;
-	padding: 5px 14px 11px 11px;
-}
-
-.agency-site-tag__text,
-.agency-site-tag__close {
-	display: inline;
-	vertical-align: middle;
-}
-
-.agency-site-tag__text {
-	@include body-small;
+.agency-site-tag {
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
 }
 
 .agency-site-tag__close {
 	cursor: pointer;
-	position: relative;
-	left: 9px;
-	top: 1px;
 }

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-migrations-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-migrations-menu-items.tsx
@@ -59,8 +59,8 @@ const useMigrationsMenuItems = ( path: string ) => {
 						extraContent: (
 							<StatusBadge
 								statusProps={ {
-									children: 1,
-									type: accountStatus.statusType,
+									children: '1',
+									intent: accountStatus.badgeIntent,
 									isRounded: true,
 									tooltip: accountStatus.statusReason,
 								} }

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-referrals-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-referrals-menu-items.tsx
@@ -47,8 +47,8 @@ const useReferralsMenuItems = ( path: string ) => {
 						extraContent: (
 							<StatusBadge
 								statusProps={ {
-									children: 1,
-									type: accountStatus.statusType,
+									children: '1',
+									intent: accountStatus.badgeIntent,
 									isRounded: true,
 									tooltip: accountStatus.statusReason,
 								} }

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-woopayments-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-woopayments-menu-items.tsx
@@ -59,8 +59,8 @@ const useWooPaymentsMenuItems = ( path: string ) => {
 						extraContent: (
 							<StatusBadge
 								statusProps={ {
-									children: 1,
-									type: accountStatus.statusType,
+									children: '1',
+									intent: accountStatus.badgeIntent,
 									isRounded: true,
 									tooltip: accountStatus.statusReason,
 								} }

--- a/client/a8c-for-agencies/components/step-section-item/status-badge.tsx
+++ b/client/a8c-for-agencies/components/step-section-item/status-badge.tsx
@@ -1,6 +1,6 @@
-import { Badge, Tooltip } from '@automattic/components';
+import { Badge, Tooltip } from '@wordpress/ui';
 import clsx from 'clsx';
-import { useRef, useState, ComponentProps, type JSX } from 'react';
+import { ComponentProps, type JSX } from 'react';
 
 import './style.scss';
 
@@ -12,19 +12,18 @@ export default function StatusBadge( {
 		isRounded?: boolean;
 	};
 } ) {
-	const [ showPopover, setShowPopover ] = useState( false );
-
-	const wrapperRef = useRef< HTMLDivElement | null >( null );
-
-	const { tooltip, isRounded, ...badgeProps } = statusProps || {};
+	const { tooltip, isRounded, intent, children, className, ...restProps } = statusProps || {};
 
 	const badge = (
 		<Badge
-			className={ clsx( 'step-section-item__status', {
+			className={ clsx( 'step-section-item__status', className, {
 				'step-section-item__status--rounded': isRounded,
 			} ) }
-			{ ...badgeProps }
-		/>
+			intent={ intent }
+			{ ...restProps }
+		>
+			{ children ?? '' }
+		</Badge>
 	);
 
 	if ( ! tooltip ) {
@@ -32,20 +31,23 @@ export default function StatusBadge( {
 	}
 
 	return (
-		<span
-			className="step-section-item__status-wrapper"
-			onMouseEnter={ () => setShowPopover( true ) }
-			onMouseLeave={ () => setShowPopover( false ) }
-			onMouseDown={ () => setShowPopover( false ) }
-			role="button"
-			tabIndex={ 0 }
-			ref={ wrapperRef }
-		>
-			{ badge }
-
-			<Tooltip context={ wrapperRef.current } isVisible={ showPopover } position="bottom">
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				render={ ( triggerProps ) => (
+					<span
+						{ ...triggerProps }
+						className={ clsx(
+							'step-section-item__status-wrapper',
+							triggerProps.className
+						) }
+					>
+						{ badge }
+					</span>
+				) }
+			/>
+			<Tooltip.Popup positioner={ <Tooltip.Positioner side="bottom" /> }>
 				{ tooltip }
-			</Tooltip>
-		</span>
+			</Tooltip.Popup>
+		</Tooltip.Root>
 	);
 }

--- a/client/a8c-for-agencies/components/step-section-item/status-badge.tsx
+++ b/client/a8c-for-agencies/components/step-section-item/status-badge.tsx
@@ -35,19 +35,16 @@ export default function StatusBadge( {
 			<Tooltip.Trigger
 				render={ ( triggerProps ) => (
 					<span
+						role="button"
+						tabIndex={ 0 }
 						{ ...triggerProps }
-						className={ clsx(
-							'step-section-item__status-wrapper',
-							triggerProps.className
-						) }
+						className={ clsx( 'step-section-item__status-wrapper', triggerProps.className ) }
 					>
 						{ badge }
 					</span>
 				) }
 			/>
-			<Tooltip.Popup positioner={ <Tooltip.Positioner side="bottom" /> }>
-				{ tooltip }
-			</Tooltip.Popup>
+			<Tooltip.Popup positioner={ <Tooltip.Positioner side="bottom" /> }>{ tooltip }</Tooltip.Popup>
 		</Tooltip.Root>
 	);
 }

--- a/client/a8c-for-agencies/components/step-section-item/status-badge.tsx
+++ b/client/a8c-for-agencies/components/step-section-item/status-badge.tsx
@@ -14,11 +14,19 @@ export default function StatusBadge( {
 } ) {
 	const { tooltip, isRounded, intent, children, className, ...restProps } = statusProps || {};
 
-	const badge = (
+	const badge = isRounded ? (
+		<span
+			className={ clsx(
+				'step-section-item__status-indicator',
+				className,
+				intent && `step-section-item__status-indicator--${ intent }`
+			) }
+		>
+			{ children ?? '' }
+		</span>
+	) : (
 		<Badge
-			className={ clsx( 'step-section-item__status', className, {
-				'step-section-item__status--rounded': isRounded,
-			} ) }
+			className={ clsx( 'step-section-item__status', className ) }
 			intent={ intent }
 			{ ...restProps }
 		>

--- a/client/a8c-for-agencies/components/step-section-item/style.scss
+++ b/client/a8c-for-agencies/components/step-section-item/style.scss
@@ -83,25 +83,10 @@
 		margin-left: auto;
 	}
 
-	&.badge {
+	.step-section-item__status {
 		white-space: nowrap;
 		position: relative;
 		top: -1px;
-	}
-
-	&.badge--success {
-		background-color: var(--color-success-5);
-		color: var(--color-success-80);
-	}
-
-	&.badge--warning {
-		background-color: var(--color-warning-5);
-		color: var(--color-warning-80);
-	}
-
-	&.badge--error {
-		background-color: var(--color-error-5);
-		color: var(--color-error-80);
 	}
 }
 

--- a/client/a8c-for-agencies/components/step-section-item/style.scss
+++ b/client/a8c-for-agencies/components/step-section-item/style.scss
@@ -82,12 +82,12 @@
 	.step-section-item__status-wrapper {
 		margin-left: auto;
 	}
+}
 
-	.step-section-item__status {
-		white-space: nowrap;
-		position: relative;
-		top: -1px;
-	}
+.step-section-item__status-wrapper .step-section-item__status {
+	white-space: nowrap;
+	position: relative;
+	top: -1px;
 }
 
 .step-section-item__content {

--- a/client/a8c-for-agencies/components/step-section-item/style.scss
+++ b/client/a8c-for-agencies/components/step-section-item/style.scss
@@ -70,15 +70,6 @@
 		}
 	}
 
-	&.step-section-item__status--rounded {
-		display: flex;
-		justify-content: center;
-		align-items: center;
-		width: 24px;
-		height: 24px;
-		padding: 0;
-	}
-
 	.step-section-item__status-wrapper {
 		margin-left: auto;
 	}
@@ -115,4 +106,24 @@
 
 .sidebar__menu-icon {
 	fill: currentColor;
+}
+
+.step-section-item__status-indicator {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: 24px;
+	height: 24px;
+	border-radius: 50%;
+	@include heading-small;
+
+	&.step-section-item__status-indicator--high {
+		background-color: var(--color-error-5);
+		color: var(--color-error-80);
+	}
+
+	&.step-section-item__status-indicator--medium {
+		background-color: var(--color-warning-5);
+		color: var(--color-warning-80);
+	}
 }

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
@@ -1,8 +1,6 @@
 import page from '@automattic/calypso-router';
-import { Badge } from '@wordpress/ui';
 import { Button } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
-import clsx from 'clsx';
 import { useContext } from 'react';
 import {
 	A4A_MARKETPLACE_CHECKOUT_LINK,
@@ -55,9 +53,7 @@ export default function ShoppingCart( {
 				<Icon className="shopping-cart__button-icon" icon={ <ShoppingCartIcon /> } />
 
 				{ items.length > 0 && (
-					<Badge className="shopping-cart__button-badge" intent="high">
-						{ items.length.toString() }
-					</Badge>
+					<span className="shopping-cart__button-badge">{ items.length }</span>
 				) }
 			</Button>
 

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/index.tsx
@@ -1,5 +1,6 @@
 import page from '@automattic/calypso-router';
-import { Badge, Button } from '@automattic/components';
+import { Badge } from '@wordpress/ui';
+import { Button } from '@automattic/components';
 import { Icon } from '@wordpress/icons';
 import clsx from 'clsx';
 import { useContext } from 'react';
@@ -53,14 +54,11 @@ export default function ShoppingCart( {
 			<Button className="shopping-cart__button" onClick={ toggleCart } borderless>
 				<Icon className="shopping-cart__button-icon" icon={ <ShoppingCartIcon /> } />
 
-				<Badge
-					className={ clsx( 'shopping-cart__button-badge', {
-						'is-hidden': ! items.length,
-					} ) }
-					type="error"
-				>
-					{ items.length }
-				</Badge>
+				{ items.length > 0 && (
+					<Badge className="shopping-cart__button-badge" intent="high">
+						{ items.length.toString() }
+					</Badge>
+				) }
 			</Button>
 
 			{ showCart && (

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/style.scss
@@ -14,7 +14,7 @@
 	justify-content: center;
 }
 
-.badge.shopping-cart__button-badge {
+.shopping-cart__button-badge {
 	display: flex;
 	@include heading-small;
 	width: 18px;
@@ -25,4 +25,7 @@
 	position: absolute;
 	margin-block-start: -12px;
 	margin-inline-start: 26px;
+	background: var(--color-error);
+	border-radius: 50%;
+	color: var(--color-text-inverted);
 }

--- a/client/a8c-for-agencies/sections/marketplace/shopping-cart/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/shopping-cart/style.scss
@@ -25,8 +25,4 @@
 	position: absolute;
 	margin-block-start: -12px;
 	margin-inline-start: 26px;
-
-	&.is-hidden {
-		visibility: hidden;
-	}
 }

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -9,6 +9,9 @@
 	--a4a-corners-sharp: 0;
 	--a4a-corners-soft: 4px;
 
+	// Match the classic .tooltip.popover layer so wp-ui tooltips render above the sidebar.
+	--wp-ui-tooltip-z-index: 100000;
+
 	--color-surface-backdrop: #021a23;
 	--color-overview-header-background: #05374a;
 	--color-light-backdrop: var(--studio-white);


### PR DESCRIPTION
Part of #113835

## Proposed Changes

* Switches from old `@automattic/components` Badge component to `@wordpress/ui` Badge in the remaining Automattic for Agencies components: the agency site tags, the shopping cart count, and the sidebar payout status indicator.
* The sidebar payout status indicator (the “1” on Payout settings) now gets its color from the badge intent returned by the payout account status helper, and its tooltip can be opened with the keyboard again.
* Site tags keep only the label inside the badge, with the remove icon rendered next to it, since the new badge only accepts text content.
* The shopping cart count is a plain counter bubble again instead of a badge, matching how the WordPress.com masterbar cart renders its count.
* Tooltips from the new design system now layer above the sidebar, so the payout status tooltip is no longer hidden behind it.

## Why are these changes being made?

* The old Badge component is being replaced with the design system’s Badge everywhere (#113835). These were among the last remaining usages in the Automattic for Agencies screens.

## Testing Instructions

Using this PR’s Calypso Live link with the `a8c-for-agencies` environment, sign in as an agency.

1. **Sites** — open a site’s details and check its tags: each tag renders as a badge with the remove icon next to it, and removing a tag still works.
2. **Marketplace** — add a product to the cart: the cart icon shows a small red count bubble in the top corner, same as production.
3. **Sidebar payout indicator** — with a payout account that needs attention (e.g. bank details missing), open **Referrals**: the Payout settings menu item shows a “1” badge colored by severity. Hover it, or focus it with the keyboard, and the tooltip with the reason appears above the sidebar. The same indicator exists under **Migrations** and **WooPayments**. All account states (not payable, suspended, blocked) were also verified locally by forcing them in code.
4. **Referrals → Dashboard** — the payment status badge on the “Prepare to get paid” step renders with the new badge styling.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
