### PR TITLE
E2E: Scroll before opening mobile partner filters

### DIFF
--- a/packages/calypso-e2e/src/lib/components/partner-directory-component.ts
+++ b/packages/calypso-e2e/src/lib/components/partner-directory-component.ts
@@ -28,6 +28,15 @@ export class PartnerDirectoryComponent {
 			// TODO: This button has no accessible name, so we have to use a CSS selector.
 			const filtersToggle = this.page.locator( '.a4a-partner-directory-filters-toggle' );
 			await filtersToggle.waitFor( { state: 'visible' } );
+
+			// Clear fixed overlays without shifting the mobile visual viewport with scrollIntoView.
+			await filtersToggle.evaluate( ( element ) => {
+				window.scrollTo( {
+					top: window.scrollY + element.getBoundingClientRect().top - window.innerHeight / 2,
+					behavior: 'instant',
+				} );
+			} );
+
 			await filtersToggle.click();
 		}
 		await this.page.getByRole( 'button', { name: dropdownName } ).click();


### PR DESCRIPTION
Alternative to #114090.

## Proposed Changes

Scroll the mobile filter toggle to the middle of the page with `window.scrollTo()` before its normal Playwright click. The Help Center launcher stays visible and click actionability checks remain enabled.

## Why are these changes being made?

The mobile smoke test times out while the launcher and fixed navigation intercept click retries. In the Pixel 7 reproduction, `scrollIntoView()` also leaves a 31px visual-viewport offset and the click still fails. Direct page scrolling leaves that offset at zero and the click succeeds.

## Testing Instructions

Run from the repository root with E2E dependencies and decrypted secrets available:

```sh
nvm use
NODE_OPTIONS="--max-old-space-size=16384" yarn workspace wp-e2e-tests build
env -u PARTNER_DIRECTORY_BASE_URL NODE_OPTIONS="--max-old-space-size=16384" yarn workspace wp-e2e-tests exec playwright test specs/a8c-for-agencies/partner-directory__smoke.spec.ts --project=mobile --project=chrome --no-deps --reporter=list --workers=1 --retries=0 --repeat-each=5
```

This uses the directory's default public URL. I've reproduced the timeout before the change; all five mobile and five desktop runs passed after it, with no retries. The E2E package build, `yarn typecheck-packages` and targeted ESLint check passed.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
