### PR TITLE
JS Utils: build keyBy results without repeated object copies

### DIFF
--- a/packages/js-utils/src/key-by.ts
+++ b/packages/js-utils/src/key-by.ts
@@ -22,7 +22,13 @@ const arrayKeyBy = < T >( array: T[], iteratee: Iteratee< T, PropertyKey > ) =>
 			);
 		}
 
-		return { ...result, [ key ]: value };
+		Object.defineProperty( result, key, {
+			value,
+			writable: true,
+			enumerable: true,
+			configurable: true,
+		} );
+		return result;
 	}, {} );
 
 const collectionKeyBy = < T >(

--- a/packages/js-utils/src/test/key-by.ts
+++ b/packages/js-utils/src/test/key-by.ts
@@ -42,6 +42,63 @@ describe( 'keyBy', () => {
 		expect( keyBy( array, 1 ) ).toEqual( { a: [ 2, 'a' ], b: [ 2, 'b' ] } );
 	} );
 
+	it( 'preserves symbol keys, key order, and the last value on collisions', () => {
+		const symbol = Symbol( 'comment' );
+		const values = [
+			{ key: 'first', value: 1 },
+			{ key: symbol, value: 2 },
+			{ key: 'second', value: 3 },
+			{ key: 'first', value: 4 },
+			{ key: symbol, value: 5 },
+		];
+		const result = keyBy( values, 'key' );
+
+		expect( Reflect.ownKeys( result ) ).toEqual( [ 'first', 'second', symbol ] );
+		expect( result.first ).toBe( values[ 3 ] );
+		expect( result[ symbol ] ).toBe( values[ 4 ] );
+	} );
+
+	it( 'defines prototype-sensitive keys as ordinary own data properties', () => {
+		const value = { key: '__proto__' };
+		const result = keyBy( [ value ], 'key' );
+
+		expect( Object.getPrototypeOf( result ) ).toBe( Object.prototype );
+		expect( Object.getOwnPropertyDescriptor( result, '__proto__' ) ).toEqual( {
+			value,
+			writable: true,
+			enumerable: true,
+			configurable: true,
+		} );
+	} );
+
+	it( 'does not call inherited setters while creating keys', () => {
+		const setter = jest.fn();
+		const key = '__keyByTestSetter__';
+		Object.defineProperty( Object.prototype, key, { set: setter, configurable: true } );
+		try {
+			const value = { key };
+			const result = keyBy( [ value ], 'key' );
+			expect( result[ key ] ).toBe( value );
+			expect( setter ).not.toHaveBeenCalled();
+		} finally {
+			Reflect.deleteProperty( Object.prototype, key );
+		}
+	} );
+
+	it( 'skips sparse slots and calls the iteratee once per present value without mutating input', () => {
+		const values = new Array< { id: string } >( 4 );
+		values[ 1 ] = { id: 'first' };
+		values[ 3 ] = { id: 'second' };
+		Object.freeze( values );
+		const iteratee = jest.fn( ( value: { id: string } | undefined ) => value?.id ?? 'hole' );
+		const result = keyBy( values, iteratee );
+
+		expect( Object.keys( result ) ).toEqual( [ 'first', 'second' ] );
+		expect( iteratee.mock.calls ).toEqual( [ [ values[ 1 ] ], [ values[ 3 ] ] ] );
+		expect( result.first ).toBe( values[ 1 ] );
+		expect( result.second ).toBe( values[ 3 ] );
+	} );
+
 	it( 'should work with an object for `collection`', () => {
 		const actual = keyBy( { a: 6.1, b: 4.2, c: 6.3 }, Math.floor );
 		expect( actual ).toEqual( { '4': 4.2, '6': 6.3 } );


### PR DESCRIPTION
## Proposed Changes

Build `keyBy` results using own data-property definitions on its private accumulator instead of copying the growing object for every item.

## Why are these changes being made?

The existing implementation does quadratic copying for unique keys. Defining each own property once preserves the published signature, last-value-wins behavior, symbols, property descriptors, prototype-sensitive keys, sparse iteration, and input references.

## Testing Instructions

```bash
yarn test-packages packages/js-utils --runInBand
yarn typecheck-packages
```

All 376 js-utils tests pass; 87 existing consumer tests also passed. Extended compatibility cases pass on unchanged trunk. Local synthetic 5,000-item comparison: 1,060 ms → 0.370 ms; 10,000 items: 4,420 ms → 0.756 ms. No application-wide speedup is claimed. ESM and CJS package builds pass.

The commands above passed on this independent branch based on trunk `7cc9ee953a3`. Client and package typechecks also passed on the integrated audit. Changed files passed lint. No browser/E2E or full production bundle validation was performed.


<details>
<summary>Reproduce keyBy compatibility and timing comparison</summary>

Run from the repository root with dependencies installed (Node 24). The script checks equivalence before timing actual source.

```bash
node <<'JS'
const fs = require('fs');
const cp = require('child_process');
const assert = require('assert/strict');
const Module = require('module');
const ts = require(process.cwd() + '/node_modules/typescript');
const target = 'packages/js-utils/src/key-by.ts';
function load(source, name) {
  const code = ts.transpileModule(source, { compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS } }).outputText;
  const mod = new Module(name);
  mod._compile(code, name);
  return mod.exports.default;
}
const baselineRef = process.argv[2] || '9620f4fcdc6';
const baseline = load(cp.execFileSync('git', ['show', `${baselineRef}:${target}`], { encoding: 'utf8' }), 'baseline-key-by.js');
const changed = load(fs.readFileSync(target, 'utf8'), 'changed-key-by.js');
const special = Symbol('special');
const datasets = [[], null, undefined, [1, 2, 3], [1, , 3], [{ id: '__proto__' }, { id: 'constructor' }, { id: special }, { id: '__proto__' }], { first: { id: 'a' }, last: { id: 'a' } }];
let comparisons = 0;
for (const input of datasets) {
  for (const iteratee of ['id', (value) => typeof value === 'object' ? value.id : value]) {
    let expected, actual, expectedError, actualError;
    try { expected = baseline(input, iteratee); } catch (error) { expectedError = error; }
    try { actual = changed(input, iteratee); } catch (error) { actualError = error; }
    if (expectedError || actualError) assert.equal(actualError?.message, expectedError?.message);
    else { assert.deepEqual(Object.getOwnPropertyDescriptors(actual), Object.getOwnPropertyDescriptors(expected)); assert.equal(Object.getPrototypeOf(actual), Object.getPrototypeOf(expected)); }
    comparisons++;
  }
}
function medianTime(fn, input, runs) {
  const measurements = [];
  for (let i = 0; i < 3; i++) fn(input, 'ID');
  for (let i = 0; i < runs; i++) { const start = performance.now(); fn(input, 'ID'); measurements.push(performance.now() - start); }
  measurements.sort((a,b) => a-b);
  return measurements[Math.floor(measurements.length / 2)];
}
const rows=[];
for (const size of [100, 1000, 5000, 10000]) {
  const input=Array.from({length:size}, (_, index) => ({ID:index+1,content:`Comment ${index}`}));
  assert.deepEqual(changed(input,'ID'), baseline(input,'ID'));
  const before=medianTime(baseline,input,9),after=medianTime(changed,input,9);
  rows.push({size,beforeMs:+before.toFixed(3),afterMs:+after.toFixed(3),speedup:+(before/after).toFixed(1)});
}
console.log(JSON.stringify({node:process.version,baseline:cp.execFileSync('git',['rev-parse',baselineRef],{encoding:'utf8'}).trim(),comparisons,rows},null,2));
JS
```

</details>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
