### PR TITLE
Dashboard: keep placeholders mounted so page translation can't crash the page

### DIFF
--- a/client/dashboard/AGENTS.md
+++ b/client/dashboard/AGENTS.md
@@ -45,6 +45,12 @@ useMutation( {
 
 When fixing a `react-google-translate` ESLint warning, leave a one-line comment noting the otherwise-pointless-looking change (an "unnecessary" `<span>`, a dropped `?.`) dodges a Google Translate DOM crash (react/react#11538) — else the next editor reverts it.
 
+Translators wrap translated text in `<font>` elements, reparenting nodes React thinks it owns. React then calls `removeChild`/`insertBefore` on a parent that no longer holds the node and the whole page crashes. The lint rules don't catch every shape, so when writing or reviewing a component that renders differently while data loads:
+
+- **Never swap one element for another across a loading boundary.** `isLoading ? <TextSkeleton length={ 6 } /> : <Text>{ value }</Text>` mounts a different element in each branch. Keep a single `<TextBlur isBlurred={ isLoading }>` mounted and change only its text.
+- **This includes branches that return a bare string.** A `return 'Not found';` next to a `return <Foo />;` is the same element/text swap. Route every branch through the same mounted element and vary only the string inside it.
+- **Prefer flipping a prop over adding or removing a node.** `{ ! isLoading && <div>{ description }</div> }` inserts and removes a sibling; where the design allows, mount it unconditionally and blur it instead.
+
 ### Testing
 
 - Read [docs/testing.md](./docs/testing.md) before writing or modifying tests.

--- a/client/dashboard/agency/earn/woopayments/commissions-table.tsx
+++ b/client/dashboard/agency/earn/woopayments/commissions-table.tsx
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 import { download, external } from '@wordpress/icons';
 import { useCallback, useMemo, useState } from 'react';
 import { DataViews } from '../../../components/dataviews';
-import { TextSkeleton } from '../../../components/text-skeleton';
+import { TextBlur } from '../../../components/text-blur';
 import { getSiteData } from './lib/site-data';
 import {
 	SiteColumn,
@@ -72,14 +72,13 @@ export default function CommissionsTable( {
 				id: 'transactions',
 				label: __( 'Transactions' ),
 				getValue: () => '-',
-				render: ( { item } ) =>
-					isLoadingWooPaymentsData ? (
-						<TextSkeleton length={ 6 } />
-					) : (
+				render: ( { item } ) => (
+					<TextBlur isBlurred={ isLoadingWooPaymentsData } length={ 6 }>
 						<TransactionsColumn
 							transactions={ getSiteData( woopaymentsData, item.blogId ).transactions }
 						/>
-					),
+					</TextBlur>
+				),
 				enableHiding: false,
 				enableSorting: false,
 			},
@@ -87,12 +86,11 @@ export default function CommissionsTable( {
 				id: 'commissionsPaid',
 				label: __( 'Commissions paid' ),
 				getValue: () => '-',
-				render: ( { item } ) =>
-					isLoadingWooPaymentsData ? (
-						<TextSkeleton length={ 6 } />
-					) : (
+				render: ( { item } ) => (
+					<TextBlur isBlurred={ isLoadingWooPaymentsData } length={ 6 }>
 						<CommissionsPaidColumn payout={ getSiteData( woopaymentsData, item.blogId ).payout } />
-					),
+					</TextBlur>
+				),
 				enableHiding: false,
 				enableSorting: false,
 			},
@@ -100,14 +98,13 @@ export default function CommissionsTable( {
 				id: 'timeframeCommissions',
 				label: __( 'Timeframe commissions' ),
 				getValue: () => '-',
-				render: ( { item } ) =>
-					isLoadingWooPaymentsData ? (
-						<TextSkeleton length={ 6 } />
-					) : (
+				render: ( { item } ) => (
+					<TextBlur isBlurred={ isLoadingWooPaymentsData } length={ 6 }>
 						<TimeframeCommissionsColumn
 							estimatedPayout={ getSiteData( woopaymentsData, item.blogId ).estimatedPayout }
 						/>
-					),
+					</TextBlur>
+				),
 				enableHiding: false,
 				enableSorting: false,
 			},

--- a/client/dashboard/agency/overview/referral-earnings-card.tsx
+++ b/client/dashboard/agency/overview/referral-earnings-card.tsx
@@ -11,7 +11,7 @@ import { Badge } from '@wordpress/ui';
 import { ButtonStack } from '../../components/button-stack';
 import { Card, CardBody } from '../../components/card';
 import { Text } from '../../components/text';
-import { TextSkeleton } from '../../components/text-skeleton';
+import { TextBlur } from '../../components/text-blur';
 import useConsolidatedPayoutData from '../earn/referrals/hooks/use-consolidated-payout-data';
 import OverviewLinkButton from './overview-link-button';
 import StatList from './stat-list';
@@ -126,11 +126,9 @@ export default function ReferralEarningsCard( {
 					</Heading>
 					<HStack spacing={ 2 } justify="flex-start" alignment="baseline" expanded={ false }>
 						<Text size={ 20 } weight={ 500 } lineHeight="24px">
-							{ isLoading ? (
-								<TextSkeleton length={ 6 } />
-							) : (
-								formatCurrency( currentQuarterExpectedCommission, 'USD' )
-							) }
+							<TextBlur isBlurred={ isLoading } length={ 6 }>
+								{ formatCurrency( currentQuarterExpectedCommission, 'USD' ) }
+							</TextBlur>
 						</Text>
 						<Text intent="success" size={ 12 } lineHeight="16px">
 							{ __( 'estimated this quarter' ) }

--- a/client/dashboard/agency/overview/stat-list.tsx
+++ b/client/dashboard/agency/overview/stat-list.tsx
@@ -5,7 +5,7 @@ import {
 } from '@wordpress/components';
 import { Fragment } from 'react';
 import { Text } from '../../components/text';
-import { TextSkeleton } from '../../components/text-skeleton';
+import { TextBlur } from '../../components/text-blur';
 
 interface Stat {
 	label: string;
@@ -22,7 +22,9 @@ export default function StatList( { stats, isLoading }: { stats: Stat[]; isLoadi
 							{ stat.label }
 						</Text>
 						<Text weight={ 500 } size={ 13 } lineHeight="20px">
-							{ isLoading ? <TextSkeleton length={ 5 } /> : stat.value }
+							<TextBlur isBlurred={ !! isLoading } length={ 5 }>
+								{ stat.value }
+							</TextBlur>
 						</Text>
 					</HStack>
 					<Divider style={ { color: 'var(--dashboard-header__divider-color)' } } />

--- a/client/dashboard/agency/overview/woopayments-revenue-card.tsx
+++ b/client/dashboard/agency/overview/woopayments-revenue-card.tsx
@@ -12,7 +12,7 @@ import { ButtonStack } from '../../components/button-stack';
 import { Callout } from '../../components/callout';
 import { Card, CardBody } from '../../components/card';
 import { Text } from '../../components/text';
-import { TextSkeleton } from '../../components/text-skeleton';
+import { TextBlur } from '../../components/text-blur';
 import OverviewLinkButton from './overview-link-button';
 import StatList from './stat-list';
 import useWooPaymentsStoreCount from './use-woopayments-store-count';
@@ -133,11 +133,9 @@ export default function WooPaymentsRevenueCard( {
 					</Heading>
 					<HStack spacing={ 2 } justify="flex-start" alignment="baseline" expanded={ false }>
 						<Text size={ 20 } weight={ 500 } lineHeight="24px">
-							{ isLoading ? (
-								<TextSkeleton length={ 6 } />
-							) : (
-								formatCurrency( currentQuarter?.payout ?? 0, 'USD' )
-							) }
+							<TextBlur isBlurred={ isLoading } length={ 6 }>
+								{ formatCurrency( currentQuarter?.payout ?? 0, 'USD' ) }
+							</TextBlur>
 						</Text>
 						<Text intent="success" size={ 12 } lineHeight="16px">
 							{ __( 'estimated this quarter' ) }

--- a/client/dashboard/components/consolidated-stat-card/index.tsx
+++ b/client/dashboard/components/consolidated-stat-card/index.tsx
@@ -10,7 +10,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
 import { useState } from 'react';
 import { Card, CardBody } from '../card';
-import { TextSkeleton } from '../text-skeleton';
+import { TextBlur } from '../text-blur';
 import type { ReactNode } from 'react';
 
 import './style.scss';
@@ -40,7 +40,9 @@ export default function ConsolidatedStatCard( {
 			<CardBody>
 				<VStack spacing={ 2 }>
 					<Heading level={ 2 } size={ 20 } weight={ 500 }>
-						{ isLoading ? <TextSkeleton length={ 8 } /> : value }
+						<TextBlur isBlurred={ isLoading } length={ 8 }>
+							{ value }
+						</TextBlur>
 					</Heading>
 					<HStack justify="flex-start" spacing={ 1 } expanded={ false }>
 						<Text variant="muted">{ footerText }</Text>

--- a/client/dashboard/components/overview-card/index.tsx
+++ b/client/dashboard/components/overview-card/index.tsx
@@ -17,7 +17,7 @@ import { Card, CardBody } from '../../components/card';
 import { isOnboardingUrl, isRelativeUrl } from '../../utils/url';
 import ComponentViewTracker from '../component-view-tracker';
 import { Text } from '../text';
-import { TextSkeleton } from '../text-skeleton';
+import { TextBlur } from '../text-blur';
 import { Truncate } from '../truncate';
 import type { ComponentProps, ReactElement, ReactNode } from 'react';
 import './style.scss';
@@ -80,9 +80,6 @@ export default function OverviewCard( {
 	const descriptionId = useId();
 
 	const renderHeading = () => {
-		if ( isLoading ) {
-			return <TextSkeleton length={ 10 } />;
-		}
 		if ( ! heading ) {
 			return <>&nbsp;</>;
 		}
@@ -96,13 +93,6 @@ export default function OverviewCard( {
 			);
 		}
 		return heading;
-	};
-
-	const renderDescription = () => {
-		if ( isLoading ) {
-			return <TextSkeleton length={ 20 } />;
-		}
-		return description ?? null;
 	};
 
 	// Stepper/onboarding flows are not considered relative links because they can't be loaded by TanStack Router.
@@ -174,7 +164,9 @@ export default function OverviewCard( {
 							variant={ disabled ? 'muted' : undefined }
 							weight={ 500 }
 						>
-							{ renderHeading() }
+							<TextBlur isBlurred={ !! isLoading } length={ 10 }>
+								{ renderHeading() }
+							</TextBlur>
 						</Heading>
 						<Text
 							id={ descriptionId }
@@ -183,7 +175,9 @@ export default function OverviewCard( {
 							lineHeight="16px"
 							size={ 12 }
 						>
-							{ renderDescription() }
+							<TextBlur isBlurred={ !! isLoading } length={ 20 }>
+								{ description }
+							</TextBlur>
 						</Text>
 					</VStack>
 				</HStack>

--- a/client/dashboard/components/stat/index.tsx
+++ b/client/dashboard/components/stat/index.tsx
@@ -1,6 +1,6 @@
 import { __experimentalHStack as HStack, ProgressBar } from '@wordpress/components';
 import clsx from 'clsx';
-import { TextSkeleton } from '../text-skeleton';
+import { TextBlur } from '../text-blur';
 import './style.scss';
 
 interface StatProps {
@@ -71,12 +71,12 @@ export function Stat( {
 				justify={ progressValue === undefined ? 'start' : 'space-between' }
 			>
 				<div className="dashboard-stat__metric">
-					{ isLoading ? <TextSkeleton length={ 5 } /> : metric }
+					<TextBlur isBlurred={ isLoading } length={ 5 }>
+						{ metric }
+					</TextBlur>
 				</div>
 				{ description && ! isLoading && (
-					<div className="dashboard-stat__description">
-						{ isLoading ? <TextSkeleton length={ 8 } /> : description }
-					</div>
+					<div className="dashboard-stat__description">{ description }</div>
 				) }
 			</HStack>
 			{ progressValue !== undefined && (

--- a/client/dashboard/components/text-blur/index.tsx
+++ b/client/dashboard/components/text-blur/index.tsx
@@ -1,9 +1,33 @@
+import clsx from 'clsx';
 import './style.scss';
 
-export function TextBlur( { children }: { children: React.ReactNode } ) {
+/**
+ * Keep this mounted and flip `isBlurred` once the real value is known instead of
+ * swapping it for another element. Page translators reparent inline nodes, so
+ * React inserting or removing elements around translated text throws; changing
+ * only the class and text of the same span is safe.
+ * A known React issue: react/react#11538
+ *
+ * Pass `length` when the final text isn't known while loading: the blurred span
+ * shows that many placeholder characters instead of `children`.
+ */
+export function TextBlur( {
+	children,
+	isBlurred,
+	length,
+}: {
+	children?: React.ReactNode;
+	isBlurred: boolean;
+	length?: number;
+} ) {
 	return (
-		<span className="dashboard-text-blur" aria-hidden="true">
-			{ children }
+		<span
+			className={ clsx( 'dashboard-text-blur', {
+				'dashboard-text-blur--is-blurred': isBlurred,
+			} ) }
+			aria-hidden={ isBlurred || undefined }
+		>
+			{ isBlurred && length !== undefined ? 'X'.repeat( length ) : children }
 		</span>
 	);
 }

--- a/client/dashboard/components/text-blur/style.scss
+++ b/client/dashboard/components/text-blur/style.scss
@@ -1,6 +1,11 @@
 .dashboard-text-blur {
+	display: contents;
+}
+
+.dashboard-text-blur--is-blurred {
+	display: inline;
 	user-select: none;
-    // The larger the font-size, the more blurring is needed.
-	filter: blur(0.3em);
+	// The larger the font-size, the more blurring is needed.
+	filter: blur( 0.3em );
 	opacity: 0.5;
 }

--- a/client/dashboard/components/text-blur/test/translate-harness.test.tsx
+++ b/client/dashboard/components/text-blur/test/translate-harness.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Page translators (Google Translate, Edge, extensions) rewrite the DOM behind
+ * React's back: they wrap translated text in `<font>` elements, which reparents
+ * the nodes React thinks it owns. React then calls `removeChild`/`insertBefore`
+ * on a parent that no longer holds the node and the page crashes.
+ * A known React issue: react/react#11538
+ *
+ * These tests fake that rewrite, then resolve the loading state, to prove the
+ * blurred span is updated in place rather than swapped for another element.
+ * If you change how blurring works and one of these goes red, the fix is to
+ * keep a single element mounted and change only its text and attributes — not
+ * to relax the assertion.
+ */
+import { act, render, screen } from '@testing-library/react';
+import React, { useState } from 'react';
+import OverviewCard from '../../overview-card';
+import { Stat } from '../../stat';
+import { TextBlur } from '../index';
+
+jest.mock( '../../../app/analytics', () => ( {
+	useAnalytics: () => ( { recordTracksEvent: () => {} } ),
+} ) );
+
+function reparentLikeATranslator( node: Element ) {
+	const font = document.createElement( 'font' );
+	node.replaceWith( font );
+	font.appendChild( node );
+}
+
+function Harness( {
+	render: renderContent,
+}: {
+	render: ( isLoading: boolean ) => React.ReactNode;
+} ) {
+	const [ isLoading, setIsLoading ] = useState( true );
+	return (
+		<>
+			<button onClick={ () => setIsLoading( false ) }>resolve</button>
+			{ renderContent( isLoading ) }
+		</>
+	);
+}
+
+function resolve() {
+	act( () => {
+		screen.getByText( 'resolve' ).click();
+	} );
+}
+
+describe( 'TextBlur survives page translation', () => {
+	it( 'updates text in place when the blurred span was reparented', () => {
+		render(
+			<Harness
+				render={ ( isLoading ) => (
+					<div>
+						<TextBlur isBlurred={ isLoading } length={ 6 }>
+							$1,234
+						</TextBlur>
+					</div>
+				) }
+			/>
+		);
+
+		reparentLikeATranslator( screen.getByText( 'XXXXXX' ) );
+		resolve();
+
+		expect( screen.getByText( '$1,234' ) ).toBeVisible();
+	} );
+
+	it( 'survives translation inside OverviewCard', () => {
+		render(
+			<Harness
+				render={ ( isLoading ) => (
+					<OverviewCard
+						title="Plan"
+						heading="Business"
+						description="Renews next year"
+						isLoading={ isLoading }
+					/>
+				) }
+			/>
+		);
+
+		reparentLikeATranslator( screen.getByText( 'XXXXXXXXXX' ) );
+		reparentLikeATranslator( screen.getByText( 'XXXXXXXXXXXXXXXXXXXX' ) );
+		resolve();
+
+		expect( screen.getByText( 'Business' ) ).toBeVisible();
+		expect( screen.getByText( 'Renews next year' ) ).toBeVisible();
+	} );
+
+	it( 'survives translation inside Stat', () => {
+		render( <Harness render={ ( isLoading ) => <Stat metric="99%" isLoading={ isLoading } /> } /> );
+
+		reparentLikeATranslator( screen.getByText( 'XXXXX' ) );
+		resolve();
+
+		expect( screen.getByText( '99%' ) ).toBeVisible();
+	} );
+} );

--- a/client/dashboard/components/text-blur/test/translate-harness.test.tsx
+++ b/client/dashboard/components/text-blur/test/translate-harness.test.tsx
@@ -15,7 +15,8 @@
  * keep a single element mounted and change only its text and attributes — not
  * to relax the assertion.
  */
-import { act, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React, { useState } from 'react';
 import OverviewCard from '../../overview-card';
 import { Stat } from '../../stat';
@@ -46,13 +47,11 @@ function Harness( {
 }
 
 function resolve() {
-	act( () => {
-		screen.getByText( 'resolve' ).click();
-	} );
+	return userEvent.click( screen.getByRole( 'button', { name: 'resolve' } ) );
 }
 
 describe( 'TextBlur survives page translation', () => {
-	it( 'updates text in place when the blurred span was reparented', () => {
+	it( 'updates text in place when the blurred span was reparented', async () => {
 		render(
 			<Harness
 				render={ ( isLoading ) => (
@@ -66,12 +65,12 @@ describe( 'TextBlur survives page translation', () => {
 		);
 
 		reparentLikeATranslator( screen.getByText( 'XXXXXX' ) );
-		resolve();
+		await resolve();
 
 		expect( screen.getByText( '$1,234' ) ).toBeVisible();
 	} );
 
-	it( 'survives translation inside OverviewCard', () => {
+	it( 'survives translation inside OverviewCard', async () => {
 		render(
 			<Harness
 				render={ ( isLoading ) => (
@@ -87,17 +86,17 @@ describe( 'TextBlur survives page translation', () => {
 
 		reparentLikeATranslator( screen.getByText( 'XXXXXXXXXX' ) );
 		reparentLikeATranslator( screen.getByText( 'XXXXXXXXXXXXXXXXXXXX' ) );
-		resolve();
+		await resolve();
 
 		expect( screen.getByText( 'Business' ) ).toBeVisible();
 		expect( screen.getByText( 'Renews next year' ) ).toBeVisible();
 	} );
 
-	it( 'survives translation inside Stat', () => {
+	it( 'survives translation inside Stat', async () => {
 		render( <Harness render={ ( isLoading ) => <Stat metric="99%" isLoading={ isLoading } /> } /> );
 
 		reparentLikeATranslator( screen.getByText( 'XXXXX' ) );
-		resolve();
+		await resolve();
 
 		expect( screen.getByText( '99%' ) ).toBeVisible();
 	} );

--- a/client/dashboard/components/text-skeleton/index.tsx
+++ b/client/dashboard/components/text-skeleton/index.tsx
@@ -1,7 +1,5 @@
 import { TextBlur } from '../text-blur';
 
 export function TextSkeleton( { length }: { length: number } ) {
-	const text = 'X'.repeat( length );
-
-	return <TextBlur>{ text }</TextBlur>;
+	return <TextBlur isBlurred length={ length } />;
 }

--- a/client/dashboard/docs/ui-components.md
+++ b/client/dashboard/docs/ui-components.md
@@ -15,6 +15,10 @@ The dashboard follows a component-based architecture with a strong focus on leve
 
 Use placeholder components such as `TextBlur`, `TextSkeleton`, or `CalloutSkeleton` instead of spinners.
 
+For inline text, keep a single `TextBlur` mounted and flip its `isBlurred` prop rather than swapping a placeholder element for the resolved value. Page translators (Edge, Chrome, extensions) reparent inline nodes behind React's back, so inserting or removing an element next to translated text throws a `NotFoundError`. Pass `length` when the final text isn't known while loading.
+
+`TextSkeleton` is appropriate for static placeholders that will always show blurred text and never switch to showing unblurred text.
+
 Placeholders for asynchronous data fetching should be used judiciously. Some dashboard pages are "heavy" and asynchronous fetching may be needed to prevent multi-second load times. On the other hand, layout shifts or flashes of default or fallback content should be avoided as much as possible. A good strategy is to use a router's `loader` function to fetch just enough data to allow a component's layout to be rendered definitively. Asynchronous fetching can then fill in the details without causing layout shifts. Note: when `loader` functions are slow, their loading state is handled by the `Root` component (`client/dashboard/app/root`).
 
 See this post on loaders: p58i-kIo-p2

--- a/client/dashboard/plugins/manage/components/plugin-sites.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-sites.tsx
@@ -1,5 +1,6 @@
 import { __experimentalVStack as VStack, ExternalLink } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { Card, CardBody, CardHeader } from '../../../components/card';
 import { Notice } from '../../../components/notice';
@@ -44,11 +45,10 @@ export const PluginSites = ( { selectedPluginSlug }: { selectedPluginSlug: strin
 			return __( 'Plugin not found' );
 		}
 
-		return plugin ? (
-			// @ts-expect-error: Can only set one of `children` or `props.dangerouslySetInnerHTML`.
-			<Text dangerouslySetInnerHTML={ { __html: plugin.name } } />
-		) : (
-			<TextBlur>{ selectedPluginSlug }</TextBlur>
+		return (
+			<TextBlur isBlurred={ ! plugin }>
+				<Text>{ plugin ? decodeEntities( plugin.name ) : selectedPluginSlug }</Text>
+			</TextBlur>
 		);
 	};
 

--- a/client/dashboard/plugins/manage/components/plugin-sites.tsx
+++ b/client/dashboard/plugins/manage/components/plugin-sites.tsx
@@ -41,13 +41,17 @@ export const PluginSites = ( { selectedPluginSlug }: { selectedPluginSlug: strin
 	};
 
 	const title = () => {
-		if ( ! isLoadingPlugin && ! plugin ) {
-			return __( 'Plugin not found' );
-		}
+		const text = () => {
+			if ( plugin ) {
+				return decodeEntities( plugin.name );
+			}
+
+			return isLoadingPlugin ? selectedPluginSlug : __( 'Plugin not found' );
+		};
 
 		return (
-			<TextBlur isBlurred={ ! plugin }>
-				<Text>{ plugin ? decodeEntities( plugin.name ) : selectedPluginSlug }</Text>
+			<TextBlur isBlurred={ ! plugin && isLoadingPlugin }>
+				<Text>{ text() }</Text>
 			</TextBlur>
 		);
 	};

--- a/client/dashboard/plugins/plugin/index.tsx
+++ b/client/dashboard/plugins/plugin/index.tsx
@@ -69,8 +69,9 @@ export function PluginTabs( {
 	);
 	// While the site data is still loading the count isn't known yet, so blur the
 	// label into a skeleton instead of asserting a misleading "Installed on 0 sites".
-	const installedTabTitle =
-		isLoading && installedCount === 0 ? <TextBlur>{ installedLabel }</TextBlur> : installedLabel;
+	const installedTabTitle = (
+		<TextBlur isBlurred={ isLoading && installedCount === 0 }>{ installedLabel }</TextBlur>
+	);
 
 	return (
 		<Tabs

--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -114,12 +114,10 @@ const DomainUpsellCardContent = ( {
 			description={
 				<Text variant="muted">
 					{ createInterpolateElement( description, {
-						// Keep this span's identity stable so that Google Translate doesn't crash the page.
-						// A known React issue: react/react#11538
 						domain: (
-							<span translate="no">
-								{ suggestedDomain ? suggestedDomain.domain_name : <TextBlur>{ search }</TextBlur> }
-							</span>
+							<TextBlur isBlurred={ ! suggestedDomain }>
+								{ suggestedDomain ? suggestedDomain.domain_name : search }
+							</TextBlur>
 						),
 						link: (
 							<UpsellCTAButton

--- a/client/dashboard/sites/site-fields/index.tsx
+++ b/client/dashboard/sites/site-fields/index.tsx
@@ -45,10 +45,6 @@ function IneligibleIndicator() {
 	return <Text color="#CCCCCC">-</Text>;
 }
 
-function LoadingIndicator( { label }: { label: string } ) {
-	return <TextBlur>{ label }</TextBlur>;
-}
-
 function getSiteManagementUrl( site: Site ) {
 	if ( canManageSite( site ) ) {
 		const path = `/sites/${ site.slug }`;
@@ -213,9 +209,10 @@ export function AsyncEngagementStat( {
 		enabled: !! site?.ID && isEligible && inView,
 	} );
 
+	const isPending = ! site || isLoading;
 	const renderContent = () => {
-		if ( ! site || isLoading ) {
-			return <LoadingIndicator label="100" />;
+		if ( isPending ) {
+			return '100';
 		}
 
 		if ( ! isEligible ) {
@@ -225,7 +222,11 @@ export function AsyncEngagementStat( {
 		return stats?.currentData[ type ];
 	};
 
-	return <span ref={ ref }>{ renderContent() }</span>;
+	return (
+		<span ref={ ref }>
+			<TextBlur isBlurred={ isPending }>{ renderContent() }</TextBlur>
+		</span>
+	);
 }
 
 export function EngagementStat( { value }: { value: number | null } ) {
@@ -245,9 +246,10 @@ export function LastBackup( { site }: { site?: Site } ) {
 		enabled: !! site?.ID && isEligible && inView,
 	} );
 
+	const isPending = ! site || isLoading;
 	const renderContent = () => {
-		if ( ! site || isLoading ) {
-			return <LoadingIndicator label="Unknown" />;
+		if ( isPending ) {
+			return 'Unknown';
 		}
 
 		if ( ! isEligible ) {
@@ -261,7 +263,11 @@ export function LastBackup( { site }: { site?: Site } ) {
 		return <TimeSince timestamp={ lastBackup.published } />;
 	};
 
-	return <span ref={ ref }>{ renderContent() }</span>;
+	return (
+		<span ref={ ref }>
+			<TextBlur isBlurred={ isPending }>{ renderContent() }</TextBlur>
+		</span>
+	);
 }
 
 export function Uptime( { site }: { site?: Site } ) {
@@ -273,9 +279,10 @@ export function Uptime( { site }: { site?: Site } ) {
 		enabled: !! site?.ID && isEligible && inView,
 	} );
 
+	const isPending = ! site || isLoading;
 	const renderContent = () => {
-		if ( ! site || isLoading ) {
-			return <LoadingIndicator label="100%" />;
+		if ( isPending ) {
+			return '100%';
 		}
 
 		if ( ! isEligible ) {
@@ -285,7 +292,11 @@ export function Uptime( { site }: { site?: Site } ) {
 		return uptime ? `${ uptime }%` : <IneligibleIndicator />;
 	};
 
-	return <span ref={ ref }>{ renderContent() }</span>;
+	return (
+		<span ref={ ref }>
+			<TextBlur isBlurred={ isPending }>{ renderContent() }</TextBlur>
+		</span>
+	);
 }
 
 export function PHPVersion( { site }: { site: Site } ) {
@@ -304,7 +315,11 @@ export function PHPVersion( { site }: { site: Site } ) {
 		return <IneligibleIndicator />;
 	}
 
-	return <span ref={ ref }>{ ! isLoading ? data : <LoadingIndicator label="X.Y" /> }</span>;
+	return (
+		<span ref={ ref }>
+			<TextBlur isBlurred={ isLoading }>{ isLoading ? 'X.Y' : data }</TextBlur>
+		</span>
+	);
 }
 
 export function MediaStorage( { site }: { site?: Site } ) {
@@ -318,9 +333,10 @@ export function MediaStorage( { site }: { site?: Site } ) {
 		enabled: !! site?.ID && inView,
 	} );
 
+	const isPending = ! site || isLoading;
 	const renderContent = () => {
-		if ( ! site || isLoading ) {
-			return <LoadingIndicator label="100%" />;
+		if ( isPending ) {
+			return '100%';
 		}
 
 		if ( ! mediaStorage ) {
@@ -331,7 +347,11 @@ export function MediaStorage( { site }: { site?: Site } ) {
 		return `${ Math.round( ( storage_used_bytes / max_storage_bytes ) * 1000 ) / 10 }%`;
 	};
 
-	return <span ref={ ref }>{ renderContent() }</span>;
+	return (
+		<span ref={ ref }>
+			<TextBlur isBlurred={ isPending }>{ renderContent() }</TextBlur>
+		</span>
+	);
 }
 
 function SiteLaunchNag( { siteSlug }: { siteSlug: string } ) {


### PR DESCRIPTION
Fixes Sentry CALYPSO-3GEB (follow-up to CALYPSO-3G00 and #113513).

## Proposed Changes

This is a big reworking of how `TextBlur` and `TextSkeleton` placeholders work to make them more resilient to extensions like Google Translate.

* `TextBlur` is now rendered permanently and told whether to blur, instead of being swapped in and out. It gains an optional `length` prop for callers that don't know the final text while loading (that's because `TextSkeleton` has a `length` prop, and many were using `TextSkeleton` when `TextBlur` would have been better.
* Converted the placeholder swaps that had the crashing shape: overview cards, stat cards, the agency overview stat list and revenue/earnings cards, and the WooPayments commissions table.
* Unblurred, the wrapper is `display: contents`, so it never affects layout — it exists only to give React something stable to update.
* Added a regression test that fakes what a translator does to the DOM.
* `TextSkeleton` stays for placeholders that are never replaced by real text in the same position.

## Why are these changes being made?

Browser page-translation (Edge's built-in translator, Chrome's Google Translate, extensions) rewrites the DOM behind React's back — it wraps translated text in `<font>` elements, which reparents nodes React thinks it owns. When React later removes or inserts an element in that region, the parent it holds no longer contains the node and the commit phase throws `NotFoundError`. The user sees the router's error page a second or two after load, without touching anything. It's a known React issue (react/react#11538) with no framework-level fix.

We've been fixing this one crash site at a time. #113376 stabilized a domain field; #113513 tried marking the region `translate="no"`. Edge ignores that hint entirely and reparented the inner span anyway, which is how CALYPSO-3GEB appeared. So the only reliable pattern is: never insert or remove an element near translated text — keep one element mounted and change only its text and attributes. React updates a lone string child via `textContent`, which can't throw no matter what the translator did around it.

The loading placeholders are where this shape is most common, because "blurred placeholder, then the real value" is exactly an element swap next to translated text. This makes the shared placeholder component enforce the safe pattern, then moves the known swap sites onto it.

## Considerations

The wrapper span is always in the DOM now, including when there's nothing to blur. `display: contents` keeps it out of layout, which matters where a card heading holds something like a truncating title or a form control rather than plain text.

Not every remaining placeholder was converted. Where loading replaces a whole block — a card body, a table, a fragment of several lines — React deletes the subtree's root, not the translated inline text, so the crash doesn't apply. Those still use `TextSkeleton` and are called out in the component docs.

The test is deliberately checked in even though it's testing a browser behaviour we can only approximate. It's the only thing that will tell a future reader that the awkward "always mounted, flip a flag" shape is load-bearing.

## Testing Instructions

Any page using these cards should look and behave exactly as before — this shouldn't be visible.

To see the bug it fixes, on `trunk`: open a site's overview in Edge with a non-English display language so the built-in translator kicks in, and let the page settle. Around a second after load it drops to the error page. On this branch it doesn't.

Worth a look for layout regressions, since a wrapper element was added inside card headings: the domain overview cards (truncating site/email titles) and the purchase settings license key card (a form control as its heading).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_011L4sXrRh6EDHGGuuEb4j1P
