### PR TITLE
SSH migration: enforce preparation readiness and preserve verified inputs

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-poll-ssh-migration-atomic-transfer.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/hooks/use-poll-ssh-migration-atomic-transfer.ts
@@ -50,12 +50,18 @@ export const usePollSSHMigrationAtomicTransfer = (
 		retry: false,
 	} );
 
-	const isTransferring =
-		query.data && ! endStates.includes( query.data.transfer_status ) ? true : false;
+	const transferStatus = query.data?.transfer_status;
+	const isTransferFailed =
+		query.isError ||
+		( !! transferStatus && transferStatus !== 'completed' && endStates.includes( transferStatus ) );
+	const isTransferReady = ! isTransferFailed && transferStatus === 'completed';
+	const isTransferring = ! isTransferReady && ! isTransferFailed;
 
 	return {
 		...query,
 		isTransferring,
-		transferStatus: query.data?.transfer_status,
+		isTransferReady,
+		isTransferFailed,
+		transferStatus,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/index.tsx
@@ -180,7 +180,9 @@ const SiteMigrationSshShareAccess: StepType< {
 			await updateMigrationStatus( { status: MigrationStatus.STARTED_DIFM } );
 
 			// Reset the site in the state to ensure the correct overview screen is shown.
-			siteId && dispatch( resetSite( siteId ) );
+			if ( siteId ) {
+				dispatch( resetSite( siteId ) );
+			}
 
 			return navigation.submit?.( {
 				destination: 'do-it-for-me',
@@ -210,14 +212,16 @@ const SiteMigrationSshShareAccess: StepType< {
 	} );
 
 	// Poll SSH migration atomic transfer status
-	const { transferStatus, isTransferring } = usePollSSHMigrationAtomicTransfer(
-		siteId,
-		transferId,
-		{
-			enabled: !! transferId && siteId > 0,
-			refetchInterval: 2000, // Poll every 2 seconds
-		}
-	);
+	const {
+		isTransferReady,
+		isTransferFailed: hasTransferFailed,
+		isTransferring,
+	} = usePollSSHMigrationAtomicTransfer( siteId, transferId, {
+		enabled: !! transferId && siteId > 0 && ! migrationStarted,
+		refetchInterval: 2000, // Poll every 2 seconds
+	} );
+
+	const isTransferFailed = ! migrationStarted && hasTransferFailed;
 
 	const { mutate: startMigration, isPending: isStartingMigration } = useStartSSHMigration();
 
@@ -230,6 +234,8 @@ const SiteMigrationSshShareAccess: StepType< {
 		onAskForHelp: navigateToDoItForMe,
 		migrationStatus: migrationStatus?.status,
 		isTransferring,
+		isTransferReady,
+		isTransferFailed,
 		isInputDisabled:
 			isStartingMigration || migrationStarted || shouldStartMigration || isProcessingNoSSH,
 		isProcessingNoSSH,
@@ -307,9 +313,12 @@ const SiteMigrationSshShareAccess: StepType< {
 				isValidIPv4( formState.serverAddress ) || isValidIPv6( formState.serverAddress ),
 			host: host,
 		} );
+		if ( isTransferFailed ) {
+			return;
+		}
 		setMigrationError( null );
 
-		if ( isTransferring ) {
+		if ( ! isTransferReady ) {
 			setShouldStartMigration( true );
 			return;
 		}
@@ -317,13 +326,19 @@ const SiteMigrationSshShareAccess: StepType< {
 		triggerSSHMigration();
 	};
 
+	useEffect( () => {
+		if ( isTransferFailed ) {
+			setShouldStartMigration( false );
+		}
+	}, [ isTransferFailed ] );
+
 	// Auto-start migration when verification completes
 	useEffect( () => {
-		if ( transferStatus === 'completed' && shouldStartMigration ) {
+		if ( isTransferReady && shouldStartMigration ) {
 			setShouldStartMigration( false );
 			triggerSSHMigration();
 		}
-	}, [ transferStatus, shouldStartMigration, triggerSSHMigration ] );
+	}, [ isTransferReady, shouldStartMigration, triggerSSHMigration ] );
 
 	const displaySiteName = urlToDomain( fromUrl );
 	const hostDisplayName = getSSHHostDisplayName( host );
@@ -378,6 +393,7 @@ const SiteMigrationSshShareAccess: StepType< {
 							onClick={ handleContinue }
 							disabled={
 								! canStartMigration ||
+								isTransferFailed ||
 								isStartingMigration ||
 								migrationStarted ||
 								shouldStartMigration ||

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-add-server-address.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-add-server-address.tsx
@@ -97,7 +97,7 @@ export const StepAddServerAddress: FC< StepAddServerAddressProps > = ( {
 							onServerAddressChange( e.target.value )
 						}
 						placeholder="ssh.wp.example-host.net"
-						disabled={ isInputDisabled }
+						disabled={ isInputDisabled || isPending }
 					/>
 				</div>
 
@@ -114,7 +114,7 @@ export const StepAddServerAddress: FC< StepAddServerAddressProps > = ( {
 							const newPort = Number.isNaN( parsedPort ) ? 22 : parsedPort;
 							onPortChange( newPort );
 						} }
-						disabled={ isInputDisabled }
+						disabled={ isInputDisabled || isPending }
 					/>
 				</div>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/step-share-ssh-access.tsx
@@ -27,6 +27,7 @@ interface StepShareSSHAccessProps {
 	onAskForHelp: () => void;
 	helpLink: ReactNode;
 	isTransferring: boolean;
+	isTransferFailed: boolean;
 	shouldGenerateKey: boolean;
 	isInputDisabled: boolean;
 	isProcessingAssistedMigration: boolean;
@@ -50,12 +51,14 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 	onAskForHelp,
 	helpLink,
 	isTransferring,
+	isTransferFailed,
 	shouldGenerateKey,
 	isInputDisabled,
 	isProcessingAssistedMigration,
 } ) => {
 	const translate = useTranslate();
 	const [ copied, setCopied ] = useState( false );
+	const isUsernameDisabled = isUsernameLockedForKey || isInputDisabled;
 
 	const handleAuthMethodChange = ( method: 'password' | 'key' ) => {
 		recordTracksEvent( 'calypso_site_migration_ssh_action', {
@@ -96,12 +99,6 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 	const getErrorMessage = () => {
 		const isCredentialFailure = error?.message === 'credential_failure';
 
-		if ( ! isCredentialFailure ) {
-			return translate(
-				'We ran into a problem starting the migration. Please check your details and try again.'
-			);
-		}
-
 		const AskForHelpButton = (
 			<Button
 				variant="link"
@@ -120,6 +117,18 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 				{ isProcessingAssistedMigration && <Spinner /> }
 			</Button>
 		);
+
+		if ( isTransferFailed ) {
+			return translate( 'We ran into a problem preparing your site for migration. {{button/}}', {
+				components: { button: AskForHelpButton },
+			} );
+		}
+
+		if ( ! isCredentialFailure ) {
+			return translate(
+				'We ran into a problem starting the migration. Please check your details and try again.'
+			);
+		}
 
 		// Provide specific guidance based on authentication method with link to assisted migration
 		if ( authMethod === 'password' ) {
@@ -153,7 +162,9 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 
 			{ helpLink }
 
-			{ error && <AccordionNotice variant="error">{ getErrorMessage() }</AccordionNotice> }
+			{ ( error || isTransferFailed ) && (
+				<AccordionNotice variant="error">{ getErrorMessage() }</AccordionNotice>
+			) }
 
 			<div className="site-migration-ssh__step-share-ssh-auth-method">
 				<label className="site-migration-ssh__step-share-ssh-label">
@@ -235,8 +246,8 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 										onUsernameChange( e.target.value )
 									}
 									placeholder={ translate( 'Enter your SSH username' ) }
-									disabled={ isUsernameLockedForKey }
-									className={ isUsernameLockedForKey ? 'is-disabled' : '' }
+									disabled={ isUsernameDisabled }
+									className={ isUsernameDisabled ? 'is-disabled' : '' }
 								/>
 							</div>
 							{ isUsernameLockedForKey && (
@@ -245,6 +256,7 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 									label={ translate( 'Edit username' ) }
 									className="site-migration-ssh__step-share-ssh-edit-button"
 									onClick={ handleEditUsername }
+									disabled={ isInputDisabled }
 								/>
 							) }
 						</div>
@@ -263,7 +275,10 @@ export const StepShareSSHAccess: FC< StepShareSSHAccessProps > = ( {
 									variant="secondary"
 									onClick={ handleGenerateSSHKey }
 									disabled={
-										! username || isGeneratingKey || ( isTransferring && shouldGenerateKey )
+										! username ||
+										isGeneratingKey ||
+										isTransferFailed ||
+										( isTransferring && shouldGenerateKey )
 									}
 									isBusy={ isGeneratingKey || ( isTransferring && shouldGenerateKey ) }
 								>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/test/pending-inputs.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/test/pending-inputs.tsx
@@ -1,0 +1,200 @@
+/** @jest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import wpcom from 'calypso/lib/wp';
+import { StepAddServerAddress } from '../step-add-server-address';
+import { useSteps } from '../use-steps';
+
+jest.mock( 'calypso/lib/wp', () => ( { req: { post: jest.fn() } } ) );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( { recordTracksEvent: jest.fn() } ) );
+jest.mock( '../help-link', () => ( { HelpLink: () => null } ) );
+
+const onVerify = jest.fn();
+const post = jest.mocked( wpcom.req.post );
+let client: QueryClient;
+let resolveRequest: ( response: { success: boolean; ssh_public_key?: string } ) => void;
+let rejectRequest: ( error: Error ) => void;
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+	post.mockImplementation(
+		() =>
+			new Promise( ( resolve, reject ) => {
+				resolveRequest = resolve;
+				rejectRequest = reject;
+			} )
+	);
+} );
+afterEach( () => client.clear() );
+
+const ServerDetails = () => {
+	const [ serverAddress, setServerAddress ] = useState( 'ssh.example' );
+	const [ port, setPort ] = useState( 22 );
+	return (
+		<StepAddServerAddress
+			siteId={ 123 }
+			serverAddress={ serverAddress }
+			port={ port }
+			helpLink={ null }
+			onServerAddressChange={ setServerAddress }
+			onPortChange={ setPort }
+			onVerify={ onVerify }
+			isInputDisabled={ false }
+		/>
+	);
+};
+const AccessDetails = () => {
+	const { steps } = useSteps( {
+		fromUrl: 'https://source.example',
+		siteId: 123,
+		siteName: 'Destination',
+		onNoSSHAccess: jest.fn(),
+		onAskForHelp: jest.fn(),
+		isTransferring: false,
+		isTransferReady: true,
+		isTransferFailed: false,
+		isInputDisabled: false,
+	} );
+	return (
+		<>
+			{ steps.map( ( step ) => (
+				<div key={ step.task.id }>{ step.expandable?.content }</div>
+			) ) }
+		</>
+	);
+};
+
+it.each( [ 'success', 'error' ] )(
+	'locks server identity until verification returns %s',
+	async ( outcome ) => {
+		render(
+			<QueryClientProvider client={ client }>
+				<ServerDetails />
+			</QueryClientProvider>
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: 'Verify server address' } ) );
+		await waitFor( () => expect( post ).toHaveBeenCalledTimes( 1 ) );
+		expect( screen.getByLabelText( 'Server address' ) ).toBeDisabled();
+		expect( screen.getByLabelText( 'Port' ) ).toBeDisabled();
+		await act( async () => {
+			if ( outcome === 'success' ) {
+				resolveRequest( { success: true } );
+			} else {
+				rejectRequest( new Error( 'Verification failed' ) );
+			}
+		} );
+		await waitFor( () => expect( screen.getByLabelText( 'Server address' ) ).toBeEnabled() );
+		expect( screen.getByLabelText( 'Port' ) ).toBeEnabled();
+		expect( onVerify ).toHaveBeenCalledTimes( outcome === 'success' ? 1 : 0 );
+		fireEvent.change( screen.getByLabelText( 'Server address' ), {
+			target: { value: 'second.example' },
+		} );
+		fireEvent.change( screen.getByLabelText( 'Port' ), { target: { value: '2222' } } );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Verify server address' } ) );
+		await waitFor( () =>
+			expect( post ).toHaveBeenLastCalledWith(
+				expect.objectContaining( {
+					body: { host: 'second.example', port: '2222' },
+				} )
+			)
+		);
+	}
+);
+
+it.each( [ 'success', 'error' ] )(
+	'locks SSH username while key generation returns %s',
+	async ( outcome ) => {
+		render(
+			<QueryClientProvider client={ client }>
+				<AccessDetails />
+			</QueryClientProvider>
+		);
+		fireEvent.click( screen.getAllByRole( 'radio' )[ 1 ] );
+		fireEvent.change( screen.getByLabelText( 'SSH username' ), {
+			target: { value: 'first-user' },
+		} );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Generate SSH key' } ) );
+		await waitFor( () => expect( post ).toHaveBeenCalledTimes( 1 ) );
+		expect( screen.getByLabelText( 'SSH username' ) ).toBeDisabled();
+		for ( const radio of screen.getAllByRole( 'radio' ) ) {
+			expect( radio ).toBeDisabled();
+		}
+		expect( screen.queryByRole( 'button', { name: 'Edit username' } ) ).not.toBeInTheDocument();
+		await act( async () => {
+			if ( outcome === 'success' ) {
+				resolveRequest( { success: true, ssh_public_key: 'public-key' } );
+			} else {
+				rejectRequest( new Error( 'Configuration failed' ) );
+			}
+		} );
+		if ( outcome === 'success' ) {
+			fireEvent.click( await screen.findByRole( 'button', { name: 'Edit username' } ) );
+		}
+		await waitFor( () => expect( screen.getByLabelText( 'SSH username' ) ).toBeEnabled() );
+		for ( const radio of screen.getAllByRole( 'radio' ) ) {
+			expect( radio ).toBeEnabled();
+		}
+		fireEvent.change( screen.getByLabelText( 'SSH username' ), {
+			target: { value: 'second-user' },
+		} );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Generate SSH key' } ) );
+		await waitFor( () =>
+			expect( post ).toHaveBeenLastCalledWith(
+				expect.objectContaining( {
+					body: expect.objectContaining( { remote_user: 'second-user' } ),
+				} )
+			)
+		);
+	}
+);
+
+it.each( [ 'success', 'error' ] )(
+	'locks the shared server context until key generation returns %s',
+	async ( outcome ) => {
+		render(
+			<QueryClientProvider client={ client }>
+				<AccessDetails />
+			</QueryClientProvider>
+		);
+		fireEvent.change( screen.getByLabelText( 'Server address' ), {
+			target: { value: 'ssh.example' },
+		} );
+		fireEvent.change( screen.getByLabelText( 'Port' ), { target: { value: '2222' } } );
+		fireEvent.click( screen.getAllByRole( 'radio' )[ 1 ] );
+		fireEvent.change( screen.getByLabelText( 'SSH username' ), {
+			target: { value: 'first-user' },
+		} );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Generate SSH key' } ) );
+		await waitFor( () =>
+			expect( post ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					body: expect.objectContaining( {
+						remote_host: 'ssh.example',
+						remote_port: '2222',
+						remote_user: 'first-user',
+					} ),
+				} )
+			)
+		);
+		expect( screen.getByLabelText( 'Server address' ) ).toBeDisabled();
+		expect( screen.getByLabelText( 'Port' ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Verify server address' } ) ).toBeDisabled();
+		await act( async () => {
+			if ( outcome === 'success' ) {
+				resolveRequest( { success: true, ssh_public_key: 'public-key' } );
+			} else {
+				rejectRequest( new Error( 'Configuration failed' ) );
+			}
+		} );
+		await waitFor( () => expect( screen.getByLabelText( 'Server address' ) ).toBeEnabled() );
+		expect( screen.getByLabelText( 'Port' ) ).toBeEnabled();
+		fireEvent.change( screen.getByLabelText( 'Server address' ), {
+			target: { value: 'second.example' },
+		} );
+		fireEvent.change( screen.getByLabelText( 'Port' ), { target: { value: '2200' } } );
+		expect( screen.getByLabelText( 'Server address' ) ).toHaveValue( 'second.example' );
+		expect( screen.getByLabelText( 'Port' ) ).toHaveValue( 2200 );
+	}
+);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/steps/use-steps.tsx
@@ -42,6 +42,7 @@ interface StepsDataOptions {
 	host?: string;
 	onNoSSHAccess: () => void;
 	isTransferring: boolean;
+	isTransferFailed: boolean;
 	shouldGenerateKey: boolean;
 	isInputDisabled: boolean;
 	isProcessingNoSSH: boolean;
@@ -83,6 +84,8 @@ interface UseStepsOptions {
 	onAskForHelp: () => void;
 	migrationStatus?: 'queued' | 'in-progress' | 'migrating' | 'completed' | 'failed';
 	isTransferring: boolean;
+	isTransferReady: boolean;
+	isTransferFailed: boolean;
 	isInputDisabled: boolean;
 	isProcessingNoSSH?: boolean;
 	isProcessingAssistedMigration?: boolean;
@@ -177,6 +180,7 @@ const useStepsData = ( options: StepsDataOptions ): StepsData => {
 						/>
 					}
 					isTransferring={ options.isTransferring }
+					isTransferFailed={ options.isTransferFailed }
 					shouldGenerateKey={ options.shouldGenerateKey }
 					isInputDisabled={ options.isInputDisabled }
 					isProcessingAssistedMigration={ options.isProcessingAssistedMigration }
@@ -197,6 +201,8 @@ export const useSteps = ( {
 	host,
 	migrationStatus,
 	isTransferring,
+	isTransferReady,
+	isTransferFailed,
 	isInputDisabled,
 	isProcessingNoSSH = false,
 	isProcessingAssistedMigration = false,
@@ -310,7 +316,10 @@ export const useSteps = ( {
 	] );
 
 	const handleGenerateSSHKey = () => {
-		if ( isTransferring ) {
+		if ( isTransferFailed ) {
+			return;
+		}
+		if ( ! isTransferReady ) {
 			setShouldGenerateKey( true );
 			return;
 		}
@@ -320,11 +329,13 @@ export const useSteps = ( {
 
 	// Auto-generate SSH key when transfer completes
 	useEffect( () => {
-		if ( ! isTransferring && shouldGenerateKey ) {
+		if ( isTransferFailed ) {
+			setShouldGenerateKey( false );
+		} else if ( isTransferReady && shouldGenerateKey ) {
 			setShouldGenerateKey( false );
 			triggerGenerateSSHKey();
 		}
-	}, [ isTransferring, shouldGenerateKey, triggerGenerateSSHKey ] );
+	}, [ isTransferReady, isTransferFailed, shouldGenerateKey, triggerGenerateSSHKey ] );
 
 	const handleEditUsername = () => {
 		setFormState( ( prev ) => ( { ...prev, sshPublicKey: '' } ) );
@@ -361,8 +372,9 @@ export const useSteps = ( {
 		onNoSSHAccess,
 		host,
 		isTransferring,
+		isTransferFailed,
 		shouldGenerateKey,
-		isInputDisabled,
+		isInputDisabled: isInputDisabled || isGeneratingKey,
 		isProcessingNoSSH,
 		isProcessingAssistedMigration,
 	} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/test/atomic-transfer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access/test/atomic-transfer.tsx
@@ -1,0 +1,249 @@
+/** @jest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import wpcom from 'calypso/lib/wp';
+import SiteMigrationSshShareAccess from '..';
+import { usePollSSHMigrationAtomicTransferQueryKey as getTransferQueryKey } from '../hooks/use-poll-ssh-migration-atomic-transfer';
+import type { PropsWithChildren } from 'react';
+
+jest.mock( 'calypso/lib/wp', () => ( { req: { get: jest.fn(), post: jest.fn() } } ) );
+jest.mock( '@automattic/i18n-utils', () => ( {
+	useLocale: () => 'en',
+	localizeUrl: ( url: string ) => url,
+} ) );
+jest.mock( '@automattic/onboarding', () => ( {
+	Step: {
+		CenteredColumnLayout: ( { children }: PropsWithChildren ) => children,
+		TopBar: () => null,
+		Heading: () => null,
+	},
+} ) );
+jest.mock( 'calypso/components/data/document-head', () => () => null );
+jest.mock( 'calypso/state', () => ( { useDispatch: () => jest.fn() } ) );
+jest.mock( 'calypso/state/sites/actions', () => ( { resetSite: jest.fn() } ) );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( { recordTracksEvent: jest.fn() } ) );
+jest.mock( 'calypso/landing/stepper/hooks/use-site', () => ( {
+	useSite: () => ( { ID: 123, name: 'Destination' } ),
+} ) );
+jest.mock( 'calypso/landing/stepper/hooks/use-query', () => ( {
+	useQuery: () => new URLSearchParams( 'from=https://source.example&transferId=456' ),
+} ) );
+jest.mock( 'calypso/landing/stepper/hooks/use-site-slug-param', () => ( {
+	useSiteSlugParam: () => 'destination.wordpress.com',
+} ) );
+jest.mock( 'calypso/landing/stepper/hooks/use-submit-migration-ticket', () => ( {
+	useSubmitMigrationTicket: () => ( { sendTicketAsync: jest.fn(), isPending: false } ),
+} ) );
+jest.mock( 'calypso/data/site-migration/landing/use-update-migration-status', () => ( {
+	useUpdateMigrationStatus: () => ( { mutateAsync: jest.fn() } ),
+} ) );
+jest.mock( '../../site-migration-credentials/hooks/use-credentials-form', () => ( {} ) );
+jest.mock( '../../site-migration-instructions/support-nudge', () => ( {
+	SupportNudge: () => null,
+} ) );
+jest.mock( '../steps/help-link', () => ( { HelpLink: () => null } ) );
+jest.mock( '../hooks/use-rotating-loading-messages', () => ( {
+	useRotatingLoadingMessages: () => ( { buttonText: 'Continue' } ),
+} ) );
+
+const queryKey = getTransferQueryKey( 123, 456 );
+const statusResponse = ( transfer_status: string ) => ( {
+	blog_id: 123,
+	transfer_id: 456,
+	transfer_status,
+} );
+const post = jest.mocked( wpcom.req.post );
+const get = jest.mocked( wpcom.req.get );
+const callsTo = ( endpoint: string ) =>
+	post.mock.calls.filter( ( [ request ]: [ { path: string } ] ) =>
+		request.path.endsWith( endpoint )
+	);
+let client: QueryClient;
+const submit = jest.fn();
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	client = new QueryClient( {
+		defaultOptions: { queries: { retry: false, staleTime: Infinity }, mutations: { retry: false } },
+	} );
+	get.mockImplementation( () => new Promise( () => {} ) );
+	post.mockResolvedValue( { success: true, ssh_public_key: 'public-key' } );
+} );
+afterEach( () => client.clear() );
+
+const renderStep = ( status?: string ) => {
+	if ( status ) {
+		client.setQueryData( queryKey, statusResponse( status ) );
+	}
+	return render(
+		<QueryClientProvider client={ client }>
+			<SiteMigrationSshShareAccess
+				navigation={ { submit } }
+				flow="site-migration"
+				stepName="site-migration-ssh-share-access"
+			/>
+		</QueryClientProvider>
+	);
+};
+
+const completeForm = async ( authMethod: 'password' | 'key' ) => {
+	fireEvent.click( screen.getByRole( 'button', { name: /Find your SSH details/ } ) );
+	fireEvent.click( screen.getByRole( 'button', { name: 'I found my SSH details' } ) );
+	fireEvent.change( screen.getByLabelText( 'Server address' ), {
+		target: { value: 'ssh.example' },
+	} );
+	fireEvent.click( screen.getByRole( 'button', { name: 'Verify server address' } ) );
+	await screen.findByLabelText( 'SSH username' );
+	if ( authMethod === 'key' ) {
+		fireEvent.click( screen.getAllByRole( 'radio' )[ 1 ] );
+	}
+	fireEvent.change( screen.getByLabelText( 'SSH username' ), { target: { value: 'user' } } );
+	if ( authMethod === 'password' ) {
+		fireEvent.change( screen.getByLabelText( 'SSH password' ), { target: { value: 'password' } } );
+	}
+};
+const actionButton = ( authMethod: 'password' | 'key' ) =>
+	screen.getByRole( 'button', {
+		name: authMethod === 'password' ? 'Continue' : 'Generate SSH key',
+	} );
+const endpointFor = ( authMethod: 'password' | 'key' ) =>
+	authMethod === 'password' ? '/start' : '/configure';
+const setStatus = async ( status: string ) => {
+	await act( async () => {
+		client.setQueryData( queryKey, statusResponse( status ) );
+		await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+	} );
+};
+
+describe.each( [ 'password', 'key' ] as const )( '%s authentication', ( authMethod ) => {
+	it.each( [ undefined, 'provisioning' ] )(
+		'waits for completed when status is %s',
+		async ( status ) => {
+			renderStep( status );
+			await completeForm( authMethod );
+			fireEvent.click( actionButton( authMethod ) );
+			await waitFor( () => expect( actionButton( authMethod ) ).toBeDisabled() );
+			expect( callsTo( endpointFor( authMethod ) ) ).toHaveLength( 0 );
+			await setStatus( 'completed' );
+			expect( screen.queryByText( /problem preparing your site/ ) ).not.toBeInTheDocument();
+			await waitFor( () => expect( callsTo( endpointFor( authMethod ) ) ).toHaveLength( 1 ) );
+		}
+	);
+
+	it.each( [ 'failed', 'error', 'reverted' ] )(
+		'settles queued work on %s without starting it',
+		async ( status ) => {
+			renderStep( 'provisioning' );
+			await completeForm( authMethod );
+			fireEvent.click( actionButton( authMethod ) );
+			await setStatus( status );
+			await waitFor( () => expect( actionButton( authMethod ) ).not.toHaveClass( 'is-busy' ) );
+			expect( actionButton( authMethod ) ).toBeDisabled();
+			expect( screen.getByLabelText( 'SSH username' ) ).toBeEnabled();
+			expect( screen.getByText( /problem preparing your site/ ) ).toBeVisible();
+			expect(
+				screen.getByRole( 'button', { name: 'Need help? Let us migrate your site' } )
+			).toBeEnabled();
+			expect( callsTo( endpointFor( authMethod ) ) ).toHaveLength( 0 );
+			fireEvent.click( actionButton( authMethod ) );
+			expect( callsTo( endpointFor( authMethod ) ) ).toHaveLength( 0 );
+			await setStatus( 'completed' );
+			expect( screen.queryByText( /problem preparing your site/ ) ).not.toBeInTheDocument();
+			expect( callsTo( endpointFor( authMethod ) ) ).toHaveLength( 0 );
+			fireEvent.click( actionButton( authMethod ) );
+			await waitFor( () => expect( callsTo( endpointFor( authMethod ) ) ).toHaveLength( 1 ) );
+		}
+	);
+
+	it( 'clears queued intent on a polling error and allows an explicit retry after recovery', async () => {
+		renderStep( 'provisioning' );
+		await completeForm( authMethod );
+		fireEvent.click( actionButton( authMethod ) );
+		get.mockRejectedValueOnce( new Error( 'Network unavailable' ) );
+		await act( async () => {
+			await client.refetchQueries( { queryKey } );
+		} );
+		await waitFor( () => expect( actionButton( authMethod ) ).not.toHaveClass( 'is-busy' ) );
+		expect( actionButton( authMethod ) ).toBeDisabled();
+		expect( screen.getByLabelText( 'SSH username' ) ).toBeEnabled();
+		expect( screen.getByText( /problem preparing your site/ ) ).toBeVisible();
+		expect(
+			screen.getByRole( 'button', { name: 'Need help? Let us migrate your site' } )
+		).toBeEnabled();
+		expect( callsTo( endpointFor( authMethod ) ) ).toHaveLength( 0 );
+		await setStatus( 'completed' );
+		expect( screen.queryByText( /problem preparing your site/ ) ).not.toBeInTheDocument();
+		expect( callsTo( endpointFor( authMethod ) ) ).toHaveLength( 0 );
+		fireEvent.click( actionButton( authMethod ) );
+		await waitFor( () => expect( callsTo( endpointFor( authMethod ) ) ).toHaveLength( 1 ) );
+	} );
+} );
+
+it( 'offers the existing assisted migration action after preparation fails', async () => {
+	renderStep( 'failed' );
+	await completeForm( 'password' );
+	fireEvent.click( screen.getByRole( 'button', { name: 'Need help? Let us migrate your site' } ) );
+	await waitFor( () => expect( submit ).toHaveBeenCalledWith( { destination: 'do-it-for-me' } ) );
+	expect( callsTo( '/start' ) ).toHaveLength( 0 );
+	expect( callsTo( '/configure' ) ).toHaveLength( 0 );
+} );
+
+it( 'preserves a migration error when atomic polling recovers', async () => {
+	renderStep( 'completed' );
+	await completeForm( 'password' );
+	post.mockRejectedValueOnce( new Error( 'Migration could not start' ) );
+	fireEvent.click( actionButton( 'password' ) );
+	await screen.findByText( /problem starting the migration/ );
+	get.mockRejectedValueOnce( new Error( 'Network unavailable' ) );
+	await act( async () => {
+		await client.refetchQueries( { queryKey } );
+	} );
+	await screen.findByText( /problem preparing your site/ );
+	await setStatus( 'completed' );
+	expect( screen.queryByText( /problem preparing your site/ ) ).not.toBeInTheDocument();
+	expect( screen.getByText( /problem starting the migration/ ) ).toBeVisible();
+} );
+
+it.each( [ 'queued', 'in-progress' ] )(
+	'ignores a late preparation error while SSH is %s',
+	async ( status ) => {
+		let rejectPreparation: ( error: Error ) => void = () => {};
+		const preparation = new Promise( ( _resolve, reject ) => {
+			rejectPreparation = reject;
+		} );
+		get.mockImplementation( ( request: { path: string } ) =>
+			request.path.endsWith( '/status' )
+				? Promise.resolve( { success: true, status, step: 'requested-migration' } )
+				: preparation
+		);
+		renderStep( 'completed' );
+		await completeForm( 'password' );
+		let pendingRefetch: Promise< void > = Promise.resolve();
+		act( () => {
+			pendingRefetch = client.refetchQueries( { queryKey } );
+		} );
+		fireEvent.click( actionButton( 'password' ) );
+		await waitFor( () =>
+			expect( client.getQueryData( [ 'ssh-migration-status', 123 ] ) ).toEqual( {
+				success: true,
+				status,
+				step: 'requested-migration',
+			} )
+		);
+		await act( async () => {
+			rejectPreparation( new Error( 'Late network failure' ) );
+			await pendingRefetch;
+		} );
+		await waitFor( () => expect( client.getQueryState( queryKey )?.status ).toBe( 'error' ) );
+		expect( screen.queryByText( /problem preparing your site/ ) ).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Need help? Let us migrate your site' } )
+		).not.toBeInTheDocument();
+		const previousCalls = get.mock.calls.length;
+		await act( async () => {
+			await client.refetchQueries( { queryKey } );
+		} );
+		expect( get ).toHaveBeenCalledTimes( previousCalls );
+		expect( actionButton( 'password' ) ).toBeDisabled();
+	}
+);


### PR DESCRIPTION
## Proposed Changes

Require confirmed Atomic preparation before starting SSH migration or configuring its key. Queue actions while preparation is pending, discard queued intent on failure, and expose the existing assisted-migration action. Stop observing obsolete preparation after SSH migration starts. Lock verification and key-configuration inputs while their requests are pending.

## Why are these changes being made?

The old boolean treats missing and terminal-failure status like readiness. This can start work too soon, generate a key after preparation fails, or leave a queued Continue stuck. Late preparation errors can also conflict with an already-started migration. Editing request inputs before their responses arrive can mark a different server verified or attach a key to different connection details.

## Testing Instructions

```bash
yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-ssh-share-access --runInBand --silent
yarn typecheck-client
```

Actual component, hook, query, and mutation tests cover initial pending, successful queued actions, failed/error/reverted preparation, polling errors, explicit recovery, assisted help, and accepted SSH starts with late preparation responses. Deferred-input tests cover pending verification and key generation, success/failure unlock, and ordinary editing afterward. Canceled intent does not replay automatically; unrelated migration errors remain visible. Assistance is invoked only by an explicit user click. Existing request payloads and backend preparation retry semantics are unchanged. One translated preparation-error string is added; browser, live migration, accessibility, and multilingual checks remain for review.

The commands above passed on this independent branch. Changed-file lint also passed. Validation baseline: trunk `7cc9ee953a3`. No browser/E2E, real payment, or live migration was performed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
