### PR TITLE
Dashboard: search the site selector by title and URL

### DIFF
--- a/client/dashboard/me/mcp/test/wordpress-agent-email.test.tsx
+++ b/client/dashboard/me/mcp/test/wordpress-agent-email.test.tsx
@@ -88,7 +88,7 @@ describe( '<WordPressAgentEmail />', () => {
 
 		expect( screen.getByRole( 'heading', { name: 'Email' } ) ).toBeVisible();
 		expect( screen.getByRole( 'combobox', { name: 'Select site' } ) ).toHaveValue(
-			'email-agent.wordpress.com'
+			'Email Agent — email-agent.wordpress.com'
 		);
 		expect( screen.getByRole( 'heading', { name: 'Connected' } ) ).toBeVisible();
 		expect( screen.getByLabelText( 'AI agent email address' ) ).toHaveValue(

--- a/client/dashboard/me/mcp/wordpress-agent-email.tsx
+++ b/client/dashboard/me/mcp/wordpress-agent-email.tsx
@@ -229,7 +229,6 @@ export default function WordPressAgentEmail() {
 						onChange={ selectSite }
 						label={ __( 'Select site' ) }
 						isLoading={ sitesQuery.isLoading }
-						useSiteUrlAsLabel
 					/>
 					{ ! sitesQuery.isLoading && sites.length === 0 && (
 						<Notice status="info" isDismissible={ false }>

--- a/client/dashboard/me/preferences-defaults/site-dropdown.tsx
+++ b/client/dashboard/me/preferences-defaults/site-dropdown.tsx
@@ -5,7 +5,9 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
 } from '@wordpress/components';
+import { sprintf, __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
+import { useMemo } from 'react';
 import SiteIcon from '../../components/site-icon';
 import { getSiteDisplayName } from '../../utils/site-name';
 import { getSiteDisplayUrl } from '../../utils/site-url';
@@ -25,7 +27,6 @@ interface PreferencesLoginSiteDropdownProps {
 	label?: string;
 	hideLabelFromVision?: boolean;
 	isLoading?: boolean;
-	useSiteUrlAsLabel?: boolean;
 }
 
 export default function PreferencesLoginSiteDropdown( {
@@ -35,14 +36,33 @@ export default function PreferencesLoginSiteDropdown( {
 	label = '',
 	hideLabelFromVision = false,
 	isLoading = false,
-	useSiteUrlAsLabel = false,
 }: PreferencesLoginSiteDropdownProps ) {
-	// Prepare options for ComboboxControl
-	const options: SiteOption[] = sites.map( ( site: Site ) => ( {
-		value: site.ID.toString(),
-		label: useSiteUrlAsLabel ? getSiteDisplayUrl( site ) : getSiteDisplayName( site ),
-		site,
-	} ) );
+	// ComboboxControl only ever filters on `option.label`, so the label has to carry both
+	// the site's name and its URL for either to be searchable. Keep it independent of the
+	// search term: the control tracks the highlighted option by reference, so rebuilding
+	// the options as you type makes it lose your place.
+	const options: SiteOption[] = useMemo(
+		() =>
+			sites.map( ( site: Site ) => {
+				const name = getSiteDisplayName( site );
+				const url = getSiteDisplayUrl( site );
+
+				return {
+					value: site.ID.toString(),
+					label:
+						name === url
+							? name
+							: sprintf(
+									/* translators: 1: site title, 2: site URL, e.g. "My Site — example.com" */
+									__( '%1$s — %2$s' ),
+									name,
+									url
+							  ),
+					site,
+				};
+			} ),
+		[ sites ]
+	);
 
 	// Custom render function for each option
 	const renderItem = ( { item }: { item: { value: string; label: string } } ) => {
@@ -61,7 +81,7 @@ export default function PreferencesLoginSiteDropdown( {
 					<VStack spacing={ 0 }>
 						{ /**using inherit to allow the text to be styled as white when hovering, otherwise it won't be readable */ }
 						<Text as="div" weight={ 500 } size={ 14 } lineHeight={ 1.5 } color="inherit">
-							{ item.label }
+							{ getSiteDisplayName( siteOption.site ) }
 						</Text>
 						<Text as="div" size={ 12 } weight={ 300 } lineHeight={ 1.2 } color="inherit">
 							{ getSiteDisplayUrl( siteOption.site ) }
@@ -81,8 +101,6 @@ export default function PreferencesLoginSiteDropdown( {
 
 	return (
 		<ComboboxControl
-			__next40pxDefaultSize
-			__nextHasNoMarginBottom
 			className="dashboard-preferences__login-site-dropdown"
 			label={ hideLabelFromVision ? '' : label }
 			value={ value }

--- a/client/dashboard/me/preferences-defaults/test/index.test.tsx
+++ b/client/dashboard/me/preferences-defaults/test/index.test.tsx
@@ -312,7 +312,9 @@ describe( '<PreferencesDefaults>', () => {
 
 			renderPage();
 
-			await expect( screen.findByDisplayValue( 'Primary Site' ) ).resolves.toBeVisible();
+			await expect(
+				screen.findByDisplayValue( 'Primary Site — primary.example.com' )
+			).resolves.toBeVisible();
 		} );
 
 		test( 'saves a newly selected primary site', async () => {
@@ -325,7 +327,9 @@ describe( '<PreferencesDefaults>', () => {
 
 			renderPage();
 
-			await currentUser.click( await screen.findByDisplayValue( 'Primary Site' ) );
+			await currentUser.click(
+				await screen.findByDisplayValue( 'Primary Site — primary.example.com' )
+			);
 			await currentUser.click( await screen.findByRole( 'option', { name: /Other Site/ } ) );
 			await currentUser.click( saveButtonFor( 'Primary site' ) );
 

--- a/client/dashboard/me/preferences-defaults/test/site-dropdown.test.tsx
+++ b/client/dashboard/me/preferences-defaults/test/site-dropdown.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../test-utils';
+import PreferencesLoginSiteDropdown from '../site-dropdown';
+import type { Site } from '@automattic/api-core';
+
+// The suggestions list scrolls the highlighted option into view, which JSDOM lacks.
+Element.prototype.scrollIntoView = jest.fn();
+
+const wombats = {
+	ID: 1,
+	name: 'Wombat Weekly',
+	URL: 'https://marsupials.example.com',
+	slug: 'marsupials.example.com',
+	site_migration: { migration_status: '' },
+} as Site;
+
+const badgers = {
+	ID: 2,
+	name: 'Badger Digest',
+	URL: 'https://mustelids.example.com',
+	slug: 'mustelids.example.com',
+	site_migration: { migration_status: '' },
+} as Site;
+
+function renderDropdown( sites: Site[] = [ wombats, badgers ] ) {
+	const onChange = jest.fn();
+	render(
+		<PreferencesLoginSiteDropdown sites={ sites } value="" onChange={ onChange } label="Site" />
+	);
+	return { onChange };
+}
+
+function suggestions() {
+	return within( screen.getByRole( 'listbox' ) ).getAllByRole( 'option' );
+}
+
+describe( '<PreferencesLoginSiteDropdown>', () => {
+	test( 'finds a site by its title', async () => {
+		const currentUser = userEvent.setup();
+		renderDropdown();
+
+		await currentUser.type( screen.getByRole( 'combobox', { name: 'Site' } ), 'Badger' );
+
+		expect( suggestions() ).toHaveLength( 1 );
+		expect( suggestions()[ 0 ] ).toHaveTextContent( 'Badger Digest' );
+		expect( suggestions()[ 0 ] ).toHaveTextContent( 'mustelids.example.com' );
+	} );
+
+	test( 'finds a site by its primary domain', async () => {
+		const currentUser = userEvent.setup();
+		renderDropdown();
+
+		await currentUser.type( screen.getByRole( 'combobox', { name: 'Site' } ), 'mustelids' );
+
+		expect( suggestions() ).toHaveLength( 1 );
+		expect( suggestions()[ 0 ] ).toHaveTextContent( 'Badger Digest' );
+		expect( suggestions()[ 0 ] ).toHaveTextContent( 'mustelids.example.com' );
+	} );
+
+	test( 'selects a site found by its primary domain', async () => {
+		const currentUser = userEvent.setup();
+		const { onChange } = renderDropdown();
+
+		await currentUser.type( screen.getByRole( 'combobox', { name: 'Site' } ), 'mustelids' );
+		await currentUser.click( suggestions()[ 0 ] );
+
+		expect( onChange ).toHaveBeenCalledWith( String( badgers.ID ) );
+	} );
+} );


### PR DESCRIPTION
Fixes DOTMSD-1560

## Proposed Changes

* Make the dashboard site selector searchable by both the site's title and its primary domain. It previously matched only one of the two, and which one varied by call site.
* To do this, the site selection dropdown needs to modified to show both name and title fields. **There's a visual change in this PR**.
* Show the title and the domain on every row, and drop the flag that made the WordPress Agent card render the domain twice with no title.

<img width="694" alt="CleanShot 2026-09-07 at 16 16 54@2x" src="https://github.com/user-attachments/assets/b1542121-a9b6-44ba-b811-bece94d3aa46" />


## Why are these changes being made?

Raised in the Dotcom Quality Review on Sept 4: you can't find a site in the WordPress Agent selector by typing its name, only its URL. The same control is used in four places, and every one of them was searchable by exactly one field — the Agent card by URL, the other three by title.

The control is a thin wrapper over `ComboboxControl`, which filters on an option's label and nothing else. The wrapper set that label to either the title or the domain, so whichever it didn't pick became unsearchable, even though both were rendered in the dropdown. Putting both in the label fixes all four call sites at once.

## Considerations

`ComboboxControl` offers no hook for the match itself, and the collapsed field displays the same label string it filters on. So anything searchable is necessarily also displayed: the field now reads "My Site — example.com" where three of the four selectors previously showed just the title. On the Agent card this is an improvement, since the title never appeared there at all.

The alternative — putting both fields in the label for every option *except* the selected one — keeps the collapsed field clean, but then typing the current site's domain finds nothing, which is the same bug in a corner. The label is also deliberately independent of the search term: the control tracks the highlighted row by object reference, so rebuilding the options on each keystroke makes the highlight blink and the list jump.

## Testing Instructions

Visit each of these and open the site picker:

* `/me/agent` — the Email card
* `/me/preferences/mcp/mcp-sites` — "Add a site" (shown as "Add a site exception" when MCP is on account-wide)
* `/me/preferences/wordpress-labs` — behind a flag that's off everywhere, so append `?flags=wordpress-labs` or the page redirects away
* `/me/preferences/defaults` — "Default login site"

In each, type part of a site's title, then part of its domain. Both should find the site, and every row should show the title above the domain.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01NNaB8amyqVinugiTtyZeSt


