### PR TITLE
Global navigation: keep dropdowns open while hovering the top bar

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/index.tsx
@@ -97,7 +97,13 @@ const UniversalNavbarHeader = ( {
 			setActiveDropdown( name );
 			return;
 		}
-		dropdownTimerRef.current = setTimeout( () => setActiveDropdown( name ), delay );
+		dropdownTimerRef.current = setTimeout( () => {
+			// The bar and dropdown share one pointer area while a menu is open.
+			if ( name === null && legacyNavRef.current?.matches( ':hover' ) ) {
+				return;
+			}
+			setActiveDropdown( name );
+		}, delay );
 	}, [] );
 	useEffect( () => () => clearTimeout( dropdownTimerRef.current ?? undefined ), [] );
 
@@ -321,6 +327,9 @@ const UniversalNavbarHeader = ( {
 								ref={ legacyNavRef }
 								className={ clsx( 'x-nav', { 'x-nav--2026-redesign': nav2026 } ) }
 								aria-label="WordPress.com"
+								onMouseLeave={
+									nav2026 ? () => showDropdown( DROPDOWN_CLOSE_DELAY, null ) : undefined
+								}
 							>
 								<ul className="x-nav-list x-nav-list__left" role="menu">
 									<li
@@ -330,12 +339,11 @@ const UniversalNavbarHeader = ( {
 											nav2026
 												? () => {
 														recordNavItemHover( isScrolled, 'logo', false );
-														// Hovering a non-dropdown item closes the open dropdown.
 														showDropdown( DROPDOWN_CLOSE_DELAY, null );
 												  }
 												: undefined
 										}
-										// Keyboard parity: focusing into the logo also closes the open dropdown.
+										// Keyboard focus on the logo closes the dropdown.
 										onFocusCapture={ nav2026 ? () => setActiveDropdown( null ) : undefined }
 									>
 										<a
@@ -391,10 +399,9 @@ const UniversalNavbarHeader = ( {
 														target="_self"
 														onItemMouseEnter={ () => {
 															recordNavItemHover( isScrolled, menu.name, false );
-															// Hovering a non-dropdown item closes the open dropdown.
 															showDropdown( DROPDOWN_CLOSE_DELAY, null );
 														} }
-														// Keyboard parity: focusing the item also closes the open dropdown.
+														// Keyboard focus on a non-dropdown item closes the dropdown.
 														onItemFocus={ () => setActiveDropdown( null ) }
 													/>
 												)


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Related to #114131

## Proposed Changes

* Keep an open dropdown visible while the pointer moves across the top navigation, including Support, Pricing, the logo, and Get started.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Let visitors move the pointer away from dropdown links to read without accidentally dismissing the menu.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With the branch running locally and signed in, open `http://calypso.localhost:3000/patterns?flags=nav-redesign/2026` on desktop.
* Hover Resources, move into its dropdown, then move back across the top bar, including blank space, Support, Pricing, the logo, and Get started. The Resources dropdown should stay open.
* Hover Products to switch menus. Move the pointer outside the bar and dropdown, or below the dropdown: it should close after the usual short delay.
* Focus Resources and press Tab to Support: keyboard navigation should still close the dropdown.

Validation: browser hover checks, ESLint, Prettier, and the template-parts package type-check passed. The full client type-check fails on unchanged trunk because of missing workspace package declarations, including omnibar. Escape also leaves a hovered menu open on unchanged trunk; that separate keyboard issue is outside this change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
