### PR TITLE
Checkout: keep the siteless flags on subscription-ID-only renewals

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
+++ b/client/my-sites/checkout/src/hooks/use-prepare-products-for-cart.ts
@@ -134,6 +134,7 @@ export default function usePrepareProductsForCart( {
 	} );
 	useAddRenewalBySubscriptionId( {
 		originalPurchaseId,
+		sitelessCheckoutType,
 		dispatch,
 		addHandler,
 	} );
@@ -465,10 +466,12 @@ function useAddRenewalItems( {
  */
 function useAddRenewalBySubscriptionId( {
 	originalPurchaseId,
+	sitelessCheckoutType,
 	dispatch,
 	addHandler,
 }: {
 	originalPurchaseId: string | number | null | undefined;
+	sitelessCheckoutType: SitelessCheckoutType;
 	dispatch: ( action: PreparedProductsAction ) => void;
 	addHandler: AddHandler;
 } ) {
@@ -510,12 +513,16 @@ function useAddRenewalBySubscriptionId( {
 				extra: {
 					purchaseId: subscriptionId,
 					purchaseType: 'renewal',
+					// The backend decides whether the cart is a siteless one from these
+					// flags alone, and rejects Akismet plans in a cart without them.
+					isAkismetSitelessCheckout: sitelessCheckoutType === 'akismet',
+					isMarketplaceSitelessCheckout: sitelessCheckoutType === 'marketplace',
 				},
 			} )
 		);
 		debug( 'preparing renewals from subscription IDs', originalPurchaseId );
 		dispatch( { type: 'RENEWALS_ADD', products: cartItems } );
-	}, [ addHandler, dispatch, originalPurchaseId, translate ] );
+	}, [ addHandler, dispatch, originalPurchaseId, sitelessCheckoutType, translate ] );
 }
 
 function useAddProductFromSlug( {

--- a/client/my-sites/checkout/src/test/use-prepare-products-for-cart.tsx
+++ b/client/my-sites/checkout/src/test/use-prepare-products-for-cart.tsx
@@ -121,6 +121,21 @@ describe( 'usePrepareProductsForCart for siteless renewals', () => {
 		expect( result.current.productsForCart[ 0 ].extra.purchaseId ).toBe( '12345' );
 	} );
 
+	it.each( [
+		[ 'akismet', 'isAkismetSitelessCheckout' ],
+		[ 'marketplace', 'isMarketplaceSitelessCheckout' ],
+	] as const )(
+		'flags a %s renewal as siteless so the backend keeps it in the cart',
+		( sitelessCheckoutType, extraKey ) => {
+			const { result } = renderPrepareProducts( {
+				purchaseId: '12345',
+				sitelessCheckoutType,
+			} );
+
+			expect( result.current.productsForCart[ 0 ].extra[ extraKey ] ).toBe( true );
+		}
+	);
+
 	it( 'renews several subscriptions from a comma-separated list of IDs', () => {
 		const { result } = renderPrepareProducts( {
 			purchaseId: '12345,67890',


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2515/

## Proposed changes

Siteless Akismet and Marketplace renewals moved to the short `/checkout/{service}/renew/{id}` URL in #114065/#114066, which routes them through `addRenewalBySubscriptionId`. That handler built its cart item without the `isAkismetSitelessCheckout` / `isMarketplaceSitelessCheckout` flags, so the backend no longer recognised the cart as siteless. This passes `sitelessCheckoutType` through to that handler and sets the flags, matching what `createRenewalItemToAddToCart` already does on the legacy path.

* Pass `sitelessCheckoutType` into `useAddRenewalBySubscriptionId` and add it to the effect's dependencies.
* Set `isAkismetSitelessCheckout` and `isMarketplaceSitelessCheckout` on the renewal cart item built from a subscription ID alone.
* Add test coverage asserting both flags survive a subscription-ID-only siteless renewal.

## Why are these changes being made?

Akismet renewals were failing outright: clicking Renew (or opening `/checkout/akismet/renew/{id}`) landed on an empty cart with "Akismet plans cannot be purchased for specific domains." It reproduced across accounts, including on subscriptions bound to a real site rather than a `siteless.akismet.com` holding site.

The root cause is entirely in how the cart item is built, not in the site binding. On the server, `Store_Shopping_Cart::set_properties_for_akismet_checkout()` derives the cart-level siteless mode from the first cart item's `extra.isAkismetSitelessCheckout` — there is no other signal. With the flag absent, `is_akismet_siteless_checkout()` returns false, and `Default_Shopping_Cart_Validator::remove_akismet_plans_from_non_siteless_checkouts()` strips the product and adds that error, leaving the cart empty.

The legacy `/checkout/akismet/{product_slug}/renew/{id}` URL went through `addRenewalItems` → `createRenewalItemToAddToCart`, which has always set the flag. Dropping the product slug from the URL switched the handler to `addRenewalBySubscriptionId`, which did not — so the fix is to set the flag in both places rather than to revert the URL change.

Marketplace is affected by the same gap, though less visibly: without `isMarketplaceSitelessCheckout` the cart resolves to `Checkout_Type::Default` instead of `Marketplace_Renewal`, so it is fixed here too.

## Testing instructions

TC:
```
yarn test-client client/my-sites/checkout/src/test/use-prepare-products-for-cart.tsx
```

Manual testing:
* Needs a WordPress.com account with an Akismet subscription
* Before the fix: go to `/me/purchases`, open the Akismet purchase, click **Renew now**. You land on `/checkout/akismet/renew/{id}` with an empty cart and a red "Akismet plans cannot be purchased for specific domains" notice.
* After the fix: the same click should load checkout with the Akismet renewal in the cart, priced correctly, and the Akismet-branded checkout experience.
* Confirm the request to the shopping cart endpoint sends `extra.isAkismetSitelessCheckout: true` on the renewal product.
* Repeat for a Marketplace (plugin) subscription renewal to confirm it still loads and shows the Marketplace checkout experience.
* Regression check: a legacy-format URL such as `/checkout/akismet/{product_slug}/renew/{id}` should still work, and a regular WordPress.com plan renewal via `/checkout/renew/{id}` should be unaffected.
