### PR TITLE
Receipts: only show business use tax detail for OH and CT

### DIFF
--- a/client/dashboard/me/billing-history/receipt.tsx
+++ b/client/dashboard/me/billing-history/receipt.tsx
@@ -232,8 +232,8 @@ export function BillingDetailsField( { receipt }: { receipt: Receipt } ) {
 	);
 }
 
-function ReceiptTaxDetails( { receipt }: { receipt: Receipt } ) {
-	const hasReceiptTaxDetails = Boolean( receipt.tax_state ) || receipt.tax_is_for_business === true;
+export function ReceiptTaxDetails( { receipt }: { receipt: Receipt } ) {
+	const hasReceiptTaxDetails = Boolean( receipt.tax_state );
 	const { data: countryList } = useSuspenseQuery( countryListQuery() );
 	const countryName =
 		countryList.find( ( country ) => country.code === receipt.tax_country_code )?.name ??
@@ -261,7 +261,7 @@ function ReceiptTaxDetails( { receipt }: { receipt: Receipt } ) {
 		} );
 	}
 
-	if ( typeof receipt.tax_is_for_business === 'boolean' ) {
+	if ( isBusinessUseTaxRegion( receipt ) && typeof receipt.tax_is_for_business === 'boolean' ) {
 		taxDetails.push( {
 			key: 'business-use',
 			label: __( 'Business use' ),
@@ -441,13 +441,21 @@ function getPaymentMethodText( receipt: Receipt ): string | null {
 	return null;
 }
 
-function getBusinessTaxStateName( state: string ): string {
-	const businessUseTaxStates: Record< string, string > = {
-		CT: 'Connecticut',
-		OH: 'Ohio',
-	};
+const BUSINESS_USE_TAX_STATES: Record< string, string > = {
+	CT: 'Connecticut',
+	OH: 'Ohio',
+};
 
-	return businessUseTaxStates[ state.toUpperCase() ] ?? state;
+function getBusinessTaxStateName( state: string ): string {
+	return BUSINESS_USE_TAX_STATES[ state.toUpperCase() ] ?? state;
+}
+
+function isBusinessUseTaxRegion( receipt: Receipt ): receipt is Receipt & { tax_state: string } {
+	if ( receipt.tax_country_code?.toUpperCase() !== 'US' || ! receipt.tax_state ) {
+		return false;
+	}
+
+	return Boolean( BUSINESS_USE_TAX_STATES[ receipt.tax_state.toUpperCase() ] );
 }
 
 function mergeTaxIsForBusiness(
@@ -462,7 +470,7 @@ function mergeTaxIsForBusiness(
 }
 
 function getBusinessTaxSuffixLabel( receipt: Receipt ): string {
-	if ( ! receipt.tax_is_for_business || ! receipt.tax_state ) {
+	if ( ! receipt.tax_is_for_business || ! isBusinessUseTaxRegion( receipt ) ) {
 		return '';
 	}
 
@@ -474,7 +482,7 @@ function getBusinessTaxSuffixLabel( receipt: Receipt ): string {
 }
 
 function hasBusinessUseTaxDetails( receipt: Receipt ): boolean {
-	return receipt.tax_is_for_business === true && Boolean( receipt.tax_state );
+	return receipt.tax_is_for_business === true && isBusinessUseTaxRegion( receipt );
 }
 
 function ReceiptLineItems( { receipt }: { receipt: Receipt } ) {

--- a/client/dashboard/me/billing-history/test/receipt.test.tsx
+++ b/client/dashboard/me/billing-history/test/receipt.test.tsx
@@ -5,7 +5,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
-import { BillingDetailsField, UserVatDetails } from '../receipt';
+import { BillingDetailsField, ReceiptTaxDetails, UserVatDetails } from '../receipt';
 import type { Receipt } from '@automattic/api-core';
 
 const receipt = {
@@ -28,6 +28,17 @@ function makeReceipt( overrides: Partial< Receipt > = {} ): Receipt {
 		id: 1,
 		...overrides,
 	} as Receipt;
+}
+
+function mockCountryList() {
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( '/rest/v1.1/domains/supported-countries' )
+		.query( true )
+		.reply( 200, [
+			{ code: 'US', name: 'United States' },
+			{ code: 'CA', name: 'Canada' },
+		] );
 }
 
 function mockCurrentTaxDetails() {
@@ -120,5 +131,54 @@ describe( '<UserVatDetails>', () => {
 		await waitFor( () => {
 			expect( screen.queryByText( 'VAT Details' ) ).not.toBeInTheDocument();
 		} );
+	} );
+} );
+
+describe( '<ReceiptTaxDetails>', () => {
+	test( 'shows business use for a receipt taxed in a state that has a business use rate', async () => {
+		mockCountryList();
+		render(
+			<ReceiptTaxDetails
+				receipt={ makeReceipt( {
+					tax_country_code: 'US',
+					tax_state: 'OH',
+					tax_is_for_business: false,
+				} ) }
+			/>
+		);
+
+		expect( await screen.findByText( 'Business use' ) ).toBeVisible();
+	} );
+
+	test( 'hides business use for a US state that has no business use rate', async () => {
+		mockCountryList();
+		render(
+			<ReceiptTaxDetails
+				receipt={ makeReceipt( {
+					tax_country_code: 'US',
+					tax_state: 'CA',
+					tax_is_for_business: false,
+				} ) }
+			/>
+		);
+
+		expect( await screen.findByText( 'State/Province' ) ).toBeVisible();
+		expect( screen.queryByText( 'Business use' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'hides business use outside the US', async () => {
+		mockCountryList();
+		render(
+			<ReceiptTaxDetails
+				receipt={ makeReceipt( {
+					tax_country_code: 'CA',
+					tax_state: 'ON',
+					tax_is_for_business: false,
+				} ) }
+			/>
+		);
+
+		expect( await screen.findByText( 'State/Province' ) ).toBeVisible();
+		expect( screen.queryByText( 'Business use' ) ).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-542

## Proposed Changes

The receipt page showed a "Business use" row in its Tax details section for essentially every receipt, including ones with no business/non-business distinction at all. Business use only affects the tax rate for US receipts taxed in Ohio or Connecticut, so this gates every business-use affordance behind that condition.

* Add an `isBusinessUseTaxRegion()` helper requiring `tax_country_code === 'US'` and a `tax_state` of `OH` or `CT`.
* Hide the "Business use" row in Tax details outside those regions.
* Hide the "%(state)s business use taxrate" suffix on the tax line item outside those regions.
* Apply the same condition to `hasBusinessUseTaxDetails()`, which forces the tax row to render.
* Hoist the state table to a module-level `BUSINESS_USE_TAX_STATES` constant shared by the helpers.
* Drop the now-dead `|| tax_is_for_business === true` half of the Tax details visibility check — business use cannot apply without a state.

## Why are these changes being made?

The "Business use" row was pushed onto the tax details list whenever `tax_is_for_business` was a boolean of any value:

```js
if ( typeof receipt.tax_is_for_business === 'boolean' ) {
```

The API returns `false` rather than `null` for most receipts, so the condition was true almost everywhere and receipts rendered `Business use  No` regardless of where they were taxed. That reads as though the user declined a business-use option that was never offered to them, and it is meaningless outside the two states where the distinction changes the rate.

<img width="694" height="672" alt="Screenshot 2026-09-03 at 5 50 03 PM" src="https://github.com/user-attachments/assets/045e4b21-9a30-4822-8d7f-cb6622a252b9" />

The `false` case is the only one that was wrong in practice — a `true` value already implies an OH or CT receipt — but the same region condition now guards the taxrate suffix and the forced tax row too, so all three call sites agree on when business use is relevant rather than each re-deriving it from a partial check.

## Testing Instructions

TC:

```
yarn test-client client/dashboard/me/billing-history/test/receipt.test.tsx
```

Manual testing:

* Run the Dashboard client locally (`yarn start-dashboard`) against a sandbox with receipts.
* Open a receipt at `/me/billing/history/<receipt id>` for a purchase taxed outside the US (or in a US state other than OH/CT) and confirm the Tax details section no longer shows a "Business use" row, while Country and State/Province still appear.
* Open a receipt taxed in Ohio or Connecticut and confirm "Business use" still appears with the correct Yes/No value, and that the tax line item still shows the "Ohio business use taxrate" suffix for business-use purchases.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
