### PR TITLE
Login: show notice confirming password was reset

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -58,6 +58,7 @@ import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import ContinueAsUser from './continue-as-user';
 import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
+import PasswordResetSuccessNotice from './password-reset-success-notice';
 import { shouldUseMagicCode } from './utils/should-use-magic-code';
 
 import './style.scss';
@@ -597,6 +598,8 @@ class Login extends Component {
 						twoFactorAuthType={ twoFactorAuthType }
 					/>
 				) }
+
+				<PasswordResetSuccessNotice />
 
 				{ isSignupExistingAccount && this.renderLoginFormSignupNotice() }
 

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -58,7 +58,6 @@ import isWooJPCFlow from 'calypso/state/selectors/is-woo-jpc-flow';
 import ContinueAsUser from './continue-as-user';
 import ErrorNotice from './error-notice';
 import LoginForm from './login-form';
-import PasswordResetSuccessNotice from './password-reset-success-notice';
 import { shouldUseMagicCode } from './utils/should-use-magic-code';
 
 import './style.scss';
@@ -598,8 +597,6 @@ class Login extends Component {
 						twoFactorAuthType={ twoFactorAuthType }
 					/>
 				) }
-
-				<PasswordResetSuccessNotice />
 
 				{ isSignupExistingAccount && this.renderLoginFormSignupNotice() }
 

--- a/client/blocks/login/password-reset-success-notice.tsx
+++ b/client/blocks/login/password-reset-success-notice.tsx
@@ -4,10 +4,7 @@ import Notice from 'calypso/components/notice';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 
 /**
- * Confirms a finished password reset.
- *
- * The WordPress.com reset-password screen no longer renders its own confirmation
- * page: it redirects to the login page with `password_reset=success` instead.
+ * Show a password reset confirmation notice when the `password_reset` query argument is set to `success`
  */
 export default function PasswordResetSuccessNotice() {
 	const translate = useTranslate();

--- a/client/blocks/login/password-reset-success-notice.tsx
+++ b/client/blocks/login/password-reset-success-notice.tsx
@@ -19,7 +19,7 @@ export default function PasswordResetSuccessNotice() {
 
 	return (
 		<Notice status="is-success" showDismiss={ false }>
-			{ translate( 'Your password has been reset.' ) }
+			{ translate( 'Your password has been reset successfully.' ) }
 		</Notice>
 	);
 }

--- a/client/blocks/login/password-reset-success-notice.tsx
+++ b/client/blocks/login/password-reset-success-notice.tsx
@@ -4,7 +4,7 @@ import Notice from 'calypso/components/notice';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 
 /**
- * Show a password reset confirmation notice when the `password_reset` query argument is set to `success`
+ * Show a password reset confirmation notice
  */
 export default function PasswordResetSuccessNotice() {
 	const translate = useTranslate();

--- a/client/blocks/login/password-reset-success-notice.tsx
+++ b/client/blocks/login/password-reset-success-notice.tsx
@@ -1,0 +1,25 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import Notice from 'calypso/components/notice';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+
+/**
+ * Confirms a finished password reset.
+ *
+ * The WordPress.com reset-password screen no longer renders its own confirmation
+ * page: it redirects to the login page with `password_reset=success` instead.
+ */
+export default function PasswordResetSuccessNotice() {
+	const translate = useTranslate();
+	const currentQuery = useSelector( getCurrentQueryArguments );
+
+	if ( currentQuery?.password_reset !== 'success' ) {
+		return null;
+	}
+
+	return (
+		<Notice status="is-success" showDismiss={ false }>
+			{ translate( 'Your password has been reset.' ) }
+		</Notice>
+	);
+}

--- a/client/blocks/login/test/password-reset-success-notice.jsx
+++ b/client/blocks/login/test/password-reset-success-notice.jsx
@@ -12,7 +12,7 @@ describe( 'PasswordResetSuccessNotice', () => {
 	test( 'shows the confirmation when password_reset is success', () => {
 		renderAtPath( '/log-in?password_reset=success' );
 
-		expect( screen.getByText( 'Your password has been reset.' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Your password has been reset successfully.' ) ).toBeInTheDocument();
 	} );
 
 	test( 'shows nothing when password_reset is absent', () => {

--- a/client/blocks/login/test/password-reset-success-notice.jsx
+++ b/client/blocks/login/test/password-reset-success-notice.jsx
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import PasswordResetSuccessNotice from 'calypso/blocks/login/password-reset-success-notice';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+
+const renderAtPath = ( initialPath ) =>
+	renderWithProvider( <PasswordResetSuccessNotice />, { initialPath } );
+
+describe( 'PasswordResetSuccessNotice', () => {
+	test( 'shows the confirmation when password_reset is success', () => {
+		renderAtPath( '/log-in?password_reset=success' );
+
+		expect( screen.getByText( 'Your password has been reset.' ) ).toBeInTheDocument();
+	} );
+
+	test( 'shows nothing when password_reset is absent', () => {
+		const { container } = renderAtPath( '/log-in' );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	test( 'shows nothing when password_reset has another value', () => {
+		const { container } = renderAtPath( '/log-in?password_reset=failure' );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/client/login/wp-login/components/one-login-layout.scss
+++ b/client/login/wp-login/components/one-login-layout.scss
@@ -8,6 +8,11 @@
 	gap: 2em;
 }
 
+// The content wrapper's gap already spaces the notice from the heading.
+.wp-login__one-login-layout-content-wrapper > .calypso-notice {
+	margin-bottom: 0;
+}
+
 .wp-login__one-login-layout-heading {
 	color: var( --color-neutral-100 );
 	font-size: $font-body;

--- a/client/login/wp-login/components/one-login-layout.tsx
+++ b/client/login/wp-login/components/one-login-layout.tsx
@@ -56,6 +56,11 @@ interface OneLoginLayoutProps {
 	 * default quiet ToS treatment.
 	 */
 	subHeadingProminent?: boolean;
+	/**
+	 * Rendered above the heading. Pass a component that returns `null` when it
+	 * has nothing to show, so the layout keeps its spacing.
+	 */
+	notice?: React.ReactNode;
 }
 
 const OneLoginLayout = ( {
@@ -71,6 +76,7 @@ const OneLoginLayout = ( {
 	columnWidth,
 	showLogo = true,
 	subHeadingProminent = false,
+	notice,
 }: OneLoginLayoutProps ) => {
 	const translate = useTranslate();
 	const urlLocale = useLocale();
@@ -164,6 +170,7 @@ const OneLoginLayout = ( {
 			verticalAlign="center"
 		>
 			<div className="wp-login__one-login-layout-content-wrapper">
+				{ notice }
 				<div className="wp-login__one-login-layout-heading">
 					{ showLogo && (
 						<HeadingLogo

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import LoginBlock from 'calypso/blocks/login';
+import PasswordResetSuccessNotice from 'calypso/blocks/login/password-reset-success-notice';
 import DocumentHead from 'calypso/components/data/document-head';
 import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import Main from 'calypso/components/main';
@@ -380,6 +381,7 @@ export class Login extends Component {
 						isLostPasswordView={ isLostPasswordView }
 						noThanksRedirectUrl={ this.getNoThanksRedirectUrl() }
 						subHeadingProminent={ this.props.isFromJetpackConnector && ! isLostPasswordView }
+						notice={ <PasswordResetSuccessNotice /> }
 					>
 						{ mainContent }
 					</OneLoginLayout>


### PR DESCRIPTION
Part of DOTCOM-18489

## Proposed Changes

Show a password reset confirmation notice when the login page is loaded with the `password_reset=success` query parameter.

### Screenshot

<img width="1920" height="1080" alt="Screenshot 2026-09-03 at 22 30 44" src="https://github.com/user-attachments/assets/69a9ef90-b332-4c91-85f6-42eaafaacf8a" />

## Why are these changes being made?

The backend "Lost your password" flow is being updated to match the latest layouts (see p9Jlb4-hus-p2), and this is how a user will know their password was updated successfully.

Before this change, there was no visual indication that the password had been updated.

## Testing Instructions

Unit tests:
```
yarn test-client client/blocks/login/test/password-reset-success-notice.jsx
```

Manual tests:
- Build this branch locally or open the live Calypso link
- Visit `/log-in?password_reset=success`. A green "Your password has been reset." notice appears above the login form
* Open `/log-in` and `/log-in?password_reset=whatever`. No notice should appear

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)