### PR TITLE
Dashboard: use parentheses in the site selector option label

### DIFF
--- a/client/dashboard/me/mcp/test/wordpress-agent-email.test.tsx
+++ b/client/dashboard/me/mcp/test/wordpress-agent-email.test.tsx
@@ -88,7 +88,7 @@ describe( '<WordPressAgentEmail />', () => {
 
 		expect( screen.getByRole( 'heading', { name: 'Email' } ) ).toBeVisible();
 		expect( screen.getByRole( 'combobox', { name: 'Select site' } ) ).toHaveValue(
-			'Email Agent — email-agent.wordpress.com'
+			'Email Agent (email-agent.wordpress.com)'
 		);
 		expect( screen.getByRole( 'heading', { name: 'Connected' } ) ).toBeVisible();
 		expect( screen.getByLabelText( 'AI agent email address' ) ).toHaveValue(

--- a/client/dashboard/me/preferences-defaults/site-dropdown.tsx
+++ b/client/dashboard/me/preferences-defaults/site-dropdown.tsx
@@ -53,8 +53,8 @@ export default function PreferencesLoginSiteDropdown( {
 						name === url
 							? name
 							: sprintf(
-									/* translators: 1: site title, 2: site URL, e.g. "My Site — example.com" */
-									__( '%1$s — %2$s' ),
+									/* translators: 1: site title, 2: site URL, e.g. "My Site (example.com)" */
+									__( '%1$s (%2$s)' ),
 									name,
 									url
 							  ),

--- a/client/dashboard/me/preferences-defaults/test/index.test.tsx
+++ b/client/dashboard/me/preferences-defaults/test/index.test.tsx
@@ -313,7 +313,7 @@ describe( '<PreferencesDefaults>', () => {
 			renderPage();
 
 			await expect(
-				screen.findByDisplayValue( 'Primary Site — primary.example.com' )
+				screen.findByDisplayValue( 'Primary Site (primary.example.com)' )
 			).resolves.toBeVisible();
 		} );
 
@@ -328,7 +328,7 @@ describe( '<PreferencesDefaults>', () => {
 			renderPage();
 
 			await currentUser.click(
-				await screen.findByDisplayValue( 'Primary Site — primary.example.com' )
+				await screen.findByDisplayValue( 'Primary Site (primary.example.com)' )
 			);
 			await currentUser.click( await screen.findByRole( 'option', { name: /Other Site/ } ) );
 			await currentUser.click( saveButtonFor( 'Primary site' ) );


### PR DESCRIPTION
Part of DOTMSD-1560

## Proposed Changes

* The site selector's option label now reads `Site Title (site.url)` instead of `Site Title — site.url`.

## Why are these changes being made?

#114116 made the site selector searchable by both title and URL, which meant the combobox label had to carry both. It joined them with an em dash. Feedback was that parentheses read better here — the URL is supporting detail for the title, not an equal partner.

## Testing Instructions

* Go to the account settings preferences page and open the primary site dropdown.
* Each site should be listed as its title followed by its URL in parentheses.
* Typing part of either the title or the URL should still narrow the list.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_011L4sXrRh6EDHGGuuEb4j1P