### PR TITLE
fix: correct the stats preview notice comment about wp-admin site features

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -167,9 +167,8 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 	//
 	// The features have to be in before that answer means anything: `shouldGateStats` reports
 	// "not gated" while they are still loading, which is the safe default for an upsell and the
-	// wrong one for an invitation. Nothing loads them in a Jetpack site's wp-admin
-	// (`stats-main` skips `QuerySiteFeatures` there), so an Atomic site is never invited from
-	// wp-admin - it fails closed, and spends no request finding out.
+	// wrong one for an invitation. In wp-admin they arrive with the page, seeded from the site's
+	// plan into Odyssey's initial state, which is why `stats-main` skips `QuerySiteFeatures` there.
 	const hasCommercialStats = useSelector(
 		( state ) =>
 			!! getSiteFeatures( state, siteId ) &&


### PR DESCRIPTION
## Proposed Changes

* Correct the comment above `hasCommercialStats` in `client/my-sites/stats/stats-notices/index.tsx`.
* Comment-only change. No behaviour change.

## Why are these changes being made?

The comment claimed that an Atomic site is never invited to the Stats v2 preview from wp-admin, because nothing loads the site features there (`stats-main` skips `QuerySiteFeatures` when running inside a Jetpack site) and so `hasCommercialStats` fails closed.

That is wrong. Jetpack seeds the site's plan features into Odyssey's initial state, under `sites.features`, and `apps/odyssey-stats/src/app.tsx` hands that object to `createStore` as preloaded state. `sites.features` is a registered sub-reducer, so the data survives and is present before the notice renders. That is exactly why `stats-main` can skip the query: it was never needed, not because the answer is unavailable.

Confirmed on a live Business-plan Atomic site: `jetpack_active_plan` carries `stats-commercial` in `features.active`, and the invitation banner does render in that site's wp-admin.

The comment also contradicts the PR that introduced it (#114009), whose description says the features are seeded so nothing is fetched and nothing waits.

## Testing Instructions

* Read the diff. There is no code change, so nothing to exercise.
* Optional sanity check: open classic Stats in the wp-admin of a Business-plan Atomic site with the preview flag on, and confirm the invitation notice renders.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
