### PR TITLE
Checkout: restore phone field country autodetection

### DIFF
--- a/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
+++ b/client/components/domains/contact-details-form-fields/managed-contact-details-form-fields.tsx
@@ -277,6 +277,7 @@ export class ManagedContactDetailsFormFields extends Component<
 					<FormPhoneMediaInput
 						label={ this.props.translate( 'Phone' ) }
 						name="phone"
+						enableStickyCountry={ false }
 						value={ {
 							phoneNumber: this.props.contactDetails.phone ?? '',
 							countryCode:

--- a/client/components/phone-input/index.tsx
+++ b/client/components/phone-input/index.tsx
@@ -216,6 +216,12 @@ function usePhoneNumberState(
 			( value === rawValue || value === displayValue || value === icannValue )
 		) {
 			debug( 'props change did not change normalized value', value );
+			// Record the value we are ignoring. Consumers of this component often
+			// normalize the value and send it back asynchronously, so by the time it
+			// arrives the user may have typed more characters. Without this, the next
+			// render would compare that same stale value against the newer displayed
+			// value, decide they differ, and overwrite what the user typed.
+			previousValue.current = value;
 			return;
 		}
 		previousValue.current = value;

--- a/client/components/phone-input/test/index.test.tsx
+++ b/client/components/phone-input/test/index.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import PhoneInput from 'calypso/components/phone-input';
+import type { CountryListItem } from '@automattic/wpcom-checkout';
+import type { PhoneInputValue } from 'calypso/components/phone-input';
+
+const countriesList: CountryListItem[] = [
+	{ code: 'US', name: 'United States', has_postal_codes: true, vat_supported: false },
+	{ code: 'AL', name: 'Albania', has_postal_codes: true, vat_supported: false },
+	{ code: 'BR', name: 'Brazil', has_postal_codes: true, vat_supported: false },
+];
+
+function TestPhoneInput( {
+	enableStickyCountry,
+	initialCountryCode = 'US',
+}: {
+	enableStickyCountry?: boolean;
+	initialCountryCode?: string;
+} ) {
+	const [ value, setValue ] = useState< PhoneInputValue >( {
+		phoneNumber: '',
+		countryCode: initialCountryCode,
+	} );
+	return (
+		<>
+			<PhoneInput
+				countriesList={ countriesList }
+				enableStickyCountry={ enableStickyCountry }
+				onChange={ setValue }
+				value={ value }
+			/>
+			<span data-testid="country-code">{ value.countryCode }</span>
+			<span data-testid="phone-number">{ value.phoneNumber }</span>
+		</>
+	);
+}
+
+describe( 'PhoneInput', () => {
+	it( 'guesses the country from a dialing code typed by the user', async () => {
+		const user = userEvent.setup();
+		render( <TestPhoneInput enableStickyCountry={ false } /> );
+
+		await user.type( screen.getByRole( 'textbox' ), '+355691234567' );
+
+		expect( screen.getByTestId( 'country-code' ) ).toHaveTextContent( 'AL' );
+		expect( screen.getByTestId( 'phone-number' ) ).toHaveTextContent( '+355 69 123 4567' );
+	} );
+
+	it( 'does not overwrite a typed dialing code with the selected country dialing code', async () => {
+		const user = userEvent.setup();
+		render( <TestPhoneInput enableStickyCountry={ false } initialCountryCode="BR" /> );
+
+		await user.type( screen.getByRole( 'textbox' ), '+12345678901' );
+
+		expect( screen.getByTestId( 'country-code' ) ).toHaveTextContent( 'US' );
+		expect( screen.getByTestId( 'phone-number' ) ).not.toHaveTextContent( '+55' );
+	} );
+
+	it( 'keeps the selected country when sticky country is enabled', async () => {
+		const user = userEvent.setup();
+		render( <TestPhoneInput enableStickyCountry /> );
+
+		await user.type( screen.getByRole( 'textbox' ), '+355691234567' );
+
+		expect( screen.getByTestId( 'country-code' ) ).toHaveTextContent( 'US' );
+	} );
+} );

--- a/client/my-sites/checkout/src/test/checkout-contact-step.tsx
+++ b/client/my-sites/checkout/src/test/checkout-contact-step.tsx
@@ -190,6 +190,19 @@ describe( 'Checkout contact step', () => {
 		expect( screen.getByText( 'ZIP code' ) ).toBeInTheDocument();
 	} );
 
+	it( 'autodetects the phone country from a dialing code typed into the phone field', async () => {
+		const user = userEvent.setup();
+		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };
+		const { container } = render(
+			<MockCheckout { ...defaultPropsForMockCheckout } cartChanges={ cartChanges } />
+		);
+		await user.selectOptions( await screen.findByLabelText( 'Country' ), 'US' );
+		await user.type( screen.getByPlaceholderText( 'Phone' ), '+447911123456' );
+
+		expect( container.querySelector( '.phone-input__country-select' ) ).toHaveValue( 'GB' );
+		expect( screen.getByPlaceholderText( 'Phone' ) ).toHaveValue( '+44 7911 123456' );
+	} );
+
 	it( 'renders domain fields except postal code when a country without postal code support has been chosen and a domain is in the cart', async () => {
 		const user = userEvent.setup();
 		const cartChanges = { products: [ planWithBundledDomain, domainProduct ] };


### PR DESCRIPTION
Fixes #85800
Related to CHE-104

## Proposed changes

The phone field in the checkout contact form has its own country selector, which picks the formatting pattern and the dialing code shown in the input. It is meant to auto-detect the country as you type an international number, but it stopped doing so, forcing users to select the country by hand. This restores that behavior by fixing two independent bugs.

* Pass `enableStickyCountry={ false }` to the phone field in `ManagedContactDetailsFormFields`, re-enabling country guessing.
* Record the incoming `value` prop in `usePhoneNumberState` when the component decides to ignore it, so a stale value can no longer overwrite what the user typed.
* Add a regression test to the checkout contact step suite.
* Add a unit test suite for `PhoneInput`, which previously had none.


https://github.com/user-attachments/assets/d53bf92e-ff12-4565-b580-3f830143aa41


## Why are these changes being made?

There are two separate causes, and both have to be fixed for autodetection to work.

**1. Country guessing was switched off.** `PhoneInput`'s `enableStickyCountry` prop defaults to `true`, which sets `freezeSelection` for the lifetime of the component and makes `shouldGuessCountry()` always return `false`. The pre-TypeScript version of `ManagedContactDetailsFormFields` passed `enableStickyCountry: false` at both of
its phone field call sites; the conversion in #77920 collapsed those into a single JSX element and dropped the prop, so checkout silently fell back to the sticky default.

**2. The input was overwriting what the user typed.** `formatDataForParent` converts the phone number to ICANN format (`+1.4479111234`) on every keystroke, and that value round-trips back down through Redux as the controlled `value` prop — arriving a keystroke late. `usePhoneNumberState` has a guard that ignores a prop whose normalized form matches what is displayed, but that early return did not update `previousValue.current`. So on the next render the same stale value was compared against a newer display value, looked like a genuine change, and clobbered the
input. Concretely, typing `+44…` from a US selection produced `+1.` after the first character, which then became the start of the number: `+1 447911123456`. Because the digits now began with `1`, `findCountryFromNumber()` could only ever answer "US", so even with fix 1 applied the country never switched.

Recording the ignored value fixes this without changing the parent's normalization, which is still needed for the value actually submitted to the API.

## Testing instructions

TC:
```
yarn test-client client/components/phone-input/ client/my-sites/checkout/src/test/checkout-contact-step.tsx
```

Manual testing:
* Visit checkout with a domain product in the cart.
* In the contact info step, select a country (e.g. United States), then type `+355691234567` into the Phone field.
* Confirm the phone country selector switches to Albania and the number formats as `+355 69 123 4567`.
* Confirm the digits you type are not replaced — before this change, typing `+4` would turn into `+1`.
* Confirm manually choosing a country from the phone selector still works and still reformats the existing number.
* Confirm the submitted contact details still carry the phone number in ICANN format.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
