### PR TITLE
E2E: skip domain specs on a ban the guards were missing

### DIFF
--- a/packages/calypso-e2e/src/lib/components/domain-search-component.ts
+++ b/packages/calypso-e2e/src/lib/components/domain-search-component.ts
@@ -307,7 +307,15 @@ export class DomainSearchComponent {
 		}
 
 		const addToCartButton = row.getByRole( 'button', { name: 'Add to cart' } );
-		await addToCartButton.waitFor();
+		try {
+			await addToCartButton.waitFor();
+		} catch ( error ) {
+			// The check on entry only sees a ban that was already in force then; this
+			// one sees one raised since, by this worker or by a peer's. Reaching the
+			// throw means none was, and the wait's own error stands.
+			handleActiveThrottles( [ 'domain-availability' ] );
+			throw error;
+		}
 
 		const cartResponseSummaries: Promise< CartResponseDiagnostic >[] = [];
 		const trackCartResponse = ( response: Response ) => {

--- a/packages/calypso-e2e/src/lib/pages/my-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/my-home-page.ts
@@ -1,5 +1,6 @@
 import { Locator, Page } from 'playwright';
 import { getCalypsoURL } from '../../data-helper';
+import { handleActiveThrottles } from '../throttle-flags';
 
 const selectors = {
 	visitSiteButton: '.button >> text=Visit site',
@@ -14,7 +15,7 @@ export class MyHomePage {
 	private page: Page;
 	private anchor: Locator;
 	readonly heading: Locator;
-	readonly suggestedUpsellDomainName: Locator;
+	private readonly suggestedUpsellDomainName: Locator;
 
 	/**
 	 * Constructs an instance of the component.
@@ -27,6 +28,26 @@ export class MyHomePage {
 		this.heading = this.page.getByRole( 'heading', { name: 'My Home' } );
 		// The <strong> renders empty until the domain suggestion query resolves.
 		this.suggestedUpsellDomainName = this.anchor.getByTestId( 'domain-upsell-domain-name' );
+	}
+
+	/**
+	 * Waits for the domain upsell card to name a suggested domain.
+	 *
+	 * The name is whatever `/domains/suggestions` answered with, so a ban leaves
+	 * the <strong> empty for as long as it lasts and the wait spends its timeout
+	 * in full. Reaching the throw means none was in force and the wait's own
+	 * error stands: the card renders on other things too.
+	 */
+	async waitForSuggestedUpsellDomain(): Promise< void > {
+		try {
+			// The suggestion API can be slow on CI, hence the raised timeout.
+			await this.suggestedUpsellDomainName
+				.filter( { hasText: /\S+\.\S+/ } )
+				.waitFor( { timeout: 60 * 1000 } );
+		} catch ( error ) {
+			handleActiveThrottles( [ 'domain-suggestions' ] );
+			throw error;
+		}
 	}
 
 	/**

--- a/test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__my-home.spec.ts
@@ -1,4 +1,4 @@
-import { expect, skipIfMailosaurLimitReached, skipIfNotTrunk, tags, test } from '../../lib/pw-base';
+import { skipIfMailosaurLimitReached, skipIfNotTrunk, tags, test } from '../../lib/pw-base';
 
 test.describe(
 	'Domain: Upsell (Home)',
@@ -23,10 +23,7 @@ test.describe(
 			} );
 
 			await test.step( 'And domain upsell card has a suggested domain', async function () {
-				// The suggestion API can be slow on CI, hence the raised timeout.
-				await expect( pageMyHome.suggestedUpsellDomainName ).toHaveText( /\S+\.\S+/, {
-					timeout: 60_000,
-				} );
+				await pageMyHome.waitForSuggestedUpsellDomain();
 			} );
 
 			await test.step( 'When I click to begin searching for a domain', async function () {


### PR DESCRIPTION
## Proposed Changes

* `MyHomePage` now owns the wait for the domain upsell card's suggested domain, behind a `handleActiveThrottles( [ 'domain-suggestions' ] )` guard in the catch. `suggestedUpsellDomainName` is `private`, so no caller can go round the guard.
* `DomainSearchComponent.selectSuggestion` wraps its wait for the `Add to cart` button in the same try/catch, guarding on `domain-availability`.

## Why are these changes being made?

The suite turns a live wpcom domain throttle into a test skip through `handleActiveThrottles`. Two paths never reached it, so a ban spent a full timeout and reddened the pre-release gate where every other domain path skips.

The Home upsell spec read the card's domain straight off a page-object locator and asserted on it for 60s. Under a `domain-suggestions` ban the `<strong>` renders empty and stays that way, so the assertion polled it 57 times and failed. Guarding the spec would have fixed one caller; the guard belongs where the domain name is exposed.

The check has to run *after* the wait, not before it. In build #38418 the ban was raised roughly 44 seconds after that test started, so a check taken at the start would have seen nothing. That is why the wait moved into the page object rather than the locator staying public with a guard in front of it.

`selectSuggestion` already guards its row wait and its add-to-cart click, and checks `domain-availability` on entry. The entry check only sees a ban already in force when the method is called, not one raised while it runs; the wait for `Add to cart` in between had no guard at all. It now answers a ban the same way the row wait above it does, and re-throws its own error when none is in force.

Worth flagging for the reviewer: the two builds that first drew attention to the add-to-cart wait (#38473, #38485) carry no `[e2e-throttle]` line, so no ban was recorded in either. Reading `packages/domain-search/src/components/suggestion-cta/index.tsx`, the availability query does not gate that button's presence — it is replaced by `Continue` when the cart already holds the domain. Those two failures look like cart state, not a throttle. The guard is still correct and costs nothing when no ban is in force, but it will not be what fixes them.

## Testing Instructions

Run against staging from `test/e2e`:

```
BRANCH_NAME=trunk CALYPSO_BASE_URL=https://wpcalypso.wordpress.com \
  yarn playwright test --project=mobile \
  specs/domain-upsell/domain-upsell__my-home.spec.ts --reporter=list
```

Passes. Now fake a ban, with `--no-deps` so the setup project does not overwrite the variable:

```
BRANCH_NAME=trunk CALYPSO_BASE_URL=https://wpcalypso.wordpress.com \
  THROTTLE_DOMAIN_SUGGESTIONS_EXPIRATION=$(( $(date +%s)000 + 1800000 )) \
  yarn playwright test --project=mobile --no-deps \
  specs/domain-upsell/domain-upsell__my-home.spec.ts --reporter=list
```

The test skips, reporting `domain-suggestions is throttled`, instead of failing after a minute.

`specs/flows/setup-domain-and-plan__skip-plan.spec.ts` also passes on mobile against staging.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
