### PR TITLE
Agents Manager: title the minimized chat bar “Agent”

### DIFF
--- a/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
+++ b/packages/agents-manager/src/components/__tests__/agent-chat.test.tsx
@@ -23,19 +23,21 @@ jest.mock(
 			children,
 			emptyView,
 			floatingChatState,
+			triggerTitle,
 			suggestions = [],
 			onSuggestionClick,
 		}: {
 			children: ReactNode;
 			emptyView: ReactNode;
 			floatingChatState?: string;
+			triggerTitle?: string;
 			suggestions?: Suggestion[];
 			onSuggestionClick?: (
 				selectedSuggestion: Suggestion,
 				availableSuggestions: Suggestion[]
 			) => void;
 		} ) {
-			mockContainerProps( { floatingChatState } );
+			mockContainerProps( { floatingChatState, triggerTitle } );
 			return (
 				<div>
 					{ emptyView }
@@ -429,7 +431,10 @@ describe( 'AgentChat', () => {
 	it( 'expands when open', () => {
 		renderAgentChat( { isOpen: true } );
 
-		expect( mockContainerProps ).toHaveBeenLastCalledWith( { floatingChatState: 'expanded' } );
+		expect( mockContainerProps ).toHaveBeenLastCalledWith( {
+			floatingChatState: 'expanded',
+			triggerTitle: 'Agent',
+		} );
 	} );
 
 	it( 'groups only writing suggestions while keeping design suggestions top level', async () => {
@@ -607,7 +612,10 @@ describe( 'AgentChat', () => {
 	it( 'collapses to a button when closed without the AI chat entry button', () => {
 		renderAgentChat( { isOpen: false } );
 
-		expect( mockContainerProps ).toHaveBeenLastCalledWith( { floatingChatState: 'collapsed' } );
+		expect( mockContainerProps ).toHaveBeenLastCalledWith( {
+			floatingChatState: 'collapsed',
+			triggerTitle: 'Agent',
+		} );
 	} );
 
 	it( 'minimizes to the bar when closed with the AI chat entry button present', () => {
@@ -615,6 +623,9 @@ describe( 'AgentChat', () => {
 
 		renderAgentChat( { isOpen: false } );
 
-		expect( mockContainerProps ).toHaveBeenLastCalledWith( { floatingChatState: 'minimized' } );
+		expect( mockContainerProps ).toHaveBeenLastCalledWith( {
+			floatingChatState: 'minimized',
+			triggerTitle: 'Agent',
+		} );
 	} );
 } );

--- a/packages/agents-manager/src/components/agent-chat/index.tsx
+++ b/packages/agents-manager/src/components/agent-chat/index.tsx
@@ -304,6 +304,7 @@ export default function AgentChat( {
 			clearSuggestions={ clearSuggestions }
 			onSuggestionClick={ onSuggestionClick ? handleDisplayedSuggestionClick : undefined }
 			floatingChatState={ floatingChatState }
+			triggerTitle={ __( 'Agent', __i18n_text_domain__ ) }
 			onClose={ onClose }
 			onExpand={ onExpand }
 			onStop={ onAbort }


### PR DESCRIPTION
Part of AM-52

## Proposed Changes

* Title the main chat's minimized bar "Agent". `AgentChat` now passes `triggerTitle`, the same translated name the entry buttons use, instead of leaving the bar on the agenttic-ui default "Ask AI".
* The "Past chats" and "Support Guides" screens already pass their own titles and are unchanged.

## Why are these changes being made?

* AM-52 renamed the AI chat entry button to "Agent" on every surface, but the minimized bar still read "Ask AI", so the name changed between minimizing and reopening.
* "Agent" already exists as a translated string in the package (the editor toolbar button), so no new strings are introduced.

## Testing Instructions

**wp-admin** (`cd apps/agents-manager && yarn dev --sync`)
1. On a Simple site with the unified agent, open the chat from the admin bar's "Agent" button, then minimize it (the chevron in the header).
2. The bar at the bottom reads "Agent" with the sparkle icon. Before this change it read "Ask AI".
3. Click the bar: the chat reopens. Close it entirely: the bar disappears as before.
4. Open "Past chats" from the header menu and minimize: the bar still reads "Past chats".

**Calypso** (`yarn start`)
1. Repeat steps 1–3 from the masterbar's "Agent" button.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
