### PR TITLE
Reader: TrainTracks instrumentation for "Discover new blogs" (READ-543)

### DIFF
--- a/client/reader/new-blogs/README.md
+++ b/client/reader/new-blogs/README.md
@@ -73,6 +73,25 @@ like the Discover feed around it. The mock therefore points at real, public
 WordPress.com posts. An error post (deleted / private / 404) renders nothing,
 which doubles as the client half of the serve-time guard.
 
+## TrainTracks (READ-543)
+
+Every rec carries a railcar (`{ railcar, fetch_algo: 'cluster_rec_v0', fetch_position,
+rec_blog_id, rec_post_id }`). The endpoint should mint these; until it exists the hook
+mints one per rec per snapshot (`buildRailcar`) so all events for a card share an id.
+
+| event                          | when                                | `action`                                                               |
+| ------------------------------ | ----------------------------------- | ---------------------------------------------------------------------- |
+| `calypso_traintracks_render`   | card 60% visible, once per railcar  | — (`ui_algo` `reader_recent_discover_new_blogs`, `ui_position` = slot) |
+| `calypso_traintracks_interact` | title click                         | `recommended_post_clicked`                                             |
+|                                | Subscribe / Unsubscribe             | `recommended_site_subscribed` / `recommended_site_unsubscribed`        |
+|                                | X                                   | `recommended_site_dismissed`                                           |
+|                                | More like this (per card on screen) | `recommended_more_clicked`                                             |
+|                                | Hide (per card on screen)           | `recommended_module_hidden`                                            |
+
+The `calypso_reader_discover_new_blogs_*` Tracks events from READ-542 fire alongside.
+`_render` now fires on the first card impression (not on mount), so it counts the same
+thing as the TrainTracks renders. Helpers live in `tracks.ts`.
+
 ## Files
 
 | file                  | role                                                                                           |
@@ -81,6 +100,7 @@ which doubles as the client half of the serve-time guard.
 | `use-oon-recs.ts`     | data hook — recs, dismissBlog (local + recommended-site dismiss), hide; mock behind `USE_MOCK` |
 | `mock-data.ts`        | fixtures keyed by user id; mirrors `wp-content/lib/reader-oon-recs/fixtures/oon-recs.json`     |
 | `placeholder.tsx`     | card-shaped loading state so the block keeps its height while posts hydrate                    |
+| `tracks.ts`           | TrainTracks helpers: railcar minting, render + interact (READ-543)                             |
 | `card.tsx`            | `usePost` hydration + site icon/name, Subscribe, X, title, excerpt (per the design)            |
 | `types.ts`            | `OonRec` / `OonRecsSnapshot` — the endpoint shape                                              |
 | `style.scss`          | module + card styles                                                                           |
@@ -91,4 +111,4 @@ which doubles as the client half of the serve-time guard.
 1. Flip `USE_MOCK` to `false` and point the hook at the endpoint once it ships.
 2. Send dismiss to the server (`POST …/blogs-you-dont-follow/dismiss`) instead of
    `localStorage` (READ-542 layer 3).
-3. A/B assignment + fuller Tracks per READ-543.
+3. ExPlat assignment for the A/B (READ-543) — needs the experiment name.

--- a/client/reader/new-blogs/card.tsx
+++ b/client/reader/new-blogs/card.tsx
@@ -12,7 +12,7 @@
 import { Button } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useState, type MouseEvent } from 'react';
+import { useCallback, useRef, useState, type MouseEvent } from 'react';
 import ReaderExcerpt from 'calypso/blocks/reader-excerpt';
 import { SiteIcon } from 'calypso/blocks/site-icon';
 import { useFeedQuery } from 'calypso/reader/data/feed';
@@ -24,17 +24,65 @@ import { getSiteName } from 'calypso/reader/get-helpers';
 import { getStreamUrl } from 'calypso/reader/route';
 import { showSelectedPost } from 'calypso/reader/utils';
 import OonRecCardPlaceholder from './placeholder';
+import { recordOonRender } from './tracks';
 import type { OonRec } from './types';
 
 interface Props {
 	rec: OonRec;
+	/** 0-based slot within the module, for TrainTracks `ui_position`. */
+	uiPosition: number;
 	onDismiss: () => void;
 	onOpen: () => void;
 	onFollowToggle: ( isFollowing: boolean ) => void;
+	/** Called once, when the card is first actually on screen. */
+	onImpression: () => void;
 }
 
-export default function OonRecCard( { rec, onDismiss, onOpen, onFollowToggle }: Props ) {
+/**
+ * Callback ref that records one TrainTracks render when the card becomes
+ * (60%) visible, once per railcar. Same approach as the stream's post view
+ * tracking (reader/stream/post-lifecycle `useTrackPostView`).
+ */
+function useTrackImpression( rec: OonRec, uiPosition: number, onImpression: () => void ) {
+	const observerRef = useRef< IntersectionObserver | null >( null );
+	const trackedRailcarRef = useRef< string | null >( null );
+
+	return useCallback(
+		( element: HTMLElement | null ) => {
+			observerRef.current?.disconnect();
+			observerRef.current = null;
+			if ( ! element || typeof IntersectionObserver === 'undefined' ) {
+				return;
+			}
+			observerRef.current = new IntersectionObserver(
+				( [ entry ] ) => {
+					const railcarId = rec.railcar?.railcar ?? null;
+					if ( ! entry.isIntersecting || trackedRailcarRef.current === railcarId ) {
+						return;
+					}
+					trackedRailcarRef.current = railcarId;
+					recordOonRender( rec, uiPosition );
+					onImpression();
+					observerRef.current?.disconnect();
+				},
+				{ threshold: [ 0.6 ] }
+			);
+			observerRef.current.observe( element );
+		},
+		[ rec, uiPosition, onImpression ]
+	);
+}
+
+export default function OonRecCard( {
+	rec,
+	uiPosition,
+	onDismiss,
+	onOpen,
+	onFollowToggle,
+	onImpression,
+}: Props ) {
 	const translate = useTranslate();
+	const impressionRef = useTrackImpression( rec, uiPosition, onImpression );
 	const postKey = { blogId: rec.blogId, postId: rec.postId };
 	const { data: post, isLoading } = usePost( postKey );
 	const siteId = post?.site_ID ? Number( post.site_ID ) : undefined;
@@ -66,7 +114,7 @@ export default function OonRecCard( { rec, onDismiss, onOpen, onFollowToggle }: 
 	};
 
 	return (
-		<li className="reader-discover-new-blogs__card">
+		<li className="reader-discover-new-blogs__card" ref={ impressionRef }>
 			<div className="reader-discover-new-blogs__card-head">
 				<a className="reader-discover-new-blogs__site" href={ streamUrl }>
 					<SiteIcon iconUrl={ siteIcon } size={ 24 } />

--- a/client/reader/new-blogs/index.tsx
+++ b/client/reader/new-blogs/index.tsx
@@ -22,10 +22,12 @@
  */
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useDispatch } from 'calypso/state';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
 import OonRecCard from './card';
+import { OON_ACTIONS, recordOonInteract } from './tracks';
+import type { OonRec } from './types';
 import type { UseOonRecsResult } from './use-oon-recs';
 import './style.scss';
 
@@ -46,37 +48,69 @@ export default function DiscoverNewBlogs( { recs, dismissBlog, hide }: Props ) {
 	const visible = recs.slice( start, start + DISPLAY_LIMIT );
 	const hasMore = recs.length > start + DISPLAY_LIMIT;
 
-	// One impression event per mount.
-	const trackedRef = useRef( false );
-	useEffect( () => {
-		if ( visible.length > 0 && ! trackedRef.current ) {
-			trackedRef.current = true;
-			dispatch(
-				recordReaderTracksEvent( 'calypso_reader_discover_new_blogs_render', {
-					count: visible.length,
-				} )
-			);
+	// One module impression per mount, fired when the FIRST card is actually on
+	// screen (not on mount — the block sits below the fold), so this count and
+	// the per-card TrainTracks renders measure the same thing.
+	const impressionTrackedRef = useRef( false );
+	const visibleCountRef = useRef( visible.length );
+	visibleCountRef.current = visible.length;
+	const handleImpression = useCallback( () => {
+		if ( impressionTrackedRef.current ) {
+			return;
 		}
-	}, [ dispatch, visible.length ] );
+		impressionTrackedRef.current = true;
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_discover_new_blogs_render', {
+				count: visibleCountRef.current,
+			} )
+		);
+	}, [ dispatch ] );
 
 	if ( visible.length === 0 ) {
 		return null;
 	}
 
-	const handleDismiss = ( blogId: number, postId: number ) => {
+	const handleDismiss = ( rec: OonRec ) => {
 		dispatch(
 			recordReaderTracksEvent( 'calypso_reader_discover_new_blogs_dismiss', {
-				blog_id: blogId,
-				post_id: postId,
+				blog_id: rec.blogId,
+				post_id: rec.postId,
 			} )
 		);
-		dismissBlog( blogId );
+		recordOonInteract( rec, OON_ACTIONS.SITE_DISMISSED );
+		dismissBlog( rec.blogId );
+	};
+
+	const handleOpen = ( rec: OonRec ) => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_discover_new_blogs_post_click', {
+				blog_id: rec.blogId,
+				post_id: rec.postId,
+			} )
+		);
+		recordOonInteract( rec, OON_ACTIONS.POST_CLICKED );
+	};
+
+	const handleFollowToggle = ( rec: OonRec, isFollowing: boolean ) => {
+		dispatch(
+			recordReaderTracksEvent( 'calypso_reader_discover_new_blogs_follow_toggle', {
+				blog_id: rec.blogId,
+				post_id: rec.postId,
+				following: isFollowing,
+			} )
+		);
+		recordOonInteract(
+			rec,
+			isFollowing ? OON_ACTIONS.SITE_SUBSCRIBED : OON_ACTIONS.SITE_UNSUBSCRIBED
+		);
 	};
 
 	const handleMore = () => {
 		dispatch(
 			recordReaderTracksEvent( 'calypso_reader_discover_new_blogs_more_click', { page: page + 1 } )
 		);
+		// "More like this" is a reaction to the cards on screen: log it against each.
+		visible.forEach( ( rec ) => recordOonInteract( rec, OON_ACTIONS.MORE_CLICKED ) );
 		setPage( page + 1 );
 	};
 
@@ -84,6 +118,8 @@ export default function DiscoverNewBlogs( { recs, dismissBlog, hide }: Props ) {
 		dispatch(
 			recordReaderTracksEvent( 'calypso_reader_discover_new_blogs_hide', { count: visible.length } )
 		);
+		// Hide applies to every card on screen: log the annoyance against each.
+		visible.forEach( ( rec ) => recordOonInteract( rec, OON_ACTIONS.MODULE_HIDDEN ) );
 		hide();
 	};
 
@@ -99,28 +135,15 @@ export default function DiscoverNewBlogs( { recs, dismissBlog, hide }: Props ) {
 			</div>
 
 			<ul className="reader-discover-new-blogs__list">
-				{ visible.map( ( rec ) => (
+				{ visible.map( ( rec, uiPosition ) => (
 					<OonRecCard
 						key={ `${ rec.blogId }-${ rec.postId }` }
 						rec={ rec }
-						onDismiss={ () => handleDismiss( rec.blogId, rec.postId ) }
-						onOpen={ () =>
-							dispatch(
-								recordReaderTracksEvent( 'calypso_reader_discover_new_blogs_post_click', {
-									blog_id: rec.blogId,
-									post_id: rec.postId,
-								} )
-							)
-						}
-						onFollowToggle={ ( isFollowing ) =>
-							dispatch(
-								recordReaderTracksEvent( 'calypso_reader_discover_new_blogs_follow_toggle', {
-									blog_id: rec.blogId,
-									post_id: rec.postId,
-									following: isFollowing,
-								} )
-							)
-						}
+						uiPosition={ uiPosition }
+						onDismiss={ () => handleDismiss( rec ) }
+						onOpen={ () => handleOpen( rec ) }
+						onFollowToggle={ ( isFollowing ) => handleFollowToggle( rec, isFollowing ) }
+						onImpression={ handleImpression }
 					/>
 				) ) }
 			</ul>

--- a/client/reader/new-blogs/test/index.test.tsx
+++ b/client/reader/new-blogs/test/index.test.tsx
@@ -7,17 +7,32 @@ import type { OonRec } from '../types';
 
 // Mock the card: it hydrates through the Reader post store and needs
 // redux / react-query / a real post.
-jest.mock( '../card', () => ( props: { rec: OonRec; onDismiss: () => void } ) => (
-	<li data-testid="oon-card">
-		<span>{ `Post ${ props.rec.postId }` }</span>
-		<button onClick={ props.onDismiss }>dismiss</button>
-	</li>
-) );
+jest.mock(
+	'../card',
+	() => ( props: { rec: OonRec; onDismiss: () => void; onImpression: () => void } ) => (
+		<li data-testid="oon-card">
+			<span>{ `Post ${ props.rec.postId }` }</span>
+			<button onClick={ props.onDismiss }>dismiss</button>
+			<button onClick={ props.onImpression }>impression</button>
+		</li>
+	)
+);
 jest.mock( 'calypso/state', () => ( {
 	useDispatch: () => jest.fn(),
 } ) );
+const mockRecordReaderTracksEvent = jest.fn();
 jest.mock( 'calypso/state/reader/analytics/actions', () => ( {
-	recordReaderTracksEvent: jest.fn(),
+	recordReaderTracksEvent: ( ...args: unknown[] ) => mockRecordReaderTracksEvent( ...args ),
+} ) );
+const mockRecordOonInteract = jest.fn();
+jest.mock( '../tracks', () => ( {
+	...jest.requireActual( '../tracks' ),
+	recordOonInteract: ( ...args: unknown[] ) => mockRecordOonInteract( ...args ),
+} ) );
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	getNewRailcarId: () => 'railcar-id',
+	recordTrainTracksRender: jest.fn(),
+	recordTrainTracksInteract: jest.fn(),
 } ) );
 jest.mock( 'i18n-calypso', () => ( {
 	useTranslate: () => ( str: string ) => str,
@@ -28,7 +43,18 @@ jest.mock( '@wordpress/components', () => ( {
 	),
 } ) );
 
-const makeRec = ( n: number ): OonRec => ( { blogId: n, postId: n * 10, score: 1 / n } );
+const makeRec = ( n: number ): OonRec => ( {
+	blogId: n,
+	postId: n * 10,
+	score: 1 / n,
+	railcar: {
+		railcar: `railcar-${ n }`,
+		fetch_algo: 'cluster_rec_v0',
+		fetch_position: n,
+		rec_blog_id: n,
+		rec_post_id: n * 10,
+	},
+} );
 
 const renderModule = ( recs: OonRec[], overrides = {} ) => {
 	const props = { recs, dismissBlog: jest.fn(), hide: jest.fn(), ...overrides };
@@ -50,16 +76,34 @@ describe( 'DiscoverNewBlogs', () => {
 		expect( screen.getByText( 'Post 20' ) ).toBeVisible();
 	} );
 
+	it( 'records the module render once, on the first card impression, not on mount', () => {
+		renderModule( [ makeRec( 1 ), makeRec( 2 ) ] );
+		const renders = () =>
+			mockRecordReaderTracksEvent.mock.calls.filter(
+				( [ name ] ) => name === 'calypso_reader_discover_new_blogs_render'
+			);
+		expect( renders() ).toHaveLength( 0 );
+		const [ first, second ] = screen.getAllByRole( 'button', { name: 'impression' } );
+		fireEvent.click( first );
+		fireEvent.click( second );
+		expect( renders() ).toHaveLength( 1 );
+		expect( renders()[ 0 ][ 1 ] ).toEqual( { count: 2 } );
+	} );
+
 	it( 'shows a fixed maximum of 3 cards', () => {
 		const many = Array.from( { length: 20 }, ( _, i ) => makeRec( i + 1 ) );
 		renderModule( many );
 		expect( screen.getAllByTestId( 'oon-card' ) ).toHaveLength( 3 );
 	} );
 
-	it( 'dismisses by blog when a card X is clicked', () => {
+	it( 'dismisses by blog when a card X is clicked, and logs the traintracks interact', () => {
 		const { props } = renderModule( [ makeRec( 3 ) ] );
 		screen.getByRole( 'button', { name: 'dismiss' } ).click();
 		expect( props.dismissBlog ).toHaveBeenCalledWith( 3 );
+		expect( mockRecordOonInteract ).toHaveBeenCalledWith(
+			expect.objectContaining( { blogId: 3 } ),
+			'recommended_site_dismissed'
+		);
 	} );
 
 	it( 'pages to the next 3 recs with "More like this", and hides the link at the end', () => {
@@ -89,9 +133,13 @@ describe( 'DiscoverNewBlogs', () => {
 		expect( screen.queryByRole( 'button', { name: 'More like this' } ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'hides the module when Hide is clicked', () => {
-		const { props } = renderModule( [ makeRec( 3 ) ] );
+	it( 'hides the module when Hide is clicked, logging an interact per visible card', () => {
+		const { props } = renderModule( [ 1, 2, 3, 4 ].map( makeRec ) );
 		screen.getByRole( 'button', { name: 'Hide' } ).click();
 		expect( props.hide ).toHaveBeenCalled();
+		const hidden = mockRecordOonInteract.mock.calls.filter(
+			( [ , action ] ) => action === 'recommended_module_hidden'
+		);
+		expect( hidden ).toHaveLength( 3 );
 	} );
 } );

--- a/client/reader/new-blogs/test/tracks.test.ts
+++ b/client/reader/new-blogs/test/tracks.test.ts
@@ -1,0 +1,67 @@
+import {
+	getNewRailcarId,
+	recordTrainTracksInteract,
+	recordTrainTracksRender,
+} from '@automattic/calypso-analytics';
+import {
+	OON_ACTIONS,
+	OON_FETCH_ALGO,
+	OON_UI_ALGO,
+	buildRailcar,
+	recordOonInteract,
+	recordOonRender,
+} from '../tracks';
+import type { OonRec } from '../types';
+
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	getNewRailcarId: jest.fn( () => 'abc123-recommendation' ),
+	recordTrainTracksRender: jest.fn(),
+	recordTrainTracksInteract: jest.fn(),
+} ) );
+
+const bare: OonRec = { blogId: 7, postId: 70, score: 0.5 };
+
+describe( 'new-blogs tracks', () => {
+	afterEach( () => jest.clearAllMocks() );
+
+	test( 'buildRailcar mints an id and stamps the recommender + rank', () => {
+		expect( buildRailcar( bare, 3 ) ).toEqual( {
+			railcar: 'abc123-recommendation',
+			fetch_algo: OON_FETCH_ALGO,
+			fetch_position: 3,
+			rec_blog_id: 7,
+			rec_post_id: 70,
+		} );
+		expect( getNewRailcarId ).toHaveBeenCalledWith( 'recommendation' );
+	} );
+
+	test( 'recordOonRender maps the railcar onto a traintracks render', () => {
+		const rec = { ...bare, railcar: buildRailcar( bare, 3 ) };
+		recordOonRender( rec, 1 );
+		expect( recordTrainTracksRender ).toHaveBeenCalledWith( {
+			railcarId: 'abc123-recommendation',
+			uiAlgo: OON_UI_ALGO,
+			uiPosition: 1,
+			fetchAlgo: OON_FETCH_ALGO,
+			fetchPosition: 3,
+			recBlogId: '7',
+			recPostId: '70',
+		} );
+	} );
+
+	test( 'recordOonInteract records the action against the railcar', () => {
+		const rec = { ...bare, railcar: buildRailcar( bare, 3 ) };
+		recordOonInteract( rec, OON_ACTIONS.SITE_DISMISSED );
+		expect( recordTrainTracksInteract ).toHaveBeenCalledWith( {
+			railcarId: 'abc123-recommendation',
+			action: 'recommended_site_dismissed',
+		} );
+	} );
+
+	test( 'nothing is recorded for a rec without a railcar', () => {
+		recordOonRender( bare, 0 );
+		recordOonInteract( bare, OON_ACTIONS.POST_CLICKED );
+		expect( recordTrainTracksRender ).not.toHaveBeenCalled();
+		expect( recordTrainTracksInteract ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/reader/new-blogs/tracks.ts
+++ b/client/reader/new-blogs/tracks.ts
@@ -1,0 +1,73 @@
+/**
+ * TrainTracks instrumentation for the "Discover new blogs" module (READ-543).
+ *
+ * One `calypso_traintracks_render` per card impression (fired when the card is
+ * actually on screen, once per railcar), and one `calypso_traintracks_interact`
+ * per user action on a card. Together with the existing
+ * `calypso_reader_discover_new_blogs_*` Tracks events this gives the A/B
+ * readout both engagement (click, follow) and annoyance (dismiss, hide).
+ *
+ * Mirrors the sidebar's Recommended sites card (reader/recommended-sites/site).
+ */
+import {
+	getNewRailcarId,
+	recordTrainTracksInteract,
+	recordTrainTracksRender,
+} from '@automattic/calypso-analytics';
+import type { OonRailcar, OonRec } from './types';
+
+/** Recommender that produced the snapshot (READ-541 / READ-543). */
+export const OON_FETCH_ALGO = 'cluster_rec_v0';
+
+/** The surface rendering the recs. */
+export const OON_UI_ALGO = 'reader_recent_discover_new_blogs';
+
+/** `action` values for `calypso_traintracks_interact`. */
+export const OON_ACTIONS = {
+	POST_CLICKED: 'recommended_post_clicked',
+	SITE_SUBSCRIBED: 'recommended_site_subscribed',
+	SITE_UNSUBSCRIBED: 'recommended_site_unsubscribed',
+	SITE_DISMISSED: 'recommended_site_dismissed',
+	MODULE_HIDDEN: 'recommended_module_hidden',
+	MORE_CLICKED: 'recommended_more_clicked',
+} as const;
+
+export type OonAction = ( typeof OON_ACTIONS )[ keyof typeof OON_ACTIONS ];
+
+/**
+ * Mint a railcar for a rec that arrived without one (mock mode today; a
+ * defensive fallback once the endpoint ships).
+ */
+export function buildRailcar( rec: OonRec, fetchPosition: number ): OonRailcar {
+	return {
+		railcar: getNewRailcarId( 'recommendation' ),
+		fetch_algo: OON_FETCH_ALGO,
+		fetch_position: fetchPosition,
+		rec_blog_id: rec.blogId,
+		rec_post_id: rec.postId,
+	};
+}
+
+/** Card impression. Call once per railcar, when the card is on screen. */
+export function recordOonRender( rec: OonRec, uiPosition: number ): void {
+	if ( ! rec.railcar ) {
+		return;
+	}
+	recordTrainTracksRender( {
+		railcarId: rec.railcar.railcar,
+		uiAlgo: OON_UI_ALGO,
+		uiPosition,
+		fetchAlgo: rec.railcar.fetch_algo,
+		fetchPosition: rec.railcar.fetch_position,
+		recBlogId: String( rec.railcar.rec_blog_id ),
+		recPostId: String( rec.railcar.rec_post_id ),
+	} );
+}
+
+/** User action on a card. */
+export function recordOonInteract( rec: OonRec, action: OonAction ): void {
+	if ( ! rec.railcar ) {
+		return;
+	}
+	recordTrainTracksInteract( { railcarId: rec.railcar.railcar, action } );
+}

--- a/client/reader/new-blogs/types.ts
+++ b/client/reader/new-blogs/types.ts
@@ -24,6 +24,25 @@ export interface OonRec {
 	blogId: number;
 	postId: number;
 	score: number;
+	/**
+	 * TrainTracks railcar for this rec (READ-543). The endpoint should mint
+	 * one per rec per response; in mock mode the hook mints it client-side.
+	 */
+	railcar?: OonRailcar;
+}
+
+/**
+ * TrainTracks railcar props for one rec. `fetch_algo` identifies the
+ * recommender (READ-543: `cluster_rec_v0`); `fetch_position` is the rec's
+ * rank in the snapshot, independent of where the card ends up on screen
+ * (that's `ui_position`, recorded at render time).
+ */
+export interface OonRailcar {
+	railcar: string;
+	fetch_algo: string;
+	fetch_position: number;
+	rec_blog_id: number;
+	rec_post_id: number;
 }
 
 /**

--- a/client/reader/new-blogs/use-oon-recs.ts
+++ b/client/reader/new-blogs/use-oon-recs.ts
@@ -33,6 +33,7 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { MOCK_OON_RECS, MOCK_DEFAULT_USER_ID } from './mock-data';
+import { buildRailcar } from './tracks';
 import type { OonRec, OonRecsSnapshot } from './types';
 
 const USE_MOCK = true; // TODO(READ-542): false once the endpoint exists.
@@ -170,11 +171,22 @@ export function useOonRecs(): UseOonRecsResult {
 		);
 	}, [ currentUserId ] );
 
-	// --- apply local dismissals -------------------------------------------
-	const recs = useMemo( () => {
+	// --- railcars (READ-543) ------------------------------------------------
+	// One railcar per rec per snapshot, minted once so every render / interact
+	// for the same card shares an id. `fetch_position` is the snapshot rank.
+	// The endpoint should send these; minting here is the mock-mode fallback.
+	const recsWithRailcars = useMemo( () => {
 		const all = snapshot?.recs ?? [];
-		return all.filter( ( r ) => ! dismissedBlogs.has( r.blogId ) );
-	}, [ snapshot, dismissedBlogs ] );
+		return all.map( ( rec, index ) =>
+			rec.railcar ? rec : { ...rec, railcar: buildRailcar( rec, index + 1 ) }
+		);
+	}, [ snapshot ] );
+
+	// --- apply local dismissals -------------------------------------------
+	const recs = useMemo(
+		() => recsWithRailcars.filter( ( r ) => ! dismissedBlogs.has( r.blogId ) ),
+		[ recsWithRailcars, dismissedBlogs ]
+	);
 
 	return {
 		recs,


### PR DESCRIPTION
Part of READ-543 (Reader Content Discovery Experiment). Stacked on #114140 (READ-542); the base branch is `READ-542`, so this diff is only the instrumentation.

## Proposed Changes

TrainTracks instrumentation for the "Discover new blogs" module, so the A/B readout covers both engagement and annoyance per recommendation.

* Each rec carries a railcar: `{ railcar, fetch_algo: 'cluster_rec_v0', fetch_position, rec_blog_id, rec_post_id }`. The endpoint should mint these per rec per response; until it exists the hook mints one per rec per snapshot (`buildRailcar`) so every event for a card shares an id.
* `calypso_traintracks_render` fires once per card when it is 60% visible, via an IntersectionObserver callback ref (same pattern as the stream's post view tracking). `ui_algo` is `reader_recent_discover_new_blogs`, `ui_position` is the card's slot in the module (0–2), `fetch_position` is the rec's rank in the snapshot.
* `calypso_traintracks_interact` fires with these actions:

  | user action | `action` |
  | --- | --- |
  | title click | `recommended_post_clicked` |
  | Subscribe / Unsubscribe | `recommended_site_subscribed` / `recommended_site_unsubscribed` |
  | X | `recommended_site_dismissed` |
  | More like this | `recommended_more_clicked`, once per card on screen |
  | Hide | `recommended_module_hidden`, once per card on screen |

* The module-level `calypso_reader_discover_new_blogs_render` Tracks event from READ-542 now fires on the **first card impression** instead of on mount, so it counts the same thing as the TrainTracks renders. The other `calypso_reader_discover_new_blogs_*` events are unchanged and fire alongside.
* Helpers live in `client/reader/new-blogs/tracks.ts` with unit tests; the module tests assert the interact and impression wiring.

### Notes for the backend contract

* Railcars should come from the endpoint. The client-side minting is a fallback for mock mode.
* The railcar shape here omits `fetch_lang`, which the shared `Railcar` type in `@automattic/calypso-analytics` includes. Add it server-side if the standard shape is wanted.
* Railcars are minted per visit to Recent, so leaving and coming back fires new renders. That's the standard TrainTracks model (a new fetch is a new railcar).
* "More like this" and Hide log an interact against every rec on the current page, including one whose post failed hydration and rendered nothing. Rare with real data because the server-side guard drops those first.

### Not in this PR

* ExPlat assignment for the A/B. Needs the experiment name.
* Likes. The design has no like control on the card, so there is nothing to instrument.

## Why are these changes being made?

READ-543's definition of done is a readable A/B result. That needs per-recommendation impressions and interactions keyed by railcar, with `fetch_algo` identifying the recommender, so the readout can separate engagement (click, follow) from annoyance (dismiss, hide) per rec.

## Testing Instructions

1. Check out this branch, `yarn start`, log in on `http://calypso.localhost:3000`, open `/read?oon_mock=23314024`.
2. In the console, capture TrainTracks events before scrolling:
   ```js
   window.__tt = []; const q = window._tkq = window._tkq || []; const orig = q.push.bind( q );
   q.push = ( ...a ) => { const [ cmd, name, props ] = a[ 0 ] || []; if ( cmd === 'recordEvent' && /traintracks/.test( name ) ) window.__tt.push( { name, props } ); return orig( ...a ); };
   ```
3. Scroll the "Discover new blogs" block into view: `window.__tt` should contain three `calypso_traintracks_render` events with `ui_position` 0, 1, 2, `fetch_algo` `cluster_rec_v0` and `ui_algo` `reader_recent_discover_new_blogs`. Scrolling away and back should not add more.
4. Click a title, an X, Subscribe, More like this and Hide: each adds `calypso_traintracks_interact` events with the actions in the table above and the matching `railcar` ids.
5. The module's `calypso_reader_discover_new_blogs_render` event fires with the first render, not on page load.
6. Reset between runs: `localStorage.removeItem( 'reader-oon-dismissed-blogs-v1' ); localStorage.removeItem( 'reader-oon-hidden-v1' )`.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
