### PR TITLE
Invites: match the invited email case-insensitively when accepting

### DIFF
--- a/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
+++ b/client/my-sites/invites-unified/screens/accept-invite-screen.tsx
@@ -18,7 +18,7 @@ import {
 	type PartnerConfig,
 } from 'calypso/lib/partner-branding';
 import { login } from 'calypso/lib/paths';
-import { getRedirectAfterAccept } from 'calypso/my-sites/invites/utils';
+import { getRedirectAfterAccept, isSameEmail } from 'calypso/my-sites/invites/utils';
 import { useDispatch } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors/has-dashboard-opt-in';
@@ -165,7 +165,7 @@ export function AcceptInviteScreen( { invite }: AcceptInviteScreenProps ) {
 
 	// Check if the invite requires a specific email that doesn't match the current user
 	const forceMatchingEmail =
-		invite?.invite?.meta?.force_matching_email && user?.email !== inviteSentTo;
+		invite?.invite?.meta?.force_matching_email && ! isSameEmail( user?.email, inviteSentTo );
 
 	// Get branding from blog_details garden info
 	const branding = getBrandingFromBlogDetails( invite?.blog_details );

--- a/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
+++ b/client/my-sites/invites-unified/screens/test/accept-invite-screen.test.tsx
@@ -178,6 +178,7 @@ jest.mock( 'calypso/lib/paths', () => ( {
 
 const mockGetRedirectAfterAccept = jest.fn( () => '/redirect-url' );
 jest.mock( 'calypso/my-sites/invites/utils', () => ( {
+	...jest.requireActual( 'calypso/my-sites/invites/utils' ),
 	getRedirectAfterAccept: ( ...args: Parameters< typeof mockGetRedirectAfterAccept > ) =>
 		mockGetRedirectAfterAccept( ...args ),
 } ) );
@@ -417,6 +418,32 @@ describe( 'AcceptInviteScreen', () => {
 
 			expect( screen.getByTestId( 'email-mismatch-screen' ) ).toBeInTheDocument();
 			expect( screen.getByText( /invited@example.com/i ) ).toBeInTheDocument();
+		} );
+
+		test( 'does not show EmailMismatchScreen when emails differ only by letter case', () => {
+			setupUser( { email: 'Invited@Example.com' } );
+			const store = createStore();
+			const invite = createInvite( {
+				invite: {
+					blog_id: '123',
+					invite_slug: 'test',
+					meta: {
+						role: 'administrator',
+						sent_to: 'invited@example.com',
+						force_matching_email: true,
+						blog_id: 123,
+					},
+				},
+			} );
+
+			render(
+				<Provider store={ store }>
+					<AcceptInviteScreen invite={ invite } />
+				</Provider>
+			);
+
+			expect( screen.queryByTestId( 'email-mismatch-screen' ) ).not.toBeInTheDocument();
+			expect( screen.getByTestId( 'action-buttons' ) ).toBeInTheDocument();
 		} );
 
 		test( 'does not show EmailMismatchScreen when emails match', () => {

--- a/client/my-sites/invites/controller.jsx
+++ b/client/my-sites/invites/controller.jsx
@@ -11,7 +11,7 @@ import {
 	getPartnerFormattedWindowTitle,
 } from 'calypso/lib/partner-branding';
 import InviteAccept from 'calypso/my-sites/invites/invite-accept';
-import { getRedirectAfterAccept } from 'calypso/my-sites/invites/utils';
+import { getRedirectAfterAccept, isSameEmail } from 'calypso/my-sites/invites/utils';
 import { setUserEmailVerified } from 'calypso/state/current-user/actions';
 import { getCurrentUserEmail, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
@@ -39,7 +39,7 @@ export function acceptInvite( context, next ) {
 	const acceptedInvite = store.get( 'invite_accepted' );
 	if ( acceptedInvite ) {
 		debug( 'invite_accepted is set in localStorage' );
-		if ( getCurrentUserEmail( context.store.getState() ) === acceptedInvite.sentTo ) {
+		if ( isSameEmail( getCurrentUserEmail( context.store.getState() ), acceptedInvite.sentTo ) ) {
 			debug( 'Setting email_verified in user object' );
 			context.store.dispatch( setUserEmailVerified( true ) );
 		}

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -13,7 +13,7 @@ import { login } from 'calypso/lib/paths';
 import wpcom from 'calypso/lib/wp';
 import LoggedIn from 'calypso/my-sites/invites/invite-accept-logged-in';
 import LoggedOut from 'calypso/my-sites/invites/invite-accept-logged-out';
-import { getRedirectAfterAccept } from 'calypso/my-sites/invites/utils';
+import { getRedirectAfterAccept, isSameEmail } from 'calypso/my-sites/invites/utils';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { hasDashboardOptIn } from 'calypso/state/dashboard/selectors';
@@ -128,7 +128,12 @@ class InviteAccept extends Component {
 	isMatchEmailError = () => {
 		const { invite } = this.state;
 		const { user } = this.props;
-		return !! ( invite && invite.forceMatchingEmail && user && user.email !== invite.sentTo );
+		return !! (
+			invite &&
+			invite.forceMatchingEmail &&
+			user &&
+			! isSameEmail( user.email, invite.sentTo )
+		);
 	};
 
 	isInvalidInvite = () => {

--- a/client/my-sites/invites/invite-accept/test/index.jsx
+++ b/client/my-sites/invites/invite-accept/test/index.jsx
@@ -143,6 +143,15 @@ describe( 'InviteAccept', () => {
 			);
 		} );
 
+		it( 'does not flag a signed-in address that differs from the invited one only by letter case', () => {
+			mockCurrentUser = { email: 'Invited@Example.com' };
+			renderInvite( { forceMatchingEmail: true } );
+
+			expect( mockLoggedIn ).toHaveBeenCalledWith(
+				expect.objectContaining( { forceMatchingEmail: false } )
+			);
+		} );
+
 		it( 'does not flag an unbound invite', () => {
 			mockCurrentUser = { email: 'someone.else@example.com' };
 			renderInvite( { forceMatchingEmail: false } );

--- a/client/my-sites/invites/test/utils.tsx
+++ b/client/my-sites/invites/test/utils.tsx
@@ -1,4 +1,4 @@
-import { getRedirectAfterAccept } from '../utils';
+import { getRedirectAfterAccept, isSameEmail } from '../utils';
 
 jest.mock( 'calypso/lib/logmein', () => ( {
 	logmeinUrl: ( _host: string, backUrl: string ) => backUrl,
@@ -99,5 +99,25 @@ describe( 'getRedirectAfterAccept', () => {
 
 			expect( getRedirectAfterAccept( invite, false ) ).toBe( 'https://wordpress.com/reader' );
 		} );
+	} );
+} );
+
+describe( 'isSameEmail', () => {
+	it( 'ignores letter case', () => {
+		expect( isSameEmail( 'RevErinHougland@gmail.com', 'reverinhougland@gmail.com' ) ).toBe( true );
+	} );
+
+	it( 'ignores surrounding whitespace', () => {
+		expect( isSameEmail( ' me@example.com ', 'me@example.com' ) ).toBe( true );
+	} );
+
+	it( 'rejects different addresses', () => {
+		expect( isSameEmail( 'me@example.com', 'me+other@example.com' ) ).toBe( false );
+	} );
+
+	it( 'rejects missing or empty addresses', () => {
+		expect( isSameEmail( undefined, 'me@example.com' ) ).toBe( false );
+		expect( isSameEmail( 'me@example.com', null ) ).toBe( false );
+		expect( isSameEmail( '', '' ) ).toBe( false );
 	} );
 } );

--- a/client/my-sites/invites/utils.tsx
+++ b/client/my-sites/invites/utils.tsx
@@ -168,10 +168,6 @@ export function acceptedNotice(
 	}
 }
 
-/**
- * Email addresses are case-insensitive in practice, and the invite's `sent_to`
- * comes back lowercased while the user's stored email keeps its original casing.
- */
 export function isSameEmail( a?: string | null, b?: string | null ): boolean {
 	const normalize = ( email?: string | null ) => email?.trim().toLowerCase() ?? '';
 	const normalizedA = normalize( a );

--- a/client/my-sites/invites/utils.tsx
+++ b/client/my-sites/invites/utils.tsx
@@ -168,6 +168,17 @@ export function acceptedNotice(
 	}
 }
 
+/**
+ * Email addresses are case-insensitive in practice, and the invite's `sent_to`
+ * comes back lowercased while the user's stored email keeps its original casing.
+ */
+export function isSameEmail( a?: string | null, b?: string | null ): boolean {
+	const normalize = ( email?: string | null ) => email?.trim().toLowerCase() ?? '';
+	const normalizedA = normalize( a );
+
+	return normalizedA !== '' && normalizedA === normalize( b );
+}
+
 export function getRedirectAfterAccept( invite: InviteType, hasDashboardOptIn: boolean ) {
 	if ( invite.site.is_wpforteams_site ) {
 		return `https://${ invite.site.domain }`;


### PR DESCRIPTION
Fixes DOTOBRD-609

## Proposed Changes

If somebody is invited to collaborate on a website and their email is not lowercased, then they will get an error. See testing instructions.


## Testing Instructions
Setup: you need two WordPress.com accounts. Account A owns a site. Account B's email contains uppercase letters, for example `Nightnei.JS+Qwe@gmail.com`.

Reproduce on trunk:
1. Logged in as A and invite B as an administrator, typing B's email in lowercase.
2. Log in as B in another browser and open the invite link from the email.
3. Assert that you see "Join" button (Previously, you would see the error):
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="674" height="654" alt="Screenshot 2026-09-07 at 15 31 31" src="https://github.com/user-attachments/assets/7ba8c1f8-309c-46e9-b59d-736b68960a56" />
<td><img width="669" height="527" alt="Screenshot 2026-09-07 at 15 33 22" src="https://github.com/user-attachments/assets/6f62d75a-cb2d-4947-87ad-69fd90b64e03" />
</tr>
</table>
