### PR TITLE
Help Center: remember article ratings on the server

### DIFF
--- a/packages/help-center/AGENTS.md
+++ b/packages/help-center/AGENTS.md
@@ -121,6 +121,7 @@ Data-fetching hooks use a dual-endpoint pattern controlled by `canAccessWpcomApi
 | `/wpcom/v2/imports/analyze-url`                     | GET    | `use-is-wporg-site`             | Detect WP.org vs WP.com site                   |
 | `/wpcom/v2/sites/{siteId}/jetpack-search/ai/search` | GET    | `use-jetpack-search-ai`         | AI-powered help article search                 |
 | `/wpcom/v2/help/search`                             | GET    | `use-help-search-query`         | Search help articles                           |
+| `/wpcom/v2/help/article/rating`                    | POST   | `use-rate-article`              | Rate a help article                            |
 | `/wpcom/v2/agency/help/zendesk/create-ticket`       | POST   | `use-submit-a4a-support-ticket` | A4A agency ticket                              |
 | `/wpcom/v2/agency/help/pressable/support`           | POST   | `use-submit-a4a-support-ticket` | Pressable agency support                       |
 
@@ -135,6 +136,7 @@ When `canAccessWpcomApis()` is `false` (Atomic sites), these hooks fall back to 
 | `/help-center/support-status`           | `/wpcom/v2/help/support-status`                     |
 | `/help-center/jetpack-search/ai/search` | `/wpcom/v2/sites/{siteId}/jetpack-search/ai/search` |
 | `/help-center/search`                   | `/wpcom/v2/help/search`                             |
+| `/help-center/article-rating`            | `/wpcom/v2/help/article/rating`                    |
 
 ### External service integrations
 

--- a/packages/help-center/AGENTS.md
+++ b/packages/help-center/AGENTS.md
@@ -121,7 +121,7 @@ Data-fetching hooks use a dual-endpoint pattern controlled by `canAccessWpcomApi
 | `/wpcom/v2/imports/analyze-url`                     | GET    | `use-is-wporg-site`             | Detect WP.org vs WP.com site                   |
 | `/wpcom/v2/sites/{siteId}/jetpack-search/ai/search` | GET    | `use-jetpack-search-ai`         | AI-powered help article search                 |
 | `/wpcom/v2/help/search`                             | GET    | `use-help-search-query`         | Search help articles                           |
-| `/wpcom/v2/help/article/rating`                    | POST   | `use-rate-article`              | Rate a help article                            |
+| `/wpcom/v2/help/article/rating`                     | POST   | `use-rate-article`              | Rate a help article                            |
 | `/wpcom/v2/agency/help/zendesk/create-ticket`       | POST   | `use-submit-a4a-support-ticket` | A4A agency ticket                              |
 | `/wpcom/v2/agency/help/pressable/support`           | POST   | `use-submit-a4a-support-ticket` | Pressable agency support                       |
 
@@ -136,7 +136,7 @@ When `canAccessWpcomApis()` is `false` (Atomic sites), these hooks fall back to 
 | `/help-center/support-status`           | `/wpcom/v2/help/support-status`                     |
 | `/help-center/jetpack-search/ai/search` | `/wpcom/v2/sites/{siteId}/jetpack-search/ai/search` |
 | `/help-center/search`                   | `/wpcom/v2/help/search`                             |
-| `/help-center/article-rating`            | `/wpcom/v2/help/article/rating`                    |
+| `/help-center/article-rating`           | `/wpcom/v2/help/article/rating`                     |
 
 ### External service integrations
 

--- a/packages/odie-client/src/components/message/get-support.scss
+++ b/packages/odie-client/src/components/message/get-support.scss
@@ -23,6 +23,9 @@
 			width: 100%;
 			min-width: 0;
 			box-sizing: border-box;
+			// Reset browser defaults; the article view has no global button reset.
+			background: transparent;
+			border: none;
 			border-bottom: 1px solid var( --studio-gray-5 );
 
 			&:first-of-type {

--- a/packages/support-articles/src/components/help-center-article/help-center-article-content.tsx
+++ b/packages/support-articles/src/components/help-center-article/help-center-article-content.tsx
@@ -35,6 +35,8 @@ const ArticleContent = ( {
 						/>
 						<HelpCenterFeedbackForm
 							postId={ post.ID }
+							blogId={ post.site_ID }
+							userRating={ post.user_rating }
 							isEligibleForChat={ isEligibleForChat }
 							forceEmailSupport={ forceEmailSupport }
 						/>

--- a/packages/support-articles/src/components/help-center-article/help-center-article-content.tsx
+++ b/packages/support-articles/src/components/help-center-article/help-center-article-content.tsx
@@ -34,6 +34,8 @@ const ArticleContent = ( {
 							ref={ articleContentRef }
 						/>
 						<HelpCenterFeedbackForm
+							// Remount when the article changes so the form re-seeds from that article's rating.
+							key={ `${ post.site_ID }-${ post.ID }` }
 							postId={ post.ID }
 							blogId={ post.site_ID }
 							userRating={ post.user_rating }

--- a/packages/support-articles/src/components/help-center-feedback-form/help-center-feedback-form.scss
+++ b/packages/support-articles/src/components/help-center-feedback-form/help-center-feedback-form.scss
@@ -5,6 +5,15 @@
 		font-style: italic;
 		margin-bottom: 0.5rem;
 	}
+	.help-center-feedback-form__rated {
+		display: flex;
+		align-items: center;
+		gap: 5px;
+
+		svg {
+			fill: currentColor;
+		}
+	}
 	.help-center-feedback-form__buttons {
 		display: flex;
 		flex-direction: row;

--- a/packages/support-articles/src/components/help-center-feedback-form/help-center-feedback-form.scss
+++ b/packages/support-articles/src/components/help-center-feedback-form/help-center-feedback-form.scss
@@ -25,7 +25,7 @@
 			align-items: center;
 			gap: 5px;
 			cursor: pointer;
-			color: var(--color-text);
+			color: var( --color-text );
 			// Atomic fix
 			background-color: transparent;
 			border: none;
@@ -36,5 +36,4 @@
 			}
 		}
 	}
-
 }

--- a/packages/support-articles/src/components/help-center-feedback-form/help-center-feedback-form.scss
+++ b/packages/support-articles/src/components/help-center-feedback-form/help-center-feedback-form.scss
@@ -10,6 +10,10 @@
 		align-items: center;
 		gap: 5px;
 
+		span {
+			display: flex;
+		}
+
 		svg {
 			fill: currentColor;
 		}

--- a/packages/support-articles/src/components/help-center-feedback-form/index.tsx
+++ b/packages/support-articles/src/components/help-center-feedback-form/index.tsx
@@ -30,7 +30,7 @@ const HelpCenterFeedbackForm = ( {
 } ) => {
 	const { __ } = useI18n();
 	const [ rating, setRating ] = useState< ArticleRating | null >(
-		userRating ?? getSessionRating( postId ) ?? null
+		userRating ?? getSessionRating( blogId, postId ) ?? null
 	);
 	const { mutate: rateArticle } = useRateArticle();
 

--- a/packages/support-articles/src/components/help-center-feedback-form/index.tsx
+++ b/packages/support-articles/src/components/help-center-feedback-form/index.tsx
@@ -3,7 +3,9 @@ import { GetSupport } from '@automattic/odie-client';
 import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
 import { useState } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
+import { useRateArticle } from '../../hooks/use-rate-article';
 import { ThumbsDownIcon, ThumbsUpIcon } from '../../icons/thumbs';
+import type { ArticleRating } from '../../types';
 
 declare const __i18n_text_domain__: string;
 
@@ -11,27 +13,38 @@ import './help-center-feedback-form.scss';
 
 const HelpCenterFeedbackForm = ( {
 	postId,
+	blogId,
+	userRating,
 	isEligibleForChat,
 	forceEmailSupport,
 }: {
 	postId: number;
+	blogId: number;
+	/**
+	 * Rating the user already gave this article. `undefined` means the server did not
+	 * send one (logged-out user), so the rating is only kept for this session.
+	 */
+	userRating?: ArticleRating | null;
 	isEligibleForChat: boolean;
 	forceEmailSupport: boolean;
 } ) => {
 	const { __ } = useI18n();
-	const [ startedFeedback, setStartedFeedback ] = useState< boolean | null >( null );
-	const [ answerValue, setAnswerValue ] = useState< number | null >( null );
+	const [ rating, setRating ] = useState< ArticleRating | null >( userRating ?? null );
+	const { mutate: rateArticle } = useRateArticle();
 
 	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
 
-	const handleFeedbackClick = ( value: number ) => {
-		setStartedFeedback( true );
-		setAnswerValue( value );
+	const handleFeedbackClick = ( value: ArticleRating ) => {
+		setRating( value );
 
 		recordTracksEvent( 'calypso_inlinehelp_article_feedback_click', {
 			did_the_article_help: value === 1 ? 'yes' : 'no',
 			post_id: postId,
 		} );
+
+		if ( userRating !== undefined ) {
+			rateArticle( { blogId, postId, rating: value } );
+		}
 	};
 
 	const FeedbackButtons = () => {
@@ -66,11 +79,14 @@ const HelpCenterFeedbackForm = ( {
 
 	return (
 		<div className="help-center-feedback__form">
-			{ startedFeedback === null && <FeedbackButtons /> }
-			{ startedFeedback !== null && answerValue === 1 && (
-				<p>{ __( 'Great! Thanks.', __i18n_text_domain__ ) }</p>
+			{ rating === null && <FeedbackButtons /> }
+			{ rating === 1 && (
+				<p className="help-center-feedback-form__rated">
+					<ThumbsUpIcon />
+					{ __( 'You found this article helpful.', __i18n_text_domain__ ) }
+				</p>
 			) }
-			{ startedFeedback !== null && answerValue === 2 && (
+			{ rating === 2 && (
 				<>
 					<div className="odie-chatbox-dislike-feedback-message">
 						<p>

--- a/packages/support-articles/src/components/help-center-feedback-form/index.tsx
+++ b/packages/support-articles/src/components/help-center-feedback-form/index.tsx
@@ -3,7 +3,7 @@ import { GetSupport } from '@automattic/odie-client';
 import { useCanConnectToZendeskMessaging } from '@automattic/zendesk-client';
 import { useState } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
-import { useRateArticle } from '../../hooks/use-rate-article';
+import { getSessionRating, useRateArticle } from '../../hooks/use-rate-article';
 import { ThumbsDownIcon, ThumbsUpIcon } from '../../icons/thumbs';
 import type { ArticleRating } from '../../types';
 
@@ -22,14 +22,16 @@ const HelpCenterFeedbackForm = ( {
 	blogId: number;
 	/**
 	 * Rating the user already gave this article. `undefined` means the server did not
-	 * send one (logged-out user), so the rating is only kept for this session.
+	 * send one (logged-out user), so the rating is only remembered for this page session.
 	 */
 	userRating?: ArticleRating | null;
 	isEligibleForChat: boolean;
 	forceEmailSupport: boolean;
 } ) => {
 	const { __ } = useI18n();
-	const [ rating, setRating ] = useState< ArticleRating | null >( userRating ?? null );
+	const [ rating, setRating ] = useState< ArticleRating | null >(
+		userRating ?? getSessionRating( postId ) ?? null
+	);
 	const { mutate: rateArticle } = useRateArticle();
 
 	const { data: canConnectToZendesk } = useCanConnectToZendeskMessaging();
@@ -42,9 +44,13 @@ const HelpCenterFeedbackForm = ( {
 			post_id: postId,
 		} );
 
-		if ( userRating !== undefined ) {
-			rateArticle( { blogId, postId, rating: value } );
-		}
+		rateArticle(
+			{ blogId, postId, rating: value, persist: userRating !== undefined },
+			{
+				// The server keeps the first rating, so show that one if this click lost the race.
+				onSuccess: ( { user_rating } ) => setRating( user_rating ),
+			}
+		);
 	};
 
 	const FeedbackButtons = () => {

--- a/packages/support-articles/src/components/help-center-feedback-form/index.tsx
+++ b/packages/support-articles/src/components/help-center-feedback-form/index.tsx
@@ -88,7 +88,9 @@ const HelpCenterFeedbackForm = ( {
 			{ rating === null && <FeedbackButtons /> }
 			{ rating === 1 && (
 				<p className="help-center-feedback-form__rated">
-					<ThumbsUpIcon />
+					<span aria-hidden="true">
+						<ThumbsUpIcon />
+					</span>
 					{ __( 'You found this article helpful.', __i18n_text_domain__ ) }
 				</p>
 			) }

--- a/packages/support-articles/src/components/test/help-center-feedback-form.tsx
+++ b/packages/support-articles/src/components/test/help-center-feedback-form.tsx
@@ -23,7 +23,7 @@ jest.mock( '@automattic/zendesk-client', () => ( {
 
 jest.mock( '../../hooks/use-rate-article', () => ( {
 	useRateArticle: () => ( { mutate: mockRateArticle } ),
-	getSessionRating: ( postId: number ) => mockSessionRatings[ postId ],
+	getSessionRating: ( _blogId: number, postId: number ) => mockSessionRatings[ postId ],
 } ) );
 
 function renderForm( userRating?: 1 | 2 | null ) {

--- a/packages/support-articles/src/components/test/help-center-feedback-form.tsx
+++ b/packages/support-articles/src/components/test/help-center-feedback-form.tsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import HelpCenterFeedbackForm from '../help-center-feedback-form';
+
+const mockRateArticle = jest.fn();
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: jest.fn(),
+} ) );
+
+jest.mock( '@automattic/odie-client', () => ( {
+	GetSupport: () => <div>support options</div>,
+} ) );
+
+jest.mock( '@automattic/zendesk-client', () => ( {
+	useCanConnectToZendeskMessaging: () => ( { data: true } ),
+} ) );
+
+jest.mock( '../../hooks/use-rate-article', () => ( {
+	useRateArticle: () => ( { mutate: mockRateArticle } ),
+} ) );
+
+function renderForm( userRating?: 1 | 2 | null ) {
+	return render(
+		<HelpCenterFeedbackForm
+			postId={ 185130 }
+			blogId={ 9619154 }
+			userRating={ userRating }
+			isEligibleForChat={ false }
+			forceEmailSupport={ false }
+		/>
+	);
+}
+
+describe( 'HelpCenterFeedbackForm', () => {
+	beforeEach( () => jest.clearAllMocks() );
+
+	it( 'asks for a rating when the article has not been rated', () => {
+		renderForm( null );
+
+		expect( screen.getByText( 'Was this helpful?' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /Yes/ } ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the thank-you message instead of the buttons when already rated helpful', () => {
+		renderForm( 1 );
+
+		expect( screen.getByText( 'You found this article helpful.' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /Yes/ } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the support options instead of the buttons when already rated not helpful', () => {
+		renderForm( 2 );
+
+		expect( screen.getByText( 'support options' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /No/ } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'stores the rating and records the event once when rating', () => {
+		renderForm( null );
+
+		fireEvent.click( screen.getByRole( 'button', { name: /Yes/ } ) );
+
+		expect( mockRateArticle ).toHaveBeenCalledWith( {
+			blogId: 9619154,
+			postId: 185130,
+			rating: 1,
+		} );
+		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_inlinehelp_article_feedback_click', {
+			did_the_article_help: 'yes',
+			post_id: 185130,
+		} );
+		expect( screen.getByText( 'You found this article helpful.' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /Yes/ } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps the rating for the session only when the server sent no rating field', () => {
+		renderForm( undefined );
+
+		fireEvent.click( screen.getByRole( 'button', { name: /No/ } ) );
+
+		expect( mockRateArticle ).not.toHaveBeenCalled();
+		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( screen.getByText( 'support options' ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/support-articles/src/components/test/help-center-feedback-form.tsx
+++ b/packages/support-articles/src/components/test/help-center-feedback-form.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import HelpCenterFeedbackForm from '../help-center-feedback-form';
 
 const mockRateArticle = jest.fn();
+const mockSessionRatings: Record< number, 1 | 2 | undefined > = {};
 
 jest.mock( '@automattic/calypso-analytics', () => ( {
 	recordTracksEvent: jest.fn(),
@@ -22,6 +23,7 @@ jest.mock( '@automattic/zendesk-client', () => ( {
 
 jest.mock( '../../hooks/use-rate-article', () => ( {
 	useRateArticle: () => ( { mutate: mockRateArticle } ),
+	getSessionRating: ( postId: number ) => mockSessionRatings[ postId ],
 } ) );
 
 function renderForm( userRating?: 1 | 2 | null ) {
@@ -37,7 +39,10 @@ function renderForm( userRating?: 1 | 2 | null ) {
 }
 
 describe( 'HelpCenterFeedbackForm', () => {
-	beforeEach( () => jest.clearAllMocks() );
+	beforeEach( () => {
+		jest.clearAllMocks();
+		delete mockSessionRatings[ 185130 ];
+	} );
 
 	it( 'asks for a rating when the article has not been rated', () => {
 		renderForm( null );
@@ -65,11 +70,10 @@ describe( 'HelpCenterFeedbackForm', () => {
 
 		fireEvent.click( screen.getByRole( 'button', { name: /Yes/ } ) );
 
-		expect( mockRateArticle ).toHaveBeenCalledWith( {
-			blogId: 9619154,
-			postId: 185130,
-			rating: 1,
-		} );
+		expect( mockRateArticle ).toHaveBeenCalledWith(
+			{ blogId: 9619154, postId: 185130, rating: 1, persist: true },
+			expect.objectContaining( { onSuccess: expect.any( Function ) } )
+		);
 		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
 		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_inlinehelp_article_feedback_click', {
 			did_the_article_help: 'yes',
@@ -79,13 +83,38 @@ describe( 'HelpCenterFeedbackForm', () => {
 		expect( screen.queryByRole( 'button', { name: /Yes/ } ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'keeps the rating for the session only when the server sent no rating field', () => {
+	it( 'does not persist the rating when the server sent no rating field', () => {
 		renderForm( undefined );
 
 		fireEvent.click( screen.getByRole( 'button', { name: /No/ } ) );
 
-		expect( mockRateArticle ).not.toHaveBeenCalled();
+		expect( mockRateArticle ).toHaveBeenCalledWith(
+			expect.objectContaining( { rating: 2, persist: false } ),
+			expect.anything()
+		);
 		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
 		expect( screen.getByText( 'support options' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the rating remembered for this session when the article is reopened', () => {
+		mockSessionRatings[ 185130 ] = 2;
+
+		renderForm( undefined );
+
+		expect( screen.getByText( 'support options' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /No/ } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the rating on record when the server kept an earlier one', () => {
+		mockRateArticle.mockImplementation( ( _variables, { onSuccess } ) =>
+			onSuccess( { user_rating: 2 } )
+		);
+
+		renderForm( null );
+
+		fireEvent.click( screen.getByRole( 'button', { name: /Yes/ } ) );
+
+		expect( screen.getByText( 'support options' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'You found this article helpful.' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/packages/support-articles/src/hooks/test/use-rate-article.ts
+++ b/packages/support-articles/src/hooks/test/use-rate-article.ts
@@ -40,7 +40,7 @@ describe( 'useRateArticle', () => {
 				body: { blog_id: 9619154, post_id: 1001, rating: 1 },
 			} )
 		);
-		expect( getSessionRating( 1001 ) ).toBe( 2 );
+		expect( getSessionRating( 9619154, 1001 ) ).toBe( 2 );
 	} );
 
 	it( 'only remembers the rating for the session when it cannot be persisted', async () => {
@@ -50,10 +50,30 @@ describe( 'useRateArticle', () => {
 
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 		expect( mockedRequest ).not.toHaveBeenCalled();
-		expect( getSessionRating( 1002 ) ).toBe( 1 );
+		expect( getSessionRating( 9619154, 1002 ) ).toBe( 1 );
+	} );
+
+	it( 'forgets the rating when the request fails', async () => {
+		mockedRequest.mockRejectedValue( new Error( 'offline' ) );
+		const { result } = renderRateArticle();
+
+		result.current.mutate( { blogId: 9619154, postId: 1003, rating: 1, persist: true } );
+
+		await waitFor( () => expect( result.current.isError ).toBe( true ) );
+		expect( getSessionRating( 9619154, 1003 ) ).toBeUndefined();
+	} );
+
+	it( 'keeps ratings apart per blog', async () => {
+		const { result } = renderRateArticle();
+
+		result.current.mutate( { blogId: 1, postId: 1004, rating: 1, persist: false } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( getSessionRating( 1, 1004 ) ).toBe( 1 );
+		expect( getSessionRating( 2, 1004 ) ).toBeUndefined();
 	} );
 
 	it( 'has no session rating for an article that was not rated', () => {
-		expect( getSessionRating( 1003 ) ).toBeUndefined();
+		expect( getSessionRating( 9619154, 1005 ) ).toBeUndefined();
 	} );
 } );

--- a/packages/support-articles/src/hooks/test/use-rate-article.ts
+++ b/packages/support-articles/src/hooks/test/use-rate-article.ts
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
+import { getSessionRating, useRateArticle } from '../use-rate-article';
+
+jest.mock( 'wpcom-proxy-request', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+	canAccessWpcomApis: () => true,
+} ) );
+
+const mockedRequest = wpcomRequest as jest.Mock;
+
+function renderRateArticle() {
+	const queryClient = new QueryClient();
+	const wrapper = ( { children }: { children: React.ReactNode } ) =>
+		React.createElement( QueryClientProvider, { client: queryClient }, children );
+
+	return renderHook( () => useRateArticle(), { wrapper } );
+}
+
+describe( 'useRateArticle', () => {
+	beforeEach( () => jest.clearAllMocks() );
+
+	it( 'posts the rating and remembers the rating on record', async () => {
+		mockedRequest.mockResolvedValue( { user_rating: 2 } );
+		const { result } = renderRateArticle();
+
+		result.current.mutate( { blogId: 9619154, postId: 1001, rating: 1, persist: true } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( mockedRequest ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/help/article/rating',
+				method: 'POST',
+				body: { blog_id: 9619154, post_id: 1001, rating: 1 },
+			} )
+		);
+		expect( getSessionRating( 1001 ) ).toBe( 2 );
+	} );
+
+	it( 'only remembers the rating for the session when it cannot be persisted', async () => {
+		const { result } = renderRateArticle();
+
+		result.current.mutate( { blogId: 9619154, postId: 1002, rating: 1, persist: false } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+		expect( mockedRequest ).not.toHaveBeenCalled();
+		expect( getSessionRating( 1002 ) ).toBe( 1 );
+	} );
+
+	it( 'has no session rating for an article that was not rated', () => {
+		expect( getSessionRating( 1003 ) ).toBeUndefined();
+	} );
+} );

--- a/packages/support-articles/src/hooks/use-rate-article.ts
+++ b/packages/support-articles/src/hooks/use-rate-article.ts
@@ -1,12 +1,17 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
-import type { ArticleRating, PostObject } from '../types';
+import type { ArticleRating } from '../types';
 
 type RateArticleVariables = {
 	blogId: number;
 	postId: number;
 	rating: ArticleRating;
+	/**
+	 * Whether the server can store the rating. False for logged-out users, who have no
+	 * server identity: their rating is then only remembered for this page session.
+	 */
+	persist: boolean;
 };
 
 type RateArticleResponse = {
@@ -15,18 +20,28 @@ type RateArticleResponse = {
 };
 
 /**
- * Stores the user's "Was this helpful?" answer for a support article on the server,
- * and updates the cached article so reopening it shows the answer instead of the buttons.
+ * Ratings given during this page session, so reopening an article shows the answer
+ * instead of the buttons even before the article is fetched again.
  */
-export function useRateArticle() {
-	const queryClient = useQueryClient();
+const sessionRatings = new Map< number, ArticleRating >();
 
+export function getSessionRating( postId: number ): ArticleRating | undefined {
+	return sessionRatings.get( postId );
+}
+
+/** Stores the user's "Was this helpful?" answer for a support article. */
+export function useRateArticle() {
 	return useMutation( {
 		mutationFn: ( {
 			blogId,
 			postId,
 			rating,
+			persist,
 		}: RateArticleVariables ): Promise< RateArticleResponse > => {
+			if ( ! persist ) {
+				return Promise.resolve( { user_rating: rating } );
+			}
+
 			const body = { blog_id: blogId, post_id: postId, rating };
 
 			return canAccessWpcomApis()
@@ -42,10 +57,11 @@ export function useRateArticle() {
 						data: body,
 				  } );
 		},
+		onMutate: ( { postId, rating } ) => {
+			sessionRatings.set( postId, rating );
+		},
 		onSuccess: ( { user_rating }, { postId } ) => {
-			queryClient.setQueriesData< PostObject >( { queryKey: [ 'support-status' ] }, ( post ) =>
-				post?.ID === postId ? { ...post, user_rating } : post
-			);
+			sessionRatings.set( postId, user_rating );
 		},
 	} );
 }

--- a/packages/support-articles/src/hooks/use-rate-article.ts
+++ b/packages/support-articles/src/hooks/use-rate-article.ts
@@ -20,13 +20,15 @@ type RateArticleResponse = {
 };
 
 /**
- * Ratings given during this page session, so reopening an article shows the answer
- * instead of the buttons even before the article is fetched again.
+ * Ratings given during this page session, keyed by blog and post, so reopening an article
+ * shows the answer instead of the buttons even before the article is fetched again.
  */
-const sessionRatings = new Map< number, ArticleRating >();
+const sessionRatings = new Map< string, ArticleRating >();
 
-export function getSessionRating( postId: number ): ArticleRating | undefined {
-	return sessionRatings.get( postId );
+const sessionKey = ( blogId: number, postId: number ) => `${ blogId }:${ postId }`;
+
+export function getSessionRating( blogId: number, postId: number ): ArticleRating | undefined {
+	return sessionRatings.get( sessionKey( blogId, postId ) );
 }
 
 /** Stores the user's "Was this helpful?" answer for a support article. */
@@ -57,11 +59,23 @@ export function useRateArticle() {
 						data: body,
 				  } );
 		},
-		onMutate: ( { postId, rating } ) => {
-			sessionRatings.set( postId, rating );
+		onMutate: ( { blogId, postId, rating } ) => {
+			const key = sessionKey( blogId, postId );
+			const previous = sessionRatings.get( key );
+			sessionRatings.set( key, rating );
+			return { previous };
 		},
-		onSuccess: ( { user_rating }, { postId } ) => {
-			sessionRatings.set( postId, user_rating );
+		onSuccess: ( { user_rating }, { blogId, postId } ) => {
+			sessionRatings.set( sessionKey( blogId, postId ), user_rating );
+		},
+		onError: ( _error, { blogId, postId }, context ) => {
+			// Forget the optimistic rating so reopening the article offers the buttons again.
+			const key = sessionKey( blogId, postId );
+			if ( context?.previous === undefined ) {
+				sessionRatings.delete( key );
+			} else {
+				sessionRatings.set( key, context.previous );
+			}
 		},
 	} );
 }

--- a/packages/support-articles/src/hooks/use-rate-article.ts
+++ b/packages/support-articles/src/hooks/use-rate-article.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import apiFetch from '@wordpress/api-fetch';
+import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
+import type { ArticleRating, PostObject } from '../types';
+
+type RateArticleVariables = {
+	blogId: number;
+	postId: number;
+	rating: ArticleRating;
+};
+
+type RateArticleResponse = {
+	/** The rating on record, which is the earlier one if the article was already rated. */
+	user_rating: ArticleRating;
+};
+
+/**
+ * Stores the user's "Was this helpful?" answer for a support article on the server,
+ * and updates the cached article so reopening it shows the answer instead of the buttons.
+ */
+export function useRateArticle() {
+	const queryClient = useQueryClient();
+
+	return useMutation( {
+		mutationFn: ( {
+			blogId,
+			postId,
+			rating,
+		}: RateArticleVariables ): Promise< RateArticleResponse > => {
+			const body = { blog_id: blogId, post_id: postId, rating };
+
+			return canAccessWpcomApis()
+				? wpcomRequest( {
+						path: '/help/article/rating',
+						apiNamespace: 'wpcom/v2',
+						method: 'POST',
+						body,
+				  } )
+				: apiFetch( {
+						path: '/help-center/article-rating',
+						method: 'POST',
+						data: body,
+				  } );
+		},
+		onSuccess: ( { user_rating }, { postId } ) => {
+			queryClient.setQueriesData< PostObject >( { queryKey: [ 'support-status' ] }, ( post ) =>
+				post?.ID === postId ? { ...post, user_rating } : post
+			);
+		},
+	} );
+}

--- a/packages/support-articles/src/types.ts
+++ b/packages/support-articles/src/types.ts
@@ -8,6 +8,9 @@ export interface LessonNavigation {
 	previous?: LessonNavigationLink;
 }
 
+/** "Was this helpful?" answer. The values match the Tracks event and the legacy Crowdsignal poll: 1 = yes, 2 = no. */
+export type ArticleRating = 1 | 2;
+
 export interface PostObject {
 	content: string;
 	title: string;
@@ -17,6 +20,8 @@ export interface PostObject {
 	slug: string;
 	source?: string;
 	lesson_navigation?: LessonNavigation;
+	/** Rating the current user gave this article. Only present for logged-in users, since ratings are stored per user. */
+	user_rating?: ArticleRating | null;
 }
 
 export interface ArticleContentProps {


### PR DESCRIPTION
Part of https://linear.app/a8c/issue/DOTCOM-18102/help-center-articles-can-be-rated-multiple-times-by-the-same-user

The wpcom side is merged: 239241-ghe-Automattic/wpcom (rating store) and 239246-ghe-Automattic/wpcom (endpoint) add `user_rating` to `GET /help/article` and the `POST /help/article/rating` endpoint. wp-admin additionally needs the Jetpack proxy in https://github.com/Automattic/jetpack/pull/51978; until that ships, wp-admin still shows the persisted rating but the save request fails silently.

## Proposed Changes

* `PostObject` gains an optional `user_rating` (1 = yes, 2 = no, `null` = not rated). It is only sent for logged-in users.
* `HelpCenterFeedbackForm` seeds its state from `user_rating`, so a rated article shows the answer instead of "Was this helpful?". A "Yes" answer now renders as "You found this article helpful." with the thumbs-up icon, since it stays on the article permanently. The two state variables were merged into one.
* New `useRateArticle` mutation posts the rating (wpcom directly, or the `help-center/article-rating` Jetpack proxy in wp-admin). It also remembers the answer in memory for the page session, so reopening the article shows it even before the article is fetched again. If the server already had an earlier rating on record, the form switches to that one.
* When the server sent no `user_rating` field (logged-out user), nothing is sent and the answer is only remembered for the page session. No `localStorage` is used.
* `GetSupport` buttons reset the browser's default button background and border. In the article view there is no global button reset, so the "No" path showed a gray box.

## Why are these changes being made?

Article feedback lived only in component state, so every remount of the article offered the buttons again and the same user could rate an article any number of times. Storing the rating on the server keeps it consistent across tabs, browsers and devices, and works the same in Calypso and wp-admin.

## Testing Instructions

* Sandbox `public-api.wordpress.com` with the wpcom branch applied.
* Open the Help Center, open any support article, scroll to the bottom and click **Yes**. Confirm "You found this article helpful." replaces the buttons.
* Close and reopen the Help Center, or reload and reopen the same article. Confirm the buttons are not offered again.
* Open another article. Confirm the buttons are available.
* Rate an article **No**. Confirm the support options appear with no gray background on the buttons, close and reopen: the support options are shown, not the buttons.
* Logged out (e.g. `/support` on the sandboxed site): rating still hides the buttons for the session, and no `article/rating` request is made.
* `yarn jest -c packages/support-articles/jest.config.js packages/support-articles`

## Screenshot

The rated state below the article, showing the new string "You found this article helpful.":

<img width="1568" height="689" alt="Help Center article showing the rated state: a thumbs-up icon followed by the text You found this article helpful." src="https://github.com/user-attachments/assets/0e1cbdcd-c6c1-487f-a257-23a55d4552e0" />

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
