### PR TITLE
WoW funnel: restart a failed blueprint import instead of dead-ending on it

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -425,6 +425,9 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 						await waitForWowFunnelReady( {
 							funnelSlug: wowFunnelSlug,
 							siteIdentifier: blueprintArchiveSiteIdentifier,
+							// Lets the readiness wait restart a restore that failed, rather than
+							// leaving the site permanently stuck on its stored failure.
+							blueprintSlug: blueprintArchiveSlug,
 						} );
 					} else {
 						await waitForAtomicTransferComplete( blueprintArchiveSiteIdentifier );

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -137,6 +137,21 @@ export async function startBlueprintArchiveImport(
 }
 
 /**
+ * Marker for the one error waitForBlueprintImportComplete() raises itself.
+ *
+ * Distinguishing it from a transient request error is load-bearing in two places: the poll keeps
+ * going on the latter, and callers may retry only the former.
+ */
+const IMPORT_FAILED_PREFIX = 'Blueprint import failed with status: ';
+
+/**
+ * Whether an error is the import reporting a terminal failure, rather than a request that blew up.
+ */
+export function isBlueprintImportFailure( error: unknown ): boolean {
+	return error instanceof Error && error.message.startsWith( IMPORT_FAILED_PREFIX );
+}
+
+/**
  * Poll the site's import status until the backup import finishes.
  * Resolves on success; throws on a terminal failure or timeout.
  *
@@ -176,12 +191,12 @@ export async function waitForBlueprintImportComplete(
 			}
 
 			if ( lastStatus && IMPORT_FAILURE_STATUSES.includes( lastStatus ) ) {
-				throw new Error( `Blueprint import failed with status: ${ lastStatus }` );
+				throw new Error( `${ IMPORT_FAILED_PREFIX }${ lastStatus }` );
 			}
 		} catch ( error ) {
 			// A terminal failure we raised ourselves should propagate; transient
 			// request errors (e.g. mid-transfer blips) should keep polling.
-			if ( error instanceof Error && error.message.startsWith( 'Blueprint import failed' ) ) {
+			if ( isBlueprintImportFailure( error ) ) {
 				throw error;
 			}
 			continue;

--- a/client/landing/stepper/utils/test/wow-funnel.ts
+++ b/client/landing/stepper/utils/test/wow-funnel.ts
@@ -2,6 +2,8 @@
  * @jest-environment jsdom
  */
 import {
+	isBlueprintImportFailure,
+	startBlueprintArchiveImport,
 	waitForAtomicTransferComplete,
 	waitForBlueprintImportComplete,
 } from '../blueprint-archive-import';
@@ -24,12 +26,19 @@ jest.mock( '../blueprint-archive-import', () => ( {
 	__esModule: true,
 	waitForAtomicTransferComplete: jest.fn( () => Promise.resolve() ),
 	waitForBlueprintImportComplete: jest.fn( () => Promise.resolve() ),
+	startBlueprintArchiveImport: jest.fn( () => Promise.resolve() ),
+	isBlueprintImportFailure: jest.fn(
+		( error ) =>
+			error instanceof Error && error.message.startsWith( 'Blueprint import failed with status: ' )
+	),
 	getSiteAdminUrl: jest.fn(),
 	getSiteEditorUrl: jest.fn(),
 } ) );
 
 const mockTransferWait = waitForAtomicTransferComplete as jest.Mock;
 const mockImportWait = waitForBlueprintImportComplete as jest.Mock;
+const mockImportStart = startBlueprintArchiveImport as jest.Mock;
+const importFailed = () => new Error( 'Blueprint import failed with status: failed' );
 
 const never = () => new Promise< void >( () => {} );
 
@@ -246,5 +255,76 @@ describe( 'waitForWowFunnelReady', () => {
 		await Promise.resolve();
 
 		jest.useRealTimers();
+	} );
+} );
+
+describe( 'waitForWowFunnelReady — recovering a failed import', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockTransferWait.mockResolvedValue( undefined );
+		( isBlueprintImportFailure as jest.Mock ).mockImplementation(
+			( error ) =>
+				error instanceof Error &&
+				error.message.startsWith( 'Blueprint import failed with status: ' )
+		);
+	} );
+
+	it( 'restarts the import once and waits again, so a stored failure is not a dead end', async () => {
+		mockImportWait.mockRejectedValueOnce( importFailed() ).mockResolvedValueOnce( undefined );
+
+		await expect(
+			waitForWowFunnelReady( {
+				funnelSlug: 'blueprint',
+				siteIdentifier: 'example.wordpress.com',
+				blueprintSlug: 'punk',
+			} )
+		).resolves.toBeUndefined();
+
+		expect( mockImportStart ).toHaveBeenCalledWith( 'example.wordpress.com', 'punk' );
+		expect( mockImportWait ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'gives up when the restarted import fails too', async () => {
+		mockImportWait.mockRejectedValue( importFailed() );
+
+		await expect(
+			waitForWowFunnelReady( {
+				funnelSlug: 'blueprint',
+				siteIdentifier: 'example.wordpress.com',
+				blueprintSlug: 'punk',
+			} )
+		).rejects.toThrow();
+
+		// Restarted exactly once: a second failure is terminal, not an invitation to loop.
+		expect( mockImportStart ).toHaveBeenCalledTimes( 1 );
+		expect( mockImportWait ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'does not restart without a blueprint slug, having nothing to restart from', async () => {
+		mockImportWait.mockRejectedValue( importFailed() );
+
+		await expect(
+			waitForWowFunnelReady( {
+				funnelSlug: 'blueprint',
+				siteIdentifier: 'example.wordpress.com',
+			} )
+		).rejects.toThrow();
+
+		expect( mockImportStart ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not restart on a transient error, which is no evidence the import is broken', async () => {
+		mockImportWait.mockRejectedValue( new Error( 'Timed out waiting for blueprint import.' ) );
+
+		await expect(
+			waitForWowFunnelReady( {
+				funnelSlug: 'blueprint',
+				siteIdentifier: 'example.wordpress.com',
+				blueprintSlug: 'punk',
+			} )
+		).rejects.toThrow();
+
+		expect( mockImportStart ).not.toHaveBeenCalled();
+		expect( mockImportWait ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -4,6 +4,8 @@ import {
 	getSiteAdminUrl,
 	getSiteEditorUrl,
 	waitForAtomicTransferComplete,
+	isBlueprintImportFailure,
+	startBlueprintArchiveImport,
 	waitForBlueprintImportComplete,
 } from './blueprint-archive-import';
 
@@ -286,9 +288,11 @@ const WAIT_TIMED_OUT = Symbol( 'wow-funnel-wait-timed-out' );
 export async function waitForWowFunnelReady( {
 	funnelSlug,
 	siteIdentifier,
+	blueprintSlug,
 }: {
 	funnelSlug: string;
 	siteIdentifier: string;
+	blueprintSlug?: string | null;
 } ): Promise< void > {
 	const { readiness, waitTimeoutSeconds } = getWowFunnelConfig( funnelSlug );
 
@@ -304,7 +308,26 @@ export async function waitForWowFunnelReady( {
 		// Atomic — and `import` simply waits for one more thing behind it.
 		await waitForAtomicTransferComplete( siteIdentifier, pollNow );
 		if ( 'import' === readiness ) {
-			await waitForBlueprintImportComplete( siteIdentifier, pollNow );
+			try {
+				await waitForBlueprintImportComplete( siteIdentifier, pollNow );
+			} catch ( error ) {
+				// A failed import record is terminal for that attempt, not for the site — but it is
+				// stored, so without this every later visit reads the same record and throws again,
+				// and the customer can never get out of the error screen however many times they
+				// re-enter. That is worth avoiding on its own, and the restore's most likely
+				// failure is one that has since resolved: fetching the archive needs the customer's
+				// Jetpack connection, which does not exist yet when the claim starts the import.
+				//
+				// So restart once and wait again. A second failure is genuinely terminal and
+				// propagates. Only a real import failure is retried; a request that blew up is not
+				// evidence the import is broken.
+				if ( ! blueprintSlug || ! isBlueprintImportFailure( error ) ) {
+					throw error;
+				}
+
+				await startBlueprintArchiveImport( siteIdentifier, blueprintSlug );
+				await waitForBlueprintImportComplete( siteIdentifier, pollNow );
+			}
 		}
 	} )();
 


### PR DESCRIPTION
### The bug

A failed import record is terminal for that *attempt*, not for the site — but it is
stored. Re-entering the funnel read the same record and threw again, so the customer
could never get out of the error screen however many times they came back. Nothing on
the client offered a way to restart.

### Why it happens more than you'd expect

Fetching the blueprint archive needs the customer's Jetpack connection, which does not
exist yet when the funnel starts the import. That is not an edge case — starting the
import before the connection is minted is deliberate, to overlap it with checkout.

Observed on a real run: the import failed at `download_archive` while the connection was
still missing, and every later visit went straight to `/error`.

### The fix

The readiness wait restarts the import once and waits again. A second failure is
genuinely terminal and propagates.

Only a *real* import failure is retried — a request that blew up is not evidence the
import is broken, so it is left alone. The restart also needs a blueprint slug to
restart from; without one the error propagates unchanged.

Extracts the failure sentinel behind `isBlueprintImportFailure()` rather than matching
the message literal in a third place.

### Testing

14 suites / 130 tests pass across the touched areas. Four new tests on the recovery path:

- restarts once and succeeds, so a stored failure is not a dead end
- gives up when the restarted import fails too (restart attempted exactly once — a second
  failure must not loop)
- does not restart without a blueprint slug
- does not restart on a transient error

eslint clean.

### Related

The server side — nothing retrying a failed import at all, so the site stayed empty even
without the client dead end — is fixed separately in wpcom (Automattic/wpcom#239405).
These are independent: either helps on its own, both together mean a failed restore
recovers without anyone noticing.

https://claude.ai/code/session_01GqsYNSWrWRpxtSMueLLDEB
