### PR TITLE
Site Launch Modals: set font-family on the modal header title

### DIFF
--- a/packages/site-launch-modals/package.json
+++ b/packages/site-launch-modals/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/site-launch-modals",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "Presentational modals for the WordPress.com site-launch flow (pre-launch confirmation and post-launch celebration).",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",

--- a/packages/site-launch-modals/src/celebration-modal/style.scss
+++ b/packages/site-launch-modals/src/celebration-modal/style.scss
@@ -5,6 +5,12 @@
 	// (e.g. a site theme's typography when shown over a site preview).
 	font-family: $default-font;
 
+	// The header title is styled by a rule that targets this element directly,
+	// which beats the inherited font above, so declare it here as well.
+	.components-modal__header-heading-container {
+		font-family: $default-font;
+	}
+
 	.flex-shrink-safe {
 		flex: 1;
 		min-width: 0;

--- a/packages/site-launch-modals/src/pre-launch-modal/style.scss
+++ b/packages/site-launch-modals/src/pre-launch-modal/style.scss
@@ -4,6 +4,12 @@
 // (e.g. a site theme's typography when shown over a site preview).
 .site-launch-pre-launch-modal {
 	font-family: $default-font;
+
+	// The header title is styled by a rule that targets this element directly,
+	// which beats the inherited font above, so declare it here as well.
+	.components-modal__header-heading-container {
+		font-family: $default-font;
+	}
 }
 
 .site-launch-pre-launch-modal__preview-card {


### PR DESCRIPTION
## Proposed Changes

* Declare `font-family: $default-font` on `.components-modal__header-heading-container` (scoped to each modal) in the celebration and pre-launch modals.
* Bump `@automattic/site-launch-modals` to 1.0.3.

## Why are these changes being made?

A prior change (#114021) set the font on the modal frame so the modal would not inherit the host page's font (e.g. a site theme's serif typography over a site preview). That covered the body content, but the header title is styled by a rule targeting `.components-modal__header-heading-container` directly, which beats the inherited value. This declares the font there too so the title also renders in the WordPress admin sans-serif.

## Testing Instructions

* Open the pre-launch and celebration modals over a site preview whose theme uses a non-default (e.g. serif) font.
* Confirm the header title now renders in the WordPress admin sans-serif, matching the modal body.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
