### PR TITLE
Checkout: stop cart error notices from stacking

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -375,9 +375,9 @@ export default function CheckoutMain( {
 		} );
 	} );
 
-	// Display errors. Note that we display all errors if any of them change,
-	// because errorNotice() otherwise will remove the previously displayed
-	// errors.
+	// Display errors. These notices share an ID so that a new one replaces the
+	// last rather than stacking; that means each notice must render every error
+	// currently active, not just the ones which have changed.
 	const errorsToDisplay = [
 		cartLoadingError,
 		stripeLoadingError?.message,
@@ -385,7 +385,10 @@ export default function CheckoutMain( {
 	].filter( isValueTruthy );
 	useActOnceOnStrings( errorsToDisplay, () => {
 		reduxDispatch(
-			errorNotice( errorsToDisplay.map( ( message ) => <p key={ message }>{ message }</p> ) )
+			errorNotice(
+				errorsToDisplay.map( ( message ) => <p key={ message }>{ message }</p> ),
+				{ id: 'checkout-cart-error' }
+			)
 		);
 	} );
 

--- a/client/my-sites/checkout/src/test/checkout-main.tsx
+++ b/client/my-sites/checkout/src/test/checkout-main.tsx
@@ -841,4 +841,22 @@ describe( 'CheckoutMain', () => {
 			expect( emailField ).toBeDisabled();
 		}, [] );
 	} );
+
+	it( 'displays cart errors in a notice with a stable ID so repeats replace rather than stack', async () => {
+		const cartChanges = { products: [] };
+		const additionalProps = { productAliasFromUrl: 'personal-bundle' };
+		render(
+			<MockCheckout
+				initialCart={ initialCart }
+				cartChanges={ cartChanges }
+				additionalProps={ additionalProps }
+				setCart={ () => Promise.reject( new Error( 'The cart could not be updated' ) ) }
+			/>
+		);
+		await waitFor( () => {
+			expect( errorNotice ).toHaveBeenCalledWith( expect.anything(), {
+				id: 'checkout-cart-error',
+			} );
+		} );
+	} );
 } );


### PR DESCRIPTION
Part of CHE-520

## Proposed changes

Checkout could stack several identical error notices for a single failing cart. This gives that notice a stable ID so a new one replaces the last instead of piling up.

* Dispatch `CheckoutMain`'s cart/Stripe/product-prep error notice with `{ id: 'checkout-cart-error' }`.
* Update the adjacent comment, whose original rationale is now the intended mechanism.
* Add a regression test asserting a failing cart request produces a notice carrying that ID.

## Why are these changes being made?

A customer following a stale renewal link was shown three error notices that all said essentially the same thing. Three things combined to produce that:

1. `CheckoutMain` called `errorNotice()` with no `id`, so `createNotice` assigned `crypto.randomUUID()` and every dispatch created a brand new notice rather than replacing the previous one. (`CartMessages` already passes `id: message.code`, which is why cart messages never duplicated.)
2. The `useActOnceOnStrings` callback re-renders the whole current error list, so a newly-arrived error reprints the earlier ones alongside it — hence notices with two lines.
3. `useActOnceOnStrings` overwrites its "already seen" ref each run instead of accumulating, so a message that disappears and comes back counts as new again.

The flap in (3) is easy to hit. `loadingError` is only exposed while `cacheStatus === 'error'` (`managers.ts`), and every cart action clears it before the retry re-raises it. Checkout sets `refetchOnWindowFocus: true`, and `CART_RELOAD` is permitted in the error state, so each time the customer tabbed away and back while the cart was failing they collected one more identical notice, unbounded.

A stable ID is the smallest fix that addresses all of it: repeats now replace. I deliberately left `useActOnceOnStrings` alone — with the ID in place, re-firing is harmless, and the current behaviour usefully preserves both re-showing an error the customer dismissed and the per-attempt `calypso_checkout_composite_cart_error` telemetry.

Note this only fixes the *count* of errors. Humanizing the wording, the other half of CHE-520, is not addressed here. Much of the underlying invalid-renewal handling was already improved in SHILL-1187, which moved most of these cases from hard 403s to deduplicated cart messages; this closes the remaining path that could still stack.

## Testing instructions

TC:
```
yarn test-client client/my-sites/checkout/src/test/checkout-main.tsx --runInBand
```

The new test fails on trunk and passes with this change.

Manual testing:
* Open checkout in a state where the cart request fails — e.g. a renewal URL for a subscription on a site your account can't access, or block `/me/shopping-cart/` in devtools.
* Confirm a single error notice appears.
* Switch to another browser tab and back a few times. Each refocus retries the cart; before this change every retry added another identical notice, and now the existing one is replaced.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
