### PR TITLE
Playground: await the OPFS flush before enabling launch

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/lib/initialize-playground.ts
@@ -77,6 +77,11 @@ export async function initializeWordPressPlayground(
 				)
 			);
 			await client.mountOpfs( mountDescriptor );
+
+			// mountOpfs() starts the final journal flush without waiting for it, and each
+			// flush pass holds PHP's single-request semaphore. Wait for it here so the
+			// first request after the Playground becomes interactive isn't queued behind it.
+			await client.flushOpfs( mountDescriptor.mountpoint );
 		}
 
 		await client.isReady();


### PR DESCRIPTION
## Proposed Changes

* Wait for the OPFS journal flush before the Playground onboarding step reports itself ready, so the first request after the mount is not queued behind it.

## Why are these changes being made?

`onboarding__playground-to-atomic` failed on 10 of 109 trunk runs between Aug 27 and Sep 2, most of them timing out on the first click inside wp-admin. A trace of one failure shows the preceding click landing, the Playground frame going provisional, and no response ever arriving for the scoped wp-admin URL.

Playground's OPFS mount handler starts its final journal flush with `void mount.flush()` and resolves without awaiting it. Each flush pass acquires `php.semaphore`, which has a concurrency of 1 and is the same lock every PHP request takes. Calypso enabled the Launch button as soon as `mountOpfs()` resolved, so the first request a user made queued behind a flush that Playground's own code notes is slow in practice. Playground's website awaits `flushOpfs()` after mounting for this reason, and Calypso already awaits it at export time.

Measured by sampling request latency inside the Playground site frame the moment Launch enables. Two independent A/Bs agree.

Deployed branch image against trunk image on calypso.live, 10 runs per arm, run sequentially so the arms could not contend for CPU. Both serve webpack chunk `46978` at different hashes, so this branch is the only variable:

| Build | First request, min / p50 / max | Steady state |
| --- | --- | --- |
| trunk, `build-195593` | 1900 / 1924 / 2036 ms | 65 ms |
| this branch, `build-195600` | 97 / 280 / 846 ms | 65 ms |

The distributions do not overlap: the slowest run with the fix is faster than the fastest run without it. Exact two-sided p = 2/C(20,10), about 1.1e-5.

Interleaved A/B on one local dev server, 10 pairs, arms alternating with the order flipped every pair so drift cannot favour either side:

| Arm | First request p50 | Launch enabled p50 |
| --- | --- | --- |
| Without the wait | 1898 ms | 4.2 s |
| With the wait | 282 ms | 5.9 s |

Paired deltas agreed 10 out of 10 in both directions: first request -1615 ms, spanning only -1602 to -1637; Launch enabled +1632 ms.

An idle wait of 8 seconds had the same effect as the fix, confirming the delay is time-bounded background work rather than a cold cache.

A third A/B walks the admin bar exactly as the e2e spec does, with the spec's own 10 s action timeout, 8 interleaved pairs:

| Step | Without the wait | With the wait |
| --- | --- | --- |
| Launch enabled | 4465 ms | 6386 ms |
| Admin-bar Dashboard click through to the Settings click | 2496 ms | 992 ms |
| Settings screen through to the Site Title field | 189 ms | 189 ms |

The stall is one-shot. It lands on the first request after the mount and is fully drained by the following navigation, whose 189 ms median is identical in both arms. Complete separation on that first hop, exact two-sided p = 2/C(16,8), about 1.6e-4.

Two caveats worth stating plainly:

* The change relocates the wait rather than removing it. Launch enables about 1.6 s later and the first request afterwards is about 1.6 s faster. Moving the work somewhere nothing is blocked on it is the point, but this is not a net speedup.
* The stall does not by itself explain a 10 s action timeout. All 16 admin-bar runs above passed, in both arms: the worst unfixed first hop was 2516 ms against a 10 s budget. Local hardware cannot reproduce the CI failure, so whether this fully accounts for the 9% failure rate will only be settled by trunk history after merge. A residual of about 215 ms also survives the fix, so the flush wait does not fully drain the queue.

## Testing Instructions

1. Open `/setup/onboarding/playground` and wait for the Launch button to enable.
2. Immediately open wp-admin inside the Playground iframe, via the admin bar.
3. The first screen should load without a multi-second stall. On trunk the same click can hang for over a second locally, and far longer on a loaded machine.

The e2e spec is unchanged by this PR and only runs on trunk. To run it:

```
CALYPSO_BASE_URL=<staging> BRANCH_NAME=trunk \
  yarn workspace wp-e2e-tests exec playwright test \
  specs/onboarding/onboarding__playground-to-atomic.spec.ts --project=chrome
```

Verified so far:

* The two A/Bs above. The calypso.live arm is the strongest evidence, since it runs this branch's own Docker image.
* The fix confirmed present in the deployed branch bundle, not merely in the source: chunk `46978` contains `await g.mountOpfs(d),await g.flushOpfs(d.mountpoint)`, while the trunk build's copy of the same chunk ends at `mountOpfs`.
* The full spec, unchanged from trunk, run against a local dev server carrying this fix: passed, 3.8 minutes, account and Atomic site cleaned up. This is the run that matters, since the spec is user-realistic and the bundle under test contains the change.
* Earlier full-spec runs against staging and a personal TeamCity build on the Pre-Release job also passed, but they ran against a revision of this branch that also changed the spec. That change has been dropped, so they no longer speak to the spec as it stands.

Note that the e2e jobs pin the browser to deployed staging, so they never exercise this branch's client bundle. The calypso.live A/B covers that gap.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01MZTc4kYpaqLzf3wcCaZYnu
