### PR TITLE
Checkout: Switch renewal links to subscription-ID-only

### DIFF
--- a/client/dashboard/components/plan-expiry-notice/get-plan-expiry-notice.ts
+++ b/client/dashboard/components/plan-expiry-notice/get-plan-expiry-notice.ts
@@ -182,7 +182,7 @@ function resolveNotice(
 	const renewAction: PlanExpiryNoticeAction = {
 		type: 'renew',
 		label: __( 'Renew now' ),
-		href: getRenewalUrlFromPurchase( purchase, undefined, renewReturnUrl ),
+		href: getRenewalUrlFromPurchase( purchase, renewReturnUrl ),
 	};
 
 	// Past the expiry date, still inside the grace period. Note that

--- a/client/dashboard/domains/dataviews/actions.tsx
+++ b/client/dashboard/domains/dataviews/actions.tsx
@@ -21,9 +21,10 @@ import {
 import { getCurrentDashboard } from '../../app/routing';
 import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import ComponentViewTracker from '../../components/component-view-tracker';
-import { isDomainRenewable, canSetAsPrimary, getDomainRenewalUrl } from '../../utils/domain';
+import { isDomainRenewable, canSetAsPrimary } from '../../utils/domain';
 import { isTransferrableToWpcom } from '../../utils/domain-types';
 import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
+import { getRenewalUrlFromPurchase } from '../../utils/purchase';
 import { AutoRenewModal } from './auto-renew-modal';
 import type { DomainSummary, Site, User } from '@automattic/api-core';
 import type { Action } from '@wordpress/dataviews';
@@ -83,7 +84,7 @@ export const useActions = ( { user, sites }: { user: User; sites?: Site[] } ) =>
 						return;
 					}
 
-					window.location.href = getDomainRenewalUrl( domain, purchase );
+					window.location.href = getRenewalUrlFromPurchase( purchase );
 				},
 				isEligible: ( item: DomainSummary ) => isDomainRenewable( item ),
 			},

--- a/client/dashboard/domains/domain-overview/actions.tsx
+++ b/client/dashboard/domains/domain-overview/actions.tsx
@@ -27,8 +27,8 @@ import InlineSupportLink from '../../components/inline-support-link';
 import RemoveDomainDialog from '../../components/purchase-dialogs/remove-domain-dialog';
 import RouterLinkButton from '../../components/router-link-button';
 import { SectionHeader } from '../../components/section-header';
-import { getDomainRenewalUrl } from '../../utils/domain';
 import { redirectToDashboardLink, wpcomLink } from '../../utils/link';
+import { getRenewalUrlFromPurchase } from '../../utils/purchase';
 import {
 	shouldShowTransferAction,
 	shouldShowTransferInAction,
@@ -120,7 +120,7 @@ export default function Actions( { isDisabled }: { isDisabled?: boolean } ) {
 							<Button
 								size="compact"
 								variant="secondary"
-								href={ getDomainRenewalUrl( domain, purchase ) }
+								href={ getRenewalUrlFromPurchase( purchase ) }
 								disabled={ isDisabled }
 							>
 								{ __( 'Renew' ) }

--- a/client/dashboard/domains/domain-overview/index.tsx
+++ b/client/dashboard/domains/domain-overview/index.tsx
@@ -19,7 +19,8 @@ import SnackbarBackButton from '../../app/snackbar-back-button';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { formatDate } from '../../utils/datetime';
-import { getDomainRenewalUrl, isTldInMaintenance } from '../../utils/domain';
+import { isTldInMaintenance } from '../../utils/domain';
+import { getRenewalUrlFromPurchase } from '../../utils/purchase';
 import { TLDMaintenanceNotice } from '../maintenance-notice';
 import Actions from './actions';
 import FeaturedCards from './featured-cards';
@@ -104,7 +105,7 @@ export default function DomainOverview() {
 									variant="primary"
 									__next40pxDefaultSize
 									disabled={ isTldInMaintenance( domain ) }
-									href={ getDomainRenewalUrl( domain, purchase ) }
+									href={ getRenewalUrlFromPurchase( purchase ) }
 								>
 									{
 										// translators: price is the price of the domain renewal.

--- a/client/dashboard/utils/domain.ts
+++ b/client/dashboard/utils/domain.ts
@@ -6,11 +6,9 @@ import {
 	DomainTypes,
 } from '@automattic/api-core';
 import { isAfter, subMinutes, subDays } from 'date-fns';
-import { getRenewalUrlFromPurchase } from './purchase';
 import { hasPlanFeature } from './site-features';
 import { userHasFlag } from './user';
 import type {
-	Purchase,
 	Domain,
 	DomainSummary,
 	Site,
@@ -22,10 +20,6 @@ import type {
 
 export function getDomainSiteSlug( domain: DomainSummary ) {
 	return domain.primary_domain ? domain.domain : domain.site_slug;
-}
-
-export function getDomainRenewalUrl( domain: DomainSummary, purchase: Purchase ) {
-	return getRenewalUrlFromPurchase( purchase, getDomainSiteSlug( domain ) );
 }
 
 export function isRegisteredDomain( domain: DomainSummary ) {

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -672,12 +672,8 @@ function getCheckoutSiteSlugForPurchase( purchase: Purchase ): string {
 	return purchase.site_slug || '';
 }
 
-export function getRenewalUrlFromPurchase(
-	purchase: Purchase,
-	checkoutSiteSlugForUrl?: string,
-	backUrl?: string
-): string {
-	return getRenewUrlForPurchases( [ purchase ], checkoutSiteSlugForUrl, backUrl );
+export function getRenewalUrlFromPurchase( purchase: Purchase, backUrl?: string ): string {
+	return getRenewUrlForPurchases( [ purchase ], backUrl );
 }
 
 /**
@@ -687,29 +683,27 @@ export function getRenewalUrlFromPurchase(
  */
 export function getRenewUrlForPurchases(
 	purchases: Purchase[],
-	checkoutSiteSlugForUrl?: string,
 	backUrl: string = redirectToDashboardLink()
 ): string {
 	if ( purchases.length < 1 ) {
 		throw new Error( 'Could not find product slug or purchase id for renewal.' );
 	}
 	const firstPurchase = purchases[ 0 ];
-	const checkoutProductSlug = purchases
-		.map( ( purchase ) => getCheckoutProductSlugFromPurchase( purchase ) )
-		.join( ',' );
-	const checkoutSiteSlug =
-		checkoutSiteSlugForUrl || getCheckoutSiteSlugForPurchase( firstPurchase );
-	const servicePath = getServicePathForCheckoutFromPurchase( firstPurchase );
 	const purchaseIds = purchases.map( ( purchase ) => purchase.ID ).join( ',' );
-	return addQueryArgs(
-		wpcomLink(
-			`/checkout/${ servicePath }${ checkoutProductSlug }/renew/${ purchaseIds }/${ checkoutSiteSlug }`
-		),
-		{
-			cancel_to: backUrl,
-			redirect_to: backUrl,
-		}
-	);
+	const servicePath = getServicePathForCheckoutFromPurchase( firstPurchase );
+
+	// Siteless Akismet and Marketplace renewals still need the legacy URL shape
+	// because their checkout routes are keyed on the service and product slug.
+	const path = servicePath
+		? `/checkout/${ servicePath }${ purchases
+				.map( ( purchase ) => getCheckoutProductSlugFromPurchase( purchase ) )
+				.join( ',' ) }/renew/${ purchaseIds }/${ getCheckoutSiteSlugForPurchase( firstPurchase ) }`
+		: `/checkout/renew/${ purchaseIds }`;
+
+	return addQueryArgs( wpcomLink( path ), {
+		cancel_to: backUrl,
+		redirect_to: backUrl,
+	} );
 }
 
 /**

--- a/client/dashboard/utils/test/purchase.ts
+++ b/client/dashboard/utils/test/purchase.ts
@@ -417,6 +417,21 @@ describe( 'creditCardExpiresBeforeSubscription', () => {
 } );
 
 describe( 'getRenewalUrlFromPurchase', () => {
+	test( 'uses the subscription-ID-only format', () => {
+		const url = getRenewalUrlFromPurchase(
+			makePurchase( {
+				ID: 12345,
+				product_slug: 'business-bundle',
+				is_attached_to_holding_site: false,
+				site_slug: 'example.wordpress.com',
+			} )
+		);
+
+		expect( url ).toContain( '/checkout/renew/12345?' );
+		expect( url ).not.toContain( 'example.wordpress.com' );
+		expect( url ).not.toContain( 'business-bundle' );
+	} );
+
 	test( 'omits the site slug for an A4A holding site purchase', () => {
 		const url = getRenewalUrlFromPurchase(
 			makePurchase( {
@@ -428,21 +443,19 @@ describe( 'getRenewalUrlFromPurchase', () => {
 			} )
 		);
 
-		expect( url ).toContain( '/checkout/pressable_build_monthly:is-a4a/renew/28259013/?' );
+		expect( url ).toContain( '/checkout/renew/28259013?' );
 		expect( url ).not.toContain( 'siteless.agencies.automattic.com' );
 	} );
 
-	test( 'keeps the site slug for a regular site purchase', () => {
+	test( 'keeps the legacy format for a siteless Akismet purchase', () => {
 		const url = getRenewalUrlFromPurchase(
 			makePurchase( {
-				ID: 12345,
-				product_slug: 'business-bundle',
-				is_attached_to_holding_site: false,
-				site_slug: 'example.wordpress.com',
+				ID: 67890,
+				product_slug: 'ak_plus_yearly_1',
 			} )
 		);
 
-		expect( url ).toContain( '/checkout/business-bundle/renew/12345/example.wordpress.com?' );
+		expect( url ).toContain( '/checkout/akismet/ak_plus_yearly_1/renew/67890/?' );
 	} );
 } );
 

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -383,9 +383,14 @@ export function handleRenewNowClick(
 				serviceSlug = 'marketplace/';
 			}
 
-			let renewalUrl = `/checkout/${ serviceSlug }${ productSlugs[ 0 ] }/renew/${
-				purchaseIds[ 0 ]
-			}/${ siteSlug || '' }`;
+			// Siteless Akismet and Marketplace renewals still need the legacy URL
+			// shape because their checkout routes are keyed on the service and
+			// product slug.
+			let renewalUrl = serviceSlug
+				? `/checkout/${ serviceSlug }${ productSlugs[ 0 ] }/renew/${ purchaseIds[ 0 ] }/${
+						siteSlug || ''
+				  }`
+				: `/checkout/renew/${ purchaseIds[ 0 ] }`;
 
 			renewalUrl = addQueryArgs(
 				{ redirect_to: options.redirectTo, cancel_to: options.cancelTo },
@@ -435,15 +440,13 @@ export function handleRenewMultiplePurchasesClick(
 					{ domain: otherPurchase.meta }
 				)
 			);
-			const { productSlugs, purchaseIds } = getProductSlugsAndPurchaseIds( renewItems );
+			const { purchaseIds } = getProductSlugsAndPurchaseIds( renewItems );
 
 			if ( purchaseIds.length === 0 ) {
 				throw new Error( 'Could not find product slug or purchase id for renewal.' );
 			}
 
-			let renewalUrl = `/checkout/${ productSlugs.join( ',' ) }/renew/${ purchaseIds.join(
-				','
-			) }/${ siteSlug || '' }`;
+			let renewalUrl = `/checkout/renew/${ purchaseIds.join( ',' ) }`;
 			if ( options.redirectTo ) {
 				renewalUrl += '?redirect_to=' + encodeURIComponent( options.redirectTo );
 			}

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -303,17 +303,13 @@ describe( 'index', () => {
 		test( 'should redirect to the checkout page', () => {
 			const dispatch = jest.fn();
 			handleRenewNowClick( purchase, siteSlug )( dispatch );
-			expect( page ).toHaveBeenCalledWith(
-				'/checkout/personal-bundle/renew/1/my-site.wordpress.com'
-			);
+			expect( page ).toHaveBeenCalledWith( '/checkout/renew/1' );
 		} );
 
 		test( 'should redirect to the checkout page with ?redirect_to', () => {
 			const dispatch = jest.fn();
 			handleRenewNowClick( purchase, siteSlug, { redirectTo: '/me/purchases' } )( dispatch );
-			expect( page ).toHaveBeenCalledWith(
-				'/checkout/personal-bundle/renew/1/my-site.wordpress.com?redirect_to=%2Fme%2Fpurchases'
-			);
+			expect( page ).toHaveBeenCalledWith( '/checkout/renew/1?redirect_to=%2Fme%2Fpurchases' );
 		} );
 
 		test( 'should send the tracks events', () => {
@@ -402,9 +398,7 @@ describe( 'index', () => {
 		test( 'should redirect to the checkout page', () => {
 			const dispatch = jest.fn();
 			handleRenewMultiplePurchasesClick( purchases, siteSlug )( dispatch );
-			expect( page ).toHaveBeenCalledWith(
-				'/checkout/personal-bundle,dotlive_domain:personalsitetest1234.live/renew/1,2/my-site.wordpress.com'
-			);
+			expect( page ).toHaveBeenCalledWith( '/checkout/renew/1,2' );
 		} );
 		describe( 'when the none of the purchase ids exist', () => {
 			test( 'should report error', () => {
@@ -427,9 +421,7 @@ describe( 'index', () => {
 				const dispatch = jest.fn();
 				const purchasesPartiallyValid = [ purchases[ 1 ], { ...purchases[ 0 ], ID: null } ];
 				handleRenewMultiplePurchasesClick( purchasesPartiallyValid, siteSlug )( dispatch );
-				expect( page ).toHaveBeenCalledWith(
-					'/checkout/dotlive_domain:personalsitetest1234.live/renew/2/my-site.wordpress.com'
-				);
+				expect( page ).toHaveBeenCalledWith( '/checkout/renew/2' );
 			} );
 		} );
 	} );

--- a/client/my-sites/customer-home/cards/tasks/renew/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/renew/index.jsx
@@ -7,9 +7,9 @@ import { TASK_RENEW_EXPIRED_PLAN } from 'calypso/my-sites/customer-home/cards/co
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 import { getSitePurchases } from 'calypso/state/purchases/selectors/get-site-purchases';
 import { getSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-const Renew = ( { card, purchases, site, siteSlug } ) => {
+const Renew = ( { card, purchases, site } ) => {
 	const translate = useTranslate();
 	const hasExpired = card === TASK_RENEW_EXPIRED_PLAN;
 
@@ -18,7 +18,6 @@ const Renew = ( { card, purchases, site, siteSlug } ) => {
 	);
 
 	const planName = site?.plan.product_name_short;
-	const planSlug = planPurchase?.productSlug;
 	const expiryText = planPurchase?.expiryDate
 		? getRelativeDayString( new Date( planPurchase.expiryDate ), hasExpired ? 'past' : 'upcoming' )
 		: '';
@@ -80,9 +79,7 @@ const Renew = ( { card, purchases, site, siteSlug } ) => {
 		);
 		actionText = translate( 'Got it' );
 	}
-	const actionUrl = isOwner
-		? `/checkout/${ planSlug }/renew/${ planPurchase?.id }/${ siteSlug }`
-		: null;
+	const actionUrl = isOwner ? `/checkout/renew/${ planPurchase?.id }` : null;
 	const illustration = hasExpired ? expiredIllustration : expiringIllustration;
 
 	return (
@@ -107,7 +104,6 @@ const mapStateToProps = ( state ) => {
 	return {
 		purchases: getSitePurchases( state, siteId ),
 		site: getSite( state, siteId ),
-		siteSlug: getSelectedSiteSlug( state ),
 	};
 };
 

--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -81,7 +81,7 @@ export class DomainWarnings extends PureComponent {
 
 	renewLink( domains, onClick ) {
 		const count = domains.length;
-		const { selectedSite, translate } = this.props;
+		const { translate } = this.props;
 		const fullMessage = translate( 'Renew it now.', 'Renew them now.', {
 			count,
 			context: 'Call to action link for renewing an expiring/expired domain',
@@ -89,13 +89,8 @@ export class DomainWarnings extends PureComponent {
 		const compactMessage = translate( 'Renew', {
 			context: 'Call to action link for renewing an expiring/expired domain',
 		} );
-		const domain = domains[ 0 ].name;
 		const subscriptionId = domains[ 0 ].subscriptionId;
-		const productSlug = domains[ 0 ].productSlug;
-		const link =
-			count === 1
-				? `/checkout/${ productSlug }:${ domain }/renew/${ subscriptionId }/${ selectedSite.slug }`
-				: purchasesRoot;
+		const link = count === 1 ? `/checkout/renew/${ subscriptionId }` : purchasesRoot;
 
 		return (
 			<NoticeAction href={ link } onClick={ onClick }>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -797,7 +797,7 @@ const PlansFeaturesMain = ( {
 	// existing plan (rather than passively reading "Your plan") so the user is
 	// reminded they can keep their plan instead of letting the downgrade apply.
 	const renewCurrentPlanWithPendingDowngrade = () => {
-		if ( ! siteSlug || ! currentPlanPurchaseId || ! currentPurchase?.product_slug ) {
+		if ( ! currentPlanPurchaseId ) {
 			return;
 		}
 		recordTracksEvent( 'calypso_plan_features_renew_pending_downgrade_click', {
@@ -814,7 +814,7 @@ const PlansFeaturesMain = ( {
 		}
 		window.location.href = addQueryArgs(
 			checkoutQuery,
-			`/checkout/${ currentPurchase.product_slug }/renew/${ currentPlanPurchaseId }/${ siteSlug }`
+			`/checkout/renew/${ currentPlanPurchaseId }`
 		);
 	};
 


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/SHILL-2506/

## Proposed Changes

Switches calypso's renewal links from the legacy `/checkout/{products}/renew/{subscription_id}/{site_domain}` format to the shorter `/checkout/renew/{subscription_id}` format added in SHILL-1695. No new routing or cart work was needed — the route and its `addRenewalBySubscriptionId` cart handler already exist and already support comma-separated subscription IDs — so this is purely a link-generation change.

* Switch `handleRenewNowClick` and `handleRenewMultiplePurchasesClick` in `client/lib/purchases/index.ts` to the new format.
* Switch `getRenewUrlForPurchases` / `getRenewalUrlFromPurchase` in `client/dashboard/utils/purchase.ts`, and drop their now-meaningless `checkoutSiteSlugForUrl` parameter.
* Switch the remaining call sites: domain expiry warnings, the customer-home renew task, and the pending-downgrade renew CTA in `plans-features-main`.
* Remove `getDomainRenewalUrl` from `client/dashboard/utils/domain.ts`; without the site slug it was a bare alias for `getRenewalUrlFromPurchase`, so its three callers now use that directly.
* Relax the guard in `renewCurrentPlanWithPendingDowngrade` from `siteSlug && currentPlanPurchaseId && currentPurchase.product_slug` to just `currentPlanPurchaseId`, since the other two are no longer used to build the URL.
* Leave siteless Akismet and Marketplace renewals on the legacy format, with a comment at each of the two branches explaining why.

## Why are these changes being made?

The trailing site domain in the legacy URL is not inert: it drives calypso's site selection at the routing level, so the whole app orients around that site. When the domain is wrong, expired, or belongs to another user, calypso may fail to load or show a confusing message — and because it happens during routing, checkout cannot work around it. Without the domain, checkout derives the site from the cart items instead. Dropping the product slugs is a bonus: the URL no longer has to encode slugs and domain meta, or keep two comma-separated lists in matching order.

Siteless Akismet and Marketplace renewals are deliberately excluded. The service segment in their URLs selects the route, and the route selects the checkout experience — `/checkout/akismet/:productSlug/renew/:purchaseId` dispatches to `checkoutAkismetSiteless`, which is what sets `sitelessCheckoutType`. The new route uses `noSite` and passes `sitelessCheckoutType: undefined`, so converting them would silently drop the service-specific checkout UI rather than fail visibly. There is a second blocker in `chooseAddHandler`, which returns `addRenewalItems` (product-slug dependent) for those services before it can reach the `addRenewalBySubscriptionId` branch. SHILL-2509 tracks adding a siteless-aware short URL so these can be migrated too.

Note that this only changes links generated by calypso. Legacy URLs still route correctly, so existing bookmarks and already-sent billing emails are unaffected. Pointing the legacy routes at the existing-but-unused `redirectToRenewalBySubscriptionId` is tracked as a follow-on in SHILL-2509, since doing it before the siteless work would break the flows above.

## Testing Instructions

TC:

```
yarn test-client client/lib/purchases/test/index.js client/dashboard/utils/test/purchase.ts
```

Existing tests were updated to assert the new format. The two dashboard cases were entirely about site-slug inclusion, so they were replaced with new-format assertions plus a new case pinning the Akismet legacy shape.

Manual testing:

* On a site with an expiring or expired paid plan, go to `/me/purchases`, open the purchase, and click **Renew now**.
* Confirm the URL is `/checkout/renew/{subscription_id}` with no product slug or site domain, and that checkout loads with the correct product and site in the cart.
* Repeat from the other migrated surfaces: the domain expiry notice on `/domains/manage/{site}`, the "Renew" task on the customer home page, and the renew CTA on the plans page when a delayed downgrade is scheduled.
* Use **Renew all** from `/me/purchases` on a site with several renewable purchases and confirm the URL is `/checkout/renew/{id1},{id2}` and that every item lands in the cart.
* Confirm `redirect_to` and `cancel_to` still work: cancelling out of checkout should return you where you started.
* Regression check on the excluded flows: renew an Akismet subscription and confirm it still uses `/checkout/akismet/{product_slug}/renew/{id}/` and still shows the Akismet-branded siteless checkout.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
