### PR TITLE
Sites: link directly to single purchase when leaving a site with one purchase

### DIFF
--- a/client/dashboard/sites/site-leave-modal/content-info.tsx
+++ b/client/dashboard/sites/site-leave-modal/content-info.tsx
@@ -18,11 +18,11 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useState } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useAuth } from '../../app/auth';
-import { purchasesRoute } from '../../app/router/me';
+import { purchaseSettingsRoute, purchasesRoute } from '../../app/router/me';
 import { ButtonStack } from '../../components/button-stack';
 import RouterLinkButton from '../../components/router-link-button';
 import { isDashboardBackport } from '../../utils/is-dashboard-backport';
-import type { Site, User } from '@automattic/api-core';
+import type { Purchase, Site, User } from '@automattic/api-core';
 
 interface ContentInfoProps {
 	site: Site;
@@ -37,7 +37,16 @@ function isSiteOwner( user: User, site: Site ) {
 	return user.ID === site.site_owner;
 }
 
-function ContentHasPurchasesCancelable( { site, onClose }: ContentInfoProps ) {
+interface ContentHasPurchasesCancelableProps extends ContentInfoProps {
+	// Set only when exactly one purchase blocks leaving, so we can link straight to it.
+	purchase?: Purchase;
+}
+
+function ContentHasPurchasesCancelable( {
+	site,
+	onClose,
+	purchase,
+}: ContentHasPurchasesCancelableProps ) {
 	const { recordTracksEvent } = useAnalytics();
 
 	const managePurchasesButtonProps = {
@@ -47,6 +56,39 @@ function ContentHasPurchasesCancelable( { site, onClose }: ContentInfoProps ) {
 		onClick: () => {
 			recordTracksEvent( 'calypso_dashboard_site_leave_modal_manage_purchases_click' );
 		},
+	};
+
+	const renderManagePurchasesButton = () => {
+		if ( isDashboardBackport() ) {
+			return (
+				<Button
+					{ ...managePurchasesButtonProps }
+					href={
+						purchase
+							? `/purchases/subscriptions/${ site.slug }/${ purchase.ID }`
+							: `/purchases/subscriptions/${ site.slug }`
+					}
+				/>
+			);
+		}
+
+		if ( purchase ) {
+			return (
+				<RouterLinkButton
+					{ ...managePurchasesButtonProps }
+					to={ purchaseSettingsRoute.fullPath }
+					params={ { purchaseId: purchase.ID } }
+				/>
+			);
+		}
+
+		return (
+			<RouterLinkButton
+				{ ...managePurchasesButtonProps }
+				to={ purchasesRoute.fullPath }
+				search={ { site: site.ID } }
+			/>
+		);
 	};
 
 	return (
@@ -62,18 +104,7 @@ function ContentHasPurchasesCancelable( { site, onClose }: ContentInfoProps ) {
 				<Button __next40pxDefaultSize variant="tertiary" onClick={ onClose }>
 					{ __( 'Cancel' ) }
 				</Button>
-				{ isDashboardBackport() ? (
-					<Button
-						{ ...managePurchasesButtonProps }
-						href={ `/purchases/subscriptions/${ site.slug }` }
-					/>
-				) : (
-					<RouterLinkButton
-						{ ...managePurchasesButtonProps }
-						to={ purchasesRoute.fullPath }
-						search={ { site: site.ID } }
-					/>
-				) }
+				{ renderManagePurchasesButton() }
 			</ButtonStack>
 		</>
 	);
@@ -214,23 +245,29 @@ function ContentLeaveSite( { site, onClose }: ContentInfoProps ) {
 
 export default function ContentInfo( { site, onClose }: ContentInfoProps ) {
 	const { user } = useAuth();
-	const { data: hasPurchasesCancelable, isLoading: isLoadingHasPurchasesCancelable } = useQuery( {
+	const { data: purchasesCancelable, isLoading: isLoadingPurchasesCancelable } = useQuery( {
 		...sitePurchasesQuery( site.ID ),
 		select: ( purchases ) =>
-			purchases.some(
+			purchases.filter(
 				( purchase ) =>
 					purchase.user_id === user.ID &&
 					( purchase.is_refundable || purchase.product_slug !== 'premium_theme' )
 			),
 	} );
 
-	if ( isLoadingHasPurchasesCancelable ) {
+	if ( isLoadingPurchasesCancelable ) {
 		return null;
 	}
 
 	const renderContent = () => {
-		if ( hasPurchasesCancelable ) {
-			return <ContentHasPurchasesCancelable site={ site } onClose={ onClose } />;
+		if ( purchasesCancelable?.length ) {
+			return (
+				<ContentHasPurchasesCancelable
+					site={ site }
+					onClose={ onClose }
+					purchase={ purchasesCancelable.length === 1 ? purchasesCancelable[ 0 ] : undefined }
+				/>
+			);
 		}
 
 		if ( isSiteOwner( user, site ) ) {

--- a/client/dashboard/sites/site-leave-modal/test/content-info.test.tsx
+++ b/client/dashboard/sites/site-leave-modal/test/content-info.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import ContentInfo from '../content-info';
+import type { Site } from '@automattic/api-core';
+
+// The blocker-counting tests run against the Calypso backport branch because it
+// builds plain string hrefs. The dashboard branch uses TanStack routes, and
+// test-utils renders a bare root route, so those hrefs never resolve.
+let mockIsBackport = true;
+
+jest.mock( '../../../utils/is-dashboard-backport', () => ( {
+	isDashboardBackport: () => mockIsBackport,
+} ) );
+
+const CURRENT_USER_ID = 1;
+const OTHER_USER_ID = 2;
+
+const site = {
+	ID: 123,
+	slug: 'example.wordpress.com',
+	name: 'Example',
+	site_owner: OTHER_USER_ID,
+} as Site;
+
+function mockPurchases( purchases: object[] ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.2/upgrades' )
+		.query( { site: site.ID } )
+		.reply( 200, purchases );
+}
+
+function purchase( overrides: object = {} ) {
+	return {
+		ID: 555,
+		user_id: CURRENT_USER_ID,
+		product_slug: 'personal-bundle',
+		is_refundable: false,
+		...overrides,
+	};
+}
+
+const renderContent = () => render( <ContentInfo site={ site } onClose={ jest.fn() } /> );
+
+const findManagePurchases = () => screen.findByRole( 'link', { name: 'Manage purchases' } );
+
+beforeEach( () => {
+	mockIsBackport = true;
+} );
+
+describe( '<ContentInfo> purchase blockers', () => {
+	test( 'links straight to the purchase when a single purchase blocks leaving', async () => {
+		mockPurchases( [ purchase( { ID: 555 } ) ] );
+		renderContent();
+
+		expect( await findManagePurchases() ).toHaveAttribute(
+			'href',
+			'/purchases/subscriptions/example.wordpress.com/555'
+		);
+	} );
+
+	test( 'links to the site purchase list when several purchases block leaving', async () => {
+		mockPurchases( [ purchase( { ID: 555 } ), purchase( { ID: 556 } ) ] );
+		renderContent();
+
+		expect( await findManagePurchases() ).toHaveAttribute(
+			'href',
+			'/purchases/subscriptions/example.wordpress.com'
+		);
+	} );
+
+	test( 'ignores non-refundable premium themes when counting blockers', async () => {
+		mockPurchases( [
+			purchase( { ID: 555 } ),
+			purchase( { ID: 556, product_slug: 'premium_theme', is_refundable: false } ),
+		] );
+		renderContent();
+
+		expect( await findManagePurchases() ).toHaveAttribute(
+			'href',
+			'/purchases/subscriptions/example.wordpress.com/555'
+		);
+	} );
+
+	test( 'counts refundable premium themes as blockers', async () => {
+		mockPurchases( [
+			purchase( { ID: 555 } ),
+			purchase( { ID: 556, product_slug: 'premium_theme', is_refundable: true } ),
+		] );
+		renderContent();
+
+		expect( await findManagePurchases() ).toHaveAttribute(
+			'href',
+			'/purchases/subscriptions/example.wordpress.com'
+		);
+	} );
+
+	test( 'ignores purchases belonging to other users when counting blockers', async () => {
+		mockPurchases( [ purchase( { ID: 555 } ), purchase( { ID: 556, user_id: OTHER_USER_ID } ) ] );
+		renderContent();
+
+		expect( await findManagePurchases() ).toHaveAttribute(
+			'href',
+			'/purchases/subscriptions/example.wordpress.com/555'
+		);
+	} );
+
+	test( 'offers the leave form when nothing blocks leaving', async () => {
+		mockPurchases( [ purchase( { ID: 556, user_id: OTHER_USER_ID } ) ] );
+		renderContent();
+
+		expect( await screen.findByRole( 'button', { name: 'Leave site' } ) ).toBeVisible();
+	} );
+
+	describe( 'on the dashboard', () => {
+		beforeEach( () => {
+			mockIsBackport = false;
+		} );
+
+		test( 'drops the site filter when a single purchase blocks leaving', async () => {
+			mockPurchases( [ purchase( { ID: 555 } ) ] );
+			renderContent();
+
+			expect( await findManagePurchases() ).not.toHaveAttribute(
+				'href',
+				expect.stringContaining( 'site=' )
+			);
+		} );
+
+		test( 'keeps the site filter when several purchases block leaving', async () => {
+			mockPurchases( [ purchase( { ID: 555 } ), purchase( { ID: 556 } ) ] );
+			renderContent();
+
+			expect( ( await findManagePurchases() ).getAttribute( 'href' ) ).toContain( 'site=123' );
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CHE-535/

## Proposed Changes

When leaving a site is blocked by purchases, the modal's "Manage purchases" button now links straight to the blocking purchase's management page if there is exactly one, instead of always landing on the site-filtered purchase list.

* Change the leave-site modal's purchase query from `.some()` to `.filter()` so it keeps the blocking purchases rather than just a boolean.
* Pass the single blocking purchase down to `ContentHasPurchasesCancelable`, and link to `purchaseSettingsRoute` (`/me/billing/purchases/:purchaseId`) when it is set.
* Do the same for the Calypso backport branch: `/purchases/subscriptions/:site/:purchaseId` instead of `/purchases/subscriptions/:site`.
* Extract the destination logic into a `renderManagePurchasesButton()` helper, matching the file's existing `renderContent()` pattern, since three branches no longer read well as a ternary.
* Add unit tests for the modal, which previously had none.

## Why are these changes being made?

Reported internally: leaving a site with a single purchase took two clicks to reach anything actionable — "Manage purchases" landed on a list page whose only row then had to be clicked. With one purchase there is no list to choose from, so the intermediate page is pure friction.

The modal already fetches the full purchase list for the site (`sitePurchasesQuery` → `GET /upgrades?site=<id>`, v1.2) to decide whether to block at all, so this needs no additional request and no new loading state — only the `select` changes from a boolean to the filtered array.

One deliberate decision worth flagging for review: the count uses the modal's **existing** cancelable filter (owned by the current user, and either refundable or not a `premium_theme`) rather than the row count of the destination list. Those two sets can legitimately differ, because the list page reads from `userPurchasesQuery()` + `userTransferredPurchasesQuery()` and applies neither filter. So a site with one cancelable plan plus a non-refundable premium theme deep-links to the plan even though the list would have shown two rows. That set is precisely what blocks leaving, so linking to it is the honest behavior, and it keeps the count and the link derived from a single expression instead of two that can drift.

Button copy is unchanged ("Manage purchases", and the plural body text). Making it singular in the one-purchase case would read better but adds new translation strings, so I left it out of scope — happy to add it if reviewers prefer.

## Testing Instructions

TC:
```
yarn test-client client/dashboard/sites/site-leave-modal
```

The blocker-counting tests run against the Calypso backport branch, which builds plain string hrefs. The dashboard branch uses TanStack routes and `test-utils` renders a bare root route, so those hrefs never resolve — the dashboard tests assert on the `site` filter param instead.

Manual testing:
* You need a site you are a user (not owner) of, with exactly one active purchase you own.
* Go to `/sites`, open the site's action menu, and choose "Leave site".
* Confirm the modal shows the "active subscriptions" blocker, and that "Manage purchases" now goes directly to `/me/billing/purchases/<purchaseId>`.
* Repeat on a site with two or more of your purchases: the button should still go to `/me/billing/purchases?site=<siteId>`.
* Repeat on a site where the only purchases belong to another user: the modal should show the leave-confirmation form, not the blocker.
