### PR TITLE
Dashboard: ask for the business use declaration in Ohio and Connecticut

### DIFF
--- a/client/dashboard/components/checkbox-with-support-link.tsx
+++ b/client/dashboard/components/checkbox-with-support-link.tsx
@@ -1,0 +1,39 @@
+import { CheckboxControl } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import InlineSupportLink from './inline-support-link';
+
+/**
+ * A checkbox whose label ends in a "Learn more" support link.
+ *
+ * `label` must contain a single `<link></link>` placeholder holding the link text.
+ */
+export function CheckboxWithSupportLink( {
+	label,
+	supportContext,
+	checked,
+	onChange,
+	hideLabelFromVision,
+}: {
+	label: string;
+	supportContext: string;
+	checked: boolean;
+	onChange: ( value: boolean ) => void;
+	hideLabelFromVision?: boolean;
+} ) {
+	return (
+		<CheckboxControl
+			__nextHasNoMarginBottom
+			// @wordpress/components types `label` as a string, but it renders as the
+			// content of the <label> element, so a node works at runtime.
+			label={
+				hideLabelFromVision
+					? ''
+					: ( createInterpolateElement( label, {
+							link: <InlineSupportLink supportContext={ supportContext } />,
+					  } ) as unknown as string )
+			}
+			checked={ checked }
+			onChange={ onChange }
+		/>
+	);
+}

--- a/client/dashboard/components/tax-location-form.tsx
+++ b/client/dashboard/components/tax-location-form.tsx
@@ -1,8 +1,10 @@
 import { countryListQuery, statesListQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
+import { CheckboxControl } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
+import InlineSupportLink from './inline-support-link';
 import type {
 	CountryListItem,
 	StatesListItem,
@@ -64,13 +66,53 @@ function getFields( {
 			label: __( 'Address' ),
 			Edit: 'text',
 		},
+		{
+			id: 'is_for_business',
+			label: __( 'Is this purchase for business?' ),
+			type: 'boolean' as const,
+			Edit: ( { field, data, onChange, hideLabelFromVision } ) => {
+				const { id, getValue } = field;
+				return (
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						label={ hideLabelFromVision ? '' : field.label }
+						help={
+							<InlineSupportLink supportContext="business-tax-rates-in-ohio-and-connecticut" />
+						}
+						checked={ Boolean( getValue( { item: data } ) ) }
+						onChange={ ( newValue ) => onChange( { [ id ]: newValue } ) }
+					/>
+				);
+			},
+		},
 	];
+}
+
+/**
+ * Ohio and Connecticut charge a reduced sales tax rate on business purchases, so
+ * buyers there are asked to declare whether the purchase is for business use.
+ * Connecticut's range skips 06390 (Fishers Island), which belongs to New York.
+ */
+export function isBusinessUseTaxLocation( taxLocation: StoredPaymentMethodTaxLocation ): boolean {
+	if ( taxLocation.country_code?.toUpperCase() !== 'US' ) {
+		return false;
+	}
+	const postalCode = parseInt( taxLocation.postal_code ?? '', 10 );
+	return (
+		( postalCode >= 43000 && postalCode <= 45999 ) ||
+		( postalCode >= 6000 && postalCode <= 6389 ) ||
+		( postalCode >= 6391 && postalCode <= 6999 )
+	);
 }
 
 export function calculateTaxLocationFields( {
 	selectedCountryItem,
+	taxLocation,
+	allowIsForBusinessCheckbox,
 }: {
 	selectedCountryItem?: CountryListItem;
+	taxLocation?: StoredPaymentMethodTaxLocation;
+	allowIsForBusinessCheckbox?: boolean;
 } ): string[] {
 	const fields = [ 'country_code' ];
 	if ( selectedCountryItem?.has_postal_codes ) {
@@ -88,7 +130,9 @@ export function calculateTaxLocationFields( {
 	if ( selectedCountryItem?.tax_needs_address ) {
 		fields.push( 'address' );
 	}
-	// FIXME: add is_for_business if elligible (two US states)
+	if ( allowIsForBusinessCheckbox && taxLocation && isBusinessUseTaxLocation( taxLocation ) ) {
+		fields.push( 'is_for_business' );
+	}
 	return fields;
 }
 
@@ -106,9 +150,11 @@ export const defaultTaxLocation: StoredPaymentMethodTaxLocation = {
 export function TaxLocationForm( {
 	data,
 	onChange,
+	allowIsForBusinessCheckbox,
 }: {
 	data: StoredPaymentMethodTaxLocation;
 	onChange: ( updated: Partial< StoredPaymentMethodTaxLocation > ) => void;
+	allowIsForBusinessCheckbox?: boolean;
 } ) {
 	const { data: countryList } = useQuery( countryListQuery() );
 
@@ -136,9 +182,13 @@ export function TaxLocationForm( {
 		() => ( {
 			type: 'regular' as const,
 			labelPosition: 'top' as const,
-			fields: calculateTaxLocationFields( { selectedCountryItem } ),
+			fields: calculateTaxLocationFields( {
+				selectedCountryItem,
+				taxLocation: data,
+				allowIsForBusinessCheckbox,
+			} ),
 		} ),
-		[ selectedCountryItem ]
+		[ selectedCountryItem, data, allowIsForBusinessCheckbox ]
 	);
 
 	const fields = useMemo(
@@ -150,12 +200,22 @@ export function TaxLocationForm( {
 		return null;
 	}
 
+	const handleChange = ( updated: Partial< StoredPaymentMethodTaxLocation > ) => {
+		// The checkbox is hidden once the location stops being eligible, so drop
+		// the declaration too rather than submitting one the buyer can't see.
+		if ( data.is_for_business && ! isBusinessUseTaxLocation( { ...data, ...updated } ) ) {
+			onChange( { ...updated, is_for_business: undefined } );
+			return;
+		}
+		onChange( updated );
+	};
+
 	return (
 		<DataForm< StoredPaymentMethodTaxLocation >
 			data={ data }
 			fields={ fields }
 			form={ form }
-			onChange={ onChange }
+			onChange={ handleChange }
 		/>
 	);
 }

--- a/client/dashboard/components/tax-location-form.tsx
+++ b/client/dashboard/components/tax-location-form.tsx
@@ -1,10 +1,9 @@
 import { countryListQuery, statesListQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import { CheckboxControl } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
-import InlineSupportLink from './inline-support-link';
+import { CheckboxWithSupportLink } from './checkbox-with-support-link';
 import type {
 	CountryListItem,
 	StatesListItem,
@@ -73,14 +72,12 @@ function getFields( {
 			Edit: ( { field, data, onChange, hideLabelFromVision } ) => {
 				const { id, getValue } = field;
 				return (
-					<CheckboxControl
-						__nextHasNoMarginBottom
-						label={ hideLabelFromVision ? '' : field.label }
-						help={
-							<InlineSupportLink supportContext="business-tax-rates-in-ohio-and-connecticut" />
-						}
+					<CheckboxWithSupportLink
+						label={ __( 'Is this purchase for business? <link>Learn more.</link>' ) }
+						supportContext="business-tax-rates-in-ohio-and-connecticut"
 						checked={ Boolean( getValue( { item: data } ) ) }
 						onChange={ ( newValue ) => onChange( { [ id ]: newValue } ) }
+						hideLabelFromVision={ hideLabelFromVision }
 					/>
 				);
 			},

--- a/client/dashboard/components/test/checkbox-with-support-link.test.tsx
+++ b/client/dashboard/components/test/checkbox-with-support-link.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../test-utils';
+import { CheckboxWithSupportLink } from '../checkbox-with-support-link';
+
+const label = 'Is this purchase for business? <link>Learn more.</link>';
+const supportContext = 'business-tax-rates-in-ohio-and-connecticut';
+
+describe( '<CheckboxWithSupportLink>', () => {
+	test( 'names the checkbox with the interpolated label', async () => {
+		render(
+			<CheckboxWithSupportLink
+				label={ label }
+				supportContext={ supportContext }
+				checked={ false }
+				onChange={ () => {} }
+			/>
+		);
+
+		expect(
+			await screen.findByRole( 'checkbox', {
+				name: 'Is this purchase for business? Learn more.',
+			} )
+		).toBeVisible();
+	} );
+
+	test( 'renders the support link inline in the label', async () => {
+		render(
+			<CheckboxWithSupportLink
+				label={ label }
+				supportContext={ supportContext }
+				checked={ false }
+				onChange={ () => {} }
+			/>
+		);
+
+		const link = await screen.findByRole( 'link', { name: /learn more/i } );
+		expect( link.closest( 'label' ) ).toBeVisible();
+	} );
+
+	test( 'reports the new value when toggled', async () => {
+		const onChange = jest.fn();
+		render(
+			<CheckboxWithSupportLink
+				label={ label }
+				supportContext={ supportContext }
+				checked={ false }
+				onChange={ onChange }
+			/>
+		);
+
+		await userEvent.click( await screen.findByRole( 'checkbox' ) );
+
+		expect( onChange ).toHaveBeenCalledWith( true );
+	} );
+
+	test( 'drops the label when it is hidden from vision', async () => {
+		render(
+			<CheckboxWithSupportLink
+				label={ label }
+				supportContext={ supportContext }
+				checked={ false }
+				onChange={ () => {} }
+				hideLabelFromVision
+			/>
+		);
+
+		expect( await screen.findByRole( 'checkbox' ) ).toBeVisible();
+		expect( screen.queryByRole( 'link', { name: /learn more/i } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/components/test/tax-location-form.test.tsx
+++ b/client/dashboard/components/test/tax-location-form.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { useState } from 'react';
+import { render } from '../../test-utils';
+import {
+	TaxLocationForm,
+	calculateTaxLocationFields,
+	defaultTaxLocation,
+} from '../tax-location-form';
+import type { CountryListItem, StoredPaymentMethodTaxLocation } from '@automattic/api-core';
+
+const unitedStates = {
+	code: 'US',
+	name: 'United States',
+	has_postal_codes: true,
+	tax_needs_subdivision: true,
+} as CountryListItem;
+
+const france = {
+	code: 'FR',
+	name: 'France',
+	has_postal_codes: true,
+} as CountryListItem;
+
+function fieldsFor(
+	taxLocation: StoredPaymentMethodTaxLocation,
+	{
+		selectedCountryItem = unitedStates,
+		allowIsForBusinessCheckbox = true,
+	}: { selectedCountryItem?: CountryListItem; allowIsForBusinessCheckbox?: boolean } = {}
+) {
+	return calculateTaxLocationFields( {
+		selectedCountryItem,
+		taxLocation,
+		allowIsForBusinessCheckbox,
+	} );
+}
+
+describe( 'calculateTaxLocationFields business use field', () => {
+	test.each( [
+		[ 'the first Ohio postal code', '43000' ],
+		[ 'a mid-range Ohio postal code', '44101' ],
+		[ 'the last Ohio postal code', '45999' ],
+		[ 'the first Connecticut postal code', '06000' ],
+		[ 'the last Connecticut postal code before the gap', '06389' ],
+		[ 'the first Connecticut postal code after the gap', '06391' ],
+		[ 'the last Connecticut postal code', '06999' ],
+	] )( 'includes is_for_business for %s', ( _label, postalCode ) => {
+		expect( fieldsFor( { country_code: 'US', postal_code: postalCode } ) ).toContain(
+			'is_for_business'
+		);
+	} );
+
+	test.each( [
+		[ 'a postal code just below Ohio', '42999' ],
+		[ 'a postal code just above Ohio', '46000' ],
+		[ 'the Fishers Island gap in the Connecticut range', '06390' ],
+		[ 'a postal code just below Connecticut', '05999' ],
+		[ 'a postal code just above Connecticut', '07000' ],
+		[ 'a California postal code', '94107' ],
+	] )( 'excludes is_for_business for %s', ( _label, postalCode ) => {
+		expect( fieldsFor( { country_code: 'US', postal_code: postalCode } ) ).not.toContain(
+			'is_for_business'
+		);
+	} );
+
+	test( 'excludes is_for_business when no postal code has been entered', () => {
+		expect( fieldsFor( { country_code: 'US', postal_code: '' } ) ).not.toContain(
+			'is_for_business'
+		);
+	} );
+
+	test( 'excludes is_for_business outside the US even if the postal code digits match', () => {
+		expect(
+			fieldsFor( { country_code: 'FR', postal_code: '44101' }, { selectedCountryItem: france } )
+		).not.toContain( 'is_for_business' );
+	} );
+
+	test( 'excludes is_for_business when the caller has not opted in', () => {
+		expect(
+			fieldsFor(
+				{ country_code: 'US', postal_code: '44101' },
+				{ allowIsForBusinessCheckbox: false }
+			)
+		).not.toContain( 'is_for_business' );
+	} );
+} );
+
+describe( '<TaxLocationForm>', () => {
+	beforeEach( () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.persist()
+			.get( ( uri ) => uri.startsWith( '/rest/v1.1/domains/supported-countries' ) )
+			.reply( 200, [ unitedStates, france ] )
+			.get( ( uri ) => uri.startsWith( '/rest/v1.1/domains/supported-states/' ) )
+			.reply( 200, [] );
+	} );
+
+	const ControlledTaxLocationForm = ( {
+		initialData,
+		allowIsForBusinessCheckbox,
+		onDataChange,
+	}: {
+		initialData: StoredPaymentMethodTaxLocation;
+		allowIsForBusinessCheckbox?: boolean;
+		onDataChange?: ( data: StoredPaymentMethodTaxLocation ) => void;
+	} ) => {
+		const [ data, setData ] = useState( initialData );
+		return (
+			<TaxLocationForm
+				data={ data }
+				allowIsForBusinessCheckbox={ allowIsForBusinessCheckbox }
+				onChange={ ( updated ) => {
+					const newData = { ...data, ...updated };
+					setData( newData );
+					onDataChange?.( newData );
+				} }
+			/>
+		);
+	};
+
+	test( 'shows the business use checkbox for an Ohio postal code', async () => {
+		render(
+			<ControlledTaxLocationForm
+				initialData={ { ...defaultTaxLocation, country_code: 'US', postal_code: '44101' } }
+				allowIsForBusinessCheckbox
+			/>
+		);
+
+		expect(
+			await screen.findByRole( 'checkbox', { name: /is this purchase for business/i } )
+		).toBeVisible();
+	} );
+
+	test( 'hides the business use checkbox for a California postal code', async () => {
+		render(
+			<ControlledTaxLocationForm
+				initialData={ { ...defaultTaxLocation, country_code: 'US', postal_code: '94107' } }
+				allowIsForBusinessCheckbox
+			/>
+		);
+
+		await waitFor( () => expect( screen.getByLabelText( 'Postal code' ) ).toBeVisible() );
+		expect(
+			screen.queryByRole( 'checkbox', { name: /is this purchase for business/i } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'reports the business use selection to the caller', async () => {
+		const onDataChange = jest.fn();
+		render(
+			<ControlledTaxLocationForm
+				initialData={ { ...defaultTaxLocation, country_code: 'US', postal_code: '44101' } }
+				allowIsForBusinessCheckbox
+				onDataChange={ onDataChange }
+			/>
+		);
+
+		await userEvent.click(
+			await screen.findByRole( 'checkbox', { name: /is this purchase for business/i } )
+		);
+
+		expect( onDataChange ).toHaveBeenCalledWith(
+			expect.objectContaining( { is_for_business: true } )
+		);
+	} );
+
+	test( 'clears a business use selection once the location stops being eligible', async () => {
+		const onDataChange = jest.fn();
+		render(
+			<ControlledTaxLocationForm
+				initialData={ { ...defaultTaxLocation, country_code: 'US', postal_code: '44101' } }
+				allowIsForBusinessCheckbox
+				onDataChange={ onDataChange }
+			/>
+		);
+
+		await userEvent.click(
+			await screen.findByRole( 'checkbox', { name: /is this purchase for business/i } )
+		);
+		await userEvent.clear( screen.getByLabelText( 'Postal code' ) );
+		await userEvent.type( screen.getByLabelText( 'Postal code' ), '94107' );
+
+		expect( onDataChange ).toHaveBeenLastCalledWith(
+			expect.objectContaining( { postal_code: '94107', is_for_business: undefined } )
+		);
+	} );
+} );

--- a/client/dashboard/me/billing-purchases/payment-methods/assign-new-card-processor.ts
+++ b/client/dashboard/me/billing-purchases/payment-methods/assign-new-card-processor.ts
@@ -32,6 +32,7 @@ export async function assignNewCardProcessor(
 			taxCity?: string;
 			taxOrganization?: string;
 			taxAddress?: string;
+			taxIsForBusiness?: boolean;
 			setupKey?: string;
 		} ) => Promise< unknown >;
 		updateCreditCard: ( params: {
@@ -46,6 +47,7 @@ export async function assignNewCardProcessor(
 			taxCity?: string;
 			taxOrganization?: string;
 			taxAddress?: string;
+			taxIsForBusiness?: boolean;
 			setupKey?: string;
 		} ) => Promise< unknown >;
 	},
@@ -71,6 +73,7 @@ export async function assignNewCardProcessor(
 			organization,
 			address,
 			useForAllSubscriptions,
+			useForBusiness,
 			cardElement,
 		} = submitData;
 
@@ -124,6 +127,7 @@ export async function assignNewCardProcessor(
 				taxCity: city,
 				taxOrganization: organization,
 				taxAddress: address,
+				taxIsForBusiness: useForBusiness,
 				setupKey,
 			} );
 
@@ -141,6 +145,7 @@ export async function assignNewCardProcessor(
 			taxCity: city,
 			taxOrganization: organization,
 			taxAddress: address,
+			taxIsForBusiness: useForBusiness,
 			setupKey,
 		} );
 
@@ -164,5 +169,6 @@ interface NewCardSubmitData {
 	organization?: string;
 	address?: string;
 	useForAllSubscriptions: boolean;
+	useForBusiness?: boolean;
 	cardElement: StripeCardNumberElement;
 }

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
@@ -7,12 +7,11 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { Fragment, useState } from 'react';
 import { useAnalytics } from '../../../app/analytics';
-import InlineSupportLink from '../../../components/inline-support-link';
+import { CheckboxWithSupportLink } from '../../../components/checkbox-with-support-link';
 import {
 	TaxLocationForm,
 	defaultTaxLocation,
@@ -176,21 +175,14 @@ function CreditCardFieldsWrapper( {
 				}
 			/>
 			{ allowUseForAllSubscriptions && (
-				<label>
-					<input
-						type="checkbox"
-						checked={ formData.useForAllSubscriptions }
-						onChange={ ( e ) => handleFieldChange( { useForAllSubscriptions: e.target.checked } ) }
-					/>
-					{ createInterpolateElement(
-						__(
-							'Use this payment method for all subscriptions on my account. <link>Learn more.</link>'
-						),
-						{
-							link: <InlineSupportLink supportContext="payment_method_all_subscriptions" />,
-						}
+				<CheckboxWithSupportLink
+					label={ __(
+						'Use this payment method for all subscriptions on my account. <link>Learn more.</link>'
 					) }
-				</label>
+					supportContext="payment_method_all_subscriptions"
+					checked={ formData.useForAllSubscriptions }
+					onChange={ ( useForAllSubscriptions ) => handleFieldChange( { useForAllSubscriptions } ) }
+				/>
 			) }
 		</VStack>
 	);

--- a/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
+++ b/client/dashboard/me/billing-purchases/payment-methods/credit-card-payment-method.tsx
@@ -13,7 +13,11 @@ import { store as noticesStore } from '@wordpress/notices';
 import { Fragment, useState } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import InlineSupportLink from '../../../components/inline-support-link';
-import { TaxLocationForm, defaultTaxLocation } from '../../../components/tax-location-form';
+import {
+	TaxLocationForm,
+	defaultTaxLocation,
+	isBusinessUseTaxLocation,
+} from '../../../components/tax-location-form';
 import { PaymentMethodImage } from '../payment-method-image';
 import { CreditCardFields } from './credit-card-fields';
 import type { StoredPaymentMethodTaxLocation } from '@automattic/api-core';
@@ -166,6 +170,7 @@ function CreditCardFieldsWrapper( {
 			/>
 			<TaxLocationForm
 				data={ formData.taxLocation }
+				allowIsForBusinessCheckbox
 				onChange={ ( updated ) =>
 					handleFieldChange( { taxLocation: { ...formData.taxLocation, ...updated } } )
 				}
@@ -231,6 +236,9 @@ function CreditCardSubmitButton( {
 			organization: formData.taxLocation.organization,
 			address: formData.taxLocation.address,
 			useForAllSubscriptions: formData.useForAllSubscriptions,
+			useForBusiness: isBusinessUseTaxLocation( formData.taxLocation )
+				? Boolean( formData.taxLocation.is_for_business )
+				: undefined,
 			cardElement,
 		} );
 	};

--- a/client/dashboard/me/billing-purchases/payment-methods/test/assign-new-card-processor.test.ts
+++ b/client/dashboard/me/billing-purchases/payment-methods/test/assign-new-card-processor.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+import { assignNewCardProcessor } from '../assign-new-card-processor';
+import type { Purchase } from '@automattic/api-core';
+import type { StripeConfiguration } from '@automattic/calypso-stripe';
+import type { Stripe, StripeCardNumberElement } from '@stripe/stripe-js';
+
+// The Stripe SDK confirmation step is not an HTTP boundary nock can intercept.
+jest.mock( '@automattic/calypso-stripe', () => ( {
+	confirmStripeSetupIntentAndAttachCard: jest.fn( async () => ( {
+		id: 'seti_123_secret',
+		payment_method: 'pm_123',
+	} ) ),
+} ) );
+
+function setup( { purchase }: { purchase?: Purchase } = {} ) {
+	const saveCreditCard = jest.fn( async () => ( {} ) );
+	const updateCreditCard = jest.fn( async () => ( {} ) );
+
+	const run = ( submitData: Record< string, unknown > ) =>
+		assignNewCardProcessor(
+			{
+				purchase,
+				stripe: {} as Stripe,
+				stripeConfiguration: { processor_id: 'stripe_ie' } as StripeConfiguration,
+				createStripeSetupIntent: async () => ( { setup_intent_id: 'seti_123' } ),
+				saveCreditCard,
+				updateCreditCard,
+			},
+			{
+				countryCode: 'US',
+				postalCode: '44101',
+				useForAllSubscriptions: false,
+				cardElement: {} as StripeCardNumberElement,
+				...submitData,
+			}
+		);
+
+	return { run, saveCreditCard, updateCreditCard };
+}
+
+describe( 'assignNewCardProcessor business use declaration', () => {
+	test( 'sends a positive business use declaration when saving a new card', async () => {
+		const { run, saveCreditCard } = setup();
+
+		await run( { useForBusiness: true } );
+
+		expect( saveCreditCard ).toHaveBeenCalledWith(
+			expect.objectContaining( { taxIsForBusiness: true } )
+		);
+	} );
+
+	test( 'sends a negative business use declaration when the buyer leaves the box unchecked', async () => {
+		const { run, saveCreditCard } = setup();
+
+		await run( { useForBusiness: false } );
+
+		expect( saveCreditCard ).toHaveBeenCalledWith(
+			expect.objectContaining( { taxIsForBusiness: false } )
+		);
+	} );
+
+	test( 'omits the declaration when the location is not eligible for it', async () => {
+		const { run, saveCreditCard } = setup();
+
+		await run( { postalCode: '94107' } );
+
+		expect( saveCreditCard ).toHaveBeenCalledWith(
+			expect.objectContaining( { taxIsForBusiness: undefined } )
+		);
+	} );
+
+	test( 'sends the declaration when replacing the card on an existing purchase', async () => {
+		const { run, updateCreditCard } = setup( { purchase: { ID: 456 } as Purchase } );
+
+		await run( { useForBusiness: true } );
+
+		expect( updateCreditCard ).toHaveBeenCalledWith(
+			expect.objectContaining( { taxIsForBusiness: true } )
+		);
+	} );
+} );

--- a/packages/api-core/src/upgrades/__tests__/mutators.test.ts
+++ b/packages/api-core/src/upgrades/__tests__/mutators.test.ts
@@ -1,0 +1,43 @@
+import nock from 'nock';
+import { updateCreditCard } from '../mutators';
+
+const BASE = 'https://public-api.wordpress.com';
+
+describe( 'updateCreditCard', () => {
+	afterEach( () => nock.cleanAll() );
+
+	const interceptUpdate = () => {
+		let body: Record< string, unknown > | undefined;
+		nock( BASE )
+			.post( '/rest/v1.2/upgrades/123/update-credit-card', ( requestBody ) => {
+				body = requestBody;
+				return true;
+			} )
+			.reply( 200, { success: true, upgrade: {} } );
+		return () => body;
+	};
+
+	test( 'sends a positive business use declaration', async () => {
+		const getBody = interceptUpdate();
+
+		await updateCreditCard( { purchaseId: 123, taxIsForBusiness: true } );
+
+		expect( getBody() ).toMatchObject( { tax_is_for_business: true } );
+	} );
+
+	test( 'sends a negative business use declaration', async () => {
+		const getBody = interceptUpdate();
+
+		await updateCreditCard( { purchaseId: 123, taxIsForBusiness: false } );
+
+		expect( getBody() ).toMatchObject( { tax_is_for_business: false } );
+	} );
+
+	test( 'sends an empty declaration when the buyer was never asked', async () => {
+		const getBody = interceptUpdate();
+
+		await updateCreditCard( { purchaseId: 123 } );
+
+		expect( getBody() ).toMatchObject( { tax_is_for_business: '' } );
+	} );
+} );

--- a/packages/api-core/src/upgrades/mutators.ts
+++ b/packages/api-core/src/upgrades/mutators.ts
@@ -14,6 +14,7 @@ export interface UpdateCreditCardParams {
 	taxCity?: string;
 	taxOrganization?: string;
 	taxAddress?: string;
+	taxIsForBusiness?: boolean;
 	setupKey?: string;
 }
 
@@ -54,6 +55,7 @@ export async function updateCreditCard(
 			tax_city: params.taxCity,
 			tax_organization: params.taxOrganization,
 			tax_address: params.taxAddress,
+			tax_is_for_business: params.taxIsForBusiness ?? '',
 			setup_key: params.setupKey,
 		},
 	} );


### PR DESCRIPTION
Fixes CHE-546

## Proposed Changes

Buyers with an Ohio or Connecticut tax location get a reduced sales tax rate on business purchases, so Calypso's add-new-payment-method flow asks them to declare business use. The Dashboard never implemented that question — the field was left as a `// FIXME: add is_for_business if elligible (two US states)` in `calculateTaxLocationFields()` — so those buyers had no way to declare it and `tax_is_for_business` was never sent. This adds the checkbox and threads the value to the API.

* Add an `is_for_business` field to `TaxLocationForm`, shown only for a US tax location with an Ohio (43000–45999) or Connecticut (06000–06389, 06391–06999) postal code.
* Gate it behind a new `allowIsForBusinessCheckbox` prop; only the new-credit-card form opts in, matching Calypso, where the PayPal fields and the edit-tax-location dialog also omit it.
* Pass `useForBusiness` from the card submit button through `assignNewCardProcessor` to `saveCreditCard` and `updateCreditCard`.
* Add `taxIsForBusiness` to `UpdateCreditCardParams` in `@automattic/api-core` and send it as `tax_is_for_business`. `saveCreditCard` already supported it.
* Clear a previously-made declaration when the location stops being eligible, so a declaration the buyer can no longer see is never submitted.

## Why are these changes being made?

The root cause is not a broken condition — the Dashboard has no such field at all, and the value was dropped at every layer between the form and the request. Calypso's chain runs from the screen (`shouldShowTaxFields`) through `ContactFields` → `TaxFields` → `IsForBusinessCheckbox`, parks the value in the `wpcom-credit-card` data store, and reads it back out in the pay button. The Dashboard's `TaxLocationForm` is a `DataForm`, so the equivalent is a conditionally-included field plus an explicit submit payload; `CreditCardSubmitButton` enumerates its payload field by field and had no entry for it, and `NewCardSubmitData` had no such property.

The eligibility test is ported from Calypso's `shouldShowBusinessOption()` so the two flows agree on exactly which postal codes are asked. Two deliberate differences from Calypso:

* **The declaration is also sent when replacing the card on an existing purchase.** Calypso renders the checkbox on its change-payment-method screen but only forwards the value on the no-purchase branch, so a declaration made while updating a card is silently discarded. A visible control that does nothing seemed worth fixing rather than reproducing, and it matters for the reporter's actual goal — being able to trust a `FALSE` value, where credit card updates are one of the events expected to prompt for it.
* **The declaration is cleared when the location becomes ineligible.** Calypso keeps the store value after the buyer switches to, say, a California postal code, and still submits it. Here it is dropped once the checkbox is hidden.

One loose end left alone: `client/dashboard/me/billing-purchases/payment-methods/stored-payment-method-api.ts` already maps `useForBusiness` → `taxIsForBusiness`, but nothing imports it except the barrel re-export — the live path calls `saveCreditCardMutation` directly. That wrapper looks like an earlier start on this work that got orphaned, and its `updateCreditCard` sibling never got the field. It probably wants deleting, but that felt out of scope here.

## Testing Instructions

TC:

```
yarn test-client client/dashboard/components/test/tax-location-form.test.tsx client/dashboard/me/billing-purchases/payment-methods
yarn jest --config packages/api-core/jest.config.js packages/api-core/src/upgrades
```

The new tests cover the postal-code boundaries on both sides of each range (including the 06390 Fishers Island gap, which is New York), the non-US case, the show/hide and clear-on-ineligible behavior of the checkbox, and the request payload on both the save and update paths.

Manual testing:

* Go to the Dashboard **Add payment method** screen (`/me/billing/payment-methods/add`) and pick **Credit or debit card**.
* Set Country to **United States** and enter postal code `44101` (Cleveland, OH). Confirm an "Is this purchase for business?" checkbox appears below the tax fields with a "Learn more" support link.
* Change the postal code to `94107`. Confirm the checkbox disappears.
* Check the box, then change the postal code to `94107` and back to `44101`. Confirm the box has reset to unchecked.
* Repeat with `06010` (Bristol, CT) — should show — and `06390` — should not.
* Save a card with the box checked and confirm the request to `/me/stored-cards` sends `tax_is_for_business: true`; save another with it unchecked and confirm `false`. From a non-eligible postal code, confirm it sends an empty value.
* Repeat the save check via **Change payment method** on an existing purchase, against `/upgrades/<id>/update-credit-card`.
* Confirm the PayPal fields and the edit-tax-location dialog on the payment methods list are unchanged.

Not yet verified, and worth a look from a reviewer: dark mode, non-English string lengths, and screen-reader behavior of the new checkbox. `Is this purchase for business?` is a new translatable string, so this needs the **[Status] String Freeze** label before merge.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
