### PR TITLE
Upsell nudge: stop recording impressions for dismissed banners (hook variant)

### DIFF
--- a/client/blocks/dismissible-card/index.jsx
+++ b/client/blocks/dismissible-card/index.jsx
@@ -1,11 +1,10 @@
 import { Card, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import QueryPreferences from 'calypso/components/data/query-preferences';
-import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
 import { dismissCard } from './actions';
-import { isCardDismissed } from './selectors';
+import useIsCardVisible from './use-is-card-visible';
 
 import './style.scss';
 
@@ -22,12 +21,11 @@ function DismissibleCard( {
 	href,
 	children,
 } ) {
-	const isDismissed = useSelector( isCardDismissed( preferenceName ) );
-	const hasReceivedPreferences = useSelector( hasReceivedRemotePreferences );
+	const isVisible = useIsCardVisible( preferenceName );
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 
-	if ( isDismissed || ! hasReceivedPreferences ) {
+	if ( ! isVisible ) {
 		return null;
 	}
 

--- a/client/blocks/dismissible-card/use-is-card-visible.js
+++ b/client/blocks/dismissible-card/use-is-card-visible.js
@@ -1,0 +1,22 @@
+import { useSelector } from 'react-redux';
+import { hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import { isCardDismissed } from './selectors';
+
+/**
+ * Whether a DismissibleCard with this preference name is currently rendered.
+ *
+ * Mirrors the condition DismissibleCard renders on, so callers outside the card
+ * can tell whether it is on screen.
+ * @param {?string} [preferenceName] The dismiss preference name, if the card is dismissible
+ * @returns {boolean} Whether the card is visible
+ */
+export default function useIsCardVisible( preferenceName ) {
+	return useSelector( ( state ) => {
+		// A card with no preference name is not dismissible, so it never waits on preferences.
+		if ( ! preferenceName ) {
+			return true;
+		}
+
+		return hasReceivedRemotePreferences( state ) && ! isCardDismissed( preferenceName )( state );
+	} );
+}

--- a/client/blocks/jitm/templates/default.jsx
+++ b/client/blocks/jitm/templates/default.jsx
@@ -1,3 +1,4 @@
+import useIsCardVisible from 'calypso/blocks/dismissible-card/use-is-card-visible';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 
 export default function DefaultTemplate( {
@@ -11,9 +12,11 @@ export default function DefaultTemplate( {
 	onClick,
 	onDismiss,
 } ) {
+	const isBannerVisible = useIsCardVisible( featureClass );
+
 	return (
 		<>
-			{ trackImpression && trackImpression() }
+			{ isBannerVisible && trackImpression && trackImpression() }
 			<UpsellNudge
 				callToAction={ CTA.message }
 				title={ message }

--- a/client/blocks/jitm/templates/sidebar-banner.jsx
+++ b/client/blocks/jitm/templates/sidebar-banner.jsx
@@ -1,3 +1,4 @@
+import useIsCardVisible from 'calypso/blocks/dismissible-card/use-is-card-visible';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 
 import './sidebar-banner.scss';
@@ -19,6 +20,8 @@ export default function SidebarBannerTemplate( {
 		dismissPreferenceName = id;
 	}
 
+	const isBannerVisible = useIsCardVisible( dismissPreferenceName );
+
 	return (
 		<>
 			<UpsellNudge
@@ -33,7 +36,7 @@ export default function SidebarBannerTemplate( {
 				onDismissClick={ onDismiss }
 				title={ message }
 			/>
-			{ trackImpression && trackImpression() }
+			{ isBannerVisible && trackImpression && trackImpression() }
 		</>
 	);
 }

--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -17,6 +17,7 @@ import clsx from 'clsx';
 import debugFactory from 'debug';
 import { useState } from 'react';
 import { connect } from 'react-redux';
+import useIsCardVisible from 'calypso/blocks/dismissible-card/use-is-card-visible';
 import AsyncLoad from 'calypso/components/async-load';
 import Banner from 'calypso/components/banner';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
@@ -161,6 +162,7 @@ export const UpsellNudge = ( {
 	isOneClickCheckoutEnabled = true,
 }: Props ) => {
 	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
+	const isBannerVisible = useIsCardVisible( dismissPreferenceName );
 	const shouldNotDisplay =
 		isVip ||
 		! canManageSite ||
@@ -246,7 +248,7 @@ export const UpsellNudge = ( {
 					setShowPurchaseModal={ setShowPurchaseModal }
 				/>
 			) }
-			{ ! isEligibleForOneClickCheckout?.isLoading && (
+			{ isBannerVisible && ! isEligibleForOneClickCheckout?.isLoading && (
 				<TrackComponentView
 					eventName="calypso_upsell_nudge_impression"
 					eventProperties={ {

--- a/client/blocks/upsell-nudge/test/impressions.jsx
+++ b/client/blocks/upsell-nudge/test/impressions.jsx
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import preferencesReducer from 'calypso/state/preferences/reducer';
+import uiReducer from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import UpsellNudge from '../index';
+
+jest.mock( 'calypso/state/analytics/actions', () => ( {
+	...jest.requireActual( 'calypso/state/analytics/actions' ),
+	recordTracksEvent: jest.fn( () => ( { type: 'ANALYTICS_EVENT_RECORD' } ) ),
+} ) );
+
+const PREFERENCE_NAME = 'upsell-nudge-test';
+
+function renderNudge( { remoteValues = {}, ...props } = {} ) {
+	return renderWithProvider(
+		<UpsellNudge
+			event="test-nudge"
+			title="Upgrade your plan"
+			callToAction="Upgrade"
+			href="/plans"
+			forceDisplay
+			{ ...props }
+		/>,
+		{
+			reducers: { preferences: preferencesReducer, ui: uiReducer },
+			initialState: { preferences: { remoteValues } },
+		}
+	);
+}
+
+const impressions = () =>
+	recordTracksEvent.mock.calls.filter( ( [ name ] ) => name === 'calypso_upsell_nudge_impression' );
+
+describe( 'UpsellNudge impressions', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'records an impression for a dismissible banner that has not been dismissed', () => {
+		renderNudge( { dismissPreferenceName: PREFERENCE_NAME } );
+
+		expect( impressions() ).toHaveLength( 1 );
+	} );
+
+	test( 'records no impression once the banner has been dismissed', () => {
+		renderNudge( {
+			dismissPreferenceName: PREFERENCE_NAME,
+			remoteValues: { [ `dismissible-card-${ PREFERENCE_NAME }` ]: true },
+		} );
+
+		expect( impressions() ).toHaveLength( 0 );
+	} );
+
+	test( 'records no impression before remote preferences have been received', () => {
+		renderNudge( { dismissPreferenceName: PREFERENCE_NAME, remoteValues: null } );
+
+		expect( impressions() ).toHaveLength( 0 );
+	} );
+
+	test( 'records an impression for a non-dismissible banner without waiting for preferences', () => {
+		renderNudge( { remoteValues: null } );
+
+		expect( impressions() ).toHaveLength( 1 );
+	} );
+} );


### PR DESCRIPTION
Part of MARTECH-3061

> **Not for merge as-is.** This is an alternative implementation of #114167, opened so the two mechanisms can be compared side by side. Pick one and close the other.

## Proposed Changes

* Extracts the condition `DismissibleCard` renders on into a `useIsCardVisible` hook.
* `DismissibleCard` uses it in place of its two inline selectors — same expression, no behaviour change.
* `UpsellNudge` and the two JITM templates call it to gate their impression events.

The tests are byte-identical to #114167, and both branches pass them. Only the mechanism differs.

## Why are these changes being made?

Same defect as #114167: `calypso_upsell_nudge_impression` is emitted from `UpsellNudge`, above the dismiss check in `DismissibleCard`, so it kept firing for banners that render nothing.

#114167 fixes it by moving the event *into* the gated subtree — `Banner` accepts `children`, and callers pass their `TrackComponentView` down. This PR instead lets callers *ask* whether the card is visible.

## How the two compare

|  | #114167 (children) | This PR (hook) |
| --- | --- | --- |
| Lines changed | +119 / −44 | +106 / −9 |
| Files touched | 6 | 6 |
| Public API added | `children` on `Banner` | `useIsCardVisible` |
| Places evaluating "is it visible" | 1 | 2 |
| Call sites needing changes to gate a new event | 0 | 1 each |

The hook produces a smaller and more local diff. #114167's extra lines are almost entirely JSX re-indentation from two JITM templates losing their fragment wrapper — not extra logic.

The difference that matters is the row about how many places evaluate the condition. Under the hook, `DismissibleCard` decides whether to render and `useIsCardVisible` separately predicts that decision. They agree today because the hook was copied from the component. If a third reason for `DismissibleCard` to render nothing is added later, the hook keeps returning `true` and phantom impressions come back — the same defect, reintroduced silently. Under #114167 there is one condition in one component; a caller cannot disagree with it because it never evaluates it.

### A concrete cost, found while building this

The first version of the hook read both selectors unconditionally:

```js
const isDismissed = useSelector( isCardDismissed( preferenceName ) );
const hasReceivedPreferences = useSelector( hasReceivedRemotePreferences );
if ( ! preferenceName ) {
	return true;
}
```

That broke 12 existing tests in `client/blocks/upsell-nudge/test/index.jsx` with `Cannot read properties of undefined (reading 'remoteValues')`. `hasReceivedRemotePreferences` does not guard `state.preferences`, so every `UpsellNudge` consumer — including non-dismissible ones that never had a dismiss preference — began requiring the preferences reducer to be registered.

It is fixable, and the committed version does fix it, by moving the short-circuit inside a single `useSelector` so the preferences slice is never touched for a non-dismissible banner. But it is the shape of problem this approach invites: a component that reads state it does not otherwise need, on behalf of a decision made elsewhere.

#114167 has no equivalent case. A non-dismissible banner renders a plain `<Card>`, its children mount immediately, and no preference is consulted — correct because of how it is built, not because someone remembered the branch.

### Where the hook is better

* Smaller, more local diff; nothing about `Banner`'s API changes.
* `DismissibleCard` gets a genuinely nicer body, and the extracted hook is reusable by anything else that needs to know whether a dismissible card is showing.
* Callers keep their events where they are, which is easier to follow when reading a single template in isolation.

If you expect other code to need "is this card visible" for reasons unrelated to analytics, the hook earns its place. If the only consumer is impression tracking, #114167 removes the question instead of answering it.

## Testing Instructions

```
yarn test-client client/blocks/upsell-nudge client/components/banner client/blocks/dismissible-card client/blocks/jitm
```

50 tests pass. The two "records no impression" cases in `client/blocks/upsell-nudge/test/impressions.jsx` fail on `trunk` and pass here; the two "records an impression" cases pass both before and after, guarding against over-suppression.

For manual testing, follow the instructions in #114167 — the observable behaviour is intended to be identical, and confirming that is the point of the comparison.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016kVqZFyDnMCDcobgRxaxe7
