### PR TITLE
Site Spec: prefetch the wow funnel hand-off URL while the spec is open

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -16,6 +16,7 @@ import {
 	getSiteEditorUrl,
 	logBlueprintArchiveEvent,
 	startBlueprintArchiveImport,
+	isAtomicTransferComplete,
 	waitForAtomicTransferComplete,
 	waitForBlueprintImportComplete,
 } from 'calypso/landing/stepper/utils/blueprint-archive-import';
@@ -168,6 +169,7 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 	const messageCountRef = useRef( 0 );
 	const isSubmittingRef = useRef( false );
 	const blueprintImportStartedRef = useRef( false );
+	const handoffUrlRef = useRef< string | null >( null );
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	// Held in a ref so the spec-confirm callback stays referentially stable: the flow hands
 	// down a fresh submit() on every render, and useSiteSpec re-initialises the widget
@@ -446,11 +448,15 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 					} );
 
 					// Resolved after the wait either way, so the URL names the site that now exists.
+					// The funnel branch prefers the URL prefetched while the customer was answering
+					// the spec: reading the ref rather than awaiting a promise means a prefetch that
+					// never settled costs nothing here, it just falls through to fetching now.
 					const siteEditorUrl = wowFunnelSlug
-						? await getWowFunnelHandoffUrl( {
+						? handoffUrlRef.current ??
+						  ( await getWowFunnelHandoffUrl( {
 								dest: wowFunnelDest,
 								siteIdentifier: blueprintArchiveSiteIdentifier,
-						  } )
+						  } ) )
 						: getSiteEditorUrl( await getSiteAdminUrl( blueprintArchiveSiteIdentifier ), {
 								canvasEdit: applied,
 						  } );
@@ -485,6 +491,45 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 			setPendingAction,
 		]
 	);
+
+	// Resolve the hand-off URL while the customer is still answering, so confirm does not spend a
+	// round trip on it. The URL depends only on the site, never on the spec, so there is nothing to
+	// wait for it on.
+	//
+	// Gated on the transfer rather than fetched outright: admin_url is read from the site record
+	// and changes when a site goes Atomic, so a URL read mid-transfer would point at the site as it
+	// was before. The gate is a single status check rather than a wait — a fleet claim has already
+	// transferred long before this page renders, and a run that has not is simply left to fetch at
+	// confirm. Failures are swallowed: this is an optimisation, not a step.
+	useEffect( () => {
+		if ( ! wowFunnelSlug || ! blueprintArchiveSiteIdentifier || handoffUrlRef.current ) {
+			return;
+		}
+
+		let cancelled = false;
+
+		( async () => {
+			// One check, never a poll: waiting here is the processing step's job, and a funnel run
+			// that has not transferred yet simply does not get the optimisation.
+			if ( ! ( await isAtomicTransferComplete( blueprintArchiveSiteIdentifier ) ) ) {
+				return;
+			}
+
+			const url = await getWowFunnelHandoffUrl( {
+				dest: wowFunnelDest,
+				siteIdentifier: blueprintArchiveSiteIdentifier,
+			} );
+			if ( ! cancelled ) {
+				handoffUrlRef.current = url;
+			}
+		} )().catch( () => {
+			// Confirm falls back to fetching it.
+		} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ wowFunnelSlug, wowFunnelDest, blueprintArchiveSiteIdentifier ] );
 
 	// Kick off the background transfer + blueprint-archive import as soon as the
 	// spec page mounts, so it runs while the user reviews the spec. A funnel run skips this:

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
@@ -5,6 +5,8 @@ import { useQuery as useReactQuery } from '@tanstack/react-query';
 import { act, render } from '@testing-library/react';
 import {
 	applyBlueprintSpec,
+	getSiteAdminUrl,
+	isAtomicTransferComplete,
 	startBlueprintArchiveImport,
 	waitForAtomicTransferComplete,
 	waitForBlueprintImportComplete,
@@ -93,6 +95,7 @@ jest.mock( 'calypso/landing/stepper/utils/blueprint-archive-import', () => ( {
 			siteSlug || ( siteId && String( siteId ) !== '0' ? String( siteId ) : null )
 	),
 	getSiteAdminUrl: jest.fn( () => Promise.resolve( 'https://example.wordpress.com/wp-admin/' ) ),
+	isAtomicTransferComplete: jest.fn( () => Promise.resolve( true ) ),
 	getSiteEditorUrl: jest.fn( () => 'https://example.wordpress.com/wp-admin/site-editor.php' ),
 	logBlueprintArchiveEvent: jest.fn(),
 	startBlueprintArchiveImport: jest.fn( () => Promise.resolve() ),
@@ -284,6 +287,53 @@ describe( 'SiteSpec blueprint archive import', () => {
 		// The poll belongs to the processing step now, so nothing has been asked for yet.
 		expect( waitForAtomicTransferComplete ).not.toHaveBeenCalled();
 		expect( waitForBlueprintImportComplete ).not.toHaveBeenCalled();
+	} );
+
+	it( 'prefetches the hand-off URL while the customer is still answering', async () => {
+		renderSiteSpec();
+		// Let the mount effect settle.
+		await act( async () => {} );
+
+		// One status check, never the poll — waiting belongs to the processing step.
+		expect( isAtomicTransferComplete ).toHaveBeenCalledWith( 'example.wordpress.com' );
+		expect( waitForAtomicTransferComplete ).not.toHaveBeenCalled();
+		expect( getSiteAdminUrl ).toHaveBeenCalledTimes( 1 );
+
+		const siteSpecOptions = mockUseSiteSpec.mock.calls[ 0 ][ 0 ];
+		await act( async () => {
+			await siteSpecOptions.onSpecConfirm( { spec_id: 'spec-789' } );
+		} );
+
+		const pendingAction = mockSetPendingAction.mock.calls[ 0 ][ 0 ];
+		await expect( pendingAction() ).resolves.toEqual( {
+			redirectTo: 'https://example.wordpress.com/wp-admin/site-editor.php',
+		} );
+
+		// Still one: confirm spent the prefetched URL instead of paying for it again.
+		expect( getSiteAdminUrl ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'skips the prefetch while the site is still transferring', async () => {
+		// admin_url changes when a site goes Atomic, so a URL read now would name the old site.
+		( isAtomicTransferComplete as jest.Mock ).mockResolvedValueOnce( false );
+
+		renderSiteSpec();
+		await act( async () => {} );
+
+		expect( getSiteAdminUrl ).not.toHaveBeenCalled();
+
+		const siteSpecOptions = mockUseSiteSpec.mock.calls[ 0 ][ 0 ];
+		await act( async () => {
+			await siteSpecOptions.onSpecConfirm( { spec_id: 'spec-789' } );
+		} );
+
+		const pendingAction = mockSetPendingAction.mock.calls[ 0 ][ 0 ];
+		await expect( pendingAction() ).resolves.toEqual( {
+			redirectTo: 'https://example.wordpress.com/wp-admin/site-editor.php',
+		} );
+
+		// Fetched at confirm, once, now that the transfer is known to be done.
+		expect( getSiteAdminUrl ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'polls the import from the waiting screen and hands back the site editor URL', async () => {

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -194,6 +194,31 @@ export async function waitForBlueprintImportComplete(
 }
 
 /**
+ * One-shot check of whether a site's Atomic transfer has already completed.
+ *
+ * Distinct from waitForAtomicTransferComplete(): a caller that must not block — a prefetch
+ * speculating on work it may not need — wants an answer now, not a poll that can run for minutes.
+ *
+ * A missing transfer, an in-flight one, or a transient error all read as `false`. This is an
+ * optimisation hint only: `false` never means the transfer failed, so callers must fall back to
+ * doing the work properly rather than treating it as a verdict.
+ */
+export async function isAtomicTransferComplete( siteIdentifier: string ): Promise< boolean > {
+	try {
+		const transfer = ( await wpcom.req.get( {
+			path: `/sites/${ siteIdentifier }/atomic/transfers/latest`,
+			apiNamespace: 'wpcom/v2',
+		} ) ) as AtomicTransferResponse;
+
+		return Boolean(
+			transfer?.status && ATOMIC_TRANSFER_COMPLETE_STATES.includes( transfer.status )
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
  * Poll the canonical Atomic transfer status endpoint until the site's transfer
  * to Atomic completes. Resolves on a complete state; throws on a terminal
  * failure or timeout. A missing transfer (404 before the backup_import job


### PR DESCRIPTION
### Why

Confirming the site spec spent a round trip resolving the site editor URL before it
could redirect. That URL depends only on the site — never on the spec — so there is
nothing to wait for it on: it can be resolved while the customer is still answering
questions, and be in hand the moment they confirm.

### How

A single status check gates the prefetch. `admin_url` is read from the site record and
changes when a site goes Atomic, so a URL read mid-transfer would name the site as it
was before. The gate is deliberately **one check, not a wait** — waiting belongs to the
processing step, and a run that has not transferred yet simply doesn't get the
optimisation and fetches at confirm as before.

The resolved value is held in a ref rather than a promise, so a prefetch that never
settles cannot block confirm — it falls through to the original fetch.

Adds `isAtomicTransferComplete()` for the one-shot check: a caller that must not block
wants an answer now rather than a poll that can run for minutes. Its `false` is an
optimisation hint, never a verdict that the transfer failed.

### Scope

This removes one round trip. It is not the whole of the post-confirm wait — on a
measured run, `applyBlueprintSpec` accounted for ~4s of server time on its own, and the
cold editor load follows. Those are separate problems; this is the free part.

### Testing

`site-spec` suite: 10/10 pass (2 new).

- prefetches while the customer is still answering, and confirm reuses it rather than
  fetching again
- skips the prefetch while the site is still transferring, and fetches at confirm instead

The existing invariant that the spec page must not poll (`waitForAtomicTransferComplete`
is never called from it) still holds and is asserted in the new test.

eslint clean.

https://claude.ai/code/session_01GqsYNSWrWRpxtSMueLLDEB
