### PR TITLE
Onboarding: switch email-verification gate to the 202609 experiment

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-email-verification-gate.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-email-verification-gate.ts
@@ -11,7 +11,7 @@ export const ACTIVATION_EMAIL_SOURCE = 'onboarding-with-email-verification';
 //   control                         -> no step (current default)
 //   treatment_post_account_creation -> gate right after account creation (Variant A)
 //   treatment_post_plan_selection   -> gate after free-plan selection or after checkout (Variant B)
-const EXPERIMENT_NAME = 'calypso_signup_onboarding_email_verification_202608';
+const EXPERIMENT_NAME = 'calypso_signup_onboarding_email_verification_202609';
 
 type EmailVerificationVariant =
 	| 'control'


### PR DESCRIPTION
Fixes # DOTCOM-18083

## Proposed Changes

* Point the onboarding email-verification gate at the new experiment `calypso_signup_onboarding_email_verification_202609` (was `..._202608`).

## Why are these changes being made?

* The new experiment record switches the audience user type from "New registrations only" to "All Users". The gate logic is unchanged; only the experiment name it reads from ExPlat is updated so assignments come from the re-scoped experiment.

## Testing Instructions

* Start a fresh browser session (new anon ID) and go to `/setup/onboarding`.
* Register with an email/password account.
* Confirm the assignment now comes from `calypso_signup_onboarding_email_verification_202609` (check the ExPlat assignment request/response).
* In the `treatment_post_account_creation` arm, verify the email-verification gate still appears on the account step; in `treatment_post_plan_selection`, verify it appears after plan selection or checkout; in `control`, verify no gate.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?