### PR TITLE
fix: Calculate accurate email click rates

### DIFF
--- a/client/my-sites/stats/features/modules/stats-emails/is-rate-known.ts
+++ b/client/my-sites/stats/features/modules/stats-emails/is-rate-known.ts
@@ -7,6 +7,36 @@ interface RateSignals {
 	sends: number;
 }
 
+interface ClickRateSignals {
+	uniqueClicks: unknown;
+	totalClicks: unknown;
+	sends: unknown;
+}
+
+/**
+ * Calculate a click rate from the underlying counts.
+ *
+ * Unique clicks are preferred when available. Older data without unique
+ * attribution falls back to total clicks so it can still produce a useful
+ * rate.
+ */
+export function calculateClickRate( {
+	uniqueClicks,
+	totalClicks,
+	sends,
+}: ClickRateSignals ): number | null {
+	const sendCount = toCount( sends );
+
+	if ( sendCount <= 0 ) {
+		return null;
+	}
+
+	const uniqueClickCount = toCount( uniqueClicks );
+	const clickCount = uniqueClickCount > 0 ? uniqueClickCount : toCount( totalClicks );
+
+	return ( clickCount / sendCount ) * 100;
+}
+
 /**
  * Whether a unique-based email rate is a known value.
  *

--- a/client/my-sites/stats/features/modules/stats-emails/test/is-rate-known.ts
+++ b/client/my-sites/stats/features/modules/stats-emails/test/is-rate-known.ts
@@ -1,4 +1,36 @@
-import { isRateKnown, toCount } from '../is-rate-known';
+import { calculateClickRate, isRateKnown, toCount } from '../is-rate-known';
+
+describe( 'calculateClickRate', () => {
+	it( 'calculates the rate from unique clicks when they are available', () => {
+		expect( calculateClickRate( { uniqueClicks: 13, totalClicks: 20, sends: 52 } ) ).toBe( 25 );
+	} );
+
+	it( 'preserves fractional precision', () => {
+		expect( calculateClickRate( { uniqueClicks: 2, totalClicks: 4, sends: 17 } ) ).toBeCloseTo(
+			11.7647
+		);
+	} );
+
+	it( 'falls back to total clicks when unique attribution is unavailable', () => {
+		expect( calculateClickRate( { uniqueClicks: 0, totalClicks: 15, sends: 209 } ) ).toBeCloseTo(
+			7.177
+		);
+		expect(
+			calculateClickRate( { uniqueClicks: undefined, totalClicks: 15, sends: 209 } )
+		).toBeCloseTo( 7.177 );
+	} );
+
+	it( 'returns zero when sends are positive and there are no clicks', () => {
+		expect( calculateClickRate( { uniqueClicks: 0, totalClicks: 0, sends: 52 } ) ).toBe( 0 );
+	} );
+
+	it( 'returns null without a usable send denominator', () => {
+		expect( calculateClickRate( { uniqueClicks: 13, totalClicks: 20, sends: 0 } ) ).toBeNull();
+		expect(
+			calculateClickRate( { uniqueClicks: 13, totalClicks: 20, sends: undefined } )
+		).toBeNull();
+	} );
+} );
 
 describe( 'isRateKnown', () => {
 	it( 'is known when uniques were attributed', () => {

--- a/client/my-sites/stats/stats-email-top-row/index.jsx
+++ b/client/my-sites/stats/stats-email-top-row/index.jsx
@@ -1,11 +1,12 @@
 import { Gridicon } from '@automattic/components';
 import { Icon, send, seen, link } from '@wordpress/icons';
 import clsx from 'clsx';
-import { useTranslate } from 'i18n-calypso';
+import { formatNumber, useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import {
+	calculateClickRate,
 	isRateKnown,
 	toCount,
 } from 'calypso/my-sites/stats/features/modules/stats-emails/is-rate-known';
@@ -80,7 +81,13 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className,
 						/>
 					</>
 				);
-			case 'clicks':
+			case 'clicks': {
+				const clickRate = calculateClickRate( {
+					uniqueClicks: counts?.unique_clicks,
+					totalClicks: counts?.total_clicks,
+					sends: counts?.total_sends,
+				} );
+
 				return (
 					<>
 						<TopCard
@@ -108,19 +115,23 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className,
 						<TopCard
 							heading={ translate( 'Click rate' ) }
 							value={
-								isRateKnown( {
-									uniques: toCount( counts?.unique_clicks ),
-									totals: toCount( counts?.total_clicks ),
-									sends: toCount( counts?.total_sends ),
-								} )
-									? `${ Math.round( ( counts.clicks_rate ?? 0 ) * 100 ) }%`
+								clickRate !== null
+									? `${ formatNumber( clickRate, {
+											numberFormatOptions: { maximumFractionDigits: 2 },
+									  } ) }%`
 									: null
 							}
-							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'clicks_rate' ) }
+							isLoading={
+								isRequesting &&
+								( ! counts?.hasOwnProperty( 'total_sends' ) ||
+									( ! counts?.hasOwnProperty( 'unique_clicks' ) &&
+										! counts?.hasOwnProperty( 'total_clicks' ) ) )
+							}
 							icon={ <Gridicon icon="trending" /> }
 						/>
 					</>
 				);
+			}
 			default:
 				return null;
 		}

--- a/client/my-sites/stats/stats-email-top-row/test/index.test.tsx
+++ b/client/my-sites/stats/stats-email-top-row/test/index.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen, within } from '@testing-library/react';
+import { useSelector } from 'react-redux';
+import {
+	getEmailStatsNormalizedData,
+	isRequestingEmailStats,
+} from 'calypso/state/stats/emails/selectors';
+import StatsEmailTopRow from '..';
+
+jest.mock( 'react-redux', () => ( {
+	useSelector: jest.fn( ( selector ) => selector( {} ) ),
+} ) );
+
+jest.mock( 'calypso/state/stats/emails/selectors' );
+
+jest.mock( 'i18n-calypso', () => ( {
+	...jest.requireActual( 'i18n-calypso' ),
+	useTranslate: () => ( text: string ) => text,
+} ) );
+
+const mockedUseSelector = useSelector as unknown as jest.Mock;
+const mockedGetEmailStatsNormalizedData = getEmailStatsNormalizedData as jest.Mock;
+const mockedIsRequestingEmailStats = isRequestingEmailStats as jest.Mock;
+
+function renderClickStats( counts: Record< string, number | undefined > ) {
+	mockedGetEmailStatsNormalizedData.mockReturnValue( counts );
+	mockedIsRequestingEmailStats.mockReturnValue( false );
+
+	render( <StatsEmailTopRow siteId={ 1 } postId={ 2 } statType="clicks" /> );
+
+	const card = screen.getByText( 'Click rate' ).closest( '.highlight-card' );
+	if ( ! card ) {
+		throw new Error( 'Click rate card was not rendered' );
+	}
+
+	return within( card ).getByText( /%|-/ );
+}
+
+describe( 'StatsEmailTopRow click rate', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockedUseSelector.mockImplementation( ( selector ) => selector( {} ) );
+	} );
+
+	it( 'calculates 25% from unique clicks and sends instead of a stale API rate', () => {
+		expect(
+			renderClickStats( {
+				total_sends: 52,
+				total_clicks: 20,
+				unique_clicks: 13,
+				clicks_rate: 0.01,
+			} )
+		).toHaveTextContent( '25%' );
+	} );
+
+	it( 'shows useful precision for a fractional click rate', () => {
+		expect(
+			renderClickStats( {
+				total_sends: 17,
+				total_clicks: 4,
+				unique_clicks: 2,
+				clicks_rate: 0.01,
+			} )
+		).toHaveTextContent( '11.76%' );
+	} );
+
+	it( 'uses total clicks for a legacy payload without unique attribution', () => {
+		expect(
+			renderClickStats( {
+				total_sends: 209,
+				total_clicks: 15,
+				clicks_rate: 0.01,
+			} )
+		).toHaveTextContent( '7.18%' );
+	} );
+
+	it( 'shows zero when sends are positive and there are no clicks', () => {
+		expect(
+			renderClickStats( {
+				total_sends: 52,
+				total_clicks: 0,
+				unique_clicks: 0,
+				clicks_rate: 0.25,
+			} )
+		).toHaveTextContent( '0%' );
+	} );
+
+	it( 'shows the unknown state without a usable send denominator', () => {
+		expect(
+			renderClickStats( {
+				total_sends: 0,
+				total_clicks: 20,
+				unique_clicks: 13,
+				clicks_rate: 0.25,
+			} )
+		).toHaveTextContent( /^-$/ );
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

*

## Why are these changes being made?

Add a production-used click-rate calculation alongside the existing email-rate helpers, deriving the percentage from the all-time counts already supplied to the top row instead of trusting the inconsistent precomputed rate. Prefer `unique_clicks` when recipient attribution is available, fall back to `total_clicks` for legacy payloads that only contain aggregate clicks, and divide by `total_sends`; a positive send count with no clicks yields 0%, while a missing or zero send count remains unknown. Update `StatsEmailTopRow` to format that calculated percentage with useful fractional precision so ratios such as 13/52 and 2/17 are not collapsed to a misleading integer.

The Email clicks detail page can show a dash or an incorrect click-rate percentage even when its count cards contain enough data to calculate the rate. The reproduced examples include 13 clicks from 52 recipients, 2 from 17, and 15 from 209, while the card shows either no value or a much smaller percentage. The top-row component currently renders the API-provided `clicks_rate` and separately suppresses it when unique-recipient attribution is absent, so stale rate fields and legacy count-only payloads can both produce the reported behavior. The fix is limited to the Email clicks detail-page rate card and preserves the existing unknown state when no valid denominator exists.

Fixes #98725

## Testing Instructions

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [x] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
