### PR TITLE
A4A: Update signup copy agency count from 8,000+ to 10,000+

### DIFF
--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -262,7 +262,7 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 					'Join %(agencyCount)s agencies and grow your business with {{span}}Automattic for Agencies.{{/span}} Get access to site management, earn commission on referrals, and explore our tier program to launch your business potential.',
 					{
 						args: {
-							agencyCount: '8,000+',
+							agencyCount: '10,000+',
 						},
 						components: {
 							span: <span className="signup-contact-form__a4a-span" />,


### PR DESCRIPTION
## Proposed Changes

* Update the agency count in the Automattic for Agencies signup copy from `8,000+` to `10,000+`.

## Why are these changes being made?

The first step of the A4A signup (`signup-v2` contact form) describes the network size: "Join 8,000+ agencies and grow your business with Automattic for Agencies…". The count is passed to `translate()` as the `agencyCount` argument rather than being part of the translated template. That split was introduced in #113184, when the copy moved from 6000+ to 8,000+, so that later bumps would not invalidate the existing translation.

The network has since grown past 10,000 agencies, so the 8,000+ figure is stale. This change updates the argument to `10,000+`. The translated string itself is untouched, so no new string enters the translation pipeline.

This is the only place the figure appears in the repository.

## Testing Instructions

Prerequisites: a local A4A dev server (`yarn start-a8c-for-agencies`).

1. Log out of WordPress.com, or use a browser profile that is not signed in.
2. Open `http://agencies.localhost:3000/signup`.
3. On the first step of the form, read the description under the "Sign up and unlock the blueprint to grow your agency's business" heading.
4. Confirm it reads "Join 10,000+ agencies and grow your business with Automattic for Agencies…" instead of "Join 8,000+ agencies…".

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
