### PR TITLE
Agents Manager: send provider_ids on unified Tracks events

### DIFF
--- a/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/load-external-providers.test.ts
@@ -14,6 +14,7 @@ import {
 	mergeCapabilitiesInto,
 	mergeUseSuggestionsHooks,
 } from '../load-external-providers';
+import { getLoadedProviderIds, setLoadedProviderIds } from '../loaded-provider-ids';
 import {
 	getProviderCheckpointObservedAt,
 	getProviderCheckpointRecords,
@@ -171,6 +172,7 @@ describe( 'loadExternalProviders', () => {
 		window.history.replaceState( {}, '', '/' );
 		delete ( globalThis as typeof globalThis & { agentsManagerData?: unknown } ).agentsManagerData;
 		delete ( window as typeof window & { agentsManagerData?: unknown } ).agentsManagerData;
+		setLoadedProviderIds( undefined );
 	} );
 
 	it( 'does not merge external editor providers into Reader Chat', async () => {
@@ -196,6 +198,28 @@ describe( 'loadExternalProviders', () => {
 		setAgentsManagerData( { agentProviders } );
 
 		await expect( loadExternalProviders() ).resolves.toEqual( {} );
+		expect( getLoadedProviderIds() ).toEqual( [] );
+	} );
+
+	it( 'publishes the loaded provider ids for the Tracks wrappers', async () => {
+		setAgentsManagerData( {
+			agentProviders: [ { providerId: 'jetpack-ai' }, { providerId: 'woocommerce-ai' } ],
+		} );
+
+		await loadExternalProviders();
+
+		expect( getLoadedProviderIds() ).toEqual( [ 'jetpack-ai', 'woocommerce-ai' ] );
+	} );
+
+	it( 'publishes an empty provider list for Reader Chat', async () => {
+		setAgentsManagerData( {
+			agentId: 'reader-chat',
+			agentProviders: [ { providerId: 'jetpack-ai' } ],
+		} );
+
+		await loadExternalProviders();
+
+		expect( getLoadedProviderIds() ).toEqual( [] );
 	} );
 
 	it( 'merges abilities from multiple tool providers and dispatches execution to the owner', async () => {

--- a/packages/agents-manager/src/utils/__tests__/tracks.test.ts
+++ b/packages/agents-manager/src/utils/__tests__/tracks.test.ts
@@ -15,6 +15,7 @@ jest.mock( '../is-reader-chat-agent', () => {
 import { select } from '@wordpress/data';
 import { getActiveSessionId } from '../agent-session';
 import { isReaderChatHost } from '../is-reader-chat-agent';
+import { setLoadedProviderIds } from '../loaded-provider-ids';
 import { setResolvedAgentId } from '../resolved-agent-id';
 import {
 	getBigSkyTracksData,
@@ -206,6 +207,7 @@ describe( 'tracks wrappers', () => {
 			expect( props ).toMatchObject( {
 				ai_session_id: 'session-xyz',
 				agent_name: 'dolly',
+				provider_ids: 'none',
 				surface: 'editor',
 				is_test: true,
 			} );
@@ -256,6 +258,34 @@ describe( 'tracks wrappers', () => {
 			setResolvedAgentId( 'reader-chat' );
 			recordAgentsManagerTracksEvent( 'calypso_agents_manager_chat_minimize' );
 			expect( mockRecordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	describe( 'provider_ids', () => {
+		afterEach( () => {
+			setLoadedProviderIds( undefined );
+		} );
+
+		it( 'joins the loaded provider ids, sorted for stable grouping', () => {
+			setLoadedProviderIds( [ 'woocommerce-ai', 'jetpack-ai' ] );
+
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_chat_minimize' );
+
+			expect( lastEventProps().provider_ids ).toBe( 'jetpack-ai,woocommerce-ai' );
+		} );
+
+		it( 'sends none when the providers loaded with no external entries', () => {
+			setLoadedProviderIds( [] );
+
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_chat_minimize' );
+
+			expect( lastEventProps().provider_ids ).toBe( 'none' );
+		} );
+
+		it( 'sends none until the providers load', () => {
+			recordAgentsManagerTracksEvent( 'calypso_agents_manager_chat_minimize' );
+
+			expect( lastEventProps().provider_ids ).toBe( 'none' );
 		} );
 	} );
 

--- a/packages/agents-manager/src/utils/load-external-providers.ts
+++ b/packages/agents-manager/src/utils/load-external-providers.ts
@@ -18,6 +18,7 @@ import { withAbilityCompletionBroadcast } from './ability-completion-broadcast';
 import { withCanvasBinding, withCanvasGuard } from './canvas-guard';
 import { getAgentsManagerInlineData } from './get-agents-manager-inline-data';
 import { isReaderChatAgent } from './is-reader-chat-agent';
+import { setLoadedProviderIds } from './loaded-provider-ids';
 import {
 	getProviderCheckpointObservedAt,
 	getProviderCheckpointRecords,
@@ -581,10 +582,12 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 	if ( registerReaderFollowups ) {
 		// Reader Chat runs on the public frontend and should not inherit editor providers
 		// such as the Jetpack AI sidebar.
+		setLoadedProviderIds( [] );
 		return { useSuggestions: useReaderFollowupSuggestions };
 	}
 
 	if ( agentProviders.length === 0 ) {
+		setLoadedProviderIds( [] );
 		return {};
 	}
 
@@ -840,6 +843,8 @@ export async function loadExternalProviders(): Promise< LoadedProviders > {
 			return combined;
 		};
 	}
+
+	setLoadedProviderIds( allProviderIds );
 
 	return {
 		toolProvider: mergedToolProvider,

--- a/packages/agents-manager/src/utils/loaded-provider-ids.ts
+++ b/packages/agents-manager/src/utils/loaded-provider-ids.ts
@@ -1,0 +1,17 @@
+/**
+ * Module bridge for the loaded external provider IDs.
+ *
+ * `loadExternalProviders()` publishes the merged provider list here so
+ * non-React callers — the Tracks wrappers — can report which providers were
+ * active. Same pattern as `resolved-agent-id`.
+ */
+
+let loadedProviderIds: string[] | undefined;
+
+export function setLoadedProviderIds( ids: string[] | undefined ): void {
+	loadedProviderIds = ids;
+}
+
+export function getLoadedProviderIds(): string[] | undefined {
+	return loadedProviderIds;
+}

--- a/packages/agents-manager/src/utils/tracks.ts
+++ b/packages/agents-manager/src/utils/tracks.ts
@@ -16,6 +16,7 @@ import { DOLLY_AGENT_ID } from '../constants';
 import { getActiveSessionId } from './agent-session';
 import { getAgentsManagerInlineData } from './get-agents-manager-inline-data';
 import { isReaderChatAgent, isReaderChatHost } from './is-reader-chat-agent';
+import { getLoadedProviderIds } from './loaded-provider-ids';
 import { getResolvedAgentId } from './resolved-agent-id';
 
 type TracksProps = Record< string, unknown >;
@@ -154,6 +155,9 @@ function getUnifiedBaseProps(): TracksProps {
 	return {
 		ai_session_id: getActiveSessionId(),
 		agent_name: getResolvedAgentId() ?? DOLLY_AGENT_ID,
+		// Sorted so the same provider set always yields the same value; 'none'
+		// until the providers load (events can fire before the chat mounts).
+		provider_ids: getLoadedProviderIds()?.slice().sort().join( ',' ) || 'none',
 		surface: isReaderChatHost() ? 'reader-chat' : 'editor',
 		path: typeof window !== 'undefined' ? window.location.pathname : '',
 		is_test: getIsTest(),


### PR DESCRIPTION
Part of AM-48

## Proposed Changes

* Send a `provider_ids` property with every unified Agents Manager Tracks event (`calypso_agents_manager_*`): the loaded external provider IDs, sorted and comma-joined (e.g. `jetpack-ai,woocommerce-ai`), or `'none'` before the providers load or when none are configured.
* `loadExternalProviders()` publishes the merged provider list through a new module bridge (`utils/loaded-provider-ids.ts`, same pattern as `resolved-agent-id`), on all three of its return paths — the normal merge, the Reader Chat early return (which deliberately loads no editor providers), and the no-providers early return. Covering the early returns keeps Reader Chat from reporting stale IDs from a previous session.
* The Tracks wrapper reads the bridge in its base props, so the property reaches both the chat-surface events and the entry-point button events (which route through the wrapper since the earlier audit fixes).

Notes for reviewers:
* IDs are sorted before joining so the same provider set always produces the same value, whatever the load order.
* An entry-point click fired before the chat first mounts reports `'none'` — the providers only load when the agent initializes.

## Why are these changes being made?

* Agents Manager computes the set of loaded external providers and sends it in the agent request context, but never to Tracks — so analytics cannot be segmented by which providers were active (e.g. Jetpack AI vs. WooCommerce AI). With multiple merged providers now supported, that segmentation is needed.
* The new property will be registered alongside the other Agents Manager events (AM-21).

## Testing Instructions

* Open the browser DevTools, switch to the **Network** tab, and filter requests by `t.gif`.
* Sync the agents-manager app with your WordPress.com sandbox (`cd apps/agents-manager && yarn dev --sync`), then open the block editor on a site with the Jetpack AI sidebar provider active, open the AI chat and interact with it — chat events (e.g. `calypso_agents_manager_chat_minimize`) should carry `provider_ids: jetpack-ai`.
* On a surface with no external providers configured, the same events should carry `provider_ids: none`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
