### PR TITLE
Docker: repoint bullseye apt sources at the pinned snapshot mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,19 @@ ENV SKIP_CALYPSO_PACKAGE_BUILDS=true
 ENV CONTAINER=docker
 ENV IS_CI=true
 
+# Debian 11 (bullseye) reached end-of-LTS on 2026-08-31: its Release files have
+# expired and the pool on deb.debian.org is already returning 404s. Repoint at the
+# pinned snapshot mirror the base image ships (commented out) so package versions
+# still match the image. Remove this whole block once we move to bookworm.
+RUN set -eux; \
+	sed -i \
+		-e 's|^deb http|# deb http|' \
+		-e 's|^# deb http://snapshot.debian.org|deb http://snapshot.debian.org|' \
+		/etc/apt/sources.list; \
+	grep -q '^deb http://snapshot.debian.org' /etc/apt/sources.list; \
+	echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries; \
+	echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/80-no-valid-until
+
 # For Sentry uploads
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 # Build a "base" layer

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -61,6 +61,18 @@ ENV PLAYWRIGHT_SKIP_DOWNLOAD=true
 
 RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 
+# Debian 11 (bullseye) reached end-of-LTS on 2026-08-31: its Release files have
+# expired and the pool on deb.debian.org is already returning 404s. Repoint at the
+# pinned snapshot mirror the base image ships (commented out) so package versions
+# still match the image. Remove this whole block once we move to bookworm.
+RUN set -eux; \
+	sed -i \
+		-e 's|^deb http|# deb http|' \
+		-e 's|^# deb http://snapshot.debian.org|deb http://snapshot.debian.org|' \
+		/etc/apt/sources.list; \
+	grep -q '^deb http://snapshot.debian.org' /etc/apt/sources.list; \
+	echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/80-no-valid-until
+
 # Add user calypso with uid 1003, give it sudo permissions
 RUN apt-get update \
 	&& apt-get install -y sudo zip jq curl git \

--- a/Dockerfile.toolchain
+++ b/Dockerfile.toolchain
@@ -26,6 +26,18 @@ ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries
 
+# Debian 11 (bullseye) reached end-of-LTS on 2026-08-31: its Release files have
+# expired and the pool on deb.debian.org is already returning 404s. Repoint at the
+# pinned snapshot mirror the base image ships (commented out) so package versions
+# still match the image. Remove this whole block once we move to bookworm.
+RUN set -eux; \
+	sed -i \
+		-e 's|^deb http|# deb http|' \
+		-e 's|^# deb http://snapshot.debian.org|deb http://snapshot.debian.org|' \
+		/etc/apt/sources.list; \
+	grep -q '^deb http://snapshot.debian.org' /etc/apt/sources.list; \
+	echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/80-no-valid-until
+
 # Add user calypso with uid 1003, give it sudo permissions
 RUN apt-get update \
 	&& apt-get install -y sudo zip jq curl git \


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Repoint `/etc/apt/sources.list` at the `snapshot.debian.org` mirror in `Dockerfile`, `Dockerfile.base`, and `Dockerfile.toolchain`.
* Add an `Acquire::Check-Valid-Until "false"` apt drop-in alongside the existing retries drop-in.
* Add the retries drop-in to `Dockerfile`, which did not have one (snapshot.debian.org is rate-limited).

The base images ship the snapshot mirror lines already, commented out, pinned to the timestamp the image was built from. The change just flips which set of lines is active, so package versions still match the image exactly. A `grep -q` guard fails the build loudly if a future base image stops shipping those lines rather than silently leaving the old mirror in place.

`Dockerfile.cache-seed` is untouched — it runs no `apt-get`.

## Why are these changes being made?

Debian 11 (bullseye) reached end-of-LTS on 2026-08-31. As of today its `Release` files have expired and the pool on `deb.debian.org` has begun returning 404s, so every `apt-get` step in our bullseye-based images fails with exit code 100:

```
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
   is expired (invalid since 4h 44min 25s).
E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/main/g/git/git_2.30.2-1%2bdeb11u5_arm64.deb  404  Not Found
```

This is not a transient mirror outage and will not recover on its own.

Two alternatives were tested and rejected:

* **`Check-Valid-Until=false` alone** — fixes the expiry error but not the 404s, since the pool is already being withdrawn.
* **`archive.debian.org`** — does not carry `bullseye-security` yet, and installs fail with broken dependencies because the image's installed packages are at security versions newer than plain `bullseye main`.

**This is a stopgap, not the fix.** The real fix is moving these images to bookworm (Debian 12, supported to 2028); the `bullseye` pins in `Dockerfile.cache-seed` and the `packages.sury.org/php/ bullseye` sources need to move too. Filing that as follow-up. The workaround is marked with a removal note in each file.

Caveat worth flagging for review: `snapshot.debian.org` is rate-limited and slower than `deb.debian.org`, so image builds may be slower and occasionally flaky under load. The retries drop-in mitigates but does not eliminate this.

## Testing Instructions

All builds run locally with `--no-cache`. Each of these fails on `trunk` and passes on this branch:

```bash
docker build --no-cache -f Dockerfile --build-arg cache_mode=none --target deps .
docker build --no-cache -f Dockerfile.toolchain --target toolchain .
docker build --no-cache -f Dockerfile.toolchain --target ci-e2e .
docker build --no-cache -f Dockerfile.base --target base .
```

The `ci-wpcom` target additionally installs PHP from `packages.sury.org`, which is unaffected by the bullseye EOL. It cannot be built on arm64 because the stage hardcodes an amd64 `libffi6` deb (pre-existing, unrelated to this change), so that path was verified separately on `linux/amd64` — apt update/upgrade/install from the snapshot mirror plus the sury repo succeeds and lands PHP 7.4.33.

Worth confirming on CI that build times remain acceptable against the snapshot mirror.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01P1SqLRxtgsg5nS6NHw5TYX
