### PR TITLE
Stats: record a Tracks event when the Traffic tab preview is not offered

### DIFF
--- a/client/my-sites/stats/hooks/use-premium-analytics-preview-cohort.ts
+++ b/client/my-sites/stats/hooks/use-premium-analytics-preview-cohort.ts
@@ -19,6 +19,8 @@ export type PremiumAnalyticsPreviewCohort = {
 	isVip: boolean;
 	isP2: boolean;
 	canManageOptions: boolean;
+	/** Whether the site's features are in - `hasCommercialStats` says nothing until they are. */
+	hasSiteFeatures: boolean;
 	hasCommercialStats: boolean;
 	premiumAnalyticsDashboardUrl: string | null;
 	/** The cohort rule and the feature flag together, before anyone asks the site for its status. */
@@ -60,10 +62,9 @@ export default function usePremiumAnalyticsPreviewCohort(
 	// "not gated" while they are still loading, which is the safe default for an upsell and the
 	// wrong one for an invitation. In wp-admin they arrive with the page, seeded from the site's
 	// plan into Odyssey's initial state, which is why `stats-main` skips `QuerySiteFeatures` there.
+	const hasSiteFeatures = useSelector( ( state ) => !! getSiteFeatures( state, siteId ) );
 	const hasCommercialStats = useSelector(
-		( state ) =>
-			!! getSiteFeatures( state, siteId ) &&
-			! shouldGateStats( state, siteId, STATS_FEATURE_UTM_STATS )
+		( state ) => hasSiteFeatures && ! shouldGateStats( state, siteId, STATS_FEATURE_UTM_STATS )
 	);
 
 	// Where accepting would land. Null when the site record carries no `admin_url`, which is
@@ -77,6 +78,7 @@ export default function usePremiumAnalyticsPreviewCohort(
 		isVip,
 		isP2,
 		canManageOptions,
+		hasSiteFeatures,
 		hasCommercialStats,
 		premiumAnalyticsDashboardUrl,
 		canBeInvited:

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -32,6 +32,7 @@ import useStatsPurchases, { shouldShowPaywallNotice } from '../hooks/use-stats-p
 import { AllTimeData } from '../sections/all-time-highlights-section';
 import ALL_STATS_NOTICES from './all-notice-definitions';
 import JITMWrapper from './jitm-wrapper';
+import usePremiumAnalyticsPreviewNotShownEvent from './premium-analytics-preview-not-shown-event';
 import { StatsNoticeProps, StatsNoticesProps } from './types';
 import './style.scss';
 
@@ -144,8 +145,11 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 	// upsell waiting for an answer nothing will use.
 	const shouldAskStatus =
 		canBeInvited && serverNoticesVisibility?.premium_analytics_preview === true;
-	const { data: isPremiumAnalyticsEnabled, isLoading: isLoadingPremiumAnalyticsStatus } =
-		usePremiumAnalyticsStatusQuery( siteId, shouldAskStatus );
+	const {
+		data: isPremiumAnalyticsEnabled,
+		isLoading: isLoadingPremiumAnalyticsStatus,
+		isError: isPremiumAnalyticsStatusError,
+	} = usePremiumAnalyticsStatusQuery( siteId, shouldAskStatus );
 
 	const noticeOptions = {
 		siteId,
@@ -182,17 +186,31 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		useSelector( ( state ) => hasLoadedSitePlansFromServer( state, siteId ) ) ||
 		config.isEnabled( 'is_odyssey' );
 
-	if (
+	const isWaitingForNoticeInputs =
 		! hasLoadedPurchases ||
 		! hasLoadedPlans ||
 		isLoading ||
-		isError ||
 		isRequestingSitePurchases ||
 		// Waiting here rather than rendering an upsell and swapping it for the preview a moment
 		// later. Only sites the server offered the preview to ever wait: the query is shared with
 		// the modules menu and reports its fetch status to every observer, disabled ones included.
-		( shouldAskStatus && isLoadingPremiumAnalyticsStatus )
-	) {
+		( shouldAskStatus && isLoadingPremiumAnalyticsStatus );
+
+	usePremiumAnalyticsPreviewNotShownEvent( {
+		siteId,
+		isWpcom,
+		isSettled: ! isWaitingForNoticeInputs && ! isError,
+		isServerVisible: serverNoticesVisibility?.premium_analytics_preview === true,
+		canManageOptions,
+		hasCommercialStats,
+		premiumAnalyticsDashboardUrl,
+		isVip,
+		isP2,
+		isPremiumAnalyticsEnabled,
+		isStatusError: isPremiumAnalyticsStatusError,
+	} );
+
+	if ( isWaitingForNoticeInputs || isError ) {
 		return null;
 	}
 

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -18,6 +18,7 @@ import { shouldGateStats } from 'calypso/my-sites/stats/hooks/use-should-gate-st
 import { useSelector, useDispatch } from 'calypso/state';
 import { resetSiteState } from 'calypso/state/purchases/actions';
 import { hasLoadedSitePurchasesFromServer } from 'calypso/state/purchases/selectors';
+import hasLoadedSiteFeatures from 'calypso/state/selectors/has-loaded-site-features';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { hasLoadedSitePlansFromServer } from 'calypso/state/sites/plans/selectors';
 import getEnvStatsFeatureSupportChecks from 'calypso/state/sites/selectors/get-env-stats-feature-supports';
@@ -84,6 +85,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		isVip,
 		isP2,
 		canManageOptions,
+		hasSiteFeatures,
 		hasCommercialStats,
 		premiumAnalyticsDashboardUrl,
 		canBeInvited,
@@ -138,6 +140,13 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 	const { isNearLimit, isOverLimit } = getUsageLimitStatus( data );
 
 	const { isLoading, isError, data: serverNoticesVisibility } = useNoticesVisibilityQuery( siteId );
+
+	// Same shape as the plans check below: waiting on the features is right in Calypso, where they
+	// arrive on their own schedule and a site that has them looks identical to one still fetching,
+	// and wrong in wp-admin, where nothing requests them and waiting would never end.
+	const hasLoadedFeatures =
+		useSelector( ( state ) => hasLoadedSiteFeatures( state, siteId ) ) ||
+		config.isEnabled( 'is_odyssey' );
 
 	// Only sites that could actually accept the invitation pay for this round-trip, and the server
 	// decides the cohort on top. The same rule the registry uses, flag included: the request holds
@@ -199,9 +208,12 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 	usePremiumAnalyticsPreviewNotShownEvent( {
 		siteId,
 		isWpcom,
-		isSettled: ! isWaitingForNoticeInputs && ! isError,
+		// The features are not among the notices' own inputs, so they are waited on here alone:
+		// reading the tier before they land answers "no" for every site.
+		isSettled: ! isWaitingForNoticeInputs && hasLoadedFeatures,
 		isServerVisible: serverNoticesVisibility?.premium_analytics_preview === true,
 		canManageOptions,
+		hasSiteFeatures,
 		hasCommercialStats,
 		premiumAnalyticsDashboardUrl,
 		isVip,

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -141,9 +141,9 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 
 	const { isLoading, isError, data: serverNoticesVisibility } = useNoticesVisibilityQuery( siteId );
 
-	// Same shape as the plans check below: waiting on the features is right in Calypso, where they
-	// arrive on their own schedule and a site that has them looks identical to one still fetching,
-	// and wrong in wp-admin, where nothing requests them and waiting would never end.
+	// Waiting matters in Calypso, where a site with no features looks identical to one still
+	// fetching. In wp-admin the seeded entry carries `data` alone, so this selector answers false
+	// however long we wait - nothing re-fetches it there to set `hasLoadedFromServer`.
 	const hasLoadedFeatures =
 		useSelector( ( state ) => hasLoadedSiteFeatures( state, siteId ) ) ||
 		config.isEnabled( 'is_odyssey' );

--- a/client/my-sites/stats/stats-notices/premium-analytics-preview-not-shown-event.ts
+++ b/client/my-sites/stats/stats-notices/premium-analytics-preview-not-shown-event.ts
@@ -55,10 +55,8 @@ const notShownReason = ( {
 	if ( ! canManageOptions ) {
 		return 'not_admin';
 	}
-	// Nothing loads the features in a Jetpack site's wp-admin, so an Atomic site arrives here with
-	// none. Kept apart from the tier answer below: that cohort is the one this event exists to
-	// size, and folding it into `no_commercial_stats` would hide it among sites that really are on
-	// the wrong tier.
+	// Kept apart from the tier answer below: with no features `shouldGateStats` cannot tell us
+	// anything, and filing that as `no_commercial_stats` would read as a site on the wrong tier.
 	if ( ! hasSiteFeatures ) {
 		return 'features_unavailable';
 	}

--- a/client/my-sites/stats/stats-notices/premium-analytics-preview-not-shown-event.ts
+++ b/client/my-sites/stats/stats-notices/premium-analytics-preview-not-shown-event.ts
@@ -1,11 +1,12 @@
 import config from '@automattic/calypso-config';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { trackPremiumAnalyticsPreviewEvent } from '../premium-analytics-preview/track-event';
 import { PREMIUM_ANALYTICS_PREVIEW_FLAG } from './premium-analytics-preview-cohort';
 
 type PreviewGateSignals = {
 	isServerVisible: boolean;
 	canManageOptions: boolean;
+	hasSiteFeatures: boolean;
 	hasCommercialStats: boolean;
 	premiumAnalyticsDashboardUrl?: string | null;
 	isVip: boolean;
@@ -21,6 +22,18 @@ type NotShownSignals = PreviewGateSignals & {
 };
 
 /**
+ * Sites already counted, for as long as the page is open.
+ *
+ * Module scope rather than a ref: the host mounts on the Traffic page alone, so a round trip
+ * through Insights would otherwise count the site again, and the answer can genuinely change
+ * under us — a dismissal refetches the notices and an accepted invitation writes the status
+ * cache, both of which look like a fresh reason to a per-mount guard.
+ *
+ * Exported for tests, which share the module across cases.
+ */
+export const recordedSiteIds = new Set< number >();
+
+/**
  * The first gate that turned the invitation away, or null when the notice is shown.
  *
  * Checked in the order the gate resolves in, so the reason is the one a reader would reach first.
@@ -28,6 +41,7 @@ type NotShownSignals = PreviewGateSignals & {
 const notShownReason = ( {
 	isServerVisible,
 	canManageOptions,
+	hasSiteFeatures,
 	hasCommercialStats,
 	premiumAnalyticsDashboardUrl,
 	isVip,
@@ -35,14 +49,18 @@ const notShownReason = ( {
 	isPremiumAnalyticsEnabled,
 	isStatusError,
 }: PreviewGateSignals ): string | null => {
-	if ( ! config.isEnabled( PREMIUM_ANALYTICS_PREVIEW_FLAG ) ) {
-		return 'flag_disabled';
-	}
 	if ( ! isServerVisible ) {
 		return 'server_hidden';
 	}
 	if ( ! canManageOptions ) {
 		return 'not_admin';
+	}
+	// Nothing loads the features in a Jetpack site's wp-admin, so an Atomic site arrives here with
+	// none. Kept apart from the tier answer below: that cohort is the one this event exists to
+	// size, and folding it into `no_commercial_stats` would hide it among sites that really are on
+	// the wrong tier.
+	if ( ! hasSiteFeatures ) {
+		return 'features_unavailable';
 	}
 	if ( ! hasCommercialStats ) {
 		return 'no_commercial_stats';
@@ -83,6 +101,7 @@ export default function usePremiumAnalyticsPreviewNotShownEvent( {
 	isSettled,
 	isServerVisible,
 	canManageOptions,
+	hasSiteFeatures,
 	hasCommercialStats,
 	premiumAnalyticsDashboardUrl,
 	isVip,
@@ -90,10 +109,15 @@ export default function usePremiumAnalyticsPreviewNotShownEvent( {
 	isPremiumAnalyticsEnabled,
 	isStatusError,
 }: NotShownSignals ) {
-	const recordedSiteId = useRef< number | null >( null );
-
 	useEffect( () => {
-		if ( ! siteId || ! isSettled || recordedSiteId.current === siteId ) {
+		// The flag is off everywhere the preview has not reached yet, so counting those sites would
+		// record one event per Traffic mount across all of WordPress.com and say only which build
+		// we are in.
+		if ( ! config.isEnabled( PREMIUM_ANALYTICS_PREVIEW_FLAG ) ) {
+			return;
+		}
+
+		if ( ! siteId || ! isSettled || recordedSiteIds.has( siteId ) ) {
 			return;
 		}
 
@@ -106,6 +130,7 @@ export default function usePremiumAnalyticsPreviewNotShownEvent( {
 		const reason = notShownReason( {
 			isServerVisible,
 			canManageOptions,
+			hasSiteFeatures,
 			hasCommercialStats,
 			premiumAnalyticsDashboardUrl,
 			isVip,
@@ -114,11 +139,14 @@ export default function usePremiumAnalyticsPreviewNotShownEvent( {
 			isStatusError,
 		} );
 
+		// Marked before the shown case returns, so a site that was offered the invitation stays out
+		// of the count when a later dismissal or acceptance changes the answer.
+		recordedSiteIds.add( siteId );
+
 		if ( ! reason ) {
 			return;
 		}
 
-		recordedSiteId.current = siteId;
 		trackPremiumAnalyticsPreviewEvent( 'notice', 'not_shown', siteId, { reason } );
 	}, [
 		siteId,
@@ -126,6 +154,7 @@ export default function usePremiumAnalyticsPreviewNotShownEvent( {
 		isSettled,
 		isServerVisible,
 		canManageOptions,
+		hasSiteFeatures,
 		hasCommercialStats,
 		premiumAnalyticsDashboardUrl,
 		isVip,

--- a/client/my-sites/stats/stats-notices/premium-analytics-preview-not-shown-event.ts
+++ b/client/my-sites/stats/stats-notices/premium-analytics-preview-not-shown-event.ts
@@ -1,0 +1,136 @@
+import config from '@automattic/calypso-config';
+import { useEffect, useRef } from 'react';
+import { trackPremiumAnalyticsPreviewEvent } from '../premium-analytics-preview/track-event';
+import { PREMIUM_ANALYTICS_PREVIEW_FLAG } from './premium-analytics-preview-cohort';
+
+type PreviewGateSignals = {
+	isServerVisible: boolean;
+	canManageOptions: boolean;
+	hasCommercialStats: boolean;
+	premiumAnalyticsDashboardUrl?: string | null;
+	isVip: boolean;
+	isP2: boolean;
+	isPremiumAnalyticsEnabled?: boolean;
+	isStatusError: boolean;
+};
+
+type NotShownSignals = PreviewGateSignals & {
+	siteId: number | null;
+	isWpcom: boolean;
+	isSettled: boolean;
+};
+
+/**
+ * The first gate that turned the invitation away, or null when the notice is shown.
+ *
+ * Checked in the order the gate resolves in, so the reason is the one a reader would reach first.
+ */
+const notShownReason = ( {
+	isServerVisible,
+	canManageOptions,
+	hasCommercialStats,
+	premiumAnalyticsDashboardUrl,
+	isVip,
+	isP2,
+	isPremiumAnalyticsEnabled,
+	isStatusError,
+}: PreviewGateSignals ): string | null => {
+	if ( ! config.isEnabled( PREMIUM_ANALYTICS_PREVIEW_FLAG ) ) {
+		return 'flag_disabled';
+	}
+	if ( ! isServerVisible ) {
+		return 'server_hidden';
+	}
+	if ( ! canManageOptions ) {
+		return 'not_admin';
+	}
+	if ( ! hasCommercialStats ) {
+		return 'no_commercial_stats';
+	}
+	if ( ! premiumAnalyticsDashboardUrl ) {
+		return 'no_admin_url';
+	}
+	if ( isVip ) {
+		return 'is_vip';
+	}
+	if ( isP2 ) {
+		return 'is_p2';
+	}
+	if ( isPremiumAnalyticsEnabled === true ) {
+		return 'already_enabled';
+	}
+	// A failed read leaves the setting undefined too, so it gets its own reason rather than being
+	// filed as a Jetpack too old to register it.
+	if ( isStatusError ) {
+		return 'status_request_failed';
+	}
+	if ( isPremiumAnalyticsEnabled === undefined ) {
+		return 'setting_unavailable';
+	}
+
+	return null;
+};
+
+/**
+ * Record one Tracks event per site when the preview invitation is not going to be shown.
+ *
+ * The five events the notice records all need it to mount first, which leaves the rate of sites
+ * we skip without a denominator.
+ */
+export default function usePremiumAnalyticsPreviewNotShownEvent( {
+	siteId,
+	isWpcom,
+	isSettled,
+	isServerVisible,
+	canManageOptions,
+	hasCommercialStats,
+	premiumAnalyticsDashboardUrl,
+	isVip,
+	isP2,
+	isPremiumAnalyticsEnabled,
+	isStatusError,
+}: NotShownSignals ) {
+	const recordedSiteId = useRef< number | null >( null );
+
+	useEffect( () => {
+		if ( ! siteId || ! isSettled || recordedSiteId.current === siteId ) {
+			return;
+		}
+
+		// Self-hosted Jetpack sites are out of this rollout round and are a large share of Odyssey
+		// traffic, so counting them would swamp the rate this event exists to measure.
+		if ( ! isWpcom ) {
+			return;
+		}
+
+		const reason = notShownReason( {
+			isServerVisible,
+			canManageOptions,
+			hasCommercialStats,
+			premiumAnalyticsDashboardUrl,
+			isVip,
+			isP2,
+			isPremiumAnalyticsEnabled,
+			isStatusError,
+		} );
+
+		if ( ! reason ) {
+			return;
+		}
+
+		recordedSiteId.current = siteId;
+		trackPremiumAnalyticsPreviewEvent( 'notice', 'not_shown', siteId, { reason } );
+	}, [
+		siteId,
+		isWpcom,
+		isSettled,
+		isServerVisible,
+		canManageOptions,
+		hasCommercialStats,
+		premiumAnalyticsDashboardUrl,
+		isVip,
+		isP2,
+		isPremiumAnalyticsEnabled,
+		isStatusError,
+	] );
+}

--- a/client/my-sites/stats/stats-notices/test/premium-analytics-preview-not-shown-event.tsx
+++ b/client/my-sites/stats/stats-notices/test/premium-analytics-preview-not-shown-event.tsx
@@ -3,6 +3,7 @@
  */
 import { render } from '@testing-library/react';
 import StatsNotices from '../index';
+import { recordedSiteIds } from '../premium-analytics-preview-not-shown-event';
 import type { Notices } from '../../hooks/use-notice-visibility-query';
 
 // The flag store is created inside the factory and parked on `globalThis`: `calypso-products`
@@ -61,8 +62,9 @@ jest.mock( 'calypso/my-sites/stats/hooks/use-plan-usage-query', () => ( {
 	getUsageLimitStatus: () => ( { isNearLimit: false, isOverLimit: false } ),
 } ) );
 
+let mockIsStatsGated = false;
 jest.mock( 'calypso/my-sites/stats/hooks/use-should-gate-stats', () => ( {
-	shouldGateStats: () => false,
+	shouldGateStats: () => mockIsStatsGated,
 } ) );
 
 jest.mock( '../../hooks/use-stats-purchases', () => ( {
@@ -95,6 +97,12 @@ let mockSiteFeatures: unknown = { active: [] };
 jest.mock( 'calypso/state/selectors/get-site-features', () => ( {
 	__esModule: true,
 	default: () => mockSiteFeatures,
+} ) );
+
+let mockHasLoadedSiteFeatures = true;
+jest.mock( 'calypso/state/selectors/has-loaded-site-features', () => ( {
+	__esModule: true,
+	default: () => mockHasLoadedSiteFeatures,
 } ) );
 
 let mockIsWpcom = true;
@@ -178,87 +186,147 @@ describe( 'premium analytics preview "not shown" event', () => {
 		mockIsP2 = false;
 		mockIsVip = false;
 		mockAdminUrl = 'https://example.com/wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin';
+		mockHasLoadedSiteFeatures = true;
+		mockIsStatsGated = false;
+		recordedSiteIds.clear();
 	} );
 
-	it( 'records the flag being off', () => {
-		delete mockFlags()[ 'stats/premium-analytics-preview' ];
+	const reasonCases: Array< [ string, () => void ] > = [
+		[
+			'server_hidden',
+			() => {
+				mockNoticesVisibility.data = { premium_analytics_preview: false } as unknown as Notices;
+			},
+		],
+		[
+			'not_admin',
+			() => {
+				mockCanManageOptions = false;
+			},
+		],
+		// Nothing loads the features in a Jetpack site's wp-admin, which is the cohort this event
+		// exists to size. Kept apart from the tier answer below.
+		[
+			'features_unavailable',
+			() => {
+				mockSiteFeatures = null;
+			},
+		],
+		[
+			'no_commercial_stats',
+			() => {
+				mockIsStatsGated = true;
+			},
+		],
+		[
+			'no_admin_url',
+			() => {
+				mockAdminUrl = null;
+			},
+		],
+		[
+			'is_vip',
+			() => {
+				mockIsVip = true;
+			},
+		],
+		[
+			'is_p2',
+			() => {
+				mockIsP2 = true;
+			},
+		],
+		[
+			'already_enabled',
+			() => {
+				mockPremiumAnalyticsStatus.data = true;
+			},
+		],
+		[
+			'status_request_failed',
+			() => {
+				mockPremiumAnalyticsStatus.isError = true;
+			},
+		],
+		[
+			'setting_unavailable',
+			() => {
+				mockPremiumAnalyticsStatus.data = undefined;
+			},
+		],
+	];
+
+	it.each( reasonCases )( 'records %s', ( reason, setUp ) => {
+		setUp();
 
 		renderNotices();
 
-		expect( notShownEvents() ).toEqual( [
-			[ EVENT_NAME, { blog_id: 123, reason: 'flag_disabled' } ],
-		] );
+		expect( notShownEvents() ).toEqual( [ [ EVENT_NAME, { blog_id: 123, reason } ] ] );
 	} );
 
-	it( 'records a site whose Jetpack never registered the setting', () => {
-		mockPremiumAnalyticsStatus = { data: undefined, isLoading: false, isError: false };
+	const quietCases: Array< [ string, () => void ] > = [
+		[ 'the invitation is shown', () => {} ],
+		// The two rows that would otherwise pass every gate, so a missing guard would leave them
+		// silent for the wrong reason. Failing one gate gives each a reason to record.
+		[
+			'the flag is off',
+			() => {
+				mockCanManageOptions = false;
+				delete mockFlags()[ 'stats/premium-analytics-preview' ];
+			},
+		],
+		[
+			'the notices are still loading',
+			() => {
+				mockNoticesVisibility = { isLoading: true, isError: false, data: undefined as never };
+				mockPremiumAnalyticsStatus = { data: undefined, isLoading: true, isError: false };
+			},
+		],
+		[
+			'the site features are still loading',
+			() => {
+				mockSiteFeatures = null;
+				mockHasLoadedSiteFeatures = false;
+			},
+		],
+		[
+			'the site is self-hosted Jetpack',
+			() => {
+				mockCanManageOptions = false;
+				mockIsWpcom = false;
+			},
+		],
+	];
+
+	it.each( quietCases )( 'stays quiet while %s', ( _label, setUp ) => {
+		setUp();
 
 		renderNotices();
 
-		expect( notShownEvents() ).toEqual( [
-			[ EVENT_NAME, { blog_id: 123, reason: 'setting_unavailable' } ],
-		] );
+		expect( notShownEvents() ).toEqual( [] );
 	} );
 
-	it( 'records a site that already switched the dashboard on', () => {
-		mockPremiumAnalyticsStatus = { data: true, isLoading: false, isError: false };
+	it( 'stays quiet for a site that was offered the invitation and then dismissed it', () => {
+		const { rerender } = renderNotices();
 
-		renderNotices();
-
-		expect( notShownEvents() ).toEqual( [
-			[ EVENT_NAME, { blog_id: 123, reason: 'already_enabled' } ],
-		] );
-	} );
-
-	it( 'records the server holding the invitation back', () => {
+		// What a dismissal does: the mutation invalidates the notices query and the refetch answers
+		// that the invitation is no longer on offer.
 		mockNoticesVisibility = {
 			isLoading: false,
 			isError: false,
 			data: { premium_analytics_preview: false } as unknown as Notices,
 		};
-
-		renderNotices();
-
-		expect( notShownEvents() ).toEqual( [
-			[ EVENT_NAME, { blog_id: 123, reason: 'server_hidden' } ],
-		] );
-	} );
-
-	it( 'records only once across re-renders', () => {
-		mockPremiumAnalyticsStatus = { data: true, isLoading: false, isError: false };
-
-		const { rerender } = renderNotices();
 		rerender( <StatsNotices siteId={ 123 } isOdysseyStats={ false } /> );
 
-		expect( notShownEvents() ).toHaveLength( 1 );
-	} );
-
-	it( 'stays quiet when the invitation is shown', () => {
-		renderNotices();
-
 		expect( notShownEvents() ).toEqual( [] );
 	} );
 
-	it( 'stays quiet while the notices are still loading', () => {
-		mockNoticesVisibility = { isLoading: true, isError: false, data: undefined as never };
-		mockPremiumAnalyticsStatus = { data: undefined, isLoading: true, isError: false };
-
+	it( 'stays quiet for a site that accepted the invitation and came back', () => {
 		renderNotices();
 
-		expect( notShownEvents() ).toEqual( [] );
-	} );
-
-	it( 'stays quiet when the notices request failed', () => {
-		mockNoticesVisibility = { isLoading: false, isError: true, data: undefined as never };
-
-		renderNotices();
-
-		expect( notShownEvents() ).toEqual( [] );
-	} );
-
-	it( 'stays quiet for a self-hosted Jetpack site', () => {
-		mockIsWpcom = false;
-
+		// Accepting writes the status cache without recording a dismissal, so the next Traffic mount
+		// still sees the invitation on offer and the dashboard already on.
+		mockPremiumAnalyticsStatus = { data: true, isLoading: false, isError: false };
 		renderNotices();
 
 		expect( notShownEvents() ).toEqual( [] );

--- a/client/my-sites/stats/stats-notices/test/premium-analytics-preview-not-shown-event.tsx
+++ b/client/my-sites/stats/stats-notices/test/premium-analytics-preview-not-shown-event.tsx
@@ -204,8 +204,6 @@ describe( 'premium analytics preview "not shown" event', () => {
 				mockCanManageOptions = false;
 			},
 		],
-		// Nothing loads the features in a Jetpack site's wp-admin, which is the cohort this event
-		// exists to size. Kept apart from the tier answer below.
 		[
 			'features_unavailable',
 			() => {

--- a/client/my-sites/stats/stats-notices/test/premium-analytics-preview-not-shown-event.tsx
+++ b/client/my-sites/stats/stats-notices/test/premium-analytics-preview-not-shown-event.tsx
@@ -1,0 +1,266 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import StatsNotices from '../index';
+import type { Notices } from '../../hooks/use-notice-visibility-query';
+
+// The flag store is created inside the factory and parked on `globalThis`: `calypso-products`
+// reads config while it is being imported, before any module-scope `const` here exists.
+jest.mock( '@automattic/calypso-config', () => {
+	const flags: Record< string, boolean > = {};
+	( globalThis as Record< string, unknown > ).__notShownEventTestFlags = flags;
+	const isEnabled = ( flag: string ) => !! flags[ flag ];
+	return { __esModule: true, default: { isEnabled }, isEnabled };
+} );
+
+const mockFlags = () =>
+	( globalThis as Record< string, unknown > ).__notShownEventTestFlags as Record< string, boolean >;
+
+const mockRecordTracksEvent = jest.fn();
+jest.mock( '@automattic/calypso-analytics', () => ( {
+	recordTracksEvent: ( ...args: unknown[] ) => mockRecordTracksEvent( ...args ),
+} ) );
+
+jest.mock( 'calypso/state', () => ( {
+	useSelector: ( selector: ( state: unknown ) => unknown ) => selector( {} ),
+	useDispatch: () => jest.fn(),
+} ) );
+
+jest.mock( '../all-notice-definitions', () => ( { __esModule: true, default: [] } ) );
+
+jest.mock( 'calypso/components/data/query-site-stats', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+jest.mock( '../jitm-wrapper', () => ( { __esModule: true, default: () => null } ) );
+
+let mockNoticesVisibility = {
+	isLoading: false,
+	isError: false,
+	data: { premium_analytics_preview: true } as unknown as Notices,
+};
+jest.mock( 'calypso/my-sites/stats/hooks/use-notice-visibility-query', () => ( {
+	...jest.requireActual( 'calypso/my-sites/stats/hooks/use-notice-visibility-query' ),
+	useNoticesVisibilityQuery: () => mockNoticesVisibility,
+} ) );
+
+let mockPremiumAnalyticsStatus: {
+	data: boolean | undefined;
+	isLoading: boolean;
+	isError: boolean;
+} = { data: false, isLoading: false, isError: false };
+jest.mock( 'calypso/my-sites/stats/hooks/use-premium-analytics-status-query', () => ( {
+	__esModule: true,
+	default: () => mockPremiumAnalyticsStatus,
+} ) );
+
+jest.mock( 'calypso/my-sites/stats/hooks/use-plan-usage-query', () => ( {
+	__esModule: true,
+	default: () => ( { data: undefined } ),
+	getUsageLimitStatus: () => ( { isNearLimit: false, isOverLimit: false } ),
+} ) );
+
+jest.mock( 'calypso/my-sites/stats/hooks/use-should-gate-stats', () => ( {
+	shouldGateStats: () => false,
+} ) );
+
+jest.mock( '../../hooks/use-stats-purchases', () => ( {
+	__esModule: true,
+	default: () => ( { isRequestingSitePurchases: false, supportCommercialUse: true } ),
+	shouldShowPaywallNotice: () => false,
+} ) );
+
+jest.mock( 'calypso/state/purchases/actions', () => ( {
+	resetSiteState: () => ( { type: 'NOOP' } ),
+} ) );
+jest.mock( 'calypso/state/purchases/selectors', () => ( {
+	hasLoadedSitePurchasesFromServer: () => true,
+} ) );
+jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
+	hasLoadedSitePlansFromServer: () => true,
+} ) );
+
+jest.mock( 'calypso/state/sites/selectors/get-env-stats-feature-supports', () => ( {
+	__esModule: true,
+	default: () => ( { supportsNewStatsNotices: true } ),
+} ) );
+
+let mockCanManageOptions = true;
+jest.mock( 'calypso/state/selectors/can-current-user', () => ( {
+	canCurrentUser: () => mockCanManageOptions,
+} ) );
+
+let mockSiteFeatures: unknown = { active: [] };
+jest.mock( 'calypso/state/selectors/get-site-features', () => ( {
+	__esModule: true,
+	default: () => mockSiteFeatures,
+} ) );
+
+let mockIsWpcom = true;
+jest.mock( 'calypso/state/selectors/is-site-wpcom', () => ( {
+	__esModule: true,
+	default: () => mockIsWpcom,
+} ) );
+
+let mockIsP2 = false;
+jest.mock( 'calypso/state/selectors/is-site-wpforteams', () => ( {
+	__esModule: true,
+	default: () => mockIsP2,
+} ) );
+
+let mockIsVip = false;
+jest.mock( 'calypso/state/selectors/is-vip-site', () => ( {
+	__esModule: true,
+	default: () => mockIsVip,
+} ) );
+
+let mockAdminUrl: string | null =
+	'https://example.com/wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin';
+jest.mock( 'calypso/state/sites/selectors/get-site-admin-url', () => ( {
+	__esModule: true,
+	default: () => mockAdminUrl,
+} ) );
+
+jest.mock( 'calypso/state/selectors/site-has-feature', () => ( {
+	__esModule: true,
+	default: () => false,
+} ) );
+jest.mock( 'calypso/state/sites/selectors/get-site-option', () => ( {
+	__esModule: true,
+	default: () => undefined,
+} ) );
+jest.mock( 'calypso/state/sites/selectors/has-site-product-jetpack-stats-free', () => ( {
+	__esModule: true,
+	default: () => false,
+} ) );
+jest.mock( 'calypso/state/sites/selectors/has-site-product-jetpack-stats-paid', () => ( {
+	__esModule: true,
+	default: () => false,
+} ) );
+jest.mock( 'calypso/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only', () => ( {
+	__esModule: true,
+	default: () => false,
+} ) );
+jest.mock( 'calypso/state/sites/selectors/is-jetpack-site', () => ( {
+	__esModule: true,
+	default: () => false,
+} ) );
+jest.mock( 'calypso/state/stats/lists/selectors', () => ( {
+	getSiteStatsNormalizedData: () => ( {} ),
+} ) );
+jest.mock( 'calypso/state/ui/selectors/get-selected-site', () => ( {
+	__esModule: true,
+	default: () => undefined,
+} ) );
+
+const EVENT_NAME = 'calypso_stats_premium_analytics_preview_notice_not_shown';
+
+const renderNotices = () => render( <StatsNotices siteId={ 123 } isOdysseyStats={ false } /> );
+
+const notShownEvents = () =>
+	mockRecordTracksEvent.mock.calls.filter( ( [ name ] ) => name === EVENT_NAME );
+
+describe( 'premium analytics preview "not shown" event', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		Object.keys( mockFlags() ).forEach( ( flag ) => delete mockFlags()[ flag ] );
+		mockFlags()[ 'stats/premium-analytics-preview' ] = true;
+		mockNoticesVisibility = {
+			isLoading: false,
+			isError: false,
+			data: { premium_analytics_preview: true } as unknown as Notices,
+		};
+		mockPremiumAnalyticsStatus = { data: false, isLoading: false, isError: false };
+		mockCanManageOptions = true;
+		mockSiteFeatures = { active: [] };
+		mockIsWpcom = true;
+		mockIsP2 = false;
+		mockIsVip = false;
+		mockAdminUrl = 'https://example.com/wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin';
+	} );
+
+	it( 'records the flag being off', () => {
+		delete mockFlags()[ 'stats/premium-analytics-preview' ];
+
+		renderNotices();
+
+		expect( notShownEvents() ).toEqual( [
+			[ EVENT_NAME, { blog_id: 123, reason: 'flag_disabled' } ],
+		] );
+	} );
+
+	it( 'records a site whose Jetpack never registered the setting', () => {
+		mockPremiumAnalyticsStatus = { data: undefined, isLoading: false, isError: false };
+
+		renderNotices();
+
+		expect( notShownEvents() ).toEqual( [
+			[ EVENT_NAME, { blog_id: 123, reason: 'setting_unavailable' } ],
+		] );
+	} );
+
+	it( 'records a site that already switched the dashboard on', () => {
+		mockPremiumAnalyticsStatus = { data: true, isLoading: false, isError: false };
+
+		renderNotices();
+
+		expect( notShownEvents() ).toEqual( [
+			[ EVENT_NAME, { blog_id: 123, reason: 'already_enabled' } ],
+		] );
+	} );
+
+	it( 'records the server holding the invitation back', () => {
+		mockNoticesVisibility = {
+			isLoading: false,
+			isError: false,
+			data: { premium_analytics_preview: false } as unknown as Notices,
+		};
+
+		renderNotices();
+
+		expect( notShownEvents() ).toEqual( [
+			[ EVENT_NAME, { blog_id: 123, reason: 'server_hidden' } ],
+		] );
+	} );
+
+	it( 'records only once across re-renders', () => {
+		mockPremiumAnalyticsStatus = { data: true, isLoading: false, isError: false };
+
+		const { rerender } = renderNotices();
+		rerender( <StatsNotices siteId={ 123 } isOdysseyStats={ false } /> );
+
+		expect( notShownEvents() ).toHaveLength( 1 );
+	} );
+
+	it( 'stays quiet when the invitation is shown', () => {
+		renderNotices();
+
+		expect( notShownEvents() ).toEqual( [] );
+	} );
+
+	it( 'stays quiet while the notices are still loading', () => {
+		mockNoticesVisibility = { isLoading: true, isError: false, data: undefined as never };
+		mockPremiumAnalyticsStatus = { data: undefined, isLoading: true, isError: false };
+
+		renderNotices();
+
+		expect( notShownEvents() ).toEqual( [] );
+	} );
+
+	it( 'stays quiet when the notices request failed', () => {
+		mockNoticesVisibility = { isLoading: false, isError: true, data: undefined as never };
+
+		renderNotices();
+
+		expect( notShownEvents() ).toEqual( [] );
+	} );
+
+	it( 'stays quiet for a self-hosted Jetpack site', () => {
+		mockIsWpcom = false;
+
+		renderNotices();
+
+		expect( notShownEvents() ).toEqual( [] );
+	} );
+} );

--- a/client/my-sites/stats/stats-notices/test/stats-notices-loading-gate.tsx
+++ b/client/my-sites/stats/stats-notices/test/stats-notices-loading-gate.tsx
@@ -98,6 +98,10 @@ jest.mock( 'calypso/state/selectors/get-site-features', () => ( {
 	__esModule: true,
 	default: () => ( { active: [] } ),
 } ) );
+jest.mock( 'calypso/state/selectors/has-loaded-site-features', () => ( {
+	__esModule: true,
+	default: () => true,
+} ) );
 let mockIsWpcom = true;
 jest.mock( 'calypso/state/selectors/is-site-wpcom', () => ( {
 	__esModule: true,


### PR DESCRIPTION
## Proposed Changes

* Record `<prefix>_stats_premium_analytics_preview_notice_not_shown` once per site when the preview invitation will not be shown, with a `reason` naming the first gate that turned it away.
* Reasons, in gate order: `server_hidden`, `not_admin`, `features_unavailable`, `no_commercial_stats`, `no_admin_url`, `is_vip`, `is_p2`, `already_enabled`, `status_request_failed`, `setting_unavailable`.
* Reuse the notice's `trackEvent` helper, so the event carries the same `jetpack_odyssey` / `calypso` prefix and `blog_id` as its five siblings.
* Skip while any input is still loading, when the flag is off, when the notice is shown, and on self-hosted Jetpack sites.
* New unit tests.

Counted once per site for as long as the page is open, not once per mount. The host mounts on the Traffic page alone, so a round trip through Insights would otherwise count a site twice, and the answer can change under us: a dismissal refetches the notices, and accepting writes the status cache. A site is marked as counted on the first settled evaluation, before the shown case returns, so a site that was offered the invitation stays out of the count whatever it does next.

`setting_unavailable` and `status_request_failed` are kept apart on purpose: a Jetpack too old to register the setting and a read that failed both leave it `undefined`, and would otherwise be indistinguishable.

`features_unavailable` is likewise kept apart from `no_commercial_stats`, but as a guard rather than a cohort: `shouldGateStats` cannot answer without the site features, so filing that as `no_commercial_stats` would read as a site that really is on the wrong tier.

Checked on an Atomic site's wp-admin rather than assumed. `intial_state.sites.features` is seeded with the site's active features, so an Atomic site does reach the tier check there and this reason should stay rare. A non-trivial count means the seeding did not reach that cohort.

The seeded entry carries `data` alone though, with no `hasLoadedFromServer`, and nothing re-fetches it in wp-admin (`stats-main` skips `QuerySiteFeatures` there). `hasLoadedSiteFeatures` therefore answers false however long we wait, which is what the `is_odyssey` fallback on the loaded check is for. In Calypso the features arrive on their own schedule, so the event waits for them.

Nothing is recorded while the flag is off. That is a per-build constant rather than a property of the site, and recording it would mean one event per Traffic mount across all of WordPress.com.

Self-hosted sites are out of this rollout round and are a large share of Odyssey traffic, so counting them would swamp the rate without adding to it. Happy to drop that exclusion if you would rather have the full picture.

## Why are these changes being made?

pejTkB-2B3-p2#comment-1994

`viewed` already tells us who saw the banner and declined. What we cannot see is the site that was never offered it, because nothing is recorded on that path.

That gap matters most for reach. Atomic sites on a build older than the one registering `jetpack_premium_analytics_enabled` cannot be invited at all, and today we have no way to tell whether that is fifty sites or fifty thousand. `reason` answers that, and says which gate to look at before widening the cohort.

Two known gaps:

* A site that passes every gate but loses the notice conflict group records neither this event nor `viewed`.
* A failed notices request resolves with the defaults rather than rejecting, so it files as `server_hidden` rather than as its own reason.

## Testing Instructions

1. Open Stats on a WordPress.com site with `stats/premium-analytics-preview` off and Tracks debugging on (`localStorage.setItem( 'debug', 'calypso:analytics*' )`). Expect no event at all.
2. Turn the flag on, open Stats on a site that already has the new Traffic tab. Expect `reason: server_hidden`, since WordPress.com stops offering the notice once the dashboard is on.
3. Open Stats on an eligible site. Expect the banner, `viewed`, and no `not_shown`. Dismiss it, then navigate Traffic to Insights and back. Expect still no `not_shown`.
4. Accept the invitation, then navigate Traffic to Insights and back. Expect no `not_shown`.
5. Open Stats on a self-hosted Jetpack site. Expect no `not_shown`.

```
yarn jest -c=test/client/jest.config.js client/my-sites/stats/stats-notices/test/premium-analytics-preview-not-shown-event.tsx
```

`server_hidden` was observed on a live Simple site, from a calypso.live build of this branch, as a real request to `pixel.wp.com` carrying `blog_id` and `reason`.

The event still needs registering in the Tracks catalog before anyone reads numbers off it.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

