### PR TITLE
Docker: move base images from Debian bullseye to trixie

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -152,7 +152,7 @@ object BuildBaseImages : BuildType({
 
 	params {
 		param("build.prefix", "1.0")
-		param("image_tag", "trixie-preview")
+		param("image_tag", "latest")
 		checkbox(
 			name = "PROFILE",
 			value = "false",
@@ -252,7 +252,7 @@ object BuildBaseImages : BuildType({
 				hour = 3
 			}
 			branchFilter = """
-				+:fix/docker-bullseye-eol-bookworm
+				+:trunk
 			""".trimIndent()
 			triggerBuild = always()
 			withPendingChangesOnly = false
@@ -299,7 +299,7 @@ object BuildToolchainPreviewImages : BuildType({
 
 	params {
 		param("build.prefix", "2.0")
-		param("image_tag", "trixie-preview")
+		param("image_tag", "latest")
 	}
 
 	vcs {
@@ -427,13 +427,12 @@ object BuildToolchainPreviewImages : BuildType({
 	triggers {
 		vcs {
 			branchFilter = """
-				+:fix/docker-bullseye-eol-bookworm
+				+:trunk
 			""".trimIndent()
 			triggerRules = """
 				+:.nvmrc
 				+:.dockerignore
 				+:Dockerfile.toolchain
-				+:.teamcity/settings.kts
 				+:composer.json
 				+:composer.lock
 			""".trimIndent()
@@ -444,7 +443,7 @@ object BuildToolchainPreviewImages : BuildType({
 				dayOfWeek = "Sun"
 			}
 			branchFilter = """
-				+:fix/docker-bullseye-eol-bookworm
+				+:trunk
 			""".trimIndent()
 			triggerBuild = always()
 			withPendingChangesOnly = false
@@ -473,7 +472,7 @@ object BuildCacheSeedImages : BuildType({
 
 	params {
 		param("build.prefix", "1.0")
-		param("image_tag", "trixie-preview")
+		param("image_tag", "latest")
 		checkbox(
 			name = "PROFILE",
 			value = "false",
@@ -560,10 +559,9 @@ object BuildCacheSeedImages : BuildType({
 
 	triggers {
 		vcs {
-			branchFilter = "+:fix/docker-bullseye-eol-bookworm"
+			branchFilter = "+:trunk"
 			triggerRules = """
 				+:yarn.lock
-				+:.teamcity/settings.kts
 				+:package.json
 				+:composer.lock
 				+:.nvmrc
@@ -576,7 +574,7 @@ object BuildCacheSeedImages : BuildType({
 				hours = "3,9,15,21"
 			}
 			branchFilter = """
-				+:fix/docker-bullseye-eol-bookworm
+				+:trunk
 			""".trimIndent()
 			triggerBuild = always()
 			withPendingChangesOnly = false
@@ -721,7 +719,7 @@ object CheckCodeStyle : BuildType({
 				hour = 5
 			}
 			branchFilter = """
-				+:fix/docker-bullseye-eol-bookworm
+				+:trunk
 			""".trimIndent()
 			triggerBuild = always()
 			withPendingChangesOnly = false

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -152,7 +152,7 @@ object BuildBaseImages : BuildType({
 
 	params {
 		param("build.prefix", "1.0")
-		param("image_tag", "latest")
+		param("image_tag", "trixie-preview")
 		checkbox(
 			name = "PROFILE",
 			value = "false",
@@ -252,7 +252,7 @@ object BuildBaseImages : BuildType({
 				hour = 3
 			}
 			branchFilter = """
-				+:trunk
+				+:fix/docker-bullseye-eol-bookworm
 			""".trimIndent()
 			triggerBuild = always()
 			withPendingChangesOnly = false
@@ -299,7 +299,7 @@ object BuildToolchainPreviewImages : BuildType({
 
 	params {
 		param("build.prefix", "2.0")
-		param("image_tag", "latest")
+		param("image_tag", "trixie-preview")
 	}
 
 	vcs {
@@ -427,12 +427,13 @@ object BuildToolchainPreviewImages : BuildType({
 	triggers {
 		vcs {
 			branchFilter = """
-				+:trunk
+				+:fix/docker-bullseye-eol-bookworm
 			""".trimIndent()
 			triggerRules = """
 				+:.nvmrc
 				+:.dockerignore
 				+:Dockerfile.toolchain
+				+:.teamcity/settings.kts
 				+:composer.json
 				+:composer.lock
 			""".trimIndent()
@@ -443,7 +444,7 @@ object BuildToolchainPreviewImages : BuildType({
 				dayOfWeek = "Sun"
 			}
 			branchFilter = """
-				+:trunk
+				+:fix/docker-bullseye-eol-bookworm
 			""".trimIndent()
 			triggerBuild = always()
 			withPendingChangesOnly = false
@@ -472,7 +473,7 @@ object BuildCacheSeedImages : BuildType({
 
 	params {
 		param("build.prefix", "1.0")
-		param("image_tag", "latest")
+		param("image_tag", "trixie-preview")
 		checkbox(
 			name = "PROFILE",
 			value = "false",
@@ -559,9 +560,10 @@ object BuildCacheSeedImages : BuildType({
 
 	triggers {
 		vcs {
-			branchFilter = "+:trunk"
+			branchFilter = "+:fix/docker-bullseye-eol-bookworm"
 			triggerRules = """
 				+:yarn.lock
+				+:.teamcity/settings.kts
 				+:package.json
 				+:composer.lock
 				+:.nvmrc
@@ -574,7 +576,7 @@ object BuildCacheSeedImages : BuildType({
 				hours = "3,9,15,21"
 			}
 			branchFilter = """
-				+:trunk
+				+:fix/docker-bullseye-eol-bookworm
 			""".trimIndent()
 			triggerBuild = always()
 			withPendingChangesOnly = false
@@ -719,7 +721,7 @@ object CheckCodeStyle : BuildType({
 				hour = 5
 			}
 			branchFilter = """
-				+:trunk
+				+:fix/docker-bullseye-eol-bookworm
 			""".trimIndent()
 			triggerBuild = always()
 			withPendingChangesOnly = false

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -363,7 +363,7 @@ object BuildToolchainPreviewImages : BuildType({
 				docker run --rm --entrypoint /bin/bash registry.a8c.com/calypso/ci-e2e:%build.number% -lc '
 					xvfb-run --help >/dev/null &&
 					aws --version &&
-					dpkg -s fonts-noto-cjk fonts-noto-core libgtk-3-0 libgbm1 libnss3 >/dev/null
+					dpkg -s fonts-noto-cjk fonts-noto-core libgtk-3-0t64 libgbm1 libnss3 >/dev/null
 				'
 			""".trimIndent()
 		}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG node_version=24.15.0
 ARG cache_seed_image=registry.a8c.com/calypso/cache-seed:latest
 
 ###################
-FROM node:${node_version}-bullseye-slim AS builder-cache-none
+FROM node:${node_version}-trixie-slim AS builder-cache-none
 
 WORKDIR /calypso
 ENV HOME=/calypso
@@ -18,7 +18,7 @@ RUN mkdir -p /calypso/.cache /calypso/.yarn
 FROM ${cache_seed_image} AS cache-seed-source
 
 ###################
-FROM node:${node_version}-bullseye-slim AS builder-cache-seed
+FROM node:${node_version}-trixie-slim AS builder-cache-seed
 
 WORKDIR /calypso
 ENV HOME=/calypso
@@ -42,19 +42,6 @@ ENV SKIP_CALYPSO_POSTINSTALL=true
 ENV SKIP_CALYPSO_PACKAGE_BUILDS=true
 ENV CONTAINER=docker
 ENV IS_CI=true
-
-# Debian 11 (bullseye) reached end-of-LTS on 2026-08-31: its Release files have
-# expired and the pool on deb.debian.org is already returning 404s. Repoint at the
-# pinned snapshot mirror the base image ships (commented out) so package versions
-# still match the image. Remove this whole block once we move to bookworm.
-RUN set -eux; \
-	sed -i \
-		-e 's|^deb http|# deb http|' \
-		-e 's|^# deb http://snapshot.debian.org|deb http://snapshot.debian.org|' \
-		/etc/apt/sources.list; \
-	grep -q '^deb http://snapshot.debian.org' /etc/apt/sources.list; \
-	echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries; \
-	echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/80-no-valid-until
 
 # For Sentry uploads
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,8 @@ ENV SKIP_CALYPSO_PACKAGE_BUILDS=true
 ENV CONTAINER=docker
 ENV IS_CI=true
 
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
+
 # For Sentry uploads
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 # Build a "base" layer

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -2,7 +2,7 @@
 #### This image is not pushed to any repository and it shouldn't be used as base image for any other docker build.
 #### Its main goal is to create a `/calypso/.cache` that can be copied over other images that can benefit from a warm cache.
 #### Note that yarn v3 cache lives in `/calypso/.yarn`
-FROM node:24.15.0-bullseye-slim AS cache
+FROM node:24.15.0-trixie-slim AS cache
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG node_memory=16384
@@ -45,7 +45,7 @@ ENTRYPOINT [ "/bin/bash" ]
 
 #### base image
 #### This image can be used as a base image for other builds, or to test and build calypso.
-FROM node:24.15.0-bullseye-slim AS base
+FROM node:24.15.0-trixie-slim AS base
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG node_memory=16384
@@ -60,18 +60,6 @@ ENV SKIP_TSC=true
 ENV PLAYWRIGHT_SKIP_DOWNLOAD=true
 
 RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
-
-# Debian 11 (bullseye) reached end-of-LTS on 2026-08-31: its Release files have
-# expired and the pool on deb.debian.org is already returning 404s. Repoint at the
-# pinned snapshot mirror the base image ships (commented out) so package versions
-# still match the image. Remove this whole block once we move to bookworm.
-RUN set -eux; \
-	sed -i \
-		-e 's|^deb http|# deb http|' \
-		-e 's|^# deb http://snapshot.debian.org|deb http://snapshot.debian.org|' \
-		/etc/apt/sources.list; \
-	grep -q '^deb http://snapshot.debian.org' /etc/apt/sources.list; \
-	echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/80-no-valid-until
 
 # Add user calypso with uid 1003, give it sudo permissions
 RUN apt-get update \
@@ -142,13 +130,9 @@ COPY --from=cache --chown=$UID /calypso/composer.* /calypso/
 RUN apt-get update && \
 	apt-get install -y apt-transport-https wget
 
-# libffi6 is no longer available from apt as of bullseye.
 RUN wget --tries=5 --retry-connrefused --waitretry=2 --timeout=20 --read-timeout=20 \
-		http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb && \
-	dpkg -i libffi6_3.2.1-8_amd64.deb && \
-	wget --tries=5 --retry-connrefused --waitretry=2 --timeout=20 --read-timeout=20 \
 		https://packages.sury.org/php/apt.gpg -O /etc/apt/trusted.gpg.d/php-sury.gpg && \
-	echo "deb https://packages.sury.org/php/ bullseye main" > /etc/apt/sources.list.d/php-sury.list && \
+	echo "deb https://packages.sury.org/php/ trixie main" > /etc/apt/sources.list.d/php-sury.list && \
 	apt-get update && \
  	apt-get upgrade -y && \
 	apt-get install -y php7.4-cli php7.4-xml php7.4-mbstring docker-compose && \

--- a/Dockerfile.cache-seed
+++ b/Dockerfile.cache-seed
@@ -8,7 +8,7 @@ ARG cache_seed_key="(unknown)"
 # Dedicated dependency-install stage.
 # By copying only manifests and the lockfile first, we can cache
 # the slow yarn install and skip it when only source files change.
-FROM node:${node_version}-bullseye-slim AS deps
+FROM node:${node_version}-trixie-slim AS deps
 
 WORKDIR /calypso
 ENV HOME=/calypso
@@ -99,7 +99,7 @@ COPY --from=cache-build /calypso/.yarn /calypso/.yarn
 # This stage exists only to make the exported cache image easy to smoke-test in
 # CI. It copies the scratch output into a debian-based node image so we can run
 # shell assertions against exactly what the published cache-seed image contains.
-FROM node:${node_version}-bullseye-slim AS cache-seed-debug
+FROM node:${node_version}-trixie-slim AS cache-seed-debug
 
 ARG commit_sha
 ARG cache_seed_key

--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -6,7 +6,7 @@
 ARG node_version=24.15.0
 ARG commit_sha="(unknown)"
 ARG cache_seed_key="(unknown)"
-FROM node:${node_version}-bullseye-slim AS toolchain
+FROM node:${node_version}-trixie-slim AS toolchain
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG node_memory=16384
@@ -25,18 +25,6 @@ ENV SKIP_TSC=true
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
-
-# Debian 11 (bullseye) reached end-of-LTS on 2026-08-31: its Release files have
-# expired and the pool on deb.debian.org is already returning 404s. Repoint at the
-# pinned snapshot mirror the base image ships (commented out) so package versions
-# still match the image. Remove this whole block once we move to bookworm.
-RUN set -eux; \
-	sed -i \
-		-e 's|^deb http|# deb http|' \
-		-e 's|^# deb http://snapshot.debian.org|deb http://snapshot.debian.org|' \
-		/etc/apt/sources.list; \
-	grep -q '^deb http://snapshot.debian.org' /etc/apt/sources.list; \
-	echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/80-no-valid-until
 
 # Add user calypso with uid 1003, give it sudo permissions
 RUN apt-get update \
@@ -113,13 +101,9 @@ COPY --chown=$UID ./composer.json ./composer.lock /calypso/
 RUN apt-get update && \
 	apt-get install -y apt-transport-https wget
 
-# libffi6 is no longer available from apt as of bullseye.
 RUN wget --tries=5 --retry-connrefused --waitretry=2 --timeout=20 --read-timeout=20 \
-		http://mirrors.kernel.org/ubuntu/pool/main/libf/libffi/libffi6_3.2.1-8_amd64.deb && \
-	dpkg -i libffi6_3.2.1-8_amd64.deb && \
-	wget --tries=5 --retry-connrefused --waitretry=2 --timeout=20 --read-timeout=20 \
 		https://packages.sury.org/php/apt.gpg -O /etc/apt/trusted.gpg.d/php-sury.gpg && \
-	echo "deb https://packages.sury.org/php/ bullseye main" > /etc/apt/sources.list.d/php-sury.list && \
+	echo "deb https://packages.sury.org/php/ trixie main" > /etc/apt/sources.list.d/php-sury.list && \
 	apt-get update && \
 	apt-get upgrade -y && \
 	apt-get install -y php7.4-cli php7.4-xml php7.4-mbstring docker-compose && \


### PR DESCRIPTION
Follow-up to #114149, which was an explicit stopgap. This is the real fix.

## Proposed Changes

* Bump every `node:*-bullseye-slim` base image to `node:*-trixie-slim` across `Dockerfile`, `Dockerfile.base`, `Dockerfile.cache-seed`, and `Dockerfile.toolchain`.
* Point the sury PHP apt repo at the `trixie` suite.
* Drop the manual `libffi6` install. It has never satisfied anything here — see below. This also removes a hardcoded `_amd64.deb` URL that would never have worked on arm64.
* Remove the `snapshot.debian.org` workaround added in #114149, since the whole point of this change is to get back onto a supported `deb.debian.org` suite.

## Why are these changes being made?

Debian 11 (bullseye) reached end of LTS on 2026-08-31. Its `bullseye-security` `Release` file has now passed its validity window, and apt treats an expired Release as fatal:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
   is expired (invalid since 4h 44min 25s). Updates for this repository will not be applied.
```

That made `apt-get update` exit 100, so every image build failed at the first apt step. #114149 unblocked builds by repointing apt at the pinned `snapshot.debian.org` mirror, but that only freezes bullseye in place — it doesn't restore security updates, and the snapshot mirror is rate-limited and slower than the regular pool.

### Why trixie and not bookworm

An earlier revision of this PR went to bookworm (Debian 12) on the assumption that trixie (Debian 13) would cause a bunch of churn — particularly package renames.

That turned out to be wrong. Debian keeps the old binary package names working across the transition, so the E2E image's package list needs no edits at all: `apt-get install libasound2 libatspi2.0-0 libgtk-3-0` on trixie resolves to `libasound2t64`, `libatspi2.0-0t64`, `libgtk-3-0t64` without complaint. Verified in a built image:

```
libasound2t64:amd64      1.2.14-1
libatspi2.0-0t64:amd64   2.56.2-1+deb13u1
libgtk-3-0t64:amd64      3.24.49-3
libnss3:amd64            2:3.110-1+deb13u4
```

With that objection gone, trixie is the better target. It's the current Debian stable, and will eventually be the LTS version. Going straight to trixie skips a hop and buys three more years before we're back here.

### On the `libffi6` removal

The `libffi6` workaround was added in the buster → bullseye migration (#67930), but it appears to have been non-load-bearing from the start.

Only one file in all of php7.4 links libffi at all: the `ffi.so` extension. Reading its `NEEDED` entries:

| suite | `ffi.so` requires | Debian ships |
| --- | --- | --- |
| bullseye | `libffi.so.7` | libffi7 |
| trixie | `libffi.so.8` | libffi8 |

Neither wants `libffi.so.6`, so the hand-installed Ubuntu `libffi6` package satisfied nothing on bullseye either. No php7.4 package declares a libffi dependency in either suite. On trixie the `FFI` extension is loaded and `ldd /usr/lib/php/20190902/ffi.so` resolves cleanly against the `libffi8` already present in the base image:

```
libffi.so.8 => /lib/x86_64-linux-gnu/libffi.so.8
```

For the avoidance of doubt: this is a Debian soname bump across releases, not a PHP change. PHP has never dropped its libffi dependency — [FFI was introduced in 7.4](https://wiki.php.net/rfc/ffi) built on top of libffi, and still requires it.

## Considerations

**`docker-compose` changes major version.** The Debian `docker-compose` package is 1.29.2 (the Python Compose v1) on bullseye, but 2.26.1 (Compose v2) on trixie. Nothing in this repo invokes `docker-compose`, so this only matters if a CI build step outside the repo shells out to it — worth a look from anyone who knows where it's used. v1 → v2 mainly changes default container naming (`project_service_1` → `project-service-1`) and drops a few v1-only flags.

**PHP 7.4 is still PHP 7.4.** The `ci-wpcom` image installs PHP 7.4 from sury, which is long past upstream EOL. Sury does publish a trixie rebuild (7.4.33, built 2026-07-03), so nothing breaks here, but it remains the next thing likely to bite us. Out of scope for this PR.

#114149 also added an `Acquire::Retries "5";` drop-in to `Dockerfile`, which is a config to make `apt-get` do retries. This config was already in `Dockerfile.base` and `Dockerfile.toolchain`, so adding it to the main `Dockerfile` makes sense too.

## Testing Instructions

Built on `linux/amd64` locally against this branch:

* `docker build --target ci-wpcom -f Dockerfile.toolchain .` — succeeds. PHP 7.4.33 installs from sury `trixie` with `xml`, `mbstring`, `dom`, and `SimpleXML` present; `composer install` and the pinned sentry-cli 2.18.1 both complete.
* `docker build --target ci-e2e -f Dockerfile.toolchain .` — succeeds. All Chromium shared libraries resolve (see the `t64` table above), and Xvfb, awscli, `git restore-mtime`, and the `calypso` uid 1003 user are all present.
* `docker build --build-arg cache_mode=none --target deps -f Dockerfile.cache-seed .` — succeeds, including the apt step that was failing, plus a full `yarn install`.

CI building the images is the real check — in particular the trunk cache-seed and E2E image builds. Worth confirming build times come back down now that apt is off the snapshot mirror.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_013nxTgHsWTSLKb2uAuzKKT5
