### PR TITLE
Monetize: render every upsell as one promo card and CTA

### DIFF
--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -17,7 +17,7 @@ export interface Props {
 
 import './style.scss';
 
-export const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
+const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
 	isPrimary,
 	title,
 	image,

--- a/client/components/promo-section/index.tsx
+++ b/client/components/promo-section/index.tsx
@@ -17,7 +17,7 @@ export interface Props {
 
 import './style.scss';
 
-const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
+export const PromoSectionCard: FunctionComponent< PromoSectionCardProps > = ( {
 	isPrimary,
 	title,
 	image,

--- a/client/components/promo-section/promo-card/style.scss
+++ b/client/components/promo-section/promo-card/style.scss
@@ -102,17 +102,19 @@
 			align-items: center;
 			font-size: $font-body;
 			font-weight: 500;
+
+			/* Scoped to the title so it can't chip an icon in the card body. */
+			.gridicon {
+				fill: var(--studio-gray-30);
+				width: 20px;
+				height: 20px;
+				background: var(--studio-gray-0);
+				padding: 8px;
+				border-radius: 3px;
+			}
 		}
 		.action-panel__cta {
 			padding-top: 0;
-		}
-		.gridicon {
-			fill: var(--studio-gray-30);
-			width: 20px;
-			height: 20px;
-			background: var(--studio-gray-0);
-			padding: 8px;
-			border-radius: 3px;
 		}
 	}
 

--- a/client/my-sites/earn/ads/test/wrapper.tsx
+++ b/client/my-sites/earn/ads/test/wrapper.tsx
@@ -12,6 +12,7 @@ import AdsWrapper from '../wrapper';
 const renderWrapper = ( {
 	manageOptions = true,
 	features = { 1: { data: { active: [] } } },
+	options = {},
 } = {} ) =>
 	renderWithProvider(
 		<AdsWrapper section="ads-earnings">
@@ -21,7 +22,7 @@ const renderWrapper = ( {
 			initialState: {
 				currentUser: { capabilities: { 1: { manage_options: manageOptions } } },
 				sites: {
-					items: { 1: { ID: 1, slug: 'example.wordpress.com', options: {} } },
+					items: { 1: { ID: 1, slug: 'example.wordpress.com', options } },
 					features,
 				},
 				ui: { selectedSiteId: 1 },
@@ -47,6 +48,14 @@ describe( 'AdsWrapper', () => {
 	// upselling on it flashes an Upgrade card at sites that already have WordAds.
 	it( 'waits for site features before offering the upgrade', () => {
 		renderWrapper( { features: {} } );
+		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( notAuthorized ) ).not.toBeInTheDocument();
+	} );
+
+	// A standalone Jetpack product connection reads as a Jetpack site without the
+	// `jetpack` flag; WordPress.com plans are the wrong product to sell it.
+	it( 'does not sell WordPress.com plans to a standalone Jetpack site', () => {
+		renderWrapper( { options: { jetpack_connection_active_plugins: [ 'jetpack-social' ] } } );
 		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( notAuthorized ) ).not.toBeInTheDocument();
 	} );

--- a/client/my-sites/earn/ads/test/wrapper.tsx
+++ b/client/my-sites/earn/ads/test/wrapper.tsx
@@ -30,10 +30,13 @@ const renderWrapper = ( {
 		}
 	);
 
+const notAuthorized = 'You are not authorized to view this page';
+
 describe( 'AdsWrapper', () => {
 	it( 'only offers the WordAds upgrade to users who can upgrade the site', () => {
 		const { unmount } = renderWrapper( { manageOptions: false } );
 		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( notAuthorized ) ).not.toBeInTheDocument();
 
 		unmount();
 		renderWrapper();
@@ -45,6 +48,7 @@ describe( 'AdsWrapper', () => {
 	it( 'waits for site features before offering the upgrade', () => {
 		renderWrapper( { features: {} } );
 		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( notAuthorized ) ).not.toBeInTheDocument();
 	} );
 
 	// P2 sites get no upsell, but hiding it must not take the gate with it and

--- a/client/my-sites/earn/ads/test/wrapper.tsx
+++ b/client/my-sites/earn/ads/test/wrapper.tsx
@@ -9,7 +9,10 @@ import wordadsReducer from 'calypso/state/wordads/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import AdsWrapper from '../wrapper';
 
-const renderWrapper = ( manageOptions ) =>
+const renderWrapper = ( {
+	manageOptions = true,
+	features = { 1: { data: { active: [] } } },
+} = {} ) =>
 	renderWithProvider(
 		<AdsWrapper section="ads-earnings">
 			<div />
@@ -19,7 +22,7 @@ const renderWrapper = ( manageOptions ) =>
 				currentUser: { capabilities: { 1: { manage_options: manageOptions } } },
 				sites: {
 					items: { 1: { ID: 1, slug: 'example.wordpress.com', options: {} } },
-					features: { 1: { data: { active: [] } } },
+					features,
 				},
 				ui: { selectedSiteId: 1 },
 			},
@@ -29,11 +32,18 @@ const renderWrapper = ( manageOptions ) =>
 
 describe( 'AdsWrapper', () => {
 	it( 'only offers the WordAds upgrade to users who can upgrade the site', () => {
-		const { unmount } = renderWrapper( false );
+		const { unmount } = renderWrapper( { manageOptions: false } );
 		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
 
 		unmount();
-		renderWrapper( true );
+		renderWrapper();
 		expect( screen.getByRole( 'link', { name: 'Upgrade' } ) ).toBeVisible();
+	} );
+
+	// An unloaded feature list is indistinguishable from an absent feature, so
+	// upselling on it flashes an Upgrade card at sites that already have WordAds.
+	it( 'waits for site features before offering the upgrade', () => {
+		renderWrapper( { features: {} } );
+		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/client/my-sites/earn/ads/test/wrapper.tsx
+++ b/client/my-sites/earn/ads/test/wrapper.tsx
@@ -46,4 +46,35 @@ describe( 'AdsWrapper', () => {
 		renderWrapper( { features: {} } );
 		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
 	} );
+
+	// P2 sites get no upsell, but hiding it must not take the gate with it and
+	// leave them a live settings form.
+	it( 'still gates the settings form for a P2 site on an ineligible plan', () => {
+		const { container } = renderWithProvider(
+			<AdsWrapper section="ads-settings">
+				<div>settings form</div>
+			</AdsWrapper>,
+			{
+				initialState: {
+					currentUser: { capabilities: { 1: { manage_options: true } } },
+					sites: {
+						items: {
+							1: {
+								ID: 1,
+								slug: 'example.wordpress.com',
+								options: { wordads: true, is_wpforteams_site: true },
+							},
+						},
+						features: { 1: { data: { active: [] } } },
+					},
+					ui: { selectedSiteId: 1 },
+					wordads: { status: { 1: { status: 'ineligible' } } },
+				},
+				reducers: { ui: uiReducer, wordads: wordadsReducer },
+			}
+		);
+
+		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
+		expect( container.querySelector( '.feature-example' ) ).toBeInTheDocument();
+	} );
 } );

--- a/client/my-sites/earn/ads/test/wrapper.tsx
+++ b/client/my-sites/earn/ads/test/wrapper.tsx
@@ -1,0 +1,39 @@
+/**
+ * @jest-environment jsdom
+ */
+// @ts-nocheck - TODO: Fix TypeScript issues
+
+import { screen } from '@testing-library/react';
+import uiReducer from 'calypso/state/ui/reducer';
+import wordadsReducer from 'calypso/state/wordads/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import AdsWrapper from '../wrapper';
+
+const renderWrapper = ( manageOptions ) =>
+	renderWithProvider(
+		<AdsWrapper section="ads-earnings">
+			<div />
+		</AdsWrapper>,
+		{
+			initialState: {
+				currentUser: { capabilities: { 1: { manage_options: manageOptions } } },
+				sites: {
+					items: { 1: { ID: 1, slug: 'example.wordpress.com', options: {} } },
+					features: { 1: { data: { active: [] } } },
+				},
+				ui: { selectedSiteId: 1 },
+			},
+			reducers: { ui: uiReducer, wordads: wordadsReducer },
+		}
+	);
+
+describe( 'AdsWrapper', () => {
+	it( 'only offers the WordAds upgrade to users who can upgrade the site', () => {
+		const { unmount } = renderWrapper( false );
+		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
+
+		unmount();
+		renderWrapper( true );
+		expect( screen.getByRole( 'link', { name: 'Upgrade' } ) ).toBeVisible();
+	} );
+} );

--- a/client/my-sites/earn/ads/test/wrapper.tsx
+++ b/client/my-sites/earn/ads/test/wrapper.tsx
@@ -12,7 +12,7 @@ import AdsWrapper from '../wrapper';
 const renderWrapper = ( {
 	manageOptions = true,
 	features = { 1: { data: { active: [] } } },
-	options = {},
+	site = {},
 } = {} ) =>
 	renderWithProvider(
 		<AdsWrapper section="ads-earnings">
@@ -22,7 +22,7 @@ const renderWrapper = ( {
 			initialState: {
 				currentUser: { capabilities: { 1: { manage_options: manageOptions } } },
 				sites: {
-					items: { 1: { ID: 1, slug: 'example.wordpress.com', options } },
+					items: { 1: { ID: 1, slug: 'example.wordpress.com', options: {}, ...site } },
 					features,
 				},
 				ui: { selectedSiteId: 1 },
@@ -52,10 +52,14 @@ describe( 'AdsWrapper', () => {
 		expect( screen.queryByText( notAuthorized ) ).not.toBeInTheDocument();
 	} );
 
-	// A standalone Jetpack product connection reads as a Jetpack site without the
-	// `jetpack` flag; WordPress.com plans are the wrong product to sell it.
-	it( 'does not sell WordPress.com plans to a standalone Jetpack site', () => {
-		renderWrapper( { options: { jetpack_connection_active_plugins: [ 'jetpack-social' ] } } );
+	// None of these can buy the WordPress.com plan the card links to. The last
+	// reads as a Jetpack site while its `jetpack` flag stays false.
+	it.each( [
+		[ 'VIP', { is_vip: true } ],
+		[ 'WP for Teams', { options: { is_wpforteams_site: true } } ],
+		[ 'standalone Jetpack', { options: { jetpack_connection_active_plugins: [ 'boost' ] } } ],
+	] )( 'offers no upgrade to a %s site', ( _label, site ) => {
+		renderWrapper( { site } );
 		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( notAuthorized ) ).not.toBeInTheDocument();
 	} );

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -66,15 +66,6 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 	const canActivateWordAds = useSelector( ( state ) =>
 		canCurrentUser( state, site?.ID, 'activate_wordads' )
 	);
-	const canManageSite = useSelector( ( state ) =>
-		canCurrentUser( state, site?.ID, 'manage_options' )
-	);
-	// An unloaded feature list is indistinguishable from an absent feature, so wait
-	// rather than upsell a site that already qualifies.
-	const featuresLoaded = useSelector(
-		( state ) => getFeaturesBySiteId( state, site?.ID ) !== null
-	);
-	const isVip = useSelector( ( state ) => isVipSite( state, site?.ID ?? 0 ) );
 	const isWPForTeams = useSelector( ( state ) => isSiteWPForTeams( state, site?.ID ?? null ) );
 	const requestingWordAdsApproval = useSelector( ( state ) =>
 		isRequestingWordAdsApprovalForSite( state, site )
@@ -87,14 +78,17 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 	const canUpgradeToUseWordAds = ! site?.options?.wordads && ! hasWordAdsFeature;
 	const isWordadsInstantEligibleButNotOwner =
 		! site?.options?.wordads && hasWordAdsFeature && ! canActivateWordAds;
-	// A site connected only through standalone Jetpack products reads as a Jetpack
-	// site without the `jetpack` flag, and WordPress.com plans are the wrong
-	// product for it.
-	const isStandaloneJetpack = useSelector(
-		( state ) => Boolean( isJetpackSite( state, site?.ID ) ) && ! site?.jetpack
-	);
+	// Everything the shared nudge checked before showing an upgrade. An unloaded
+	// feature list reads as an absent one, so wait for it; and a standalone Jetpack
+	// connection reads as a Jetpack site while its `jetpack` flag stays false.
 	const canShowUpsell =
-		featuresLoaded && canManageSite && ! isVip && ! isWPForTeams && ! isStandaloneJetpack;
+		useSelector(
+			( state ) =>
+				getFeaturesBySiteId( state, site?.ID ) !== null &&
+				Boolean( canCurrentUser( state, site?.ID, 'manage_options' ) ) &&
+				! isVipSite( state, site?.ID ?? 0 ) &&
+				! ( Boolean( isJetpackSite( state, site?.ID ) ) && ! site?.jetpack )
+		) && ! isWPForTeams;
 	const isEnrolledWithIneligiblePlan =
 		site?.options?.wordads && ! hasWordAdsFeature && wordAdsStatus === WordAdsStatus.ineligible;
 
@@ -244,24 +238,19 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 		learnMoreUrl?: string;
 		fitToContent?: boolean;
 	} ) => {
+		const nudgeProperties = {
+			cta_name: ctaName,
+			cta_feature: WPCOM_FEATURES_WORDADS,
+			cta_size: 'regular',
+		};
 		const trackNudge = ( eventName: string ) =>
-			dispatch(
-				recordTracksEvent( eventName, {
-					cta_name: ctaName,
-					cta_feature: WPCOM_FEATURES_WORDADS,
-					cta_size: 'regular',
-				} )
-			);
+			dispatch( recordTracksEvent( eventName, nudgeProperties ) );
 
 		return (
 			<>
 				<TrackComponentView
 					eventName="calypso_upgrade_nudge_impression"
-					eventProperties={ {
-						cta_name: ctaName,
-						cta_feature: WPCOM_FEATURES_WORDADS,
-						cta_size: 'regular',
-					} }
+					eventProperties={ nudgeProperties }
 				/>
 				<PromoCard
 					className={ clsx( 'earn__upsell-card', {

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -3,15 +3,12 @@ import {
 	PLAN_JETPACK_SECURITY_DAILY,
 	WPCOM_FEATURES_WORDADS,
 	FEATURE_WORDADS_INSTANT,
-	Plan,
 	getPlan,
-	getPlanFeaturesObject,
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import wordAdsImage from 'calypso/assets/images/illustrations/dotcom-wordads.svg';
-import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import ActionCard from 'calypso/components/action-card';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySites from 'calypso/components/data/query-sites';
@@ -21,9 +18,13 @@ import FeatureExample from 'calypso/components/feature-example';
 import FormButton from 'calypso/components/forms/form-button';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
+import { PromoSectionCard } from 'calypso/components/promo-section';
+import { PromoCardVariation } from 'calypso/components/promo-section/promo-card';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { WordAdsStatus } from 'calypso/my-sites/earn/ads/types';
 import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getSiteWordadsStatus from 'calypso/state/selectors/get-site-wordads-status';
 import siteHasWordAds from 'calypso/state/selectors/site-has-wordads';
@@ -59,6 +60,9 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 	const isUnsafe = useSelector( ( state ) => isSiteWordadsUnsafe( state, site?.ID ) );
 	const canActivateWordAds = useSelector( ( state ) =>
 		canCurrentUser( state, site?.ID, 'activate_wordads' )
+	);
+	const canManageSite = useSelector( ( state ) =>
+		canCurrentUser( state, site?.ID, 'manage_options' )
 	);
 	const requestingWordAdsApproval = useSelector( ( state ) =>
 		isRequestingWordAdsApprovalForSite( state, site )
@@ -201,64 +205,77 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 		);
 	};
 
-	const renderUpsell = () => {
-		const bannerURL = buildCheckoutURL( siteSlug as string, PLAN_PREMIUM );
-		const plan = getPlan( PLAN_PREMIUM ) as Plan;
-		const jetpackFeatures = plan?.get2023PricingGridSignupJetpackFeatures?.();
-		const jetpackFeaturesObject = getPlanFeaturesObject( jetpackFeatures );
+	const renderUpsellCard = ( {
+		title,
+		body,
+		href,
+		tracksClickName,
+		learnMoreUrl,
+	}: {
+		title: TranslateResult;
+		body: TranslateResult;
+		href: string;
+		tracksClickName: string;
+		learnMoreUrl?: string;
+	} ) => {
+		const trackNudge = ( eventName: string ) =>
+			dispatch( recordTracksEvent( eventName, { cta_feature: WPCOM_FEATURES_WORDADS } ) );
 
 		return (
-			<UpsellNudge
-				callToAction={ translate( 'Upgrade' ) }
-				plan={ PLAN_PREMIUM }
-				title={ translate( 'Upgrade to the %(premiumPlanName)s plan and start earning', {
-					args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
-				} ) }
-				description={ translate(
-					"By upgrading to the %(premiumPlanName)s plan, you'll be able to monetize your site through the <a href='%(url)s'>WordAds program</>.",
-					{
-						args: {
-							url: 'https://wordads.co/',
-							premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '',
+			<>
+				<TrackComponentView
+					eventName="calypso_upgrade_nudge_impression"
+					eventProperties={ { cta_feature: WPCOM_FEATURES_WORDADS } }
+				/>
+				<PromoSectionCard
+					variation={ PromoCardVariation.Compact }
+					icon="speaker"
+					title={ title }
+					body={ body }
+					actions={ {
+						cta: {
+							text: translate( 'Upgrade' ),
+							isPrimary: true,
+							action: {
+								url: href,
+								selfTarget: true,
+								onClick: () => trackNudge( tracksClickName ),
+							},
 						},
-					}
-				) }
-				feature={ WPCOM_FEATURES_WORDADS }
-				href={ bannerURL }
-				showIcon
-				event="calypso_upgrade_nudge_impression"
-				tracksImpressionName="calypso_upgrade_nudge_impression"
-				tracksImpressionProperties={ { cta_name: undefined, cta_size: 'regular' } }
-				tracksClickName="calypso_upgrade_nudge_cta_click"
-				tracksClickProperties={ { cta_name: undefined, cta_size: 'regular' } }
-				list={ [
-					translate( 'Instantly enroll into the WordAds network.' ),
-					translate( 'Earn money from your content and traffic.' ),
-					...jetpackFeaturesObject.map( ( feature ) => feature.getTitle() ),
-				] }
-			/>
+						learnMoreLink: learnMoreUrl
+							? {
+									url: learnMoreUrl,
+									onClick: () => trackNudge( 'calypso_upgrade_nudge_learn_more_click' ),
+							  }
+							: null,
+					} }
+				/>
+			</>
 		);
 	};
 
-	const renderjetpackUpsell = () => {
-		const bannerURL = `/checkout/${ siteSlug }/${ PLAN_JETPACK_SECURITY_DAILY }`;
-		return (
-			<UpsellNudge
-				callToAction={ translate( 'Upgrade' ) }
-				plan={ PLAN_JETPACK_SECURITY_DAILY }
-				title={ translate( 'Upgrade and start earning' ) }
-				description={ translate(
-					'Make money each time someone visits your site by displaying ads on all your posts and pages.'
-				) }
-				href={ bannerURL }
-				feature={ WPCOM_FEATURES_WORDADS }
-				showIcon
-				event="calypso_upgrade_nudge_impression"
-				tracksImpressionName="calypso_upgrade_nudge_impression"
-				tracksClickName="calypso_upgrade_nudge_click"
-			/>
-		);
-	};
+	const renderUpsell = () =>
+		renderUpsellCard( {
+			title: translate( 'Upgrade to the %(premiumPlanName)s plan and start earning', {
+				args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
+			} ),
+			body: translate(
+				'Make money each time someone visits your site by displaying ads on your posts and pages.'
+			),
+			href: buildCheckoutURL( siteSlug as string, PLAN_PREMIUM ),
+			tracksClickName: 'calypso_upgrade_nudge_cta_click',
+			learnMoreUrl: 'https://wordads.co/',
+		} );
+
+	const renderjetpackUpsell = () =>
+		renderUpsellCard( {
+			title: translate( 'Upgrade and start earning' ),
+			body: translate(
+				'Make money each time someone visits your site by displaying ads on all your posts and pages.'
+			),
+			href: `/checkout/${ siteSlug }/${ PLAN_JETPACK_SECURITY_DAILY }`,
+			tracksClickName: 'calypso_upgrade_nudge_click',
+		} );
 
 	const renderNoticeSiteIsPrivate = () => {
 		const privacySettingPageLink = `https://wordpress.com/settings/general/${ siteSlug }#site-privacy-settings`;
@@ -282,25 +299,16 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 		const url = `/plans/${ siteSlug }?feature=${ FEATURE_WORDADS_INSTANT }&plan=${ PLAN_PREMIUM }`;
 		return (
 			<>
-				<UpsellNudge
-					forceDisplay
-					callToAction={ translate( 'Upgrade' ) }
-					plan={ PLAN_PREMIUM }
-					title={ translate( 'Upgrade to the %(premiumPlanName)s plan to continue earning', {
+				{ renderUpsellCard( {
+					title: translate( 'Upgrade to the %(premiumPlanName)s plan to continue earning', {
 						args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
-					} ) }
-					description={ translate(
+					} ),
+					body: translate(
 						'WordAds is disabled for this site because it does not have an eligible plan. You are no longer earning ad revenue, but you can view your earning and payment history. To restore access to WordAds please upgrade to an eligible plan.'
-					) }
-					feature={ WPCOM_FEATURES_WORDADS }
-					href={ url }
-					showIcon
-					event="calypso_upgrade_nudge_impression"
-					tracksImpressionName="calypso_upgrade_nudge_impression"
-					tracksImpressionProperties={ { cta_name: undefined, cta_size: 'regular' } }
-					tracksClickName="calypso_upgrade_nudge_cta_click"
-					tracksClickProperties={ { cta_name: undefined, cta_size: 'regular' } }
-				/>
+					),
+					href: url,
+					tracksClickName: 'calypso_upgrade_nudge_cta_click',
+				} ) }
 				{ isAllowedSection ? component : <FeatureExample>{ component }</FeatureExample> }
 			</>
 		);
@@ -320,9 +328,14 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 			component = renderInstantActivationToggle( component );
 		} else if ( isWordadsInstantEligibleButNotOwner ) {
 			component = renderOwnerRequiredMessage();
-		} else if ( canUpgradeToUseWordAds && site?.jetpack && ! site?.is_wpcom_atomic ) {
+		} else if (
+			canUpgradeToUseWordAds &&
+			canManageSite &&
+			site?.jetpack &&
+			! site?.is_wpcom_atomic
+		) {
 			component = renderjetpackUpsell();
-		} else if ( canUpgradeToUseWordAds ) {
+		} else if ( canUpgradeToUseWordAds && canManageSite ) {
 			component = renderUpsell();
 		} else if ( ! canAccessAds ) {
 			component = renderEmptyContent();

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -244,19 +244,24 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 		learnMoreUrl?: string;
 		fitToContent?: boolean;
 	} ) => {
-		const nudgeProperties = {
-			cta_name: ctaName,
-			cta_feature: WPCOM_FEATURES_WORDADS,
-			cta_size: 'regular',
-		};
 		const trackNudge = ( eventName: string ) =>
-			dispatch( recordTracksEvent( eventName, nudgeProperties ) );
+			dispatch(
+				recordTracksEvent( eventName, {
+					cta_name: ctaName,
+					cta_feature: WPCOM_FEATURES_WORDADS,
+					cta_size: 'regular',
+				} )
+			);
 
 		return (
 			<>
 				<TrackComponentView
 					eventName="calypso_upgrade_nudge_impression"
-					eventProperties={ nudgeProperties }
+					eventProperties={ {
+						cta_name: ctaName,
+						cta_feature: WPCOM_FEATURES_WORDADS,
+						cta_size: 'regular',
+					} }
 				/>
 				<PromoCard
 					className={ clsx( 'earn__upsell-card', {

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -267,7 +267,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 				"By upgrading to the %(premiumPlanName)s plan, you'll be able to monetize your site through the {{link}}WordAds program{{/link}}.",
 				{
 					args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
-					components: { link: <ExternalLink href="https://wordads.co/" /> },
+					components: { link: <ExternalLink href="https://wordads.co/" icon /> },
 				}
 			),
 			benefits: [

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -6,6 +6,7 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
+import clsx from 'clsx';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import wordAdsImage from 'calypso/assets/images/illustrations/dotcom-wordads.svg';
@@ -213,6 +214,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 		href,
 		tracksClickName,
 		learnMoreUrl,
+		fitToContent,
 	}: {
 		title: TranslateResult;
 		body: TranslateResult;
@@ -220,6 +222,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 		href: string;
 		tracksClickName: string;
 		learnMoreUrl?: string;
+		fitToContent?: boolean;
 	} ) => {
 		const trackNudge = ( eventName: string ) =>
 			dispatch( recordTracksEvent( eventName, { cta_feature: WPCOM_FEATURES_WORDADS } ) );
@@ -231,7 +234,9 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 					eventProperties={ { cta_feature: WPCOM_FEATURES_WORDADS } }
 				/>
 				<PromoCard
-					className="earn__upsell-card"
+					className={ clsx( 'earn__upsell-card', {
+						'is-content-width': fitToContent,
+					} ) }
 					variation={ PromoCardVariation.Compact }
 					icon="speaker"
 					title={ preventWidows( title ) }
@@ -282,6 +287,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 			href: buildCheckoutURL( siteSlug as string, PLAN_PREMIUM ),
 			tracksClickName: 'calypso_upgrade_nudge_cta_click',
 			learnMoreUrl: 'https://wordads.co/',
+			fitToContent: true,
 		} );
 
 	const renderjetpackUpsell = () =>

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -5,7 +5,7 @@ import {
 	FEATURE_WORDADS_INSTANT,
 	getPlan,
 } from '@automattic/calypso-products';
-import { Card } from '@automattic/components';
+import { Card, ExternalLink } from '@automattic/components';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import wordAdsImage from 'calypso/assets/images/illustrations/dotcom-wordads.svg';
@@ -211,14 +211,12 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 		benefits,
 		href,
 		tracksClickName,
-		learnMoreUrl,
 	}: {
 		title: TranslateResult;
 		body: TranslateResult;
 		benefits?: TranslateResult[];
 		href: string;
 		tracksClickName: string;
-		learnMoreUrl?: string;
 	} ) => {
 		const trackNudge = ( eventName: string ) =>
 			dispatch( recordTracksEvent( eventName, { cta_feature: WPCOM_FEATURES_WORDADS } ) );
@@ -253,14 +251,6 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 								onClick: () => trackNudge( tracksClickName ),
 							},
 						} }
-						learnMoreLink={
-							learnMoreUrl
-								? {
-										url: learnMoreUrl,
-										onClick: () => trackNudge( 'calypso_upgrade_nudge_learn_more_click' ),
-								  }
-								: null
-						}
 					/>
 				</PromoCard>
 			</>
@@ -273,8 +263,11 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 				args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
 			} ),
 			body: translate(
-				"By upgrading to the %(premiumPlanName)s plan, you'll be able to monetize your site through the WordAds program.",
-				{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' } }
+				"By upgrading to the %(premiumPlanName)s plan, you'll be able to monetize your site through the {{link}}WordAds program{{/link}}.",
+				{
+					args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
+					components: { link: <ExternalLink href="https://wordads.co/" icon /> },
+				}
 			),
 			benefits: [
 				translate( 'Instantly enroll into the WordAds network.' ),
@@ -282,7 +275,6 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 			],
 			href: buildCheckoutURL( siteSlug as string, PLAN_PREMIUM ),
 			tracksClickName: 'calypso_upgrade_nudge_cta_click',
-			learnMoreUrl: 'https://wordads.co/',
 		} );
 
 	const renderjetpackUpsell = () =>

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -28,7 +28,10 @@ import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purch
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import getSiteWordadsStatus from 'calypso/state/selectors/get-site-wordads-status';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasWordAds from 'calypso/state/selectors/site-has-wordads';
 import { canAccessWordAds, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -66,6 +69,13 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 	const canManageSite = useSelector( ( state ) =>
 		canCurrentUser( state, site?.ID, 'manage_options' )
 	);
+	// An unloaded feature list is indistinguishable from an absent feature, so wait
+	// rather than upsell a site that already qualifies.
+	const featuresLoaded = useSelector(
+		( state ) => getFeaturesBySiteId( state, site?.ID ) !== null
+	);
+	const isVip = useSelector( ( state ) => isVipSite( state, site?.ID ?? 0 ) );
+	const isWPForTeams = useSelector( ( state ) => isSiteWPForTeams( state, site?.ID ?? null ) );
 	const requestingWordAdsApproval = useSelector( ( state ) =>
 		isRequestingWordAdsApprovalForSite( state, site )
 	);
@@ -77,6 +87,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 	const canUpgradeToUseWordAds = ! site?.options?.wordads && ! hasWordAdsFeature;
 	const isWordadsInstantEligibleButNotOwner =
 		! site?.options?.wordads && hasWordAdsFeature && ! canActivateWordAds;
+	const canShowUpsell = featuresLoaded && canManageSite && ! isVip && ! isWPForTeams;
 	const isEnrolledWithIneligiblePlan =
 		site?.options?.wordads && ! hasWordAdsFeature && wordAdsStatus === WordAdsStatus.ineligible;
 
@@ -213,6 +224,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 		benefits,
 		href,
 		tracksClickName,
+		ctaName,
 		learnMoreUrl,
 		fitToContent,
 	}: {
@@ -221,17 +233,23 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 		benefits?: TranslateResult[];
 		href: string;
 		tracksClickName: string;
+		ctaName?: string;
 		learnMoreUrl?: string;
 		fitToContent?: boolean;
 	} ) => {
+		const nudgeProperties = {
+			cta_name: ctaName,
+			cta_feature: WPCOM_FEATURES_WORDADS,
+			cta_size: 'regular',
+		};
 		const trackNudge = ( eventName: string ) =>
-			dispatch( recordTracksEvent( eventName, { cta_feature: WPCOM_FEATURES_WORDADS } ) );
+			dispatch( recordTracksEvent( eventName, nudgeProperties ) );
 
 		return (
 			<>
 				<TrackComponentView
 					eventName="calypso_upgrade_nudge_impression"
-					eventProperties={ { cta_feature: WPCOM_FEATURES_WORDADS } }
+					eventProperties={ nudgeProperties }
 				/>
 				<PromoCard
 					className={ clsx( 'earn__upsell-card', {
@@ -298,6 +316,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 			),
 			href: `/checkout/${ siteSlug }/${ PLAN_JETPACK_SECURITY_DAILY }`,
 			tracksClickName: 'calypso_upgrade_nudge_click',
+			ctaName: 'calypso_upgrade_nudge_impression',
 		} );
 
 	const renderNoticeSiteIsPrivate = () => {
@@ -353,12 +372,12 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 			component = renderOwnerRequiredMessage();
 		} else if (
 			canUpgradeToUseWordAds &&
-			canManageSite &&
+			canShowUpsell &&
 			site?.jetpack &&
 			! site?.is_wpcom_atomic
 		) {
 			component = renderjetpackUpsell();
-		} else if ( canUpgradeToUseWordAds && canManageSite ) {
+		} else if ( canUpgradeToUseWordAds && canShowUpsell ) {
 			component = renderUpsell();
 		} else if ( ! canAccessAds ) {
 			component = renderEmptyContent();
@@ -366,7 +385,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 			component = null;
 		} else if ( site.options?.wordads && site.is_private ) {
 			notice = renderNoticeSiteIsPrivate();
-		} else if ( isEnrolledWithIneligiblePlan ) {
+		} else if ( isEnrolledWithIneligiblePlan && ! isWPForTeams ) {
 			component = renderContentWithUpsell( component );
 		}
 		return { component, notice };

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -341,16 +341,17 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 		const url = `/plans/${ siteSlug }?feature=${ FEATURE_WORDADS_INSTANT }&plan=${ PLAN_PREMIUM }`;
 		return (
 			<>
-				{ renderUpsellCard( {
-					title: translate( 'Upgrade to the %(premiumPlanName)s plan to continue earning', {
-						args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
-					} ),
-					body: translate(
-						'WordAds is disabled for this site because it does not have an eligible plan. You are no longer earning ad revenue, but you can view your earning and payment history. To restore access to WordAds please upgrade to an eligible plan.'
-					),
-					href: url,
-					tracksClickName: 'calypso_upgrade_nudge_cta_click',
-				} ) }
+				{ ! isWPForTeams &&
+					renderUpsellCard( {
+						title: translate( 'Upgrade to the %(premiumPlanName)s plan to continue earning', {
+							args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
+						} ),
+						body: translate(
+							'WordAds is disabled for this site because it does not have an eligible plan. You are no longer earning ad revenue, but you can view your earning and payment history. To restore access to WordAds please upgrade to an eligible plan.'
+						),
+						href: url,
+						tracksClickName: 'calypso_upgrade_nudge_cta_click',
+					} ) }
 				{ isAllowedSection ? component : <FeatureExample>{ component }</FeatureExample> }
 			</>
 		);
@@ -385,7 +386,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 			component = null;
 		} else if ( site.options?.wordads && site.is_private ) {
 			notice = renderNoticeSiteIsPrivate();
-		} else if ( isEnrolledWithIneligiblePlan && ! isWPForTeams ) {
+		} else if ( isEnrolledWithIneligiblePlan ) {
 			component = renderContentWithUpsell( component );
 		}
 		return { component, notice };

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -18,8 +18,8 @@ import FeatureExample from 'calypso/components/feature-example';
 import FormButton from 'calypso/components/forms/form-button';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import { PromoSectionCard } from 'calypso/components/promo-section';
-import { PromoCardVariation } from 'calypso/components/promo-section/promo-card';
+import PromoCard, { PromoCardVariation } from 'calypso/components/promo-section/promo-card';
+import PromoCardCta from 'calypso/components/promo-section/promo-card/cta';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { WordAdsStatus } from 'calypso/my-sites/earn/ads/types';
 import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
@@ -208,12 +208,14 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 	const renderUpsellCard = ( {
 		title,
 		body,
+		benefits,
 		href,
 		tracksClickName,
 		learnMoreUrl,
 	}: {
 		title: TranslateResult;
 		body: TranslateResult;
+		benefits?: TranslateResult[];
 		href: string;
 		tracksClickName: string;
 		learnMoreUrl?: string;
@@ -227,13 +229,22 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 					eventName="calypso_upgrade_nudge_impression"
 					eventProperties={ { cta_feature: WPCOM_FEATURES_WORDADS } }
 				/>
-				<PromoSectionCard
+				<PromoCard
+					className="earn__upsell-card"
 					variation={ PromoCardVariation.Compact }
 					icon="speaker"
 					title={ title }
-					body={ body }
-					actions={ {
-						cta: {
+				>
+					<p>{ body }</p>
+					{ benefits && (
+						<ul className="earn__upsell-card-benefits">
+							{ benefits.map( ( benefit, index ) => (
+								<li key={ index }>{ benefit }</li>
+							) ) }
+						</ul>
+					) }
+					<PromoCardCta
+						cta={ {
 							text: translate( 'Upgrade' ),
 							isPrimary: true,
 							action: {
@@ -241,15 +252,17 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 								selfTarget: true,
 								onClick: () => trackNudge( tracksClickName ),
 							},
-						},
-						learnMoreLink: learnMoreUrl
-							? {
-									url: learnMoreUrl,
-									onClick: () => trackNudge( 'calypso_upgrade_nudge_learn_more_click' ),
-							  }
-							: null,
-					} }
-				/>
+						} }
+						learnMoreLink={
+							learnMoreUrl
+								? {
+										url: learnMoreUrl,
+										onClick: () => trackNudge( 'calypso_upgrade_nudge_learn_more_click' ),
+								  }
+								: null
+						}
+					/>
+				</PromoCard>
 			</>
 		);
 	};
@@ -260,8 +273,13 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 				args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
 			} ),
 			body: translate(
-				'Make money each time someone visits your site by displaying ads on your posts and pages.'
+				"By upgrading to the %(premiumPlanName)s plan, you'll be able to monetize your site through the WordAds program.",
+				{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' } }
 			),
+			benefits: [
+				translate( 'Instantly enroll into the WordAds network.' ),
+				translate( 'Earn money from your content and traffic.' ),
+			],
 			href: buildCheckoutURL( siteSlug as string, PLAN_PREMIUM ),
 			tracksClickName: 'calypso_upgrade_nudge_cta_click',
 			learnMoreUrl: 'https://wordads.co/',

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -5,7 +5,7 @@ import {
 	FEATURE_WORDADS_INSTANT,
 	getPlan,
 } from '@automattic/calypso-products';
-import { Card, ExternalLink } from '@automattic/components';
+import { Card } from '@automattic/components';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import wordAdsImage from 'calypso/assets/images/illustrations/dotcom-wordads.svg';
@@ -212,12 +212,14 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 		benefits,
 		href,
 		tracksClickName,
+		learnMoreUrl,
 	}: {
 		title: TranslateResult;
 		body: TranslateResult;
 		benefits?: TranslateResult[];
 		href: string;
 		tracksClickName: string;
+		learnMoreUrl?: string;
 	} ) => {
 		const trackNudge = ( eventName: string ) =>
 			dispatch( recordTracksEvent( eventName, { cta_feature: WPCOM_FEATURES_WORDADS } ) );
@@ -252,6 +254,14 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 								onClick: () => trackNudge( tracksClickName ),
 							},
 						} }
+						learnMoreLink={
+							learnMoreUrl
+								? {
+										url: learnMoreUrl,
+										onClick: () => trackNudge( 'calypso_upgrade_nudge_learn_more_click' ),
+								  }
+								: null
+						}
 					/>
 				</PromoCard>
 			</>
@@ -260,15 +270,10 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 
 	const renderUpsell = () =>
 		renderUpsellCard( {
-			title: translate( 'Upgrade to the %(premiumPlanName)s plan and start earning', {
-				args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
-			} ),
+			title: translate( 'Earn ad revenue' ),
 			body: translate(
-				"By upgrading to the %(premiumPlanName)s plan, you'll be able to monetize your site through the {{link}}WordAds program{{/link}}.",
-				{
-					args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
-					components: { link: <ExternalLink href="https://wordads.co/" icon /> },
-				}
+				"By upgrading to the %(premiumPlanName)s plan, you'll be able to monetize your site through the WordAds program.",
+				{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' } }
 			),
 			benefits: [
 				translate( 'Instantly enroll into the WordAds network.' ),
@@ -276,6 +281,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 			],
 			href: buildCheckoutURL( siteSlug as string, PLAN_PREMIUM ),
 			tracksClickName: 'calypso_upgrade_nudge_cta_click',
+			learnMoreUrl: 'https://wordads.co/',
 		} );
 
 	const renderjetpackUpsell = () =>

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -21,6 +21,7 @@ import NoticeAction from 'calypso/components/notice/notice-action';
 import PromoCard, { PromoCardVariation } from 'calypso/components/promo-section/promo-card';
 import PromoCardCta from 'calypso/components/promo-section/promo-card/cta';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { preventWidows } from 'calypso/lib/formatting';
 import { WordAdsStatus } from 'calypso/my-sites/earn/ads/types';
 import { buildCheckoutURL } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -231,9 +232,9 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 					className="earn__upsell-card"
 					variation={ PromoCardVariation.Compact }
 					icon="speaker"
-					title={ title }
+					title={ preventWidows( title ) }
 				>
-					<p>{ body }</p>
+					<p>{ preventWidows( body ) }</p>
 					{ benefits && (
 						<ul className="earn__upsell-card-benefits">
 							{ benefits.map( ( benefit, index ) => (
@@ -266,7 +267,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 				"By upgrading to the %(premiumPlanName)s plan, you'll be able to monetize your site through the {{link}}WordAds program{{/link}}.",
 				{
 					args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
-					components: { link: <ExternalLink href="https://wordads.co/" icon /> },
+					components: { link: <ExternalLink href="https://wordads.co/" /> },
 				}
 			),
 			benefits: [

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -87,7 +87,14 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 	const canUpgradeToUseWordAds = ! site?.options?.wordads && ! hasWordAdsFeature;
 	const isWordadsInstantEligibleButNotOwner =
 		! site?.options?.wordads && hasWordAdsFeature && ! canActivateWordAds;
-	const canShowUpsell = featuresLoaded && canManageSite && ! isVip && ! isWPForTeams;
+	// A site connected only through standalone Jetpack products reads as a Jetpack
+	// site without the `jetpack` flag, and WordPress.com plans are the wrong
+	// product for it.
+	const isStandaloneJetpack = useSelector(
+		( state ) => Boolean( isJetpackSite( state, site?.ID ) ) && ! site?.jetpack
+	);
+	const canShowUpsell =
+		featuresLoaded && canManageSite && ! isVip && ! isWPForTeams && ! isStandaloneJetpack;
 	const isEnrolledWithIneligiblePlan =
 		site?.options?.wordads && ! hasWordAdsFeature && wordAdsStatus === WordAdsStatus.ineligible;
 

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -371,15 +371,16 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 			component = renderInstantActivationToggle( component );
 		} else if ( isWordadsInstantEligibleButNotOwner ) {
 			component = renderOwnerRequiredMessage();
-		} else if (
-			canUpgradeToUseWordAds &&
-			canShowUpsell &&
-			site?.jetpack &&
-			! site?.is_wpcom_atomic
-		) {
-			component = renderjetpackUpsell();
-		} else if ( canUpgradeToUseWordAds && canShowUpsell ) {
-			component = renderUpsell();
+		} else if ( canUpgradeToUseWordAds ) {
+			// Terminal: a site that needs an upgrade shows the upsell or nothing, never
+			// the authorization notice below, which asks a different question.
+			if ( ! canShowUpsell ) {
+				component = null;
+			} else if ( site?.jetpack && ! site?.is_wpcom_atomic ) {
+				component = renderjetpackUpsell();
+			} else {
+				component = renderUpsell();
+			}
 		} else if ( ! canAccessAds ) {
 			component = renderEmptyContent();
 		} else if ( ! site?.options?.wordads && ! ( site?.jetpack && canUpgradeToUseWordAds ) ) {

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -179,7 +179,7 @@ const Home = () => {
 					},
 			  }
 			: {
-					text: translate( 'Unlock this feature' ),
+					text: translate( 'Upgrade' ),
 					isPrimary: true,
 					action: () => {
 						trackUpgrade( 'plans', 'simple-payments' );
@@ -400,7 +400,7 @@ const Home = () => {
 					disabled: isPeerReferralCtaDisabled,
 			  }
 			: {
-					text: translate( 'Unlock this feature' ),
+					text: translate( 'Upgrade' ),
 					isPrimary: true,
 					action: () => {
 						trackUpgrade( 'plans', 'peer-referral' );
@@ -477,7 +477,7 @@ const Home = () => {
 						},
 				  }
 				: {
-						text: translate( 'Unlock this feature' ),
+						text: translate( 'Upgrade' ),
 						isPrimary: true,
 						action: () => {
 							trackUpgrade( 'plans', 'ads' );

--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -19,6 +19,7 @@ import PromoCard, { PromoCardVariation } from 'calypso/components/promo-section/
 import PromoCardCta from 'calypso/components/promo-section/promo-card/cta';
 import SectionHeader from 'calypso/components/section-header';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import { preventWidows } from 'calypso/lib/formatting';
 import { useDispatch, useSelector } from 'calypso/state';
 import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
@@ -193,11 +194,15 @@ function ProductsList() {
 						className="earn__upsell-card"
 						variation={ PromoCardVariation.Compact }
 						icon="credit-card"
-						title={ translate( 'Upgrade to modify payment plans or add new plans' ) }
+						title={ preventWidows(
+							translate( 'Upgrade to modify payment plans or add new plans' )
+						) }
 					>
 						<p>
-							{ translate(
-								'Payment plans let you charge for memberships, subscriptions, and one-time offers.'
+							{ preventWidows(
+								translate(
+									'Payment plans let you charge for memberships, subscriptions, and one-time offers.'
+								)
 							) }
 						</p>
 						<PromoCardCta

--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -186,7 +186,15 @@ function ProductsList() {
 				// Purposefully isn't a dismissible nudge as without this nudge, the page would appear to be
 				// broken as it only does listing and deleting of plans and it wouldn't be clear how to change that.
 				<UpsellNudge
+					callToAction={ translate( 'Upgrade' ) }
 					title={ translate( 'Upgrade to modify payment plans or add new plans' ) }
+					description={ translate(
+						'Payment plans let you charge for memberships, subscriptions, and one-time offers.'
+					) }
+					list={ [
+						translate( 'Create as many payment plans as you need.' ),
+						translate( 'Charge one-time, monthly, or yearly.' ),
+					] }
 					href={ '/plans/' + site?.slug }
 					showIcon
 					onClick={ () => trackUpgrade() }

--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -15,8 +15,8 @@ import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import { PromoSectionCard } from 'calypso/components/promo-section';
-import { PromoCardVariation } from 'calypso/components/promo-section/promo-card';
+import PromoCard, { PromoCardVariation } from 'calypso/components/promo-section/promo-card';
+import PromoCardCta from 'calypso/components/promo-section/promo-card/cta';
 import SectionHeader from 'calypso/components/section-header';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -189,15 +189,19 @@ function ProductsList() {
 			{ hasLoadedFeatures && ! hasStripeFeature && (
 				<>
 					<TrackComponentView eventName="calypso_earn_page_payment_plans_upgrade_button_view" />
-					<PromoSectionCard
+					<PromoCard
+						className="earn__upsell-card"
 						variation={ PromoCardVariation.Compact }
 						icon="credit-card"
 						title={ translate( 'Upgrade to modify payment plans or add new plans' ) }
-						body={ translate(
-							'Payment plans let you charge for memberships, subscriptions, and one-time offers.'
-						) }
-						actions={ {
-							cta: {
+					>
+						<p>
+							{ translate(
+								'Payment plans let you charge for memberships, subscriptions, and one-time offers.'
+							) }
+						</p>
+						<PromoCardCta
+							cta={ {
 								text: translate( 'Upgrade' ),
 								isPrimary: true,
 								action: {
@@ -205,9 +209,9 @@ function ProductsList() {
 									onClick: trackUpgrade,
 									selfTarget: true,
 								},
-							},
-						} }
-					/>
+							} }
+						/>
+					</PromoCard>
 				</>
 			) }
 			{ hasLoadedFeatures && hasStripeFeature && (

--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -108,18 +108,13 @@ function ProductsList() {
 		window.location.hash === ADD_TIER_PLAN_HASH;
 	const default_product_type = defaultToTierPanel ? TYPE_TIER : null;
 
-	const upgradeNudgeProperties = {
-		cta_name: 'calypso_earn_page_payment_plans_upgrade_nudge',
-		cta_feature: FEATURE_RECURRING_PAYMENTS,
-		cta_size: 'regular',
-	};
-
 	const trackUpgrade = () => {
 		dispatch(
-			recordTracksEvent(
-				'calypso_earn_page_payment_plans_upgrade_button_click',
-				upgradeNudgeProperties
-			)
+			recordTracksEvent( 'calypso_earn_page_payment_plans_upgrade_button_click', {
+				cta_name: 'calypso_earn_page_payment_plans_upgrade_nudge',
+				cta_feature: FEATURE_RECURRING_PAYMENTS,
+				cta_size: 'regular',
+			} )
 		);
 		dispatch( bumpStat( 'calypso_earn_page', 'payment-plans-upgrade-button' ) );
 	};
@@ -216,7 +211,11 @@ function ProductsList() {
 				<>
 					<TrackComponentView
 						eventName="calypso_earn_page_payment_plans_upgrade_button_view"
-						eventProperties={ upgradeNudgeProperties }
+						eventProperties={ {
+							cta_name: 'calypso_earn_page_payment_plans_upgrade_nudge',
+							cta_feature: FEATURE_RECURRING_PAYMENTS,
+							cta_size: 'regular',
+						} }
 					/>
 					<PromoCard
 						variation={ PromoCardVariation.Compact }

--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -9,14 +9,16 @@ import { __experimentalHStack as HStack } from '@wordpress/components';
 import DOMPurify from 'dompurify';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
-import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import { PromoSectionCard } from 'calypso/components/promo-section';
+import { PromoCardVariation } from 'calypso/components/promo-section/promo-card';
 import SectionHeader from 'calypso/components/section-header';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { useDispatch, useSelector } from 'calypso/state';
 import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
@@ -91,8 +93,10 @@ function ProductsList() {
 		window.location.hash === ADD_TIER_PLAN_HASH;
 	const default_product_type = defaultToTierPanel ? TYPE_TIER : null;
 
-	const trackUpgrade = () =>
+	const trackUpgrade = () => {
+		dispatch( recordTracksEvent( 'calypso_earn_page_payment_plans_upgrade_button_click' ) );
 		dispatch( bumpStat( 'calypso_earn_page', 'payment-plans-upgrade-button' ) );
+	};
 
 	function renderEllipsisMenu( productId: number ) {
 		return (
@@ -183,28 +187,28 @@ function ProductsList() {
 			     request on donation-only / non-newsletter sites. */ }
 			{ hasNewsletterTier && site?.ID && <QuerySiteSettings siteId={ site.ID } /> }
 			{ hasLoadedFeatures && ! hasStripeFeature && (
-				// Purposefully isn't a dismissible nudge as without this nudge, the page would appear to be
-				// broken as it only does listing and deleting of plans and it wouldn't be clear how to change that.
-				<UpsellNudge
-					callToAction={ translate( 'Upgrade' ) }
-					title={ translate( 'Upgrade to modify payment plans or add new plans' ) }
-					description={ translate(
-						'Payment plans let you charge for memberships, subscriptions, and one-time offers.'
-					) }
-					list={ [
-						translate( 'Create as many payment plans as you need.' ),
-						translate( 'Charge one-time, monthly, or yearly.' ),
-					] }
-					href={ '/plans/' + site?.slug }
-					showIcon
-					onClick={ () => trackUpgrade() }
-					// This could be any stripe payment features (see `hasStripeFeature`) but UpsellNudge only
-					// supports 1. They're all available on the same plans anyway, so practically it's ok to pick 1.
-					feature={ FEATURE_RECURRING_PAYMENTS }
-					event="calypso_earn_page_payment_plans_upgrade_nudge"
-					tracksClickName="calypso_earn_page_payment_plans_upgrade_button_click"
-					tracksImpressionName="calypso_earn_page_payment_plans_upgrade_button_view"
-				/>
+				<>
+					<TrackComponentView eventName="calypso_earn_page_payment_plans_upgrade_button_view" />
+					<PromoSectionCard
+						variation={ PromoCardVariation.Compact }
+						icon="credit-card"
+						title={ translate( 'Upgrade to modify payment plans or add new plans' ) }
+						body={ translate(
+							'Payment plans let you charge for memberships, subscriptions, and one-time offers.'
+						) }
+						actions={ {
+							cta: {
+								text: translate( 'Upgrade' ),
+								isPrimary: true,
+								action: {
+									url: `/plans/${ site?.slug }`,
+									onClick: trackUpgrade,
+									selfTarget: true,
+								},
+							},
+						} }
+					/>
+				</>
 			) }
 			{ hasLoadedFeatures && hasStripeFeature && (
 				<SectionHeader label={ translate( 'Manage plans' ) }>

--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -28,6 +28,7 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSettings } from 'calypso/state/site-settings/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import RecurringPaymentsPlanAddEditModal from '../components/add-edit-plan-modal';
 import FreePlanModal from '../components/free-plan-modal';
@@ -93,7 +94,14 @@ function ProductsList() {
 	const isVip = useSelector( ( state ) => isVipSite( state, site?.ID ?? 0 ) );
 	const isWPForTeams = useSelector( ( state ) => isSiteWPForTeams( state, site?.ID ?? null ) );
 	// Admins are already the only ones here; the section returns a notice for everyone else.
-	const canShowUpsell = hasLoadedFeatures && ! hasStripeFeature && ! isVip && ! isWPForTeams;
+	// A site connected only through standalone Jetpack products reads as a Jetpack
+	// site without the `jetpack` flag, and WordPress.com plans are the wrong
+	// product for it.
+	const isStandaloneJetpack = useSelector(
+		( state ) => Boolean( isJetpackSite( state, site?.ID ) ) && ! site?.jetpack
+	);
+	const canShowUpsell =
+		hasLoadedFeatures && ! hasStripeFeature && ! isVip && ! isWPForTeams && ! isStandaloneJetpack;
 
 	const defaultToTierPanel =
 		window.location.hash === OLD_ADD_NEWSLETTER_PAYMENT_PLAN_HASH ||

--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -24,6 +24,8 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { bumpStat, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
 import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSiteSettings } from 'calypso/state/site-settings/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -88,14 +90,29 @@ function ProductsList() {
 
 	const hasStripeFeature =
 		hasDonationsFeature || hasPremiumContentFeature || hasRecurringPaymentsFeature;
+	const isVip = useSelector( ( state ) => isVipSite( state, site?.ID ?? 0 ) );
+	const isWPForTeams = useSelector( ( state ) => isSiteWPForTeams( state, site?.ID ?? null ) );
+	// Admins are already the only ones here; the section returns a notice for everyone else.
+	const canShowUpsell = hasLoadedFeatures && ! hasStripeFeature && ! isVip && ! isWPForTeams;
 
 	const defaultToTierPanel =
 		window.location.hash === OLD_ADD_NEWSLETTER_PAYMENT_PLAN_HASH ||
 		window.location.hash === ADD_TIER_PLAN_HASH;
 	const default_product_type = defaultToTierPanel ? TYPE_TIER : null;
 
+	const upgradeNudgeProperties = {
+		cta_name: 'calypso_earn_page_payment_plans_upgrade_nudge',
+		cta_feature: FEATURE_RECURRING_PAYMENTS,
+		cta_size: 'regular',
+	};
+
 	const trackUpgrade = () => {
-		dispatch( recordTracksEvent( 'calypso_earn_page_payment_plans_upgrade_button_click' ) );
+		dispatch(
+			recordTracksEvent(
+				'calypso_earn_page_payment_plans_upgrade_button_click',
+				upgradeNudgeProperties
+			)
+		);
 		dispatch( bumpStat( 'calypso_earn_page', 'payment-plans-upgrade-button' ) );
 	};
 
@@ -187,9 +204,12 @@ function ProductsList() {
 			     only appears when a newsletter tier exists — avoid the extra
 			     request on donation-only / non-newsletter sites. */ }
 			{ hasNewsletterTier && site?.ID && <QuerySiteSettings siteId={ site.ID } /> }
-			{ hasLoadedFeatures && ! hasStripeFeature && (
+			{ canShowUpsell && (
 				<>
-					<TrackComponentView eventName="calypso_earn_page_payment_plans_upgrade_button_view" />
+					<TrackComponentView
+						eventName="calypso_earn_page_payment_plans_upgrade_button_view"
+						eventProperties={ upgradeNudgeProperties }
+					/>
 					<PromoCard
 						variation={ PromoCardVariation.Compact }
 						icon="credit-card"

--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -191,7 +191,6 @@ function ProductsList() {
 				<>
 					<TrackComponentView eventName="calypso_earn_page_payment_plans_upgrade_button_view" />
 					<PromoCard
-						className="earn__upsell-card is-content-width"
 						variation={ PromoCardVariation.Compact }
 						icon="credit-card"
 						title={ preventWidows(

--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -91,30 +91,36 @@ function ProductsList() {
 
 	const hasStripeFeature =
 		hasDonationsFeature || hasPremiumContentFeature || hasRecurringPaymentsFeature;
-	const isVip = useSelector( ( state ) => isVipSite( state, site?.ID ?? 0 ) );
-	const isWPForTeams = useSelector( ( state ) => isSiteWPForTeams( state, site?.ID ?? null ) );
-	// Admins are already the only ones here; the section returns a notice for everyone else.
-	// A site connected only through standalone Jetpack products reads as a Jetpack
-	// site without the `jetpack` flag, and WordPress.com plans are the wrong
-	// product for it.
-	const isStandaloneJetpack = useSelector(
-		( state ) => Boolean( isJetpackSite( state, site?.ID ) ) && ! site?.jetpack
-	);
+	// Admins are already the only ones here; the section returns a notice for
+	// everyone else. A standalone Jetpack connection reads as a Jetpack site while
+	// its `jetpack` flag stays false, and none of these can buy a WordPress.com plan.
 	const canShowUpsell =
-		hasLoadedFeatures && ! hasStripeFeature && ! isVip && ! isWPForTeams && ! isStandaloneJetpack;
+		useSelector(
+			( state ) =>
+				! isVipSite( state, site?.ID ?? 0 ) &&
+				! isSiteWPForTeams( state, site?.ID ?? null ) &&
+				! ( Boolean( isJetpackSite( state, site?.ID ) ) && ! site?.jetpack )
+		) &&
+		hasLoadedFeatures &&
+		! hasStripeFeature;
 
 	const defaultToTierPanel =
 		window.location.hash === OLD_ADD_NEWSLETTER_PAYMENT_PLAN_HASH ||
 		window.location.hash === ADD_TIER_PLAN_HASH;
 	const default_product_type = defaultToTierPanel ? TYPE_TIER : null;
 
+	const upgradeNudgeProperties = {
+		cta_name: 'calypso_earn_page_payment_plans_upgrade_nudge',
+		cta_feature: FEATURE_RECURRING_PAYMENTS,
+		cta_size: 'regular',
+	};
+
 	const trackUpgrade = () => {
 		dispatch(
-			recordTracksEvent( 'calypso_earn_page_payment_plans_upgrade_button_click', {
-				cta_name: 'calypso_earn_page_payment_plans_upgrade_nudge',
-				cta_feature: FEATURE_RECURRING_PAYMENTS,
-				cta_size: 'regular',
-			} )
+			recordTracksEvent(
+				'calypso_earn_page_payment_plans_upgrade_button_click',
+				upgradeNudgeProperties
+			)
 		);
 		dispatch( bumpStat( 'calypso_earn_page', 'payment-plans-upgrade-button' ) );
 	};
@@ -211,11 +217,7 @@ function ProductsList() {
 				<>
 					<TrackComponentView
 						eventName="calypso_earn_page_payment_plans_upgrade_button_view"
-						eventProperties={ {
-							cta_name: 'calypso_earn_page_payment_plans_upgrade_nudge',
-							cta_feature: FEATURE_RECURRING_PAYMENTS,
-							cta_size: 'regular',
-						} }
+						eventProperties={ upgradeNudgeProperties }
 					/>
 					<PromoCard
 						variation={ PromoCardVariation.Compact }

--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -191,7 +191,7 @@ function ProductsList() {
 				<>
 					<TrackComponentView eventName="calypso_earn_page_payment_plans_upgrade_button_view" />
 					<PromoCard
-						className="earn__upsell-card"
+						className="earn__upsell-card is-content-width"
 						variation={ PromoCardVariation.Compact }
 						icon="credit-card"
 						title={ preventWidows(

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -250,6 +250,12 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 .earn__upsell-card.promo-card {
 	max-width: 660px;
 	margin-inline: 0 auto;
+
+	/* The WordAds pitch is one sentence that reads better unbroken, so this card
+	   takes its own copy's width rather than the shared measure. */
+	&.is-content-width {
+		max-width: fit-content;
+	}
 }
 
 /* The benefits finish the thought the paragraph starts, so they sit tight to it

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -251,8 +251,9 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 	max-width: 660px;
 	margin-inline: 0 auto;
 
-	/* The WordAds pitch is one sentence that reads better unbroken, so this card
-	   takes its own copy's width rather than the shared measure. */
+	/* Cards whose copy is a single sentence take its width rather than the shared
+	   measure. The rest keep the cap: the ineligible-plan copy is long enough
+	   that fit-content would resolve to the full page width. */
 	&.is-content-width {
 		max-width: fit-content;
 	}

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -245,22 +245,19 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 	text-decoration: none;
 }
 
-/* Alone on a tab rather than in the promo grid: cap the measure, and undo the
-   centering that Card's `margin: 0 auto` applies once the width is capped. */
+/* Card's own `margin: 0 auto` would center these once the width is capped. */
 .earn__upsell-card.promo-card {
 	max-width: 660px;
 	margin-inline: 0 auto;
 
-	/* An upsell that is a tab's whole content has nothing beside it to line up
-	   with, so it takes its copy's width. One that sits in a stack of cards
-	   keeps the cap and aligns with them instead. */
+	/* For an upsell that is a whole tab's content, with nothing beside it to line
+	   up with. Ones sitting in a stack of cards keep the cap and align instead. */
 	&.is-content-width {
 		max-width: fit-content;
 	}
 }
 
-/* The benefits finish the thought the paragraph starts, so they sit tight to it
-   and keep the paragraph's usual 20px in front of the buttons. */
+/* The benefits continue the paragraph, so the 20px gap moves below them. */
 .earn__upsell-card p:has(+ .earn__upsell-card-benefits) {
 	margin-bottom: 8px;
 }

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -245,6 +245,18 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 	text-decoration: none;
 }
 
+/* Standalone upsell cards sit alone on a tab rather than in the promo grid,
+   so they need a measure of their own instead of the full content width. */
+.earn__upsell-card.promo-card {
+	max-width: 660px;
+}
+
+.earn__upsell-card-benefits {
+	margin-block: 0 16px;
+	margin-inline-start: 20px;
+	list-style: disc;
+}
+
 .earn__notes {
 	clear: both;
 	padding-bottom: 12px;

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -251,9 +251,9 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 	max-width: 660px;
 	margin-inline: 0 auto;
 
-	/* Cards whose copy is a single sentence take its width rather than the shared
-	   measure. The rest keep the cap: the ineligible-plan copy is long enough
-	   that fit-content would resolve to the full page width. */
+	/* An upsell that is a tab's whole content has nothing beside it to line up
+	   with, so it takes its copy's width. One that sits in a stack of cards
+	   keeps the cap and aligns with them instead. */
 	&.is-content-width {
 		max-width: fit-content;
 	}

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -245,10 +245,11 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 	text-decoration: none;
 }
 
-/* Standalone upsell cards sit alone on a tab rather than in the promo grid,
-   so they need a measure of their own instead of the full content width. */
+/* Alone on a tab rather than in the promo grid: cap the measure, and undo the
+   centering that Card's `margin: 0 auto` applies once the width is capped. */
 .earn__upsell-card.promo-card {
 	max-width: 660px;
+	margin-inline: 0 auto;
 }
 
 .earn__upsell-card-benefits {

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -252,9 +252,16 @@ See https://dequeuniversity.com/rules/axe/4.6/link-in-text-block?application=Axe
 	margin-inline: 0 auto;
 }
 
+/* The benefits finish the thought the paragraph starts, so they sit tight to it
+   and keep the paragraph's usual 20px in front of the buttons. */
+.earn__upsell-card p:has(+ .earn__upsell-card-benefits) {
+	margin-bottom: 8px;
+}
+
 .earn__upsell-card-benefits {
-	margin-block: 0 16px;
-	margin-inline-start: 20px;
+	margin-block: 0 20px;
+	margin-inline-start: 0;
+	padding-inline-start: 20px;
 	list-style: disc;
 }
 


### PR DESCRIPTION
Fixes DSGCOM-581

## Proposed Changes

* Render every upsell in the Monetize section as the same promo card, replacing the full-width banners on Ads and Payment Settings and the bare title-and-chevron row that had no button at all.
* Settle on one CTA. The Monetization Options cards said "Unlock this feature" and the banners said "Upgrade"; everything now says "Upgrade".
* Size each card to its surroundings: the Ads upsell takes its copy's width, since it is that tab's whole content, while the Payment Settings one matches the full-width cards it sits above.
* Fix a promo card bug the conversion exposed, where the compact variation styled every icon it contained as the grey title chip.

## Why are these changes being made?

The section offered three shapes for the same ask, with two different CTA labels between them. It read as three unrelated products, and the Payment Settings row gave people no idea what upgrading would buy them.

That shared block carried eligibility rules and analytics beyond its markup, so both are applied locally now. The upsells check upgrade permission, exclude VIP, P2 and standalone-Jetpack sites, wait for site features to load rather than reading an unloaded list as an absent feature, and send the properties the banner sent. The Ads upgrade state is terminal too, so a suppressed upsell no longer falls through to an authorization notice.

One deliberate loss remains: people with a stored card no longer get the one-click purchase modal and land on checkout instead. That came from a default on the shared component rather than a choice made for these banners.

## Testing Instructions

* On a free site, visit Monetize. The Collect PayPal payments, Earn ad revenue, and Refer a friend cards should all show an **Upgrade** button.
* Open the **Ads** tab. The upsell should be a card matching those — description, two WordAds benefits, **Upgrade** and **Learn more** — not a full-width banner.
* Open **Payment Settings**. The old title-and-chevron row should now be a card with body copy and an **Upgrade** button, aligned with the Settings card below it. It only renders for sites with none of the `donations`, `recurring-payments` or `premium-content/container` features — if you see the "Manage plans" header instead, the site has them and the upsell is correctly suppressed.
* As a non-admin on a free site, the Ads tab should offer no upgrade and show no authorization error.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPwiDeyGWygfgFRvDge6BB
