### PR TITLE
Add logged out tag server redirects

### DIFF
--- a/client/reader/controller.jsx
+++ b/client/reader/controller.jsx
@@ -422,7 +422,7 @@ export function redirectLoggedOutToDiscover( context, next ) {
 
 /**
  * Middleware to redirect logged out users to the Discover tags tab, selecting
- * the requested tag when the route has one.
+ * the requested tag when the route has one and preserving any locale prefix.
  * Intended for the tag pages, which no longer support logged out users.
  * @param   {Object}   context Context object
  * @param   {Function} next    Calls next middleware
@@ -434,8 +434,9 @@ export function redirectLoggedOutToDiscoverTags( context, next ) {
 		next();
 		return;
 	}
+	const localePrefix = context.params.lang ? '/' + context.params.lang : '';
 	const tag = context.params.tag ? encodeURIComponent( context.params.tag ) : 'dailyprompt';
-	return page.redirect( `/discover/tags?selectedTag=${ tag }` );
+	return page.redirect( `${ localePrefix }/discover/tags?selectedTag=${ tag }` );
 }
 
 /**

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -1058,9 +1058,10 @@ function wpcomPages( app ) {
 		}
 	} );
 
-	// The tag pages no longer render logged out; 301 old links (and search
-	// engines) to the Discover tags tab. Logged-in users fall through to the
-	// client-side routes.
+	// The tag pages no longer render logged out; redirect old links (and search
+	// engines) to the Discover tags tab. A 302 rather than a 301 because the
+	// response depends on login state and browsers cache 301s unconditionally.
+	// Logged-in users fall through to the client-side routes.
 	app.get(
 		[
 			'/:locale([a-z]{2,3}|[a-z]{2}-[a-z]{2})?/tags',
@@ -1073,7 +1074,7 @@ function wpcomPages( app ) {
 			}
 			const localePrefix = req.params.locale ? '/' + req.params.locale : '';
 			const selectedTag = req.params.tag ? encodeURIComponent( req.params.tag ) : 'dailyprompt';
-			res.redirect( 301, `${ localePrefix }/discover/tags?selectedTag=${ selectedTag }` );
+			res.redirect( 302, `${ localePrefix }/discover/tags?selectedTag=${ selectedTag }` );
 		}
 	);
 

--- a/client/server/pages/index.js
+++ b/client/server/pages/index.js
@@ -1058,6 +1058,25 @@ function wpcomPages( app ) {
 		}
 	} );
 
+	// The tag pages no longer render logged out; 301 old links (and search
+	// engines) to the Discover tags tab. Logged-in users fall through to the
+	// client-side routes.
+	app.get(
+		[
+			'/:locale([a-z]{2,3}|[a-z]{2}-[a-z]{2})?/tags',
+			'/:locale([a-z]{2,3}|[a-z]{2}-[a-z]{2})?/tag/:tag?',
+		],
+		( req, res, next ) => {
+			if ( req.context.isLoggedIn ) {
+				next();
+				return;
+			}
+			const localePrefix = req.params.locale ? '/' + req.params.locale : '';
+			const selectedTag = req.params.tag ? encodeURIComponent( req.params.tag ) : 'dailyprompt';
+			res.redirect( 301, `${ localePrefix }/discover/tags?selectedTag=${ selectedTag }` );
+		}
+	);
+
 	// Redirect legacy `/menus` routes to the corresponding Customizer panel
 	// TODO: Move to `my-sites/customize` route defs once that section is isomorphic
 	app.get( [ '/menus', '/menus/:site?' ], ( req, res ) => {

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -1105,6 +1105,31 @@ describe( 'main app', () => {
 		} );
 	} );
 
+	describe( 'Route /tags and /tag', () => {
+		it( 'permanently redirects logged-out visitors to the Discover tags tab', async () => {
+			const { response } = await app.run( { request: { url: '/tags' } } );
+			expect( response.redirect ).toHaveBeenCalledWith(
+				301,
+				'/discover/tags?selectedTag=dailyprompt'
+			);
+		} );
+
+		it( 'carries the tag and locale prefix through the redirect', async () => {
+			const { response } = await app.run( { request: { url: '/fr/tag/travel' } } );
+			expect( response.redirect ).toHaveBeenCalledWith(
+				301,
+				'/fr/discover/tags?selectedTag=travel'
+			);
+		} );
+
+		it( 'does not redirect logged-in users', async () => {
+			const { response } = await app.run( {
+				request: { url: '/tags', cookies: { wordpress_logged_in: true } },
+			} );
+			expect( response.redirect ).not.toHaveBeenCalled();
+		} );
+	} );
+
 	describe( 'Route /menus', () => {
 		it( 'redirects to menus when there is a site', async () => {
 			const { response } = await app.run( { request: { url: '/menus/my-site' } } );

--- a/client/server/pages/test/index.js
+++ b/client/server/pages/test/index.js
@@ -1106,10 +1106,10 @@ describe( 'main app', () => {
 	} );
 
 	describe( 'Route /tags and /tag', () => {
-		it( 'permanently redirects logged-out visitors to the Discover tags tab', async () => {
+		it( 'redirects logged-out visitors to the Discover tags tab', async () => {
 			const { response } = await app.run( { request: { url: '/tags' } } );
 			expect( response.redirect ).toHaveBeenCalledWith(
-				301,
+				302,
 				'/discover/tags?selectedTag=dailyprompt'
 			);
 		} );
@@ -1117,7 +1117,7 @@ describe( 'main app', () => {
 		it( 'carries the tag and locale prefix through the redirect', async () => {
 			const { response } = await app.run( { request: { url: '/fr/tag/travel' } } );
 			expect( response.redirect ).toHaveBeenCalledWith(
-				301,
+				302,
 				'/fr/discover/tags?selectedTag=travel'
 			);
 		} );


### PR DESCRIPTION
## Proposed Changes

* Follow-up to #114046: add real server-side redirects for logged-out requests to the removed tag pages, following the existing `wpcomPages()` pattern in `client/server/pages/index.js`.
* Logged-out `GET`s to `/tags`, `/tag/:tag`, and their locale-prefixed variants now respond `302 → /discover/tags?selectedTag=<tag>` (falling back to `selectedTag=dailyprompt` when the route carries no tag, and preserving the locale prefix, e.g. `/fr/tag/travel` → `/fr/discover/tags?selectedTag=travel`).
* The client-side `redirectLoggedOutToDiscoverTags` middleware stays in place to cover in-app SPA navigations, and now preserves the locale prefix too — previously a logged-out visit to `/fr/tag/photographie` redirected to the unprefixed `/discover/tags`. Logged-in requests fall through to the client-side routes unchanged.
* New tests in `client/server/pages/test/index.js` cover the redirect target, the tag/locale carry-through, and the logged-in fall-through.

## Notes for reviewers

* We implemented a `302` rather than a `301`, deliberately: the response depends on login state, and browsers cache `301`s unconditionally — a visitor who hit `/tags` logged out would keep the redirect after logging in. Search engines treat a long-lived `302` much like a `301` for deindexing purposes, without the client-side caching hazard.

## Why are these changes being made?

* #114046 replaced the logged-out tag pages with a client-side redirect, which search engines don't reliably follow — the SPA shell has to boot before the redirect happens. A real HTTP redirect lets crawlers deindex the old URLs cleanly and pass them to the Discover tags tab, and spares logged-out visitors a shell render before landing.

## Testing Instructions

* `curl -sI http://calypso.localhost:3000/tags | grep -i 'HTTP\|location'` — expect `302` with `location: /discover/tags?selectedTag=dailyprompt`.
* `curl -sI http://calypso.localhost:3000/fr/tag/travel | grep -i 'HTTP\|location'` — expect `302` with `location: /fr/discover/tags?selectedTag=travel`.
* Logged in (browser), visit `/tags` and `/tag/travel` — both should render the normal logged-in pages with no redirect.
* `yarn test-server client/server/pages/test/index.js` — all tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)