### PR TITLE
Stepper: bound automatic preview creation and isolate site mutations

### DIFF
--- a/client/components/site-preview-links/use-create-site-preview-link.ts
+++ b/client/components/site-preview-links/use-create-site-preview-link.ts
@@ -18,6 +18,7 @@ export const useCreateSitePreviewLink = ( options: UseCreateSitePreviewLinkOptio
 	const queryKey = [ SITE_PREVIEW_LINKS_QUERY_KEY, siteId ];
 	const queryClient = useQueryClient();
 	const createLinkMutation = useMutation( {
+		mutationKey: queryKey,
 		mutationFn: () =>
 			wpcom.req.post( {
 				path: `/sites/${ siteId }/preview-links`,
@@ -25,10 +26,6 @@ export const useCreateSitePreviewLink = ( options: UseCreateSitePreviewLinkOptio
 			} ),
 		onSuccess: () => {
 			onSuccess?.();
-		},
-		onError: ( err, code, context ) => {
-			queryClient.setQueryData( queryKey, context );
-			onError?.();
 		},
 		onMutate: async () => {
 			await queryClient.cancelQueries( {
@@ -44,6 +41,10 @@ export const useCreateSitePreviewLink = ( options: UseCreateSitePreviewLinkOptio
 				},
 			] );
 			return cachedData;
+		},
+		onError: ( err, code, context ) => {
+			queryClient.setQueryData( queryKey, context );
+			onError?.();
 		},
 		onSettled: ( data: PreviewLink | undefined ) => {
 			if ( data?.code ) {

--- a/client/landing/stepper/hooks/test/use-site-preview-share-code.tsx
+++ b/client/landing/stepper/hooks/test/use-site-preview-share-code.tsx
@@ -1,0 +1,137 @@
+/**
+ * @jest-environment jsdom
+ */
+import { PLAN_BUSINESS } from '@automattic/calypso-products';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import wpcom from 'calypso/lib/wp';
+import { useSite } from '../use-site';
+import { useSitePreviewShareCode } from '../use-site-preview-share-code';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { PropsWithChildren } from 'react';
+
+jest.mock( '../use-site', () => ( { useSite: jest.fn() } ) );
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: { get: jest.fn(), post: jest.fn() },
+} ) );
+
+const site = {
+	ID: 123,
+	is_coming_soon: true,
+	is_wpcom_atomic: true,
+	plan: { product_slug: PLAN_BUSINESS },
+} as SiteDetails;
+const previewLink = { code: 'preview-code', created_at: '2026-09-05' };
+
+describe( 'useSitePreviewShareCode', () => {
+	let queryClient: QueryClient;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		jest.clearAllMocks();
+		queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+		} );
+		jest.mocked( useSite ).mockReturnValue( site );
+		jest.mocked( wpcom.req.get ).mockResolvedValue( [] );
+		jest.mocked( wpcom.req.post ).mockImplementation( async () => {
+			jest.mocked( wpcom.req.get ).mockResolvedValue( [ previewLink ] );
+			return previewLink;
+		} );
+	} );
+
+	afterEach( () => {
+		queryClient.clear();
+		jest.useRealTimers();
+	} );
+
+	const render = () =>
+		renderHook( useSitePreviewShareCode, {
+			wrapper: ( { children }: PropsWithChildren ) => (
+				<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+			),
+		} );
+
+	const settle = async () => {
+		for ( let i = 0; i < 5; i++ ) {
+			await act( () => jest.advanceTimersByTimeAsync( 100 ) );
+		}
+	};
+
+	it( 'creates one missing preview link and exposes its code', async () => {
+		const { result } = render();
+		await settle();
+		expect( wpcom.req.post ).toHaveBeenCalledTimes( 1 );
+		expect( result.current.shareCode ).toBe( previewLink.code );
+	} );
+
+	it.each( [ { is_coming_soon: false }, { is_wpcom_atomic: false } ] )(
+		'does not create a link from cached empty data for an ineligible site: %p',
+		async ( overrides ) => {
+			jest.mocked( useSite ).mockReturnValue( { ...site, ...overrides } );
+			queryClient.setQueryData( [ 'site-preview-links', site.ID ], [] );
+			render();
+			await settle();
+			expect( wpcom.req.get ).not.toHaveBeenCalled();
+			expect( wpcom.req.post ).not.toHaveBeenCalled();
+		}
+	);
+
+	it( 'does not automatically repeat a failed creation', async () => {
+		jest.mocked( wpcom.req.post ).mockRejectedValueOnce( new Error( 'Preview creation failed' ) );
+		render();
+		await settle();
+		expect( wpcom.req.post ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'can create a link for another site after the previous site fails', async () => {
+		jest.mocked( wpcom.req.post ).mockRejectedValueOnce( new Error( 'Preview creation failed' ) );
+		const { result, rerender } = render();
+		await settle();
+		jest.mocked( useSite ).mockReturnValue( { ...site, ID: 456 } );
+		rerender();
+		await settle();
+		expect( wpcom.req.post ).toHaveBeenCalledTimes( 2 );
+		expect( wpcom.req.post ).toHaveBeenLastCalledWith( {
+			path: '/sites/456/preview-links',
+			apiNamespace: 'wpcom/v2',
+		} );
+		expect( result.current.shareCode ).toBe( previewLink.code );
+	} );
+
+	it( 'keeps a late creation response associated with the site that started it', async () => {
+		const links = new Map< string, ( typeof previewLink )[] >();
+		let finishFirstCreation: ( value: typeof previewLink ) => void = () => {};
+		jest
+			.mocked( wpcom.req.get )
+			.mockImplementation( async ( { path }: { path: string } ) => links.get( path ) ?? [] );
+		jest.mocked( wpcom.req.post ).mockImplementation( ( { path }: { path: string } ) => {
+			if ( path === '/sites/123/preview-links' ) {
+				return new Promise( ( resolve ) => {
+					finishFirstCreation = ( value ) => {
+						links.set( path, [ value ] );
+						resolve( value );
+					};
+				} );
+			}
+			const link = { ...previewLink, code: 'second-site' };
+			links.set( path, [ link ] );
+			return Promise.resolve( link );
+		} );
+		const { result, rerender } = render();
+		await settle();
+		jest.mocked( useSite ).mockReturnValue( { ...site, ID: 456 } );
+		rerender();
+		await settle();
+		finishFirstCreation( { ...previewLink, code: 'first-site' } );
+		await settle();
+		expect( wpcom.req.post ).toHaveBeenCalledTimes( 2 );
+		expect( queryClient.getQueryData( [ 'site-preview-links', 123 ] ) ).toEqual( [
+			{ ...previewLink, code: 'first-site' },
+		] );
+		expect( queryClient.getQueryData( [ 'site-preview-links', 456 ] ) ).toEqual( [
+			{ ...previewLink, code: 'second-site' },
+		] );
+		expect( result.current.shareCode ).toBe( 'second-site' );
+	} );
+} );

--- a/client/landing/stepper/hooks/use-site-preview-share-code.ts
+++ b/client/landing/stepper/hooks/use-site-preview-share-code.ts
@@ -14,29 +14,36 @@ export function useSitePreviewShareCode() {
 		? isWpComEcommercePlan( site?.plan?.product_slug )
 		: false;
 
-	const usePreviewSiteLinksQueryEnabled =
+	const isPreviewEligible =
 		site?.is_coming_soon && ( isBusinessPlan || isEcommercePlan ) && site?.is_wpcom_atomic;
 
 	// Retrieves site preview share code if it exists
 	const { data: previewLinks, isInitialLoading: isPreviewLinksLoading } = useSitePreviewLinks( {
 		siteId: Number( site?.ID ),
-		isEnabled: usePreviewSiteLinksQueryEnabled ?? false,
+		isEnabled: isPreviewEligible ?? false,
 	} );
 
 	// Provides createLink() function used to generate a new site preview share code
-	const { createLink, isPending: isCreatingSitePreviewLinks } = useCreateSitePreviewLink( {
+	const {
+		createLink,
+		isPending: isCreatingSitePreviewLinks,
+		isError: hasCreateError,
+	} = useCreateSitePreviewLink( {
 		siteId: Number( site?.ID ),
 	} );
 
 	// Generate preview link for site on business or ecommerce plan
 	// Preview links are only available on these two plans
 	useEffect( () => {
-		if ( previewLinks && Array.isArray( previewLinks ) && previewLinks.length === 0 ) {
-			if ( isBusinessPlan || isEcommercePlan ) {
-				createLink();
-			}
+		if (
+			isPreviewEligible &&
+			! hasCreateError &&
+			Array.isArray( previewLinks ) &&
+			previewLinks.length === 0
+		) {
+			createLink();
 		}
-	}, [ previewLinks, createLink, isBusinessPlan, isEcommercePlan ] );
+	}, [ previewLinks, createLink, isPreviewEligible, hasCreateError ] );
 
 	const shareCode = previewLinks?.[ 0 ]?.code;
 


### PR DESCRIPTION
## Proposed Changes

Gate automatic preview-link creation by the same eligibility condition as its query and stop automatic creation after a mutation failure. Give the shared creation mutation a site-scoped key so changing sites resets its observer without retargeting an older pending mutation's callbacks.

## Why are these changes being made?

Cached empty preview data currently triggers creation even for an ineligible site. Restoring an empty cache after an error triggers another write, creating a retry loop. Without a site key, a pending response can also write to the new site's cache after a site switch. The fix keeps automatic work bounded and associated with the site that initiated it.

## Testing Instructions

```bash
yarn test-client client/landing/stepper/hooks/test/use-site-preview-share-code.tsx --runInBand --silent
yarn typecheck-client
```

Six actual QueryClient/hook tests cover successful creation, both ineligible-site cases, failure without automatic retry, a new site after failure, and a deferred response from the previous site. Four initial regressions fail on trunk; both site-switch regressions fail without the mutation key. Manual creation remains callable after failure, and remounting allows a fresh automatic attempt. The mutation's request shape, optimistic update, rollback, and cache invalidation are preserved. The local failed-attempt fixture drops from two writes to one; no production latency claim.

The commands above passed on this independent branch. Changed-file lint also passed. Validation baseline: trunk `7cc9ee953a3`. No browser/E2E, real payment, or live migration was performed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
