### PR TITLE
Login: read immediate login prefill from the query, not the store

### DIFF
--- a/client/controller/index.web.jsx
+++ b/client/controller/index.web.jsx
@@ -236,11 +236,18 @@ function buildLoginParameters( context, state ) {
 	// original URL, to ensure the login form is pre-filled with the
 	// correct email address and built with the correct language (when
 	// either of those are requested).
-	const login_email = getImmediateLoginEmail( state );
+	//
+	// Read the query before the state. `setupRoutes()` registers this
+	// middleware ahead of the `ROUTE_SET` catch-all that copies these
+	// values into the store, so on the request that arrives from an
+	// immediate login link the store is still empty. The state is the
+	// fallback for later navigations, where the immediate login
+	// parameters have already been stripped from the URL.
+	const login_email = context.query?.login_email || getImmediateLoginEmail( state );
 	if ( login_email ) {
 		loginParameters.emailAddress = login_email;
 	}
-	const login_locale = getImmediateLoginLocale( state );
+	const login_locale = context.query?.login_locale || getImmediateLoginLocale( state );
 	if ( login_locale ) {
 		loginParameters.locale = login_locale;
 	}

--- a/client/controller/test/controller.js
+++ b/client/controller/test/controller.js
@@ -174,6 +174,56 @@ describe( 'redirectLoggedOut', () => {
 
 		replaceState.mockRestore();
 	} );
+
+	describe( 'immediate login prefill', () => {
+		const buildImmediateLoginContext = ( { query = {}, immediateLogin = {} } = {} ) => ( {
+			store: mockStore( {
+				currentUser: { id: null },
+				immediateLogin,
+			} ),
+			query,
+			params: {},
+			path: '/me/purchases',
+			pathname: '/me/purchases',
+		} );
+
+		it( 'prefills the email and locale from the query before ROUTE_SET has run', async () => {
+			// `setupRoutes()` registers this middleware ahead of the `ROUTE_SET`
+			// catch-all, so an immediate login link reaches it with an empty store.
+			const context = buildImmediateLoginContext( {
+				query: {
+					immediate_login_attempt: '1',
+					login_email: 'jane@example.com',
+					login_locale: 'fr',
+				},
+			} );
+
+			await redirectLoggedOut( context, next );
+
+			expect( window.location ).toBe(
+				'/log-in/fr?redirect_to=%2Fme%2Fpurchases&email_address=jane%40example.com'
+			);
+			expect( next ).not.toHaveBeenCalled();
+		} );
+
+		it( 'falls back to the stored values once the query has been stripped', async () => {
+			const context = buildImmediateLoginContext( {
+				immediateLogin: { email: 'jane@example.com', locale: 'fr' },
+			} );
+
+			await redirectLoggedOut( context, next );
+
+			expect( window.location ).toBe(
+				'/log-in/fr?redirect_to=%2Fme%2Fpurchases&email_address=jane%40example.com'
+			);
+		} );
+
+		it( 'omits both parameters when neither the query nor the store has them', async () => {
+			await redirectLoggedOut( buildImmediateLoginContext(), next );
+
+			expect( window.location ).toBe( '/log-in?redirect_to=%2Fme%2Fpurchases' );
+		} );
+	} );
 } );
 
 describe( 'redirectMyJetpack', () => {

--- a/test/e2e/specs/authentication/authentication__immediate-login-prefill.spec.ts
+++ b/test/e2e/specs/authentication/authentication__immediate-login-prefill.spec.ts
@@ -1,0 +1,35 @@
+import { DataHelper } from '@automattic/calypso-e2e';
+import { tags, test, expect } from '../../lib/pw-base';
+
+test.describe(
+	'Authentication: Immediate login email prefill',
+	{ tag: [ tags.AUTHENTICATION, tags.CALYPSO_RELEASE ] },
+	() => {
+		const email = 'e2e-immediate-login@example.com';
+
+		test( 'A failed immediate login reaches the login form with the email prefilled', async ( {
+			page,
+		} ) => {
+			await test.step( 'Given I follow an immediate login link that did not log me in', async function () {
+				await page.goto(
+					DataHelper.getCalypsoURL( 'me/purchases', {
+						immediate_login_attempt: '1',
+						login_email: email,
+					} ),
+					{ waitUntil: 'domcontentloaded' }
+				);
+			} );
+
+			await test.step( 'Then I am redirected to the login form', async function () {
+				await page.waitForURL( /\/log-in/, { timeout: 30_000 } );
+			} );
+
+			await test.step( 'And the email field holds the address from the link', async function () {
+				const usernameInput = page.getByRole( 'textbox', {
+					name: /email address|username/i,
+				} );
+				await expect( usernameInput ).toHaveValue( email, { timeout: 15_000 } );
+			} );
+		} );
+	}
+);


### PR DESCRIPTION
Related to #DOTOBRD-597

## The problem

`buildLoginParameters()` reads the email address and the locale for the login
redirect out of `state.immediateLogin`. Only the `ROUTE_SET` handler in
`client/state/lib/middleware.js` writes that key, and `setupRoutes()` registers
the section routes — and with them `redirectLoggedOut` — before
`setRouteMiddleware()` registers the `ROUTE_SET` catch-all. page.js runs
handlers in registration order.

A logged-out user who arrives from an immediate login link therefore hits
`redirectLoggedOut` while the store is still empty. Both selectors return
`null`, neither `if` runs, and `window.location` is assigned right there, so the
`ROUTE_SET` handler never runs at all. The login URL carries no `email_address`
and no locale, and the login form opens blank and in English.

This is renewal traffic. Per the issue, 32,626 people in 27 days reach the login
form this way, and 37,531 of the 44,881 who failed an immediate login were sent
by a billing or expiry email.

## The fix

Read `login_email` and `login_locale` from `context.query` first, and keep the
store as the fallback. `context.query` is already in scope in that function —
two lines below, the checkout branch reads `context.query?.unlinked`.

The store fallback still matters for later navigations: the `ROUTE_SET` handler
calls `page.replace()` to strip the immediate login parameters from the URL, so
a subsequent logged-out navigation has the values in the store and not in the
query.

Email and locale are fixed together — the locale was dropped by the same null
read.

## Testing instructions

<details>
<summary>Unit tests</summary>

```bash
yarn test-client client/controller/test/controller.js
```

Three new cases under `redirectLoggedOut > immediate login prefill`. The first
one fails on `trunk` with:

```
Expected: "/log-in/fr?redirect_to=%2Fme%2Fpurchases&email_address=jane%40example.com"
Received: "/log-in?redirect_to=%2Fme%2Fpurchases"
```
</details>

<details>
<summary>End-to-end spec</summary>

`test/e2e/specs/authentication/authentication__immediate-login-prefill.spec.ts`
follows an immediate login link as a logged-out user and asserts the email field
holds the address from the link.

```bash
cd test/e2e
yarn playwright test specs/authentication/authentication__immediate-login-prefill.spec.ts \
  --project=authentication --reporter=list
```

Against a local Calypso on this branch it passes. With `buildLoginParameters`
reverted to the `trunk` version it fails on the last step:

```
Expected: "e2e-immediate-login@example.com"
Received: ""
```
</details>

<details>
<summary>Manual check in the browser</summary>

Run Calypso locally and, in a logged-out browser profile, open:

```
http://calypso.localhost:3000/me/purchases?immediate_login_attempt=1&login_email=jane%40example.com&login_locale=fr
```

Expected: Calypso redirects to
`/log-in/fr?redirect_to=%2Fme%2Fpurchases&email_address=jane%40example.com`, the
email field is pre-filled with `jane@example.com`, and the form renders in
French.

On `trunk` the same URL lands on `/log-in?redirect_to=%2Fme%2Fpurchases` with an
empty field and an English form.
</details>

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01UvbX2peAn1jbBmU62mYk3v
