### PR TITLE
Site generation: keep spec_id off the editor URL a finished build lands on

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/editor-url.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/editor-url.ts
@@ -34,7 +34,7 @@ export function getSafeEditorUrl( rawUrl: string | null ): string | null {
 // response, before the generated front page existed, so it names no route.
 // Once the build is live the status endpoint's site_editor_url points at
 // that page on the edit canvas: prefer it, and carry over the query args the
-// flow added to the captured URL (source) that it does not have.
+// flow added to the captured URL that it does not have.
 // Anything unusable falls back to the captured URL.
 export function getLiveEditorUrl( capturedUrl: string, liveUrl: unknown ): string {
 	const safeLiveUrl = getSafeEditorUrl( typeof liveUrl === 'string' ? liveUrl : null );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/editor-url.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/editor-url.ts
@@ -34,7 +34,7 @@ export function getSafeEditorUrl( rawUrl: string | null ): string | null {
 // response, before the generated front page existed, so it names no route.
 // Once the build is live the status endpoint's site_editor_url points at
 // that page on the edit canvas: prefer it, and carry over the query args the
-// flow added to the captured URL (spec_id, source) that it does not have.
+// flow added to the captured URL (source) that it does not have.
 // Anything unusable falls back to the captured URL.
 export function getLiveEditorUrl( capturedUrl: string, liveUrl: unknown ): string {
 	const safeLiveUrl = getSafeEditorUrl( typeof liveUrl === 'string' ? liveUrl : null );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/editor-url.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/editor-url.ts
@@ -82,7 +82,7 @@ describe( 'getSafeEditorUrl', () => {
 
 describe( 'getLiveEditorUrl', () => {
 	const captured =
-		'https://example.wordpress.com/wp-admin/site-editor.php?easy-mode=true&spec_id=spec-1&source=dashboard';
+		'https://example.wordpress.com/wp-admin/site-editor.php?easy-mode=true&source=dashboard';
 	const live =
 		'https://example.wordpress.com/wp-admin/site-editor.php?easy-mode=true&p=%2Fpage%2F12&canvas=edit';
 
@@ -95,7 +95,6 @@ describe( 'getLiveEditorUrl', () => {
 		expect( url.searchParams.get( 'p' ) ).toBe( '/page/12' );
 		expect( url.searchParams.get( 'canvas' ) ).toBe( 'edit' );
 		expect( url.searchParams.get( 'easy-mode' ) ).toBe( 'true' );
-		expect( url.searchParams.get( 'spec_id' ) ).toBe( 'spec-1' );
 		expect( url.searchParams.get( 'source' ) ).toBe( 'dashboard' );
 		// Not duplicated: the live URL's own value wins for a shared key.
 		expect( url.searchParams.getAll( 'easy-mode' ) ).toEqual( [ 'true' ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
@@ -168,7 +168,7 @@ describe( 'useSiteGeneration', () => {
 				useSiteGeneration( {
 					siteIdentifier: '123',
 					editorUrl:
-						'https://example.wordpress.com/wp-admin/site-editor.php?easy-mode=true&spec_id=spec-1',
+						'https://example.wordpress.com/wp-admin/site-editor.php?easy-mode=true&source=dashboard',
 					steps: STEPS,
 				} )
 			);
@@ -182,7 +182,7 @@ describe( 'useSiteGeneration', () => {
 				} );
 			} );
 			expect( window.location.assign ).toHaveBeenCalledWith(
-				'https://example.wordpress.com/wp-admin/site-editor.php?easy-mode=true&p=%2Fpage%2F12&canvas=edit&spec_id=spec-1'
+				'https://example.wordpress.com/wp-admin/site-editor.php?easy-mode=true&p=%2Fpage%2F12&canvas=edit&source=dashboard'
 			);
 		} finally {
 			Object.defineProperty( window, 'location', {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -332,10 +332,10 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 
 				const ref = queryParams.get( 'ref' );
 				const source = queryParams.get( 'source' );
-				const destination = addQueryArgs( response.site_editor_url, {
-					spec_id: specId,
-					...( source ? { source } : {} ),
-				} );
+				// No spec_id on the editor URL: that param asks the editor plugin
+				// to build the site itself, and this build already ran on the
+				// server. Carrying it would start a second build on the canvas.
+				const destination = addQueryArgs( response.site_editor_url, source ? { source } : {} );
 
 				logBuildWowEvent(
 					'site_generation_redirect',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -334,7 +334,7 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 				const source = queryParams.get( 'source' );
 				// No spec_id on the editor URL: that param asks the editor plugin
 				// to build the site itself, and this build already ran on the
-				// server. Carrying it would start a second build on the canvas.
+				// server. A second build on the canvas wipes the generated pages.
 				const destination = addQueryArgs( response.site_editor_url, source ? { source } : {} );
 
 				logBuildWowEvent(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
@@ -216,8 +216,6 @@ describe( 'SiteSpec early provisioning step', () => {
 		expect( redirect.searchParams.get( 'specId' ) ).toBe( 'spec-456' );
 		expect( redirect.searchParams.get( 'ref' ) ).toBe( 'site-card' );
 		expect( redirect.searchParams.get( 'source' ) ).toBe( 'site-overview' );
-		// spec_id stays off the editor URL: on the editor it means "build the
-		// site here", and this build already ran on the server.
 		expect( redirect.searchParams.get( 'editorUrl' ) ).toBe(
 			'https://example.wordpress.com/wp-admin/site-editor.php?source=site-overview'
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
@@ -216,8 +216,10 @@ describe( 'SiteSpec early provisioning step', () => {
 		expect( redirect.searchParams.get( 'specId' ) ).toBe( 'spec-456' );
 		expect( redirect.searchParams.get( 'ref' ) ).toBe( 'site-card' );
 		expect( redirect.searchParams.get( 'source' ) ).toBe( 'site-overview' );
+		// spec_id stays off the editor URL: on the editor it means "build the
+		// site here", and this build already ran on the server.
 		expect( redirect.searchParams.get( 'editorUrl' ) ).toBe(
-			'https://example.wordpress.com/wp-admin/site-editor.php?spec_id=spec-456&source=site-overview'
+			'https://example.wordpress.com/wp-admin/site-editor.php?source=site-overview'
 		);
 
 		expect( logToLogstashMock ).toHaveBeenCalledWith(


### PR DESCRIPTION
## What

The site-generation flow no longer puts `spec_id` on the editor URL it hands off to after a build.

## Why

On the editor, `spec_id` tells the Big Sky plugin to build the site itself. The site-generation flow already built it on the server, so the param started a second build after landing.

It stayed hidden until now: the build used to land on the site editor home, where there is no edit canvas, and the plugin only starts a build once the canvas iframe is loaded. Since #113998 the build lands on the generated front page's edit canvas, the iframe loads, and the plugin ran the old build screen on top of the finished site. That second build is not just wasted work: it deletes every page except the home page and blanks the header and footer before rebuilding, so it wiped what the server had just generated. A reload looked fine only because the plugin strips `spec_id` from the URL after picking it up.

The retry path is not affected: it reads its own `specId` param on the site-generation step, not the editor URL.

## Testing

1. Start a site build from the AI site builder flow and wait for it to finish.
2. It should land on the generated front page in the editor, with no build screen.
3. Reloading should look the same as the first landing.

Tests updated for the three fixtures that carried `spec_id` on the editor URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdszEPV7CwtpM6suRFZLQP
