### PR TITLE
Global Nav 2026: keep the dropdown open while the pointer crosses nearby links

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -33,6 +33,9 @@ import {
 } from './nav-2026/tracks';
 import './style.scss';
 
+// Matches the Landpack nav's mouseleave grace period.
+const DROPDOWN_CLOSE_DELAY = 150;
+
 const UniversalNavbarHeader = ( {
 	className,
 	hideGetStartedCta = false,
@@ -82,6 +85,21 @@ const UniversalNavbarHeader = ( {
 		footerRef: mobileFooterRef,
 	} );
 	const dropdownRef = useDropdownFlip( { nav2026, activeDropdown } );
+	// One timer for pointer-driven open/close, so a newer call replaces a pending
+	// close and a diagonal move into the panel can cross Support/Pricing first.
+	const dropdownTimerRef = useRef< ReturnType< typeof setTimeout > | null >( null );
+	const showDropdown = useCallback( ( delay: number, name: string | null ) => {
+		if ( dropdownTimerRef.current ) {
+			clearTimeout( dropdownTimerRef.current );
+			dropdownTimerRef.current = null;
+		}
+		if ( ! delay ) {
+			setActiveDropdown( name );
+			return;
+		}
+		dropdownTimerRef.current = setTimeout( () => setActiveDropdown( name ), delay );
+	}, [] );
+	useEffect( () => () => clearTimeout( dropdownTimerRef.current ?? undefined ), [] );
 
 	const nav2026Menus = useMemo(
 		() =>
@@ -284,7 +302,7 @@ const UniversalNavbarHeader = ( {
 					className={ clsx( 'lpc-header-nav-container', {
 						'is-scrolled': nav2026 && isScrolled,
 					} ) }
-					onMouseLeave={ nav2026 ? () => setActiveDropdown( null ) : undefined }
+					onMouseLeave={ nav2026 ? () => showDropdown( DROPDOWN_CLOSE_DELAY, null ) : undefined }
 					onBlur={
 						nav2026
 							? ( event ) => {
@@ -313,7 +331,7 @@ const UniversalNavbarHeader = ( {
 												? () => {
 														recordNavItemHover( isScrolled, 'logo', false );
 														// Hovering a non-dropdown item closes the open dropdown.
-														setActiveDropdown( null );
+														showDropdown( DROPDOWN_CLOSE_DELAY, null );
 												  }
 												: undefined
 										}
@@ -348,7 +366,7 @@ const UniversalNavbarHeader = ( {
 														key={ menu.name }
 														onMouseEnter={ () => {
 															recordNavItemHover( isScrolled, menu.name, true );
-															setActiveDropdown( menu.name );
+															showDropdown( 0, menu.name );
 														} }
 														onFocus={ () => {
 															recordNavItemHover( isScrolled, menu.name, true );
@@ -374,7 +392,7 @@ const UniversalNavbarHeader = ( {
 														onItemMouseEnter={ () => {
 															recordNavItemHover( isScrolled, menu.name, false );
 															// Hovering a non-dropdown item closes the open dropdown.
-															setActiveDropdown( null );
+															showDropdown( DROPDOWN_CLOSE_DELAY, null );
 														} }
 														// Keyboard parity: focusing the item also closes the open dropdown.
 														onItemFocus={ () => setActiveDropdown( null ) }
@@ -399,7 +417,9 @@ const UniversalNavbarHeader = ( {
 												localizeUrl( '//wordpress.com/log-in', locale, isLoggedIn, true )
 											}
 											type="nav"
-											onItemMouseEnter={ nav2026 ? () => setActiveDropdown( null ) : undefined }
+											onItemMouseEnter={
+												nav2026 ? () => showDropdown( DROPDOWN_CLOSE_DELAY, null ) : undefined
+											}
 											onItemFocus={ nav2026 ? () => setActiveDropdown( null ) : undefined }
 										/>
 									) }
@@ -415,7 +435,9 @@ const UniversalNavbarHeader = ( {
 											urlValue={ startUrl }
 											type="nav"
 											typeClassName="x-nav-link x-nav-link__primary x-link cta-btn-nav"
-											onItemMouseEnter={ nav2026 ? () => setActiveDropdown( null ) : undefined }
+											onItemMouseEnter={
+												nav2026 ? () => showDropdown( DROPDOWN_CLOSE_DELAY, null ) : undefined
+											}
 											onItemFocus={ nav2026 ? () => setActiveDropdown( null ) : undefined }
 										/>
 									) }
@@ -460,7 +482,8 @@ const UniversalNavbarHeader = ( {
 							dropdownRef={ dropdownRef }
 							activeDropdown={ activeDropdown }
 							nav2026Menus={ nav2026Menus }
-							onMouseLeave={ () => setActiveDropdown( null ) }
+							onMouseEnter={ () => showDropdown( 0, activeDropdown ) }
+							onMouseLeave={ () => showDropdown( DROPDOWN_CLOSE_DELAY, null ) }
 						/>
 					) }
 					{ /*<!-- Nav bar ends here. -->*/ }

--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -370,7 +370,7 @@ const UniversalNavbarHeader = ( {
 														} }
 														onFocus={ () => {
 															recordNavItemHover( isScrolled, menu.name, true );
-															setActiveDropdown( menu.name );
+															showDropdown( 0, menu.name );
 														} }
 													>
 														<NonClickableItem

--- a/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/desktop-dropdown.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/nav-2026/desktop-dropdown.tsx
@@ -29,6 +29,7 @@ interface Nav2026DesktopDropdownProps {
 	dropdownRef: React.RefObject< HTMLDivElement | null >;
 	activeDropdown: string | null;
 	nav2026Menus: Nav2026Menu[];
+	onMouseEnter?: React.MouseEventHandler< HTMLDivElement >;
 	onMouseLeave?: React.MouseEventHandler< HTMLDivElement >;
 }
 
@@ -37,6 +38,7 @@ export function Nav2026DesktopDropdown( {
 	dropdownRef,
 	activeDropdown,
 	nav2026Menus,
+	onMouseEnter,
 	onMouseLeave,
 }: Nav2026DesktopDropdownProps ) {
 	return (
@@ -45,6 +47,7 @@ export function Nav2026DesktopDropdown( {
 			className={ clsx( 'x-dropdown x-dropdown--2026', {
 				'is-dropdown-open': activeDropdown !== null,
 			} ) }
+			onMouseEnter={ onMouseEnter }
 			onMouseLeave={ onMouseLeave }
 		>
 			{ nav2026Menus.map( ( menu ) => {


### PR DESCRIPTION
Related to 239633-ghe-Automattic/wpcom (the same fix in the Landpack nav).

## Proposed Changes

* When the pointer leaves an open desktop dropdown, or moves over Support, Pricing, the logo, Log in, or Get started, the menu now waits a beat (150ms) before closing. Entering the dropdown panel or a dropdown trigger during that beat cancels the close. This mirrors how the Landpack nav already behaves: one timer, where any newer open replaces a pending close.
* Opening a menu, switching between menus, and keyboard dismissal (Escape, focus leaving) stay immediate.
* Mobile navigation, animations, and the minimal header are unchanged.

## Why are these changes being made?

* Moving diagonally from the Resources trigger down to a link like "Latest news" crosses Support and Pricing on the way. Those links closed the dropdown instantly, so the link disappeared before the pointer reached it.
* Pausing over Support or Pricing still closes the menu, matching the agreed design behaviour; only a quick crossing is forgiven.

## Testing Instructions

1. Log out and open `/themes` on a desktop-width window.
2. Hover **Resources** so the dropdown opens, then move the pointer diagonally across **Support** / **Pricing** into a link in the lower part of the panel. The dropdown should stay open.
3. Hover **Resources**, then stop on **Support** for half a second. The dropdown should close.
4. Hover **Resources**, move the pointer out below the nav and straight back into the panel. It should stay open.
5. Hover **Resources** then **Products**: the switch is instant. Press Escape and Tab through the nav: nothing waits for the delay.
6. At a phone width, open and close the hamburger menu.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [x] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
