### PR TITLE
API Queries: refresh redirect-specific domain connection setup

### DIFF
--- a/packages/api-queries/src/__tests__/domain-connection-setup.test.ts
+++ b/packages/api-queries/src/__tests__/domain-connection-setup.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryObserver } from '@tanstack/react-query';
+import { waitFor } from '@testing-library/react';
+import nock from 'nock';
+import {
+	domainConnectionSetupInfoQuery,
+	domainMappingStatusQuery,
+	updateConnectionModeMutation,
+} from '../domain-connection-setup';
+import { queryClient } from '../query-client';
+
+jest.mock( '../query-client', () => {
+	const { QueryClient } = jest.requireActual( '@tanstack/react-query' );
+	return {
+		queryClient: new QueryClient( {
+			defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+		} ),
+	};
+} );
+
+const domainName = 'example.com';
+const redirectURL = 'https://dashboard.example/domains/example.com?step=dc_return';
+
+function mockModeUpdate() {
+	return nock( 'https://public-api.wordpress.com' )
+		.post( `/rest/v1.1/domains/${ domainName }/mapping-status`, { mode: 'advanced' } )
+		.reply( 200, { mode: 'advanced' } );
+}
+
+async function updateMode() {
+	await queryClient
+		.getMutationCache()
+		.build( queryClient, updateConnectionModeMutation( domainName, 123 ) )
+		.execute( 'advanced' );
+}
+
+afterEach( () => {
+	queryClient.clear();
+	nock.cleanAll();
+} );
+
+test( 'invalidates every return URL for this domain and site while leaving other domains and sites fresh', async () => {
+	const keys = [
+		domainConnectionSetupInfoQuery( domainName, 123 ).queryKey,
+		domainConnectionSetupInfoQuery( domainName, 123, redirectURL ).queryKey,
+		domainConnectionSetupInfoQuery( domainName, 123, 'https://another.example/return' ).queryKey,
+		domainMappingStatusQuery( domainName ).queryKey,
+		domainConnectionSetupInfoQuery( domainName, 456, redirectURL ).queryKey,
+		domainConnectionSetupInfoQuery( 'other.example', 123, redirectURL ).queryKey,
+	];
+	keys.forEach( ( key ) => queryClient.setQueryData< unknown >( key, {} ) );
+	const request = mockModeUpdate();
+
+	await updateMode();
+
+	expect( request.isDone() ).toBe( true );
+	expect( keys.map( ( key ) => queryClient.getQueryState( key )?.isInvalidated ) ).toEqual( [
+		true,
+		true,
+		true,
+		true,
+		false,
+		false,
+	] );
+} );
+
+test( 'refetches the mounted setup query with its original return URL after updating connection mode', async () => {
+	const options = domainConnectionSetupInfoQuery( domainName, 123, redirectURL );
+	queryClient.setQueryData< unknown >( options.queryKey, { connection_mode: 'suggested' } );
+	const observer = new QueryObserver( queryClient, options );
+	const unsubscribe = observer.subscribe( () => {} );
+	const updateRequest = mockModeUpdate();
+	const setupRequest = nock( 'https://public-api.wordpress.com' )
+		.get( `/rest/v1.1/domains/${ domainName }/mapping-setup-info/123` )
+		.query( { redirect_uri: redirectURL } )
+		.reply( 200, { connection_mode: 'advanced' } );
+
+	try {
+		await updateMode();
+		await waitFor( () =>
+			expect( observer.getCurrentResult().data?.connection_mode ).toBe( 'advanced' )
+		);
+		expect( updateRequest.isDone() ).toBe( true );
+		expect( setupRequest.isDone() ).toBe( true );
+	} finally {
+		unsubscribe();
+	}
+} );

--- a/packages/api-queries/src/domain-connection-setup.ts
+++ b/packages/api-queries/src/domain-connection-setup.ts
@@ -28,7 +28,7 @@ export const updateConnectionModeMutation = ( domainName: string, siteId: number
 		mutationFn: ( connectionMode: string | null ) =>
 			updateConnectionModeAndGetMappingStatus( domainName, connectionMode ),
 		onSuccess: () => {
-			queryClient.invalidateQueries( domainConnectionSetupInfoQuery( domainName, siteId ) );
+			queryClient.invalidateQueries( { queryKey: [ 'domain-setup-info', domainName, siteId ] } );
 			queryClient.invalidateQueries( domainMappingStatusQuery( domainName ) );
 		},
 	} );


### PR DESCRIPTION
## Proposed Changes

Invalidate domain connection setup queries by domain/site prefix after changing connection mode.

## Why are these changes being made?

The old invalidation key includes a trailing undefined redirect URI, so it misses mounted queries that supply a real URI. The mutation must refresh every redirect-specific variant for the same domain and site.

## Testing Instructions

```bash
yarn test-packages packages/api-queries --runInBand --silent
yarn typecheck-packages
```

All 627 api-queries tests pass. Two regressions fail on trunk and pass with the fix, using actual MutationCache, mounted QueryObserver, and network mocks. Redirect URI is preserved during refetch; unrelated domains/sites remain untouched.

The commands above passed on this independent branch based on trunk `7cc9ee953a3`. Client and package typechecks also passed on the integrated audit. Changed files passed lint. No browser/E2E or full production bundle validation was performed.

