### PR TITLE
Notifications: record note list render times in Tracks

### DIFF
--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -52,7 +52,11 @@ type NoteListProps = {
 const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListProps ) => {
 	const renderStartedAt = useRef( 0 );
 	renderStartedAt.current = performance.now();
-	const trackListRender = useMemo( () => createListRenderTracker( 'app' ), [] );
+	const trackListRenderRef = useRef< ReturnType< typeof createListRenderTracker > | null >( null );
+	if ( ! trackListRenderRef.current ) {
+		trackListRenderRef.current = createListRenderTracker( 'app' );
+	}
+	const trackListRender = trackListRenderRef.current;
 
 	const filter = getFilters()[ filterName ];
 	const isAllTab = filterName === 'all';

--- a/apps/notifications/src/app/note-list/index.tsx
+++ b/apps/notifications/src/app/note-list/index.tsx
@@ -5,8 +5,9 @@ import {
 	Spinner,
 } from '@wordpress/components';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useCallback, useMemo, useRef } from 'react';
 import { useSelector } from 'react-redux';
+import { createListRenderTracker } from '../../panel/helpers/track-list-render';
 import getAllNotes from '../../panel/state/selectors/get-all-notes';
 import getFilteredLoading from '../../panel/state/selectors/get-filtered-loading';
 import getFilteredNoteIds from '../../panel/state/selectors/get-filtered-note-ids';
@@ -49,6 +50,10 @@ type NoteListProps = {
 };
 
 const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListProps ) => {
+	const renderStartedAt = useRef( 0 );
+	renderStartedAt.current = performance.now();
+	const trackListRender = useMemo( () => createListRenderTracker( 'app' ), [] );
+
 	const filter = getFilters()[ filterName ];
 	const isAllTab = filterName === 'all';
 	const allNotes = useSelector( ( state ) => getAllNotes( state ) || [] ) as Note[];
@@ -154,6 +159,15 @@ const NoteList = ( { filterName, selectedNoteId, setSelectedNoteId }: NoteListPr
 		}
 		return { ...note, read: isRead ? 1 : 0, isActive };
 	} );
+
+	const renderedCount = data.length;
+	useLayoutEffect( () => {
+		trackListRender( {
+			filterName,
+			noteCount: renderedCount,
+			startedAt: renderStartedAt.current,
+		} );
+	}, [ trackListRender, filterName, renderedCount ] );
 
 	// `filterSortAndPaginate` reports `totalItems` as the count of notes loaded
 	// so far. DataViews advances its infinite-scroll window only while

--- a/apps/notifications/src/panel/helpers/test/track-list-render.js
+++ b/apps/notifications/src/panel/helpers/test/track-list-render.js
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment jsdom
+ */
+import { recordTracksEvent } from '../stats';
+import { createListRenderTracker } from '../track-list-render';
+
+jest.mock( '../stats', () => ( { recordTracksEvent: jest.fn() } ) );
+
+describe( 'createListRenderTracker', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		jest.spyOn( performance, 'now' ).mockReturnValue( 1000 );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	const render = ( track, noteCount, filterName = 'all' ) =>
+		track( { filterName, noteCount, startedAt: 988 } );
+
+	it( 'reports a baseline on the first render', () => {
+		render( createListRenderTracker( 'panel' ), 10 );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith( 'calypso_notification_list_render', {
+			surface: 'panel',
+			filter: 'all',
+			note_count: 10,
+			render_time_in_ms: 12,
+		} );
+	} );
+
+	it( 'ignores an empty list so the first real count still reports', () => {
+		const track = createListRenderTracker( 'app' );
+
+		render( track, 0 );
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+
+		render( track, 10 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_notification_list_render',
+			expect.objectContaining( { note_count: 10 } )
+		);
+	} );
+
+	it( 'reports once per milestone crossed, not once per render', () => {
+		const track = createListRenderTracker( 'app' );
+
+		[ 10, 20, 30, 40, 50, 60, 70, 100, 110 ].forEach( ( count ) => render( track, count ) );
+
+		expect( recordTracksEvent.mock.calls.map( ( [ , props ] ) => props.note_count ) ).toEqual( [
+			10, 50, 100,
+		] );
+	} );
+
+	it( 'stays quiet while the count grows within a milestone', () => {
+		const track = createListRenderTracker( 'app' );
+		render( track, 50 );
+		recordTracksEvent.mockClear();
+
+		[ 60, 70, 80, 90, 99 ].forEach( ( count ) => render( track, count ) );
+
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not report when the list shrinks back past a milestone', () => {
+		const track = createListRenderTracker( 'app' );
+		render( track, 100 );
+		recordTracksEvent.mockClear();
+
+		render( track, 60 );
+
+		expect( recordTracksEvent ).not.toHaveBeenCalled();
+	} );
+
+	it( 'restarts its milestones when the filter changes', () => {
+		const track = createListRenderTracker( 'app' );
+		render( track, 100, 'all' );
+		recordTracksEvent.mockClear();
+
+		render( track, 10, 'unread' );
+
+		expect( recordTracksEvent ).toHaveBeenCalledTimes( 1 );
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_notification_list_render',
+			expect.objectContaining( { filter: 'unread', note_count: 10 } )
+		);
+	} );
+} );

--- a/apps/notifications/src/panel/helpers/track-list-render.js
+++ b/apps/notifications/src/panel/helpers/track-list-render.js
@@ -1,0 +1,44 @@
+import { recordTracksEvent } from './stats';
+
+const MILESTONE_SIZE = 50;
+
+/**
+ * Build a reporter that records how long the note list takes to render as it grows.
+ *
+ * The list is not virtualized, so every loaded note is a live DOM row and render
+ * cost climbs with the count. Reporting on milestone crossings keeps a full scroll
+ * to the cap at ~10 events while bucketing the counts for the query.
+ * @param {string} surface Which list is reporting: 'panel' or 'app'.
+ * @returns {Function} Called after each commit with the render's start time.
+ */
+export function createListRenderTracker( surface ) {
+	// -1 so the first render reports a baseline below the first milestone.
+	let highestMilestone = -1;
+	let trackedFilter = null;
+
+	return ( { filterName, noteCount, startedAt } ) => {
+		// An empty list has nothing to measure, and reporting it would spend the
+		// first-render slot that the smallest real count needs.
+		if ( noteCount === 0 ) {
+			return;
+		}
+
+		if ( filterName !== trackedFilter ) {
+			trackedFilter = filterName;
+			highestMilestone = -1;
+		}
+
+		const milestone = Math.floor( noteCount / MILESTONE_SIZE ) * MILESTONE_SIZE;
+		if ( milestone <= highestMilestone ) {
+			return;
+		}
+		highestMilestone = milestone;
+
+		recordTracksEvent( 'calypso_notification_list_render', {
+			surface,
+			filter: filterName,
+			note_count: noteCount,
+			render_time_in_ms: Math.round( performance.now() - startedAt ),
+		} );
+	};
+}

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
+import { createListRenderTracker } from '../helpers/track-list-render';
 import actions from '../state/actions';
 import getFilterName from '../state/selectors/get-filter-name';
 import getIsLoading from '../state/selectors/get-is-loading';
@@ -37,6 +38,8 @@ export class NoteList extends Component {
 
 	noteElements = {};
 
+	trackListRender = createListRenderTracker( 'panel' );
+
 	listElementInternalRef = createRef();
 
 	constructor( props ) {
@@ -53,6 +56,8 @@ export class NoteList extends Component {
 	}
 
 	componentDidMount() {
+		this.reportListRender();
+
 		this.scrollableContainer.addEventListener( 'scroll', this.onScroll );
 
 		// Prevent wheel events from propagating to the parent container, since they would
@@ -109,7 +114,19 @@ export class NoteList extends Component {
 		if ( prevProps.selectedNoteId !== this.props.selectedNoteId ) {
 			this.ensureSelectedNoteVisibility();
 		}
+
+		if ( prevProps.notes.length !== this.props.notes.length ) {
+			this.reportListRender();
+		}
 	}
+
+	reportListRender = () => {
+		this.trackListRender( {
+			filterName: this.props.filterName,
+			noteCount: this.props.notes.length,
+			startedAt: this.renderStartedAt,
+		} );
+	};
 
 	mergeListElementRefs = ( node ) => {
 		// Set the internal ref.
@@ -259,6 +276,8 @@ export class NoteList extends Component {
 	};
 
 	render() {
+		this.renderStartedAt = performance.now();
+
 		const { translate } = this.props;
 
 		const groupTitles = [


### PR DESCRIPTION
## Proposed Changes

* Record how long the notifications list takes to render as it grows, as `calypso_notification_list_render`.

## Why are these changes being made?

* The list isn't virtualized and the note cap is now 500, so we need to see whether render times degrade before anyone complains.

## Testing Instructions

* Open the notifications panel, scroll to the bottom of the list, and check that `calypso_notification_list_render` fires every 50 notes with a rising `note_count`.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9oWnR8esFiUoUd6JYTxm3