### PR TITLE
E2E: wait for Playground navigations in the Playground to Atomic spec

### DIFF
--- a/test/e2e/specs/onboarding/onboarding__playground-to-atomic.spec.ts
+++ b/test/e2e/specs/onboarding/onboarding__playground-to-atomic.spec.ts
@@ -8,6 +8,8 @@ import {
 import { expect, skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 import { apiCancelAtomicPlan, apiCloseAccount, recordAccountLeakMarker } from '../shared';
 
+const PLAYGROUND_NAVIGATION_TIMEOUT = 60 * 1000;
+
 test.describe(
 	DataHelper.createSuiteTitle( 'Onboarding: Publish a Playground site to Atomic' ),
 	{ tag: [ tags.CALYPSO_RELEASE, tags.IMPORTS, tags.DESKTOP_ONLY ] },
@@ -82,16 +84,26 @@ test.describe(
 					.frameLocator( 'iframe[title="WordPress Playground"]' )
 					.frameLocator( 'iframe[title="The WordPress site"]' );
 				await expect( playground.locator( '#wpadminbar' ) ).toBeVisible( {
-					timeout: 60 * 1000,
+					timeout: PLAYGROUND_NAVIGATION_TIMEOUT,
 				} );
 				await playground.locator( '#wp-admin-bar-site-name' ).hover();
 				await playground.locator( '#wp-admin-bar-dashboard > a' ).click();
-				await playground.getByRole( 'link', { name: 'Settings', exact: true } ).first().click();
+
+				// Every page load inside Playground runs PHP in WebAssembly and can take
+				// longer than the default action timeout, so wait for each navigation.
+				const settingsLink = playground
+					.getByRole( 'link', { name: 'Settings', exact: true } )
+					.first();
+				await expect( settingsLink ).toBeVisible( { timeout: PLAYGROUND_NAVIGATION_TIMEOUT } );
+				await settingsLink.click();
 
 				const siteTitle = playground.getByRole( 'textbox', { name: 'Site Title' } );
+				await expect( siteTitle ).toBeVisible( { timeout: PLAYGROUND_NAVIGATION_TIMEOUT } );
 				await siteTitle.fill( playgroundSiteTitle );
 				await playground.getByRole( 'button', { name: 'Save Changes' } ).click();
-				await expect( playground.getByText( 'Settings saved.' ) ).toBeVisible();
+				await expect( playground.getByText( 'Settings saved.' ) ).toBeVisible( {
+					timeout: PLAYGROUND_NAVIGATION_TIMEOUT,
+				} );
 				await expect( siteTitle ).toHaveValue( playgroundSiteTitle );
 			} );
 


### PR DESCRIPTION
Related to #113535

## Proposed Changes

* After clicking Dashboard in the Playground admin bar, wait for the Settings link before clicking it.
* Wait for the Site Title field and the "Settings saved." notice with the same 60s timeout the spec already uses for the admin bar.

## Why are these changes being made?

The pre-release run of `onboarding__playground-to-atomic.spec.ts` fails intermittently, always at the same spot: after clicking Dashboard, the Settings link is not there within the 10s action timeout. On a retry the snapshot shows the dashboard loaded with the Settings link present, just after the timeout expired. Page loads inside Playground run PHP in WebAssembly and regularly take longer than 10s, so each navigation needs to be waited for explicitly.

## Testing Instructions

* This spec only runs on trunk (`skipIfNotTrunk`), so it will run in the next pre-release build after merge.
* `yarn eslint`, `prettier` and `tsc` pass on the file.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Az3f2VYravdpp5Bv1QmggV
