### PR TITLE
Fix Gutenberg widgets E2E readiness waits

### DIFF
--- a/packages/calypso-e2e/src/lib/components/block-widget-editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/block-widget-editor-component.ts
@@ -12,6 +12,14 @@ const selectors = {
 	blockSearch: 'input[placeholder="Search"]',
 };
 
+// The container is server-rendered, so it is present as soon as the response is parsed.
+const EDITOR_SHELL_TIMEOUT = 15 * 1000;
+
+// The editor boots from deferred module scripts, which hold back both `load` and
+// `domcontentloaded`. The default action timeout is far too short a budget for that,
+// and this wait, not the one above, is what absorbs a slow boot.
+const EDITOR_READY_TIMEOUT = 60 * 1000;
+
 /**
  * Component for the block-based Widget editor in Appearance > Widgets.
  */
@@ -28,15 +36,41 @@ export class BlockWidgetEditorComponent {
 	}
 
 	/**
+	 * Waits until the editor can insert the given legacy widget.
+	 *
+	 * Legacy widgets reach the inserter as block variations, registered only once the
+	 * widget types have been fetched. The inserter indexes what is registered when the
+	 * search term is entered and does not re-index, so searching too early returns
+	 * "No results found" for as long as the panel stays open.
+	 *
+	 * @param {string} legacyWidget Name of the legacy widget variation, eg. 'authors'.
+	 */
+	async waitUntilLoaded( legacyWidget: string ): Promise< void > {
+		await this.page.locator( selectors.editor ).waitFor( { timeout: EDITOR_SHELL_TIMEOUT } );
+
+		await this.page.waitForFunction(
+			( name ) => {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const blocks = ( window as any )?.wp?.data?.select( 'core/blocks' );
+				const variations = blocks?.getBlockVariations( 'core/legacy-widget' ) ?? [];
+
+				return variations.some( ( variation: { name: string } ) => variation.name === name );
+			},
+			legacyWidget,
+			{ timeout: EDITOR_READY_TIMEOUT }
+		);
+	}
+
+	/**
 	 * Dismiss any welcome modals that appear.
+	 *
+	 * Call once `waitUntilLoaded` has resolved: neither modal renders before the editor.
 	 *
 	 * These include:
 	 * 	- Welcome modal
 	 * 	- Welcome Tour
 	 */
 	async dismissModals(): Promise< void > {
-		await this.page.waitForLoadState( 'networkidle' );
-
 		const locators = [
 			this.page.locator( selectors.welcomeModalDismissButton ),
 			this.page.locator( selectors.welcomeTourDismissButton ),
@@ -44,10 +78,10 @@ export class BlockWidgetEditorComponent {
 
 		for await ( const locator of locators ) {
 			try {
-				// Whether Welcome Tour appears is not deterministic.
-				// If it is not present, exit early.
+				// Neither modal is guaranteed to appear, and the Welcome Tour can show
+				// without the Welcome modal, so a missing one skips rather than stops.
 				if ( ( await locator.count() ) === 0 ) {
-					return;
+					continue;
 				}
 				await locator.click();
 			} catch {

--- a/packages/calypso-e2e/src/lib/components/block-widget-editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/block-widget-editor-component.ts
@@ -12,12 +12,9 @@ const selectors = {
 	blockSearch: 'input[placeholder="Search"]',
 };
 
-// The container is server-rendered, so it is present as soon as the response is parsed.
-const EDITOR_SHELL_TIMEOUT = 15 * 1000;
-
 // The editor boots from deferred module scripts, which hold back both `load` and
-// `domcontentloaded`. The default action timeout is far too short a budget for that,
-// and this wait, not the one above, is what absorbs a slow boot.
+// `domcontentloaded`. This wait is what absorbs a slow boot, so it needs a budget far
+// beyond the default action timeout.
 const EDITOR_READY_TIMEOUT = 60 * 1000;
 
 /**
@@ -46,16 +43,15 @@ export class BlockWidgetEditorComponent {
 	 * @param {string} legacyWidget Name of the legacy widget variation, eg. 'authors'.
 	 */
 	async waitUntilLoaded( legacyWidget: string ): Promise< void > {
-		await this.page.locator( selectors.editor ).waitFor( { timeout: EDITOR_SHELL_TIMEOUT } );
+		await this.page.locator( selectors.editor ).waitFor();
 
 		await this.page.waitForFunction(
-			( name ) => {
+			( name ) =>
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				const blocks = ( window as any )?.wp?.data?.select( 'core/blocks' );
-				const variations = blocks?.getBlockVariations( 'core/legacy-widget' ) ?? [];
-
-				return variations.some( ( variation: { name: string } ) => variation.name === name );
-			},
+				!! ( window as any ).wp?.data
+					?.select( 'core/blocks' )
+					?.getBlockVariations( 'core/legacy-widget' )
+					?.some( ( variation: { name: string } ) => variation.name === name ),
 			legacyWidget,
 			{ timeout: EDITOR_READY_TIMEOUT }
 		);

--- a/packages/calypso-e2e/src/lib/components/block-widget-editor-component.ts
+++ b/packages/calypso-e2e/src/lib/components/block-widget-editor-component.ts
@@ -12,6 +12,11 @@ const selectors = {
 	blockSearch: 'input[placeholder="Search"]',
 };
 
+// Server-rendered, so present once the response is parsed: 0.9-1.9s measured on the
+// production configs. The margin absorbs the PR suite, where contention from a full
+// parallel run stretches this spec five-fold.
+const EDITOR_SHELL_TIMEOUT = 15 * 1000;
+
 // The editor boots from deferred module scripts, which hold back both `load` and
 // `domcontentloaded`. This wait is what absorbs a slow boot, so it needs a budget far
 // beyond the default action timeout.
@@ -43,7 +48,7 @@ export class BlockWidgetEditorComponent {
 	 * @param {string} legacyWidget Name of the legacy widget variation, eg. 'authors'.
 	 */
 	async waitUntilLoaded( legacyWidget: string ): Promise< void > {
-		await this.page.locator( selectors.editor ).waitFor();
+		await this.page.locator( selectors.editor ).waitFor( { timeout: EDITOR_SHELL_TIMEOUT } );
 
 		await this.page.waitForFunction(
 			( name ) =>

--- a/packages/calypso-e2e/src/rest-api-client.ts
+++ b/packages/calypso-e2e/src/rest-api-client.ts
@@ -1603,7 +1603,7 @@ export class RestAPIClient {
 	async deleteAllWidgets( siteID: number ): Promise< void > {
 		const widgets = await this.getAllWidgets( siteID );
 
-		widgets.map( async ( widget ) => await this.deleteWidget( siteID, widget.id ) );
+		await Promise.all( widgets.map( ( widget ) => this.deleteWidget( siteID, widget.id ) ) );
 	}
 
 	/* Search */

--- a/packages/calypso-e2e/src/test/rest-api-client.widgets.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.widgets.test.ts
@@ -1,11 +1,5 @@
 /**
- * Tests for RestAPIClient.deleteAllWidgets, focused on awaiting the deletions.
- *
- * The method previously called `widgets.map( async ... )` and discarded the
- * resulting promises, so it resolved before a single widget had been deleted and
- * rejections surfaced as unhandled. The E2E step that clears widgets before the
- * Appearance > Widgets spec was therefore a no-op that could leave the editor in a
- * dirty state. These tests pin the awaited behavior.
+ * Tests for RestAPIClient.deleteAllWidgets.
  */
 import { describe, expect, test, jest, beforeEach } from '@jest/globals';
 import nock from 'nock';
@@ -44,28 +38,6 @@ describe( 'RestAPIClient: deleteAllWidgets', function () {
 			} );
 	} );
 
-	test( 'resolves only once every widget deletion has completed', async function () {
-		nock( listURL.origin )
-			.get( listURL.pathname )
-			.reply( 200, { widgets: [ { id: 'authors-1' }, { id: 'text-2' } ] } );
-
-		// The delay is what separates an awaited deletion from a discarded promise: a
-		// fire-and-forget map resolves with both interceptors still pending.
-		const first = nock( deleteURL( 'authors-1' ).origin )
-			.post( deleteURL( 'authors-1' ).pathname )
-			.delay( 50 )
-			.reply( 200, [] );
-		const second = nock( deleteURL( 'text-2' ).origin )
-			.post( deleteURL( 'text-2' ).pathname )
-			.delay( 50 )
-			.reply( 200, [] );
-
-		await restAPIClient.deleteAllWidgets( siteID );
-
-		expect( first.isDone() ).toBe( true );
-		expect( second.isDone() ).toBe( true );
-	} );
-
 	test( 'rejects when a widget deletion fails', async function () {
 		nock( listURL.origin )
 			.get( listURL.pathname )
@@ -76,11 +48,5 @@ describe( 'RestAPIClient: deleteAllWidgets', function () {
 			.reply( 200, { error: 'unauthorized', message: 'User cannot edit widgets.' } );
 
 		await expect( restAPIClient.deleteAllWidgets( siteID ) ).rejects.toThrow( 'unauthorized' );
-	} );
-
-	test( 'makes no delete calls when the site has no widgets', async function () {
-		nock( listURL.origin ).get( listURL.pathname ).reply( 200, { widgets: [] } );
-
-		await expect( restAPIClient.deleteAllWidgets( siteID ) ).resolves.toBeUndefined();
 	} );
 } );

--- a/packages/calypso-e2e/src/test/rest-api-client.widgets.test.ts
+++ b/packages/calypso-e2e/src/test/rest-api-client.widgets.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for RestAPIClient.deleteAllWidgets, focused on awaiting the deletions.
+ *
+ * The method previously called `widgets.map( async ... )` and discarded the
+ * resulting promises, so it resolved before a single widget had been deleted and
+ * rejections surfaced as unhandled. The E2E step that clears widgets before the
+ * Appearance > Widgets spec was therefore a no-op that could leave the editor in a
+ * dirty state. These tests pin the awaited behavior.
+ */
+import { describe, expect, test, jest, beforeEach } from '@jest/globals';
+import nock from 'nock';
+import { RestAPIClient, BEARER_TOKEN_URL } from '../rest-api-client';
+import { SecretsManager } from '../secrets';
+import type { Secrets } from '../secrets';
+
+const fakeSecrets = {
+	calypsoOauthApplication: {
+		client_id: 'some_value',
+		client_secret: 'some_value',
+	},
+} as unknown as Secrets;
+
+jest.spyOn( SecretsManager, 'secrets', 'get' ).mockImplementation( () => fakeSecrets );
+
+describe( 'RestAPIClient: deleteAllWidgets', function () {
+	const restAPIClient = new RestAPIClient( {
+		username: 'fake_user',
+		password: 'fake_password',
+	} );
+
+	const siteID = 12345;
+	const listURL = restAPIClient.getRequestURL( '1.1', `/sites/${ siteID }/widgets` );
+	const deleteURL = ( widgetID: string ) =>
+		restAPIClient.getRequestURL( '1.1', `/sites/${ siteID }/widgets/widget:${ widgetID }/delete` );
+
+	beforeEach( function () {
+		nock.cleanAll();
+		nock( BEARER_TOKEN_URL )
+			.persist()
+			.post( /.*/ )
+			.reply( 200, {
+				success: true,
+				data: { bearer_token: 'abcdefghijklmn', token_links: [] },
+			} );
+	} );
+
+	test( 'resolves only once every widget deletion has completed', async function () {
+		nock( listURL.origin )
+			.get( listURL.pathname )
+			.reply( 200, { widgets: [ { id: 'authors-1' }, { id: 'text-2' } ] } );
+
+		// The delay is what separates an awaited deletion from a discarded promise: a
+		// fire-and-forget map resolves with both interceptors still pending.
+		const first = nock( deleteURL( 'authors-1' ).origin )
+			.post( deleteURL( 'authors-1' ).pathname )
+			.delay( 50 )
+			.reply( 200, [] );
+		const second = nock( deleteURL( 'text-2' ).origin )
+			.post( deleteURL( 'text-2' ).pathname )
+			.delay( 50 )
+			.reply( 200, [] );
+
+		await restAPIClient.deleteAllWidgets( siteID );
+
+		expect( first.isDone() ).toBe( true );
+		expect( second.isDone() ).toBe( true );
+	} );
+
+	test( 'rejects when a widget deletion fails', async function () {
+		nock( listURL.origin )
+			.get( listURL.pathname )
+			.reply( 200, { widgets: [ { id: 'authors-1' } ] } );
+
+		nock( deleteURL( 'authors-1' ).origin )
+			.post( deleteURL( 'authors-1' ).pathname )
+			.reply( 200, { error: 'unauthorized', message: 'User cannot edit widgets.' } );
+
+		await expect( restAPIClient.deleteAllWidgets( siteID ) ).rejects.toThrow( 'unauthorized' );
+	} );
+
+	test( 'makes no delete calls when the site has no widgets', async function () {
+		nock( listURL.origin ).get( listURL.pathname ).reply( 200, { widgets: [] } );
+
+		await expect( restAPIClient.deleteAllWidgets( siteID ) ).resolves.toBeUndefined();
+	} );
+} );

--- a/test/e2e/specs/appearance/widgets__legacy-visibility.spec.ts
+++ b/test/e2e/specs/appearance/widgets__legacy-visibility.spec.ts
@@ -1,4 +1,8 @@
-import { tags, test } from '../../lib/pw-base';
+import { expect, tags, test } from '../../lib/pw-base';
+
+// Name of the legacy widget block variation under test. The inserter renders it as a
+// button whose class carries the same name, so both must stay in step.
+const LEGACY_WIDGET = 'authors';
 
 // Mobile viewport is skipped due to https://github.com/Automattic/wp-calypso/issues/64536. Remove DESKTOP_ONLY when fixed.
 test.describe(
@@ -17,6 +21,10 @@ test.describe(
 				'Skipping for Atomic sites as the themes do not support widgets'
 			);
 
+			// The editor boot alone is budgeted at 60s, which the default 120s ceiling cannot
+			// hold alongside login, setup and the insertion steps.
+			test.setTimeout( 180 * 1000 );
+
 			await test.step( `Given I am authenticated as '${ accountGivenByEnvironment.accountName }'`, async function () {
 				await accountGivenByEnvironment.authenticate( page );
 			} );
@@ -28,10 +36,22 @@ test.describe(
 			} );
 
 			await test.step( 'When I navigate to Appearance > Widgets', async function () {
-				await page.goto(
+				// The editor's deferred module scripts hold back both `load` and
+				// `domcontentloaded` long after the server has answered, so this waits only for
+				// the response. Readiness is asserted against the editor in the next step.
+				const response = await page.goto(
 					`https://${ accountGivenByEnvironment.credentials.testSites?.primary.url }/wp-admin/widgets.php`,
-					{ timeout: 25 * 1000 }
+					{ timeout: 25 * 1000, waitUntil: 'commit' }
 				);
+
+				// `goto` resolves for any status, so a 500 or a bounce to wp-login.php would
+				// otherwise surface much later as a missing editor.
+				expect( response?.status() ).toBe( 200 );
+				await expect( page ).toHaveURL( /widgets\.php/ );
+			} );
+
+			await test.step( 'And the widget editor is ready', async function () {
+				await componentBlockWidgetEditor.waitUntilLoaded( LEGACY_WIDGET );
 			} );
 
 			await test.step( 'And I dismiss the Welcome modals', async function () {
@@ -41,7 +61,7 @@ test.describe(
 			await test.step( 'And I insert a Legacy Widget', async function () {
 				await page.getByRole( 'button', { name: 'Add block' } ).click();
 				await page.fill( 'input[placeholder="Search"]', 'Authors' );
-				await page.click( 'button.editor-block-list-item-legacy-widget\\/authors' );
+				await page.click( `button.editor-block-list-item-legacy-widget\\/${ LEGACY_WIDGET }` );
 			} );
 
 			await test.step( 'Then visibility options are shown for the Legacy Widget', async function () {


### PR DESCRIPTION
## Proposed Changes

* Wait for the widget editor to be ready instead of for `networkidle`, which never resolves on this screen.
* Gate readiness on the `core/legacy-widget` block variation the test goes on to click, so the inserter is only searched once that variation is registered.
* Navigate with `waitUntil: 'commit'` and assert the response status and final URL.
* Await the deletions in `RestAPIClient.deleteAllWidgets`, and add unit tests covering it.

## Why are these changes being made?

`appearance/widgets__legacy-visibility.spec.ts` failed roughly 5% of nightly Gutenberg runs after retries (2 of the last 43 runs on the two Simple configs, with `retries: 1`). Three separate mechanisms were involved.

**`networkidle` never arrives.** Traces show the page interactive at 7s, the network then silent for 55s, and `waitForLoadState( 'networkidle' )` still pending at 116s, at which point the 120s test timeout fires. The editor keeps long-lived connections open (notifications iframe, help center, analytics), so Playwright's in-flight request count never reaches zero even while nothing is happening.

**That wait was load-bearing.** Removing it alone turned a 1-in-5 local failure into 9-in-10. Legacy widgets reach the inserter as `core/legacy-widget` block variations, registered only once `/wp/v2/sites/<id>/widget-types` resolves. The inserter indexes what is registered at the moment the search term is typed and never re-indexes, so searching too early returns "No results found" for as long as the panel stays open — verified with a 45s probe, where the entry is either present within 4ms or absent for the full 45s. Readiness now gates on the specific variation rather than on elapsed time.

**Deferred module scripts run before `DOMContentLoaded`.** The editor boots from `type=module` loader scripts, so neither `load` nor `domcontentloaded` avoids waiting for them; delaying only those scripts by 30s still times out a 25s `goto` on both. Only `commit` returns promptly, so readiness is asserted separately afterwards. Because `goto` does not throw on any status, the status and final URL are now checked explicitly — a server error or a redirect to the login page previously surfaced much later as a missing editor.

**`deleteAllWidgets` never awaited anything.** It called `widgets.map( async … )` and discarded the resulting promises, so it resolved before a single widget had been deleted and rejections became unhandled. The "clear all widgets" precondition was a no-op on every run, and is a plausible flake contributor in its own right.

## Testing Instructions

Local, against production (the environment this suite runs in):

```
cd test/e2e
CALYPSO_BASE_URL=https://wordpress.com npx playwright test --project=chrome --repeat-each=10 widgets__legacy-visibility
GUTENBERG_EDGE=true CALYPSO_BASE_URL=https://wordpress.com npx playwright test --project=chrome --repeat-each=10 widgets__legacy-visibility
```

Both pass 10/10. Spec duration drops from 15-120s to 6-13s. Baseline before the change was 1 failure in 5.

A controlled experiment pins the mechanism. Injecting a 30s delay on `build/modules/*loader.min.js` reproduces the original CI error exactly on the old code (`TimeoutError: page.goto: Timeout 25000ms exceeded`) and passes on the new code, reaching readiness in 32s.

Unit tests:

```
npx jest --config packages/calypso-e2e/jest.config.js
```

297 tests pass. The three new cases fail against the old fire-and-forget `deleteAllWidgets`, including Jest's `Cannot log after tests are done`, which is that bug's signature.

CI: a personal build on the Gutenberg E2E config (build 19288784) ran the full `@gutenberg` group across all 10 matrix legs with these changes applied. All 10 legs passed, 254 tests, no failures and no retries. The spec ran on the two Simple desktop legs at 15.0s and 20.1s. The other legs skip it — Atomic by `test.skip`, mobile by `@desktop-only`.

Not covered: Atomic and self-hosted Jetpack, since the spec skips Atomic (themes there do not support widgets) and the flow is WordPress.com-only.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01XcUx66yv5e8MZesPMPdb6u
