### PR TITLE
Omnibar: match AI chat label alignment with wp-admin

### DIFF
--- a/client/dashboard/app/omnibar/plugin-ai-chat.scss
+++ b/client/dashboard/app/omnibar/plugin-ai-chat.scss
@@ -1,3 +1,9 @@
+.omnibar .omnibar__secondary .omnibar__menu.masterbar__item-agents-manager-ai-chat {
+	@media ( min-width: 782px ) {
+		padding-inline: 10px 12px;
+	}
+}
+
 .omnibar .omnibar__menu .omnibar__ai-chat-icon {
 	display: flex;
 
@@ -8,8 +14,6 @@
 		@media ( min-width: 782px ) {
 			width: 22px;
 			height: 22px;
-			margin-inline-start: 2px;
-			margin-inline-end: 3px;
 		}
 	}
 }


### PR DESCRIPTION
## Proposed Changes

The gap between the AI chat node and its label in Calypso, is different from wp-admin's. This PR fixes that to make it pixel-perfect. 

### Before

Calypso

<img width="445" height="32" alt="image" src="https://github.com/user-attachments/assets/dc57b5fd-791a-48ba-a702-cee65ffd667e" />

wp-admin

<img width="445" height="32" alt="image" src="https://github.com/user-attachments/assets/eb73ec36-39b3-4a7f-b8f0-7127d84d972b" />

### After

They now match.