### PR TITLE
E2E: Fix preview menu item locator for Gutenberg 24.0

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -20,8 +20,6 @@ const selectors = {
 	// Post status
 	postStatusButton: '.editor-post-status > button',
 
-	desktopPreviewMenuItem: ( target: EditorPreviewOptions ) =>
-		`button[role*="menuitem"] span:text-is("${ target }")`,
 	previewPane: '.edit-post-visual-editor',
 
 	// Publish
@@ -196,10 +194,7 @@ export class EditorToolbarComponent {
 
 		// Locate and click on the intended preview target.
 		const editorParent = await this.editor.parent();
-		const desktopPreviewMenuItemLocator = editorParent.locator(
-			selectors.desktopPreviewMenuItem( target )
-		);
-		await desktopPreviewMenuItemLocator.click();
+		await editorParent.getByRole( 'menuitemradio', { name: target } ).click();
 
 		// Verify the editor panel is resized and stable.
 		const desktopPreviewPaneLocator = editorParent.locator( selectors.previewPane );


### PR DESCRIPTION
## Proposed Changes

* Locate the editor View menu's preview options by role and accessible name (`getByRole( 'menuitemradio', { name: target } )`) instead of the CSS selector `button[role*="menuitem"] span:text-is("...")`.
* Delete `selectors.desktopPreviewMenuItem`; `openDesktopPreview()` was its only consumer.

## Why are these changes being made?

Gutenberg PR #82321 ("Editor: Refactor the View menu to use the Menu component", milestone 24.0, merged 2026-09-04) rebuilt the View menu on the new `Menu` component. The items changed from `<button role="menuitemradio" class="components-menu-item__button">` to `<div role="menuitemradio">`, and their accessible name changed from the full text content (`Mobile Preview mobile viewport.`) to just `Mobile`.

The old selector requires a `<button>` ancestor, so it resolves to nothing on the new markup and every `previewAsDesktop` / `closePreview` call times out. This is not flake: 8/8 consecutive reds on `calypso_WPComTests_gutenberg_atomic_nightly_desktop` since the first Nightly containing the commit (`vnightly-23.9.0-c9e00c1`, 2026-09-05), reproduced locally in ~45s.

Fixing now rather than waiting: eight consecutive reds hide any other Nightly regression, and 24.0-rc.1 is expected around 2026-09-09, which puts the same failure on Atomic Edge the day it is tagged and Simple Edge about a day later, then on production at 24.0 stable.

The role + name locator is a widening, not a replacement — both markups render `role="menuitemradio"`, and the name match is non-exact so it matches both the old and the new accessible name. `exact: true` would drop the old markup and is deliberately not used. Uniqueness holds in both wordings of the item description: no other item's name contains Desktop, Tablet or Mobile. `EditorPopoverMenuComponent.clickMenuButton()` already uses this pattern, and upstream Gutenberg's own e2e suite uses this exact locator for these items.

Not in this PR: `EditorPage.unpublish()` / `switchToDraft()` carry an unrelated race and a dead `confirmUnpublish()` whose substring "OK" match breaks on any post title containing "ok". That is latent, environment-independent, and not caused by this markup change — follow-up.

## Testing Instructions

`packages/calypso-e2e` changes clear `TEST_GROUP`, so the PR's own matrix runs every spec on both viewports and covers Simple Production. The Gutenberg Nightly and Edge jobs are not part of that matrix; they were exercised with a personal build and locally.

Locally, from `test/e2e`, after `yarn workspace @automattic/calypso-e2e build` (specs load the package from `dist`, so the edit is a no-op until rebuilt):

```bash
# New markup (Nightly) — fails on trunk, passes here
GUTENBERG_NIGHTLY=true TEST_ON_ATOMIC=true CALYPSO_BASE_URL=https://wordpress.com \
  yarn playwright test --project=chrome --retries=0 specs/editor/editor__post-basic-flow.spec.ts

# Old markup (Edge, 23.9.x) — must stay green
GUTENBERG_EDGE=true TEST_ON_ATOMIC=true CALYPSO_BASE_URL=https://wordpress.com \
  yarn playwright test --project=chrome --retries=0 specs/editor/editor__post-basic-flow.spec.ts
```

The two runs use different accounts and can run concurrently; pass `--output=<dir>` if running both at once. Avoid 01:00 and 04:00 UTC, when scheduled jobs use the same sites.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
