### PR TITLE
A4A: remove the MCP private-beta gating

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
@@ -55,7 +55,6 @@ const useLearnMenuItems = ( path: string ) => {
 				path: A4A_AI_MCP_LINK,
 				link: A4A_AI_MCP_LINK,
 				title: translate( 'AI and MCP' ),
-				badge: translate( 'Beta' ),
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Resources and tools / AI and MCP',
 				},

--- a/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/hooks/use-learn-menu-items.tsx
@@ -3,8 +3,6 @@ import { BigSkyLogo } from '@automattic/components/src/logos/big-sky-logo';
 import { brush, chartBar, pages, tool } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
-import { useSelector } from 'react-redux';
-import { getActiveAgency } from 'calypso/state/a8c-for-agencies/agency/selectors';
 import {
 	A4A_AGENT_STUDIO_LINK,
 	A4A_AI_MCP_LINK,
@@ -17,9 +15,7 @@ import { createItem } from '../lib/utils';
 
 const useLearnMenuItems = ( path: string ) => {
 	const translate = useTranslate();
-	const agency = useSelector( getActiveAgency );
 	const isAgentStudioEnabled = isEnabled( 'a4a-agent-studio' );
-	const isAiMcpEnabled = !! agency?.mcp?.allowed;
 	const isBenchmarksEnabled = isEnabled( 'a4a-benchmarks' );
 
 	const menuItems = useMemo( () => {
@@ -50,24 +46,20 @@ const useLearnMenuItems = ( path: string ) => {
 						},
 				  ]
 				: [] ),
-			...( isAiMcpEnabled
-				? [
-						{
-							icon: (
-								<span className="sidebar__menu-icon">
-									<BigSkyLogo.CentralLogo heartless size={ 24 } fill="currentColor" />
-								</span>
-							),
-							path: A4A_AI_MCP_LINK,
-							link: A4A_AI_MCP_LINK,
-							title: translate( 'AI and MCP' ),
-							badge: translate( 'Beta' ),
-							trackEventProps: {
-								menu_item: 'Automattic for Agencies / Resources and tools / AI and MCP',
-							},
-						},
-				  ]
-				: [] ),
+			{
+				icon: (
+					<span className="sidebar__menu-icon">
+						<BigSkyLogo.CentralLogo heartless size={ 24 } fill="currentColor" />
+					</span>
+				),
+				path: A4A_AI_MCP_LINK,
+				link: A4A_AI_MCP_LINK,
+				title: translate( 'AI and MCP' ),
+				badge: translate( 'Beta' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Resources and tools / AI and MCP',
+				},
+			},
 			{
 				icon: tool,
 				path: A4A_DEV_TOOLS_LINK,
@@ -87,7 +79,7 @@ const useLearnMenuItems = ( path: string ) => {
 				},
 			},
 		].map( ( item ) => createItem( item, path ) );
-	}, [ path, translate, isAgentStudioEnabled, isAiMcpEnabled, isBenchmarksEnabled ] );
+	}, [ path, translate, isAgentStudioEnabled, isBenchmarksEnabled ] );
 
 	return menuItems;
 };

--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -96,16 +96,6 @@ export const requireTierAccessContext: Callback = ( context, next ) => {
 	next();
 };
 
-export const requireMcpBetaAccessContext: Callback = ( context, next ) => {
-	const agency = getActiveAgency( context.store.getState() );
-
-	if ( ! agency?.mcp?.allowed ) {
-		page.redirect( A4A_OVERVIEW_LINK );
-		return;
-	}
-	next();
-};
-
 export const requireAmplifyAccessContext: Callback = ( context, next ) => {
 	const agency = getActiveAgency( context.store.getState() );
 

--- a/client/a8c-for-agencies/sections/learn/index.ts
+++ b/client/a8c-for-agencies/sections/learn/index.ts
@@ -12,10 +12,7 @@ import {
 	A4A_LEARN_LINK,
 	A4A_RESOURCES_LINK,
 } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
-import {
-	requireAccessContext,
-	requireMcpBetaAccessContext,
-} from 'calypso/a8c-for-agencies/controller';
+import { requireAccessContext } from 'calypso/a8c-for-agencies/controller';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import {
 	agentStudioBriefContext,
@@ -71,18 +68,10 @@ export default function () {
 		page( A4A_BENCHMARKS_LINK, requireAccessContext, benchmarksContext, makeLayout, clientRender );
 	}
 
-	page(
-		A4A_AI_MCP_LINK,
-		requireAccessContext,
-		requireMcpBetaAccessContext,
-		aiMcpOverviewContext,
-		makeLayout,
-		clientRender
-	);
+	page( A4A_AI_MCP_LINK, requireAccessContext, aiMcpOverviewContext, makeLayout, clientRender );
 	page(
 		A4A_AI_MCP_READ_TOOLS_LINK,
 		requireAccessContext,
-		requireMcpBetaAccessContext,
 		aiMcpReadToolsContext,
 		makeLayout,
 		clientRender
@@ -90,7 +79,6 @@ export default function () {
 	page(
 		A4A_AI_MCP_WRITE_TOOLS_LINK,
 		requireAccessContext,
-		requireMcpBetaAccessContext,
 		aiMcpWriteToolsContext,
 		makeLayout,
 		clientRender
@@ -98,7 +86,6 @@ export default function () {
 	page(
 		A4A_AI_MCP_STARTER_PROMPTS_LINK,
 		requireAccessContext,
-		requireMcpBetaAccessContext,
 		aiMcpStarterPromptsContext,
 		makeLayout,
 		clientRender
@@ -106,7 +93,6 @@ export default function () {
 	page(
 		A4A_AI_MCP_CONNECT_LINK,
 		requireAccessContext,
-		requireMcpBetaAccessContext,
 		aiMcpConnectContext,
 		makeLayout,
 		clientRender

--- a/client/dashboard/app/responsive-sidebar/agency.tsx
+++ b/client/dashboard/app/responsive-sidebar/agency.tsx
@@ -44,8 +44,7 @@ export default function AgencySidebar() {
 		isMarketplaceSectionAvailable( section, agencySupports, capabilities )
 	);
 	const canAccessLearn = !! supports.agency.learn && canAccess( learnRoute );
-	const canAccessMcp =
-		!! ( supports.agency.mcp && activeAgency?.mcp?.allowed ) && canAccess( mcpRoute );
+	const canAccessMcp = !! supports.agency.mcp && canAccess( mcpRoute );
 	const canAccessEarn =
 		!! supports.agency.earn &&
 		[

--- a/client/dashboard/app/responsive-sidebar/test/agency.test.tsx
+++ b/client/dashboard/app/responsive-sidebar/test/agency.test.tsx
@@ -36,7 +36,6 @@ function mockAgency( capabilities: string[] ) {
 		.reply( 200, [
 			{
 				id: 1,
-				mcp: { allowed: true },
 				partner_directory: { allowed: true, directories: [] },
 				user: { capabilities },
 			},
@@ -143,16 +142,13 @@ describe( '<AgencySidebar>', () => {
 		expect( screen.queryByRole( 'link', { name: 'Partner Directories' } ) ).not.toBeInTheDocument();
 	} );
 
-	// MCP is the one item gated by both a tier flag (`mcp.allowed`) and a
-	// capability (`a4a_read_learn`). `mockAgency` always reports the tier flag
-	// on, so these cases isolate the capability gate.
-	test( 'shows MCP when the agency is MCP-enabled and the user holds the learn capability', async () => {
+	test( 'shows MCP when the user holds the learn capability', async () => {
 		await renderSidebar( [ 'a4a_read_learn' ] );
 
 		expect( screen.getByRole( 'link', { name: 'AI and MCP' } ) ).toBeVisible();
 	} );
 
-	test( 'hides MCP when the agency is MCP-enabled but the user lacks the learn capability', async () => {
+	test( 'hides MCP when the user lacks the learn capability', async () => {
 		await renderSidebar( [ 'a4a_read_managed_sites' ] );
 
 		expect( screen.queryByRole( 'link', { name: 'AI and MCP' } ) ).not.toBeInTheDocument();

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -419,16 +419,6 @@ export const mcpRoute = createRoute( {
 	head: () => ( { meta: [ { title: __( 'AI and MCP' ) } ] } ),
 	getParentRoute: () => agencyRoute,
 	path: 'resources/ai-mcp',
-	beforeLoad: async ( { cause } ) => {
-		if ( cause === 'preload' ) {
-			return;
-		}
-
-		const agency = await queryClient.ensureQueryData( activeAgencyQuery() );
-		if ( ! agency?.mcp?.allowed ) {
-			throw redirectAsNotAllowed( { to: '/overview' } );
-		}
-	},
 } );
 
 const mcpOverviewRoute = createRoute( {

--- a/packages/api-core/src/agency/types.ts
+++ b/packages/api-core/src/agency/types.ts
@@ -147,9 +147,6 @@ export interface Agency {
 	name: string;
 	url: string;
 	tier?: AgencyTier;
-	mcp?: {
-		allowed: boolean;
-	};
 	influenced_revenue?: number;
 	approval_status?: AgencyApprovalStatus | '';
 	profile?: AgencyProfile;


### PR DESCRIPTION
Frontend half of the A4A MCP GA rollout. Backend: https://github.a8c.com/Automattic/wpcom/pull/239546

## Proposed Changes

* Drop every `agency.mcp.allowed` check: the route guards in Calypso A4A and the Dashboard, and the two sidebar items.
* Remove the now-unread `mcp` field from the `Agency` type.

## Why are these changes being made?

The private beta is over. The backend pins `mcp.allowed` to `true` for everyone, so these checks no longer decide anything. Access now rests on the `a4a_read_learn` capability alone, like the rest of Resources and tools.

This does not switch MCP on for anyone — the per-agency master toggle still defaults to off. Deploy order does not matter either way.

## Testing Instructions

As a user in an agency that was not in the beta allowlist, in both Calypso A4A and the Dashboard:

1. "AI and MCP" shows in the Resources and tools sidebar.
2. `/resources/ai-mcp` and its sub-pages load instead of redirecting to `/overview`.
3. Without the `a4a_read_learn` capability, the item stays hidden and the routes still redirect.

```
yarn test-client client/dashboard/app/responsive-sidebar/test/agency.test.tsx
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? (PCYsg-S3g-p2)
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label? (p4TIVU-5Jq-p2)
    - [ ] For UI changes, have we tested the change in various languages?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label? (p4TIVU-aUh-p2)

*Generated by JK Bot, powered by Claude.*
