### PR TITLE
Dashboard: stop the domain upsell card flipping copy after the site refetch (CALYPSO-3GEB)

### DIFF
--- a/client/dashboard/sites/overview-domain-upsell-card/index.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/index.tsx
@@ -1,3 +1,4 @@
+import { SubscriptionBillPeriod } from '@automattic/api-core';
 import { domainSuggestionsQuery, siteCurrentPlanQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalText as Text } from '@wordpress/components';
@@ -15,13 +16,17 @@ import { TextBlur } from '../../components/text-blur';
 import UpsellCTAButton from '../../components/upsell-cta-button';
 import { dashboardLink, redirectToDashboardLink, wpcomLink } from '../../utils/link';
 import { DomainUpsellIllustraction } from './upsell-illustration';
-import type { Site } from '@automattic/api-core';
+import type { Site, SiteContextualPlan } from '@automattic/api-core';
 
 /**
  * Returns true if the site requires a plan upgrade.
+ *
+ * The billing period is read from the plans endpoint rather than `site.plan.billing_period`
+ * because the sites list endpoint omits that field. A site seeded from the list would
+ * otherwise flip from "no upgrade needed" to "upgrade needed" once the full site loads.
  */
-const requiresPlanUpgrade = ( site: Site ) => {
-	return site.plan?.is_free || site.plan?.billing_period === 'Monthly';
+const requiresPlanUpgrade = ( site: Site, sitePlan: SiteContextualPlan ) => {
+	return !! site.plan?.is_free || sitePlan.interval === SubscriptionBillPeriod.PLAN_MONTHLY_PERIOD;
 };
 
 const useDomainSuggestion = ( site: Site ) => {
@@ -45,12 +50,14 @@ const DomainUpsellCardContent = ( {
 	description,
 	upsellCTAButtonText,
 	upsellId,
+	isPlanUpgradeRequired,
 }: {
 	site: Site;
 	title: string;
 	description: string;
 	upsellCTAButtonText: string;
 	upsellId: string;
+	isPlanUpgradeRequired: boolean;
 } ) => {
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
 	const { search, suggestedDomain } = useDomainSuggestion( site );
@@ -81,7 +88,7 @@ const DomainUpsellCardContent = ( {
 			}
 		}
 
-		if ( requiresPlanUpgrade( site ) ) {
+		if ( isPlanUpgradeRequired ) {
 			window.location.href = wpcomLink(
 				getDomainAndPlanUpsellUrl( {
 					siteSlug: site.slug,
@@ -112,7 +119,9 @@ const DomainUpsellCardContent = ( {
 			title={ title }
 			titleAs="h2"
 			description={
-				<Text variant="muted">
+				// Remount when the string changes: page translators reparent the interpolated
+				// text nodes, so React can't safely reconcile a differently shaped string.
+				<Text key={ description } variant="muted">
 					{ createInterpolateElement( description, {
 						domain: (
 							<TextBlur isBlurred={ ! suggestedDomain }>
@@ -159,6 +168,8 @@ const DomainUpsellCard = ( { site }: { site: Site } ) => {
 		return null;
 	}
 
+	const isPlanUpgradeRequired = requiresPlanUpgrade( site, sitePlan );
+
 	if ( sitePlan.has_domain_credit ) {
 		return (
 			<DomainUpsellCardContent
@@ -169,11 +180,12 @@ const DomainUpsellCard = ( { site }: { site: Site } ) => {
 				) }
 				upsellId="site-overview-claim-this-domain"
 				upsellCTAButtonText={ __( 'Claim this domain' ) }
+				isPlanUpgradeRequired={ isPlanUpgradeRequired }
 			/>
 		);
 	}
 
-	if ( requiresPlanUpgrade( site ) ) {
+	if ( isPlanUpgradeRequired ) {
 		return (
 			<DomainUpsellCardContent
 				site={ site }
@@ -183,6 +195,7 @@ const DomainUpsellCard = ( { site }: { site: Site } ) => {
 				) }
 				upsellId="site-overview-get-this-domain"
 				upsellCTAButtonText={ __( 'Choose a plan' ) }
+				isPlanUpgradeRequired={ isPlanUpgradeRequired }
 			/>
 		);
 	}
@@ -200,6 +213,7 @@ const DomainUpsellCard = ( { site }: { site: Site } ) => {
 			) }
 			upsellId="site-overview-get-this-domain"
 			upsellCTAButtonText={ __( 'Get this domain' ) }
+			isPlanUpgradeRequired={ isPlanUpgradeRequired }
 		/>
 	);
 };

--- a/client/dashboard/sites/overview-domain-upsell-card/test/index.test.tsx
+++ b/client/dashboard/sites/overview-domain-upsell-card/test/index.test.tsx
@@ -78,6 +78,26 @@ beforeEach( () => {
 } );
 
 describe( 'DomainUpsellCard', () => {
+	test( 'treats a monthly plan as needing an upgrade even when the site object lacks a billing period', async () => {
+		mockFetchSitePlans.mockResolvedValue( {
+			plans: [ { current_plan: true, has_domain_credit: false, interval: 31 } ],
+		} );
+
+		render( <DomainUpsellCard site={ { ...mockSite, plan: { is_free: false } } as Site } /> );
+
+		expect( await screen.findByRole( 'button', { name: 'Choose a plan' } ) ).toBeVisible();
+	} );
+
+	test( 'offers the domain directly on an annual plan without domain credit', async () => {
+		mockFetchSitePlans.mockResolvedValue( {
+			plans: [ { current_plan: true, has_domain_credit: false, interval: 365 } ],
+		} );
+
+		render( <DomainUpsellCard site={ { ...mockSite, plan: { is_free: false } } as Site } /> );
+
+		expect( await screen.findByRole( 'button', { name: 'Get this domain' } ) ).toBeVisible();
+	} );
+
 	test( 'shows an error notice when the shopping cart chunk fails to load', async () => {
 		const user = userEvent.setup();
 		mockShoppingCartImportError = new Error( 'Loading chunk failed' );


### PR DESCRIPTION
Fixes Sentry CALYPSO-3GEB regression (follow-up to #114078).

## Proposed Changes

* The domain upsell card now reads the plan's billing period from the plans query instead of `site.plan.billing_period`.
* The interpolated description is keyed by its string, so a copy change replaces the span instead of reconciling text nodes inside it.
* Tests cover the monthly and annual cases when the site object has no billing period.

## Why are these changes being made?

CALYPSO-3GEB came back on a build that already contained #114078, this time in Chrome with Google Translate active (Khmer). Symbolicating the component stack put the deleted node directly inside the card's description text, not inside the placeholder that #114078 stabilised.

The cause is a data mismatch between two endpoints. The sites list seeds the per-site cache, and its `plan` object has no `billing_period`. The single-site endpoint does include it. For a site on a monthly plan, the card first rendered the "get this domain" copy, then the refetch of the full site arrived about a second later and switched it to the "choose a plan" copy. Those two strings interpolate the domain placeholder at different positions, so React deleted and re-created text nodes in the description. If a translator had already wrapped those text nodes in `<font>`, the delete throws and the page drops to the error screen.

The affected site is on a monthly Personal plan, which matches.

The billing period from the plans endpoint is loaded once and never seeded from a list, so the card no longer changes copy after mount. The key on the description is a guard for any future reason the string might change: removing and inserting the whole span next to sibling elements is safe under translation, reconciling text nodes inside it is not.

## Testing Instructions

* On `trunk`, in Chrome with the page auto-translated (or a translation extension), go to the sites list, then open the overview of a site on a monthly plan that has no custom domain. About a second after the card appears the page errors. On this branch it doesn't.
* Both with and without translation, a monthly-plan site should show "Choose a plan" from the first paint and never switch copy. An annual site without domain credit should show "Get this domain". A site with domain credit should show "Claim this domain".
* Clicking the CTA should go to the plans step for free and monthly sites, and to checkout for annual sites, as before.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01P1SqLRxtgsg5nS6NHw5TYX
