### PR TITLE
Document agenttic package development and release process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 ## Packages
 
 - **Agents Manager** (`packages/agents-manager`) — shared component library for WordPress.com's unified AI agent experience, running in Calypso, Simple, and Atomic sites. Also deployed via `apps/agents-manager/` to `widgets.wp.com`. See its `AGENTS.md` for architecture and conventions.
+- **Agenttic** (`packages/agenttic-client`, `packages/agenttic-ui`) — AI agent chat client library and UI components. Also published to npm for consumers outside this repo. ⚠️ Still on its pre-migration package layout (vite-built, ESM-only, flat `dist/`, no `calypso:src`); normalizing it is a future goal, but the published artifact shape is a contract with external consumers — read the Development and Releasing sections in `packages/agenttic-client/README.md` before restructuring or publishing.
 - **Help Center** (`packages/help-center`) — shared component library for WordPress.com support. Also deployed via `apps/help-center/` to `widgets.wp.com`.
 - **Image Studio** (`packages/image-studio`) — AI-powered image editing and generation
 - **Calypso Products** (`packages/calypso-products`) — ⚠️ **Avoid.** Deprecated/frozen: a bloated client-side duplicate of product data the backend already owns. Don't add to it; prefer backend-driven data (e.g. `@automattic/api-queries`). See `packages/calypso-products/AGENTS.md`.

--- a/packages/agenttic-client/README.md
+++ b/packages/agenttic-client/README.md
@@ -584,16 +584,62 @@ message matches, nothing runs and the update stays final.
 
 ## Development
 
+This package lives in the wp-calypso monorepo but still carries its
+pre-migration build setup: it is built by vite into a flat, ESM-only `dist/`
+(not the usual `dist/esm` + `dist/cjs` tsc layout), and it is consumed from
+`dist/` even inside the repo — there is no `calypso:src` entry, because the
+source relies on vite-only features such as `import.meta.glob`. Converging on
+the standard Calypso package layout is a goal, but it cannot happen casually:
+the published artifact shape is a contract with npm consumers outside this
+repository, so restructuring needs a coordinated release.
+
 ```bash
-# Build the package
-pnpm build
-
-# Run tests
-pnpm test
-
-# Type checking
-pnpm type-check
-
-# Lint
-pnpm lint
+# From the wp-calypso root
+yarn workspace @automattic/agenttic-client run build
+yarn workspace @automattic/agenttic-client run test        # vitest — not part of CI yet
+yarn workspace @automattic/agenttic-client run type-check
 ```
+
+For live rebuilds while developing against an in-repo consumer (e.g.
+`apps/agents-manager` with `yarn dev --sync`), run
+`yarn workspace @automattic/agenttic-client run dev` (`vite build --watch`) —
+webpack watches the workspace `dist/` and rebuilds the consumer automatically.
+
+## Releasing
+
+`@automattic/agenttic-client` and `@automattic/agenttic-ui` are published to npm
+for consumers outside this repository; in-repo consumers use `workspace:^` and
+never need a release. The two packages are versioned in lockstep and released
+together. See [the monorepo guide](../../docs/guide/monorepo.md) for npm
+permissions and the general publishing rules.
+
+1. Bump the version of **both** packages in one PR and merge it to trunk.
+2. From the latest trunk, build both packages explicitly:
+
+   ```bash
+   yarn workspace @automattic/agenttic-client run build
+   yarn workspace @automattic/agenttic-ui run build
+   ```
+
+   This step is **required**: `yarn npm publish` packs whatever `dist/` contains
+   and runs no build lifecycle (`prepare` and `prepublishOnly` are ignored), so
+   a stale or missing `dist/` publishes a broken package silently. The
+   agenttic-ui build downloads translation files and needs network access.
+
+3. `yarn npm login --scope automattic`, then publish each package:
+
+   ```bash
+   cd packages/agenttic-client && yarn npm publish
+   cd ../agenttic-ui && yarn npm publish
+   ```
+
+4. Tag both packages on the release commit and push the tags:
+
+   ```bash
+   git tag "@automattic/agenttic-client@<version>"
+   git tag "@automattic/agenttic-ui@<version>"
+   git push origin "@automattic/agenttic-client@<version>" "@automattic/agenttic-ui@<version>"
+   ```
+
+   If git asks to confirm pushing to trunk, that is fine here — you are pushing
+   tags, not commits, and branch protection guards against the rest.

--- a/packages/agenttic-ui/README.md
+++ b/packages/agenttic-ui/README.md
@@ -578,22 +578,30 @@ import {
 
 ## Development
 
+This package lives in the wp-calypso monorepo but still carries its
+pre-migration build setup — vite-built, ESM-only, flat `dist/`, consumed from
+`dist/` even in-repo. See the Development section in
+[`packages/agenttic-client/README.md`](../agenttic-client/README.md) for the
+full context before restructuring anything.
+
 ```bash
-# Build the package
-pnpm build
-
-# Run in development mode
-pnpm dev
-
-# Run tests
-pnpm test
-
-# Type checking
-pnpm type-check
-
-# Start Storybook
-pnpm storybook
+# From the wp-calypso root
+yarn workspace @automattic/agenttic-ui run build       # downloads translations; needs network
+yarn workspace @automattic/agenttic-ui run test        # vitest — not part of CI yet
+yarn workspace @automattic/agenttic-ui run type-check
+yarn workspace @automattic/agenttic-ui run storybook
 ```
+
+For live rebuilds while developing against an in-repo consumer, run
+`yarn workspace @automattic/agenttic-ui exec vite build --watch` — webpack
+watches the workspace `dist/` and rebuilds the consumer automatically.
+
+## Releasing
+
+Published to npm together with `@automattic/agenttic-client`, in lockstep. The
+release process — including the mandatory explicit build before
+`yarn npm publish` — is documented in the Releasing section of
+[`packages/agenttic-client/README.md`](../agenttic-client/README.md).
 
 ## Integration with agenttic-client
 


### PR DESCRIPTION
## Proposed Changes

Documents how the agenttic packages are developed and released now that they live in the monorepo (first monorepo release, 0.1.90, was published this week).

* `packages/agenttic-client/README.md` — replace the stale pnpm-era Development section with current yarn workspace commands, explain the carried-over pre-migration build setup (vite-built, ESM-only, flat `dist/`, no `calypso:src`; normalizing to the standard layout is a future goal but needs a coordinated release since the artifact shape is a contract with external npm consumers), document the watch-mode dev loop against in-repo consumers, and add the canonical Releasing runbook: lockstep version bump, the **mandatory explicit build** before `yarn npm publish` (yarn ignores `prepare`/`prepublishOnly` when packing, so a stale or missing `dist/` publishes silently broken), login/publish steps, and per-package tags.
* `packages/agenttic-ui/README.md` — same Development refresh (yarn commands, watch recipe), with Releasing pointing at the canonical runbook in the agenttic-client README.
* `AGENTS.md` — add an Agenttic entry to the Packages list flagging the npm publishing and the pre-migration layout.

`docs/guide/monorepo.md` is intentionally untouched — the generic publish flow there worked as written for the 0.1.90 release.

## Why are these changes being made?

* The 0.1.90 release exercised the full publish flow from the monorepo for the first time and surfaced knowledge that only lived in heads: the explicit-build requirement (verified empirically — `yarn pack` with a missing `dist/` silently produces a near-empty tarball), the translation-download network dependency, the tag conventions, and the reason the packages don't follow the standard Calypso layout. Writing it down keeps the next release and the eventual layout normalization from rediscovering all of it.

## Testing Instructions

* Docs-only change — proofread the rendered READMEs and the AGENTS.md entry.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
