### PR TITLE
Signup: use sentence case for the account creation button label

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -388,7 +388,7 @@ class PasswordlessSignupForm extends Component {
 			!! this.props.isSubmitBlocked ||
 			this.props.blackbox.isSubmitBlocked;
 		const submitButtonText = isSubmitting
-			? this.props.submitButtonLoadingLabel || this.props.translate( 'Creating Your Account…' )
+			? this.props.submitButtonLoadingLabel || this.props.translate( 'Creating your account…' )
 			: this.props.submitButtonLabel || this.props.translate( 'Create your account' );
 
 		if ( this.props.useConnectScreenActions ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -538,7 +538,7 @@ export class UserStep extends Component {
 		const { translate } = this.props;
 
 		if ( this.userCreationPending() ) {
-			return translate( 'Creating Your Account…' );
+			return translate( 'Creating your account…' );
 		}
 
 		return translate( 'Create your account' );


### PR DESCRIPTION
## Proposed Changes

* Change the signup submit button's loading label from "Creating Your Account…" to "Creating your account…" so it uses sentence case, in both the passwordless signup form and the classic signup user step.

## Why are these changes being made?

* WordPress.com uses sentence case for UI copy. This label was title cased and looked inconsistent next to its own idle state, "Create your account", which is already sentence case.

## Testing Instructions

* Go to `/start` and submit the account creation form. While the request is in flight, the button should read "Creating your account…".
* Repeat on a passwordless signup entry point (e.g. `/start/account` or a flow using the passwordless form) and confirm the same label.
* Confirm the idle label is unchanged: "Create your account".

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M5yzzk3zaeFEM3R8y1UuP1
