### PR TITLE
Dashboard: skip purchase queries for inaccessible holding sites

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -46,6 +46,7 @@ import {
 	creditCardHasAlreadyExpired,
 	getRenewalUrlFromPurchase,
 	isAkismetFreeProduct,
+	hasQueryableSite,
 } from '../../../utils/purchase';
 import {
 	getPlanChangeReturnUrls,
@@ -152,6 +153,7 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 	} );
 	const { data: sitePurchases } = useQuery( {
 		...sitePurchasesQuery( purchase.blog_id ?? 0 ),
+		enabled: hasQueryableSite( purchase ),
 	} );
 	const { data: site } = useQuery( {
 		...siteBySlugQuery( purchase.site_slug ?? '' ),

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/purchase-notice.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/purchase-notice.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { sitePurchasesQuery } from '@automattic/api-queries';
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import { purchaseSettingsRoute } from '../../../../app/router/me';
+import { render } from '../../../../test-utils';
+import { PurchaseNotice } from '../purchase-notice';
+import type { Purchase } from '@automattic/api-core';
+
+test.each( [
+	{ blogId: 1, holding: true, expectedRequests: 0 },
+	{ blogId: 0, holding: false, expectedRequests: 0 },
+	{ blogId: 1, holding: false, expectedRequests: 1 },
+] )(
+	'site purchases query for $blogId, holding=$holding',
+	async ( { blogId, holding, expectedRequests } ) => {
+		jest.spyOn( purchaseSettingsRoute, 'useSearch' ).mockReturnValue( {} );
+		jest.spyOn( purchaseSettingsRoute, 'useNavigate' ).mockReturnValue( jest.fn() );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/preferences' )
+			.query( true )
+			.reply( 200, { calypso_preferences: {} } );
+		const scope = nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/upgrades' )
+			.query( { site: blogId } )
+			.reply( 200, [] );
+		const purchase = {
+			ID: 10,
+			blog_id: blogId,
+			is_attached_to_holding_site: holding,
+			product_slug: 'akismet_free',
+			product_name: 'Akismet',
+			subscription_status: 'active',
+			expiry_status: 'auto-renewing',
+			is_auto_renew_enabled: true,
+		} as Purchase;
+		const { queryClient } = render(
+			<>
+				<PurchaseNotice purchase={ purchase } />
+				<p>Ready</p>
+			</>
+		);
+		await waitFor( () => expect( screen.getByText( 'Ready' ) ).toBeVisible() );
+		await waitFor( () => {
+			expect(
+				queryClient.getQueryState( sitePurchasesQuery( blogId ).queryKey )?.fetchStatus
+			).toBe( 'idle' );
+		} );
+		expect( Number( scope.isDone() ) ).toBe( expectedRequests );
+	}
+);


### PR DESCRIPTION
## Proposed Changes

Gate the site-purchases query with the existing `hasQueryableSite` condition.

## Why are these changes being made?

Holding-site and missing-site purchases cannot provide a queryable site. These notices currently request site purchases anyway. The notice should respect the existing distinction between purchase ownership and site access.

## Testing Instructions

```bash
yarn test-client client/dashboard/me/billing-purchases/purchase-settings/test --runInBand --silent
yarn typecheck-client
```

New tests reproduce requests for holding/missing site IDs on trunk and confirm zero after the change. The real-site control still fetches. Notice content and renewal routes are unchanged.

The commands above passed on this independent branch based on trunk `7cc9ee953a3`. Client and package typechecks also passed on the integrated audit. Changed files passed lint. No browser/E2E or full production bundle validation was performed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
