### PR TITLE
Upsell nudge: stop recording impressions for dismissed banners

### DIFF
--- a/client/blocks/jitm/templates/default.jsx
+++ b/client/blocks/jitm/templates/default.jsx
@@ -12,24 +12,23 @@ export default function DefaultTemplate( {
 	onDismiss,
 } ) {
 	return (
-		<>
+		<UpsellNudge
+			callToAction={ CTA.message }
+			title={ message }
+			description={ description }
+			disableHref
+			dismissPreferenceName={ featureClass }
+			dismissTemporary
+			onDismissClick={ onDismiss }
+			onClick={ onClick }
+			event={ tracks?.click?.name || `jitm_nudge_click_${ id }` }
+			href={ CTA.link }
+			horizontal
+			target={ CTA.target }
+			showIcon
+			forceDisplay
+		>
 			{ trackImpression && trackImpression() }
-			<UpsellNudge
-				callToAction={ CTA.message }
-				title={ message }
-				description={ description }
-				disableHref
-				dismissPreferenceName={ featureClass }
-				dismissTemporary
-				onDismissClick={ onDismiss }
-				onClick={ onClick }
-				event={ tracks?.click?.name || `jitm_nudge_click_${ id }` }
-				href={ CTA.link }
-				horizontal
-				target={ CTA.target }
-				showIcon
-				forceDisplay
-			/>
-		</>
+		</UpsellNudge>
 	);
 }

--- a/client/blocks/jitm/templates/sidebar-banner.jsx
+++ b/client/blocks/jitm/templates/sidebar-banner.jsx
@@ -20,21 +20,20 @@ export default function SidebarBannerTemplate( {
 	}
 
 	return (
-		<>
-			<UpsellNudge
-				callToAction={ CTA.message }
-				compact
-				forceHref={ forceHref }
-				forceDisplay
-				dismissPreferenceName={ dismissPreferenceName }
-				dismissTemporary
-				event={ id }
-				href={ CTA.link }
-				onClick={ onClick }
-				onDismissClick={ onDismiss }
-				title={ message }
-			/>
+		<UpsellNudge
+			callToAction={ CTA.message }
+			compact
+			forceHref={ forceHref }
+			forceDisplay
+			dismissPreferenceName={ dismissPreferenceName }
+			dismissTemporary
+			event={ id }
+			href={ CTA.link }
+			onClick={ onClick }
+			onDismissClick={ onDismiss }
+			title={ message }
+		>
 			{ trackImpression && trackImpression() }
-		</>
+		</UpsellNudge>
 	);
 }

--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -15,7 +15,7 @@ import {
 } from '@automattic/calypso-products';
 import clsx from 'clsx';
 import debugFactory from 'debug';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import Banner from 'calypso/components/banner';
@@ -104,6 +104,7 @@ type OwnProps = {
 	tracksDismissProperties?: Record< string, unknown >;
 	tracksImpressionName?: string;
 	tracksImpressionProperties?: Record< string, unknown >;
+	children?: ReactNode;
 };
 
 type Props = OwnProps & ConnectedProps;
@@ -159,6 +160,7 @@ export const UpsellNudge = ( {
 	isBusy,
 	isEligibleForOneClickCheckout,
 	isOneClickCheckoutEnabled = true,
+	children,
 }: Props ) => {
 	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
 	const shouldNotDisplay =
@@ -246,16 +248,6 @@ export const UpsellNudge = ( {
 					setShowPurchaseModal={ setShowPurchaseModal }
 				/>
 			) }
-			{ ! isEligibleForOneClickCheckout?.isLoading && (
-				<TrackComponentView
-					eventName="calypso_upsell_nudge_impression"
-					eventProperties={ {
-						is_eligible_for_one_click_checkout: !! isEligibleForOneClickCheckout?.result,
-						plan: plan,
-						event,
-					} }
-				/>
-			) }
 			<Banner
 				callToAction={ callToAction }
 				secondaryCallToAction={ secondaryCallToAction }
@@ -297,7 +289,19 @@ export const UpsellNudge = ( {
 				isBusy={
 					isBusy || ( isOneClickCheckoutEnabled && isEligibleForOneClickCheckout?.isLoading )
 				}
-			/>
+			>
+				{ ! isEligibleForOneClickCheckout?.isLoading && (
+					<TrackComponentView
+						eventName="calypso_upsell_nudge_impression"
+						eventProperties={ {
+							is_eligible_for_one_click_checkout: !! isEligibleForOneClickCheckout?.result,
+							plan: plan,
+							event,
+						} }
+					/>
+				) }
+				{ children }
+			</Banner>
 		</>
 	);
 };

--- a/client/blocks/upsell-nudge/test/impressions.jsx
+++ b/client/blocks/upsell-nudge/test/impressions.jsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import preferencesReducer from 'calypso/state/preferences/reducer';
+import uiReducer from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import UpsellNudge from '../index';
+
+jest.mock( 'calypso/state/analytics/actions', () => ( {
+	...jest.requireActual( 'calypso/state/analytics/actions' ),
+	recordTracksEvent: jest.fn( () => ( { type: 'ANALYTICS_EVENT_RECORD' } ) ),
+} ) );
+
+const PREFERENCE_NAME = 'upsell-nudge-test';
+
+function renderNudge( { remoteValues = {}, ...props } = {} ) {
+	return renderWithProvider(
+		<UpsellNudge
+			event="test-nudge"
+			title="Upgrade your plan"
+			callToAction="Upgrade"
+			href="/plans"
+			forceDisplay
+			{ ...props }
+		/>,
+		{
+			reducers: { preferences: preferencesReducer, ui: uiReducer },
+			initialState: { preferences: { remoteValues } },
+		}
+	);
+}
+
+const impressions = () =>
+	recordTracksEvent.mock.calls.filter( ( [ name ] ) => name === 'calypso_upsell_nudge_impression' );
+
+describe( 'UpsellNudge impressions', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'records an impression for a dismissible banner that has not been dismissed', () => {
+		renderNudge( { dismissPreferenceName: PREFERENCE_NAME } );
+
+		expect( impressions() ).toHaveLength( 1 );
+	} );
+
+	test( 'records no impression once the banner has been dismissed', () => {
+		renderNudge( {
+			dismissPreferenceName: PREFERENCE_NAME,
+			remoteValues: { [ `dismissible-card-${ PREFERENCE_NAME }` ]: true },
+		} );
+
+		expect( impressions() ).toHaveLength( 0 );
+	} );
+
+	test( 'records no impression before remote preferences have been received', () => {
+		renderNudge( { dismissPreferenceName: PREFERENCE_NAME, remoteValues: null } );
+
+		expect( impressions() ).toHaveLength( 0 );
+	} );
+
+	test( 'records an impression for a non-dismissible banner without waiting for preferences', () => {
+		renderNudge( { remoteValues: null } );
+
+		expect( impressions() ).toHaveLength( 1 );
+	} );
+} );

--- a/client/components/banner/README.md
+++ b/client/components/banner/README.md
@@ -44,6 +44,7 @@ function render() {
 | Name                         | Type                   | Default | Description                                                                                                                                          |
 | ---------------------------- | ---------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `callToAction`               | `string`               | null    | Shows a CTA text.                                                                                                                                    |
+| `children`                   | `node`                 | null    | Rendered inside the banner body, so it is dismissed along with the banner.                                                                           |
 | `className`                  | `string`               | null    | Any additional CSS classes.                                                                                                                          |
 | `compact`                    | `bool`                 | false   | Display a compact version of the banner.                                                                                                             |
 | `description`                | `string`               | null    | The banner description.                                                                                                                              |

--- a/client/components/banner/index.jsx
+++ b/client/components/banner/index.jsx
@@ -31,6 +31,7 @@ const noop = () => {};
 export class Banner extends Component {
 	static propTypes = {
 		callToAction: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
+		children: PropTypes.node,
 		secondaryCallToAction: PropTypes.oneOfType( [ PropTypes.string, PropTypes.element ] ),
 		className: PropTypes.string,
 		compactButton: PropTypes.bool,
@@ -261,6 +262,7 @@ export class Banner extends Component {
 			extraContent,
 			isBusy,
 			isCallToActionDisabled,
+			children,
 		} = this.props;
 
 		const prices = Array.isArray( price ) ? price : [ price ];
@@ -278,6 +280,7 @@ export class Banner extends Component {
 						} }
 					/>
 				) }
+				{ children }
 				<div className="banner__info">
 					<h3 className="banner__title">{ title }</h3>
 					{ this.renderDescription( description ) }


### PR DESCRIPTION
Part of MARTECH-3061

## Human Summary
The complaint was that dismissed upsell nudges still record impressions. A dismissible upsell nudge exists on /read if you only have one site. Claude proposed a solution [with a hook](https://github.com/Automattic/wp-calypso/pull/114171), which I created as a PR just for comparison. I convinced Opus that it would be better to move the tracking in so it's after any eligibility/visibility checks. A code review with Fable preferred this approach as well. I manually updated the test plan to reflect how I tested it. Auto-generated text follows until the text plan.

## Proposed Changes

* `Banner` now renders `children` inside the card body.
* `UpsellNudge` passes its `calypso_upsell_nudge_impression` `TrackComponentView` down as a child of `<Banner>` instead of rendering it as a sibling.
* The two JITM templates built on `UpsellNudge` (`default`, `sidebar-banner`) pass their `trackImpression()` callback the same way.
* Adds tests covering when the impression should and should not be recorded.

Depends on nothing, but is intended to land **after** #114165, which makes the effect of this change measurable per surface. See below.

## Why are these changes being made?

`calypso_upsell_nudge_impression` was rendered as a sibling of `<Banner>`:

```jsx
<>
	<TrackComponentView eventName="calypso_upsell_nudge_impression" ... />
	<Banner ... />
</>
```

The dismiss check lives two levels down, in `DismissibleCard`:

```js
if ( isDismissed || ! hasReceivedPreferences ) {
	return null;
}
```

`TrackComponentView` records its event in `componentDidMount`, so "did the event fire" is exactly "did the component mount". The banner's own impression is inside `DismissibleCard`'s children and therefore stops correctly once dismissed. The outer one is outside it and kept firing on every mount, for a banner rendering nothing at all.

Measured on the Reader sidebar nudge over 30 days: of 507 people who dismissed it, the inner event fired zero times afterwards while the outer one fired ~1k more times across 130 of them.

This affects every Dotcom upsell built on the shared block — plugins browser, theme install, SEO and Google Analytics settings, activity log, Akismet and scan settings, the Reader sidebar, and all JITMs.

### Why children rather than a shared "is dismissed" hook

The obvious alternative is for `UpsellNudge` to read the dismiss preference itself and gate the event on it. That makes two components derive the same fact and hope they stay in sync — if another reason for `DismissibleCard` to render nothing is added later, the copy silently drifts and phantom impressions come back.

It also needs a special case. `UpsellNudge` would have to skip the preference check when there is no `dismissPreferenceName`, or every non-dismissible upsell would suppress its impression until remote preferences loaded, and permanently for anyone whose preference fetch fails — trading over-counting for under-counting.

Passing the element down needs neither. React's rendering is already the gate: a non-dismissible banner renders a plain `<Card>`, children mount immediately, and the impression fires with no preference wait. There is one condition, in one component.

### Why the event is gated rather than returning null

`UpsellNudge` could return `null` outright when dismissed, but the one-click purchase modal is also a sibling of `<Banner>`. Unmounting the whole component on a preference change could tear down an open checkout. Gating only the event has no rendering side effects.

### Expected effect on dashboards

`calypso_upsell_nudge_impression` volume drops, most visibly on high-remount surfaces such as the JITM banners. Click and dismiss events are unaffected. Nothing else changes.

`calypso_banner_cta_impression` is unchanged — it was always gated correctly, which is what makes it the control for verifying this change.

## Testing Instructions

Automated:

```
yarn test-client client/blocks/upsell-nudge client/components/banner client/blocks/dismissible-card client/blocks/jitm
```

The two "records no impression" cases fail on `trunk` and pass here. The two "records an impression" cases pass both before and after — they are regression guards against over-suppressing.

Manually, with a local Calypso instance:

1. Enable Tracks logging in the browser console, then reload:
   ```js
   localStorage.setItem( 'debug', 'calypso:analytics' );
   ```
2. Bottom left part of /read on a user with just one site has a dismissible upsell nudge
3. Confirm both `calypso_upsell_nudge_impression` and `calypso_upgrade_nudge_impression` are recorded.
4. Dismiss the banner.
5. Reload.

Expected: neither event is recorded, and the banner is not on screen. On `trunk`, `calypso_upsell_nudge_impression` is still recorded on every load.

You can also test non-dismissible banners, like those you can find on 
http://calypso.localhost:3000/marketing/traffic/SITE

The changes should not affect the events there.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kVqZFyDnMCDcobgRxaxe7
