### PR TITLE
Support subscription-ID-only renewal URLs for siteless checkout

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -181,7 +181,11 @@ function sitelessCheckout( context, next, extraProps ) {
 
 	const state = context.store.getState();
 	const isLoggedOut = ! isUserLoggedIn( state );
-	const { productSlug: product, purchaseId } = context.params;
+	// Siteless renewals come in two shapes: the legacy
+	// /checkout/:service/:productSlug/renew/:purchaseId, and the newer
+	// /checkout/:service/renew/:subscriptionId, which leaves the product for the
+	// backend to derive from the subscription record.
+	const { productSlug: product, purchaseId, subscriptionId } = context.params;
 	const isUserComingFromLoginForm = context.query?.flow === 'coming_from_login';
 
 	setSectionMiddleware( { name: 'checkout' } )( context );
@@ -199,7 +203,7 @@ function sitelessCheckout( context, next, extraProps ) {
 			<CheckoutSitelessDocumentTitle />
 
 			<CheckoutMainWrapper
-				purchaseId={ purchaseId }
+				purchaseId={ purchaseId ?? subscriptionId }
 				productAliasFromUrl={ product }
 				productSourceFromUrl={ context.query.source }
 				couponCode={ couponCode }

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -162,6 +162,18 @@ export default function () {
 		clientRender
 	);
 
+	// Must be registered before the generic /checkout/:product/renew/:purchaseId
+	// route, which would otherwise read "marketplace" as the product slug.
+	page(
+		`/checkout/marketplace/renew/:subscriptionId`,
+		setLocaleMiddleware(),
+		redirectLoggedOut,
+		noSite,
+		checkoutMarketplaceSiteless,
+		makeLayout,
+		clientRender
+	);
+
 	// Passport Marketplace checkout custom URLs
 	page(
 		`/checkout/passport/:productSlug`,
@@ -182,6 +194,16 @@ export default function () {
 		clientRender
 	);
 
+	page(
+		`/checkout/passport/renew/:subscriptionId`,
+		setLocaleMiddleware(),
+		redirectLoggedOut,
+		noSite,
+		checkoutMarketplaceSiteless,
+		makeLayout,
+		clientRender
+	);
+
 	// Akismet siteless checkout works logged-out, so do not include redirectLoggedOut or siteSelection.
 	page(
 		`/checkout/akismet/:productSlug`,
@@ -194,6 +216,16 @@ export default function () {
 
 	page(
 		`/checkout/akismet/:productSlug/renew/:purchaseId`,
+		setLocaleMiddleware(),
+		redirectLoggedOut,
+		noSite,
+		checkoutAkismetSiteless,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		`/checkout/akismet/renew/:subscriptionId`,
 		setLocaleMiddleware(),
 		redirectLoggedOut,
 		noSite,

--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -226,12 +226,15 @@ function chooseAddHandler( {
 	isNoSiteCart?: boolean;
 	isGiftPurchase?: boolean;
 } ): AddHandler {
-	// Akismet and some Marketplace products can be renewed in a "siteless" context
+	// Akismet and some Marketplace products can be renewed in a "siteless" context.
+	// Without a product slug in the URL there is nothing for `addRenewalItems` to
+	// build a cart product from, so fall back to the subscription ID and let the
+	// backend derive the product from the subscription record.
 	if (
 		( sitelessCheckoutType === 'akismet' || sitelessCheckoutType === 'marketplace' ) &&
 		originalPurchaseId
 	) {
-		return 'addRenewalItems';
+		return productAliasFromUrl ? 'addRenewalItems' : 'addRenewalBySubscriptionId';
 	}
 
 	if (

--- a/client/my-sites/checkout/src/test/use-prepare-products-for-cart.tsx
+++ b/client/my-sites/checkout/src/test/use-prepare-products-for-cart.tsx
@@ -9,15 +9,17 @@ jest.mock( 'calypso/my-sites/checkout/use-cart-key' );
 
 function renderPrepareProducts( {
 	productAliasFromUrl,
+	purchaseId,
 	sitelessCheckoutType,
 }: {
-	productAliasFromUrl: string;
+	productAliasFromUrl?: string;
+	purchaseId?: string;
 	sitelessCheckoutType: SitelessCheckoutType;
 } ) {
 	return renderHook( () =>
 		usePrepareProductsForCart( {
 			productAliasFromUrl,
-			purchaseId: undefined,
+			purchaseId,
 			usesJetpackProducts: false,
 			isPrivate: false,
 			siteSlug: undefined,
@@ -85,5 +87,49 @@ describe( 'usePrepareProductsForCart for WordPress.com siteless checkout', () =>
 
 		expect( replaceState ).not.toHaveBeenCalled();
 		replaceState.mockRestore();
+	} );
+} );
+
+describe( 'usePrepareProductsForCart for siteless renewals', () => {
+	it.each( [ 'akismet', 'marketplace' ] as const )(
+		'renews a %s subscription from the subscription ID alone',
+		( sitelessCheckoutType ) => {
+			const { result } = renderPrepareProducts( {
+				purchaseId: '12345',
+				sitelessCheckoutType,
+			} );
+
+			expect( result.current.isLoading ).toBe( false );
+			expect( result.current.error ).toBeNull();
+			expect( result.current.productsForCart ).toHaveLength( 1 );
+			// The backend derives the product from the subscription record.
+			expect( result.current.productsForCart[ 0 ].product_slug ).toBe( '' );
+			expect( result.current.productsForCart[ 0 ].extra.purchaseId ).toBe( '12345' );
+			expect( result.current.productsForCart[ 0 ].extra.purchaseType ).toBe( 'renewal' );
+		}
+	);
+
+	it( 'still uses the product slug when the legacy URL supplies one', () => {
+		const { result } = renderPrepareProducts( {
+			productAliasFromUrl: 'ak_pro5h_yearly',
+			purchaseId: '12345',
+			sitelessCheckoutType: 'akismet',
+		} );
+
+		expect( result.current.productsForCart ).toHaveLength( 1 );
+		expect( result.current.productsForCart[ 0 ].product_slug ).toBe( 'ak_pro5h_yearly' );
+		expect( result.current.productsForCart[ 0 ].extra.purchaseId ).toBe( '12345' );
+	} );
+
+	it( 'renews several subscriptions from a comma-separated list of IDs', () => {
+		const { result } = renderPrepareProducts( {
+			purchaseId: '12345,67890',
+			sitelessCheckoutType: 'akismet',
+		} );
+
+		expect( result.current.productsForCart ).toHaveLength( 2 );
+		expect( result.current.productsForCart.map( ( product ) => product.extra.purchaseId ) ).toEqual(
+			[ '12345', '67890' ]
+		);
 	} );
 } );

--- a/client/my-sites/checkout/test/index.ts
+++ b/client/my-sites/checkout/test/index.ts
@@ -4,7 +4,11 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, redirectLoggedOut, render as clientRender } from 'calypso/controller';
 import { noSite } from 'calypso/my-sites/controller';
-import { checkoutWpcomSiteless } from '../controller';
+import {
+	checkoutAkismetSiteless,
+	checkoutMarketplaceSiteless,
+	checkoutWpcomSiteless,
+} from '../controller';
 import registerCheckoutRoutes from '../index';
 
 const mockLocaleMiddleware = jest.fn();
@@ -73,5 +77,42 @@ describe( 'checkout routes', () => {
 		expect( studioReturnIndex ).toBeGreaterThanOrEqual( 0 );
 		expect( genericIndex ).toBeGreaterThanOrEqual( 0 );
 		expect( studioReturnIndex ).toBeLessThan( genericIndex );
+	} );
+
+	describe( 'siteless renewals by subscription ID', () => {
+		it.each( [
+			[ '/checkout/akismet/renew/:subscriptionId', checkoutAkismetSiteless ],
+			[ '/checkout/marketplace/renew/:subscriptionId', checkoutMarketplaceSiteless ],
+			[ '/checkout/passport/renew/:subscriptionId', checkoutMarketplaceSiteless ],
+		] )( 'registers %s with its siteless handler', ( path, handler ) => {
+			registerCheckoutRoutes();
+
+			expect( page ).toHaveBeenCalledWith(
+				path,
+				mockLocaleMiddleware,
+				redirectLoggedOut,
+				noSite,
+				handler,
+				makeLayout,
+				clientRender
+			);
+		} );
+
+		// These are four-segment paths, so /checkout/:product/renew/:purchaseId would
+		// swallow them and read the service name as the product slug.
+		it.each( [
+			'/checkout/akismet/renew/:subscriptionId',
+			'/checkout/marketplace/renew/:subscriptionId',
+			'/checkout/passport/renew/:subscriptionId',
+		] )( 'registers %s ahead of the generic renewal route', ( path ) => {
+			registerCheckoutRoutes();
+
+			const sitelessIndex = registrationIndexOf( path );
+			const genericIndex = registrationIndexOf( '/checkout/:product/renew/:purchaseId' );
+
+			expect( sitelessIndex ).toBeGreaterThanOrEqual( 0 );
+			expect( genericIndex ).toBeGreaterThanOrEqual( 0 );
+			expect( sitelessIndex ).toBeLessThan( genericIndex );
+		} );
 	} );
 } );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2509/support-subscription-id-only-renewal-urls-for-siteless-checkout-flows

## Proposed Changes

Adds a siteless-aware short renewal URL — `/checkout/{service}/renew/{subscriptionId}` — so that Akismet and Marketplace renewals can drop the product slug from the URL the way every other renewal entry point already has, without losing their service-specific checkout experience.

* Register `/checkout/akismet/renew/:subscriptionId`, `/checkout/marketplace/renew/:subscriptionId`, and `/checkout/passport/renew/:subscriptionId`, each dispatching to the same siteless handler as its legacy sibling.
* Teach `sitelessCheckout` to read a `subscriptionId` route param, leaving `productAliasFromUrl` undefined on the new shape.
* Route siteless renewals with no product alias to `addRenewalBySubscriptionId` in `chooseAddHandler`, instead of unconditionally to `addRenewalItems`.
* Add tests for the handler wiring, the route registration order, and the resulting cart contents.

## Why are these changes being made?

SHILL-1695 added the shorter `/checkout/renew/{subscription_id}` renewal URL, and SHILL-2506 (https://github.com/Automattic/wp-calypso/pull/114063) is migrating calypso's renewal links to it. Siteless Akismet and Marketplace renewals were deliberately left behind on `/checkout/{service}/{product_slug}/renew/{subscription_id}`, because two things blocked them.

First, the service segment in the legacy URL is not decoration — it selects the route, and the route selects the checkout experience. The generic `/checkout/renew/:subscriptionId` route uses `noSite` and passes `sitelessCheckoutType: undefined`, so pointing these products at it would have silently dropped the service-specific UI rather than failing loudly. Adding a per-service short route keeps the service in the path, where the router can still see it, while letting the backend derive the product from the subscription record.

Second, `chooseAddHandler` returned `addRenewalItems` for a `sitelessCheckoutType` of `akismet` or `marketplace` whenever a purchase ID was present, short-circuiting before the `addRenewalBySubscriptionId` branch the new format relies on. `addRenewalItems` builds each cart item from a product slug, so with no slug in the URL it produces an empty cart and dispatches a `RENEWALS_ADD_ERROR`. Keying that choice on the presence of a product alias lets both URL shapes work through the same handler.

The new routes have to be registered ahead of the generic `/checkout/:product/renew/:purchaseId` route: page.js matches in registration order, and all four paths are four segments, so the generic route would otherwise match first and read `akismet` as a product slug. There is a test covering that ordering so it is not quietly broken later.

Switching calypso's own link builders (`handleRenewNowClick`, `getRenewUrlForPurchases`) over to these URLs is left for a follow-up, since those helpers are being refactored in #114063. This PR is the piece that unblocks it.

## Testing Instructions

TC:
```
yarn test-client client/my-sites/checkout/test/index.ts client/my-sites/checkout/src/test/use-prepare-products-for-cart.tsx
```

Manual testing:
* You need an account with a renewable siteless Akismet or Marketplace subscription; grab its subscription ID from the purchase management page.
* Visit `/checkout/akismet/renew/{subscriptionId}` (or `/checkout/marketplace/renew/{subscriptionId}`) on your sandbox.
* Confirm the cart loads with the correct product, resolved from the subscription rather than from the URL, and that the page renders the Akismet/Marketplace checkout experience rather than the generic one.
* Complete the renewal and confirm it lands on the siteless Akismet purchase management page.
* Regression check: the legacy `/checkout/akismet/{productSlug}/renew/{subscriptionId}` URL should still behave exactly as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
