### PR TITLE
Login: show a nine-digit example for the emailed 2FA code

### DIFF
--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -157,7 +157,9 @@ class VerificationCodeForm extends Component {
 							isError={ requestError && requestError.field === 'twoStepCode' }
 							id="twoStepCode"
 							name="twoStepCode"
-							method={ twoFactorAuthType }
+							// An email nonce means the code was emailed, whatever the route says.
+							// Resolved the same way onSubmitForm does.
+							method={ twoFactorEmailNonce ? 'email' : twoFactorAuthType }
 							ref={ this.saveRef }
 							disabled={ this.state.isDisabled }
 							placeholder={ this.props.verificationCodeInputPlaceholder }

--- a/client/components/forms/form-verification-code-input/index.jsx
+++ b/client/components/forms/form-verification-code-input/index.jsx
@@ -42,6 +42,8 @@ export default class FormVerificationCodeInput extends Component {
 			defaultPlaceholder = constants.eightDigitBackupCodePlaceholder;
 		} else if ( method === 'sms' ) {
 			defaultPlaceholder = constants.sevenDigit2faPlaceholder;
+		} else if ( method === 'email' ) {
+			defaultPlaceholder = constants.nineDigit2faPlaceholder;
 		}
 
 		return (

--- a/client/me/constants.js
+++ b/client/me/constants.js
@@ -6,4 +6,5 @@ export default {
 	eightDigitBackupCodePlaceholder: i18n.translate( 'E.g. %(example)s', {
 		args: { example: '12345678' },
 	} ),
+	nineDigit2faPlaceholder: i18n.translate( 'E.g. %(example)s', { args: { example: '123456789' } } ),
 };


### PR DESCRIPTION
Related to #DOTOBRD-604

## Proposed Changes

* Add a `nineDigit2faPlaceholder` constant ("E.g. 123456789") to `client/me/constants.js`.
* Use it in `FormVerificationCodeInput` when `method === 'email'`, which previously fell through to the six-digit placeholder.
* In `VerificationCodeForm`, resolve the input's `method` from `twoFactorEmailNonce` rather than the raw route param, mirroring what `onSubmitForm` already does.

## Why are these changes being made?

Follow-up to #113958, which removed the digit counts from the 2FA code label because they didn't match what users received. The label is fixed, but the placeholder underneath it still is not.

wpcom emails a **nine**-digit code for locked accounts — `TwoStepAuthenticator::send_code_by_email()` sends `str_pad( random_int( 100000000, 999999999 ), 9, '0', STR_PAD_LEFT )`, and `LOCKED_ACCOUNT_AUTHCODE_LENGTH = 9`. `FormVerificationCodeInput` had branches for `backup` (8) and `sms` (7) but none for `email`, so it fell through to the six-digit default. Locked-account users were shown "E.g. 123456" for a nine-digit code.

The `method` change is belt-and-braces. `two-factor-content.jsx` already lists `email` as a valid `twoFactorAuthType` and `/log-in/email` is a registered route, so the route param is normally correct. But `onSubmitForm` treats the email nonce as the authoritative signal, and the render path did not — so a locked account reached via a different `/log-in/<type>` route would still get the wrong placeholder. Now both paths agree.

## Testing Instructions

Requires an account in the two-step locked state, which is what makes `send_code_by_email()` fire and puts `email` in `two_step_supported_auth_types`.

1. Trigger the locked-account 2FA flow and log in. You land on `/log-in/email` with the "Enter the code from the email we sent you." help text.
2. Check the code input's placeholder.
   * Before: `E.g. 123456`
   * After: `E.g. 123456789`
3. Confirm the emailed code is nine digits and that entering it still logs you in.

Regression check on the paths that already worked — no behavior change expected:

* Authenticator app (`/log-in/authenticator`): `E.g. 123456`
* SMS (`/log-in/sms`): `E.g. 1234567`
* Backup code (`/log-in/backup`): `E.g. 12345678`
* Gravatar-powered clients still override the placeholder via `verificationCodeInputPlaceholder`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes? — no. This is a copy-only change and neither `FormVerificationCodeInput` nor `VerificationCodeForm` has an existing test suite; a test here would only assert the constant back to itself. Happy to add one if a reviewer wants it.
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)? — n/a, login UI only.
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)? — n/a, no styling change.
- [x] Have you tested accessibility for your changes? No markup or semantics change; the placeholder is supplementary to the existing `FormLabel`.
- [ ] Have you used memoizing on expensive computations? — n/a.
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)? — the new string reuses the existing `E.g. %(example)s` translatable, so only the argument is new.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)? — n/a.
