### PR TITLE
Login: say "backup code" when an invalid backup code is entered on the 2FA form

### DIFF
--- a/client/blocks/login/two-factor-authentication/get-verification-code-error-message.js
+++ b/client/blocks/login/two-factor-authentication/get-verification-code-error-message.js
@@ -1,0 +1,17 @@
+/**
+ * The two-step endpoint returns the same "not a valid verification code"
+ * message for every auth type, which is misleading on the backup-code form.
+ * @param {Object} requestError      Error from the two-step login request
+ * @param {string} twoFactorAuthType Two factor authentication method (authenticator, backup, sms ...)
+ * @param {Function} translate       Localized translate function
+ * @returns {string|undefined} The message to show under the code input
+ */
+export function getVerificationCodeErrorMessage( requestError, twoFactorAuthType, translate ) {
+	if ( twoFactorAuthType === 'backup' && requestError?.code === 'invalid_two_step_code' ) {
+		return translate(
+			'Hmm, that’s not a valid backup code. Please double-check your codes and try again.'
+		);
+	}
+
+	return requestError?.message;
+}

--- a/client/blocks/login/two-factor-authentication/test/get-verification-code-error-message.js
+++ b/client/blocks/login/two-factor-authentication/test/get-verification-code-error-message.js
@@ -1,0 +1,42 @@
+import { getVerificationCodeErrorMessage } from '../get-verification-code-error-message';
+
+const translate = ( text ) => text;
+const apiMessage =
+	"Hmm, that's not a valid verification code. Please double-check your app and try again.";
+
+describe( 'getVerificationCodeErrorMessage', () => {
+	test( 'replaces the generic invalid-code message on the backup code form', () => {
+		const error = { code: 'invalid_two_step_code', message: apiMessage, field: 'twoStepCode' };
+
+		expect( getVerificationCodeErrorMessage( error, 'backup', translate ) ).toBe(
+			'Hmm, that’s not a valid backup code. Please double-check your codes and try again.'
+		);
+	} );
+
+	test.each( [ 'authenticator', 'sms', 'email' ] )(
+		'keeps the API message for the %s form',
+		( twoFactorAuthType ) => {
+			const error = { code: 'invalid_two_step_code', message: apiMessage, field: 'twoStepCode' };
+
+			expect( getVerificationCodeErrorMessage( error, twoFactorAuthType, translate ) ).toBe(
+				apiMessage
+			);
+		}
+	);
+
+	test( 'keeps the API message for other error codes on the backup code form', () => {
+		const error = {
+			code: 'empty_two_step_code',
+			message: 'Please enter a code.',
+			field: 'twoStepCode',
+		};
+
+		expect( getVerificationCodeErrorMessage( error, 'backup', translate ) ).toBe(
+			'Please enter a code.'
+		);
+	} );
+
+	test( 'returns undefined when there is no error', () => {
+		expect( getVerificationCodeErrorMessage( null, 'backup', translate ) ).toBeUndefined();
+	} );
+} );

--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -15,6 +15,7 @@ import {
 	sendSmsCode,
 } from 'calypso/state/login/actions';
 import { getTwoFactorAuthNonce, getTwoFactorAuthRequestError } from 'calypso/state/login/selectors';
+import { getVerificationCodeErrorMessage } from './get-verification-code-error-message';
 import TwoFactorActions from './two-factor-actions';
 
 import './verification-code-form.scss';
@@ -165,7 +166,14 @@ class VerificationCodeForm extends Component {
 							placeholder={ this.props.verificationCodeInputPlaceholder }
 						/>
 						{ requestError && requestError.field === 'twoStepCode' && (
-							<FormInputValidation isError text={ requestError.message } />
+							<FormInputValidation
+								isError
+								text={ getVerificationCodeErrorMessage(
+									requestError,
+									twoFactorAuthType,
+									translate
+								) }
+							/>
 						) }
 
 						{ smallPrint }


### PR DESCRIPTION
Fixes DOTOBRD-374

## Proposed Changes
This PR fixes the error when an incorrect backup code is used during authorization. See testing instructions.

## Testing Instructions
Setup: a WordPress.com test account with two-step authentication enabled. Test logged out, in an incognito window.
1. Open `/log-in`
2. On the verification code screen, choose "Use a backup code instead" (under "I can't access my phone")
3. Enter a wrong code, for example `12345678`, and continue
4.  Assert that you see `"Hmm, that’s not a valid backup code. Please double-check your codes and try again.` ( Before it was `Hmm, that's not a valid verification code. Please double-check your app and try again.`)
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="651" height="637" alt="Screenshot 2026-09-07 at 16 43 43" src="https://github.com/user-attachments/assets/54f9832f-5817-46fc-84cd-66f80dd30c24" />
<td><img width="649" height="638" alt="Screenshot 2026-09-07 at 16 45 15" src="https://github.com/user-attachments/assets/b3c2c7c5-c5b4-48ee-8b45-d3fb3c35f81b" />
</tr>
</table>