### PR TITLE
Dashboard: stop long headings widening overview cards

### DIFF
--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -86,10 +86,8 @@ export default function OverviewCard( {
 		if ( ! heading ) {
 			return <>&nbsp;</>;
 		}
-		// Headings are usually a single line already, but the ones carrying user
-		// data — site names, domains, email addresses — can be arbitrarily long
-		// and unbreakable. Clamp to one line and put the full value in a tooltip.
-		// Callers passing their own markup are left to handle it themselves.
+		// Headings are usually a single line, but the can carry arbitrarily long
+		// user data — site names, domains, email addresses. Clamp to one line.
 		if ( typeof heading === 'string' ) {
 			return (
 				<Truncate tooltip={ heading } numberOfLines={ 1 }>

--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -18,6 +18,7 @@ import { isOnboardingUrl, isRelativeUrl } from '../../utils/url';
 import ComponentViewTracker from '../component-view-tracker';
 import { Text } from '../text';
 import { TextSkeleton } from '../text-skeleton';
+import { Truncate } from '../truncate';
 import type { ComponentProps, ReactElement, ReactNode } from 'react';
 import './style.scss';
 
@@ -82,10 +83,21 @@ export default function OverviewCard( {
 		if ( isLoading ) {
 			return <TextSkeleton length={ 10 } />;
 		}
-		if ( heading ) {
-			return heading;
+		if ( ! heading ) {
+			return <>&nbsp;</>;
 		}
-		return <>&nbsp;</>;
+		// Headings are usually a single line already, but the ones carrying user
+		// data — site names, domains, email addresses — can be arbitrarily long
+		// and unbreakable. Clamp to one line and put the full value in a tooltip.
+		// Callers passing their own markup are left to handle it themselves.
+		if ( typeof heading === 'string' ) {
+			return (
+				<Truncate tooltip={ heading } numberOfLines={ 1 }>
+					{ heading }
+				</Truncate>
+			);
+		}
+		return heading;
 	};
 
 	const renderDescription = () => {

--- a/client/dashboard/components/overview-card/style.scss
+++ b/client/dashboard/components/overview-card/style.scss
@@ -39,6 +39,12 @@
 	// HStacks are width 100% and will try to grow as wide as the card body.
 	// We need to ensure this new padding is included as part of that 100%.
 	box-sizing: border-box;
+
+	// Cards sit in grid tracks sized from their content, so an unbreakable
+	// string — a long site name, domain or email address — would otherwise widen
+	// the track and push the whole grid past the page. `anywhere` only breaks
+	// when there is no other opportunity, so ordinary prose is unaffected.
+	overflow-wrap: anywhere;
 }
 
 .dashboard-overview-card--has-bottom {

--- a/client/dashboard/components/overview-card/style.scss
+++ b/client/dashboard/components/overview-card/style.scss
@@ -40,10 +40,7 @@
 	// We need to ensure this new padding is included as part of that 100%.
 	box-sizing: border-box;
 
-	// Cards sit in grid tracks sized from their content, so an unbreakable
-	// string — a long site name, domain or email address — would otherwise widen
-	// the track and push the whole grid past the page. `anywhere` only breaks
-	// when there is no other opportunity, so ordinary prose is unaffected.
+	// Prevents unbreakable strings (site names, domains) from widening grid tracks.
 	overflow-wrap: anywhere;
 }
 

--- a/client/dashboard/domains/domain-overview/featured-card-emails.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-emails.tsx
@@ -7,7 +7,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { envelope } from '@wordpress/icons';
 import { emailsRoute, chooseEmailSolutionRoute } from '../../app/router/emails';
 import OverviewCard from '../../components/overview-card';
-import { Truncate } from '../../components/truncate';
 import type { EmailProvider, Mailbox } from '@automattic/api-core';
 
 const getAccountTypeLabel = ( accountType: EmailProvider ) => {
@@ -64,11 +63,7 @@ export default function FeaturedCardEmails( { domain }: Props ) {
 	return (
 		<OverviewCard
 			title={ mailboxes.length > 0 ? __( 'Emails' ) : __( 'Add mailbox' ) }
-			heading={
-				<Truncate tooltip={ email } numberOfLines={ 1 }>
-					{ email }
-				</Truncate>
-			}
+			heading={ email }
 			link={
 				mailboxes.length > 0
 					? router.buildLocation( {

--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { layout } from '@wordpress/icons';
 import OverviewCard from '../../components/overview-card';
 import SiteIcon from '../../components/site-icon';
+import { Truncate } from '../../components/truncate';
 
 interface Props {
 	domain: Domain;
@@ -35,9 +36,13 @@ export default function FeaturedCardSite( { domain }: Props ) {
 			}
 			icon={ shouldShowAddAttachSite ? <Icon icon={ layout } /> : <SiteIcon site={ site } /> }
 			description={
-				shouldShowAddAttachSite
-					? __( 'Attach this domain name to a new or existing site.' )
-					: domain.site_slug
+				shouldShowAddAttachSite ? (
+					__( 'Attach this domain name to a new or existing site.' )
+				) : (
+					<Truncate tooltip={ domain.site_slug } numberOfLines={ 1 }>
+						{ domain.site_slug }
+					</Truncate>
+				)
 			}
 			intent={ shouldShowAddAttachSite ? 'upsell' : 'success' }
 		/>

--- a/client/dashboard/domains/domain-overview/featured-card-site.tsx
+++ b/client/dashboard/domains/domain-overview/featured-card-site.tsx
@@ -6,7 +6,6 @@ import { __ } from '@wordpress/i18n';
 import { layout } from '@wordpress/icons';
 import OverviewCard from '../../components/overview-card';
 import SiteIcon from '../../components/site-icon';
-import { Truncate } from '../../components/truncate';
 
 interface Props {
 	domain: Domain;
@@ -28,15 +27,7 @@ export default function FeaturedCardSite( { domain }: Props ) {
 	return (
 		<OverviewCard
 			title={ shouldShowAddAttachSite ? __( 'Attach to a site' ) : __( 'Site' ) }
-			heading={
-				shouldShowAddAttachSite ? (
-					__( 'No site attached' )
-				) : (
-					<Truncate tooltip={ site.name } numberOfLines={ 1 }>
-						{ site.name }
-					</Truncate>
-				)
-			}
+			heading={ shouldShowAddAttachSite ? __( 'No site attached' ) : site.name }
 			link={
 				shouldShowAddAttachSite
 					? `/domains/${ domain.domain }/transfer/other-site`
@@ -44,13 +35,9 @@ export default function FeaturedCardSite( { domain }: Props ) {
 			}
 			icon={ shouldShowAddAttachSite ? <Icon icon={ layout } /> : <SiteIcon site={ site } /> }
 			description={
-				shouldShowAddAttachSite ? (
-					__( 'Attach this domain name to a new or existing site.' )
-				) : (
-					<Truncate tooltip={ domain.site_slug } numberOfLines={ 1 }>
-						{ domain.site_slug }
-					</Truncate>
-				)
+				shouldShowAddAttachSite
+					? __( 'Attach this domain name to a new or existing site.' )
+					: domain.site_slug
 			}
 			intent={ shouldShowAddAttachSite ? 'upsell' : 'success' }
 		/>


### PR DESCRIPTION
Fixes DOTMSD-1521

<img width="1110" alt="CleanShot 2026-09-03 at 20 02 25@2x" src="https://github.com/user-attachments/assets/37f8f15d-e33d-40a4-b624-43fef72a4aea" />


## Proposed Changes

* `<OverviewCard>` headings given as plain text now clamp to a single line, with the full value in a tooltip.
* Card content can no longer widen its own grid track, so the grid always fits the page.
* Removed the hand-rolled truncation in the domain overview's site and emails cards — the shared card does it now.

## Why are these changes being made?

On the purchase page, a site with a very long name blew the card grid out past the page width, and overflowed the screen entirely on mobile.

The cause is grid track sizing. A track's automatic minimum is the width of its content's longest unbreakable run, and site names, domains and email addresses have no break opportunities. One long name and the Site card claimed most of the row, squashing its neighbour and pushing the grid off the page.

The domain overview had already hit this and solved it locally by wrapping its headings in a truncating component. That fix never reached the other overview cards, and the same problem was live on the purchase page, the email plan mailbox card, and the monetize subscriptions cards. Moving it into the shared card fixes all of them at once and removes the duplicated call-site code.

Descriptions deliberately still wrap rather than truncate. Most of them are prose that legitimately runs to two lines, and clamping those would hide real copy behind a tooltip.

## Considerations

Truncation alone isn't enough. The truncating component only breaks long words when clamped to exactly one line, so it doesn't protect descriptions, the card's bottom slot, or a heading a caller passes as markup. The wrapping rule covers those, and keeps the grid safe for any future card content.

Truncating headings to one line was checked against every heading currently in use — all of them already fit on one line at normal card widths, so nothing visible changes except for the runaway values this fixes.

## Testing Instructions

Needs a site whose name is long and has no spaces. `wpbakeryphilipmjacksonsnip20260813150812710047170` is a realistic example.

1. Open that site's purchase at Billing → Active upgrades → the purchase.
2. The Site and Owner cards should be equal width and sit inside the page, with the site name on one line ending in an ellipsis. Hovering it shows the full name.
3. Narrow to a mobile width. The cards stack to one column and stay within the screen — no horizontal scrolling.
4. Check the domain overview for a domain attached to that site. Its Site and Emails cards should look exactly as they did before.
5. Worth a glance at a site overview and the monetize subscriptions list to confirm ordinary cards are unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01HBWuqJjgam3o35fayFgXZx
