### PR TITLE
Dashboard: scope plugin requests and simplify query-derived choices

### DIFF
--- a/client/dashboard/plugins/plugin/test/use-plugin-requests.test.tsx
+++ b/client/dashboard/plugins/plugin/test/use-plugin-requests.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { marketplaceSearchQuery, pluginsQuery } from '@automattic/api-queries';
+import { QueryClient } from '@tanstack/react-query';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import fetchMock from 'jest-fetch-mock';
+import nock from 'nock';
+import { useState } from 'react';
+import { render } from '../../../test-utils';
+import { usePlugin } from '../use-plugin';
+
+const originalFetch = global.fetch;
+beforeAll( () => {
+	fetchMock.enableMocks();
+	fetchMock.dontMock();
+} );
+afterAll( () => {
+	fetchMock.disableMocks();
+	global.fetch = originalFetch;
+} );
+
+function PluginProbe( { enabled = true }: { enabled?: boolean } ) {
+	const { plugin, icon, isLoading } = usePlugin( 'selected', { enabled } );
+	return (
+		<>
+			<p>{ isLoading ? 'Loading' : 'Ready' }</p>
+			<p>Name: { plugin?.name }</p>
+			<p>Author: { plugin?.author }</p>
+			<p>Icon: { icon }</p>
+		</>
+	);
+}
+
+function ToggleProbe() {
+	const [ enabled, setEnabled ] = useState( false );
+	return (
+		<>
+			<button onClick={ () => setEnabled( true ) }>Open details</button>
+			<PluginProbe enabled={ enabled } />
+		</>
+	);
+}
+
+function cacheIcon( queryClient: QueryClient, groupId = 'wporg' ) {
+	queryClient.setQueryData< unknown >(
+		marketplaceSearchQuery( { slugs: [ 'selected' ], perPage: 20, groupId } ).queryKey,
+		{
+			data: {
+				results: [
+					{ fields: { slug: 'selected', plugin: { icons: 'https://example.com/cached.png' } } },
+				],
+			},
+		}
+	);
+}
+
+function mockPluginSources( { installed = true, status = 200 } = {} ) {
+	return nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.2/me/sites' )
+		.query( true )
+		.reply( 200, { sites: [] } )
+		.get( '/rest/v1.1/me/sites/plugins' )
+		.query( true )
+		.reply( status, {
+			sites: installed
+				? { 1: [ { slug: 'selected', name: 'Installed plugin', author: 'Installed Author' } ] }
+				: {},
+		} )
+		.get( '/rest/v1.2/sites/1/plugins/selected' )
+		.query( true )
+		.reply( 200, {} )
+		.get( '/wpcom/v2/marketplace/products' )
+		.query( true )
+		.reply( 200, { results: {} } );
+}
+
+function mockDirectory() {
+	return nock( 'https://api.wordpress.org' )
+		.get( '/plugins/info/1.2/' )
+		.query( true )
+		.reply( 200, {
+			name: 'Directory plugin',
+			author: '<a href="https://example.com/author">Directory Author</a>',
+			icons: { '1x': 'https://example.com/directory.png' },
+		} );
+}
+
+test( 'uses a cached directory icon without requesting redundant plugin metadata', async () => {
+	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	cacheIcon( queryClient );
+	mockPluginSources();
+	const directory = mockDirectory();
+	render( <PluginProbe />, { queryClient } );
+	await waitFor( () => expect( screen.getByText( 'Ready' ) ).toBeVisible() );
+	expect( screen.getByText( 'Name: Installed plugin' ) ).toBeVisible();
+	expect( screen.getByText( 'Author: Installed Author' ) ).toBeVisible();
+	expect( screen.getByText( 'Icon: https://example.com/cached.png' ) ).toBeVisible();
+	expect( directory.isDone() ).toBe( false );
+} );
+
+test.each( [ 200, 500 ] )(
+	'fetches directory metadata when installed metadata is absent (HTTP %i), despite a cached icon',
+	async ( status ) => {
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		cacheIcon( queryClient );
+		mockPluginSources( { installed: false, status } );
+		const directory = mockDirectory();
+		render( <PluginProbe />, { queryClient } );
+		await waitFor( () => expect( screen.getByText( 'Name: Directory plugin' ) ).toBeVisible() );
+		expect( screen.getByText( 'Author: Directory Author' ) ).toBeVisible();
+		expect( screen.getByText( 'Icon: https://example.com/cached.png' ) ).toBeVisible();
+		expect( directory.isDone() ).toBe( true );
+	}
+);
+
+test( 'does not use marketplace-product icons as directory plugin icons', async () => {
+	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	cacheIcon( queryClient, 'marketplace' );
+	mockPluginSources();
+	const directory = mockDirectory();
+	render( <PluginProbe />, { queryClient } );
+	await waitFor( () => expect( screen.getByText( 'Ready' ) ).toBeVisible() );
+	expect( screen.getByText( 'Icon: https://example.com/directory.png' ) ).toBeVisible();
+	expect( directory.isDone() ).toBe( true );
+} );
+
+test( 'fetches metadata after the last installed copy disappears from the cache', async () => {
+	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	cacheIcon( queryClient );
+	mockPluginSources();
+	const directory = mockDirectory();
+	render( <PluginProbe />, { queryClient } );
+	await waitFor( () => expect( screen.getByText( 'Ready' ) ).toBeVisible() );
+	expect( screen.getByText( 'Author: Installed Author' ) ).toBeVisible();
+	expect( directory.isDone() ).toBe( false );
+	act( () => {
+		queryClient.setQueryData( pluginsQuery().queryKey, { sites: {} } );
+	} );
+	await waitFor( () => expect( screen.getByText( 'Name: Directory plugin' ) ).toBeVisible() );
+	expect( screen.getByText( 'Author: Directory Author' ) ).toBeVisible();
+	expect( directory.isDone() ).toBe( true );
+} );
+
+test( 'defers all detail requests until enabled, even with cached plugins from 100 sites', async () => {
+	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	queryClient.setQueryData< unknown >( pluginsQuery().queryKey, {
+		sites: Object.fromEntries(
+			Array.from( { length: 100 }, ( _, index ) => [
+				index + 1,
+				[ { slug: 'selected', name: 'Installed plugin', author: 'Installed Author' } ],
+			] )
+		),
+	} );
+	let siteRequests = 0;
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( /\/rest\/v1\.2\/sites\/\d+\/plugins\/selected/ )
+		.query( true )
+		.reply( 200, () => {
+			siteRequests++;
+			return {};
+		} );
+	const sources = mockPluginSources();
+	const directory = mockDirectory();
+	render( <ToggleProbe />, { queryClient } );
+	await waitFor( () => expect( screen.getByText( 'Ready' ) ).toBeVisible() );
+	expect( siteRequests ).toBe( 0 );
+	expect( directory.isDone() ).toBe( false );
+	expect( sources.isDone() ).toBe( false );
+	expect( sources.pendingMocks() ).toHaveLength( 4 );
+	await userEvent.click( screen.getByRole( 'button', { name: 'Open details' } ) );
+	await waitFor( () => expect( screen.getByText( 'Ready' ) ).toBeVisible() );
+	expect( siteRequests ).toBeGreaterThan( 0 );
+	expect( directory.isDone() ).toBe( true );
+} );

--- a/client/dashboard/plugins/plugin/test/use-plugin.test.tsx
+++ b/client/dashboard/plugins/plugin/test/use-plugin.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import { usePlugin } from '../use-plugin';
+
+function PluginSummary( { slug }: { slug: string } ) {
+	const { isLoading, sitesWithThisPlugin, sitesWithoutThisPlugin } = usePlugin( slug );
+	if ( isLoading ) {
+		return <p>Loading</p>;
+	}
+	return (
+		<>
+			<p>Installed: { sitesWithThisPlugin.length }</p>
+			<p>Available: { sitesWithoutThisPlugin.length }</p>
+			{ sitesWithThisPlugin.map( ( site ) => (
+				<a key={ site.ID } href={ site.actionLinks?.Settings }>
+					{ site.name }
+				</a>
+			) ) }
+		</>
+	);
+}
+
+test.each( [
+	[ 0, 200 ],
+	[ 1, 200 ],
+	[ 100, 200 ],
+	[ 1, 500 ],
+] )( 'fetches action links for %i installed sites with HTTP %i', async ( installed, status ) => {
+	const sites = Array.from( { length: 100 }, ( _, index ) => ( {
+		ID: index + 1,
+		name: `Site ${ index + 1 }`,
+		URL: `https://site-${ index + 1 }.example`,
+		capabilities: { update_plugins: true },
+	} ) );
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.2/me/sites' )
+		.query( true )
+		.reply( 200, { sites } )
+		.get( '/rest/v1.1/me/sites/plugins' )
+		.query( true )
+		.reply( 200, {
+			sites: Object.fromEntries(
+				sites.map( ( site ) => [
+					site.ID,
+					[ { slug: site.ID <= installed ? 'selected' : 'other', name: 'Plugin', author: '' } ],
+				] )
+			),
+		} )
+		.get( '/wpcom/v2/marketplace/products' )
+		.query( true )
+		.reply( 200, { results: {} } );
+	nock( 'https://api.wordpress.org' ).get( '/plugins/info/1.2/' ).query( true ).reply( 200, {} );
+	const pluginRequests: string[] = [];
+	nock( 'https://public-api.wordpress.com' )
+		.persist()
+		.get( /\/rest\/v1\.2\/sites\/\d+\/plugins\/selected/ )
+		.query( true )
+		.reply( status, ( uri ) => {
+			pluginRequests.push( uri );
+			return { action_links: { Settings: 'https://site-1.example/plugin-settings' } };
+		} );
+
+	render( <PluginSummary slug="selected" /> );
+	await waitFor( () => expect( screen.getByText( `Installed: ${ installed }` ) ).toBeVisible() );
+	expect( screen.getByText( `Available: ${ 100 - installed }` ) ).toBeVisible();
+	expect( pluginRequests ).toHaveLength( installed );
+	const expectedSettingsLink =
+		status === 200
+			? 'https://site-1.example/plugin-settings'
+			: 'https://site-1.example/wp-admin/plugins.php';
+	const expectedFirstLink = installed ? expectedSettingsLink : undefined;
+	expect( screen.queryByRole( 'link', { name: 'Site 1' } )?.getAttribute( 'href' ) ).toBe(
+		expectedFirstLink
+	);
+} );

--- a/client/dashboard/plugins/plugin/use-plugin.ts
+++ b/client/dashboard/plugins/plugin/use-plugin.ts
@@ -47,8 +47,7 @@ const useMarketplaceSearchIcon = ( pluginSlug: string ) => {
 	const queryClient = useQueryClient();
 	const marketplaceSearchPluginData = queryClient
 		.getQueriesData< MarketplaceSearch >( {
-			queryKey: [ 'marketplace-search' ],
-			predicate: ( query ) => query.queryKey.includes( pluginSlug ),
+			queryKey: [ 'marketplace-search', 'wporg' ],
 		} )
 		.flatMap( ( [ , data ] ) => data?.data.results || [] )
 		.find( ( result ) => result.fields.slug === pluginSlug );
@@ -57,7 +56,6 @@ const useMarketplaceSearchIcon = ( pluginSlug: string ) => {
 };
 
 export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: boolean } = {} ) => {
-	const queryClient = useQueryClient();
 	const availableIcon = useMarketplaceSearchIcon( pluginSlug );
 	const { queries } = useAppContext();
 	const locale = useLocale();
@@ -68,34 +66,15 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 		isLoading: isLoadingSitesPlugins,
 		isFetching: isFetchingSitePlugins,
 	} = useQuery( { ...pluginsQuery(), enabled } );
-	const { data: sites, isLoading: isLoadingSites } = useQuery( queries.sitesQuery() );
-	const { data: marketplacePlugins, isLoading: isLoadingMarketplacePlugins } = useQuery(
-		marketplacePluginsQuery()
-	);
-	const isMarketplacePlugin = !! marketplacePlugins?.results[ pluginSlug ];
-	const { data: wpOrgPlugin, isLoading: isLoadingWpOrgPlugin } = useQuery( {
-		...wpOrgPluginQuery( pluginSlug, locale ),
-		enabled: ! availableIcon && hasPluginSlug,
+	const { data: sites, isLoading: isLoadingSites } = useQuery( {
+		...queries.sitesQuery(),
+		enabled,
 	} );
-	// Query needed to get the action_links
-	const sitePluginQueryResults = useQueries( {
-		queries: hasPluginSlug
-			? Object.keys( sitesPlugins?.sites || {} ).map( ( id ) =>
-					sitePluginQuery( Number( id ), pluginSlug )
-			  )
-			: [],
+	const { data: marketplacePlugins, isLoading: isLoadingMarketplacePlugins } = useQuery( {
+		...marketplacePluginsQuery(),
+		enabled,
 	} );
-	const isLoadingSitePlugins = sitePluginQueryResults.some( ( query ) => query.isLoading );
-
-	const actionLinksBySiteId = Object.keys( sitesPlugins?.sites || {} ).reduce( ( acc, siteId ) => {
-		const { queryKey } = sitePluginQuery( Number( siteId ), pluginSlug );
-		const data: SitePlugin | undefined = queryClient.getQueryData( queryKey );
-
-		acc.set( Number( siteId ), data?.action_links );
-
-		return acc;
-	}, new Map< number, SitePlugin[ 'action_links' ] >() );
-
+	const marketplacePlugin = marketplacePlugins?.results[ pluginSlug ];
 	const pluginBySiteId = useMemo(
 		() =>
 			Object.entries( sitesPlugins?.sites || {} ).reduce( ( acc, [ siteId, plugins ] ) => {
@@ -107,15 +86,33 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 			}, new Map< number, PluginItem >() ),
 		[ sitesPlugins, pluginSlug ]
 	);
+	const primaryPlugin = pluginBySiteId.values().next().value ?? marketplacePlugin;
+	const needsPluginMetadata =
+		! primaryPlugin && ! isLoadingSitesPlugins && ! isLoadingMarketplacePlugins;
+	const { data: wpOrgPlugin, isLoading: isLoadingWpOrgPlugin } = useQuery( {
+		...wpOrgPluginQuery( pluginSlug, locale ),
+		enabled: enabled && hasPluginSlug && ( ! availableIcon || needsPluginMetadata ),
+	} );
 
 	const siteIdsWithThisPlugin = Array.from( pluginBySiteId.keys() );
+	// Query needed to get the action_links
+	const sitePluginQueryResults = useQueries( {
+		queries:
+			enabled && hasPluginSlug
+				? siteIdsWithThisPlugin.map( ( id ) => sitePluginQuery( id, pluginSlug ) )
+				: [],
+	} );
+	const isLoadingSitePlugins = sitePluginQueryResults.some( ( query ) => query.isLoading );
+	const actionLinksBySiteId = new Map(
+		siteIdsWithThisPlugin.map( ( id, index ) => [
+			id,
+			sitePluginQueryResults[ index ]?.data?.action_links,
+		] )
+	);
 
 	// Normalize the author per source so consumers get one shape
 	const plugin = useMemo< NormalizedPlugin | undefined >( () => {
-		const raw =
-			pluginBySiteId.values().next().value ??
-			( isMarketplacePlugin ? marketplacePlugins?.results[ pluginSlug ] : undefined ) ??
-			wpOrgPlugin;
+		const raw = primaryPlugin ?? wpOrgPlugin;
 
 		if ( ! raw ) {
 			return undefined;
@@ -131,14 +128,14 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 					undefined
 			),
 		};
-	}, [ pluginBySiteId, isMarketplacePlugin, marketplacePlugins, pluginSlug, wpOrgPlugin ] );
+	}, [ primaryPlugin, wpOrgPlugin ] );
 
 	const [ sitesWithThisPlugin, sitesWithoutThisPlugin ]: [ SiteWithPluginData[], Site[] ] = sites
 		? sites
 				.filter( ( site ) => site.capabilities?.update_plugins )
 				.reduce(
 					( acc, site ) => {
-						if ( siteIdsWithThisPlugin.includes( site.ID ) ) {
+						if ( pluginBySiteId.has( site.ID ) ) {
 							const plugin = pluginBySiteId.get( site.ID );
 
 							const hasPluginUpdate = !! plugin?.update;
@@ -170,8 +167,8 @@ export const usePlugin = ( pluginSlug: string, { enabled = true }: { enabled?: b
 	let icon;
 	if ( availableIcon ) {
 		icon = availableIcon;
-	} else if ( isMarketplacePlugin ) {
-		icon = marketplacePlugins?.results[ pluginSlug ]?.icons;
+	} else if ( marketplacePlugin ) {
+		icon = marketplacePlugin.icons;
 	} else if ( wpOrgPlugin?.icons ) {
 		if ( '1x' in wpOrgPlugin.icons ) {
 			icon = wpOrgPlugin.icons[ '1x' ];

--- a/client/dashboard/plugins/scheduled-updates/hooks/test/use-eligible-plugins.test.tsx
+++ b/client/dashboard/plugins/scheduled-updates/hooks/test/use-eligible-plugins.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { siteCorePluginsQuery } from '@automattic/api-queries';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useEligiblePlugins } from '../use-eligible-plugins';
+import type { CorePlugin } from '@automattic/api-core';
+import type { PropsWithChildren } from 'react';
+
+function plugin( id: string, overrides: Partial< CorePlugin > = {} ): CorePlugin {
+	return {
+		plugin: id,
+		name: id,
+		status: 'active',
+		plugin_uri: '',
+		author: '',
+		author_uri: '',
+		description: '',
+		version: '1.0',
+		network_only: false,
+		requires_wp: '',
+		requires_php: '',
+		textdomain: '',
+		_links: { self: {} },
+		...overrides,
+	};
+}
+
+function setup( sites: Record< number, CorePlugin[] >, selectedSiteIds = [ '1' ] ) {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { staleTime: Infinity, retry: false } },
+	} );
+	const updatedAt = Date.now();
+	for ( const [ siteId, plugins ] of Object.entries( sites ) ) {
+		queryClient.setQueryData( siteCorePluginsQuery( Number( siteId ) ).queryKey, plugins, {
+			updatedAt,
+		} );
+	}
+	const wrapper = ( { children }: PropsWithChildren ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+	return {
+		...renderHook( ( ids ) => useEligiblePlugins( ids ), {
+			initialProps: selectedSiteIds,
+			wrapper,
+		} ),
+		queryClient,
+		updatedAt,
+	};
+}
+
+test( 'switches plugin choices when cached sites have the same update timestamp', async () => {
+	const { result, rerender } = setup( { 1: [ plugin( 'first' ) ], 2: [ plugin( 'second' ) ] } );
+	expect( result.current.map( ( item ) => item.plugin ) ).toEqual( [ 'first.php' ] );
+	rerender( [ '2' ] );
+	await waitFor( () => {
+		expect( result.current.map( ( item ) => item.plugin ) ).toEqual( [ 'second.php' ] );
+	} );
+	rerender( [] );
+	await waitFor( () => expect( result.current ).toEqual( [] ) );
+} );
+
+test( 'reflects changed cache data even when the update timestamp does not change', async () => {
+	const { result, queryClient, updatedAt } = setup( { 1: [ plugin( 'first' ) ] } );
+	act( () => {
+		queryClient.setQueryData( siteCorePluginsQuery( 1 ).queryKey, [ plugin( 'replacement' ) ], {
+			updatedAt,
+		} );
+	} );
+	await waitFor( () => {
+		expect( result.current.map( ( item ) => item.plugin ) ).toEqual( [ 'replacement.php' ] );
+	} );
+} );
+
+test( 'keeps normalization, last-site deduplication, sorting, and managed-plugin exclusion', () => {
+	const { result } = setup(
+		{
+			1: [ plugin( 'shared', { name: 'Old' } ), plugin( 'managed', { is_managed: true } ) ],
+			2: [ plugin( 'shared.php', { name: 'Zebra &amp; Co' } ), plugin( 'alpha' ) ],
+		},
+		[ '1', '2' ]
+	);
+	expect( result.current.map( ( { plugin: id, name } ) => ( { id, name } ) ) ).toEqual( [
+		{ id: 'alpha.php', name: 'alpha' },
+		{ id: 'shared.php', name: 'Zebra & Co' },
+	] );
+} );

--- a/client/dashboard/plugins/scheduled-updates/hooks/use-eligible-plugins.ts
+++ b/client/dashboard/plugins/scheduled-updates/hooks/use-eligible-plugins.ts
@@ -1,41 +1,28 @@
 import { siteCorePluginsQuery } from '@automattic/api-queries';
 import { useQueries } from '@tanstack/react-query';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useMemo } from 'react';
 import type { CorePlugin } from '@automattic/api-core';
 
+function combinePlugins( results: { data?: CorePlugin[] }[] ): CorePlugin[] {
+	const normalized = results
+		.flatMap( ( query ) => query.data ?? [] )
+		.filter( ( plugin ) => ! plugin.is_managed )
+		.map( ( plugin ) => {
+			const pluginFile = plugin.plugin;
+			const canonical = pluginFile?.endsWith( '.php' ) ? pluginFile : `${ pluginFile }.php`;
+			const name = plugin.name ? decodeEntities( plugin.name ) : plugin.name;
+			return { ...plugin, plugin: canonical, name };
+		} );
+
+	const unique = new Map< string, CorePlugin >( normalized.map( ( p ) => [ p.plugin, p ] ) );
+	return Array.from( unique.values() ).sort( ( a, b ) =>
+		( a.name || a.plugin ).localeCompare( b.name || b.plugin )
+	);
+}
+
 export function useEligiblePlugins( selectedSiteIds: string[] ) {
-	const queries = useQueries( {
-		queries: selectedSiteIds.map( ( id ) => ( {
-			...siteCorePluginsQuery( Number( id ) ),
-		} ) ),
+	return useQueries( {
+		queries: selectedSiteIds.map( ( id ) => siteCorePluginsQuery( Number( id ) ) ),
+		combine: combinePlugins,
 	} );
-
-	const updatesKey = queries.map( ( query ) => String( query.dataUpdatedAt ?? 0 ) ).join( '|' );
-
-	return useMemo< CorePlugin[] >( () => {
-		const allPlugins = queries.flatMap( ( query ) => query.data ?? [] );
-		if ( allPlugins.length === 0 ) {
-			return [];
-		}
-		// Normalize to match original behavior:
-		// - Ensure canonical plugin file id ends with .php
-		// - Decode HTML entities in name
-		// - Dedupe by normalized id
-		const normalized = allPlugins
-			.filter( ( plugin ) => ! plugin.is_managed )
-			.map( ( plugin ) => {
-				const pluginFile = plugin.plugin;
-				const canonical = pluginFile?.endsWith( '.php' ) ? pluginFile : `${ pluginFile }.php`;
-				const name = plugin.name ? decodeEntities( plugin.name ) : plugin.name;
-				return { ...plugin, plugin: canonical, name };
-			} );
-
-		const unique = new Map< string, CorePlugin >( normalized.map( ( p ) => [ p.plugin, p ] ) );
-		return Array.from( unique.values() ).sort( ( a, b ) =>
-			( a.name || a.plugin ).localeCompare( b.name || b.plugin )
-		);
-		// We intentionally memoize on updatesKey only; queries array identity changes every render.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ updatesKey ] );
 }


### PR DESCRIPTION
## Proposed Changes

Request plugin action links only for sites with the selected plugin, honor the hook's `enabled` flag for every underlying request, and reuse query results for action links. Use the WordPress.org search cache for icons while separately resolving missing plugin metadata. Replace the scheduled-plugin timestamp surrogate and manual memoization with a stable `useQueries.combine` function.

## Why are these changes being made?

Opening plugin details should not request details from every unrelated site. Disabled mobile-list hooks should not fetch in the background. Cached icons must not suppress name/author metadata, and equal query timestamps must not leave scheduled-plugin choices stale when switching sites.

## Testing Instructions

```bash
yarn test-client client/dashboard/plugins --runInBand --silent
yarn typecheck-client
```
