### PR TITLE
Checkout: reuse current site domains and deduplicate initial requests

### DIFF
--- a/client/my-sites/checkout/src/hooks/test/use-site-domains.tsx
+++ b/client/my-sites/checkout/src/hooks/test/use-site-domains.tsx
@@ -1,0 +1,107 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
+import { thunk } from 'redux-thunk';
+import wpcom from 'calypso/lib/wp';
+import { SITE_DOMAINS_RECEIVE } from 'calypso/state/action-types';
+import { createSiteDomainObject } from 'calypso/state/sites/domains/assembler';
+import domainsReducer from 'calypso/state/sites/domains/reducer';
+import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import useSiteDomains from '../use-site-domains';
+import type { ReactNode } from 'react';
+
+jest.mock( 'calypso/lib/wp', () => ( { req: { get: jest.fn() } } ) );
+
+const domainsReceiveAction = ( siteId: number, domains: { domain: string }[] ) => ( {
+	type: SITE_DOMAINS_RECEIVE,
+	siteId,
+	domains: domains.map( createSiteDomainObject ),
+} );
+
+function setup() {
+	const store = createStore(
+		combineReducers( { sites: combineReducers( { domains: domainsReducer } ) } ),
+		applyMiddleware( thunk )
+	);
+	const wrapper = ( { children }: { children: ReactNode } ) => (
+		<Provider store={ store }>{ children }</Provider>
+	);
+	return { store, wrapper };
+}
+
+beforeEach( () => {
+	jest.mocked( wpcom.req.get ).mockReset();
+	jest.mocked( wpcom.req.get ).mockImplementation( () => new Promise( () => {} ) );
+} );
+
+test( 'shares an in-flight domain request between checkout consumers', async () => {
+	const { wrapper } = setup();
+	let resolveRequest: ( value: { domains: [] } ) => void = () => {};
+	jest.mocked( wpcom.req.get ).mockImplementation(
+		() =>
+			new Promise( ( resolve ) => {
+				resolveRequest = resolve;
+			} )
+	);
+	const { result } = renderHook( () => [ useSiteDomains( 1 ), useSiteDomains( 1 ) ], { wrapper } );
+	expect( wpcom.req.get ).toHaveBeenCalledTimes( 1 );
+	await act( async () => resolveRequest( { domains: [] } ) );
+	expect( result.current ).toEqual( [ [], [] ] );
+} );
+
+test( 'does not retain another site domains when the current site is empty or absent', () => {
+	const { store, wrapper } = setup();
+	store.dispatch( domainsReceiveAction( 1, [ { domain: 'first.example' } ] ) );
+	store.dispatch( domainsReceiveAction( 2, [] ) );
+	const { result, rerender } = renderHook( ( { siteId } ) => useSiteDomains( siteId ), {
+		wrapper,
+		initialProps: { siteId: 1 as number | undefined },
+	} );
+	expect( result.current ).toBe( getDomainsBySiteId( store.getState(), 1 ) );
+	rerender( { siteId: 2 } );
+	expect( result.current ).toEqual( [] );
+	rerender( { siteId: undefined } );
+	expect( result.current ).toEqual( [] );
+	expect( wpcom.req.get ).not.toHaveBeenCalled();
+} );
+
+test( 'clears a domain list when the last domain is removed', () => {
+	const { store, wrapper } = setup();
+	store.dispatch( domainsReceiveAction( 1, [ { domain: 'first.example' } ] ) );
+	const { result } = renderHook( () => useSiteDomains( 1 ), { wrapper } );
+	act( () => {
+		store.dispatch( domainsReceiveAction( 1, [] ) );
+	} );
+	expect( result.current ).toEqual( [] );
+} );
+
+test( 'returns an empty list while a different site loads', () => {
+	const { store, wrapper } = setup();
+	store.dispatch( domainsReceiveAction( 1, [ { domain: 'first.example' } ] ) );
+	const { result, rerender } = renderHook( ( { siteId } ) => useSiteDomains( siteId ), {
+		wrapper,
+		initialProps: { siteId: 1 },
+	} );
+	rerender( { siteId: 2 } );
+	expect( result.current ).toEqual( [] );
+	expect( wpcom.req.get ).toHaveBeenCalledWith( '/sites/2/domains', { apiVersion: '1.2' } );
+} );
+
+test( 'does not loop on failure and allows a new checkout mount to retry', async () => {
+	const { wrapper } = setup();
+	jest.mocked( wpcom.req.get ).mockRejectedValueOnce( new Error( 'Network error' ) );
+	const { result, unmount } = renderHook( () => useSiteDomains( 1 ), { wrapper } );
+	await act( async () => {} );
+	expect( result.current ).toEqual( [] );
+	expect( wpcom.req.get ).toHaveBeenCalledTimes( 1 );
+	unmount();
+	jest
+		.mocked( wpcom.req.get )
+		.mockResolvedValueOnce( { domains: [ { domain: 'first.example' } ] } );
+	const retried = renderHook( () => useSiteDomains( 1 ), { wrapper } );
+	await waitFor( () => expect( retried.result.current ).toHaveLength( 1 ) );
+	expect( wpcom.req.get ).toHaveBeenCalledTimes( 2 );
+} );

--- a/client/my-sites/checkout/src/hooks/use-site-domains.ts
+++ b/client/my-sites/checkout/src/hooks/use-site-domains.ts
@@ -1,8 +1,12 @@
 import debugFactory from 'debug';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import { fetchSiteDomains } from 'calypso/state/sites/domains/actions';
-import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
+import {
+	getDomainsBySiteId,
+	hasLoadedSiteDomains,
+	isRequestingSiteDomains,
+} from 'calypso/state/sites/domains/selectors';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
 
 const debug = debugFactory( 'calypso:composite-checkout:use-site-domains' );
@@ -10,28 +14,24 @@ const debug = debugFactory( 'calypso:composite-checkout:use-site-domains' );
 export default function useSiteDomains( siteId: number | undefined ): ResponseDomain[] {
 	const dispatch = useDispatch();
 
-	const [ siteDomains, setSiteDomains ] = useState< ResponseDomain[] >( [] );
-
 	const areDomainsLoaded = useSelector( ( state ) =>
 		siteId ? hasLoadedSiteDomains( state, siteId ) : false
 	);
 	const domains: ResponseDomain[] = useSelector( ( state ) => getDomainsBySiteId( state, siteId ) );
 
 	useEffect( () => {
-		if ( areDomainsLoaded && domains.length > 0 ) {
-			setSiteDomains( domains );
-		}
-	}, [ areDomainsLoaded, domains ] );
-
-	useEffect( () => {
 		if ( areDomainsLoaded ) {
 			return;
 		}
 		if ( siteId ) {
-			debug( 'Fetching list of domains' );
-			dispatch( fetchSiteDomains( siteId ) );
+			dispatch( ( dispatch, getState ) => {
+				if ( ! isRequestingSiteDomains( getState(), siteId ) ) {
+					debug( 'Fetching list of domains' );
+					dispatch( fetchSiteDomains( siteId ) );
+				}
+			} );
 		}
 	}, [ areDomainsLoaded, dispatch, siteId ] );
 
-	return siteDomains;
+	return domains;
 }


### PR DESCRIPTION
## Proposed Changes

Remove the local copy of Redux domain data from the checkout hook. Read current-site data directly and check the existing in-flight request flag when dispatching a domain fetch.

## Why are these changes being made?

Checkout mounts two consumers of this hook. On an uncached site, both currently start the same domain request. The copied state also retains another site's domains when the destination site has no domains, and retains removed domains when the current list becomes empty. These stale values can feed checkout and post-payment routing decisions.

## Testing Instructions

```bash
yarn test-client client/my-sites/checkout/src/hooks/test client/my-sites/checkout/get-thank-you-page-url --runInBand --silent
yarn typecheck-client
```

Actual-hook tests use the real Redux domain reducer and fetch action, with only the API boundary mocked. Two concurrent consumers now make one GET instead of two. Regressions cover site switches, loading/empty destinations, removal of the last domain, and retry on remount after a failed request. Existing thank-you routing tests remain unchanged. No query freshness policy, checkout API, or redirect contract changes.

The commands above passed on this independent branch. Changed-file lint also passed. Validation baseline: trunk `7cc9ee953a3`. No browser/E2E, real payment, or live migration was performed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
