### PR TITLE
Receipts: show the billing details field on all receipts

### DIFF
--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -195,15 +195,18 @@ function ReceiptDetails( { receipt }: { receipt: Receipt } ) {
 
 export function BillingDetailsField( { receipt }: { receipt: Receipt } ) {
 	const [ billingDetailsText, setBillingDetailsText ] = useState(
-		receipt.cc_num !== 'XXXX' ? `${ receipt.cc_name }\n${ receipt.cc_email }` : ''
+		receipt.cc_num !== 'XXXX'
+			? [ receipt.cc_name, receipt.cc_email ].filter( Boolean ).join( '\n' )
+			: ''
 	);
-
-	if ( receipt.cc_num === 'XXXX' || ( ! receipt.cc_name && ! receipt.cc_email ) ) {
-		return null;
-	}
+	const isEmpty = billingDetailsText.trim().length === 0;
 
 	return (
-		<VStack spacing={ 1 } alignment="flex-start" className="receipt-billing-details">
+		<VStack
+			spacing={ 1 }
+			alignment="flex-start"
+			className={ clsx( 'receipt-billing-details', { 'is-empty': isEmpty } ) }
+		>
 			<Text upperCase variant="muted" size={ 11 }>
 				{ __( 'Billing details' ) }
 			</Text>
@@ -216,13 +219,7 @@ export function BillingDetailsField( { receipt }: { receipt: Receipt } ) {
 				__nextHasNoMarginBottom
 			/>
 			{ /* A printed textarea clips its overflow, so mirror the text into a print-only element. */ }
-			<div
-				className={ clsx( 'receipt-billing-details-printable', {
-					'is-empty': billingDetailsText.trim().length === 0,
-				} ) }
-			>
-				{ billingDetailsText }
-			</div>
+			<div className="receipt-billing-details-printable">{ billingDetailsText }</div>
 			<Text variant="muted" size={ 11 } className="receipt-billing-details-description">
 				{ __(
 					'Use this field to add your billing information (eg. business address) before printing.'

--- a/client/dashboard/me/billing-history/styles.scss
+++ b/client/dashboard/me/billing-history/styles.scss
@@ -52,6 +52,11 @@
 }
 
 @media print {
+	// Nothing was entered, so the label and description are just noise on paper.
+	.receipt-billing-details.is-empty {
+		display: none;
+	}
+
 	.receipt-billing-details-input,
 	.receipt-billing-details-description {
 		display: none;
@@ -60,10 +65,6 @@
 	.receipt-billing-details-printable {
 		display: block;
 		white-space: pre-wrap;
-
-		&.is-empty {
-			display: none;
-		}
 	}
 }
 

--- a/client/dashboard/me/billing-history/test/receipt.test.tsx
+++ b/client/dashboard/me/billing-history/test/receipt.test.tsx
@@ -47,6 +47,37 @@ describe( '<BillingDetailsField>', () => {
 		expect( field ).toHaveValue( 'Jane Doe\njane@example.com' );
 	} );
 
+	test( 'renders an empty field for a receipt that was not paid by card', () => {
+		render(
+			<BillingDetailsField
+				receipt={ makeReceipt( { cc_num: 'XXXX', cc_name: '', cc_email: '' } ) }
+			/>
+		);
+
+		expect( screen.getByRole( 'textbox', { name: 'Billing details' } ) ).toHaveValue( '' );
+	} );
+
+	test( 'renders an empty field for a card receipt served without a name or email', () => {
+		render(
+			<BillingDetailsField
+				receipt={ makeReceipt( { cc_num: '1234', cc_name: '', cc_email: '' } ) }
+			/>
+		);
+
+		expect( screen.getByRole( 'textbox', { name: 'Billing details' } ) ).toHaveValue( '' );
+	} );
+
+	test( 'marks the field as empty so its label is not printed', async () => {
+		const user = userEvent.setup();
+		const { container } = render( <BillingDetailsField receipt={ receipt } /> );
+
+		expect( container.querySelector( '.receipt-billing-details' ) ).not.toHaveClass( 'is-empty' );
+
+		await user.clear( screen.getByRole( 'textbox', { name: 'Billing details' } ) );
+
+		expect( container.querySelector( '.receipt-billing-details' ) ).toHaveClass( 'is-empty' );
+	} );
+
 	test( 'accepts line breaks typed by the user', async () => {
 		const user = userEvent.setup();
 		render( <BillingDetailsField receipt={ receipt } /> );

--- a/client/dashboard/me/billing-history/test/receipt.test.tsx
+++ b/client/dashboard/me/billing-history/test/receipt.test.tsx
@@ -67,17 +67,6 @@ describe( '<BillingDetailsField>', () => {
 		expect( screen.getByRole( 'textbox', { name: 'Billing details' } ) ).toHaveValue( '' );
 	} );
 
-	test( 'marks the field as empty so its label is not printed', async () => {
-		const user = userEvent.setup();
-		const { container } = render( <BillingDetailsField receipt={ receipt } /> );
-
-		expect( container.querySelector( '.receipt-billing-details' ) ).not.toHaveClass( 'is-empty' );
-
-		await user.clear( screen.getByRole( 'textbox', { name: 'Billing details' } ) );
-
-		expect( container.querySelector( '.receipt-billing-details' ) ).toHaveClass( 'is-empty' );
-	} );
-
 	test( 'accepts line breaks typed by the user', async () => {
 		const user = userEvent.setup();
 		render( <BillingDetailsField receipt={ receipt } /> );

--- a/client/me/purchases/billing-history/receipt.tsx
+++ b/client/me/purchases/billing-history/receipt.tsx
@@ -753,10 +753,12 @@ function ReceiptLineItems( { transaction }: { transaction: BillingTransaction } 
 	);
 }
 
-function ReceiptDetails( { transaction }: { transaction: BillingTransaction } ) {
+export function ReceiptDetails( { transaction }: { transaction: BillingTransaction } ) {
 	// Pre-load the billing details textarea and hidden div with the name and email if available.
 	const initialDetailsText =
-		transaction.cc_num !== 'XXXX' ? transaction.cc_name + '\n' + transaction.cc_email : '';
+		transaction.cc_num !== 'XXXX'
+			? [ transaction.cc_name, transaction.cc_email ].filter( Boolean ).join( '\n' )
+			: '';
 	// When the content of the text area is empty, hide the "Billing Details" label for printing.
 	const [ hideDetailsOnPrint, setHideDetailsOnPrint ] = useState(
 		initialDetailsText.trim().length === 0
@@ -773,16 +775,12 @@ function ReceiptDetails( { transaction }: { transaction: BillingTransaction } ) 
 		[ setHideDetailsOnPrint ]
 	);
 
-	if ( transaction.cc_num !== 'XXXX' && ! transaction.cc_name && ! transaction.cc_email ) {
-		return null;
-	}
-
 	return (
 		<li className="billing-history__billing-details">
 			<ReceiptLabels hideDetailsOnPrint={ hideDetailsOnPrint } />
 			<TextareaAutosize
 				className="billing-history__billing-details-editable receipt__no-print"
-				aria-labelledby="billing-history__billing-details-description"
+				aria-describedby="billing-history__billing-details-description"
 				id="billing-history__billing-details-textarea"
 				rows="1"
 				value={ billingDetailsText }

--- a/client/me/purchases/billing-history/test/receipt.test.tsx
+++ b/client/me/purchases/billing-history/test/receipt.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import { ReceiptDetails } from '../receipt';
+import type { BillingTransaction } from 'calypso/state/billing-transactions/types';
+
+function makeTransaction( overrides: Partial< BillingTransaction > = {} ): BillingTransaction {
+	return {
+		id: '1',
+		cc_num: 'XXXX',
+		cc_name: '',
+		cc_email: '',
+		...overrides,
+	} as BillingTransaction;
+}
+
+describe( '<ReceiptDetails>', () => {
+	test( 'prefills the field with the cardholder name and email', () => {
+		render(
+			<ReceiptDetails
+				transaction={ makeTransaction( {
+					cc_num: '1234',
+					cc_name: 'Jane Doe',
+					cc_email: 'jane@example.com',
+				} ) }
+			/>
+		);
+
+		expect( screen.getByRole( 'textbox', { name: 'Billing details' } ) ).toHaveValue(
+			'Jane Doe\njane@example.com'
+		);
+	} );
+
+	test( 'renders an empty field for a receipt that was not paid by card', () => {
+		render( <ReceiptDetails transaction={ makeTransaction() } /> );
+
+		expect( screen.getByRole( 'textbox', { name: 'Billing details' } ) ).toHaveValue( '' );
+	} );
+
+	test( 'renders an empty field for a card receipt served without a name or email', () => {
+		render( <ReceiptDetails transaction={ makeTransaction( { cc_num: '1234' } ) } /> );
+
+		expect( screen.getByRole( 'textbox', { name: 'Billing details' } ) ).toHaveValue( '' );
+	} );
+} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-543/

## Proposed Changes

The "Billing details" field — the free-text box a user fills in before printing a receipt — was only rendered on some receipts. This removes the visibility conditions that gated it, so it now appears on every receipt in both Calypso and the Dashboard.

* Remove the `cc_name`/`cc_email` guard in `client/me/purchases/billing-history/receipt.tsx` so the field renders on card receipts served without a cardholder name or email.
* Remove the card-only guard in `client/dashboard/me/billing-history/receipt.tsx` so the field renders on receipts paid by PayPal or credits.
* Build the prefill from whichever card fields are present, instead of unconditionally joining both with a newline.
* Hide the whole Dashboard billing details block on print when the field is empty, rather than only its mirrored print element.
* Change the Calypso textarea's `aria-labelledby` to `aria-describedby` so its `<label>` provides the accessible name.
* Add unit tests for both surfaces.

## Why are these changes being made?

The gate was a leftover from 2017, when this UI *displayed* the cardholder name and email rather than accepting user input. Back then the call site read `transaction.cc_num !== 'XXXX' ? this.renderBillingDetails() : null`, and `renderBillingDetails()` itself bailed out on `! cc_name && ! cc_email` — both conditions were correct, because with no card and no name there was genuinely nothing to render.

\#16830 ("Purchases: Make empty billing details editable") then made the empty field editable and rendered it for non-card receipts too, which is the point at which the field was meant to be available everywhere. But the old "no name or email" bail-out stayed behind inside the card branch. #102637 later merged the two branches into a single component and mechanically AND-ed the two conditions together, preserving the dead guard. Separately, the Dashboard port copied the pre-2017 card-only semantics, so it hid the field on every receipt not paid by card. Neither guard has anything to do with the input itself — nothing about typing a business address into a textarea depends on the receipt having card data — so both are removed rather than adjusted.

Two follow-on fixes fall out of opening the gate. The prefill was `cc_name + '\n' + cc_email`, which was only safe because the guard hid exactly the case it broke; unguarded, a card receipt with no name or email would prefill a stray newline. And on the Dashboard only the mirrored print element was hidden when empty, not its label, so a receipt the user never typed into would have printed a bare "BILLING DETAILS" heading with nothing under it — Calypso already handled this via `hideDetailsOnPrint`.

The `aria-labelledby` fix is incidental but real: it pointed at the field's description element, which overrode the `<label>` and left the textarea announcing its help text as its name. It surfaced because the new test could not find the field by its visible label.

## Testing Instructions

TC:
```
yarn test-client client/me/purchases/billing-history/test/receipt.test.tsx client/dashboard/me/billing-history/test/receipt.test.tsx
```

Manual testing:
* You need an account with at least one receipt **not** paid by credit card (PayPal or account credits) and, ideally, one paid by card.
* Calypso: visit `/me/purchases/billing`, open a non-card receipt (`/me/purchases/billing/<receiptId>`). Confirm the "Billing details" field and its "Use this field to add your billing information…" description are present. Before this change the field appeared here already; confirm no regression.
* Dashboard: visit `/me/billing/history`, open the same non-card receipt (`/me/billing/history/<receiptId>`). Confirm the "Billing details" field now appears — before this change it was absent.
* On a card receipt, confirm the field is still prefilled with the cardholder name on the first line and email on the second.
* Type a multi-line address into the field, then use Print Receipt (or print-to-PDF) and confirm the text appears on the printed output with its line breaks intact.
* Leave the field empty and print again: confirm neither the "Billing details" label nor its description appear on the printed output.
* With a screen reader or the browser's accessibility inspector, confirm the Calypso textarea is announced as "Billing details" with the help text as its description.
