### PR TITLE
Checkout: show a wrong-account screen for renewal links

### DIFF
--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -4,6 +4,7 @@ import { JETPACK_CONTACT_SUPPORT, JETPACK_SUPPORT } from '@automattic/urls';
 import { useDisplayCartMessages } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
+import { WRONG_ACCOUNT_RENEWAL_ERROR_CODE } from 'calypso/my-sites/checkout/src/hooks/use-has-wrong-account-renewal-error';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
@@ -41,7 +42,7 @@ export default function CartMessages( {
 
 	const showErrorMessages = useCallback(
 		( messages: ResponseCartMessage[] ) => {
-			showMessages( messages, reduxDispatch, 'error' );
+			showMessages( messages.filter( hasNoScreenOfItsOwn ), reduxDispatch, 'error' );
 		},
 		[ reduxDispatch ]
 	);
@@ -62,6 +63,17 @@ export default function CartMessages( {
 	} );
 
 	return null;
+}
+
+/**
+ * Errors that checkout renders as a dedicated screen with its own explanation
+ * and a way out. A notice for those would only repeat, in one line and with no
+ * action attached, what the screen already says better.
+ */
+const CART_ERROR_CODES_WITH_THEIR_OWN_SCREEN = [ WRONG_ACCOUNT_RENEWAL_ERROR_CODE ];
+
+function hasNoScreenOfItsOwn( message: ResponseCartMessage ): boolean {
+	return ! CART_ERROR_CODES_WITH_THEIR_OWN_SCREEN.includes( message.code );
 }
 
 function getChargebackErrorMessage( {

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -125,6 +125,7 @@ import {
 } from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 import WPContactFormSummary from './wp-contact-form-summary';
+import { LogInToCorrectAccountButton, WrongAccountRenewal } from './wrong-account-renewal';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type {
 	CheckoutPageErrorCallback,
@@ -416,6 +417,7 @@ export default function CheckoutMainContent( {
 	siteUrl,
 	isRemovingProductFromCart,
 	areThereErrors,
+	isWrongAccountRenewal,
 	isInitialCartLoading,
 	customizedPreviousPath,
 	loadingHeader,
@@ -439,6 +441,7 @@ export default function CheckoutMainContent( {
 	siteUrl: string | undefined;
 	isRemovingProductFromCart: boolean;
 	areThereErrors: boolean;
+	isWrongAccountRenewal: boolean;
 	isInitialCartLoading: boolean;
 	customizedPreviousPath?: string;
 	loadingHeader?: ReactNode;
@@ -666,6 +669,26 @@ export default function CheckoutMainContent( {
 					<Loading className="checkout__pending-content" title={ headingText } />
 				</WPCheckoutCompletedMainContent>
 			</WPCheckoutCompletedWrapper>
+		);
+	}
+
+	// This must be checked before the empty cart page below: the renewal was
+	// rejected by the cart, so the cart is also empty, but "you have no items in
+	// your cart" tells the customer nothing they can act on.
+	if ( isWrongAccountRenewal ) {
+		debug( 'rendering wrong account renewal page' );
+		return (
+			<WPCheckoutWrapper>
+				<WPCheckoutSidebarContent></WPCheckoutSidebarContent>
+				<WPCheckoutMainContent isMobileCheckoutStickySummary={ isMobileCheckoutStickySummary }>
+					<PerformanceTrackerStop />
+					<WPCheckoutTitle className="checkout__main-title">
+						{ translate( 'Checkout' ) }
+					</WPCheckoutTitle>
+					<WrongAccountRenewal />
+					<CheckoutFormSubmit submitButton={ <LogInToCorrectAccountButton /> } />
+				</WPCheckoutMainContent>
+			</WPCheckoutWrapper>
 		);
 	}
 

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -41,6 +41,7 @@ import { existingPayPalPPCPPrefix } from '../hooks/use-create-payment-methods/us
 import useCreatePaymentSubmittedAndProcessingCallback from '../hooks/use-create-payment-submitted-and-processing-callback';
 import useDetectedCountryCode from '../hooks/use-detected-country-code';
 import useGetThankYouUrl from '../hooks/use-get-thank-you-url';
+import { useHasWrongAccountRenewalError } from '../hooks/use-has-wrong-account-renewal-error';
 import { useMobileCheckoutStickySummaryExperiment } from '../hooks/use-mobile-checkout-sticky-summary-experiment';
 import usePrepareProductsForCart from '../hooks/use-prepare-products-for-cart';
 import useRecordCartLoaded from '../hooks/use-record-cart-loaded';
@@ -390,6 +391,12 @@ export default function CheckoutMain( {
 	} );
 
 	const responseCartErrors = responseCart.messages?.errors ?? [];
+
+	// A renewal for a subscription owned by another account gets its own screen
+	// rather than the generic empty cart page, because there is something the
+	// customer can do about it.
+	const isWrongAccountRenewal = useHasWrongAccountRenewalError( responseCart );
+
 	const areThereErrors =
 		[ ...responseCartErrors, cartLoadingError, cartProductPrepError ].filter( isValueTruthy )
 			.length > 0;
@@ -914,6 +921,7 @@ export default function CheckoutMain( {
 						customizedPreviousPath={ customizedPreviousPath }
 						isRemovingProductFromCart={ isRemovingProductFromCart }
 						areThereErrors={ areThereErrors }
+						isWrongAccountRenewal={ isWrongAccountRenewal }
 						isInitialCartLoading={ isInitialCartLoading }
 						addItemToCart={ addItemAndLog }
 						changeSelection={ changeSelection }

--- a/client/my-sites/checkout/src/components/wrong-account-renewal.tsx
+++ b/client/my-sites/checkout/src/components/wrong-account-renewal.tsx
@@ -1,0 +1,79 @@
+import { Button, CheckoutStepBody } from '@automattic/composite-checkout';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { login } from 'calypso/lib/paths';
+import { useSelector, useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { redirectToLogout } from 'calypso/state/current-user/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+
+export function WrongAccountRenewal() {
+	const reduxDispatch = useDispatch();
+	useEffect( () => {
+		reduxDispatch( recordTracksEvent( 'calypso_checkout_wrong_account_renewal' ) );
+	}, [ reduxDispatch ] );
+
+	return (
+		<CheckoutStepBody
+			stepId="wrong-account-renewal"
+			isStepActive={ false }
+			isStepComplete
+			titleContent={ <WrongAccountRenewalTitle /> }
+			completeStepContent={ <WrongAccountRenewalExplanation /> }
+		/>
+	);
+}
+
+function WrongAccountRenewalTitle() {
+	const translate = useTranslate();
+	return <>{ String( translate( 'This subscription belongs to a different account' ) ) }</>;
+}
+
+function WrongAccountRenewalExplanation() {
+	const translate = useTranslate();
+	const username = useSelector( getCurrentUser )?.username;
+
+	if ( ! username ) {
+		return (
+			<>
+				{ translate(
+					'The subscription you are trying to renew was purchased with a different WordPress.com account. Log in to that account to renew it.'
+				) }
+			</>
+		);
+	}
+
+	return (
+		<>
+			{ translate(
+				'The subscription you are trying to renew was purchased with a different WordPress.com account. You are currently logged in as {{strong}}%(username)s{{/strong}}, so log in to the account that purchased it to renew it.',
+				{
+					args: { username },
+					components: { strong: <strong /> },
+				}
+			) }
+		</>
+	);
+}
+
+/**
+ * Logs the customer out and sends them to the login page, which will return
+ * them to this checkout page once they have logged in to the right account.
+ */
+export function LogInToCorrectAccountButton() {
+	const translate = useTranslate();
+	const reduxDispatch = useDispatch();
+
+	return (
+		<Button
+			buttonType="primary"
+			fullWidth
+			onClick={ () => {
+				reduxDispatch( recordTracksEvent( 'calypso_checkout_wrong_account_renewal_login_click' ) );
+				reduxDispatch( redirectToLogout( login( { redirectTo: window.location.href } ) ) );
+			} }
+		>
+			{ translate( 'Log in to the right account' ) }
+		</Button>
+	);
+}

--- a/client/my-sites/checkout/src/hooks/use-has-wrong-account-renewal-error.ts
+++ b/client/my-sites/checkout/src/hooks/use-has-wrong-account-renewal-error.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import type { ResponseCart } from '@automattic/shopping-cart';
+
+/**
+ * The cart error code returned when a renewal names a subscription that belongs
+ * to another user. Must match the code sent by the shopping cart backend.
+ */
+export const WRONG_ACCOUNT_RENEWAL_ERROR_CODE = 'renewal-wrong-account';
+
+/**
+ * Whether the cart has rejected a renewal because it belongs to a different
+ * WordPress.com account, which usually means the customer has more than one
+ * account and followed a renewal link while signed in to the wrong one.
+ *
+ * Regular cart errors are transient: they are returned only by the request that
+ * caused them, so any later fetch of the cart (the cart refetches on window
+ * focus) would drop this one and leave behind an empty cart with no explanation
+ * of what went wrong. Once we have seen the error we therefore keep reporting
+ * it for the rest of the page's life.
+ */
+export function useHasWrongAccountRenewalError( responseCart: ResponseCart ): boolean {
+	const isInCurrentCart = ( responseCart.messages?.errors ?? [] ).some(
+		( error ) => error.code === WRONG_ACCOUNT_RENEWAL_ERROR_CODE
+	);
+	const [ wasInAnyCart, setWasInAnyCart ] = useState( false );
+	useEffect( () => {
+		if ( isInCurrentCart ) {
+			setWasInAnyCart( true );
+		}
+	}, [ isInCurrentCart ] );
+	return isInCurrentCart || wasInAnyCart;
+}

--- a/client/my-sites/checkout/src/test/wrong-account-renewal.tsx
+++ b/client/my-sites/checkout/src/test/wrong-account-renewal.tsx
@@ -1,0 +1,122 @@
+/**
+ * @jest-environment jsdom
+ */
+import { CheckoutProvider } from '@automattic/composite-checkout';
+import { getEmptyResponseCart } from '@automattic/shopping-cart';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { redirectToLogout } from 'calypso/state/current-user/actions';
+import { renderWithProvider, renderHookWithProvider } from 'calypso/test-helpers/testing-library';
+import {
+	LogInToCorrectAccountButton,
+	WrongAccountRenewal,
+} from '../components/wrong-account-renewal';
+import {
+	useHasWrongAccountRenewalError,
+	WRONG_ACCOUNT_RENEWAL_ERROR_CODE,
+} from '../hooks/use-has-wrong-account-renewal-error';
+import type { ResponseCart } from '@automattic/shopping-cart';
+
+jest.mock( 'calypso/state/current-user/actions', () => ( {
+	...jest.requireActual( 'calypso/state/current-user/actions' ),
+	redirectToLogout: jest.fn( () => ( { type: 'REDIRECT_TO_LOGOUT_MOCK' } ) ),
+} ) );
+
+function getCartWithErrorCodes( codes: string[] ): ResponseCart {
+	return {
+		...getEmptyResponseCart(),
+		messages: {
+			errors: codes.map( ( code ) => ( { code, message: 'Something went wrong' } ) ),
+		},
+	};
+}
+
+/**
+ * Both components are rendered inside checkout, so they rely on its theme and
+ * form state the same way every other step of the page does.
+ */
+function CheckoutWrapper( { children }: { children: React.ReactNode } ) {
+	return (
+		<CheckoutProvider paymentMethods={ [] } paymentProcessors={ {} }>
+			{ children }
+		</CheckoutProvider>
+	);
+}
+
+const stateWithUser = {
+	currentUser: {
+		id: 12345,
+		user: { ID: 12345, username: 'wrongaccount' },
+	},
+};
+
+describe( 'useHasWrongAccountRenewalError', () => {
+	it( 'is false for a cart with no errors', () => {
+		const { result } = renderHookWithProvider( () =>
+			useHasWrongAccountRenewalError( getEmptyResponseCart() )
+		);
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'is false for a cart with some other error', () => {
+		const { result } = renderHookWithProvider( () =>
+			useHasWrongAccountRenewalError( getCartWithErrorCodes( [ 'invalid-product-id' ] ) )
+		);
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'is true for a cart with the wrong account renewal error', () => {
+		const { result } = renderHookWithProvider( () =>
+			useHasWrongAccountRenewalError(
+				getCartWithErrorCodes( [ WRONG_ACCOUNT_RENEWAL_ERROR_CODE ] )
+			)
+		);
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'stays true once the error has been seen, because cart errors are transient', () => {
+		const { result, rerender } = renderHookWithProvider(
+			( cart: ResponseCart ) => useHasWrongAccountRenewalError( cart ),
+			{ initialProps: getCartWithErrorCodes( [ WRONG_ACCOUNT_RENEWAL_ERROR_CODE ] ) }
+		);
+		expect( result.current ).toBe( true );
+
+		// A later fetch of the cart (the cart refetches when the window regains
+		// focus) returns no messages at all.
+		rerender( getEmptyResponseCart() );
+		expect( result.current ).toBe( true );
+	} );
+} );
+
+describe( 'WrongAccountRenewal', () => {
+	it( 'explains the problem and names the account the customer is logged in to', () => {
+		renderWithProvider(
+			<CheckoutWrapper>
+				<WrongAccountRenewal />
+			</CheckoutWrapper>,
+			{ initialState: stateWithUser }
+		);
+		expect(
+			screen.getByText( 'This subscription belongs to a different account' )
+		).toBeInTheDocument();
+		expect( screen.getByText( /wrongaccount/ ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'LogInToCorrectAccountButton', () => {
+	it( 'logs the customer out and sends them to log in again, returning here afterwards', async () => {
+		const user = userEvent.setup();
+		renderWithProvider(
+			<CheckoutWrapper>
+				<LogInToCorrectAccountButton />
+			</CheckoutWrapper>,
+			{ initialState: stateWithUser }
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Log in to the right account' } ) );
+
+		expect( redirectToLogout ).toHaveBeenCalledWith(
+			`/log-in?redirect_to=${ encodeURIComponent( window.location.href ) }`
+		);
+	} );
+} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2497/

Backend counterpart: Automattic/wpcom#238866

## Proposed changes

This gives the new `renewal-wrong-account` cart error its own checkout screen, with a button that logs the customer out and brings them back to the same renewal once they have signed in to the account that owns the subscription.

* Add `useHasWrongAccountRenewalError()`, which reads the code off the cart and latches it.
* Add a `WrongAccountRenewal` screen naming the account the customer is currently signed in to, plus a `LogInToCorrectAccountButton`.
* Render it in `CheckoutMainContent` ahead of the empty cart page.
* Suppress the generic error notice for this one code in `CartMessages` so the screen is the only message.
* Add unit tests for the hook, the screen copy and the button's destination.

Before (with backend change)            |  After
:-------------------------:|:-------------------------:
<img width="1499" height="482" alt="Screenshot 2026-09-03 at 10 55 05 AM" src="https://github.com/user-attachments/assets/533cabc1-8d47-4b5a-b990-c531bed95784" /> | <img width="1505" height="417" alt="Screenshot 2026-09-03 at 10 57 22 AM" src="https://github.com/user-attachments/assets/1ef35d05-5675-403e-b1b0-95a98b3380c6" />


## Why are these changes being made?

Since #106661 removed the "verify that you are logged into the correct account" message, a renewal link followed from a second WordPress.com account produces a checkout that appears to work and then fails at payment with "Please ask the subscription owner to renew the subscription" — advice that makes no sense to someone who believes they *are* the owner. With the paired wpcom change the cart now rejects it at load, but the default handling for a cart error is a red notice over "You have no items in your cart", which is no more actionable.

The screen exists so there is one obvious thing to click. It has to log the customer out first: sending a logged-in user to `/log-in` just bounces them straight back (`client/login/redirect-logged-in/index.web.js`), so the button dispatches `redirectToLogout()` with the login page and this checkout URL as the redirect. Signing in as the owner lands them back on the same URL with the renewal correctly in the cart.

The error is latched because cart errors are transient — they are returned only by the request that caused them, so the refetch on window focus would drop it and leave the unexplained empty cart described in the issue.

## Testing instructions

TC:
```
yarn jest client/my-sites/checkout/src/test/wrong-account-renewal.tsx
```

Manual testing:
* Requires the wpcom change on your sandbox; without it the code is never sent and nothing here changes.
* Sandbox `public-api.wordpress.com` and run Calypso locally.
* Log in as account B and visit `/checkout/renew/<A's purchase ID>`.
* Confirm the wrong-account screen appears as soon as checkout loads, names account B, and shows no duplicate red notice.
* Switch tabs and back to confirm the screen survives the cart refetch.
* Click "Log in to the right account", sign in as account A, and confirm you land back on the same renewal URL with the product in the cart.
* Confirm a renewal for a subscription you do own is unaffected.
