### PR TITLE
Dashboard: allow editing the business use declaration from the edit billing address modal

### DIFF
--- a/client/dashboard/me/billing-payment-methods/payment-method-edit-dialog.tsx
+++ b/client/dashboard/me/billing-payment-methods/payment-method-edit-dialog.tsx
@@ -53,6 +53,7 @@ export function PaymentMethodEditDialog( {
 
 				<TaxLocationForm
 					data={ formData }
+					allowIsForBusinessCheckbox
 					onChange={ ( updated ) => {
 						setFormData( ( previous ) => ( { ...previous, ...updated } ) );
 					} }

--- a/client/dashboard/me/billing-payment-methods/test/payment-method-edit-dialog.test.tsx
+++ b/client/dashboard/me/billing-payment-methods/test/payment-method-edit-dialog.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import { PaymentMethodEditDialog } from '../payment-method-edit-dialog';
+import type { StoredPaymentMethod, StoredPaymentMethodTaxLocation } from '@automattic/api-core';
+
+const paymentMethod = {
+	stored_details_id: '12345',
+	name: 'Test Cardholder',
+	card_last_4: '4242',
+	card_type: 'visa',
+	payment_partner: 'stripe',
+	tax_location: { country_code: 'US', postal_code: '43201' },
+} as StoredPaymentMethod;
+
+function renderDialog( {
+	taxLocation,
+	onConfirm = () => {},
+}: {
+	taxLocation?: StoredPaymentMethodTaxLocation;
+	onConfirm?: ( updated: StoredPaymentMethod ) => void;
+} = {} ) {
+	return render(
+		<PaymentMethodEditDialog
+			paymentMethod={
+				taxLocation ? { ...paymentMethod, tax_location: taxLocation } : paymentMethod
+			}
+			isVisible
+			onCancel={ () => {} }
+			onConfirm={ onConfirm }
+		/>
+	);
+}
+
+describe( '<PaymentMethodEditDialog>', () => {
+	beforeEach( () => {
+		nock( 'https://public-api.wordpress.com:443' )
+			.persist()
+			.get( ( uri ) => uri.startsWith( '/rest/v1.1/domains/supported-countries' ) )
+			.reply( 200, [
+				{ code: 'US', name: 'United States', has_postal_codes: true },
+				{ code: 'FR', name: 'France', has_postal_codes: true },
+			] )
+			.get( ( uri ) => uri.startsWith( '/rest/v1.1/domains/supported-states/' ) )
+			.reply( 200, [] );
+	} );
+
+	test( 'offers the business use checkbox for an Ohio billing address', async () => {
+		renderDialog();
+
+		expect(
+			await screen.findByRole( 'checkbox', { name: /is this purchase for business/i } )
+		).toBeVisible();
+	} );
+
+	test( 'hides the business use checkbox for a billing address outside Ohio and Connecticut', async () => {
+		renderDialog( { taxLocation: { country_code: 'US', postal_code: '94107' } } );
+
+		await waitFor( () => expect( screen.getByLabelText( 'Postal code' ) ).toBeVisible() );
+		expect(
+			screen.queryByRole( 'checkbox', { name: /is this purchase for business/i } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'reflects a declaration already stored on the payment method', async () => {
+		renderDialog( {
+			taxLocation: { country_code: 'US', postal_code: '43201', is_for_business: true },
+		} );
+
+		expect(
+			await screen.findByRole( 'checkbox', { name: /is this purchase for business/i } )
+		).toBeChecked();
+	} );
+
+	test( 'saves a new declaration', async () => {
+		const onConfirm = jest.fn();
+		renderDialog( { onConfirm } );
+
+		await userEvent.click(
+			await screen.findByRole( 'checkbox', { name: /is this purchase for business/i } )
+		);
+		await userEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+		expect( onConfirm ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				tax_location: expect.objectContaining( { is_for_business: true } ),
+			} )
+		);
+	} );
+} );

--- a/packages/api-core/src/me-payment-methods/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/me-payment-methods/__tests__/fetchers.test.ts
@@ -1,0 +1,49 @@
+import nock from 'nock';
+import { setPaymentMethodTaxInfo } from '../fetchers';
+import type { StoredPaymentMethodTaxLocation } from '../types';
+
+const BASE = 'https://public-api.wordpress.com';
+
+const ohio: StoredPaymentMethodTaxLocation = {
+	country_code: 'US',
+	postal_code: '43201',
+};
+
+describe( 'setPaymentMethodTaxInfo', () => {
+	afterEach( () => nock.cleanAll() );
+
+	const interceptTaxLocation = () => {
+		let body: Record< string, unknown > | undefined;
+		nock( BASE )
+			.post( '/rest/v1.1/me/payment-methods/12345/tax-location', ( requestBody ) => {
+				body = requestBody;
+				return true;
+			} )
+			.reply( 200, {} );
+		return () => body;
+	};
+
+	test( 'sends a positive business use declaration', async () => {
+		const getBody = interceptTaxLocation();
+
+		await setPaymentMethodTaxInfo( '12345', { ...ohio, is_for_business: true } );
+
+		expect( getBody() ).toMatchObject( { tax_is_for_business: true } );
+	} );
+
+	test( 'sends a negative business use declaration', async () => {
+		const getBody = interceptTaxLocation();
+
+		await setPaymentMethodTaxInfo( '12345', { ...ohio, is_for_business: false } );
+
+		expect( getBody() ).toMatchObject( { tax_is_for_business: false } );
+	} );
+
+	test( 'omits the declaration when none has been made, so the stored value is left alone', async () => {
+		const getBody = interceptTaxLocation();
+
+		await setPaymentMethodTaxInfo( '12345', ohio );
+
+		expect( getBody() ).not.toHaveProperty( 'tax_is_for_business' );
+	} );
+} );

--- a/packages/api-core/src/me-payment-methods/fetchers.ts
+++ b/packages/api-core/src/me-payment-methods/fetchers.ts
@@ -33,6 +33,7 @@ interface TaxInfoForServer {
 	tax_city?: string;
 	tax_organization?: string;
 	tax_address?: string;
+	tax_is_for_business?: boolean;
 }
 
 function transformPaymentMethodTaxInfoForEndpoint(
@@ -45,6 +46,9 @@ function transformPaymentMethodTaxInfoForEndpoint(
 		tax_city: paymentMethodTaxInfo?.city,
 		tax_organization: paymentMethodTaxInfo?.organization,
 		tax_address: paymentMethodTaxInfo?.address,
+		// Left undefined when no declaration has been made, which the endpoint
+		// reads as "leave any stored declaration alone" rather than "clear it".
+		tax_is_for_business: paymentMethodTaxInfo?.is_for_business,
 	};
 }
 


### PR DESCRIPTION
Related to https://linear.app/a8c/issue/CHE-547/

Requires Automattic/wpcom#239505. **Do not merge before that deploys**

## Proposed Changes

This wires the edit tax location modal to allow reading and editing a payment method's "is for business" value (for CT and OH zipcodes).

* Send `tax_is_for_business` from `setPaymentMethodTaxInfo()`, added to `TaxInfoForServer` and `transformPaymentMethodTaxInfoForEndpoint()`.
* Opt the edit billing address modal's `TaxLocationForm` into `allowIsForBusinessCheckbox`.
* Add tests for the fetcher payload and for the modal's show/hide, initial state, and save behaviour.

## Why are these changes being made?

CHE-546 let an Ohio or Connecticut buyer declare business use when *adding* a payment method, so they get the reduced business tax rate those two states apply. The edit billing address modal on the payment methods list could not set the value, so a buyer who got it wrong, or whose circumstances changed, had no way to correct it. Raised in review of #114092.

The gating and the checkbox already exist from CHE-546 — `isBusinessUseTaxLocation()` and the `is_for_business` field in `TaxLocationForm` — so the UI change is a single prop. The real work was on the backend, where `POST /me/payment-methods/<id>/tax-location` did not accept the parameter at all; `$this->input()` returns only declared params, so anything sent was silently discarded.

Omitting the field is meaningful, not just a default: the endpoint reads a missing value as "leave any stored declaration alone" rather than "clear it". That's why `transformPaymentMethodTaxInfoForEndpoint()` passes `is_for_business` straight through as possibly-`undefined` instead of coercing to a boolean — coercing would turn "never declared" into an explicit "no". The fetcher test pins that behaviour.

One thing I looked into and can rule out: the endpoint rebuilds the whole `Tax_Location` object on every save, which looks like it would wipe an existing declaration whenever someone edits their address. It doesn't. `is_for_business` is stored only as a `billing_stored_details_meta` row, the repository skips writing that row when the value is null, and `save_meta()` never deletes keys absent from the update set. So no existing data is at risk either before or after this change.

## Testing Instructions

TC:

```
yarn test-client client/dashboard/me/billing-payment-methods
yarn jest --config packages/api-core/jest.config.js packages/api-core/src/me-payment-methods
```

Manual testing (requires a sandbox with Automattic/wpcom#239505 applied):

* Add a card with an Ohio postal code (e.g. `43201`) and leave the business use box unchecked.
* On the payment methods list, open **Edit billing address** for that card. Confirm the "Is this purchase for business?" checkbox appears with a "Learn more" link, and is unchecked.
* Check it and Save. Reopen the modal and confirm it is still checked, and that the list shows the business-use indicator.
* Uncheck it and Save. Reopen and confirm it is unchecked — the negative declaration should persist rather than reverting to "never declared".
* Change the postal code to `94107` and confirm the checkbox disappears. Save, reopen, and change back to `43201`.
* Confirm the modal is unchanged for a non-US address and for one outside those two states.

Not verified: I have not exercised this against a live sandbox, since the endpoint change isn't deployed yet. Also unverified for this modal specifically: dark mode, non-English string lengths, and screen-reader behaviour of the checkbox — though the component itself is unchanged from #114092, so anything found there would apply to both surfaces. No new translatable strings.
