### PR TITLE
Purchases: preserve renewal choices when purchase data refreshes

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/test/upcoming-renewals-dialog.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/upcoming-renewals-dialog.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { render } from '../../../../test-utils';
+import { UpcomingRenewalsDialog } from '../upcoming-renewals-dialog';
+import type { Purchase } from '@automattic/api-core';
+
+const purchase = ( ID: number ): Purchase =>
+	( {
+		ID,
+		product_name: `Plan ${ ID }`,
+		product_slug: 'personal-bundle',
+		is_plan: true,
+		currency_code: 'USD',
+		amount: 100,
+		expiry_date: '2027-01-01',
+		expiry_status: 'manual-renew',
+	} ) as Purchase;
+
+function Harness( { onConfirm }: { onConfirm: ( purchases: Purchase[] ) => void } ) {
+	const [ purchases, setPurchases ] = useState( [ purchase( 1 ), purchase( 2 ) ] );
+	const [ isOpen, setIsOpen ] = useState( true );
+	return (
+		<>
+			{ isOpen && (
+				<UpcomingRenewalsDialog
+					siteDomain="example.com"
+					purchases={ purchases }
+					onClose={ () => setIsOpen( false ) }
+					onConfirm={ ( selected ) => {
+						onConfirm( selected );
+						setIsOpen( false );
+					} }
+				/>
+			) }
+			<button onClick={ () => setIsOpen( true ) }>Open renewals</button>
+			<button onClick={ () => setPurchases( purchases.map( ( p ) => ( { ...p, amount: 200 } ) ) ) }>
+				Refresh purchases
+			</button>
+			<button onClick={ () => setPurchases( [ purchase( 1 ), purchase( 3 ) ] ) }>
+				Replace second purchase
+			</button>
+		</>
+	);
+}
+
+test( 'keeps an unchecked renewal excluded when purchase details refresh', async () => {
+	const user = userEvent.setup();
+	const onConfirm = jest.fn();
+	render( <Harness onConfirm={ onConfirm } /> );
+	await user.click( await screen.findByRole( 'checkbox', { name: 'Plan 1' } ) );
+	await user.click( screen.getByText( 'Refresh purchases' ) );
+	expect( screen.getByRole( 'checkbox', { name: 'Plan 1' } ) ).not.toBeChecked();
+	await user.click( screen.getByRole( 'button', { name: 'Renew now' } ) );
+	expect( onConfirm ).toHaveBeenCalledWith( [ { ...purchase( 2 ), amount: 200 } ] );
+} );
+
+test( 'includes newly available purchases without restoring deselected ones or submitting removed ones', async () => {
+	const user = userEvent.setup();
+	const onConfirm = jest.fn();
+	render( <Harness onConfirm={ onConfirm } /> );
+	await user.click( await screen.findByRole( 'checkbox', { name: 'Plan 1' } ) );
+	await user.click( screen.getByText( 'Replace second purchase' ) );
+	expect( screen.getByRole( 'checkbox', { name: 'Plan 1' } ) ).not.toBeChecked();
+	expect( screen.getByRole( 'checkbox', { name: 'Plan 3' } ) ).toBeChecked();
+	await user.click( screen.getByRole( 'button', { name: 'Renew now' } ) );
+	expect( onConfirm ).toHaveBeenCalledWith( [ purchase( 3 ) ] );
+} );
+
+test( 'keeps all exclusions through refresh and selects everything again after reopening', async () => {
+	const user = userEvent.setup();
+	const onConfirm = jest.fn();
+	render( <Harness onConfirm={ onConfirm } /> );
+	await user.click( await screen.findByRole( 'checkbox', { name: 'Plan 1' } ) );
+	await user.click( screen.getByRole( 'checkbox', { name: 'Plan 2' } ) );
+	await user.click( screen.getByText( 'Refresh purchases' ) );
+	await user.click( screen.getByRole( 'button', { name: 'Renew now' } ) );
+	expect( onConfirm ).toHaveBeenCalledWith( [] );
+	await user.click( screen.getByText( 'Open renewals' ) );
+	expect( await screen.findByRole( 'checkbox', { name: 'Plan 1' } ) ).toBeChecked();
+	expect( screen.getByRole( 'checkbox', { name: 'Plan 2' } ) ).toBeChecked();
+} );

--- a/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/upcoming-renewals-dialog.tsx
@@ -8,7 +8,7 @@ import {
 	__experimentalHeading as Heading,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState, useEffect, useMemo, Fragment } from 'react';
+import { useState, useMemo, Fragment } from 'react';
 import { useLocale } from '../../../app/locale';
 import { CardDivider } from '../../../components/card';
 import { formatDate } from '../../../utils/datetime';
@@ -102,17 +102,10 @@ export function UpcomingRenewalsDialog( {
 		[ purchases ]
 	);
 
-	const [ selection, setSelection ] = useState< string[] >(
-		purchases.map( ( p ) => String( p.ID ) )
-	);
-
-	useEffect( () => {
-		setSelection( purchases.map( ( p ) => String( p.ID ) ) );
-	}, [ purchases ] );
+	const [ excludedIds, setExcludedIds ] = useState< number[] >( [] );
 
 	const handleConfirm = () => {
-		const selectedIds = new Set( selection );
-		const selectedPurchasesData = purchases.filter( ( p ) => selectedIds.has( String( p.ID ) ) );
+		const selectedPurchasesData = purchases.filter( ( p ) => ! excludedIds.includes( p.ID ) );
 		onConfirm( selectedPurchasesData );
 	};
 
@@ -136,7 +129,7 @@ export function UpcomingRenewalsDialog( {
 				</VStack>
 				<VStack spacing={ 4 }>
 					{ purchasesSortByRecentExpiryDate.map( ( item ) => {
-						const id = String( item.ID );
+						const id = item.ID;
 						return (
 							<Fragment key={ id }>
 								<CardDivider />
@@ -144,9 +137,9 @@ export function UpcomingRenewalsDialog( {
 									__nextHasNoMarginBottom
 									label={ item.is_domain ? item.meta ?? '' : item.product_name }
 									help={ getRenewalDescription( item, locale, hasEnTranslation ) }
-									checked={ selection.includes( id ) }
+									checked={ ! excludedIds.includes( id ) }
 									onChange={ () => {
-										setSelection( ( prev ) =>
+										setExcludedIds( ( prev ) =>
 											prev.includes( id ) ? prev.filter( ( s ) => s !== id ) : [ ...prev, id ]
 										);
 									} }

--- a/client/me/purchases/upcoming-renewals/test/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/test/upcoming-renewals-dialog.tsx
@@ -173,4 +173,24 @@ describe( '<UpcomingRenewalsDialog>', () => {
 
 		expect( screen.getByText( 'Renew now' ) ).toHaveProperty( 'disabled', true );
 	} );
+	test( 'preserves deselection across refreshed and changed purchases, then resets on reopening', async () => {
+		const user = userEvent.setup();
+		const purchases = mockPurchases();
+		const onConfirm = jest.fn();
+		const props = { isVisible: true, purchases, site, onConfirm, onClose: jest.fn() };
+		const { rerender } = render( <UpcomingRenewalsDialog { ...props } /> );
+		await user.click( document.body.querySelector( 'input[name=personal-bundle-1]' ) );
+		const refreshed = purchases.map( ( purchase ) => ( { ...purchase, amount: 300 } ) );
+		rerender( <UpcomingRenewalsDialog { ...props } purchases={ refreshed } /> );
+		expect( document.body.querySelector( 'input[name=personal-bundle-1]' ) ).not.toBeChecked();
+		const added = { ...refreshed[ 1 ], ID: 3 };
+		rerender( <UpcomingRenewalsDialog { ...props } purchases={ [ refreshed[ 0 ], added ] } /> );
+		expect( document.body.querySelector( 'input[name=personal-bundle-1]' ) ).not.toBeChecked();
+		expect( document.body.querySelector( 'input[name=dotlive_domain-3]' ) ).toBeChecked();
+		await user.click( screen.getByText( 'Renew now' ) );
+		expect( onConfirm ).toHaveBeenCalledWith( [ added ] );
+		rerender( <UpcomingRenewalsDialog { ...props } isVisible={ false } /> );
+		rerender( <UpcomingRenewalsDialog { ...props } /> );
+		expect( document.body.querySelector( 'input[name=personal-bundle-1]' ) ).toBeChecked();
+	} );
 } );

--- a/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
+++ b/client/me/purchases/upcoming-renewals/upcoming-renewals-dialog.tsx
@@ -2,7 +2,7 @@ import { Button, Dialog, FormLabel } from '@automattic/components';
 import { capitalize } from '@automattic/js-utils';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
-import { FunctionComponent, Fragment, useState, useEffect, useCallback, useMemo } from 'react';
+import { FunctionComponent, Fragment, useState, useEffect, useMemo } from 'react';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import { getRelativeDayString } from 'calypso/dashboard/utils/datetime';
 import {
@@ -72,7 +72,10 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 	getManagePurchaseUrlFor = managePurchase,
 } ) => {
 	const translate = useTranslate();
-	const [ selectedPurchases, setSelectedPurchases ] = useState< number[] >( [] );
+	const [ excludedIds, setExcludedIds ] = useState< number[] >( [] );
+	const selectedPurchases = purchases.filter(
+		( purchase ) => ! excludedIds.includes( purchase.ID )
+	);
 
 	const purchasesSortByRecentExpiryDate = useMemo(
 		() =>
@@ -87,13 +90,13 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 
 	useEffect( () => {
 		if ( isVisible ) {
-			setSelectedPurchases( purchases.map( ( purchase ) => purchase.ID ) );
+			setExcludedIds( [] );
 		}
-	}, [ isVisible, purchases ] );
+	}, [ isVisible ] );
 
-	const confirmSelectedPurchases = useCallback( () => {
-		onConfirm( purchases.filter( ( purchase ) => selectedPurchases.includes( purchase.ID ) ) );
-	}, [ purchases, selectedPurchases, onConfirm ] );
+	const confirmSelectedPurchases = () => {
+		onConfirm( selectedPurchases );
+	};
 
 	return (
 		<Dialog
@@ -111,11 +114,11 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 				const expiresText = getExpiresText( translate, purchase ) as string;
 				const purchaseTypeText = purchaseType( purchase );
 				const onChange = () => {
-					if ( selectedPurchases.includes( purchase.ID ) ) {
-						setSelectedPurchases( selectedPurchases.filter( ( id ) => id !== purchase.ID ) );
-					} else {
-						setSelectedPurchases( selectedPurchases.concat( [ purchase.ID ] ) );
-					}
+					setExcludedIds( ( ids ) =>
+						ids.includes( purchase.ID )
+							? ids.filter( ( id ) => id !== purchase.ID )
+							: [ ...ids, purchase.ID ]
+					);
 				};
 				return (
 					<Fragment key={ purchase.ID }>
@@ -129,7 +132,7 @@ const UpcomingRenewalsDialog: FunctionComponent< Props > = ( {
 									<FormInputCheckbox
 										className="upcoming-renewals-dialog__checkbox-input"
 										name={ `${ purchase.product_slug }-${ purchase.ID }` }
-										checked={ selectedPurchases.includes( purchase.ID ) }
+										checked={ ! excludedIds.includes( purchase.ID ) }
 										onChange={ onChange }
 									/>
 								</div>


### PR DESCRIPTION
## Proposed Changes

Track explicit exclusions in Dashboard and Classic renewal dialogs instead of resetting all selected purchases whenever the purchases array changes. Confirm against the current purchase list and retain the existing reset-on-reopen behavior.

## Why are these changes being made?

A background purchase refresh or a parent rerender can currently reselect a renewal that the user deliberately unchecked. Keeping user choices separate from refreshed purchase metadata preserves intent while avoiding stale records at confirmation.

## Testing Instructions

```bash
yarn test-client client/me/purchases/upcoming-renewals/test client/dashboard/me/billing-purchases/purchase-settings/test client/my-sites/checkout/cart/test/upcoming-renewals-reminder.test.tsx --runInBand --silent
yarn typecheck-client
```

Actual component regressions deselect a purchase, refresh metadata/change membership, and confirm the result. Current purchase values are submitted; removed purchases cannot submit. New entries retain the existing default-selected behavior. Dashboard remount and Classic visibility reset restore defaults when reopening; empty-selection behavior remains covered. No renewal URL or payment action changes.

The commands above passed on this independent branch. Changed-file lint also passed. Validation baseline: trunk `7cc9ee953a3`. No browser/E2E, real payment, or live migration was performed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
