### PR TITLE
A4A: Use compact buttons on Exclusive Offers and Tiers cards

### DIFF
--- a/client/dashboard/agency/marketplace/exclusive-offers/partner-offers.tsx
+++ b/client/dashboard/agency/marketplace/exclusive-offers/partner-offers.tsx
@@ -85,6 +85,7 @@ function PartnerOfferCard( {
 					>
 						{ /* TODO: non-external URLs are classic A4A marketplace paths that 404 until the dashboard Marketplace exists. */ }
 						<Button
+							size="compact"
 							variant="secondary"
 							href={ item.cta.url }
 							target={ item.cta.external ? '_blank' : undefined }
@@ -93,6 +94,7 @@ function PartnerOfferCard( {
 							{ item.cta.label }
 						</Button>
 						<Button
+							size="compact"
 							variant="link"
 							href={ item.termsUrl ?? VIEW_TERMS_URL }
 							target="_blank"

--- a/client/dashboard/agency/tiers/tier-cards.tsx
+++ b/client/dashboard/agency/tiers/tier-cards.tsx
@@ -176,6 +176,7 @@ export default function TierCards( {
 							<Text color={ TEXT_COLOR }>{ tier.subheading }</Text>
 						</VStack>
 						<Button
+							size="compact"
 							onClick={ () => handleViewBenefits( tier.id as string ) }
 							variant={ isSecondary ? 'secondary' : 'primary' }
 							style={ { marginBlockStart: '24px', alignSelf: 'flex-start' } }


### PR DESCRIPTION
Fixes A4A-3329

## Proposed Changes

* On the Exclusive Offers page, the offer call-to-action button (for example “Refer Pressable”) and the “View terms” link next to it now use the compact button size.
* On the Tiers page, the “See what you’ll unlock” / “View your benefits” button on each tier card now uses the compact button size.

## Why are these changes being made?

* The offer buttons on the Exclusive Offers page looked noticeably larger than the tier card buttons, even though both use the same button style. Making both compact keeps the two pages visually consistent and matches the compact secondary buttons already used elsewhere in the agency dashboard (Overview tier card, Referrals empty state).

## Testing Instructions

* Open the Dashboard (A4A) live link > Manually change the URL to `/exclusive-offers`.
* Confirm each offer card’s button (for example “Refer Pressable”) and the “View terms” link are the compact size and vertically aligned with each other.
* Manually change the URL to `/tiers`.
* Confirm the “See what you’ll unlock” / “View your benefits” button on each tier card is the compact size.
* Compare the two pages: the buttons should now look the same size.

### Screenshots

**Exclusive offers**

<img width="1920" height="766" alt="Exclusive offers page with compact offer buttons" src="https://github.com/user-attachments/assets/4cda20fe-5fc7-49b6-b763-588b1a8766cd" />

**Tiers**

<img width="1920" height="890" alt="Tiers page with compact tier card buttons" src="https://github.com/user-attachments/assets/7579e1ec-4f88-4e34-a811-9eed9ac99c3d" />

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

