### PR TITLE
Retire PHP 8.2 in the version selectors for every site

### DIFF
--- a/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
+++ b/client/a8c-for-agencies/components/site-configurations-modal/index.tsx
@@ -45,7 +45,7 @@ export default function SiteConfigurationsModal( {
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const translate = useTranslate();
 	const dataCenterOptions = getDataCenterOptions();
-	const { phpVersions, recommendedValue } = getPHPVersions( siteId );
+	const { phpVersions, recommendedValue } = getPHPVersions();
 	const siteName = useSiteName( randomSiteName, isRandomSiteNameLoading );
 	const { mutate: createWPCOMSite } = useCreateWPCOMSiteMutation();
 	const { mutate: createWPCOMDevSite } = useCreateWPCOMDevSiteMutation();

--- a/client/dashboard/sites/settings-php/index.tsx
+++ b/client/dashboard/sites/settings-php/index.tsx
@@ -39,7 +39,7 @@ export default function PHPVersionSettings( { siteSlug }: { siteSlug: string } )
 		version: currentVersion ?? '',
 	} );
 
-	const { phpVersions } = getPHPVersions( site.ID );
+	const { phpVersions } = getPHPVersions();
 
 	const fields: Field< { version: string } >[] = [
 		{

--- a/client/dashboard/sites/settings-php/summary.tsx
+++ b/client/dashboard/sites/settings-php/summary.tsx
@@ -16,7 +16,7 @@ export default function PHPSettingsSummary( { site, density }: { site: Site; den
 		enabled: hasHostingFeature( site, HostingFeatures.PHP ),
 	} );
 
-	const { recommendedValue } = getPHPVersions( site.ID );
+	const { recommendedValue } = getPHPVersions();
 
 	const getBadge = () => {
 		if ( ! version ) {

--- a/client/dashboard/sites/settings-php/test/index.test.tsx
+++ b/client/dashboard/sites/settings-php/test/index.test.tsx
@@ -95,20 +95,6 @@ describe( '<PHPVersionSettings>', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	test( 'offers PHP 8.2 to allowlisted sites', async () => {
-		const allowlistedSite = { ...site, ID: 255633016 } as Site;
-		mockSite( allowlistedSite );
-		mockPHPVersion( '8.3', allowlistedSite.ID );
-
-		const queryClient = new QueryClient();
-		await queryClient.ensureQueryData( sitePHPVersionQuery( allowlistedSite.ID ) );
-
-		render( <PHPVersionSettings siteSlug={ allowlistedSite.slug } />, { queryClient } );
-
-		const versionSelect = await screen.findByRole( 'combobox', { name: 'PHP version' } );
-		expect( within( versionSelect ).getByRole( 'option', { name: '8.2' } ) ).toBeVisible();
-	} );
-
 	test( 'renders upsell when the site does not have the plan feature', async () => {
 		mockSite( {
 			...site,

--- a/client/data/php-versions/index.jsx
+++ b/client/data/php-versions/index.jsx
@@ -1,16 +1,15 @@
 import { __, sprintf } from '@wordpress/i18n';
 
-export const getPHPVersions = ( siteId ) => {
+export const getPHPVersions = () => {
 	const recommendedValue = '8.4';
 	// translators: %s: PHP version number, e.g. "8.4", for a version switcher
 	const recommendedLabel = sprintf( __( '%s (Recommended)' ), recommendedValue );
-	const PHP82AllowedSites = [ 255633016 ];
 
 	const phpVersions = [
 		{
 			label: '8.2',
 			value: '8.2',
-			disabled: ! PHP82AllowedSites.includes( siteId ?? 0 ), // EOL 31 December 2026
+			disabled: true, // Retired. Still listed so sites on it show their current version. EOL 31 December 2026
 		},
 		{
 			label: '8.3',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/playground/components/playground-iframe/index.tsx
@@ -2,11 +2,9 @@ import { ProgressBar } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import clsx from 'clsx';
 import { useEffect, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
 import { getPHPVersions } from 'calypso/data/php-versions';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { getBlueprintID } from '../../lib/blueprint';
 import { initializeWordPressPlayground } from '../../lib/initialize-playground';
 import { PlaygroundError } from '../playground-error';
@@ -23,9 +21,8 @@ export function PlaygroundIframe( {
 	hasPlaygroundClient: boolean;
 	setPlaygroundClient: ( client: PlaygroundClient ) => void;
 } ) {
-	const siteId = useSelector( getSelectedSiteId ) ?? 0;
 	const iframeRef = useRef< HTMLIFrameElement >( null );
-	const recommendedPHPVersion = getPHPVersions( siteId ).recommendedValue;
+	const recommendedPHPVersion = getPHPVersions().recommendedValue;
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const [ playgroundError, setPlaygroundError ] = useState< string | null >( null );
 	const [ isLoading, setIsLoading ] = useState( true );

--- a/client/sites/settings/server/server-configuration-form.tsx
+++ b/client/sites/settings/server/server-configuration-form.tsx
@@ -94,7 +94,7 @@ export default function ServerConfigurationForm( { disabled }: ServerConfigurati
 	const isPhpVersionChanged = selectedPhpVersion && selectedPhpVersion !== phpVersion;
 	const isStaticFile404Changed = selectedStaticFile404 && selectedStaticFile404 !== staticFile404;
 
-	const { recommendedValue, phpVersions } = getPHPVersions( siteId );
+	const { recommendedValue, phpVersions } = getPHPVersions();
 	const dataCenterOptions = getDataCenterOptions();
 
 	const wpVersionRef = useRef< HTMLLabelElement >( null );


### PR DESCRIPTION
Part of DOTCOM-17393. Follow-up to #112863.

## Proposed Changes

* Retire PHP 8.2 for every site in `getPHPVersions()`. The option stays in the list but is always disabled, so a site still running 8.2 shows its current version while nothing can select it.
* Remove the temporary `PHP82AllowedSites` allowlist that kept 8.2 selectable for the one site under remediation. That site has been migrated to 8.4.
* Without the allowlist the helper no longer needs a site ID, so the argument is dropped from its five callers (Multi-site Dashboard PHP settings and summary, classic Calypso server settings, the A4A site-creation modal, and the Playground iframe, which loses its now-unused selected site lookup).
* Drop the unit test that covered the allowlisted site. The remaining tests still cover "8.2 hidden for regular sites" and "a site currently on 8.2 shows it as the current version".

## Why are these changes being made?

* The allowlist was a stopgap while the last non-policy site on 8.2 was being fixed. It is done, and the MC surfaces now reject 8.2 server-side as well, so Calypso should offer the same set of versions everywhere.

## Testing Instructions

* Run the unit tests: `yarn test-client client/dashboard/sites/settings-php`
* On the live branch, open **Hosting → Server Settings** for an Atomic site on 8.3 or 8.4 and verify the PHP dropdown offers only 8.3 and 8.4 (Recommended).
* For the Multi-site Dashboard, run `yarn start-dashboard` and open `http://my.localhost:3000/sites/<site-slug>/settings/php`. Same expectation. A site still on 8.2 shows 8.2 as the current value but it cannot be re-selected once changed.
* In A4A, open the site-creation modal and verify 8.2 is not offered.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
