### PR TITLE
Bump Site Spec to v1.17.1

### DIFF
--- a/config/_shared.json
+++ b/config/_shared.json
@@ -225,7 +225,7 @@
 	"blackbox_url": "https://blackbox-api.wp.com/v1/dist/v.js",
 	"blackbox_api_key": "1b4f123e7dae4d83bbd18170c4358f8e",
 	"site_spec": {
-		"script_url": "https://widgets.wp.com/site-spec/v1.17.0/index.js",
-		"css_url": "https://widgets.wp.com/site-spec/v1.17.0/style.css"
+		"script_url": "https://widgets.wp.com/site-spec/v1.17.1/index.js",
+		"css_url": "https://widgets.wp.com/site-spec/v1.17.1/style.css"
 	}
 }

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -225,7 +225,7 @@
 	"blackbox_url": "https://blackbox-api.wp.com/v1/dist/v.js",
 	"blackbox_api_key": "1b4f123e7dae4d83bbd18170c4358f8e",
 	"site_spec": {
-		"script_url": "https://widgets.wp.com/site-spec/v1.16.2/index.js",
-		"css_url": "https://widgets.wp.com/site-spec/v1.16.2/style.css"
+		"script_url": "https://widgets.wp.com/site-spec/v1.17.0/index.js",
+		"css_url": "https://widgets.wp.com/site-spec/v1.17.0/style.css"
 	}
 }


### PR DESCRIPTION
## Summary

- Points the Site Spec `script_url`/`css_url` config at `v1.17.1`.

Originally opened for v1.17.0. That version never shipped — a site brief fix
(325-ghe-Automattic/site-spec: keep the add row open, stop discarding the click
that blurred a field) landed on site-spec trunk right after the version bump, so
the release was re-cut as **v1.17.1**. The branch name still says `1-17-0`; the
second commit moves it to v1.17.1.

v1.17.1 = everything that was in v1.17.0, plus that one fix.

Depends on 239077-ghe-Automattic/wpcom (syncs the v1.17.1 build to the CDN) being
merged/deployed first.

Version bump: 343-ghe-Automattic/site-spec

## Test plan

- [ ] Confirm `https://widgets.wp.com/site-spec/v1.17.1/index.js` is live before merging
- [ ] Smoke test the Site Spec chat widget still loads wherever it's embedded in Calypso
