### PR TITLE
Domains: Remove ES from the EU address-format list so the province dropdown can render

### DIFF
--- a/client/components/domains/contact-details-form-fields/custom-form-fieldsets/constants.js
+++ b/client/components/domains/contact-details-form-fields/custom-form-fieldsets/constants.js
@@ -29,7 +29,6 @@ export const CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES = [
 	'DE',
 	'DK',
 	'EE',
-	'ES',
 	'FI',
 	'FR',
 	'HU',

--- a/client/dashboard/components/domain-contact-details-form/custom-form-fieldsets/constants.ts
+++ b/client/dashboard/components/domain-contact-details-form/custom-form-fieldsets/constants.ts
@@ -14,7 +14,6 @@ export const CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES = [
 	'DE',
 	'DK',
 	'EE',
-	'ES',
 	'FI',
 	'FR',
 	'HU',


### PR DESCRIPTION
Part of DOMAINS-2306 (blocker for DOMAINS-2298)

## Proposed Changes

* Remove `ES` from `CHECKOUT_EU_ADDRESS_FORMAT_COUNTRY_CODES` in both copies of the constants:
  * `client/components/domains/contact-details-form-fields/custom-form-fieldsets/constants.js` (checkout, stepper, classic edit contact info)
  * `client/dashboard/components/domain-contact-details-form/custom-form-fieldsets/constants.ts` (new dashboard)

## Why are these changes being made?

DOMAINS-2298 adds the 52 Spanish provinces to the backend state list and makes the state field required for `ES` contacts, with `GET /domains/supported-states/ES` now returning that list.

The contact forms never show a state field for Spain regardless of what the API returns, because of a chicken-and-egg in the fieldset selection:

1. The forms compute `hasCountryStates` from the store but never fetch country states themselves. The only fetcher (`QueryCountryStates`) lives inside `StateSelect`, which only renders in the default (US-format) fieldset.
2. `RegionAddressFieldsets` gives countries in the EU address-format list a fieldset with no state field at all, and the managed form strips any state value for those countries before submitting.
3. `ES` was in that list, so no state field, no `StateSelect`, no fetch, and `hasCountryStates` stays `false` forever.

The comment above the array already says countries with a localized state list from the backend must be excluded, and even names ES. It was never removed because the backend used to return an empty list for Spain. With `ES` removed, Spain falls through to the default fieldset, `StateSelect` mounts, fetches the provinces, and renders the dropdown, the same way Italy works today.

**Deploy order:** this PR must deploy before the wpcom change from DOMAINS-2298. Otherwise Spanish customers are hard-blocked at checkout, since the backend would require a state they have no field to enter.

## Testing Instructions

With `public-api.wordpress.com` sandboxed to a sandbox running the DOMAINS-2298 branch:

1. In checkout, add a domain to the cart and select Spain in the domain contact form.
2. In the stepper contact step (`/setup/domain` flow), select Spain.
3. In the dashboard edit-contact form for an existing domain, select Spain.

Each should show a province dropdown with 52 entries. Picking a province whose INE code does not match the first two postal-code digits should surface "This postal code does not match the selected province." on the postal code field.

Without the sandbox, confirm that selecting Spain in each form now renders the default fieldset (with a State field) instead of the EU fieldset.

Unit tests: `yarn test-client client/components/domains/contact-details-form-fields client/dashboard/components/domain-contact-details-form`

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015FNqu9PS1UhgLNVuP8PgJC
