### PR TITLE
Notification settings: clarify the Jetpack Social toggle label

### DIFF
--- a/client/dashboard/me/notifications-sites/helpers/translations.ts
+++ b/client/dashboard/me/notifications-sites/helpers/translations.ts
@@ -8,7 +8,7 @@ const translations = {
 	follow: __( 'Subscriptions' ),
 	achievement: __( 'Site achievements' ),
 	mentions: __( 'Username mentions' ),
-	scheduled_publicize: __( 'Jetpack Social' ),
+	scheduled_publicize: __( 'Scheduled social shares' ),
 	blogging_prompt: __( 'Daily writing prompts' ),
 	draft_post_prompt: __( 'Draft post reminders' ),
 	store_order: __( 'New order' ),

--- a/client/me/notification-settings/settings-form/locales.js
+++ b/client/me/notification-settings/settings-form/locales.js
@@ -14,10 +14,7 @@ export const settingLabels = {
 	follow: () => i18n.translate( 'Subscriptions' ),
 	achievement: () => i18n.translate( 'Site achievements' ),
 	mentions: () => i18n.translate( 'Username mentions' ),
-	scheduled_publicize: () =>
-		i18n.translate( 'Jetpack Social', {
-			comment: 'brand Jetpack Social does not need translation',
-		} ),
+	scheduled_publicize: () => i18n.translate( 'Scheduled social shares' ),
 	blogging_prompt: () => i18n.translate( 'Daily writing prompts' ),
 	draft_post_prompt: () => i18n.translate( 'Draft post reminders' ),
 	store_order: () => i18n.translate( 'New order' ),


### PR DESCRIPTION
Fixes SOCIAL-566

## Proposed Changes

* Rename the `scheduled_publicize` notification setting label from "Jetpack Social" to "Scheduled social shares", in both the new dashboard (`/me/notifications/sites`) and the legacy `/me/notifications` page.

## Why are these changes being made?

The row was labelled with a product name, while every sibling row names an event ("Comments on my site", "Likes on my posts", "Daily writing prompts"). That made the label over-promise in both directions: turning it off looks like it silences everything Jetpack Social does, and leaving it on suggests you'd hear about failed shares.

It controls exactly one notification — the `published_scheduled_publicize_notif` note, sent when a share you scheduled from the Jetpack Social sharing modal successfully goes out. Not auto-share on publish, not "Share now" reshares, and not failures.

"Scheduled social shares" fits the noun-phrase register of the rows around it and is unambiguous: "social" rules out post scheduling, "scheduled" rules out normal auto-sharing.

The linked issue suggests an infotip for extra context. No other toggle in this list has help text, and adding the capability for one row out of ten would make it look special rather than clearer, so the label carries it alone — which is what "provide additional context ... when needed" points at.

Note the label previously carried a `comment: 'brand Jetpack Social does not need translation'` translator note. The new string has no brand name in it, so the note is dropped and the entry collapses to a one-liner like its siblings.

## Testing Instructions

1. Go to `/me/notifications/sites` and expand a site.
2. On the **Web** tab, confirm the row previously labelled "Jetpack Social" now reads "Scheduled social shares", and that toggling it still saves.
3. Switch to the **Devices** tab (needs a registered device) and confirm the same label there.
4. Confirm the row is still absent from the **Email** tab — this setting has no email stream.
5. Visit the legacy `/me/notifications` page (on an account not redirected to the multi-site dashboard) and confirm the same label in the checkbox grid.

No behaviour change — this is a string-only change, the `scheduled_publicize` setting key is untouched.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
