### PR TITLE
Calypso: isolate query variants and derive current viewer details

### DIFF
--- a/client/data/site-profiler/test/performance-queries.test.tsx
+++ b/client/data/site-profiler/test/performance-queries.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useUrlPerformanceInsightsQuery } from '../use-url-performance-insights';
+import { useUrlPerformanceMetricsQuery } from '../use-url-performance-metrics-query';
+import type { PropsWithChildren } from 'react';
+
+const mockGet = jest.fn();
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: { get: ( ...args: unknown[] ) => mockGet( ...args ) },
+} ) );
+
+let queryClient: QueryClient;
+beforeEach( () => {
+	queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	mockGet.mockReset();
+} );
+afterEach( () => queryClient.clear() );
+
+function wrapper( { children }: PropsWithChildren ) {
+	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+}
+
+test.each( [ 'metrics', 'insights' ] )(
+	'keeps performance responses separate when %s loads first',
+	async ( first ) => {
+		const metrics = { webtestpage_org: { status: 'completed', report: { performance: 91 } } };
+		const insights = {
+			pagespeed: { status: 'completed', mobile: 'report', desktop: 'report' },
+			wpscan: { status: 'completed' },
+		};
+		mockGet.mockImplementation( ( { path } ) =>
+			Promise.resolve( path.endsWith( '/insights' ) ? insights : metrics )
+		);
+		const hooks =
+			first === 'metrics'
+				? [ useUrlPerformanceMetricsQuery, useUrlPerformanceInsightsQuery ]
+				: [ useUrlPerformanceInsightsQuery, useUrlPerformanceMetricsQuery ];
+		const firstHook = renderHook( () => hooks[ 0 ]( 'https://example.com', 'scan-hash' ), {
+			wrapper,
+		} );
+		const secondHook = renderHook( () => hooks[ 1 ]( 'https://example.com', 'scan-hash' ), {
+			wrapper,
+		} );
+		await waitFor( () => {
+			expect( firstHook.result.current.isSuccess ).toBe( true );
+			expect( secondHook.result.current.isSuccess ).toBe( true );
+		} );
+		expect( firstHook.result.current.data ).toEqual(
+			first === 'metrics' ? metrics.webtestpage_org.report : insights
+		);
+		expect( secondHook.result.current.data ).toEqual(
+			first === 'metrics' ? insights : metrics.webtestpage_org.report
+		);
+		expect( mockGet ).toHaveBeenCalledTimes( 2 );
+	}
+);

--- a/client/data/site-profiler/use-url-performance-insights.ts
+++ b/client/data/site-profiler/use-url-performance-insights.ts
@@ -4,7 +4,7 @@ import { UrlPerformanceInsightsQueryResponse } from './types';
 
 export const useUrlPerformanceInsightsQuery = ( url?: string, hash?: string ) => {
 	return useQuery< UrlPerformanceInsightsQueryResponse >( {
-		queryKey: [ 'url', 'performance', url, hash ],
+		queryKey: [ 'url', 'performance-insights', url, hash ],
 		queryFn: () =>
 			wp.req.get(
 				{

--- a/client/data/users/test/use-users-query.test.tsx
+++ b/client/data/users/test/use-users-query.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import useDeleteUserMutation from '../use-delete-user-mutation';
+import useUsersQuery from '../use-users-query';
+
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: {
+		get: ( ...args: unknown[] ) => mockGet( ...args ),
+		post: ( ...args: unknown[] ) => mockPost( ...args ),
+	},
+} ) );
+
+function renderUsers( pages: { users: { ID: number; display_name: string }[]; found: number }[] ) {
+	const queryClient = new QueryClient();
+	const data = { pages, pageParams: pages.map( ( _, index ) => index * 100 ) };
+	queryClient.setQueryData( [ 'users', 123, {} ], data );
+	const wrapper = ( { children }: { children: ReactNode } ) =>
+		createElement( QueryClientProvider, { client: queryClient }, children );
+	const hook = renderHook( () => useUsersQuery( 123, {}, { enabled: false } ), { wrapper } );
+	return { ...hook, queryClient, data };
+}
+
+describe( 'useUsersQuery', () => {
+	beforeEach( () => {
+		mockGet.mockReset();
+		mockPost.mockReset();
+	} );
+
+	it( 'isolates simultaneous user lists with different role filters', async () => {
+		mockGet.mockImplementation( ( _, options ) =>
+			Promise.resolve( {
+				users: [
+					{
+						ID: options.authors_only ? 1 : 2,
+						display_name: options.authors_only ? 'Author' : 'Administrator',
+					},
+				],
+				found: 1,
+			} )
+		);
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+		const wrapper = ( { children }: { children: ReactNode } ) =>
+			createElement( QueryClientProvider, { client: queryClient }, children );
+		const { result } = renderHook(
+			() => ( {
+				authors: useUsersQuery( 123, { authors_only: 1 } ),
+				administrators: useUsersQuery( 123, { role: 'administrator' } ),
+			} ),
+			{ wrapper }
+		);
+
+		await waitFor( () => {
+			expect( result.current.authors.data?.users ).toEqual( [ { ID: 1, display_name: 'Author' } ] );
+			expect( result.current.administrators.data?.users ).toEqual( [
+				{ ID: 2, display_name: 'Administrator' },
+			] );
+		} );
+		expect( mockGet ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'invalidates every list for the deleted user’s site while retaining other sites', async () => {
+		mockPost.mockResolvedValue( {} );
+		const queryClient = new QueryClient();
+		const keys = [
+			[ 'users', 123, { authors_only: 1 } ],
+			[ 'users', 123, { role: 'administrator' } ],
+			[ 'users', 456, {} ],
+		];
+		keys.forEach( ( key ) => queryClient.setQueryData( key, { pages: [], pageParams: [] } ) );
+		const wrapper = ( { children }: { children: ReactNode } ) =>
+			createElement( QueryClientProvider, { client: queryClient }, children );
+		const { result } = renderHook( () => useDeleteUserMutation( 123 ), { wrapper } );
+
+		act( () => {
+			result.current.deleteUser( 1, {} );
+		} );
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( keys.map( ( key ) => queryClient.getQueryState( key )?.isInvalidated ) ).toEqual( [
+			true,
+			true,
+			false,
+		] );
+	} );
+
+	it( 'keeps the first user for duplicate IDs across pages without modifying cached pages', () => {
+		const firstUser = { ID: 1, display_name: 'First role' };
+		const secondUser = { ID: 2, display_name: 'Second user' };
+		const pages = [
+			{ users: [ firstUser, { ID: 1, display_name: 'Other role' } ], found: 4 },
+			{ users: [ secondUser, { ID: 1, display_name: 'Viewer role' } ], found: 4 },
+		];
+		const { result, queryClient, data } = renderUsers( pages );
+
+		expect( result.current.data?.users ).toEqual( [ firstUser, secondUser ] );
+		expect( result.current.data?.users[ 0 ] ).toBe( firstUser );
+		expect( result.current.data?.total ).toBe( 2 );
+		expect( result.current.data?.pages ).toBe( pages );
+		expect( result.current.data?.pageParams ).toBe( data.pageParams );
+		expect( queryClient.getQueryData( [ 'users', 123, {} ] ) ).toEqual( data );
+		expect( pages.map( ( page ) => page.users.length ) ).toEqual( [ 2, 2 ] );
+	} );
+
+	it( 'reports zero loaded users for an empty page', () => {
+		const { result } = renderUsers( [ { users: [], found: 0 } ] );
+
+		expect( result.current.data?.users ).toEqual( [] );
+		expect( result.current.data?.total ).toBe( 0 );
+	} );
+} );

--- a/client/data/users/use-users-query.js
+++ b/client/data/users/use-users-query.js
@@ -12,10 +12,8 @@ const extractPages = ( pages = [] ) => pages.flatMap( ( page ) => page.users );
 const compareUnique = ( a, b ) => a.ID === b.ID;
 
 const useUsersQuery = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
-	const { search } = fetchOptions;
-
 	return useInfiniteQuery( {
-		queryKey: [ 'users', siteId, search ],
+		queryKey: [ 'users', siteId, fetchOptions ],
 		queryFn: ( { pageParam } ) =>
 			wpcom.req.get( `/sites/${ siteId }/users`, {
 				...defaults,
@@ -39,8 +37,8 @@ const useUsersQuery = ( siteId, fetchOptions = {}, queryOptions = {} ) => {
 			 */
 			const users = uniqueBy( extractPages( data.pages ), compareUnique );
 			return {
-				users: uniqueBy( extractPages( data.pages ), compareUnique ),
-				total: users?.length ?? data.pages[ 0 ].found,
+				users,
+				total: users.length,
 				...data,
 			};
 		},

--- a/client/data/viewers/test/use-viewer-query.test.tsx
+++ b/client/data/viewers/test/use-viewer-query.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import useViewerQuery from '../use-viewer-query';
+import type { PropsWithChildren } from 'react';
+
+const mockGet = jest.fn();
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: { get: ( ...args: unknown[] ) => mockGet( ...args ) },
+} ) );
+
+let queryClient: QueryClient;
+beforeEach( () => {
+	queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+	mockGet.mockReset();
+} );
+afterEach( () => queryClient.clear() );
+
+function wrapper( { children }: PropsWithChildren ) {
+	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+}
+
+test( 'keeps the same viewer’s site-specific invitation data separate', async () => {
+	const first = { ID: 42, invite_key: 'site-one-invite' };
+	const second = { ID: 42, invite_key: 'site-two-invite' };
+	mockGet.mockImplementation( ( { path } ) =>
+		Promise.resolve( path.includes( '/sites/1/' ) ? first : second )
+	);
+	const firstHook = renderHook( () => useViewerQuery( 1, 42 ), { wrapper } );
+	const secondHook = renderHook( () => useViewerQuery( 2, 42 ), { wrapper } );
+	await waitFor( () => {
+		expect( firstHook.result.current.isSuccess ).toBe( true );
+		expect( secondHook.result.current.isSuccess ).toBe( true );
+	} );
+	expect( firstHook.result.current.data ).toEqual( first );
+	expect( secondHook.result.current.data ).toEqual( second );
+	expect( mockGet ).toHaveBeenCalledTimes( 2 );
+} );

--- a/client/data/viewers/use-viewer-query.js
+++ b/client/data/viewers/use-viewer-query.js
@@ -3,7 +3,7 @@ import wpcom from 'calypso/lib/wp';
 
 const useViewerQuery = ( siteId, userId ) => {
 	return useQuery( {
-		queryKey: [ 'viewer', userId ],
+		queryKey: [ 'viewer', siteId, userId ],
 		queryFn: () =>
 			wpcom.req.get( {
 				path: `/sites/${ siteId }/viewer/${ userId }?http_envelope=1`,

--- a/client/my-sites/people/viewer-details/index.tsx
+++ b/client/my-sites/people/viewer-details/index.tsx
@@ -1,7 +1,6 @@
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
 import QuerySiteInvites from 'calypso/components/data/query-site-invites';
 import EmptyContent from 'calypso/components/empty-content';
 import HeaderCake from 'calypso/components/header-cake';
@@ -18,7 +17,6 @@ import { deleteInvite } from 'calypso/state/invites/actions';
 import { getAcceptedInvitesForSite } from 'calypso/state/invites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { Member } from '@automattic/data-stores';
-import type { Invite } from 'calypso/my-sites/people/team-invites/types';
 
 interface Props {
 	userId: string;
@@ -33,33 +31,12 @@ export default function ViewerDetails( props: Props ) {
 	const acceptedInvites = useSelector( ( state ) =>
 		getAcceptedInvitesForSite( state, site?.ID as number )
 	);
-	const [ invite, setInvite ] = useState< Invite >();
-	const [ templateState, setTemplateState ] = useState( 'loading' );
 	const { data: viewer, isLoading } = useViewerQuery( site?.ID, userId ) as {
 		data: Member;
 		isLoading: boolean;
 	};
 	const { removeViewer } = useRemoveViewer();
-
-	useEffect( () => checkTemplateState(), [ viewer ] );
-	useEffect( () => findInviteObject(), [ acceptedInvites, viewer ] );
-
-	function findInviteObject() {
-		const inv =
-			viewer && acceptedInvites && acceptedInvites.find( ( x ) => x.key === viewer.invite_key );
-
-		inv && setInvite( inv );
-	}
-
-	function checkTemplateState() {
-		if ( isLoading ) {
-			setTemplateState( 'loading' );
-		} else if ( ! viewer ) {
-			setTemplateState( 'not-found' );
-		} else {
-			setTemplateState( 'default' );
-		}
-	}
+	const invite = viewer && acceptedInvites?.find( ( entry ) => entry.key === viewer.invite_key );
 
 	function onRemove() {
 		dispatch( recordGoogleEvent( 'People', 'Clicked Remove Viewer Button On Viewer Details' ) );
@@ -69,8 +46,12 @@ export default function ViewerDetails( props: Props ) {
 	function onRemoveAccept() {
 		// since we show the full user details with the invite information,
 		// the button Remove simultaneously calls, remove the viewer | delete the invite
-		viewer && removeViewer( site?.ID, viewer.ID );
-		invite && dispatch( deleteInvite( site?.ID, invite.key ) );
+		if ( viewer ) {
+			removeViewer( site?.ID, viewer.ID );
+		}
+		if ( invite ) {
+			dispatch( deleteInvite( site?.ID, invite.key ) );
+		}
 		goBack();
 	}
 
@@ -120,17 +101,17 @@ export default function ViewerDetails( props: Props ) {
 				{ translate( 'User Details' ) }
 			</HeaderCake>
 
-			{ templateState === 'loading' && (
+			{ isLoading && (
 				<Card>
 					<PeopleListItem key="people-list-item-placeholder" />
 				</Card>
 			) }
 
-			{ templateState === 'not-found' && (
+			{ ! isLoading && ! viewer && (
 				<EmptyContent title={ translate( 'The requested subscriber does not exist.' ) } />
 			) }
 
-			{ templateState === 'default' && (
+			{ ! isLoading && viewer && (
 				<Card className="member-details">
 					<PeopleListItem
 						key={ `viewer-details-${ viewer.ID }` }

--- a/client/my-sites/people/viewer-details/test/index.tsx
+++ b/client/my-sites/people/viewer-details/test/index.tsx
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import ViewerDetails from '../index';
+import type { PropsWithChildren } from 'react';
+
+let mockViewer: { data: { ID: number; invite_key: string } | undefined; isLoading: boolean };
+const mockInvites = [
+	{ key: 'first', invitedBy: { name: 'Previous inviter', login: 'previous' } },
+];
+
+jest.mock( 'i18n-calypso', () => ( { useTranslate: () => ( text: string ) => text } ) );
+jest.mock( '@automattic/calypso-router', () => ( { back: jest.fn() } ) );
+jest.mock( '@automattic/components', () => ( {
+	Card: ( { children }: PropsWithChildren ) => <>{ children }</>,
+} ) );
+jest.mock( 'calypso/components/main', () => ( { children }: PropsWithChildren ) => (
+	<>{ children }</>
+) );
+jest.mock( 'calypso/components/header-cake', () => ( { children }: PropsWithChildren ) => (
+	<>{ children }</>
+) );
+jest.mock( 'calypso/components/empty-content', () => ( { title }: { title: string } ) => (
+	<h2>{ title }</h2>
+) );
+jest.mock( 'calypso/components/data/query-site-invites', () => () => null );
+jest.mock( 'calypso/lib/analytics/page-view-tracker', () => () => null );
+jest.mock( 'calypso/lib/accept', () => jest.fn() );
+jest.mock( 'calypso/components/localized-moment', () => ( {
+	useLocalizedMoment: () => jest.requireActual( 'moment' ),
+} ) );
+jest.mock( 'calypso/data/viewers/use-viewer-query', () => () => mockViewer );
+jest.mock( 'calypso/data/viewers/use-remove-viewer-mutation', () => () => ( {
+	removeViewer: jest.fn(),
+} ) );
+jest.mock( 'calypso/state', () => ( {
+	useDispatch: () => jest.fn(),
+	useSelector: ( selector: ( state: object ) => unknown ) => selector( {} ),
+} ) );
+jest.mock( 'calypso/state/ui/selectors', () => ( { getSelectedSite: () => ( { ID: 1 } ) } ) );
+jest.mock( 'calypso/state/invites/selectors', () => ( {
+	getAcceptedInvitesForSite: () => mockInvites,
+} ) );
+jest.mock( 'calypso/state/invites/actions', () => ( { deleteInvite: jest.fn() } ) );
+jest.mock( 'calypso/state/analytics/actions', () => ( { recordGoogleEvent: jest.fn() } ) );
+jest.mock(
+	'calypso/my-sites/people/people-list-item',
+	() =>
+		( { user }: { user?: { ID: number } } ) => (
+			<p>{ user ? `Viewer ${ user.ID }` : 'Loading viewer' }</p>
+		)
+);
+
+test( 'shows not-found when loading finishes without a viewer', () => {
+	mockViewer = { data: undefined, isLoading: true };
+	const { rerender } = render( <ViewerDetails userId="42" /> );
+	expect( screen.getByText( 'Loading viewer' ) ).toBeVisible();
+	mockViewer = { data: undefined, isLoading: false };
+	rerender( <ViewerDetails userId="42" /> );
+	expect( screen.getByText( 'The requested subscriber does not exist.' ) ).toBeVisible();
+} );
+
+test( 'does not retain the previous viewer’s invitation after switching viewers', () => {
+	mockViewer = { data: { ID: 42, invite_key: 'first' }, isLoading: false };
+	const { rerender } = render( <ViewerDetails userId="42" /> );
+	expect( screen.getByText( /Previous inviter/ ) ).toBeVisible();
+	mockViewer = { data: { ID: 43, invite_key: 'missing' }, isLoading: false };
+	rerender( <ViewerDetails userId="43" /> );
+	expect( screen.getByText( 'Viewer 43' ) ).toBeVisible();
+	expect( screen.queryByText( /Previous inviter/ ) ).not.toBeInTheDocument();
+} );


### PR DESCRIPTION
## Proposed Changes

Include all user-list fetch options in the query key, include site ID in individual viewer keys, and give performance insights a key distinct from performance metrics. Reuse the deduplicated user list and derive viewer rendering/invite metadata directly from current query and Redux data.

## Why are these changes being made?

Concurrent role-filtered user lists, viewers on different sites, and incompatible performance response shapes currently share cache entries. ViewerDetails also retains stale invite metadata and can remain in loading state after an empty result because derived state is copied through effects. Removing that state fixes both transitions.

## Testing Instructions

```bash
yarn test-client client/data/users/test client/data/viewers/test client/data/site-profiler/test/performance-queries.test.tsx client/my-sites/people --runInBand --silent
yarn typecheck-client
```

Regressions fail against trunk for role collisions, cross-site viewer metadata, both performance fetch orders, empty viewer loading completion, and switching to a viewer without a matching invite. User deletion still invalidates all variants through `['users', siteId]`. Old user/viewer cache keys cause a fresh fetch; performance queries remain unpersisted. Deduplication keeps first-ID-wins and loaded-user totals.

The commands above passed on this independent branch based on trunk `7cc9ee953a3`. Client and package typechecks also passed on the integrated audit. Changed files passed lint. No browser/E2E or full production bundle validation was performed.


<details>
<summary>Reproduce user-list selector comparison</summary>

Run from the repository root with dependencies installed (Node 24). The script checks equivalence before timing actual source.

```bash
node --input-type=module <<'JS'
import fs from 'node:fs';
import { execFileSync } from 'node:child_process';
import assert from 'node:assert/strict';
import { performance } from 'node:perf_hooks';
const root = process.cwd();
const { default: uniqueBy } = await import(root + '/packages/js-utils/src/unique-by.ts');
const file = 'client/data/users/use-users-query.js';
function load(source) {
 const code = source.replace(/^import .*;\n/gm, '').replace('export const defaults', 'const defaults').replace('export default useUsersQuery;', 'return useUsersQuery;');
 return new Function('uniqueBy', 'useInfiniteQuery', 'wpcom', code)(uniqueBy, options=>options, {}).call(null, 123).select;
}
const baseline=load(execFileSync('git',['show','9620f4fcdc6:'+file],{encoding:'utf8'}));
const current=load(fs.readFileSync(file,'utf8'));
const median=values=>values.sort((a,b)=>a-b)[Math.floor(values.length/2)];
for (const count of [100,1000,5000]) {
 const users=Array.from({length:count},(_,ID)=>({ID,display_name:'User '+ID}));
 const data={pages:Array.from({length:Math.ceil(count/100)},(_,i)=>({users:users.slice(i*100,i*100+100),found:count})),pageParams:[]};
 assert.deepEqual(current(data),baseline(data));
 for(let i=0;i<10;i++){baseline(data);current(data);}
 const times={trunk:[],changed:[]};
 for(let i=0;i<25;i++)for(const [name,select] of i%2 ? [['changed',current],['trunk',baseline]]:[['trunk',baseline],['changed',current]]){
  const start=performance.now();select(data);times[name].push(performance.now()-start);
 }
 const before=median(times.trunk),after=median(times.changed);
 console.log(JSON.stringify({users:count,trunkMedianMs:+before.toFixed(3),changedMedianMs:+after.toFixed(3),speedup:+(before/after).toFixed(2)}));
}
JS
```

</details>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
