### PR TITLE
Pin a Storybook port for each smoke-test package

### DIFF
--- a/packages/composite-checkout/package.json
+++ b/packages/composite-checkout/package.json
@@ -20,7 +20,7 @@
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch",
-		"storybook:start": "storybook dev"
+		"storybook:start": "storybook dev -p 26835"
 	},
 	"files": [
 		"dist",

--- a/packages/domain-search/package.json
+++ b/packages/domain-search/package.json
@@ -41,7 +41,7 @@
 		"build": "tsc --build ./tsconfig-build.json ./tsconfig-cjs.json && yarn run -T copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch",
-		"storybook:start": "storybook dev"
+		"storybook:start": "storybook dev -p 26836"
 	},
 	"dependencies": {
 		"@automattic/api-core": "workspace:^",

--- a/packages/launchpad/package.json
+++ b/packages/launchpad/package.json
@@ -35,7 +35,7 @@
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch",
-		"storybook:start": "storybook dev"
+		"storybook:start": "storybook dev -p 26837"
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "workspace:^",

--- a/packages/onboarding/package.json
+++ b/packages/onboarding/package.json
@@ -41,7 +41,7 @@
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && yarn run -T copy-assets && npx copyfiles ./styles/** dist",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch",
-		"storybook:start": "storybook dev"
+		"storybook:start": "storybook dev -p 26838"
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "workspace:^",

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -43,7 +43,7 @@
 		"prepare": "yarn run build",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch",
-		"storybook:start": "yarn msw init && storybook dev"
+		"storybook:start": "yarn msw init && storybook dev -p 26839"
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "workspace:^",

--- a/packages/privacy-toolset/package.json
+++ b/packages/privacy-toolset/package.json
@@ -39,7 +39,7 @@
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch",
-		"storybook:start": "storybook dev"
+		"storybook:start": "storybook dev -p 26840"
 	},
 	"dependencies": {
 		"@wordpress/components": "^37.0.0",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -73,6 +73,6 @@
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"prepack": "yarn run clean && yarn run build",
-		"storybook:start": "storybook dev"
+		"storybook:start": "storybook dev -p 26841"
 	}
 }


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Pin a distinct `-p <port>` on `storybook:start` for the seven packages that ran bare `storybook dev`: `composite-checkout`, `domain-search`, `launchpad`, `onboarding`, `plans-grid-next`, `privacy-toolset`, `search`.

## Why are these changes being made?

The `Run All Unit Tests` job on trunk has gone red twice with every test passing (`Tests passed: 27301, ignored: 31; exit code 1`). The failing step is `check_storybook`, which `bin/unit-test-suite.mjs` runs as:

```
yarn workspaces foreach -A --verbose --parallel run storybook:start --ci --smoke-test
```

Twelve workspaces start at once. Five already pin a port (`components` 56833, `grid` 56834, `ui` 56851, `site-admin` 57862, repo root 6006) and have never collided. The other seven ran bare `storybook dev`, so each probed the OS for a free port and bound it a moment later. Two probes can settle on the same port in that window, and the loser dies:

```
[@automattic/composite-checkout]: Error: listen EADDRINUSE: address already in use :::32869
    at storybookDevServer (node_modules/storybook/dist/core-server/index.cjs:46755:11)
```

The observed occurrences fit a race rather than a stuck process — a different package and a different high random port each time:

| Build | When (UTC) | Package | Port |
|---|---|---|---|
| #208888 | 2026-09-06 23:19 | `privacy-toolset` | 35259 |
| #208916 | 2026-09-07 05:42 | `composite-checkout` | 32869 |

A 27,301-test gate that reddens on a port collision teaches everyone to ignore it going red.

Alternative considered and rejected: dropping `--parallel` from `bin/unit-test-suite.mjs` is a one-line change that removes the race, but it serialises twelve Storybook builds and costs CI wall-clock.

## Testing Instructions

Run the same command CI runs, from the repository root:

```
NODE_OPTIONS="--max-old-space-size=16384" yarn workspaces foreach -A --verbose --parallel run storybook:start --ci --smoke-test
```

All twelve smoke tests should pass. The seven ports above are otherwise unreferenced in the repository, and binding all seven simultaneously succeeds locally.

What this does not prove: the collision is a timing race that did not reproduce locally in five unmodified runs. CI machines are faster and more parallel than a laptop, so a local non-reproduction is expected and is not evidence the race is gone. The claim here is narrower — a fixed port removes the probe-then-bind window entirely, so the race cannot occur regardless of timing.

Note: this is a separate signature from the previously seen `A worker process has failed to exit gracefully` failure on the same job (build 19245851, 08-31), which also produces exit code 1 on a passing run. Different cause; not addressed here.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
