### PR TITLE
Use subscription-ID-only renewal URLs for siteless purchases

### DIFF
--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -20,7 +20,6 @@ import { isWithinLast, isWithinNext, getDateFromCreditCardExpiry } from './datet
 import { isGSuiteProductSlug } from './gsuite';
 import { redirectToDashboardLink, wpcomLink } from './link';
 import { getStudioCodeAiCreditsTitle } from './studio-code-ai-credits';
-import { encodeProductForUrl } from './wpcom-checkout';
 import type { Product, Purchase } from '@automattic/api-core';
 
 export const CANCEL_FLOW_TYPE = {
@@ -657,21 +656,6 @@ function getServicePathForCheckoutFromPurchase( purchase: Purchase ): string {
 	return '';
 }
 
-function getCheckoutProductSlugFromPurchase( purchase: Purchase ): string {
-	const productSlug = encodeProductForUrl( purchase.product_slug );
-	const productDomain = purchase.meta ? encodeProductForUrl( purchase.meta ) : undefined;
-	const checkoutProductSlug = productDomain ? `${ productSlug }:${ productDomain }` : productSlug;
-	return checkoutProductSlug;
-}
-
-function getCheckoutSiteSlugForPurchase( purchase: Purchase ): string {
-	// Neither Akismet nor A4A holding sites should use a site slug
-	if ( isAkismetProduct( purchase ) || isA4AHoldingSitePurchase( purchase ) ) {
-		return '';
-	}
-	return purchase.site_slug || '';
-}
-
 export function getRenewalUrlFromPurchase( purchase: Purchase, backUrl?: string ): string {
 	return getRenewUrlForPurchases( [ purchase ], backUrl );
 }
@@ -688,19 +672,13 @@ export function getRenewUrlForPurchases(
 	if ( purchases.length < 1 ) {
 		throw new Error( 'Could not find product slug or purchase id for renewal.' );
 	}
-	const firstPurchase = purchases[ 0 ];
 	const purchaseIds = purchases.map( ( purchase ) => purchase.ID ).join( ',' );
-	const servicePath = getServicePathForCheckoutFromPurchase( firstPurchase );
+	// Siteless Akismet and Marketplace renewals keep the service in the path
+	// because the route is what selects the service-specific checkout
+	// experience. Everything else renews from the subscription ID alone.
+	const servicePath = getServicePathForCheckoutFromPurchase( purchases[ 0 ] );
 
-	// Siteless Akismet and Marketplace renewals still need the legacy URL shape
-	// because their checkout routes are keyed on the service and product slug.
-	const path = servicePath
-		? `/checkout/${ servicePath }${ purchases
-				.map( ( purchase ) => getCheckoutProductSlugFromPurchase( purchase ) )
-				.join( ',' ) }/renew/${ purchaseIds }/${ getCheckoutSiteSlugForPurchase( firstPurchase ) }`
-		: `/checkout/renew/${ purchaseIds }`;
-
-	return addQueryArgs( wpcomLink( path ), {
+	return addQueryArgs( wpcomLink( `/checkout/${ servicePath }renew/${ purchaseIds }` ), {
 		cancel_to: backUrl,
 		redirect_to: backUrl,
 	} );

--- a/client/dashboard/utils/test/purchase.ts
+++ b/client/dashboard/utils/test/purchase.ts
@@ -447,7 +447,7 @@ describe( 'getRenewalUrlFromPurchase', () => {
 		expect( url ).not.toContain( 'siteless.agencies.automattic.com' );
 	} );
 
-	test( 'keeps the legacy format for a siteless Akismet purchase', () => {
+	test( 'keeps the service in the URL but drops the product slug for siteless Akismet', () => {
 		const url = getRenewalUrlFromPurchase(
 			makePurchase( {
 				ID: 67890,
@@ -455,7 +455,22 @@ describe( 'getRenewalUrlFromPurchase', () => {
 			} )
 		);
 
-		expect( url ).toContain( '/checkout/akismet/ak_plus_yearly_1/renew/67890/?' );
+		expect( url ).toContain( '/checkout/akismet/renew/67890?' );
+		expect( url ).not.toContain( 'ak_plus_yearly_1' );
+	} );
+
+	test( 'keeps the service in the URL but drops the product slug for siteless Marketplace', () => {
+		const url = getRenewalUrlFromPurchase(
+			makePurchase( {
+				ID: 54321,
+				product_slug: 'wpcom_dotcompatch_yearly',
+				product_type: 'saas_plugin',
+				is_attached_to_holding_site: true,
+			} )
+		);
+
+		expect( url ).toContain( '/checkout/marketplace/renew/54321?' );
+		expect( url ).not.toContain( 'wpcom_dotcompatch_yearly' );
 	} );
 } );
 

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -383,14 +383,10 @@ export function handleRenewNowClick(
 				serviceSlug = 'marketplace/';
 			}
 
-			// Siteless Akismet and Marketplace renewals still need the legacy URL
-			// shape because their checkout routes are keyed on the service and
-			// product slug.
-			let renewalUrl = serviceSlug
-				? `/checkout/${ serviceSlug }${ productSlugs[ 0 ] }/renew/${ purchaseIds[ 0 ] }/${
-						siteSlug || ''
-				  }`
-				: `/checkout/renew/${ purchaseIds[ 0 ] }`;
+			// Siteless Akismet and Marketplace renewals keep the service in the path
+			// because the route is what selects the service-specific checkout
+			// experience. Everything else renews from the subscription ID alone.
+			let renewalUrl = `/checkout/${ serviceSlug }renew/${ purchaseIds[ 0 ] }`;
 
 			renewalUrl = addQueryArgs(
 				{ redirect_to: options.redirectTo, cancel_to: options.cancelTo },

--- a/client/lib/purchases/test/index.js
+++ b/client/lib/purchases/test/index.js
@@ -366,10 +366,10 @@ describe( 'index', () => {
 		// No site
 		const siteSlug = '';
 
-		test( 'should redirect to the purchase management page with service slug URL', () => {
+		test( 'should keep the service in the URL but drop the product slug', () => {
 			const dispatch = jest.fn();
 			handleRenewNowClick( purchase, siteSlug )( dispatch );
-			expect( page ).toHaveBeenCalledWith( '/checkout/akismet/ak_plus_yearly_1/renew/1/' );
+			expect( page ).toHaveBeenCalledWith( '/checkout/akismet/renew/1' );
 		} );
 	} );
 


### PR DESCRIPTION
Fixes SHILL-2509

## Proposed Changes

Points calypso's two renewal link builders at the short `/checkout/{service}/renew/{subscriptionId}` URL added in #114065, so siteless Akismet and Marketplace renewals no longer put the product slug and site slug in the URL.

* Build `/checkout/${serviceSlug}renew/${id}` in `handleRenewNowClick`, collapsing the legacy/short branch into one template.
* Do the same in the Dashboard's `getRenewUrlForPurchases`.
* Remove `getCheckoutProductSlugFromPurchase` and `getCheckoutSiteSlugForPurchase`, which no longer have callers.
* Update the Akismet assertions in both test suites and add a siteless Marketplace case.

## Why are these changes being made?

SHILL-1695 added `/checkout/renew/{subscription_id}` and #114063 migrated calypso's renewal links to it, but siteless Akismet and Marketplace were left on the legacy shape because the short route dropped `sitelessCheckoutType` and with it the service-specific checkout experience. #114065 closed that gap by adding a per-service short route. This is the last step: actually generating those URLs.

The service segment stays in the path because the route is what selects the checkout experience. What goes away is the product slug and the trailing site slug, both of which the backend derives from the subscription record — and both of which were failure modes in their own right. The site slug in particular is the one described in SHILL-2506: it is read from the purchase's own `site_slug`, so a purchase whose site is unreachable, renamed, or a holding site produced a URL that pointed checkout at the wrong place.

Because `serviceSlug` is already `''` for the non-siteless case, both builders collapse to a single template rather than a ternary. The two dashboard helpers that formatted the product and site segments then have no callers left, so they come out with the branch that used them.

Multi-purchase renewals still work: `getRenewUrlForPurchases` over several Akismet purchases yields `/checkout/akismet/renew/1,2`, which the route matches as one segment and `addRenewalBySubscriptionId` splits on the comma (covered by a test added in #114065).

## Testing Instructions

TC:
```
yarn test-client client/dashboard/utils/test/purchase.ts client/lib/purchases/test/index.js
```

Manual testing:
* You need an account with a renewable siteless Akismet or Marketplace subscription.
* From `/me/purchases`, open the subscription and click **Renew now**. Confirm you land on `/checkout/akismet/renew/{id}` (or `/checkout/marketplace/renew/{id}`) with no product slug in the URL.
* Confirm checkout loads the right product and still renders the Akismet/Marketplace experience rather than the generic one.
* Repeat from the Dashboard's billing/purchases screens, which use the other builder.
* Regression check: renewing a normal WordPress.com plan should still produce `/checkout/renew/{id}`, and `redirect_to` / `cancel_to` should still return you where you started in both cases.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
