### PR TITLE
Onboarding: name the domain step as the way back for a skipping visit

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -771,7 +771,11 @@ const onboarding: FlowV2< typeof initialize > = {
 											: redirectTo,
 									signup: 1,
 									flow: ONBOARDING_FLOW,
-									checkoutBackUrl: pathToUrl( backDestination ?? '' ),
+									// A skipping visit's last screen was the domain step, so that is where
+									// leaving checkout belongs.
+									checkoutBackUrl: pathToUrl(
+										( shouldSkipPlans ? backDestinationDomains : backDestination ) ?? ''
+									),
 									...( backDestinationDomains
 										? { checkoutBackUrlDomains: pathToUrl( backDestinationDomains ) }
 										: {} ),


### PR DESCRIPTION
## Proposed Changes

* The checkout redirect picks the domain-step back URL when the visit skipped the plans step, instead of always sending the plan-step one. The redirect already builds both.
* That moves every exit that reads the plain back URL — the mobile back button, the leave-checkout prompt's "Save cart", the empty-cart page's "Go back", and the automatic redirect when the last product is removed.
* Nothing in checkout changes. The step count it receives stays something it draws, rather than something it routes on.

## Why are these changes being made?

A visit that arrives with a plan already chosen never sees the plans grid, and since the indicator stopped listing that step, leaving checkout was the one place still pointing at it. The flow knows which screen the visit last saw; it just wasn't saying so in the URL it builds.

The two exits that use the dedicated domain-step URL — the indicator's "Select a domain" and the prompt's "Empty cart" — were already right. The four that use the plain one were not, and they include both routes out of an emptied cart, which disagreed with the prompt about where an emptied cart belongs.

Picking at the source rather than reconstructing the same fact at the far end also keeps `steps_current` / `steps_total` a display concern. Checkout has no per-flow knowledge and does not gain any here.

## Testing Instructions

1. Visit `/start/personal` on a mobile viewport and continue to checkout.
2. Press Back and choose "Save cart". You should land on the domain step.
3. At checkout, remove the plan from the cart. The empty-cart page's "Go back" should also land on the domain step; submitting the domain from there reaches the plans grid, since the cart no longer names a plan.
4. Visit `/setup/onboarding` with no plan in the query and repeat step 2. Back should still lead to the plan step, as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WhYXBgVSD1eW42PaDNhiq
