### PR TITLE
E2E: hide the Help Center launcher before opening the partner directory filters on mobile

### DIFF
--- a/packages/calypso-e2e/src/lib/components/partner-directory-component.ts
+++ b/packages/calypso-e2e/src/lib/components/partner-directory-component.ts
@@ -25,6 +25,11 @@ export class PartnerDirectoryComponent {
 	async applyDropdownFilter( dropdownName: string, filterName: string ): Promise< void > {
 		// On mobile, we need to click the filters toggle button first to open the filters panel.
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
+			// The Help Center launcher is a fixed button in the same corner as the filters toggle
+			// on mobile and intercepts the click, so hide it for this page.
+			await this.page.addStyleTag( {
+				content: '.wpcom-help-center-fab { display: none !important; }',
+			} );
 			// TODO: This button has no accessible name, so we have to use a CSS selector.
 			const filtersToggle = this.page.locator( '.a4a-partner-directory-filters-toggle' );
 			await filtersToggle.waitFor( { state: 'visible' } );


### PR DESCRIPTION
## Proposed Changes

* In `PartnerDirectoryComponent.applyDropdownFilter`, on the mobile viewport, inject a style tag that hides the Help Center launcher button (`.wpcom-help-center-fab`) before clicking the partner directory filters toggle.

## Why are these changes being made?

* An internal wpcom change merged on 2026-09-04 (wpcom PR 239251) makes the Help Center launcher button appear at page load on every logged-out landing page. Previously it only appeared after a scroll or a 10 second delay, so it was never present by the time this test clicked the toggle.
* On a Pixel 7 viewport that fixed button sits in the same bottom-right corner as the partner directory filters toggle. Playwright's click retries cycle through scroll alignments: the bottom alignments land under the Help Center button, the top alignment lands under the fixed global nav, and the centre alignment fails Playwright's hit-target check on this page. The click never lands and the test times out after 10 seconds.
* The failure reproduces locally on trunk against the live page, and every full-suite mobile E2E run since 12:55 UTC on 2026-09-04 fails on exactly this test. The last green full-suite run was at 09:47 UTC, before the wpcom change landed.
* Most PRs do not hit this because the `@calypso-pr` subset does not include the spec. Any PR that touches a file in `packages/calypso-e2e` or a non-spec file in `test/e2e` runs the full suite and turns red.
* Hiding the launcher keeps Playwright's real click and actionability checks. Scrolling the toggle into a clear position first was tried and still fails, and dispatching the click event directly would bypass the hit-target check entirely.

## Testing Instructions

* Build the E2E package: `cd test/e2e && yarn build`.
* Run the spec on mobile: `yarn playwright test specs/a8c-for-agencies/partner-directory__smoke.spec.ts --project=mobile --no-deps --reporter=list`. It should pass in a few seconds. On trunk, it fails with `locator.click: Timeout 10000ms exceeded` and the Help Center button listed as intercepting pointer events.
* Run the same spec with `--project=chrome` to confirm desktop is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)