### PR TITLE
Desktop: restore keyboard focus to the content view on window activation

### DIFF
--- a/desktop/app/mainWindow/index.js
+++ b/desktop/app/mainWindow/index.js
@@ -107,6 +107,15 @@ function showAppWindow() {
 		}, 10 );
 	} );
 
+	// The window's own webContents renders the title bar, so Electron gives it the keyboard
+	// every time the window is activated. Hand it to the content view instead, otherwise the
+	// user cannot type anywhere until the app restarts. See DOTAPP-7.
+	mainWindow.on( 'focus', function () {
+		if ( ! mainView.webContents.isDestroyed() ) {
+			mainView.webContents.focus();
+		}
+	} );
+
 	SessionManager.init( mainWindow );
 
 	mainView.webContents.on( 'did-finish-load', function () {


### PR DESCRIPTION
Part of #75520
Part of DOTAPP-7

## Proposed Changes

* Focus the content `BrowserView` on every main window `focus` event, so the keyboard goes to the page instead of to the title bar.
* One handler covers both triggers, Cmd-Tab and the dock click that runs `app.on( 'activate' )`, so no platform branch is needed.
* Out of scope: the Multi-Site Dashboard opens a mailbox with `window.open( url, '_blank' )`, and Electron 39 turns that into a separate unmanaged window because the app's `new-window` interceptor no longer fires.

## Why are these changes being made?

* The app renders its title bar in the `BrowserWindow`'s own webContents and all web content in a `BrowserView`. Electron gives the keyboard to the window's webContents on activation, and nothing handed it back. After switching away from the app and back, typed characters went to the title bar, which has no text field. Nothing could be typed anywhere, including the Titan login fields, posts, pages and search, until the app was restarted.

## Testing Instructions

* Run `cd desktop && yarn dev` and log in.
* Open devtools and issue `window.open = ( url ) => { location.href = url; return window; };`
* In the wp.com sidebar, click Emails, then click "View mailbox" on one of the rows
* In the Titan page opened, check that keyboard input works
* Switch away from the window, switch back, and confirm that keyboard input still works

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

**Note on tests:** verifying this needs a GUI session and a real application switch, which the packaged-build e2e suite cannot drive. I verified it manually and with a scripted probe that reports which webContents holds focus after three real app switches: FAIL on `trunk`, PASS with this change.
