### PR TITLE
Site generation: align fallback progress labels with wpcom

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/index.tsx
@@ -23,11 +23,11 @@ const SiteGeneration: StepType = function SiteGeneration() {
 	const steps = useMemo(
 		() => [
 			{ id: 'prepare', label: translate( 'Preparing your site' ) },
-			{ id: 'design', label: translate( 'Choosing your design' ) },
+			{ id: 'design', label: translate( 'Creating your design' ) },
 			{ id: 'pages', label: translate( 'Building your pages' ) },
 			{ id: 'images', label: translate( 'Adding your images' ) },
 			{ id: 'polish', label: translate( 'Polishing your site' ) },
-			{ id: 'publish', label: translate( 'Publishing your site' ) },
+			{ id: 'publish', label: translate( 'Doing final checks' ) },
 		],
 		[ translate ]
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-generation/test/use-site-generation.tsx
@@ -24,22 +24,22 @@ const originalLocation = window.location;
 
 const STEPS = [
 	{ id: 'preparing', label: 'Preparing your site' },
-	{ id: 'designing', label: 'Choosing your design' },
+	{ id: 'designing', label: 'Creating your design' },
 	{ id: 'building', label: 'Building your pages' },
 	{ id: 'images', label: 'Adding your images' },
 	{ id: 'polishing', label: 'Polishing your site' },
-	{ id: 'publishing', label: 'Publishing your site' },
+	{ id: 'publishing', label: 'Doing final checks' },
 ];
 
 // A server checklist in the shape big_sky_build_wow_status_ui_steps() emits.
 const SERVER_STEPS = ( activeIndex: number ) =>
 	[
 		{ id: 'prepare', label: 'Preparing your site' },
-		{ id: 'design', label: 'Choosing your design' },
+		{ id: 'design', label: 'Creating your design' },
 		{ id: 'pages', label: 'Building your pages' },
 		{ id: 'images', label: 'Adding your images' },
 		{ id: 'polish', label: 'Polishing your site' },
-		{ id: 'publish', label: 'Publishing your site' },
+		{ id: 'publish', label: 'Doing final checks' },
 	].map( ( step, index ) => {
 		let state = 'pending';
 		if ( index < activeIndex ) {


### PR DESCRIPTION
Fixes [BIGR-948](https://linear.app/a8c/issue/BIGR-948/clarify-ai-site-building-progress-step-labels)

Depends on 238794-gh-Automattic/wpcom

## Proposed Changes

* Change “Choosing your design” to “Creating your design”.
* Change “Publishing your site” to “Doing final checks”.

<img width="1400" height="842" alt="Capture d’écran 2026-09-04 à 14 42 08" src="https://github.com/user-attachments/assets/8bb1fb23-426b-4a52-9743-eb5ffd1da811" />


## Testing Instructions

* Apply the companion wpcom PR to a sandbox and run the asynchronous job watcher.
* Start Calypso locally and complete the Generate Theme flow.
* Confirm the sidebar labels have changed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
