### PR TITLE
Login: make the "account found" social-linking notice informational and clear it when linking is abandoned

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -760,11 +760,11 @@ export class LoginForm extends Component {
 
 		const renderSocialLinkingNotice = () => {
 			return (
-				<Notice variant="error">
+				<Notice variant="info">
 					{ this.props.translate(
-						'We found a WordPress.com account with the email address "%(email)s". ' +
-							'Log in to this account to connect it to your %(service)s profile, ' +
-							'or choose a different %(service)s profile.',
+						'We found a WordPress.com account registered to "%(email)s". ' +
+							'Log in to link it with your %(service)s account, ' +
+							'or choose a different %(service)s account.',
 						{
 							args: {
 								email: this.props.socialAccountLinkEmail,

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -762,8 +762,8 @@ export class LoginForm extends Component {
 			return (
 				<Notice variant="info">
 					{ this.props.translate(
-						'We found a WordPress.com account registered to "%(email)s" which uses our standard email login. ' +
-							'Please click the log in button to link it with your %(service)s account.',
+						'There’s already a WordPress.com account for "%(email)s". ' +
+							'Log in to it and you’ll be able to connect your %(service)s account.',
 						{
 							args: {
 								email: this.props.socialAccountLinkEmail,

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -762,9 +762,8 @@ export class LoginForm extends Component {
 			return (
 				<Notice variant="info">
 					{ this.props.translate(
-						'We found a WordPress.com account registered to "%(email)s". ' +
-							'Log in to link it with your %(service)s account, ' +
-							'or choose a different %(service)s account.',
+						'We found a WordPress.com account registered to "%(email)s" which uses our standard email login. ' +
+							'Please click the log in button to link it with your %(service)s account.',
 						{
 							args: {
 								email: this.props.socialAccountLinkEmail,

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -762,7 +762,7 @@ export class LoginForm extends Component {
 			return (
 				<Notice variant="info">
 					{ this.props.translate(
-						'There’s already a WordPress.com account for "%(email)s". ' +
+						'There’s already a WordPress.com account for "%(email)s" that isn’t connected to %(service)s yet. ' +
 							'Log in to it and you’ll be able to connect your %(service)s account.',
 						{
 							args: {

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -53,8 +53,9 @@ describe( 'LoginForm', () => {
 			initialState: { login: { socialAccountLink: { isLinking: true } } },
 		} );
 
-		const notice = screen.getByText( /We found a WordPress.com account with the email address/i );
-		expect( notice ).toBeInTheDocument();
+		const notice = screen.getByText( /We found a WordPress.com account registered to/i );
+		expect( notice ).toBeVisible();
+		expect( notice.closest( '.dashboard-notice' ) ).toHaveClass( 'is-info' );
 	} );
 
 	test( 'displays notice when social account is linking and last used authentication method is set', async () => {
@@ -64,7 +65,7 @@ describe( 'LoginForm', () => {
 			initialState: { login: { socialAccountLink: { isLinking: true } } },
 		} );
 
-		const notice = screen.getByText( /We found a WordPress.com account with the email address/i );
+		const notice = screen.getByText( /We found a WordPress.com account registered to/i );
 		expect( notice ).toBeInTheDocument();
 	} );
 
@@ -94,7 +95,7 @@ describe( 'LoginForm', () => {
 		const username = screen.getByLabelText( /username/i );
 		await userEvent.type( username, 'test@example.com' );
 
-		const notice = screen.queryByText( /We found a WordPress.com account with the email address/i );
+		const notice = screen.queryByText( /We found a WordPress.com account registered to/i );
 		expect( notice ).not.toBeInTheDocument();
 	} );
 

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -53,7 +53,7 @@ describe( 'LoginForm', () => {
 			initialState: { login: { socialAccountLink: { isLinking: true } } },
 		} );
 
-		const notice = screen.getByText( /We found a WordPress.com account registered to/i );
+		const notice = screen.getByText( /already a WordPress.com account for/i );
 		expect( notice ).toBeVisible();
 		expect( notice.closest( '.dashboard-notice' ) ).toHaveClass( 'is-info' );
 	} );
@@ -65,7 +65,7 @@ describe( 'LoginForm', () => {
 			initialState: { login: { socialAccountLink: { isLinking: true } } },
 		} );
 
-		const notice = screen.getByText( /We found a WordPress.com account registered to/i );
+		const notice = screen.getByText( /already a WordPress.com account for/i );
 		expect( notice ).toBeInTheDocument();
 	} );
 
@@ -95,7 +95,7 @@ describe( 'LoginForm', () => {
 		const username = screen.getByLabelText( /username/i );
 		await userEvent.type( username, 'test@example.com' );
 
-		const notice = screen.queryByText( /We found a WordPress.com account registered to/i );
+		const notice = screen.queryByText( /already a WordPress.com account for/i );
 		expect( notice ).not.toBeInTheDocument();
 	} );
 

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -400,9 +400,7 @@ const userExistsErrorHandler = ( state, { error, authInfo } ) => {
 	return state;
 };
 
-// Linking can only complete through the password (or 2FA) path. Requesting a
-// magic link or a password reset ends in a full page load, so the pending
-// social auth info would be lost anyway.
+// Both end in a full page load, so a pending social link cannot survive them.
 const socialAccountLinkAbandonPaths = [
 	login( { twoFactorAuthType: 'link' } ),
 	login( { twoFactorAuthType: 'link', isJetpack: true } ),

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -1,3 +1,4 @@
+import { removeLocaleFromPath } from '@automattic/i18n-utils';
 import { pick, isEmpty } from '@automattic/js-utils';
 import { withStorageKey } from '@automattic/state-utils';
 import { login } from 'calypso/lib/paths';
@@ -402,8 +403,15 @@ const userExistsErrorHandler = ( state, { error, authInfo } ) => {
 // Linking can only complete through the password (or 2FA) path. Requesting a
 // magic link or a password reset ends in a full page load, so the pending
 // social auth info would be lost anyway.
+const socialAccountLinkAbandonPaths = [
+	login( { twoFactorAuthType: 'link' } ),
+	login( { twoFactorAuthType: 'link', isJetpack: true } ),
+	login( { action: 'lostpassword' } ),
+	login( { action: 'jetpack/lostpassword' } ),
+];
+
 const isAbandoningSocialAccountLinkPath = ( path ) =>
-	/^\/log-in\/(?:jetpack\/|new\/)?(?:link|lostpassword)\b/.test( path );
+	socialAccountLinkAbandonPaths.includes( removeLocaleFromPath( path ) );
 
 export const socialAccountLink = ( state = { isLinking: false }, action ) => {
 	switch ( action.type ) {

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -403,7 +403,7 @@ const userExistsErrorHandler = ( state, { error, authInfo } ) => {
 // magic link or a password reset ends in a full page load, so the pending
 // social auth info would be lost anyway.
 const isAbandoningSocialAccountLinkPath = ( path ) =>
-	/^\/log-in(?:\/jetpack|\/new)?\/(?:link|lostpassword)(?:\/|$)/.test( path );
+	/^\/log-in\/(?:jetpack\/|new\/)?(?:link|lostpassword)\b/.test( path );
 
 export const socialAccountLink = ( state = { isLinking: false }, action ) => {
 	switch ( action.type ) {

--- a/client/state/login/reducer.js
+++ b/client/state/login/reducer.js
@@ -399,8 +399,16 @@ const userExistsErrorHandler = ( state, { error, authInfo } ) => {
 	return state;
 };
 
+// Linking can only complete through the password (or 2FA) path. Requesting a
+// magic link or a password reset ends in a full page load, so the pending
+// social auth info would be lost anyway.
+const isAbandoningSocialAccountLinkPath = ( path ) =>
+	/^\/log-in(?:\/jetpack|\/new)?\/(?:link|lostpassword)(?:\/|$)/.test( path );
+
 export const socialAccountLink = ( state = { isLinking: false }, action ) => {
 	switch ( action.type ) {
+		case ROUTE_SET:
+			return isAbandoningSocialAccountLinkPath( action.path ) ? { isLinking: false } : state;
 		case SOCIAL_CREATE_ACCOUNT_REQUEST_FAILURE:
 			return userExistsErrorHandler( state, action );
 		case SOCIAL_HANDOFF_CONNECT_ACCOUNT:

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -588,5 +588,39 @@ describe( 'reducer', () => {
 
 			expect( newState ).toEqual( { isLinking: false } );
 		} );
+
+		describe( 'on route change', () => {
+			const linkingState = {
+				isLinking: true,
+				email: 'hello@test.com',
+				authInfo: { id_token: '123', access_token: '123', service: 'google' },
+			};
+
+			test.each( [
+				'/log-in/link',
+				'/log-in/link/fr',
+				'/log-in/jetpack/link',
+				'/log-in/new/link',
+				'/log-in/lostpassword',
+				'/log-in/jetpack/lostpassword',
+			] )( 'should reset linking mode when navigating to %s', ( path ) => {
+				const newState = socialAccountLink( linkingState, { type: ROUTE_SET, path, query: {} } );
+
+				expect( newState ).toEqual( { isLinking: false } );
+			} );
+
+			test.each( [
+				'/log-in',
+				'/log-in/fr',
+				'/log-in/authenticator',
+				'/log-in/sms',
+				'/log-in/social-connect',
+				'/log-in/linkedin',
+			] )( 'should keep linking mode when navigating to %s', ( path ) => {
+				const newState = socialAccountLink( linkingState, { type: ROUTE_SET, path, query: {} } );
+
+				expect( newState ).toBe( linkingState );
+			} );
+		} );
 	} );
 } );

--- a/client/state/login/test/reducer.js
+++ b/client/state/login/test/reducer.js
@@ -600,9 +600,9 @@ describe( 'reducer', () => {
 				'/log-in/link',
 				'/log-in/link/fr',
 				'/log-in/jetpack/link',
-				'/log-in/new/link',
 				'/log-in/lostpassword',
 				'/log-in/jetpack/lostpassword',
+				'/log-in/jetpack/lostpassword/de',
 			] )( 'should reset linking mode when navigating to %s', ( path ) => {
 				const newState = socialAccountLink( linkingState, { type: ROUTE_SET, path, query: {} } );
 


### PR DESCRIPTION

Fixes DOTOBRD-367

## Proposed Changes
Visiting `wordpress.com/log-in/` and logging in using 'Continue with Google' or another oAuth to an existing account at the email address leads to this error:<br /><img width="705" height="650" alt="Screenshot 2026-09-07 at 12 15 47" src="https://github.com/user-attachments/assets/6a12deb8-1a7c-47ce-b4e0-1ad197752753" />
We need to replace the error with an info notice. and also adjust the wording to `We found a WordPress.com account registered to ‘[xyz@abc.com](mailto:xyz@abc.com)‘ which uses our standard email login. Please click the log in button to link it with your Google account.`

Also, I tested this part of the issue - `Logging-in again in this way after “connecting” worked, but if I already connected my Google account, why do I keep seeing this same error on [/log-in/link](https://wordpress.com/log-in/link)  every time?` and I don't see any error after connecting google account and using `Email me a login link`. But I caught another thing, maybe it was the mentioned point. See step 3 in the testing instructions.

## Testing Instructions
1. Open `http://calypso.localhost:3000/log-in?email_address=<YOU_EMAIL_ADDRESS>&service=google&access_token=fake&id_token=fake`
2. Assert that you see:

<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="728" height="693" alt="Screenshot 2026-09-07 at 12 21 56" src="https://github.com/user-attachments/assets/d71ed499-c5d9-4062-a9fe-82414dafdc70" />
<td><img width="723" height="688" alt="Screenshot 2026-09-07 at 12 21 01" src="https://github.com/user-attachments/assets/30860288-6717-44b0-a3b4-7b9c6a954f35" />
</tr>
</table>

3. Click `Email me a login link`
4. Click "Back' in browser
5. Assert that you don't see that error:

<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="755" height="653" alt="Screenshot 2026-09-07 at 12 46 51" src="https://github.com/user-attachments/assets/568f6c40-860c-4340-9266-b91e353e42fe" />
<td><img width="748" height="509" alt="Screenshot 2026-09-07 at 12 46 24" src="https://github.com/user-attachments/assets/fc8d494c-df2d-4788-b24d-be47dc6f189b" />
</tr>
</table>