### PR TITLE
Server: close asset file handles when reads fail

### DIFF
--- a/client/server/middleware/assets.js
+++ b/client/server/middleware/assets.js
@@ -28,13 +28,16 @@ export default () => {
 	let assetsFileModified = 0;
 	async function doReadAssets() {
 		const fd = await open( ASSETS_FILE );
-		const stats = await fd.stat();
-		if ( ! assetsFile || stats.mtimeMs > assetsFileModified ) {
-			assetsFile = JSON.parse( await fd.readFile( 'utf8' ) );
-			assetsFileModified = stats.mtimeMs;
+		try {
+			const stats = await fd.stat();
+			if ( ! assetsFile || stats.mtimeMs > assetsFileModified ) {
+				assetsFile = JSON.parse( await fd.readFile( 'utf8' ) );
+				assetsFileModified = stats.mtimeMs;
+			}
+			return assetsFile;
+		} finally {
+			await fd.close();
 		}
-		await fd.close();
-		return assetsFile;
 	}
 
 	let checking = null;

--- a/client/server/middleware/test/assets.js
+++ b/client/server/middleware/test/assets.js
@@ -1,0 +1,69 @@
+import { open } from 'fs/promises';
+import middlewareAssets from '../assets';
+
+jest.mock( 'fs/promises', () => ( { open: jest.fn() } ) );
+
+describe( 'assets middleware', () => {
+	let file;
+	const assets = { manifests: [], assets: { reader: [ '/calypso/reader.js' ] } };
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		file = {
+			stat: jest.fn().mockResolvedValue( { mtimeMs: 1 } ),
+			readFile: jest.fn().mockResolvedValue( JSON.stringify( assets ) ),
+			close: jest.fn().mockResolvedValue( undefined ),
+		};
+		open.mockResolvedValue( file );
+	} );
+
+	it.each( [ 'stat', 'read', 'parse' ] )(
+		'closes the file after a %s failure and permits the next request to recover',
+		async ( failure ) => {
+			if ( failure === 'stat' ) {
+				file.stat.mockRejectedValueOnce( new Error( 'stat failed' ) );
+			} else if ( failure === 'read' ) {
+				file.readFile.mockRejectedValueOnce( new Error( 'read failed' ) );
+			} else {
+				file.readFile.mockResolvedValueOnce( '{' );
+			}
+			const middleware = middlewareAssets();
+			const next = jest.fn();
+			await middleware( {}, {}, next );
+			expect( next ).toHaveBeenCalledWith( expect.any( Error ) );
+			expect( file.close ).toHaveBeenCalledTimes( 1 );
+
+			const request = {};
+			await middleware( request, {}, jest.fn() );
+			expect( request.getAssets() ).toEqual( assets );
+			expect( file.close ).toHaveBeenCalledTimes( 2 );
+		}
+	);
+
+	it( 'coalesces concurrent reads and reuses unchanged assets until the file changes', async () => {
+		const middleware = middlewareAssets();
+		const first = {};
+		const second = {};
+		await Promise.all( [
+			middleware( first, {}, jest.fn() ),
+			middleware( second, {}, jest.fn() ),
+		] );
+		expect( open ).toHaveBeenCalledTimes( 1 );
+		expect( file.close ).toHaveBeenCalledTimes( 1 );
+		expect( first.getAssets() ).toBe( second.getAssets() );
+
+		const cached = {};
+		await middleware( cached, {}, jest.fn() );
+		expect( file.readFile ).toHaveBeenCalledTimes( 1 );
+		expect( cached.getAssets() ).toBe( first.getAssets() );
+
+		const updatedAssets = { ...assets, manifests: [ 'new runtime' ] };
+		file.stat.mockResolvedValue( { mtimeMs: 2 } );
+		file.readFile.mockResolvedValue( JSON.stringify( updatedAssets ) );
+		const updated = {};
+		await middleware( updated, {}, jest.fn() );
+		expect( updated.getAssets() ).toEqual( updatedAssets );
+		expect( file.readFile ).toHaveBeenCalledTimes( 2 );
+		expect( file.close ).toHaveBeenCalledTimes( 3 );
+	} );
+} );


### PR DESCRIPTION
## Proposed Changes

Close the asset file handle in `finally`, including stat, read, and JSON parse failures.

## Why are these changes being made?

A failed asset manifest read currently leaks its file handle. Cleanup belongs to the same read operation so retries can recover without accumulating open descriptors. Existing unchanged-file caching and concurrent request coalescing remain unchanged.

## Testing Instructions

```bash
yarn test-server --runInBand
```

All 385 server tests and 24 snapshots pass. Three failure/recovery regressions fail against trunk; the added success test covers coalescing and cached reads.

The commands above passed on this independent branch based on trunk `7cc9ee953a3`. Client and package typechecks also passed on the integrated audit. Changed files passed lint. No browser/E2E or full production bundle validation was performed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
