### PR TITLE
Domain flow: recover from failed or empty processing steps

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -45,6 +45,7 @@ function initialize() {
 		STEPS.UNIFIED_PLANS,
 		STEPS.SITE_CREATION_STEP,
 		STEPS.PROCESSING,
+		STEPS.ERROR,
 	];
 
 	return stepsWithRequiredLogin( steps );
@@ -223,6 +224,7 @@ const domain: FlowV2< typeof initialize > = {
 						window.location.href = domainConnectionSetupUrl
 							? domainConnectionSetupUrl.replace( '%s', providedDependencies.domain )
 							: defaultRedirect;
+						return;
 					}
 
 					if (
@@ -455,6 +457,10 @@ const domain: FlowV2< typeof initialize > = {
 				case STEPS.SITE_CREATION_STEP.slug:
 					return navigate( STEPS.PROCESSING.slug, undefined, true );
 				case STEPS.PROCESSING.slug: {
+					if ( providedDependencies.processingResult === ProcessingResult.NO_ACTION ) {
+						return navigate( STEPS.DOMAIN_SEARCH.slug, undefined, true );
+					}
+
 					if ( providedDependencies.processingResult === ProcessingResult.SUCCESS ) {
 						if ( providedDependencies.redirectTo ) {
 							return window.location.replace( providedDependencies.redirectTo );
@@ -478,8 +484,7 @@ const domain: FlowV2< typeof initialize > = {
 						// replace the location to delete processing step from history.
 						window.location.replace( destination );
 					} else {
-						// TODO: Handle errors
-						// navigate( 'error' );
+						return navigate( STEPS.ERROR.slug, undefined, true );
 					}
 					return;
 				}

--- a/client/landing/stepper/declarative-flow/flows/domain/test/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/test/domain.ts
@@ -1,0 +1,132 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import wpcom from 'calypso/lib/wp';
+import { STEPS } from '../../../internals/steps';
+import { ProcessingResult } from '../../../internals/steps-repository/processing-step/constants';
+import domain from '../domain';
+
+const mockSetPendingAction = jest.fn();
+
+jest.mock( '@automattic/components', () => ( {
+	MaterialIcon: () => null,
+	ExternalLink: () => null,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( { setPendingAction: mockSetPendingAction } ),
+	useSelect: () => ( {} ),
+} ) );
+jest.mock( '@automattic/data-stores', () => ( {
+	AddOns: jest.requireActual( '@automattic/data-stores/src/add-ons/constants' ),
+} ) );
+jest.mock( '@automattic/onboarding', () => ( { DOMAIN_FLOW: 'domain' } ) );
+jest.mock( 'calypso/landing/stepper/utils/steps-with-required-login', () => ( {
+	stepsWithRequiredLogin: ( steps: unknown[] ) => steps,
+} ) );
+jest.mock( 'calypso/landing/stepper/hooks/use-site-data', () => ( {
+	useSiteData: () => ( {
+		siteSlug: 'example.wordpress.com',
+		site: {
+			ID: 123,
+			plan: { product_slug: 'value_bundle', is_free: false, features: { active: [] } },
+		},
+	} ),
+} ) );
+jest.mock( 'calypso/landing/stepper/hooks/use-query', () => ( {
+	useQuery: () => new URLSearchParams(),
+} ) );
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: { post: jest.fn() },
+} ) );
+jest.mock( 'calypso/signup/steps/site-picker/site-picker-submit', () => ( {
+	siteHasPaidPlan: () => true,
+} ) );
+jest.mock( 'calypso/state/ui/selectors/get-selected-site', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+jest.mock( 'calypso/state', () => ( { useDispatch: jest.fn(), useSelector: jest.fn() } ) );
+jest.mock( 'calypso/landing/stepper/stores', () => ( { ONBOARD_STORE: 'onboard' } ) );
+
+const originalLocation = window.location;
+
+beforeAll( () => {
+	Object.defineProperty( window, 'location', {
+		value: {
+			href: 'https://wordpress.com/setup/domain/use-my-domain?siteSlug=example.wordpress.com',
+			replace: jest.fn(),
+		},
+		writable: true,
+	} );
+} );
+
+afterAll( () => {
+	Object.defineProperty( window, 'location', { value: originalLocation } );
+} );
+
+beforeEach( () => {
+	jest.clearAllMocks();
+} );
+
+it( 'registers an error screen for failed processing', async () => {
+	const steps = await domain.initialize();
+	expect( steps ).toContainEqual( STEPS.ERROR );
+} );
+
+it( 'leaves processing after a failed domain mapping without retrying the write', async () => {
+	const navigate = jest.fn();
+	const { result } = renderHook( () => domain.useStepNavigation( 'use-my-domain', navigate ) );
+	await result.current.submit?.( {
+		slug: 'use-my-domain',
+		providedDependencies: { domainCartItem: { product_slug: 'domain_map', meta: 'example.com' } },
+	} );
+	expect( navigate ).toHaveBeenCalledWith( 'processing' );
+	const error = new Error( 'Mapping failed' );
+	jest.mocked( wpcom.req.post ).mockRejectedValueOnce( error );
+	await expect( mockSetPendingAction.mock.calls[ 0 ][ 0 ]() ).rejects.toThrow( error );
+	await result.current.submit?.( {
+		slug: 'processing',
+		providedDependencies: { processingResult: ProcessingResult.FAILURE },
+	} );
+	expect( navigate ).toHaveBeenLastCalledWith( 'error', undefined, true );
+	expect( wpcom.req.post ).toHaveBeenCalledTimes( 1 );
+} );
+
+it( 'returns an empty processing visit to domain selection', async () => {
+	const navigate = jest.fn();
+	const { result } = renderHook( () => domain.useStepNavigation( 'processing', navigate ) );
+	await result.current.submit?.( {
+		slug: 'processing',
+		providedDependencies: { processingResult: ProcessingResult.NO_ACTION },
+	} );
+	expect( navigate ).toHaveBeenCalledWith( 'domains', undefined, true );
+	expect( mockSetPendingAction ).not.toHaveBeenCalled();
+} );
+
+it( 'finishes verified ownership without expecting another domain cart item', async () => {
+	const navigate = jest.fn();
+	const { result } = renderHook( () => domain.useStepNavigation( 'use-my-domain', navigate ) );
+	await expect(
+		result.current.submit?.( {
+			slug: 'use-my-domain',
+			providedDependencies: { ownershipVerificationCompleted: true, domain: 'example.com' },
+		} )
+	).resolves.toBeUndefined();
+	expect( window.location.href ).toContain( '/sites/example.wordpress.com/domains' );
+	expect( wpcom.req.post ).not.toHaveBeenCalled();
+	expect( mockSetPendingAction ).not.toHaveBeenCalled();
+} );
+
+it( 'preserves successful mapping redirects', async () => {
+	const navigate = jest.fn();
+	const { result } = renderHook( () => domain.useStepNavigation( 'processing', navigate ) );
+	const redirectTo = 'https://my.wordpress.com/domains/example.com/domain-connection-setup';
+	await result.current.submit?.( {
+		slug: 'processing',
+		providedDependencies: { processingResult: ProcessingResult.SUCCESS, redirectTo },
+	} );
+	expect( window.location.replace ).toHaveBeenCalledWith( redirectTo );
+	expect( navigate ).not.toHaveBeenCalled();
+} );


### PR DESCRIPTION
## Proposed Changes

Register the existing error step in the domain flow, route failed processing to it, and return empty processing visits to domain selection. Replace the processing history entry on recovery. Return immediately after a successful ownership-verification redirect.

## Why are these changes being made?

Failed domain mapping/cart operations currently leave processing on a spinner because failure handling is a TODO and the flow has no error step. An empty processing visit has no action to finish. Ownership verification also falls through after redirecting and throws for a domain-cart item it no longer needs.

## Testing Instructions

```bash
yarn test-client client/landing/stepper/declarative-flow/flows/domain --runInBand --silent
yarn typecheck-client
```

Four regressions fail on trunk; a success redirect control remains green. Failed writes are not retried automatically. Replacing processing history prevents Back from replaying the failed/empty processing entry. Recovery uses the existing error component and flow navigation, preserving current site/query parameters. Existing successful checkout/domain-setup destinations remain unchanged.

The commands above passed on this independent branch. Changed-file lint also passed. Validation baseline: trunk `7cc9ee953a3`. No browser/E2E, real payment, or live migration was performed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
