### PR TITLE
E2E: Accept both activation email subjects

### DIFF
--- a/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
+++ b/test/e2e/specs/authentication/authentication__dashboard-two-step.spec.ts
@@ -221,8 +221,13 @@ test.describe(
 				const message = await clientEmail.getLastMatchingMessage( {
 					inboxId: testUser.inboxId,
 					sentTo: testUser.email,
-					subject: 'Activate',
 				} );
+
+				// Onboarding treatments send a different subject from the control group.
+				expect( [ `Activate ${ testUser.email }`, 'Verify your email.' ] ).toContain(
+					message.subject
+				);
+
 				const links = await clientEmail.getLinksFromMessage( message );
 				const activationLink = links.find( ( link ) => link.includes( 'activate' ) ) as string;
 				await page.goto( activationLink );


### PR DESCRIPTION
## Proposed Changes

Accept both `Activate <email>` and `Verify your email.` in the dashboard two-step E2E spec. Look up the fresh recipient, then check the subject before following the activation link and waiting for `email_verified`.

## Why are these changes being made?

The onboarding experiment's treatment sends `Verify your email.`; control sends `Activate <email>`. The old subject filter times out even when the treatment email arrives within seconds.

wpcom introduced the treatment mailer in `22b51b342bf` on August 27. Calypso switched to the September experiment in [cfd42bba255](https://github.com/Automattic/wp-calypso/commit/cfd42bba255c54d648d64d327de1a7623989b6fd) on September 3.

## Testing Instructions

With `CALYPSO_BASE_URL` set to staging and `DASHBOARD_BASE_URL` set to the hosted multi-site dashboard, run:

```sh
NODE_OPTIONS="--max-old-space-size=16384" yarn workspace wp-e2e-tests test:pw:authentication specs/authentication/authentication__dashboard-two-step.spec.ts --reporter=list --repeat-each=5 --workers=5
```

- Five staging runs passed email verification. All used control emails; the patched treatment path still needs validation.
- All five full runs failed later at the existing security-key login timeout in `continueWithSecurityKey`. All test accounts were deleted.
- Before the change, a pinned treatment reproduced the 120-second subject-filter timeout despite receiving `Verify your email.` within two seconds.
- E2E TypeScript checking and Prettier passed. ESLint passed with three warnings on unchanged lines.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
