### PR TITLE
Purchases: clarify free trial status for already-renewed trials

### DIFF
--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -19,6 +19,7 @@ import {
 	isRenewingBeforeExpiration,
 	isExpiring,
 	isExpiredOrRemoved,
+	isFreeTrialEndingOnExpiryDate,
 	isIncludedWithPlan,
 	isOneTimePurchase,
 	isAkismetFreeProduct,
@@ -255,12 +256,8 @@ export function PurchaseExpiryStatus( {
 		);
 	}
 
-	const isIntroductoryOfferFreeTrial = purchase.introductory_offer?.cost_per_interval === 0;
-	if (
-		purchase.introductory_offer?.is_within_period &&
-		isIntroductoryOfferFreeTrial &&
-		isRenewingBeforeExpiration( purchase )
-	) {
+	const isFreeTrial = isFreeTrialEndingOnExpiryDate( purchase );
+	if ( isFreeTrial && isRenewingBeforeExpiration( purchase ) ) {
 		return createInterpolateElement(
 			sprintf(
 				// translators: %(date)s: a formatted date, %(amount)s: a currency amount, excludeTaxStringAbbreviation: something like "excludes VAT"
@@ -283,11 +280,7 @@ export function PurchaseExpiryStatus( {
 		);
 	}
 
-	if (
-		purchase.introductory_offer?.is_within_period &&
-		isIntroductoryOfferFreeTrial &&
-		! isExpiredOrRemoved( purchase )
-	) {
+	if ( isFreeTrial && ! isExpiredOrRemoved( purchase ) ) {
 		return (
 			<span>
 				{

--- a/client/dashboard/components/purchase-expiry-status/test/index.test.tsx
+++ b/client/dashboard/components/purchase-expiry-status/test/index.test.tsx
@@ -119,6 +119,53 @@ describe( '<PurchaseExpiryStatus>', () => {
 		} );
 	} );
 
+	describe( 'a free trial', () => {
+		const freeTrial = ( overrides: Partial< Purchase > = {} ) =>
+			createPurchase( {
+				expiry_status: 'manual-renew',
+				expiry_date: daysFromNow( 30 ),
+				introductory_offer: {
+					cost_per_interval: 0,
+					end_date: daysFromNow( 30 ),
+					is_within_period: true,
+				},
+				...overrides,
+			} as Partial< Purchase > );
+
+		test( 'is described by when the trial runs out', () => {
+			render( <PurchaseExpiryStatus purchase={ freeTrial() } /> );
+
+			expect( screen.getByText( /free trial ends on march 26, 2026/i ) ).toBeVisible();
+		} );
+
+		test( 'is described by its expiry once an early renewal has paid past the trial', () => {
+			render(
+				<PurchaseExpiryStatus purchase={ freeTrial( { expiry_date: daysFromNow( 395 ) } ) } />
+			);
+
+			expect( screen.queryByText( /free trial/i ) ).toBeNull();
+			expect( screen.getByText( /expires on/i ) ).toBeVisible();
+			expect( screen.getByText( 'March 26, 2027' ) ).toBeVisible();
+		} );
+
+		test( 'is described by its renewal once an early renewal has paid past the trial', () => {
+			render(
+				<PurchaseExpiryStatus
+					purchase={ freeTrial( {
+						expiry_status: 'active',
+						expiry_date: daysFromNow( 395 ),
+						renew_date: daysFromNow( 395 ),
+						price_integer: 3500,
+						currency_code: 'USD',
+					} ) }
+				/>
+			);
+
+			expect( screen.queryByText( /free trial/i ) ).toBeNull();
+			expect( screen.getByText( /renews yearly at \$35/i ) ).toBeVisible();
+		} );
+	} );
+
 	describe( 'a purchase the viewer cannot renew', () => {
 		test.each( [
 			[ 'is not theirs', { user_id: OWNER_ID + 1 } ],

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -203,6 +203,33 @@ export function isCloseToExpiration( purchase: Purchase ): boolean {
 	return isWithinNext( new Date( purchase.expiry_date ), threshold, 'days' );
 }
 
+/**
+ * Returns true if the purchase is a free trial that runs all the way to its
+ * expiration date — i.e. the trial is the only thing keeping the subscription
+ * alive, and nothing has been paid for beyond it.
+ *
+ * A trial can be renewed early, which pushes the expiration date out by a full
+ * billing period while leaving the trial's own end date alone (the backend
+ * derives that from the original subscribed date, so a renewal never moves it).
+ * Such a subscription is still technically inside its trial period, but it is
+ * already paid up past the end of it, so describing it as a free trial ending
+ * on the expiration date is wrong twice over: that date is not when the trial
+ * ends, and the customer has stopped being a trialist.
+ *
+ * Both dates are day-granular UTC values from the same source, so they compare
+ * exactly for a trial that has not been renewed.
+ */
+export function isFreeTrialEndingOnExpiryDate( purchase: Purchase ): boolean {
+	const offer = purchase.introductory_offer;
+	if ( ! offer?.is_within_period || offer.cost_per_interval !== 0 ) {
+		return false;
+	}
+	if ( ! purchase.expiry_date || ! offer.end_date ) {
+		return false;
+	}
+	return ! isAfter( parseISO( purchase.expiry_date ), parseISO( offer.end_date ) );
+}
+
 export function creditCardExpiresBeforeSubscription( purchase: Purchase ): boolean {
 	if ( 'credit_card' !== purchase.payment_type ) {
 		return false;

--- a/client/dashboard/utils/purchase.ts
+++ b/client/dashboard/utils/purchase.ts
@@ -203,22 +203,10 @@ export function isCloseToExpiration( purchase: Purchase ): boolean {
 	return isWithinNext( new Date( purchase.expiry_date ), threshold, 'days' );
 }
 
-/**
- * Returns true if the purchase is a free trial that runs all the way to its
- * expiration date — i.e. the trial is the only thing keeping the subscription
- * alive, and nothing has been paid for beyond it.
- *
- * A trial can be renewed early, which pushes the expiration date out by a full
- * billing period while leaving the trial's own end date alone (the backend
- * derives that from the original subscribed date, so a renewal never moves it).
- * Such a subscription is still technically inside its trial period, but it is
- * already paid up past the end of it, so describing it as a free trial ending
- * on the expiration date is wrong twice over: that date is not when the trial
- * ends, and the customer has stopped being a trialist.
- *
- * Both dates are day-granular UTC values from the same source, so they compare
- * exactly for a trial that has not been renewed.
- */
+// An early renewal pushes expiry_date past the trial's end_date while
+// is_within_period remains true; comparing the two dates catches that.
+// Both are day-granular UTC from the same backend arithmetic, so they
+// compare exactly for an un-renewed trial.
 export function isFreeTrialEndingOnExpiryDate( purchase: Purchase ): boolean {
 	const offer = purchase.introductory_offer;
 	if ( ! offer?.is_within_period || offer.cost_per_interval !== 0 ) {

--- a/client/dashboard/utils/test/purchase.ts
+++ b/client/dashboard/utils/test/purchase.ts
@@ -15,6 +15,7 @@ import {
 	mightStillAutoRenew,
 	isExpiredWithNoAutoRenewAttemptsLeft,
 	creditCardExpiresBeforeSubscription,
+	isFreeTrialEndingOnExpiryDate,
 	getRenewalUrlFromPurchase,
 	getTitleForDisplay,
 	isPurchaseDowngradeEligible,
@@ -412,6 +413,71 @@ describe( 'creditCardExpiresBeforeSubscription', () => {
 					expiry_date: null as unknown as string,
 				} )
 			)
+		).toBe( false );
+	} );
+} );
+
+describe( 'isFreeTrialEndingOnExpiryDate', () => {
+	const freeTrial = ( overrides: Partial< Purchase > = {} ) =>
+		makePurchase( {
+			expiry_date: '2026-05-24T00:00:00+00:00',
+			introductory_offer: {
+				cost_per_interval: 0,
+				end_date: '2026-05-24T00:00:00+00:00',
+				is_within_period: true,
+			},
+			...overrides,
+		} as Partial< Purchase > );
+
+	test( 'is true while the trial is what the expiry date represents', () => {
+		expect( isFreeTrialEndingOnExpiryDate( freeTrial() ) ).toBe( true );
+	} );
+
+	test( 'is false once an early renewal has pushed the expiry past the trial', () => {
+		expect(
+			isFreeTrialEndingOnExpiryDate( freeTrial( { expiry_date: '2027-05-24T00:00:00+00:00' } ) )
+		).toBe( false );
+	} );
+
+	test( 'is false for a discounted introductory offer that is not free', () => {
+		expect(
+			isFreeTrialEndingOnExpiryDate(
+				freeTrial( {
+					introductory_offer: {
+						cost_per_interval: 12,
+						end_date: '2026-05-24T00:00:00+00:00',
+						is_within_period: true,
+					},
+				} as Partial< Purchase > )
+			)
+		).toBe( false );
+	} );
+
+	test( 'is false once the trial period is over', () => {
+		expect(
+			isFreeTrialEndingOnExpiryDate(
+				freeTrial( {
+					introductory_offer: {
+						cost_per_interval: 0,
+						end_date: '2026-05-24T00:00:00+00:00',
+						is_within_period: false,
+					},
+				} as Partial< Purchase > )
+			)
+		).toBe( false );
+	} );
+
+	test( 'is false for a purchase with no introductory offer', () => {
+		expect( isFreeTrialEndingOnExpiryDate( makePurchase( { introductory_offer: null } ) ) ).toBe(
+			false
+		);
+	} );
+
+	// The API returns no expiry date for some purchases even though the type
+	// says otherwise, and parsing it as a date throws.
+	test( 'is false when the purchase has no expiry date', () => {
+		expect(
+			isFreeTrialEndingOnExpiryDate( freeTrial( { expiry_date: null as unknown as string } ) )
 		).toBe( false );
 	} );
 } );

--- a/client/me/purchases/lib/raw-purchase-helpers.ts
+++ b/client/me/purchases/lib/raw-purchase-helpers.ts
@@ -205,10 +205,6 @@ export function isWithinIntroductoryOfferPeriod( purchase: Purchase ): boolean {
 	return purchase.introductory_offer?.is_within_period ?? false;
 }
 
-export function isIntroductoryOfferFreeTrial( purchase: Purchase ): boolean {
-	return purchase.introductory_offer?.cost_per_interval === 0;
-}
-
 export function mightStillAutoRenew( purchase: Purchase ): boolean {
 	return purchase.might_still_auto_renew;
 }

--- a/client/me/purchases/purchase-item/index.tsx
+++ b/client/me/purchases/purchase-item/index.tsx
@@ -38,6 +38,7 @@ import {
 	isA4ABillingDragonPurchase,
 	isA4AHoldingSitePurchase,
 	isAkismetHoldingSitePurchase,
+	isFreeTrialEndingOnExpiryDate,
 	isJetpackHoldingSitePurchase,
 	isMarketplaceHoldingSitePurchase,
 	isPartnerPurchase,
@@ -68,8 +69,6 @@ import {
 	creditCardExpiresBeforeSubscription,
 	creditCardHasAlreadyExpired,
 	getPartnerName,
-	isWithinIntroductoryOfferPeriod,
-	isIntroductoryOfferFreeTrial,
 	hasPaymentMethod,
 	isPaidWithCredits,
 	mightStillAutoRenew,
@@ -566,11 +565,7 @@ export function PurchaseItemStatus( {
 		);
 	}
 
-	if (
-		isWithinIntroductoryOfferPeriod( purchase ) &&
-		isIntroductoryOfferFreeTrial( purchase ) &&
-		! isExpiredOrRemoved( purchase )
-	) {
+	if ( isFreeTrialEndingOnExpiryDate( purchase ) && ! isExpiredOrRemoved( purchase ) ) {
 		if ( isRenewingBeforeExpiration( purchase ) ) {
 			return translate(
 				'Free trial ends on {{span}}%(date)s{{/span}}, renews automatically at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}}',

--- a/client/me/purchases/purchase-item/test/index.js
+++ b/client/me/purchases/purchase-item/test/index.js
@@ -170,6 +170,57 @@ describe( 'PurchaseItem', () => {
 		} );
 	} );
 
+	describe( 'a free trial', () => {
+		const freeTrial = ( overrides = {} ) => ( {
+			product_slug: 'wp_titan_mail_monthly',
+			expiry_status: 'manual-renew',
+			subscription_status: 'active',
+			// Three months out, matching the end of the trial below.
+			expiry_date: '2026-05-24T00:00:00+00:00',
+			introductory_offer: {
+				cost_per_interval: 0,
+				end_date: '2026-05-24T00:00:00+00:00',
+				is_within_period: true,
+			},
+			...overrides,
+		} );
+
+		test( 'should be described by when the trial runs out', () => {
+			renderWithProvider( <PurchaseItem purchase={ freeTrial() } /> );
+
+			expect( screen.getByText( /free trial ends on/i ) ).toBeInTheDocument();
+			expect( screen.getByText( 'May 24, 2026' ) ).toBeInTheDocument();
+		} );
+
+		test( 'should be described by its expiry once an early renewal has paid past the trial', () => {
+			renderWithProvider(
+				<PurchaseItem purchase={ freeTrial( { expiry_date: '2027-05-24T00:00:00+00:00' } ) } />
+			);
+
+			expect( screen.queryByText( /free trial/i ) ).toBeNull();
+			expect( screen.getByText( /expires on/i ) ).toBeInTheDocument();
+			expect( screen.getByText( 'May 24, 2027' ) ).toBeInTheDocument();
+		} );
+
+		test( 'should be described by its renewal once an early renewal has paid past the trial', () => {
+			renderWithProvider(
+				<PurchaseItem
+					purchase={ freeTrial( {
+						expiry_status: 'active',
+						expiry_date: '2027-05-24T00:00:00+00:00',
+						renew_date: '2027-05-24T00:00:00+00:00',
+						bill_period_days: 365,
+						price_integer: 3500,
+						currency_code: 'USD',
+					} ) }
+				/>
+			);
+
+			expect( screen.queryByText( /free trial/i ) ).toBeNull();
+			expect( screen.getByText( /renews yearly at \$35/i ) ).toBeInTheDocument();
+		} );
+	} );
+
 	describe( 'an in-app purchase', () => {
 		const purchase = {
 			is_iap_purchase: true,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-447/
Fixes #70247

## Proposed Changes

This stops the purchases list from calling a subscription a "free trial" once it has been renewed and paid for beyond the end of that trial. It adds a new shared helper that requires the subscription's expiry date to still fall inside the introductory offer before the free-trial wording is used; otherwise the status falls through to the standard Expires/Renews copy.

* Add `isFreeTrialEndingOnExpiryDate()` to `client/dashboard/utils/purchase.ts`, which gates the free-trial wording on the expiry date not having moved past `introductory_offer.end_date`.
* Use the helper in the Dashboard status column (`client/dashboard/components/purchase-expiry-status`), which also backs the site overview plan card.
* Use the same helper in the Calypso purchases list (`client/me/purchases/purchase-item`), replacing the local `isWithinIntroductoryOfferPeriod` + `isIntroductoryOfferFreeTrial` pair.
* Remove the now-unused `isIntroductoryOfferFreeTrial` from `client/me/purchases/lib/raw-purchase-helpers.ts`.
* Add unit tests for the helper and behavior tests for both status columns.

## Why are these changes being made?

All new Professional Email accounts start as three-month trials. After renewing one early, the purchases page still reported `Free trial ends on July 14, 2027` (or `Free trial ends on July 14, 2027, renews automatically at $35 (excludes tax)`), styled as a warning, even though the customer had just paid for years of service.

The root cause is that the two conditions the copy relied on both survive a renewal, while the date it interpolates does not. On the backend, `Store_Subscription::get_introductory_offer_end_date()` derives the trial's end from the *original* subscribed date, so an early renewal never moves it, and `is_within_introductory_offer_period()` only asks whether now falls between the subscribed date and that end date. Meanwhile `expiry_date` is pushed out by a full billing period on every renewal. Both status columns keyed off `is_within_period` alone and then rendered `expiry_date` as though it were the trial end date, so the sentence was wrong twice over: that date is not when the trial ends, and the customer had stopped being a trialist.

This is fixable entirely on the client because `introductory_offer.end_date` is already on the purchase payload and simply was not being consulted. Comparing it against `expiry_date` is the narrowest correct signal, and it leaves the normal case untouched: for a trial that has not been renewed, the backend derives both dates from the same arithmetic and serializes them as day-granular midnight-UTC values, so they compare equal and the free-trial copy still shows.

The helper lives in the Dashboard utils because `client/me/purchases/purchase-item` already imports its expiry helpers from there. Sharing one predicate keeps the two surfaces from drifting, which is how they ended up with slightly different versions of this logic in the first place.

## Testing Instructions

TC:

```
yarn test-client client/dashboard/utils/test/purchase.ts client/dashboard/components/purchase-expiry-status client/me/purchases/purchase-item
```

Manual testing:

* On a sandboxed WordPress.com account, add a Professional Email mailbox, which is created as a three-month free trial.
* Visit `/me/purchases` (Calypso) and `/v2/me/billing/purchases` (Dashboard) and confirm the status still reads `Free trial ends on <date>`, where the date is three months out.
* Renew the subscription early via "Renew Now".
* Reload both purchases lists. The status should now read `Expires on <new date>` (auto-renew off) or `Renews yearly at <amount> on <new date>` (auto-renew on), in the normal text treatment rather than the yellow warning style, and should no longer mention a free trial.
* Also confirm the site overview plan card, which shares the Dashboard status component, reads the same way.
