### PR TITLE
Dashboard: warn about the masked two-step state in support sessions

### DIFF
--- a/client/dashboard/me/security-two-step-auth/summary.tsx
+++ b/client/dashboard/me/security-two-step-auth/summary.tsx
@@ -1,4 +1,5 @@
 import { userSettingsQuery } from '@automattic/api-queries';
+import { isSupportSession } from '@automattic/calypso-support-session';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -17,6 +18,24 @@ export default function SecurityTwoStepAuthSummary( { density }: { density?: Den
 	const { data: userSettings } = useSuspenseQuery( userSettingsQuery() );
 
 	const { two_step_enabled, two_step_backup_codes_printed } = userSettings;
+
+	// The API masks `two_step_enabled` to false inside support sessions so no 2FA challenge is
+	// enforced or sent for the supported user, which would make this read "Not enabled" for
+	// accounts that have two-step on.
+	if ( isSupportSession() ) {
+		return (
+			<RouterLinkSummaryButton
+				density={ density }
+				to="/me/security/two-step-auth"
+				title={ __( 'Two-step authentication' ) }
+				description={ __(
+					'Two-step status is not available in support sessions. Use the User Report Card for the full configuration.'
+				) }
+				decoration={ <Icon icon={ mobile } /> }
+				badges={ [ { text: __( 'Support session' ), intent: 'medium' } ] }
+			/>
+		);
+	}
 
 	const badges: SummaryButtonBadgeProps[] = [
 		{

--- a/client/dashboard/me/security-two-step-auth/summary.tsx
+++ b/client/dashboard/me/security-two-step-auth/summary.tsx
@@ -2,10 +2,13 @@ import { userSettingsQuery } from '@automattic/api-queries';
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Icon } from '@wordpress/components';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { mobile } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 import { useAuth } from '../../app/auth';
 import RouterLinkSummaryButton from '../../components/router-link-summary-button';
+import DashboardSummaryButton from '../../components/summary-button';
 import type {
 	Density,
 	SummaryButtonBadgeProps,
@@ -22,17 +25,24 @@ export default function SecurityTwoStepAuthSummary( { density }: { density?: Den
 	// The API masks `two_step_enabled` to false inside support sessions so no 2FA challenge is
 	// enforced or sent for the supported user, which would make this read "Not enabled" for
 	// accounts that have two-step on.
+	const { createErrorNotice } = useDispatch( noticesStore );
 	if ( isSupportSession() ) {
 		return (
-			<RouterLinkSummaryButton
+			<DashboardSummaryButton
 				density={ density }
-				to="/me/security/two-step-auth"
+				onClick={ () => {
+					createErrorNotice(
+						__(
+							'Two-step authentication status is not available during a support session. Use the User Report Card for the full configuration.'
+						),
+						{ type: 'snackbar' }
+					);
+				} }
 				title={ __( 'Two-step authentication' ) }
-				description={ __(
-					'Two-step status is not available in support sessions. Use the User Report Card for the full configuration.'
-				) }
 				decoration={ <Icon icon={ mobile } /> }
-				badges={ [ { text: __( 'Support session' ), intent: 'medium' } ] }
+				badges={ [
+					{ text: __( 'Not available during a support session' ), intent: 'informational' },
+				] }
 			/>
 		);
 	}

--- a/client/dashboard/me/security-two-step-auth/test/summary.test.tsx
+++ b/client/dashboard/me/security-two-step-auth/test/summary.test.tsx
@@ -4,6 +4,9 @@
 
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { dispatch, select } from '@wordpress/data';
+import { store as noticesStore } from '@wordpress/notices';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import SecurityTwoStepAuthSummary from '../summary';
@@ -23,6 +26,9 @@ function mockUserSettings( data: Partial< UserSettings > ) {
 afterEach( () => {
 	nock.cleanAll();
 	( isSupportSession as jest.Mock ).mockReturnValue( false );
+	select( noticesStore )
+		.getNotices()
+		.forEach( ( notice ) => dispatch( noticesStore ).removeNotice( notice.id ) );
 } );
 
 describe( '<SecurityTwoStepAuthSummary>', () => {
@@ -42,15 +48,25 @@ describe( '<SecurityTwoStepAuthSummary>', () => {
 		expect( await screen.findByText( 'Enabled' ) ).toBeVisible();
 	} );
 
-	test( 'points to the User Report Card instead of a state inside a support session', async () => {
+	test( 'shows no state and points to the User Report Card inside a support session', async () => {
 		( isSupportSession as jest.Mock ).mockReturnValue( true );
 		mockUserSettings( { two_step_enabled: false } );
 
 		render( <SecurityTwoStepAuthSummary /> );
 
-		expect( await screen.findByText( 'Support session' ) ).toBeVisible();
-		expect( screen.getByText( /Use the User Report Card/ ) ).toBeVisible();
+		expect( await screen.findByText( 'Not available during a support session' ) ).toBeVisible();
 		expect( screen.queryByText( 'Enabled' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Not enabled' ) ).not.toBeInTheDocument();
+
+		await userEvent.click( screen.getByText( 'Two-step authentication' ) );
+
+		expect( select( noticesStore ).getNotices() ).toEqual( [
+			expect.objectContaining( {
+				status: 'error',
+				type: 'snackbar',
+				content:
+					'Two-step authentication status is not available during a support session. Use the User Report Card for the full configuration.',
+			} ),
+		] );
 	} );
 } );

--- a/client/dashboard/me/security-two-step-auth/test/summary.test.tsx
+++ b/client/dashboard/me/security-two-step-auth/test/summary.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { isSupportSession } from '@automattic/calypso-support-session';
+import { screen } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import SecurityTwoStepAuthSummary from '../summary';
+import type { UserSettings } from '@automattic/api-core';
+
+jest.mock( '@automattic/calypso-support-session', () => ( {
+	isSupportSession: jest.fn( () => false ),
+} ) );
+
+function mockUserSettings( data: Partial< UserSettings > ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/me/settings' )
+		.query( true )
+		.reply( 200, data );
+}
+
+afterEach( () => {
+	nock.cleanAll();
+	( isSupportSession as jest.Mock ).mockReturnValue( false );
+} );
+
+describe( '<SecurityTwoStepAuthSummary>', () => {
+	test( 'shows "Not enabled" outside a support session when two-step is off', async () => {
+		mockUserSettings( { two_step_enabled: false } );
+
+		render( <SecurityTwoStepAuthSummary /> );
+
+		expect( await screen.findByText( 'Not enabled' ) ).toBeVisible();
+	} );
+
+	test( 'shows "Enabled" outside a support session when two-step is on', async () => {
+		mockUserSettings( { two_step_enabled: true, two_step_backup_codes_printed: true } );
+
+		render( <SecurityTwoStepAuthSummary /> );
+
+		expect( await screen.findByText( 'Enabled' ) ).toBeVisible();
+	} );
+
+	test( 'points to the User Report Card instead of a state inside a support session', async () => {
+		( isSupportSession as jest.Mock ).mockReturnValue( true );
+		mockUserSettings( { two_step_enabled: false } );
+
+		render( <SecurityTwoStepAuthSummary /> );
+
+		expect( await screen.findByText( 'Support session' ) ).toBeVisible();
+		expect( screen.getByText( /Use the User Report Card/ ) ).toBeVisible();
+		expect( screen.queryByText( 'Enabled' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Not enabled' ) ).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Part of DOTOBRD-466


## Proposed Changes

On MSD, when accessing/me/security, if we're in a support session, let's make it clear to HE that we can't access the real information from users. If they still click, we show more details on how to get that info

| Before | After |
|--------|--------|
| <img width="768" height="566" alt="image" src="https://github.com/user-attachments/assets/b6b1b430-0b5e-4b75-b7a2-fd475bfcae3c" /> | <img width="922" height="787" alt="image" src="https://github.com/user-attachments/assets/cf2809f2-fca6-410b-8df9-23d171fb188c" /> | 

## Why are these changes being made?

Inside a support session the API masks `two_step_enabled` to `false` so that no 2FA to avoid sending unintended authentication code for our users.

We don't want to disable that, so a better strategy is to make it clear for HE that we need to go on RC to see that information.

## Testing Instructions

1. Start a support session for any user with 2FA enabled and open `/me/security` on the Multi-site Dashboard.
2. Set this cookie for testing the local or staging changes `document.cookie = 'support_session_id=1; path=/';`
   * Before: the two-step summary shows **Not enabled** even when the account has two-step on. 
   * After: it shows a **Support session** badge and points to the User Report Card.
3. Outside a support session, `/me/security` renders the two-step summary exactly as before (**Enabled** / **Not enabled**, plus **Backup codes not printed** when applicable).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you written new tests for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in Memoizing with create-selector and Using memoizing selectors and Our Approach to Data
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

