### PR TITLE
A4A Sites: Use a design-system Card and legend on the Monitor tab

### DIFF
--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
@@ -98,7 +98,7 @@ export function JetpackMonitorPreview( { site, trackEvent, hasError = false }: P
 						{ hasMonitor && (
 							<Text variant="muted">
 								{ __(
-									'Jetpack will continuously monitor your site, and alert you the moment downtime is detected.'
+									'We will continuously monitor your site and alert you the moment downtime is detected.'
 								) }{ ' ' }
 								<ExternalLink href="https://jetpack.com/support/monitor/">
 									{ __( 'Learn more' ) }

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
@@ -3,8 +3,10 @@ import {
 	Card,
 	CardBody,
 	CardFooter,
+	ExternalLink,
 	__experimentalHStack as HStack,
 	__experimentalText as Text,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { bell } from '@wordpress/icons';
@@ -77,21 +79,33 @@ export function JetpackMonitorPreview( { site, trackEvent, hasError = false }: P
 						</Button>
 					</A4AEmptyState>
 				) : (
-					<Card>
-						<CardBody>
-							<MonitorActivity
-								hasMonitor={ hasMonitor }
-								site={ site }
-								trackEvent={ trackEvent }
-								hasError={ hasError }
-							/>
-						</CardBody>
+					<VStack spacing={ 4 }>
+						<Card>
+							<CardBody>
+								<MonitorActivity
+									hasMonitor={ hasMonitor }
+									site={ site }
+									trackEvent={ trackEvent }
+									hasError={ hasError }
+								/>
+							</CardBody>
+							{ hasMonitor && (
+								<CardFooter justify="flex-start">
+									<MonitorLegend />
+								</CardFooter>
+							) }
+						</Card>
 						{ hasMonitor && (
-							<CardFooter justify="flex-start">
-								<MonitorLegend />
-							</CardFooter>
+							<Text variant="muted">
+								{ __(
+									'Jetpack will continuously monitor your site, and alert you the moment downtime is detected.'
+								) }{ ' ' }
+								<ExternalLink href="https://jetpack.com/support/monitor/">
+									{ __( 'Learn more' ) }
+								</ExternalLink>
+							</Text>
 						) }
-					</Card>
+					</VStack>
 				) }
 			</div>
 		</>

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
@@ -1,4 +1,11 @@
-import { Button, Card, CardBody } from '@wordpress/components';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardFooter,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { bell } from '@wordpress/icons';
 import A4AEmptyState from 'calypso/a8c-for-agencies/components/a4a-empty-state';
@@ -14,6 +21,28 @@ type Props = {
 	trackEvent: ( eventName: string ) => void;
 	hasError?: boolean;
 };
+
+function MonitorLegend() {
+	const items = [
+		{ key: 'uptime', label: __( 'Uptime' ) },
+		{ key: 'downtime', label: __( 'Downtime' ) },
+		{ key: 'no-data', label: __( 'No data' ) },
+	];
+
+	return (
+		<HStack spacing={ 4 } justify="flex-start" wrap>
+			{ items.map( ( { key, label } ) => (
+				<HStack key={ key } spacing={ 2 } expanded={ false }>
+					<span
+						className={ `site-preview-pane__monitor-legend-swatch is-${ key }` }
+						aria-hidden="true"
+					/>
+					<Text variant="muted">{ label }</Text>
+				</HStack>
+			) ) }
+		</HStack>
+	);
+}
 
 export function JetpackMonitorPreview( { site, trackEvent, hasError = false }: Props ) {
 	const hasMonitor = site.monitor_settings.monitor_active;
@@ -57,6 +86,11 @@ export function JetpackMonitorPreview( { site, trackEvent, hasError = false }: P
 								hasError={ hasError }
 							/>
 						</CardBody>
+						{ hasMonitor && (
+							<CardFooter justify="flex-start">
+								<MonitorLegend />
+							</CardFooter>
+						) }
 					</Card>
 				) }
 			</div>

--- a/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
+++ b/client/a8c-for-agencies/sections/sites/features/jetpack/jetpack-monitor.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components';
+import { Button, Card, CardBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { bell } from '@wordpress/icons';
 import A4AEmptyState from 'calypso/a8c-for-agencies/components/a4a-empty-state';
@@ -48,12 +48,16 @@ export function JetpackMonitorPreview( { site, trackEvent, hasError = false }: P
 						</Button>
 					</A4AEmptyState>
 				) : (
-					<MonitorActivity
-						hasMonitor={ hasMonitor }
-						site={ site }
-						trackEvent={ trackEvent }
-						hasError={ hasError }
-					/>
+					<Card>
+						<CardBody>
+							<MonitorActivity
+								hasMonitor={ hasMonitor }
+								site={ site }
+								trackEvent={ trackEvent }
+								hasError={ hasError }
+							/>
+						</CardBody>
+					</Card>
 				) }
 			</div>
 		</>

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/a4a-style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/a4a-style.scss
@@ -109,7 +109,7 @@
 		max-width: unset;
 	}
 
-	// Same studio tokens the shared chart styles resolve the bar colours to.
+	// A4A aliases of the studio tokens the shared chart styles paint the bars with.
 	.site-preview-pane__monitor-legend-swatch {
 		flex-shrink: 0;
 		width: 12px;
@@ -117,16 +117,16 @@
 		border-radius: 2px;
 
 		&.is-uptime {
-			background-color: var(--studio-jetpack-green-40);
+			background-color: var(--color-jetpack-40);
 		}
 
 		&.is-downtime {
-			background-color: var(--studio-red-50);
+			background-color: var(--color-scary-50);
 		}
 
 		&.is-no-data {
-			background-color: var(--studio-gray-0);
-			border: 1px solid var(--studio-gray-5);
+			background-color: var(--color-accent-0);
+			border: 1px solid var(--color-accent-5);
 		}
 	}
 

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/a4a-style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/a4a-style.scss
@@ -109,6 +109,27 @@
 		max-width: unset;
 	}
 
+	// Same studio tokens the shared chart styles resolve the bar colours to.
+	.site-preview-pane__monitor-legend-swatch {
+		flex-shrink: 0;
+		width: 12px;
+		height: 12px;
+		border-radius: 2px;
+
+		&.is-uptime {
+			background-color: var(--studio-jetpack-green-40);
+		}
+
+		&.is-downtime {
+			background-color: var(--studio-red-50);
+		}
+
+		&.is-no-data {
+			background-color: var(--studio-gray-0);
+			border: 1px solid var(--studio-gray-5);
+		}
+	}
+
 	.chart__bars {
 		overflow: hidden;
 		gap: 3px;

--- a/client/a8c-for-agencies/sections/sites/site-preview-pane/a4a-style.scss
+++ b/client/a8c-for-agencies/sections/sites/site-preview-pane/a4a-style.scss
@@ -101,6 +101,10 @@
 	padding-block-start: 16px;
 	text-align: unset !important;
 
+	.expanded-card {
+		min-height: unset;
+	}
+
 	.site-expanded-content__card-content-column {
 		max-width: unset;
 	}


### PR DESCRIPTION
## Proposed Changes

* On the Sites > site > **Monitor** tab, render the shared Monitor activity component inside `Card` / `CardBody` from `@wordpress/components`, and reset the shared card's 160px minimum height in the preview pane so the bordered card hugs its content.
* Add a legend in a `CardFooter` under the chart: **Uptime**, **Downtime**, **No data**, each with an `aria-hidden` swatch coloured by the same studio tokens the chart bars use (`--color-jetpack-40`, `--color-scary-50`, `--color-accent-0`, the A4A aliases of the studio tokens the chart uses).
* Add a muted caption below the card explaining what Monitor does ("We will continuously monitor your site and alert you the moment downtime is detected."), with a "Learn more" `ExternalLink` to the Jetpack Monitor support page.
* The legend and caption only render when Monitor is active. The inactive empty state is unchanged.
* Everything lives in the A4A-only wrapper (`jetpack-monitor.tsx`) and the A4A pane stylesheet. The shared `MonitorActivity` component and its stylesheet are untouched, so the Jetpack Cloud agency dashboard renders exactly as before.

## Why are these changes being made?

* The Monitor tab reuses the `MonitorActivity` card from the Jetpack Cloud agency dashboard, where it sits in a four-up grid of compact cards. The A4A preview pane stylesheet strips that card's border, shadow and padding to fit the pane, so the tab rendered as a bare "Monitor activity" heading over a strip of pale bars with "20d ago" and "Today" underneath. Nothing on the tab said what the bar colours mean (the meaning was only in the per-bar tooltips) or what Monitor does for the site.
* That looked unfinished next to the other A4A screens that already use design-system cards, and it was hard to read at a glance.
* This wraps the shared component in the design system's Card in the A4A wrapper only, and adds the two pieces of context that were missing, without adding any new stats or data. An earlier attempt (#112971) added summary stats, a status pill and a lot of bespoke CSS; this PR keeps only the legend from that direction and uses design-system primitives and public APIs instead.

## Screenshots

Before:

<img width="1451" height="251" alt="image" src="https://github.com/user-attachments/assets/407bb59f-c14c-415e-ae0e-f4712561eaa6" />

After:

<img width="1450" height="341" alt="image" src="https://github.com/user-attachments/assets/0ef92765-1467-432e-81fc-19bc3ffcbbf6" />

## Testing Instructions

Using this PR's Calypso Live link with the `a8c-for-agencies` environment, sign in as an agency that has a site with Jetpack Monitor active.

* Go to **Sites**, click a site with Monitor active, then open the **Monitor** tab.
* Confirm the activity strip now renders inside a bordered, rounded card with the "Monitor activity" heading, the bars and the "20d ago" / "Today" labels.
* Confirm a legend with three swatches (Uptime, Downtime, No data) sits in the card footer, and the swatch colours match the bar colours.
* Confirm a muted caption below the card reads "We will continuously monitor your site and alert you the moment downtime is detected. Learn more", and that "Learn more" opens the Jetpack Monitor support page in a new tab.
* Click a site where Monitor is **not** active and open the **Monitor** tab. Confirm the existing "Monitor is not active" empty state with its "Activate Monitor" button is unchanged, with no legend or caption.
* Optional Jetpack Cloud check: run `yarn start-jetpack-cloud`, open the agency dashboard Sites list, expand a site row, and confirm the compact "Monitor activity" card there looks exactly as it does on trunk.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
