### PR TITLE
Reader: Added noindex to logged out tags pages

### DIFF
--- a/client/reader/discover/discover-document-head.jsx
+++ b/client/reader/discover/discover-document-head.jsx
@@ -1,7 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 
-export const DiscoverDocumentHead = () => {
+export const DiscoverDocumentHead = ( { noindex = false } ) => {
 	const translate = useTranslate();
 
 	const title = translate( 'Browse popular blogs & read articles ‹ Reader' );
@@ -14,6 +14,10 @@ export const DiscoverDocumentHead = () => {
 			),
 		},
 	];
+
+	if ( noindex ) {
+		meta.push( { name: 'robots', content: 'noindex' } );
+	}
 
 	const link = [
 		{

--- a/client/reader/discover/index.node.jsx
+++ b/client/reader/discover/index.node.jsx
@@ -5,6 +5,7 @@ import PostPlaceholder from 'calypso/reader/stream/post-placeholder';
 import { setDiscoverLoggedOutHero } from './components/logged-out-hero';
 import { DiscoverDocumentHead } from './discover-document-head';
 import { getLocalizedRoutes, getSelectedTab } from './routes';
+import { setDiscoverTagNoindex } from './set-discover-tag-noindex';
 
 const discoverSsr = ( context, next ) => {
 	setDiscoverLoggedOutHero( context );
@@ -12,7 +13,7 @@ const discoverSsr = ( context, next ) => {
 
 	context.primary = (
 		<>
-			<DiscoverDocumentHead />
+			<DiscoverDocumentHead noindex={ !! context.query?.selectedTag } />
 			<DiscoverHeaderAndNavigation selectedTab={ selectedTab } />
 			<PostPlaceholder />
 		</>
@@ -23,5 +24,11 @@ const discoverSsr = ( context, next ) => {
 export default function ( router ) {
 	const anyLangParam = getAnyLanguageRouteParam();
 
-	router( getLocalizedRoutes( anyLangParam ), ssrSetupLocale, discoverSsr, makeLayout );
+	router(
+		getLocalizedRoutes( anyLangParam ),
+		ssrSetupLocale,
+		setDiscoverTagNoindex,
+		discoverSsr,
+		makeLayout
+	);
 }

--- a/client/reader/discover/index.web.jsx
+++ b/client/reader/discover/index.web.jsx
@@ -52,7 +52,7 @@ const discover = ( context, next ) => {
 
 	context.primary = (
 		<>
-			<DiscoverDocumentHead />
+			<DiscoverDocumentHead noindex={ !! context.query?.selectedTag } />
 			<AsyncLoad
 				require={ loadDiscoverStream }
 				key="discover-page"

--- a/client/reader/discover/set-discover-tag-noindex.js
+++ b/client/reader/discover/set-discover-tag-noindex.js
@@ -1,0 +1,22 @@
+import { setDocumentHeadMeta } from 'calypso/state/document-head/actions';
+import { getDocumentHeadMeta } from 'calypso/state/document-head/selectors';
+
+/**
+ * Mark tag-parameterized Discover pages (`/discover/tags?selectedTag=…`) as `noindex`.
+ *
+ * Requests with query args are never server-side rendered (@see setShouldServerSideRender),
+ * so `DiscoverDocumentHead` does not run on the server for these URLs. The document head is
+ * still built from the store, so dispatch the robots meta directly to get it into the HTML.
+ * The bare `/discover/tags` page is left indexable.
+ */
+export function setDiscoverTagNoindex( context, next ) {
+	if ( context.query?.selectedTag ) {
+		const meta = getDocumentHeadMeta( context.store.getState() )
+			.filter( ( { name } ) => name !== 'robots' )
+			.concat( { name: 'robots', content: 'noindex' } );
+
+		context.store.dispatch( setDocumentHeadMeta( meta ) );
+	}
+
+	next();
+}

--- a/client/reader/discover/test/discover-document-head.jsx
+++ b/client/reader/discover/test/discover-document-head.jsx
@@ -1,0 +1,24 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import { DiscoverDocumentHead } from '../discover-document-head';
+
+const mockDocumentHead = jest.fn( () => null );
+jest.mock( 'calypso/components/data/document-head', () => ( props ) => mockDocumentHead( props ) );
+
+const getMeta = () => mockDocumentHead.mock.calls[ 0 ][ 0 ].meta;
+
+describe( 'DiscoverDocumentHead', () => {
+	beforeEach( () => mockDocumentHead.mockClear() );
+
+	test( 'does not emit a robots meta by default', () => {
+		render( <DiscoverDocumentHead /> );
+		expect( getMeta() ).not.toContainEqual( expect.objectContaining( { name: 'robots' } ) );
+	} );
+
+	test( 'emits a noindex robots meta when noindex is set', () => {
+		render( <DiscoverDocumentHead noindex /> );
+		expect( getMeta() ).toContainEqual( { name: 'robots', content: 'noindex' } );
+	} );
+} );

--- a/client/reader/discover/test/set-discover-tag-noindex.js
+++ b/client/reader/discover/test/set-discover-tag-noindex.js
@@ -1,0 +1,54 @@
+import { setDiscoverTagNoindex } from '../set-discover-tag-noindex';
+
+function makeContext( query, meta = [] ) {
+	const dispatched = [];
+	return {
+		query,
+		store: {
+			getState: () => ( { documentHead: { meta } } ),
+			dispatch: ( action ) => dispatched.push( action ),
+		},
+		dispatched,
+	};
+}
+
+const robotsMeta = ( context ) =>
+	context.dispatched
+		.flatMap( ( action ) => action.meta || [] )
+		.filter( ( { name } ) => name === 'robots' );
+
+describe( 'setDiscoverTagNoindex', () => {
+	test( 'adds a noindex robots meta when a tag is selected', () => {
+		const next = jest.fn();
+		const context = makeContext( { selectedTag: 'food' } );
+
+		setDiscoverTagNoindex( context, next );
+
+		expect( robotsMeta( context ) ).toEqual( [ { name: 'robots', content: 'noindex' } ] );
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'keeps existing meta and replaces any prior robots meta', () => {
+		const context = makeContext( { selectedTag: 'food' }, [
+			{ name: 'description', content: 'Discover' },
+			{ name: 'robots', content: 'index' },
+		] );
+
+		setDiscoverTagNoindex( context, jest.fn() );
+
+		expect( context.dispatched[ 0 ].meta ).toEqual( [
+			{ name: 'description', content: 'Discover' },
+			{ name: 'robots', content: 'noindex' },
+		] );
+	} );
+
+	test( 'does nothing for the bare /discover/tags page', () => {
+		const next = jest.fn();
+		const context = makeContext( {} );
+
+		setDiscoverTagNoindex( context, next );
+
+		expect( context.dispatched ).toHaveLength( 0 );
+		expect( next ).toHaveBeenCalledTimes( 1 );
+	} );
+} );


### PR DESCRIPTION
Part of the logged-out tag page SEO cleanup.

## Proposed Changes

* Emit `<meta name="robots" content="noindex" />` on the tag-parameterized Discover pages (`/discover/tags?selectedTag=<tag>`, including localized variants like `/es/discover/tags?selectedTag=<tag>`).
* Leave the bare `/discover/tags` page, and every other Discover page, indexable.
* Add a server middleware (`setDiscoverTagNoindex`) that dispatches the robots meta into the document head store. URLs with a query string are never server-side rendered in Calypso (see `setShouldServerSideRender`), so the meta cannot come from the React document head component on the server. The head is still built from the store on every request, so dispatching directly gets the tag into the raw HTML. This is the same approach `setBrowsePluginsNoindex` uses for uncurated plugin browse pages.
* Pass a `noindex` prop to `DiscoverDocumentHead` on the client so the head stays consistent after hydration and on client-side navigation.
* Unit tests for the middleware and the component prop.

## Why are these changes being made?

Logged-out `/tag/<tag>` URLs now redirect to `/discover/tags?selectedTag=<tag>`. Those parameterized pages are a long tail of thin, near-duplicate URLs that compete with the main Discover pages in search results and AI Overviews. Marking them `noindex` tells search engines to drop them while keeping them live for people who follow the links.

Because these URLs skip SSR entirely, crawlers currently receive an empty app shell for them (generic title, no description), so nothing of value is lost by de-indexing them.

## Testing Instructions

The change is server-side, and `yarn start` only builds the server bundle once, so restart the dev server after checking out the branch.

1. Check out this branch and run `yarn start`.
2. In a logged-out browser (or with `curl`), load `view-source:http://calypso.localhost:3000/discover/tags?selectedTag=food`. Confirm the head contains `<meta name="robots" content="noindex"/>`.
3. Repeat for a localized URL, for example `/es/discover/tags?selectedTag=comida`. Confirm the same meta is present.
4. Load `view-source:http://calypso.localhost:3000/discover/tags` and `view-source:http://calypso.localhost:3000/discover`. Confirm there is no robots meta.
5. While logged in, navigate client-side from `/discover` to `/discover/tags?selectedTag=food` and inspect the DOM head. Confirm the robots meta is added, and removed again when navigating back to `/discover`.
6. Run `yarn test-client client/reader/discover`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
