### PR TITLE
Reader: respect disabled subscription queries during pagination

### DIFF
--- a/packages/data-stores/src/reader/queries/test/use-post-subscriptions-query.tsx
+++ b/packages/data-stores/src/reader/queries/test/use-post-subscriptions-query.tsx
@@ -1,0 +1,58 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { callApi, getSubkey } from '../../helpers';
+import buildQueryKey from '../../helpers/query-key';
+import usePostSubscriptionsQuery, {
+	postSubscriptionsQueryKeyPrefix,
+} from '../use-post-subscriptions-query';
+import type { PropsWithChildren } from 'react';
+
+jest.mock( '../../helpers', () => ( {
+	...jest.requireActual( '../../helpers' ),
+	callApi: jest.fn(),
+	getSubkey: jest.fn(),
+} ) );
+
+test( 'defers cached pagination until a subscriber key is available', async () => {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+	} );
+	const first = {
+		id: '1',
+		post_title: 'First post',
+		post_url: 'https://example.com/first',
+		date_subscribed: '2026-01-01T00:00:00Z',
+	};
+	queryClient.setQueryData( buildQueryKey( postSubscriptionsQueryKeyPrefix, false ), {
+		pages: [ { comment_subscriptions: [ first ], total_comment_subscriptions_count: 2 } ],
+		pageParams: [ 1 ],
+	} );
+	jest.mocked( getSubkey ).mockReturnValue( undefined );
+	jest.mocked( callApi ).mockResolvedValue( {
+		comment_subscriptions: [ { ...first, id: '2', post_title: 'Second post' } ],
+		total_comment_subscriptions_count: 2,
+	} );
+	const wrapper = ( { children }: PropsWithChildren ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+
+	const { result, rerender, unmount } = renderHook(
+		() => usePostSubscriptionsQuery( { number: 1 } ),
+		{ wrapper }
+	);
+	await waitFor( () => expect( result.current.isFetching ).toBe( false ) );
+	expect( callApi ).not.toHaveBeenCalled();
+	expect( result.current.data.posts ).toHaveLength( 1 );
+
+	jest.mocked( getSubkey ).mockReturnValue( 'subscriber-key' );
+	rerender();
+	await waitFor( () => expect( result.current.data.posts ).toHaveLength( 2 ) );
+	expect( callApi ).toHaveBeenCalledTimes( 1 );
+	expect( jest.mocked( callApi ).mock.calls[ 0 ][ 0 ].path ).toContain( 'page=2' );
+	expect( result.current.hasNextPage ).toBe( false );
+	unmount();
+	queryClient.clear();
+} );

--- a/packages/data-stores/src/reader/queries/test/use-site-subscriptions-query.tsx
+++ b/packages/data-stores/src/reader/queries/test/use-site-subscriptions-query.tsx
@@ -158,6 +158,32 @@ describe( 'useSiteSubscriptionsQuery hook', () => {
 		);
 	} );
 
+	it( 'defers cached pagination until a subscriber key is available', async () => {
+		( getSubkey as jest.Mock ).mockReturnValue( undefined );
+		seedSiteSubscriptions(
+			[ Array.from( { length: 100 }, ( _, index ) => makeFollow( { ID: String( index + 1 ) } ) ) ],
+			101
+		);
+		( callApi as jest.Mock ).mockResolvedValue( {
+			subscriptions: [ makeApiSubscription( 101 ) ],
+			total_subscriptions: 101,
+			page: 2,
+			number: 1,
+		} );
+
+		const { result, rerender } = renderHook( () => useSiteSubscriptionsQuery(), { wrapper } );
+		await waitFor( () => expect( result.current.isFetching ).toBe( false ) );
+		expect( callApi ).not.toHaveBeenCalled();
+		expect( result.current.data.subscriptions ).toHaveLength( 100 );
+
+		( getSubkey as jest.Mock ).mockReturnValue( 'subscriber-key' );
+		rerender();
+		await waitFor( () => expect( result.current.data.subscriptions ).toHaveLength( 101 ) );
+		expect( callApi ).toHaveBeenCalledTimes( 1 );
+		expect( ( callApi as jest.Mock ).mock.calls[ 0 ][ 0 ].path ).toContain( 'page=2' );
+		expect( result.current.hasNextPage ).toBe( false );
+	} );
+
 	it( 'fetches subscriptions data with search term', async () => {
 		seedSiteSubscriptions( [
 			[

--- a/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-post-subscriptions-query.ts
@@ -69,10 +69,10 @@ const usePostSubscriptionsQuery = ( {
 	const { data, isFetching, isFetchingNextPage, fetchNextPage, hasNextPage } = infiniteQuery;
 
 	useEffect( () => {
-		if ( hasNextPage && ! isFetchingNextPage && ! isFetching ) {
+		if ( enabled && hasNextPage && ! isFetchingNextPage && ! isFetching ) {
 			fetchNextPage();
 		}
-	}, [ hasNextPage, isFetchingNextPage, isFetching, fetchNextPage ] );
+	}, [ enabled, hasNextPage, isFetchingNextPage, isFetching, fetchNextPage ] );
 
 	const filterFunction = useCallback(
 		( item: PostSubscription ) => {

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -80,7 +80,7 @@ const useSiteSubscriptionsQuery = () => {
 		refetch,
 	} = query;
 
-	const nextPage = hasNextPage && ! isFetching && data ? data.pages.length + 1 : null;
+	const nextPage = enabled && hasNextPage && ! isFetching && data ? data.pages.length + 1 : null;
 
 	useEffect( () => {
 		if ( nextPage ) {


### PR DESCRIPTION
## Proposed Changes

Respect the computed `enabled` flag before auto-paginating Reader site and post subscription queries.

## Why are these changes being made?

Imperative `fetchNextPage` bypasses TanStack Query enablement. A disabled query with cached partial pages can therefore continue loading subscription data. Gate the pagination effect with the same enablement condition as the query.

## Testing Instructions

```bash
yarn test-packages packages/data-stores/src/reader --runInBand --silent
yarn typecheck-packages
```

All 24 Reader data-store tests pass. Regressions fail on trunk with cached partial pages, then confirm no extra request while disabled and exactly one continuation after enabling. Cached data remains readable. ESM/CJS package builds pass.

The commands above passed on this independent branch based on trunk `7cc9ee953a3`. Client and package typechecks also passed on the integrated audit. Changed files passed lint. No browser/E2E or full production bundle validation was performed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
