### PR TITLE
Site Performance: Resolve the launch flow URL against wpcom_url

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -1,4 +1,5 @@
 import { domainsQuery } from '@automattic/api-queries';
+import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useQuery } from '@tanstack/react-query';
@@ -204,9 +205,9 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 			case 'semi_gated_site_launch':
 			case null:
 			default: {
-				const url = addQueryArgs( '/start/launch-site', {
+				const url = addQueryArgs( new URL( '/start/launch-site', config( 'wpcom_url' ) ).href, {
 					siteSlug: site?.slug,
-					back_to: window.location.pathname,
+					back_to: new URL( window.location.pathname, window.location.origin ).href,
 				} );
 
 				if ( ! canOfferPreLaunch ) {


### PR DESCRIPTION
Fixes A4A-3312. Regression from #111638.

## Proposed Changes

**How it worked before.** The "Launch your site to start measuring performance" notice on the Performance page (`client/hosting/performance/site-performance.tsx`) originally launched the site in place by dispatching `launchSite()`. #111638 shipped the semi-gated launch flow as the default and replaced that dispatch with a redirect to the `/start/launch-site` flow, built as an origin-relative URL with `back_to` set to the current pathname. #113773 later put the pre-launch confirmation modal in front of the same redirect without changing the destination.

**The problem.** The Performance page is also mounted by Automattic for Agencies (A4A) in the site overview pane on agencies.automattic.com. That origin has no `/start/launch-site` route, so since #111638 the button there lands on a 404. The relative `back_to` has the same issue in reverse: the flow would resolve it against wordpress.com.

**What this change does.** Resolve the flow URL against `config( 'wpcom_url' )` and make `back_to` absolute against the current origin, which is how the Dashboard's `wpcomLink()` builds the same link (`client/dashboard/sites/site-launch-button/use-site-launch.tsx`). `wpcom_url` comes from `config/_shared.json`, so every environment has it:

- On wordpress.com it is the same origin, so the resulting navigation is identical to today.
- On A4A it points at wordpress.com, and the flow's `back_to` handling sends the user back to the A4A performance tab after launch.
- In local development it points at the local Calypso origin.

The pre-launch modal keeps working since it only redirects to the `launchUrl` it is given.

## Why are these changes being made?

The launch button on the A4A Performance tab has been a dead link since the launch flow became the default path. Building the link against `wpcom_url` fixes it at the source, without A4A-specific branches, and matches how the Dashboard already does it.

## Testing Instructions

Prerequisites: an A4A agency with an Atomic site that is still "Coming soon", and a wordpress.com account with a "Coming soon" site.

### A4A

1. Run `yarn start-a8c-for-agencies` and log in at `http://agencies.localhost:3000`.
2. Open `http://agencies.localhost:3000/sites/overview/<coming-soon-site-slug>/jetpack-performance`.
3. Click "Launch your site" in the notice.
4. Expected: the browser goes to `http://calypso.localhost:3000/start/launch-site?siteSlug=<slug>&back_to=http%3A%2F%2Fagencies.localhost%3A3000%2Fsites%2Foverview%2F<slug>%2Fjetpack-performance` (production builds use wordpress.com). On trunk it goes to `http://agencies.localhost:3000/start/launch-site?…`, a 404.

### wordpress.com hosting dashboard (no change)

1. Run `yarn start` and open `http://calypso.localhost:3000/sites/performance/<coming-soon-site-slug>` (set `dashboard/enable-percentage-rollout` to `false` if the new dashboard takes over).
2. Click "Launch your site".
3. Expected: same as trunk. The flow opens at `/start/launch-site` on the same origin, and finishing or backing out of it returns to the performance page.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VaTPdyGttFgE96G34w2DVX
