### PR TITLE
Global navigation: make diagonal movement into dropdowns more forgiving

### DIFF
--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1355,6 +1355,15 @@ $x-menu-2026-admin-bar-mobile: 46px;
 }
 
 @media ( min-width: 1025px ) {
+	// Keep diagonal pointer travel below the nav labels inside the open dropdown.
+	.x-dropdown.x-dropdown--2026.is-dropdown-open::before {
+		content: '';
+		position: absolute;
+		inset-inline: 0;
+		top: -16px;
+		height: 16px;
+	}
+
 	// Close: wipe the content at the rising edge so nothing trails below the roll.
 	.x-dropdown.x-dropdown--2026:not( .is-dropdown-open ) .x-dropdown-content {
 		opacity: 0;

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -1355,13 +1355,20 @@ $x-menu-2026-admin-bar-mobile: 46px;
 }
 
 @media ( min-width: 1025px ) {
-	// Keep diagonal pointer travel below the nav labels inside the open dropdown.
-	.x-dropdown.x-dropdown--2026.is-dropdown-open::before {
-		content: '';
-		position: absolute;
-		inset-inline: 0;
-		top: -16px;
-		height: 16px;
+	$x-dropdown-hover-area: 16px;
+
+	.x-dropdown.x-dropdown--2026.is-dropdown-open {
+		// Override the animation's inline overflow; clip only below the hover area.
+		overflow: visible !important;
+		clip-path: inset( -$x-dropdown-hover-area 0 0 );
+
+		&::before {
+			content: '';
+			position: absolute;
+			inset-inline: 0;
+			top: -$x-dropdown-hover-area;
+			height: $x-dropdown-hover-area;
+		}
 	}
 
 	// Close: wipe the content at the rising edge so nothing trails below the roll.


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Alternative to #114159

## Proposed Changes

* Give an open desktop dropdown a little extra hover space below the top navigation labels, so diagonal movement into its columns does not dismiss it.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Make the dropdown less sensitive to accidental pointer movement while keeping direct hovering over Support or Pricing as a way to close it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With this branch running locally and signed in, open `http://calypso.localhost:3000/patterns?flags=nav-redesign/2026` at desktop width.
* Hover Resources, then slowly move right just below the navigation labels and into the dropdown columns. The dropdown should stay open, with no visible layout change.
* Hover directly over the Support or Pricing label. The dropdown should close. Open Products, move into its dropdown, then below it: it should also close.

Browser checks and Stylelint passed. The extra hover area is disabled below desktop width. While a dropdown is open, the bottom strip of the top navigation belongs to the dropdown, so clicks there no longer activate the links underneath.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
