### PR TITLE
Stats: switch the Traffic tab preview invitation on in production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -130,7 +130,7 @@
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/paid-wpcom-v2": true,
-		"stats/premium-analytics-preview": false,
+		"stats/premium-analytics-preview": true,
 		"stats/premium-analytics-preview-atomic": false,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,

--- a/config/production.json
+++ b/config/production.json
@@ -164,7 +164,7 @@
 		"stats/locations": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
-		"stats/premium-analytics-preview": false,
+		"stats/premium-analytics-preview": true,
 		"stats/premium-analytics-preview-atomic": false,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -162,7 +162,7 @@
 		"stats/locations": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
-		"stats/premium-analytics-preview": false,
+		"stats/premium-analytics-preview": true,
 		"stats/premium-analytics-preview-atomic": false,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,


### PR DESCRIPTION
Part of STATS-461. Follow up to #114009.

## Proposed Changes

* Flips `stats/premium-analytics-preview` to `true` in `production.json`, `stage.json` and `horizon.json`. It was already on in development, wpcalypso and test.
* Odyssey embeds the production config, so this switches the invitation on in wp-admin as well as Calypso Stats.

## Why are these changes being made?

#114009 shipped the "Try the new Traffic tab" banner behind this flag. The flag is checked in two places - the notice registry's `disabled` and the gate on the `wp/v2/settings` read - so with it off, production renders nothing and spends no request. Flipping it is the whole rollout switch on the Calypso side.

What it does NOT change: who gets invited. The server still decides the cohort through the notices endpoint (238515-ghe-Automattic/wpcom), and the client only offers it to WPCOM sites on the commercial Stats tier whose admin is looking - self-hosted Jetpack sites stay out for this phase.

Worth a look before merging:

* The banner copy promises a way to switch it off again ("from the settings in the new Traffic tab"). That toggle is STATS-468 - if it hasn't landed, the banner promises something customers can't find yet.
* Simple sites need the wpcom side of the enablement in place for "Switch it on" to actually stick (the enablement setting and the gate honouring it), otherwise they get the failure banner.

## Testing Instructions

* On an eligible WPCOM site (Premium or higher, as an administrator, dashboard not yet enabled), go to `/stats/day/<site>` in Calypso and ensure the "Try the new Traffic tab" banner shows up without any `?flags=` on the URL.
* Same in wp-admin Stats on an Atomic site, and ensure the tracks events carry the `jetpack_odyssey_` prefix there.
* On a site that already has the new Traffic tab, ensure no banner shows.
* On a self-hosted Jetpack site, ensure no banner shows and no `wp/v2/settings` request goes out.
* Ensure the config files still parse: `node -e "require('./config/production.json')"`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MZs2qHYoy7KYCw1hn64qUM
