### PR TITLE
JITM: Name the sidebar banner in its Tracks events

### DIFF
--- a/client/blocks/jitm/templates/sidebar-banner.jsx
+++ b/client/blocks/jitm/templates/sidebar-banner.jsx
@@ -28,6 +28,7 @@ export default function SidebarBannerTemplate( {
 				forceDisplay
 				dismissPreferenceName={ dismissPreferenceName }
 				dismissTemporary
+				event={ id }
 				href={ CTA.link }
 				onClick={ onClick }
 				onDismissClick={ onDismiss }

--- a/client/blocks/jitm/templates/test/sidebar-banner.test.jsx
+++ b/client/blocks/jitm/templates/test/sidebar-banner.test.jsx
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import preferencesReducer from 'calypso/state/preferences/reducer';
+import uiReducer from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import SidebarBannerTemplate from '../sidebar-banner';
+
+jest.mock( 'calypso/state/analytics/actions', () => ( {
+	...jest.requireActual( 'calypso/state/analytics/actions' ),
+	recordTracksEvent: jest.fn( () => ( { type: 'ANALYTICS_EVENT_RECORD' } ) ),
+} ) );
+
+// jsdom cannot navigate, so keep link clicks from logging "Not implemented" errors.
+const preventNavigation = ( event ) => event.preventDefault();
+
+function renderBanner( props ) {
+	return renderWithProvider(
+		<SidebarBannerTemplate
+			id="upsell_jitm_id"
+			message="Upgrade your plan"
+			CTA={ { message: 'Upgrade', link: '/plans/example.com' } }
+			isDismissible
+			{ ...props }
+		/>,
+		{
+			reducers: { preferences: preferencesReducer, ui: uiReducer },
+			initialState: { preferences: { remoteValues: {} } },
+		}
+	);
+}
+
+describe( 'SidebarBannerTemplate', () => {
+	beforeAll( () => {
+		document.addEventListener( 'click', preventNavigation );
+	} );
+
+	afterAll( () => {
+		document.removeEventListener( 'click', preventNavigation );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'records an impression naming the JITM it came from', () => {
+		renderBanner();
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_banner_cta_impression',
+			expect.objectContaining( { cta_name: 'upsell_jitm_id' } )
+		);
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_upsell_nudge_impression',
+			expect.objectContaining( { event: 'upsell_jitm_id' } )
+		);
+	} );
+
+	test( 'records a click naming the JITM it came from', async () => {
+		const user = userEvent.setup();
+		renderBanner();
+
+		await user.click( screen.getByRole( 'link', { name: 'Upgrade' } ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_banner_cta_click',
+			expect.objectContaining( { cta_name: 'upsell_jitm_id' } )
+		);
+	} );
+
+	test( 'records a dismiss naming the JITM it came from', async () => {
+		const user = userEvent.setup();
+		renderBanner();
+
+		await user.click( screen.getByLabelText( 'Dismiss' ) );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_banner_dismiss',
+			expect.objectContaining( { cta_name: 'upsell_jitm_id' } )
+		);
+	} );
+} );


### PR DESCRIPTION
Part of MARTECH-3061

## Proposed Changes

* Pass `event={ id }` from the JITM `sidebar-banner` template to `UpsellNudge`, matching what the `notice` and `default` templates already do.
* Add tests covering the impression, click and dismiss events for this template.

This is the first of two PRs. It only adds identifying information to events; it changes no rendering and no gating. A follow-up will stop `calypso_upsell_nudge_impression` firing for banners that have been dismissed.

## Why are these changes being made?

`Banner` gates all three of its Tracks events on the `event` prop:

```js
if ( event && tracksClickName ) { ... }    // click
if ( event && tracksDismissName ) { ... }  // dismiss
{ tracksImpressionName && event && ( ... ) }  // impression
```

`sidebar-banner.jsx` never passed it. So the JITM sidebar banner — rendered in the site sidebar on effectively every Calypso page via `calypso:sites:sidebar_notice` — recorded **no** banner impression, **no** click and **no** dismiss. Its funnel was entirely dark.

The one event it did emit, `calypso_upsell_nudge_impression`, fires from outside `Banner` and is not gated on `event`, so it recorded the impression with an empty CTA name. That accounts for roughly 4M of the 4.6M nameless upsell impressions over a recent 30-day window: a single call site, on the highest-traffic surface.

Passing the JITM id restores the whole funnel and lets every upsell impression be attributed to the surface it came from.

### Why this lands before the dismissal fix

A separate defect keeps `calypso_upsell_nudge_impression` firing after a banner is dismissed, because the dismiss check lives in `DismissibleCard`, one level below where that event is emitted.

That fix is deliberately not in this PR. Its risky failure mode is over-suppression, and today it could not be verified: with ~87% of impressions carrying no CTA name, an unexpected drop could not be attributed to any surface, and a correct drop and an over-suppressing bug would look identical.

Landing this first gives that verification. It adds per-surface attribution across nearly all the volume, and for this banner it turns on `calypso_banner_cta_impression` — which *is* correctly gated on dismissal — alongside the ungated `calypso_upsell_nudge_impression`. The gap between the two, on the same banner, measures the phantom-impression rate directly.

### Expected effect on dashboards

* `calypso_upsell_nudge_impression`: volume unchanged, but `event` is now populated where it was empty.
* `calypso_banner_cta_impression`, `calypso_banner_cta_click`, `calypso_banner_dismiss`: a step increase, from a surface that previously reported none. This is new coverage, not new traffic.

Worth noting for anyone reading upsell dashboards: #114124 recently changed click behaviour on dismissible banners, so click volume has already moved for reasons unrelated to this PR.

## Testing Instructions

Automated:

```
yarn test-client client/blocks/jitm/templates/test/sidebar-banner.test.jsx
```

All three tests fail on `trunk` and pass with this change.

Manually, with a local Calypso instance:

1. Enable Tracks logging in the browser console, then reload:
   ```js
   localStorage.setItem( 'debug', 'calypso:analytics*' );
   ```
2. Open any single-site page that renders the sidebar, e.g. `/home/<your-site>` (the site shouldn't have the sidebar upsell dismissed)
3. Filter the console by events for calypso_upsell_nudge_impression and  calypso_banner_cta_impression
   * **Before this change:** only `calypso_upsell_nudge_impression`, with an empty `event` property.
   * **After:** `calypso_upsell_nudge_impression` carries `event`
   * calypso_banner_cta_impression` is recorded with non-empty `cta_name`.

(after and before in reverse order in the screenshot)

<img width="951" height="419" alt="Screenshot 2026-09-08 at 16 17 43" src="https://github.com/user-attachments/assets/ba11c478-3da9-4cdf-b07d-af9c0d07ffb0" />

5. Click the **Upgrade** button — `calypso_banner_cta_click` is recorded with the `cta_name`. Nothing was recorded here before.
6. Reload, re-insert, and click the **×** — `calypso_banner_dismiss` is recorded with the `cta_name`. Nothing was recorded here before.

To confirm nothing else changed, repeat on a banner that already passed `event` (the Reader sidebar nudge at `/read`, for an account eligible for the free-to-paid upsell) and check its events are unaffected.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kVqZFyDnMCDcobgRxaxe7
