### PR TITLE
Calypso: remove redundant collection work in data updates

### DIFF
--- a/client/data/plugins/test/use-update-schedules-query.test.tsx
+++ b/client/data/plugins/test/use-update-schedules-query.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { createElement, type ReactNode } from 'react';
+import {
+	useMultisiteUpdateScheduleQuery,
+	type MultisiteSchedulesUpdatesResponse,
+	type ScheduleUpdates,
+} from '../use-update-schedules-query';
+
+jest.mock( 'calypso/components/localized-moment', () => ( {
+	useLocalizedMoment: () => jest.requireActual( 'moment' ),
+} ) );
+jest.mock( 'calypso/state', () => ( {
+	useSelector: () => [
+		{ ID: 1, slug: 'first-site' },
+		{ ID: 2, slug: 'second-site' },
+	],
+} ) );
+jest.mock( 'calypso/state/selectors/get-sites', () => jest.fn() );
+jest.mock( 'wpcom-proxy-request', () => jest.fn() );
+
+const timestamp = 1700000000;
+const schedule = ( overrides: Partial< ScheduleUpdates > = {} ): ScheduleUpdates => ( {
+	id: 'daily',
+	schedule: 'daily',
+	interval: 86400,
+	timestamp,
+	args: [ 'first-plugin' ],
+	active: true,
+	last_run_timestamp: null,
+	last_run_status: null,
+	...overrides,
+} );
+
+function renderSchedules( data: MultisiteSchedulesUpdatesResponse ) {
+	const queryClient = new QueryClient();
+	queryClient.setQueryData( [ 'multisite-schedules-update' ], data );
+	const wrapper = ( { children }: { children: ReactNode } ) =>
+		createElement( QueryClientProvider, { client: queryClient }, children );
+	return renderHook( () => useMultisiteUpdateScheduleQuery( false ), { wrapper } );
+}
+
+describe( 'useMultisiteUpdateScheduleQuery', () => {
+	it( 'groups matching local times across dates while preserving first schedule metadata and site status', () => {
+		const data: MultisiteSchedulesUpdatesResponse = {
+			sites: {
+				1: { daily: schedule() },
+				2: {
+					daily: schedule( {
+						timestamp: timestamp + 86400,
+						args: [ 'second-plugin' ],
+						active: false,
+						last_run_status: 'failure',
+					} ),
+				},
+			},
+		};
+		const original = structuredClone( data );
+		const { result } = renderSchedules( data );
+
+		expect( result.current.data ).toHaveLength( 1 );
+		expect( result.current.data?.[ 0 ] ).toMatchObject( {
+			schedule_id: 'daily',
+			timestamp,
+			args: [ 'first-plugin' ],
+			sites: [
+				{ ID: 1, slug: 'first-site', active: true, last_run_status: null },
+				{ ID: 2, slug: 'second-site', active: false, last_run_status: 'failure' },
+			],
+		} );
+		expect( data ).toEqual( original );
+	} );
+
+	it( 'keeps different IDs and intervals separate and sorts daily before weekly with stable timestamp ties', () => {
+		const { result } = renderSchedules( {
+			sites: {
+				1: {
+					weekly: schedule( { schedule: 'weekly', interval: 604800 } ),
+					later: schedule( { timestamp: timestamp + 3600 } ),
+					first: schedule(),
+					second: schedule(),
+				},
+				2: { first: schedule( { interval: 172800 } ) },
+			},
+		} );
+
+		expect( result.current.data?.map( ( item ) => [ item.schedule_id, item.interval ] ) ).toEqual( [
+			[ 'first', 86400 ],
+			[ 'second', 86400 ],
+			[ 'first', 172800 ],
+			[ 'later', 86400 ],
+			[ 'weekly', 604800 ],
+		] );
+	} );
+
+	it( 'returns no groups for an empty response', () => {
+		const { result } = renderSchedules( { sites: {} } );
+		expect( result.current.data ).toEqual( [] );
+	} );
+} );

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -117,7 +117,7 @@ export const useMultisiteUpdateScheduleQuery = (
 		enabled: isEligibleForFeature,
 		retry: false,
 		select: ( data ) => {
-			const result: MultisiteSchedulesUpdates[] = [];
+			const schedulesById = new Map< string, MultisiteSchedulesUpdates >();
 
 			for ( const site_id in data.sites ) {
 				for ( const scheduleId in data.sites[ site_id ] ) {
@@ -133,10 +133,7 @@ export const useMultisiteUpdateScheduleQuery = (
 
 					const id = generateId( scheduleId, timestamp, schedule, interval );
 
-					const existingSchedule = result.find(
-						( item ) =>
-							generateId( item.schedule_id, item.timestamp, item.schedule, item.interval ) === id
-					);
+					const existingSchedule = schedulesById.get( id );
 
 					const site = retrieveSite( parseInt( site_id, 10 ) ) as SiteDetails;
 					if ( existingSchedule ) {
@@ -147,7 +144,7 @@ export const useMultisiteUpdateScheduleQuery = (
 							last_run_timestamp,
 						} );
 					} else {
-						result.push( {
+						schedulesById.set( id, {
 							id,
 							schedule_id: scheduleId,
 							timestamp,
@@ -166,6 +163,8 @@ export const useMultisiteUpdateScheduleQuery = (
 					}
 				}
 			}
+
+			const result = [ ...schedulesById.values() ];
 
 			// sort by schedule (daily/weekly) then timestamp
 			result.sort( ( a, b ) => {

--- a/client/lib/query-manager/index.js
+++ b/client/lib/query-manager/index.js
@@ -1,4 +1,3 @@
-import { omit } from '@automattic/js-utils';
 import isEqual from 'fast-deep-equal/es6';
 import QueryKey from './key';
 
@@ -251,24 +250,18 @@ export default class QueryManager {
 			const item = this.getItem( receivedItemKey );
 			const mergedItem = this.constructor.mergeItem( item, receivedItem, options.patch );
 
-			if ( undefined === mergedItem ) {
-				if ( item ) {
-					// `undefined` item is an intended omission from set
-					return omit( memo, receivedItemKey );
-				}
-
-				// Item never existed in set in the first place, skip and
-				// return same memo
+			if ( undefined === mergedItem && ! item ) {
 				return memo;
 			}
-
-			if ( ! item || ! isEqual( mergedItem, item ) ) {
-				// Did not exist previously or has changed
-				if ( memo === this.data.items ) {
-					// Create a copy of memo, as we don't want to mutate the original items set
-					memo = { ...memo };
-				}
-
+			if ( undefined !== mergedItem && item && isEqual( mergedItem, item ) ) {
+				return memo;
+			}
+			if ( memo === this.data.items ) {
+				memo = { ...memo };
+			}
+			if ( undefined === mergedItem ) {
+				delete memo[ receivedItemKey ];
+			} else {
 				memo[ receivedItemKey ] = mergedItem;
 			}
 

--- a/client/lib/query-manager/test/index.js
+++ b/client/lib/query-manager/test/index.js
@@ -184,6 +184,49 @@ describe( 'QueryManager', () => {
 	} );
 
 	describe( '#removeItems()', () => {
+		test( 'retains a prototype-named item when removing other items', () => {
+			const prototypeItem = { ID: '__proto__' };
+			manager = new QueryManager( {
+				items: { [ '__proto__' ]: prototypeItem, first: { ID: 'first' }, last: { ID: 'last' } },
+			} );
+			const next = manager.removeItems( [ 'first', 'last' ] );
+
+			expect( next.getItems() ).toEqual( [ prototypeItem ] );
+			expect( Object.getPrototypeOf( next.data.items ) ).toBe( Object.prototype );
+			expect( Object.hasOwn( next.data.items, '__proto__' ) ).toBe( true );
+			expect( manager.getItems() ).toHaveLength( 3 );
+		} );
+
+		test( 'preserves prior items and query counts when deleting duplicate and missing keys', () => {
+			manager = manager.receive( [ { ID: 144 }, { ID: 152 }, { ID: 160 } ], {
+				query: {},
+				found: 3,
+			} );
+			Object.freeze( manager.data.items );
+			Object.freeze( manager.data.queries[ '[]' ].itemKeys );
+			const remaining = manager.getItem( 160 );
+			const next = manager.removeItems( [ 144, 144, 152, 999 ] );
+
+			expect( manager.getItems( {} ) ).toEqual( [ { ID: 144 }, { ID: 152 }, { ID: 160 } ] );
+			expect( manager.getFound( {} ) ).toBe( 3 );
+			expect( next.getItems( {} ) ).toEqual( [ remaining ] );
+			expect( next.getFound( {} ) ).toBe( 1 );
+			expect( next.getItem( 160 ) ).toBe( remaining );
+		} );
+
+		test( 'keeps mixed deletions, updates, and insertions in one immutable batch', () => {
+			manager = manager.receive( [ { ID: 1 }, { ID: 2, title: 'Before' }, { ID: 3 } ] );
+			Object.freeze( manager.data.items );
+			const next = manager.receive(
+				[ { ID: 1, [ DELETE_PATCH_KEY ]: true }, { ID: 2, title: 'After' }, { ID: 4 } ],
+				{ patch: true }
+			);
+
+			expect( manager.getItems() ).toEqual( [ { ID: 1 }, { ID: 2, title: 'Before' }, { ID: 3 } ] );
+			expect( next.getItems() ).toEqual( [ { ID: 2, title: 'After' }, { ID: 3 }, { ID: 4 } ] );
+			expect( next.getItem( 3 ) ).toBe( manager.getItem( 3 ) );
+		} );
+
 		test( 'should remove an array of items by their item keys', () => {
 			manager = manager.receive( [ { ID: 144 }, { ID: 152 } ] );
 			const newManager = manager.removeItems( [ 144, 152 ] );

--- a/client/reader/data/post/cache/index.ts
+++ b/client/reader/data/post/cache/index.ts
@@ -289,6 +289,9 @@ export const upsertPostCache = (
 	ensurePostCacheQueryDefaults( queryClient );
 
 	const validPosts = posts.filter( Boolean ) as Post[];
+	if ( ! validPosts.length ) {
+		return;
+	}
 	const keyStringsByPost = new Map(
 		validPosts.map( ( post ) => [ post, new Set( postKeyStringsFromPost( post ) ) ] )
 	);

--- a/client/reader/data/post/cache/test/index.test.tsx
+++ b/client/reader/data/post/cache/test/index.test.tsx
@@ -36,6 +36,21 @@ function blogPost( id: number, overrides: Record< string, unknown > = {} ) {
 }
 
 describe( 'reader post cache', () => {
+	it.each( [
+		{ name: 'empty', posts: [] },
+		{ name: 'null-only', posts: [ null, undefined ] },
+	] )( 'preserves cached data for a $name post batch', ( { posts } ) => {
+		const queryClient = makeQueryClient();
+		const queryKey = [ 'read', 'post', 'cache', 'blog-1-100' ];
+		const cachedData = { base: blogPost( 1 ), overlay: { i_like: true } };
+		queryClient.setQueryData( queryKey, cachedData );
+
+		upsertPostCache( queryClient, posts );
+
+		expect( queryClient.getQueryData( queryKey ) ).toBe( cachedData );
+		expect( queryClient.getQueryDefaults( queryKey ).meta ).toEqual( { persist: false } );
+	} );
+
 	it( 'upserts stream posts into a canonical post cache', () => {
 		const queryClient = makeQueryClient();
 


### PR DESCRIPTION
## Proposed Changes

Use a Map to group multisite update schedules, clone QueryManager's item map only on its first actual batch change, and return early when Reader post-cache upserts contain no valid posts.

## Why are these changes being made?

These paths repeat work without producing additional data. Schedule grouping repeatedly searches prior groups and formats the same time. QueryManager deletion repeatedly copies its item map. Empty Reader batches scan cached aliases despite having nothing to apply.

## Testing Instructions

```bash
yarn test-client client/data/plugins/test client/lib/query-manager client/lib/media client/reader/data/post --runInBand --silent
yarn typecheck-client
```

Compatibility tests preserve schedule ordering/metadata, immutable inputs, duplicate and mixed QueryManager revisions, query counts, and Reader overlays/defaults. Deleting another item now also preserves an own `__proto__` item, which the previous omit/Object.assign path lost. Local synthetic comparisons: 500 distinct schedule groups 55 → 0.415 ms; empty Reader batch with 5,000 posts / 10,000 aliases 1.48 → 0.003 ms. QueryManager's 5,000-item / 500-deletion fixture improved modestly, 7.59 → 7.10 ms; single deletion was effectively unchanged. No broad cache rewrite or production-latency claim.

The commands above passed on this independent branch based on trunk `7cc9ee953a3`. Client and package typechecks also passed on the integrated audit. Changed files passed lint. No browser/E2E or full production bundle validation was performed.


<details>
<summary>Reproduce schedule-grouping comparison</summary>

Run from the repository root with dependencies installed (Node 24). The script checks equivalence before timing actual source.

```bash
node <<'JS'
const fs=require('node:fs');
const {execFileSync}=require('node:child_process');
const {stripTypeScriptTypes}=require('node:module');
const {performance}=require('node:perf_hooks');
const assert=require('node:assert/strict');
const moment=require(process.cwd()+'/node_modules/moment');
const path='client/data/plugins/use-update-schedules-query.ts';
function load(source,sites) {
 const stripped=stripTypeScriptTypes(source).replace(/import[\s\S]*?;/g,'').replaceAll('export const','const');
 return new Function('useQuery','useCallback','useLocalizedMoment','useSelector','getSites',stripped+';return useMultisiteUpdateScheduleQuery(true).select;')(options=>options,fn=>fn,()=>moment,()=>sites,{});
}
const trunk=execFileSync('git',['show','9620f4fcdc6:'+path],{encoding:'utf8'}),current=fs.readFileSync(path,'utf8');
const median=arr=>arr.sort((a,b)=>a-b)[Math.floor(arr.length/2)];
for(const count of [10,100,500]){
 const sites=Array.from({length:count},(_,ID)=>({ID,slug:'site'+ID}));
 const data={sites:Object.fromEntries(sites.map(({ID})=>[ID,{schedule:{timestamp:1700000000+ID*60,schedule:'daily',interval:86400,args:['hello'],active:true,last_run_timestamp:null,last_run_status:null}}]))};
 const before=load(trunk,sites),after=load(current,sites);
 assert.deepEqual(after(data),before(data));
 for(let i=0;i<5;i++){before(data);after(data);}
 const timings={trunk:[],changed:[]};
 for(let i=0;i<15;i++)for(const [name,fn] of i%2?[['changed',after],['trunk',before]]:[['trunk',before],['changed',after]]){let start=performance.now();fn(data);timings[name].push(performance.now()-start);}
 console.log(JSON.stringify({sites:count,trunkMedianMs:+median(timings.trunk).toFixed(3),changedMedianMs:+median(timings.changed).toFixed(3)}));
}
JS
```

</details>

<details>
<summary>Reproduce empty Reader batch comparison</summary>

Run from the repository root with dependencies installed (Node 24). The script checks equivalence before timing actual source.

```bash
node <<'JS'
const fs=require('node:fs');
const {execFileSync}=require('node:child_process');
const {stripTypeScriptTypes}=require('node:module');
const {performance}=require('node:perf_hooks');
const assert=require('node:assert/strict');
const {QueryClient}=require(process.cwd()+'/node_modules/@tanstack/react-query');
const file='client/reader/data/post/cache/index.ts';
const keysSource=fs.readFileSync('client/reader/post-key.js','utf8').replaceAll('export function','function').replace(/export \{[^;]+;/g,'');
const keys=new Function(keysSource+';return {keyForPost,keyToString};')();
function load(source){
 const code=stripTypeScriptTypes(source.slice(0,source.indexOf('const numberValue ='))).replace(/import[\s\S]*?;/g,'').replaceAll('export const','const');
 return new Function('keyForPost','keyToString',code+';return {upsertPostCache,updateCachedPost};')(keys.keyForPost,keys.keyToString);
}
const trunk=load(execFileSync('git',['show','9620f4fcdc6:'+file],{encoding:'utf8'}));
const changed=load(fs.readFileSync(file,'utf8'));
const median=arr=>arr.sort((a,b)=>a-b)[Math.floor(arr.length/2)];
const data=client=>client.getQueriesData({queryKey:['read','post','cache']});
for(const count of [100,1000,5000]){
 const posts=Array.from({length:count},(_,i)=>({ID:i+1,site_ID:1,global_ID:'global-'+i,feed_ID:2,feed_item_ID:i+10000,title:'Post '+i,discussion:{comment_count:1}}));
 const incoming=[];
 const beforeClient=new QueryClient(),afterClient=new QueryClient();
 trunk.upsertPostCache(beforeClient,posts);changed.upsertPostCache(afterClient,posts);
 trunk.upsertPostCache(beforeClient,incoming);changed.upsertPostCache(afterClient,incoming);
 assert.deepEqual(data(afterClient),data(beforeClient));
 const timings={trunk:[],changed:[]};
 for(let i=0;i<13;i++)for(const [name,api,client] of i%2?[['changed',changed,afterClient],['trunk',trunk,beforeClient]]:[['trunk',trunk,beforeClient],['changed',changed,afterClient]]){
  const start=performance.now();api.upsertPostCache(client,incoming);const elapsed=performance.now()-start;if(i>=3)timings[name].push(elapsed);
 }
 console.log(JSON.stringify({cachedPosts:count,aliases:count*2,batch:0,trunkMedianMs:+median(timings.trunk).toFixed(3),changedMedianMs:+median(timings.changed).toFixed(3)}));
 beforeClient.clear();afterClient.clear();
}
JS
```

</details>

<details>
<summary>Reproduce QueryManager batch comparison</summary>

Run from the repository root with dependencies installed (Node 24). The script checks equivalence before timing actual source.

```bash
node <<'JS'
const fs = require('node:fs');
const { execFileSync } = require('node:child_process');
const { createRequire, Module } = require('node:module');
const { performance } = require('node:perf_hooks');
const assert = require('node:assert/strict');
const root = process.cwd();
const localRequire = createRequire(root + '/package.json');
const ts = localRequire('typescript');
function load(source, key) {
 const module = new Module(root + '/client/lib/query-manager/benchmark.cjs');
 module.require = name => name === './key' ? { __esModule: true, default: key } : localRequire(name);
 module._compile(ts.transpileModule(source, { compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS } }).outputText, module.id);
 return module.exports.default;
}
const key=load(fs.readFileSync(root+'/client/lib/query-manager/key.js','utf8'));
const path='client/lib/query-manager/index.js';
const Trunk=load(execFileSync('git',['show','9620f4fcdc6:'+path],{cwd:root,encoding:'utf8'}),key);
const Changed=load(fs.readFileSync(root+'/'+path,'utf8'),key);
const median = xs => xs.sort((a,b)=>a-b)[Math.floor(xs.length/2)];
for(const [count,removed] of [[100,1],[1000,100],[5000,500],[5000,1]]) {
 const entries=Array.from({length:count},(_,i)=>({ID:i+1,title:'Item '+i}));
 const data={items:Object.fromEntries(entries.map(item=>[item.ID,item])),queries:{'[]':{itemKeys:entries.map(item=>item.ID),found:count}}};
 const before=new Trunk(data),after=new Changed(data),keys=entries.slice(0,removed).map(item=>item.ID);
 assert.deepEqual(after.removeItems(keys).data,before.removeItems(keys).data);
 const original=structuredClone(data);
 const jobs={trunk:()=>before.removeItems(keys),changed:()=>after.removeItems(keys)};
 for(let i=0;i<3;i++){jobs.trunk();jobs.changed();}
 const samples={trunk:[],changed:[]};
 for(let i=0;i<9;i++) for(const name of i%2?['changed','trunk']:['trunk','changed']) {const start=performance.now();jobs[name]();samples[name].push(performance.now()-start);}
 assert.deepEqual(data,original);
 console.log(JSON.stringify({items:count,removed,queries:1,outputIdentical:true,trunkMedianMs:+median(samples.trunk).toFixed(3),changedMedianMs:+median(samples.changed).toFixed(3)}));
}
JS
```

</details>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
