### PR TITLE
Onboarding: send a connected domain to the domain connection setup after checkout

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { isDomainMapping } from '@automattic/calypso-products';
 import { OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import { getLanguageSlugs } from '@automattic/i18n-utils';
 import { clearStepPersistedState, ONBOARDING_FLOW, SITE_SETUP_FLOW } from '@automattic/onboarding';
@@ -7,6 +8,7 @@ import { resolveSelect, useDispatch, useSelect } from '@wordpress/data';
 import { addQueryArgs, getQueryArg, getQueryArgs } from '@wordpress/url';
 import { useEffect, useMemo } from 'react';
 import { clearSessionStorageQuery } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
+import { dashboardLink } from 'calypso/dashboard/utils/link';
 import {
 	STEPPER_TRACKS_EVENT_SIGNUP_START,
 	WOO_HOSTING_SOLUTIONS_REF,
@@ -324,10 +326,11 @@ const onboarding: FlowV2< typeof initialize > = {
 			setHideFreePlan,
 		} = useDispatch( ONBOARD_STORE ) as OnboardActions;
 		const locale = useFlowLocale();
-		const { signupDomainOrigin, planCartItem, blueprint } = useSelect(
+		const { signupDomainOrigin, planCartItem, domainCartItem, blueprint } = useSelect(
 			( select ) => ( {
 				signupDomainOrigin: ( select( ONBOARD_STORE ) as OnboardSelect ).getSignupDomainOrigin(),
 				planCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getPlanCartItem(),
+				domainCartItem: ( select( ONBOARD_STORE ) as OnboardSelect ).getDomainCartItem(),
 				blueprint: ( select( ONBOARD_STORE ) as OnboardSelect ).getBlueprint(),
 			} ),
 			[]
@@ -788,6 +791,16 @@ const onboarding: FlowV2< typeof initialize > = {
 							// build_dest=wow and the WoW funnel never show the
 							// setup-your-site-ai chooser; go straight to their destination.
 							window.location.replace( destination );
+						} else if (
+							domainCartItem &&
+							isDomainMapping( domainCartItem ) &&
+							domainCartItem.meta
+						) {
+							// A connected domain still has to be pointed at the site once it is paid
+							// for, so finish on the setup instructions rather than the chooser or My Home.
+							window.location.replace(
+								dashboardLink( `/domains/${ domainCartItem.meta }/domain-connection-setup` )
+							);
 						} else if (
 							refParameter === WOO_HOSTING_SOLUTIONS_REF &&
 							isEnabled( 'onboarding/woo-hosting-post-purchase-setup-choice' )

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { isDomainMapping } from '@automattic/calypso-products';
+import { isDomainMapping, isDomainTransfer } from '@automattic/calypso-products';
 import { OnboardActions, OnboardSelect } from '@automattic/data-stores';
 import { getLanguageSlugs } from '@automattic/i18n-utils';
 import { clearStepPersistedState, ONBOARDING_FLOW, SITE_SETUP_FLOW } from '@automattic/onboarding';
@@ -790,16 +790,20 @@ const onboarding: FlowV2< typeof initialize > = {
 						} else if ( blueprintArchiveSlug || isKnownWowFunnel( wowFunnelSlug ) ) {
 							// build_dest=wow and the WoW funnel never show the
 							// setup-your-site-ai chooser; go straight to their destination.
+							// This can stay ahead of the domain branches below: a connected or
+							// transferred domain forces a paid plan (use-my-domain hides the free
+							// plan), and a paid funnel order's checkout redirect_to is the funnel
+							// destination itself, so it never comes back through here.
 							window.location.replace( destination );
-						} else if (
-							domainCartItem &&
-							isDomainMapping( domainCartItem ) &&
-							domainCartItem.meta
-						) {
+						} else if ( domainCartItem?.meta && isDomainMapping( domainCartItem ) ) {
 							// A connected domain still has to be pointed at the site once it is paid
 							// for, so finish on the setup instructions rather than the chooser or My Home.
 							window.location.replace(
 								dashboardLink( `/domains/${ domainCartItem.meta }/domain-connection-setup` )
+							);
+						} else if ( domainCartItem?.meta && isDomainTransfer( domainCartItem ) ) {
+							window.location.replace(
+								dashboardLink( `/domains/${ domainCartItem.meta }/domain-transfer-setup` )
 							);
 						} else if (
 							refParameter === WOO_HOSTING_SOLUTIONS_REF &&

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-domain-connection-post-checkout.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-domain-connection-post-checkout.ts
@@ -1,0 +1,197 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { ProcessingResult } from '../../../internals/steps-repository/processing-step/constants';
+import onboarding from '../onboarding';
+import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
+
+let mockDomainCartItem: MinimalRequestCartProduct | undefined;
+
+jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', () => ( {
+	clearSessionStorageQuery: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/components', () => ( {
+	MaterialIcon: () => null,
+	ExternalLink: () => null,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		resetOnboardStore: jest.fn(),
+		setDomain: jest.fn(),
+		setDomainCartItem: jest.fn(),
+		setDomainCartItems: jest.fn(),
+		setPlanCartItem: jest.fn(),
+		setProductCartItems: jest.fn(),
+		setSiteUrl: jest.fn(),
+		setSignupDomainOrigin: jest.fn(),
+		setHideFreePlan: jest.fn(),
+	} ),
+	useSelect: jest.fn( () => ( { domainCartItem: mockDomainCartItem } ) ),
+	resolveSelect: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-query', () => ( {
+	useQuery: jest.fn( () => new URLSearchParams( '' ) ),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/hooks/use-flow-locale', () => ( {
+	useFlowLocale: jest.fn( () => 'en' ),
+} ) );
+
+jest.mock( 'calypso/state', () => ( {
+	useSelector: jest.fn(),
+	useDispatch: () => jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/analytics/survicate', () => ( { addSurvicate: jest.fn() } ) );
+jest.mock( 'calypso/lib/analytics/signup', () => ( { SIGNUP_DOMAIN_ORIGIN: {} } ) );
+jest.mock( 'calypso/lib/explat', () => ( {
+	loadExperimentAssignment: jest.fn(),
+	useExperiment: jest.fn( () => [ false, null ] ),
+} ) );
+
+jest.mock( 'calypso/landing/stepper/stores', () => ( {
+	ONBOARD_STORE: 'ONBOARD_STORE',
+	SITE_STORE: 'SITE_STORE',
+} ) );
+
+jest.mock( '@automattic/data-stores', () => ( {} ) );
+
+jest.mock(
+	'calypso/landing/stepper/declarative-flow/internals/hooks/use-purchase-plan-notification',
+	() => ( {
+		usePurchasePlanNotification: jest.fn( () => ( { setShouldShowNotification: jest.fn() } ) ),
+	} )
+);
+
+jest.mock( 'calypso/signup/storageUtils', () => ( {
+	persistSignupDestination: jest.fn(),
+	setSignupCompleteFlowName: jest.fn(),
+	setSignupCompleteSlug: jest.fn(),
+	clearSignupCompleteSlug: jest.fn(),
+	clearSignupCompleteFlowName: jest.fn(),
+	clearSignupDestinationCookie: jest.fn(),
+	clearSignupCompleteSiteID: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/onboarding', () => ( {
+	ONBOARDING_FLOW: 'onboarding',
+	SITE_SETUP_FLOW: 'site-setup',
+	clearStepPersistedState: jest.fn(),
+	isOnboardingFlow: ( flow: string ) => flow === 'onboarding',
+} ) );
+
+jest.mock( 'calypso/lib/ai-launchpad', () => ( {
+	resolveLaunchpadPersonalizationVariation: jest.fn( async () => 'control' ),
+	getLaunchpadPersonalizationDestination: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/lib/url', () => ( { pathToUrl: ( path: string ) => path } ) );
+
+jest.mock( 'calypso/dashboard/utils/link', () => ( {
+	dashboardLink: ( path: string ) => `https://my.wordpress.com${ path }`,
+} ) );
+
+jest.mock( '../../../helpers/get-onboarding-post-checkout-destination', () => ( {
+	getOnboardingPostCheckoutDestination: jest.fn( () => [
+		'/home/example.wordpress.com',
+		null,
+		null,
+	] ),
+} ) );
+
+jest.mock( '../step-counter-config', () => ( {
+	getOnboardingStepperPosition: () => ( { current: 3, total: 3 } ),
+} ) );
+
+// Runs the `processing` case for a successful order that has already been through checkout,
+// i.e. the return leg from post-checkout-onboarding. Returns the navigate spy and the URL
+// handed to `window.location.replace`, if any.
+const submitPostCheckoutProcessing = async ( providedDependencies: Record< string, unknown > ) => {
+	const replace = jest.fn();
+	const originalLocation = Object.getOwnPropertyDescriptor( window, 'location' );
+	Object.defineProperty( window, 'location', {
+		configurable: true,
+		value: { href: 'http://localhost/', search: '', replace },
+	} );
+
+	try {
+		const navigate = jest.fn();
+		const { result } = renderHook( () =>
+			onboarding.useStepNavigation.call(
+				onboarding,
+				'processing' as Parameters< typeof onboarding.useStepNavigation >[ 0 ],
+				navigate
+			)
+		);
+
+		await result.current.submit?.( {
+			slug: 'processing',
+			providedDependencies: {
+				processingResult: ProcessingResult.SUCCESS,
+				siteSlug: 'example.wordpress.com',
+				siteId: 123,
+				...providedDependencies,
+			},
+		} as Parameters< NonNullable< typeof result.current.submit > >[ 0 ] );
+
+		return { navigate, replacedWith: replace.mock.calls[ 0 ]?.[ 0 ] as string | undefined };
+	} finally {
+		if ( originalLocation ) {
+			Object.defineProperty( window, 'location', originalLocation );
+		}
+	}
+};
+
+describe( 'onboarding post-checkout destination for a connected domain', () => {
+	beforeEach( () => {
+		mockDomainCartItem = undefined;
+		jest.clearAllMocks();
+	} );
+
+	it( 'sends a connected domain to the domain connection setup instead of the setup chooser', async () => {
+		mockDomainCartItem = { product_slug: 'domain_map', meta: 'example.com' };
+
+		const { navigate, replacedWith } = await submitPostCheckoutProcessing( {
+			postCheckoutBigSky: true,
+		} );
+
+		expect( replacedWith ).toBe(
+			'https://my.wordpress.com/domains/example.com/domain-connection-setup'
+		);
+		expect( navigate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'sends a connected domain to the domain connection setup instead of My Home', async () => {
+		mockDomainCartItem = { product_slug: 'domain_map', meta: 'example.com' };
+
+		const { replacedWith } = await submitPostCheckoutProcessing( {} );
+
+		expect( replacedWith ).toBe(
+			'https://my.wordpress.com/domains/example.com/domain-connection-setup'
+		);
+	} );
+
+	it( 'keeps the setup chooser for a registered domain', async () => {
+		mockDomainCartItem = { product_slug: 'domain_reg', meta: 'example.com' };
+
+		const { navigate, replacedWith } = await submitPostCheckoutProcessing( {
+			postCheckoutBigSky: true,
+		} );
+
+		expect( navigate ).toHaveBeenCalledWith( 'setup-your-site-ai' );
+		expect( replacedWith ).toBeUndefined();
+	} );
+
+	it( 'keeps the setup chooser when no domain is in the cart', async () => {
+		const { navigate, replacedWith } = await submitPostCheckoutProcessing( {
+			postCheckoutBigSky: true,
+		} );
+
+		expect( navigate ).toHaveBeenCalledWith( 'setup-your-site-ai' );
+		expect( replacedWith ).toBeUndefined();
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-domain-connection-post-checkout.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-domain-connection-post-checkout.ts
@@ -29,7 +29,16 @@ jest.mock( '@wordpress/data', () => ( {
 		setSignupDomainOrigin: jest.fn(),
 		setHideFreePlan: jest.fn(),
 	} ),
-	useSelect: jest.fn( () => ( { domainCartItem: mockDomainCartItem } ) ),
+	// Run the real selector callback against a stubbed store so the flow's own
+	// `getDomainCartItem` call is what feeds the test, not a hand-built result.
+	useSelect: jest.fn( ( selector: ( select: ( store: string ) => unknown ) => unknown ) =>
+		selector( () => ( {
+			getSignupDomainOrigin: () => undefined,
+			getPlanCartItem: () => null,
+			getDomainCartItem: () => mockDomainCartItem,
+			getBlueprint: () => undefined,
+		} ) )
+	),
 	resolveSelect: jest.fn(),
 } ) );
 
@@ -172,6 +181,29 @@ describe( 'onboarding post-checkout destination for a connected domain', () => {
 
 		expect( replacedWith ).toBe(
 			'https://my.wordpress.com/domains/example.com/domain-connection-setup'
+		);
+	} );
+
+	it( 'sends a transferred domain to the domain transfer setup instead of the setup chooser', async () => {
+		mockDomainCartItem = { product_slug: 'domain_transfer', meta: 'example.com' };
+
+		const { navigate, replacedWith } = await submitPostCheckoutProcessing( {
+			postCheckoutBigSky: true,
+		} );
+
+		expect( replacedWith ).toBe(
+			'https://my.wordpress.com/domains/example.com/domain-transfer-setup'
+		);
+		expect( navigate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'sends a transferred domain to the domain transfer setup instead of My Home', async () => {
+		mockDomainCartItem = { product_slug: 'domain_transfer', meta: 'example.com' };
+
+		const { replacedWith } = await submitPostCheckoutProcessing( {} );
+
+		expect( replacedWith ).toBe(
+			'https://my.wordpress.com/domains/example.com/domain-transfer-setup'
 		);
 	} );
 


### PR DESCRIPTION
Part of DOTMSD-1453

## Proposed Changes

* In the `/setup/onboarding` flow, when the domain cart item is a domain connection (mapping), the return from checkout now lands on the dashboard's domain connection setup page for that domain (`/domains/{domain}/domain-connection-setup`).
* A domain transfer from the same use-my-domain step lands on `/domains/{domain}/domain-transfer-setup` for the same reason.
* The post-checkout "Set up your site" chooser (Build with AI / Manual setup / Generate Theme) and the My Home fallback are skipped for those two paths. Registered domains and carts without a domain behave exactly as before.
* The checkout `redirect_to` is unchanged: the `post-checkout-onboarding` step still runs its Atomic transfer and plugin waits before the destination is picked.
* Adds unit tests covering both redirects (with and without the Big Sky chooser eligibility) and the unchanged chooser behaviour for registered domains and empty carts. The tests run the flow's real store selector against a stubbed store, so a wrong `getDomainCartItem` call would fail them.

## Why are these changes being made?

A connected domain still has to be pointed at the site once it is paid for, and a transferred domain still has to be authorised, but the onboarding flow never surfaced either set of instructions. Users were dropped on the setup chooser or My Home with the domain sitting in a pending state and no in-product guidance. The `/setup/domain` and `/setup/domain-and-plan` flows already redirect a single domain connection or transfer to the setup page after checkout; this brings the onboarding flow in line with them.

The onboarding flow persists the domain cart item in the onboard store across the checkout round trip (it is in the store's `persist` list, like the plan cart item the flow already reads post-checkout), so the decision can be made on the return leg without threading anything extra through checkout.

### Design notes

* **Branch order.** The WoW funnel / blueprint-archive branch stays ahead of the domain branches on purpose. A connected or transferred domain forces a paid plan (the use-my-domain step hides the free plan), and a paid funnel order's checkout `redirect_to` is the funnel destination itself, so it never returns through `post-checkout-onboarding`. The two cannot collide; a comment in the flow records this.
* **Trusting the store over the checkout cart.** If a user removes the domain line item in checkout while keeping the plan, the store still holds it and the redirect lands on a setup page for a domain the site doesn't have (the dashboard route errors on the missing domain). This is the same trade-off the domain and domain-and-plan flows already ship, the line item is a $0 inclusion so removal is unlikely, and fixing it properly means keying off the site's actual domain list in all three flows. Left as is here; happy to file a follow-up covering the three flows together.

## Testing Instructions

1. Go to `/setup/onboarding`.
2. Click **Already have a domain?**, enter a domain you own, and choose **Connect your domain name** (connect, not transfer).
3. Pick a paid plan and complete checkout.
4. Verify you land on `/domains/{domain}/domain-connection-setup` in the dashboard, not on the "Set up your site" chooser or My Home.
5. Repeat from step 2 choosing **Transfer your domain** and verify you land on `/domains/{domain}/domain-transfer-setup`.
6. Repeat with a registered domain (search and buy a new one) on a Personal/Premium/Business plan and verify the "Set up your site" chooser still appears.
7. Run `yarn test-client client/landing/stepper/declarative-flow/flows/onboarding` and verify all tests pass.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1opu6XxnUGS2ZMXjXVX2J
