### PR TITLE
Feat(difm): add explainer video link to the content submission form

### DIFF
--- a/client/signup/steps/website-content/dialogs.tsx
+++ b/client/signup/steps/website-content/dialogs.tsx
@@ -29,6 +29,24 @@ const DialogButton = styled( Button )`
 	}
 `;
 
+const EXPLAINER_VIDEO_EMBED_URL = 'https://www.youtube.com/embed/Gr1c7_heEkE?autoplay=1';
+
+const VideoPlayer = styled.div`
+	position: relative;
+	width: 100%;
+	aspect-ratio: 16 / 9;
+	background: var( --color-neutral-90 );
+	overflow: hidden;
+
+	iframe {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		border: 0;
+	}
+`;
+
 export function ConfirmDialog( {
 	isConfirmDialogOpen,
 	setIsConfirmDialogOpen,
@@ -181,6 +199,43 @@ export function ContentGuidelinesDialog( {
 					</li>
 				</ul>
 			</DialogContent>
+		</Dialog>
+	);
+}
+
+export function ExplainerVideoDialog( {
+	isExplainerVideoDialogOpen,
+	setIsExplainerVideoDialogOpen,
+}: {
+	isExplainerVideoDialogOpen: boolean;
+	setIsExplainerVideoDialogOpen: ( arg0: boolean ) => void;
+} ) {
+	const translate = useTranslate();
+	const close = () => setIsExplainerVideoDialogOpen( false );
+
+	return (
+		<Dialog
+			isVisible={ isExplainerVideoDialogOpen }
+			onClose={ close }
+			additionalClassNames="website-content__explainer-video-dialog"
+			label={ translate( 'Watch how to submit your content' ) }
+			buttons={ [
+				<DialogButton key="close" primary onClick={ close }>
+					{ translate( 'Close' ) }
+				</DialogButton>,
+			] }
+		>
+			<VideoPlayer>
+				{ isExplainerVideoDialogOpen && (
+					<iframe
+						src={ EXPLAINER_VIDEO_EMBED_URL }
+						title={ translate( 'Watch how to submit your content' ) }
+						allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+						sandbox="allow-scripts allow-same-origin allow-presentation"
+						allowFullScreen
+					/>
+				) }
+			</VideoPlayer>
 		</Dialog>
 	);
 }

--- a/client/signup/steps/website-content/dialogs.tsx
+++ b/client/signup/steps/website-content/dialogs.tsx
@@ -29,7 +29,7 @@ const DialogButton = styled( Button )`
 	}
 `;
 
-const EXPLAINER_VIDEO_EMBED_URL = 'https://www.youtube.com/embed/Gr1c7_heEkE?autoplay=1';
+const EXPLAINER_VIDEO_EMBED_URL = 'https://www.youtube.com/embed/Gr1c7_heEkE?autoplay=1&mute=1';
 
 const VideoPlayer = styled.div`
 	position: relative;

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { Button, ConfettiAnimation } from '@automattic/components';
+import { Button, ConfettiAnimation, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
@@ -32,7 +32,7 @@ import {
 	hasUnsavedChanges as hasUnsavedWebsiteContentChanges,
 } from 'calypso/state/signup/steps/website-content/selectors';
 import { getSiteId } from 'calypso/state/sites/selectors';
-import { ContentGuidelinesDialog, ConfirmDialog } from './dialogs';
+import { ContentGuidelinesDialog, ConfirmDialog, ExplainerVideoDialog } from './dialogs';
 import { sectionGenerator } from './section-generator';
 import type { ValidationErrors } from 'calypso/signup/accordion-form/types';
 import type { WebsiteContentServerState } from 'calypso/state/signup/steps/website-content/types';
@@ -43,14 +43,45 @@ import './style.scss';
 const debug = debugFactory( 'calypso:difm' );
 
 const LinkButton = styled( Button )`
-	text-decoration: underline;
-	cursor: pointer;
+	&.button {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		height: auto;
+		padding: 0;
+		overflow: visible;
+		text-decoration: none;
+		cursor: pointer;
+	}
+
+	&.button.is-borderless .gridicon {
+		position: static;
+		top: auto;
+		flex-shrink: 0;
+		width: 16px;
+		height: 16px;
+		margin: 0;
+		overflow: visible;
+		fill: currentColor;
+	}
+
+	span {
+		text-decoration: underline;
+	}
 
 	.formatted-header__subtitle
 		button&[type='button'].button.is-borderless.is-primary.is-transparent:focus {
 		border-color: transparent;
 		box-shadow: none;
 	}
+`;
+
+const SidebarLinks = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 4px;
+	margin-top: 16px;
 `;
 
 const LoadingContainer = styled.div`
@@ -234,32 +265,43 @@ export default function WrapperWebsiteContent(
 	const { isLoading, isError, data } = useGetWebsiteContentQuery( selectedSiteId );
 
 	const [ isContentGuidelinesDialogOpen, setIsContentGuidelinesDialogOpen ] = useState( true );
+	const [ isExplainerVideoDialogOpen, setIsExplainerVideoDialogOpen ] = useState( false );
 
 	const headerText = translate( 'Website Content' );
 
-	const subHeaderTextTranslateArgs = {
-		components: {
-			br: <br />,
-			Link: (
+	const descriptionText = data?.isStoreFlow
+		? translate(
+				'Provide content for your website build. You can add products later with the WordPress editor.'
+		  )
+		: translate(
+				'Provide content for your website build. You will be able to edit all content later using the WordPress editor.'
+		  );
+
+	const subHeaderText = (
+		<>
+			{ descriptionText }
+			<SidebarLinks>
 				<LinkButton
 					borderless
 					primary
 					transparent
 					onClick={ () => setIsContentGuidelinesDialogOpen( true ) }
-				/>
-			),
-		},
-	};
-
-	const subHeaderText = data?.isStoreFlow
-		? translate(
-				'Provide content for your website build. You can add products later with the WordPress editor.{{br}}{{/br}}{{br}}{{/br}}{{Link}}View Content Guidelines{{/Link}}',
-				subHeaderTextTranslateArgs
-		  )
-		: translate(
-				'Provide content for your website build. You will be able to edit all content later using the WordPress editor.{{br}}{{/br}}{{br}}{{/br}}{{Link}}View Content Guidelines{{/Link}}',
-				subHeaderTextTranslateArgs
-		  );
+				>
+					<Gridicon icon="pages" size={ 16 } aria-hidden="true" />
+					<span>{ translate( 'View content guidelines' ) }</span>
+				</LinkButton>
+				<LinkButton
+					borderless
+					primary
+					transparent
+					onClick={ () => setIsExplainerVideoDialogOpen( true ) }
+				>
+					<Gridicon icon="play" size={ 16 } aria-hidden="true" />
+					<span>{ translate( 'Watch how to submit your content' ) }</span>
+				</LinkButton>
+			</SidebarLinks>
+		</>
+	);
 
 	useEffect( () => {
 		if ( data?.isWebsiteContentSubmitted ) {
@@ -304,6 +346,10 @@ export default function WrapperWebsiteContent(
 			<ContentGuidelinesDialog
 				isContentGuidelinesDialogOpen={ isContentGuidelinesDialogOpen }
 				setIsContentGuidelinesDialogOpen={ setIsContentGuidelinesDialogOpen }
+			/>
+			<ExplainerVideoDialog
+				isExplainerVideoDialogOpen={ isExplainerVideoDialogOpen }
+				setIsExplainerVideoDialogOpen={ setIsExplainerVideoDialogOpen }
 			/>
 
 			<StepWrapper

--- a/client/signup/steps/website-content/index.tsx
+++ b/client/signup/steps/website-content/index.tsx
@@ -76,7 +76,7 @@ const LinkButton = styled( Button )`
 	}
 `;
 
-const SidebarLinks = styled.div`
+const SidebarLinks = styled.span`
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;

--- a/client/signup/steps/website-content/style.scss
+++ b/client/signup/steps/website-content/style.scss
@@ -36,4 +36,13 @@
 	.ReactModal__Content.ReactModal__Content--after-open.dialog.card {
 		max-width: 700px;
 	}
+
+	.ReactModal__Content.ReactModal__Content--after-open.dialog.card.website-content__explainer-video-dialog {
+		width: 90%;
+		max-width: 840px;
+	}
+
+	.website-content__explainer-video-dialog .dialog__content {
+		padding: 0;
+	}
 }


### PR DESCRIPTION
DIFMX-5761 : https://linear.app/a8c/issue/DIFMX-5761/add-explainer-video-link-to-content-submission-form-sidebar

## Proposed Changes

* Add a “Watch how to submit your content” link in the content submission form sidebar, under “View content guidelines”.
* Open the explainer video in a modal (same Dialog pattern as the guidelines link), with autoplay and a Close button.
* Use Gridicons (`pages` and `play`) so the new icons match existing form chrome and stay distinct from the video upload placeholder.

See video of change tested and working: 
https://github.com/user-attachments/assets/2c633393-7478-4fd6-a6b5-ca4bf0c59eff

## Why are these changes being made?

Customers filling in DIFM content don’t always know what to submit. Linking Mike’s explainer video from the form sidebar makes that help available at the point of use, without leaving the flow.

## Testing Instructions

* Open the content form for a DIFM site that hasn’t submitted yet: `http://calypso.localhost:3000/start/site-content-collection/website-content?siteSlug=YOUR_SITE`
* Dismiss the guidelines modal if it auto-opens.
* Confirm the sidebar shows:
  * View content guidelines (document icon)
  * Watch how to submit your content (play icon)
* Confirm both icons are fully visible (not cropped).
* Click the video link: the modal should open with the video autoplaying, no title, and a Close button.
* Close via Close, overlay click, and Escape. Playback should stop.
* Re-open the guidelines link and confirm that modal is unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->