### PR TITLE
Dashboard: keep the sidebar gutter out of printed pages

### DIFF
--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -7,15 +7,6 @@
 
 .dashboard-root__body {
 	display: flex;
-	min-height: calc( 100vh - var( --masterbar-height ) );
-
-	&:has( > .dashboard-responsive-sidebar__sidebar ) {
-		padding-inline-start: $sidebar-width;
-	}
-
-	&:has( .dashboard-responsive-sidebar ) {
-		overflow-x: hidden;
-	}
 }
 
 .dashboard-root__content {
@@ -24,11 +15,33 @@
 	flex-direction: column;
 	flex: 1;
 	min-width: 0;
-	transition: transform 0.3s ease-in;
+}
 
-	.dashboard-root__body:has( .dashboard-responsive-sidebar.is-open ) & {
-		transform: translateX( $sidebar-width );
-		overflow: hidden;
+// Reserving the sidebar gutter, clipping the off-canvas sidebar and sliding it
+// in are all screen-only concerns. They are scoped to `screen` rather than
+// undone under `print` because the selectors below use `:has()`, which outranks
+// the bare `.dashboard-root__body` a print override would use — the override
+// would silently lose and leave an empty 272px gutter on the page.
+@media screen {
+	.dashboard-root__body {
+		min-height: calc( 100vh - var( --masterbar-height ) );
+
+		&:has( > .dashboard-responsive-sidebar__sidebar ) {
+			padding-inline-start: $sidebar-width;
+		}
+
+		&:has( .dashboard-responsive-sidebar ) {
+			overflow-x: hidden;
+		}
+	}
+
+	.dashboard-root__content {
+		transition: transform 0.3s ease-in;
+
+		.dashboard-root__body:has( .dashboard-responsive-sidebar.is-open ) & {
+			transform: translateX( $sidebar-width );
+			overflow: hidden;
+		}
 	}
 }
 
@@ -37,15 +50,5 @@
 	.dashboard-responsive-sidebar__sidebar,
 	.dashboard-responsive-sidebar__overlay {
 		display: none;
-	}
-
-	.dashboard-root__body {
-		padding-inline-start: 0;
-		overflow-x: visible;
-	}
-
-	.dashboard-root__content {
-		transform: none;
-		overflow: visible;
 	}
 }

--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -15,11 +15,9 @@
 	flex-direction: column;
 	flex: 1;
 	min-width: 0;
-}
-
-// Reserving the sidebar gutter, clipping the off-canvas sidebar and sliding it
-// in are all screen-only concerns. They are scoped to `screen` rather than
-// undone under `print` because the selectors below use `:has()`, which outranks
+// Scoped to `screen` rather than undone under `print` because the `:has()`
+// selectors below outrank the bare `.dashboard-root__body` a print override
+// would use — the override would silently lose.
 // the bare `.dashboard-root__body` a print override would use — the override
 // would silently lose and leave an empty 272px gutter on the page.
 @media screen {

--- a/client/dashboard/app/root/style.scss
+++ b/client/dashboard/app/root/style.scss
@@ -15,6 +15,8 @@
 	flex-direction: column;
 	flex: 1;
 	min-width: 0;
+}
+
 // Scoped to `screen` rather than undone under `print` because the `:has()`
 // selectors below outrank the bare `.dashboard-root__body` a print override
 // would use — the override would silently lose.

--- a/client/dashboard/me/security-legacy-contact/style.scss
+++ b/client/dashboard/me/security-legacy-contact/style.scss
@@ -96,16 +96,6 @@
 	// Scope the print rules to this page (the key block only exists here) so the
 	// shared layout/card components print normally on other pages.
 	body:has( .legacy-contact-print__key ) {
-		// The shared print reset for the body gutter/overflow loses to the
-		// higher-specificity `:has()` selectors that set them, so re-apply with
-		// enough specificity here. Also drop the viewport-height floor, which
-		// otherwise overflows the document onto a blank second page.
-		.dashboard-root__body {
-			padding-inline-start: 0;
-			overflow-x: visible;
-			min-height: 0;
-		}
-
 		// Hide the dev/staging environment badge (position: fixed, so it leaks
 		// into the printed output).
 		.environment-badge {


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/SHILL-2510/

## Proposed Changes

Printing any Dashboard page via a `window.print()` button (e.g. "print receipt" in Billing > Billing History) left an empty 272px gutter where the sidebar sits on screen, pushing the content off-centre and narrowing it. This scopes the shell's screen-only layout rules to `@media screen` so printed pages never inherit them.

* Move the sidebar gutter, `overflow-x` clip, slide-in `transform`/`transition` and `100vh` min-height floor into `@media screen` in `client/dashboard/app/root/style.scss`.
* Reduce the `@media print` block to just hiding the sidebar elements.
* Remove the per-page workaround in `client/dashboard/me/security-legacy-contact/style.scss`, which was re-applying those same three declarations at a higher specificity.

## Why are these changes being made?

The body wrapper reserves the gutter with `.dashboard-root__body:has( > .dashboard-responsive-sidebar__sidebar )` — specificity (0,2,0) — and the print block tried to undo it with a bare `.dashboard-root__body` — specificity (0,1,0). Media queries contribute no specificity, so `padding-inline-start: 0` never won and the gutter survived into print. Measured against the compiled stylesheet in Chromium, `padding-inline-start` computes to `272px` under `print` even though the sidebar itself is correctly `display: none`. The companion `overflow-x: visible` reset lost the same way, so printed pages also kept `overflow-x: hidden` and could clip wide content.

What made this confusing to diagnose is that Cmd+P produced correct output while the on-page "Print Receipt" button did not, from identical CSS. The sidebar is conditionally rendered on `useViewportMatch( 'medium' )`, and Chrome lays print pages out at the page box width (7.5in ≈ 720px on US Letter), which is under the 782px breakpoint. Instrumenting a real print shows Chrome firing a `matchMedia` change to `matches=false` between `beforeprint` and `afterprint`, so the desktop sidebar unmounts mid-print and the `:has()` selector stops matching — which is what accidentally produced correct output. Cmd+P opens a long-lived preview that re-lays out after that re-render lands; a synchronous, blocking `window.print()` rasterizes before React processes the state update. So the printed result depended on which side won a race.

Scoping the rules to `screen` was chosen over bumping the print overrides' specificity to match. Re-specifying each `:has()` selector inside the print block would work, but it silently re-breaks whenever someone edits a screen selector and forgets its print twin — which is exactly how this bug survived, and why a second page had already grown a local workaround for it. Putting screen-only concerns behind `screen` means print has nothing to override, and the two print paths now produce byte-identical layout regardless of the re-render.

## Testing Instructions

Manual testing:
* Open a receipt at `/me/billing/history/<receiptId>` on a desktop-width window, so the sidebar is visible.
* Click the "Print Receipt" button. In the print preview, confirm the content starts at the left page margin and uses the full page width — before this change it was indented by the sidebar's width and correspondingly narrower.
* Print the same page with Cmd+P and confirm the two previews are now identical.
* Repeat on `/me/security/legacy-contact` (which has its own print styles) and confirm no regression: full-width content, no sidebar gutter, and still a single page.
* Narrow the window below 782px and confirm on-screen behaviour is unchanged — the sidebar opens as an off-canvas panel, slides in, and the content is not indented.
* At desktop width, confirm on-screen layout is unchanged: the sidebar is pinned and the content sits beside it, not under it.