### PR TITLE
Onboarding: clear abandoned registrations when using an existing domain

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/flows/newsletter/newsletter.ts
@@ -138,6 +138,7 @@ const newsletter: Flow = {
 						setHideFreePlan( true );
 						setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
 						setDomainCartItem( providedDependencies.domainCartItem as MinimalRequestCartProduct );
+						setDomainCartItems( [] );
 					}
 
 					return navigate( 'plans' );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -538,6 +538,7 @@ const onboarding: FlowV2< typeof initialize > = {
 						setSignupDomainOrigin( SIGNUP_DOMAIN_ORIGIN.USE_YOUR_DOMAIN );
 						setHideFreePlan( true );
 						setDomainCartItem( providedDependencies.domainCartItem );
+						setDomainCartItems( [] );
 					}
 
 					return navigateAfterDomain();

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding.ts
@@ -1,17 +1,27 @@
 /**
  * @jest-environment jsdom
  */
+import { setDomainCartItem, setDomainCartItems } from '@automattic/data-stores/src/onboard/actions';
+import onboardReducer from '@automattic/data-stores/src/onboard/reducer';
+import {
+	getDomainCartItem,
+	getDomainCartItems,
+} from '@automattic/data-stores/src/onboard/selectors';
 import { renderHook } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
+import { createStore } from 'redux';
 import { clearSessionStorageQuery } from 'calypso/components/domains/wpcom-domain-search/use-query-handler';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { loadExperimentAssignment } from 'calypso/lib/explat';
+import newsletter from '../../newsletter/newsletter';
 import onboarding from '../onboarding';
 
 jest.mock( 'calypso/components/domains/wpcom-domain-search/use-query-handler', () => ( {
 	clearSessionStorageQuery: jest.fn(),
 } ) );
 
+const mockSetDomainCartItem = jest.fn();
+const mockSetDomainCartItems = jest.fn();
 const mockResetOnboardStore = jest.fn();
 const mockSetPlanCartItem = jest.fn();
 const mockSetProductCartItems = jest.fn();
@@ -23,12 +33,28 @@ jest.mock( '@automattic/components', () => ( {
 	ExternalLink: () => null,
 } ) );
 
+jest.mock( 'calypso/landing/stepper/hooks/use-exit-flow', () => ( { useExitFlow: () => ( {} ) } ) );
+jest.mock( 'calypso/landing/stepper/hooks/use-site-slug', () => ( {
+	useSiteSlug: () => undefined,
+} ) );
+jest.mock( 'calypso/landing/stepper/hooks/use-site-id-param', () => ( {
+	useSiteIdParam: () => undefined,
+} ) );
+jest.mock( 'calypso/lib/guides/trigger-guides-for-step', () => ( {
+	triggerGuidesForStep: jest.fn(),
+} ) );
+jest.mock(
+	'calypso/landing/stepper/declarative-flow/internals/hooks/use-launchpad-decider',
+	() => ( { useLaunchpadDecider: () => ( {} ) } )
+);
+
 jest.mock( '@wordpress/data', () => ( {
+	combineReducers: jest.requireActual( '@wordpress/data' ).combineReducers,
 	useDispatch: () => ( {
 		resetOnboardStore: mockResetOnboardStore,
 		setDomain: jest.fn(),
-		setDomainCartItem: jest.fn(),
-		setDomainCartItems: jest.fn(),
+		setDomainCartItem: mockSetDomainCartItem,
+		setDomainCartItems: mockSetDomainCartItems,
 		setHideFreePlan: jest.fn(),
 		setPlanCartItem: mockSetPlanCartItem,
 		setProductCartItems: mockSetProductCartItems,
@@ -354,5 +380,74 @@ describe( 'onboarding flow plans-page experiment enrolment', () => {
 		expect( loadExperimentAssignment ).toHaveBeenCalledWith(
 			'calypso_plans_page_visual_separation_2025_09_v2'
 		);
+	} );
+} );
+
+describe( 'replacing searched domains with an existing domain', () => {
+	afterEach( () => {
+		mockSetDomainCartItem.mockReset();
+		mockSetDomainCartItems.mockReset();
+	} );
+	it.each( [ 'domain_map', 'domain_transfer' ] )(
+		'discards previous registrations when selecting %s',
+		async ( productSlug ) => {
+			const store = createStore( onboardReducer );
+			mockSetDomainCartItem.mockImplementation( ( item ) =>
+				store.dispatch( setDomainCartItem( item ) )
+			);
+			mockSetDomainCartItems.mockImplementation( ( items ) =>
+				store.dispatch( setDomainCartItems( items ) )
+			);
+			const navigate = jest.fn();
+			const { result } = renderHook( () =>
+				onboarding.useStepNavigation.call( onboarding, 'domains', navigate )
+			);
+			const registrations = [
+				{ product_slug: 'domain_reg', meta: 'old-selection.com' },
+				{ product_slug: 'domain_reg', meta: 'old-selection.blog' },
+			];
+
+			await result.current.submit?.( {
+				slug: 'domains',
+				providedDependencies: { domainItem: registrations[ 0 ], domainCart: registrations },
+			} );
+			expect( getDomainCartItems( store.getState() ) ).toEqual( registrations );
+
+			const existingDomain = { product_slug: productSlug, meta: 'already-owned.com' };
+			await result.current.submit?.( {
+				slug: 'use-my-domain',
+				providedDependencies: { domainCartItem: existingDomain },
+			} );
+
+			expect( getDomainCartItem( store.getState() ) ).toEqual( existingDomain );
+			expect( getDomainCartItems( store.getState() ) ).toEqual( [] );
+		}
+	);
+	it( 'discards previous registrations in the newsletter flow', async () => {
+		const store = createStore( onboardReducer );
+		mockSetDomainCartItem.mockImplementation( ( item ) =>
+			store.dispatch( setDomainCartItem( item ) )
+		);
+		mockSetDomainCartItems.mockImplementation( ( items ) =>
+			store.dispatch( setDomainCartItems( items ) )
+		);
+		const navigate = jest.fn();
+		const { result, rerender } = renderHook(
+			( { step }: { step: 'domains' | 'use-my-domain' } ) =>
+				newsletter.useStepNavigation.call( newsletter, step, navigate ),
+			{ initialProps: { step: 'domains' } }
+		);
+		const registration = { product_slug: 'domain_reg', meta: 'old-selection.com' };
+		await result.current.submit?.( {
+			domainItem: registration,
+			domainCart: [ registration ],
+			suggestion: { is_free: false },
+		} );
+		expect( getDomainCartItems( store.getState() ) ).toEqual( [ registration ] );
+		rerender( { step: 'use-my-domain' } );
+		const existingDomain = { product_slug: 'domain_map', meta: 'already-owned.com' };
+		await result.current.submit?.( { domainCartItem: existingDomain } );
+		expect( getDomainCartItem( store.getState() ) ).toEqual( existingDomain );
+		expect( getDomainCartItems( store.getState() ) ).toEqual( [] );
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

Clear the plural domain-cart selection when onboarding or newsletter signup switches to one existing domain.

## Why are these changes being made?

A user can choose registrations, go back, then choose to connect or transfer an existing domain. The single domain item is replaced, but the old registration array remains and is later combined into the checkout cart. Two existing setter calls clear this abandoned selection at the point where the user replaces it.

## Testing Instructions

```bash
yarn test-client client/landing/stepper/declarative-flow/flows/onboarding client/landing/stepper/declarative-flow/test/onboarding-flow.tsx --runInBand --silent
yarn typecheck-client
```

Three regressions fail on trunk using actual flow submissions, the onboard reducer, and exported cart selectors: onboarding mapping, onboarding transfer, and newsletter mapping. The new single item remains intact and the abandoned registration array becomes empty. Other domain metadata and site URL selection semantics remain unchanged.

The commands above passed on this independent branch. Changed-file lint also passed. Validation baseline: trunk `7cc9ee953a3`. No browser/E2E, real payment, or live migration was performed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
