### PR TITLE
Login: keep the 2FA page when redirect_to is a Jetpack SSO login

### DIFF
--- a/client/lib/paths/login/index.js
+++ b/client/lib/paths/login/index.js
@@ -76,9 +76,7 @@ export function login( {
 	}
 
 	if ( redirectTo ) {
-		url = redirectTo.includes( 'jetpack-sso' )
-			? redirectTo
-			: addQueryArgs( { redirect_to: redirectTo }, url );
+		url = addQueryArgs( { redirect_to: redirectTo }, url );
 	}
 
 	if ( emailAddress ) {

--- a/client/lib/paths/login/test/index.js
+++ b/client/lib/paths/login/test/index.js
@@ -18,6 +18,15 @@ describe( 'login', () => {
 		);
 	} );
 
+	test( 'should keep the two factor auth page when the redirect url is a Jetpack SSO login', () => {
+		const redirectTo =
+			'https://wordpress.com/wp-login.php?action=jetpack-sso&site_id=123&sso_nonce=abc';
+		const url = login( { twoFactorAuthType: 'push', redirectTo } );
+		expect( url ).toBe(
+			'/log-in/push?redirect_to=https%3A%2F%2Fwordpress.com%2Fwp-login.php%3Faction%3Djetpack-sso%26site_id%3D123%26sso_nonce%3Dabc'
+		);
+	} );
+
 	test( 'should return the login url with encoded email_address param', () => {
 		const url = login( { emailAddress: 'foo@bar.com' } );
 		expect( url ).toBe( '/log-in?email_address=foo%40bar.com' );

--- a/client/login/magic-login/test/handle-emailed-link-form.test.jsx
+++ b/client/login/magic-login/test/handle-emailed-link-form.test.jsx
@@ -60,6 +60,31 @@ describe( 'HandleEmailedLinkForm 2FA handoff', () => {
 		expect( instance.setState ).toHaveBeenCalledWith( { isRedirecting: true } );
 	} );
 
+	it( 'keeps the 2FA prompt when the redirect is a Jetpack SSO login', () => {
+		// Regression: `login()` used to hand back a `redirect_to` containing `jetpack-sso`
+		// verbatim, so this navigated to the SSO handler before the second factor was
+		// collected. With no session yet, the handler bounced the user back to the login page.
+		const redirectToSanitized =
+			'https://wordpress.com/wp-login.php?action=jetpack-sso&site_id=123&sso_nonce=abc';
+		const instance = buildInstance( { redirectToSanitized } );
+
+		instance.UNSAFE_componentWillUpdate(
+			{
+				...instance.props,
+				...TWO_FACTOR_PROPS,
+				isAuthenticated: true,
+				isFetching: false,
+				authError: null,
+			},
+			{ hasSubmitted: true, isRedirecting: false }
+		);
+
+		expect( page ).toHaveBeenCalledWith(
+			'/log-in/authenticator?redirect_to=https%3A%2F%2Fwordpress.com%2Fwp-login.php%3Faction%3Djetpack-sso%26site_id%3D123%26sso_nonce%3Dabc'
+		);
+		expect( instance.setState ).toHaveBeenCalledWith( { isRedirecting: true } );
+	} );
+
 	it( 'reboots after login when the account has no second factor', () => {
 		const instance = buildInstance();
 


### PR DESCRIPTION
Part of DOTOBRD-359

## Proposed Changes

* `login()` in `client/lib/paths/login` no longer returns a `redirectTo` that contains `jetpack-sso` verbatim. A Jetpack SSO redirect is encoded as `redirect_to` like every other destination.
* Add a unit test for a Jetpack SSO redirect combined with a two-factor page.

### Recordings

- Without the PR

https://github.com/user-attachments/assets/9438e843-2696-4a77-bc02-7bcca7bcbd74

- With the PR

https://github.com/user-attachments/assets/d3b983a7-6a51-44c6-8d4a-4d293b5d2916

## Why are these changes being made?

A user with 2FA enabled who logs in with a magic link from a WoW site's `/wp-admin` never got to the 2FA prompt.

After a magic link is used, the 2FA page URL is built with `login()`. When `redirect_to` is a `wp-login.php?action=jetpack-sso` URL, `login()` returned that URL itself instead of `/log-in/push?redirect_to=…`. The browser went to the SSO handler on WordPress.com before 2FA, with no session yet, and the handler sent it back to the login page. The "Email me a login link" and QR links use the same helper and bounced the same way.

For plain login links the result is unchanged: a logged-out user lands on the same login page the SSO handler would have bounced them to, and a logged-in user is sent to the SSO URL by the `redirectLoggedIn` middleware.

## Testing Instructions

Unit tests:

```
yarn test-client client/lib/paths/login
```

Manual test:

This is kinda cumbersome to test. First, you need a WPCOM account with these characteristics:
- 2FA enabled (an authenticator app is enough)
- Not an Automattician (the magic-login endpoint rejects those)
- Admin on a WoW site

Also, add this function to your `0-sandbox.php` file to facilitate testing. This function will extract the `redirect_to` query parameter from the magic link and replace the `wpcalypso.wordpress.com` environment with the live Calypso container so we can test this PR.

```php
function test_114031_get_redirect_url_for_container() {
	$container_domain = '<CALYPSO LIVE CONTAINER NAME>.calypso.live';
	$magic_link = '<PASTE YOUR MAGIC LINK URL HERE>';

	parse_str( parse_url( $magic_link, PHP_URL_QUERY ), $query );
	$parts = parse_url( $query['redirect_to'] );
	echo 'https://' . $container_domain . $parts['path'] . '?' . $parts['query'] . "\n";
}
```

The `<CALYPSO LIVE CONTAINER NAME>` should be checked by clicking the live Calypso link [here](https://github.com/Automattic/wp-calypso/pull/114031#issuecomment-5511474654). The magic link URL will be retrieved in step 5.

Run the tests without the A8C proxy and in an incognito window.

1. Open the WoW site's `/wp-admin`. You land on `https://wordpress.com/log-in?redirect_to=https%3A%2F%2Fwordpress.com%2Fwp-login.php%3Faction%3Djetpack-sso%26site_id%3D…%26sso_nonce%3D…`.
2. Reproduce the bug on production first: click "Email me a login link". The login page reloads instead of showing "Check your email".
3. In the address bar, replace only `wordpress.com/log-in` with `<your container>.calypso.live/log-in`. Don't change the query string.
4. Click "Email me a login link", or type the email and press Continue. The "Check your email" screen opens.
5. Check the email you receive from WordPress.com. Copy the login link, paste it in the test function and run it, then open the URL it returns
6. Expected: the container shows `/log-in/authenticator?redirect_to=…` (or `/log-in/push`), and after the code you land in the site's wp-admin through `wp-login.php?action=jetpack-sso`. Without this branch the login page reloads with the same `redirect_to`.
7. Controls: from the container's `/log-in` with no `redirect_to`, the magic link still leads to the 2FA prompt and then `/home`. Password plus 2FA from the URL in step 3 still lands in wp-admin.

The `sso_nonce` expires 10 minutes after step 1. If the email is slow to arrive, start again from step 1 rather than reusing the link.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)





