### PR TITLE
E2E: fix intercepted clicks in the partner directory smoke test

### DIFF
--- a/packages/calypso-e2e/src/lib/components/partner-directory-component.ts
+++ b/packages/calypso-e2e/src/lib/components/partner-directory-component.ts
@@ -1,5 +1,11 @@
 import { envVariables } from '../..';
-import type { Page } from 'playwright';
+import type { Locator, Page } from 'playwright';
+
+const selectors = {
+	// TODO: This button has no accessible name, so we have to use a CSS selector.
+	filtersToggle: '.a4a-partner-directory-filters-toggle',
+	helpCenterButton: 'button.wpcom-help-center-fab',
+};
 
 /**
  * Component representing the a partner directory block.
@@ -23,15 +29,22 @@ export class PartnerDirectoryComponent {
 	 * @param {string} filterName The name of the filter to apply.
 	 */
 	async applyDropdownFilter( dropdownName: string, filterName: string ): Promise< void > {
+		await this.deactivateHelpCenterButton();
+
 		// On mobile, we need to click the filters toggle button first to open the filters panel.
 		if ( envVariables.VIEWPORT_NAME === 'mobile' ) {
-			// TODO: This button has no accessible name, so we have to use a CSS selector.
-			const filtersToggle = this.page.locator( '.a4a-partner-directory-filters-toggle' );
-			await filtersToggle.waitFor( { state: 'visible' } );
+			const filtersToggle = this.page.locator( selectors.filtersToggle );
+			await this.scrollToCenterOfViewport( filtersToggle );
 			await filtersToggle.click();
 		}
-		await this.page.getByRole( 'button', { name: dropdownName } ).click();
-		await this.page.getByRole( 'checkbox', { name: filterName } ).click();
+
+		const dropdown = this.page.getByRole( 'button', { name: dropdownName } );
+		await this.scrollToCenterOfViewport( dropdown );
+		await dropdown.click();
+
+		const filter = this.page.getByRole( 'checkbox', { name: filterName } );
+		await this.scrollToCenterOfViewport( filter );
+		await filter.click();
 	}
 
 	/**
@@ -49,6 +62,62 @@ export class PartnerDirectoryComponent {
 	async clickFirstPartner(): Promise< void > {
 		const partner = this.page.getByRole( 'link', { name: 'Accepting new clients' } ).first();
 
+		await this.scrollToCenterOfViewport( partner );
 		await partner.click();
+	}
+
+	/**
+	 * Stops the floating Help Center button from swallowing clicks aimed at the
+	 * directory. The button is injected asynchronously and hovers over the page
+	 * content, so it can cover the directory controls on narrow viewports.
+	 */
+	private async deactivateHelpCenterButton(): Promise< void > {
+		await this.page.addStyleTag( {
+			content: `${ selectors.helpCenterButton } { pointer-events: none !important; }`,
+		} );
+	}
+
+	/**
+	 * Scrolls the target to the middle of the viewport, then waits for its
+	 * position to settle.
+	 *
+	 * The directory is embedded in a marketing page topped by a sticky global
+	 * navigation. Playwright only scrolls a target just far enough to be in view,
+	 * which on narrow viewports leaves it beneath that navigation, and the
+	 * scroll-linked reflow of the navigation keeps moving the target from under
+	 * the pointer.
+	 *
+	 * @param {Locator} locator The target to bring into view.
+	 */
+	private async scrollToCenterOfViewport( locator: Locator ): Promise< void > {
+		await locator.waitFor( { state: 'visible' } );
+
+		await locator.evaluate( ( element ) => {
+			element.scrollIntoView( { block: 'center', behavior: 'instant' } );
+
+			return new Promise< void >( ( resolve ) => {
+				const maxFrames = 100;
+				const requiredStableFrames = 3;
+				let previousTop: number | undefined;
+				let stableFrames = 0;
+				let frames = 0;
+
+				const measure = () => {
+					const { top } = element.getBoundingClientRect();
+					stableFrames = top === previousTop ? stableFrames + 1 : 0;
+					previousTop = top;
+					frames += 1;
+
+					if ( stableFrames >= requiredStableFrames || frames >= maxFrames ) {
+						resolve();
+						return;
+					}
+
+					requestAnimationFrame( measure );
+				};
+
+				requestAnimationFrame( measure );
+			} );
+		} );
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* `PartnerDirectoryComponent` now centres each click target in the viewport before clicking it, waiting in-page on `requestAnimationFrame` until the element's position has been stable for three consecutive frames.
* Applying a dropdown filter now sets `pointer-events: none` on the Help Center floating button, so the late-mounting widget cannot swallow a click aimed at the directory.
* Selectors are lifted into a module-level `selectors` object, per the E2E style guide. No spec files changed; this is a page-object-only change.

## Why are these changes being made?

The `partner-directory__smoke.spec.ts` test "As a user, I can filter partners and view a partner details page" fails intermittently on the mobile viewport with `TimeoutError: locator.click: Timeout 10000ms exceeded` on the filters toggle. Example failure: https://teamcity.a8c.com/buildConfiguration/calypso_calypso_WebApp_A4A_E2E_Playwright_Test_Matrix/19357609

The directory is embedded in the `/development-services` marketing page, which carries two pieces of floating chrome that are not part of the feature under test: a sticky global navigation that reflows as the page scrolls, and an asynchronously injected Help Center floating button anchored to the bottom of the viewport. Playwright scrolls a click target only just far enough to be in view, which on a narrow viewport parks the toggle either under the sticky header or beside the floating button. That same scroll flips the navigation into its scrolled state, so the page reflows and the toggle moves out from under the point Playwright had already measured — the hit test then resolves to the page's own content wrapper. Each retry repeats the same minimal scroll and the same reflow, so the actionability check never converges and the click exhausts its timeout.

This is not a product bug: a sticky header and a floating help button legitimately overlay page content. The test was simply clicking without ensuring the target was clear of them. Centring the target puts it well clear of both, and the frame-settle loop absorbs the scroll-linked reflow so the position Playwright measures is still valid when it clicks. The fix uses no `force: true`, no skips, and no arbitrary timeouts.

## Testing Instructions

Run the spec against the mobile viewport locally and confirm it passes consistently:

```
cd test/e2e
VIEWPORT_NAME=mobile yarn playwright test specs/a8c-for-agencies/partner-directory__smoke.spec.ts --reporter=list --repeat-each=10
```

All runs should pass. The A4A E2E CI check on this PR exercises the same path.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WHECQPMNx3uVwcH2UTe1Gz