### PR TITLE
Site Spec: take the hand-off admin URL from the apply-spec response

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -17,7 +17,6 @@ import {
 	getSiteEditorUrl,
 	logBlueprintArchiveEvent,
 	startBlueprintArchiveImport,
-	isAtomicTransferComplete,
 	waitForAtomicTransferComplete,
 	waitForBlueprintImportComplete,
 } from 'calypso/landing/stepper/utils/blueprint-archive-import';
@@ -170,7 +169,6 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 	const messageCountRef = useRef( 0 );
 	const isSubmittingRef = useRef( false );
 	const blueprintImportStartedRef = useRef( false );
-	const handoffUrlRef = useRef< string | null >( null );
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 	const { setSiteSetupError } = useDispatch( SITE_STORE );
 	// Held in a ref so the spec-confirm callback stays referentially stable: the flow hands
@@ -459,7 +457,7 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 					// Only once the restore is done: it replaces the site's options
 					// wholesale, so a spec applied earlier would be overwritten.
 					// Never blocks the hand-off — applyBlueprintSpec() resolves either way.
-					const applied = await applyBlueprintSpec(
+					const { applied, adminUrl } = await applyBlueprintSpec(
 						blueprintArchiveSiteIdentifier,
 						specId,
 						blueprintArchiveSlug
@@ -471,18 +469,20 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 					} );
 
 					// Resolved after the wait either way, so the URL names the site that now exists.
-					// The funnel branch prefers the URL prefetched while the customer was answering
-					// the spec: reading the ref rather than awaiting a promise means a prefetch that
-					// never settled costs nothing here, it just falls through to fetching now.
+					// The apply response already carries the site's admin base, so handing it over
+					// saves a /sites/<id> round trip here — on the one path where the customer is
+					// watching a spinner. Null on an older wpcom, or when the apply failed, in which
+					// case the helper fetches it as before.
 					const siteEditorUrl = wowFunnelSlug
-						? handoffUrlRef.current ??
-						  ( await getWowFunnelHandoffUrl( {
+						? await getWowFunnelHandoffUrl( {
 								dest: wowFunnelDest,
 								siteIdentifier: blueprintArchiveSiteIdentifier,
-						  } ) )
-						: getSiteEditorUrl( await getSiteAdminUrl( blueprintArchiveSiteIdentifier ), {
-								canvasEdit: applied,
-						  } );
+								adminUrl,
+						  } )
+						: getSiteEditorUrl(
+								adminUrl ?? ( await getSiteAdminUrl( blueprintArchiveSiteIdentifier ) ),
+								{ canvasEdit: applied }
+						  );
 
 					logBlueprintArchiveEvent( 'redirect_site_editor', {
 						site_identifier: blueprintArchiveSiteIdentifier,
@@ -514,45 +514,6 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 			setPendingAction,
 		]
 	);
-
-	// Resolve the hand-off URL while the customer is still answering, so confirm does not spend a
-	// round trip on it. The URL depends only on the site, never on the spec, so there is nothing to
-	// wait for it on.
-	//
-	// Gated on the transfer rather than fetched outright: admin_url is read from the site record
-	// and changes when a site goes Atomic, so a URL read mid-transfer would point at the site as it
-	// was before. The gate is a single status check rather than a wait — a fleet claim has already
-	// transferred long before this page renders, and a run that has not is simply left to fetch at
-	// confirm. Failures are swallowed: this is an optimisation, not a step.
-	useEffect( () => {
-		if ( ! wowFunnelSlug || ! blueprintArchiveSiteIdentifier || handoffUrlRef.current ) {
-			return;
-		}
-
-		let cancelled = false;
-
-		( async () => {
-			// One check, never a poll: waiting here is the processing step's job, and a funnel run
-			// that has not transferred yet simply does not get the optimisation.
-			if ( ! ( await isAtomicTransferComplete( blueprintArchiveSiteIdentifier ) ) ) {
-				return;
-			}
-
-			const url = await getWowFunnelHandoffUrl( {
-				dest: wowFunnelDest,
-				siteIdentifier: blueprintArchiveSiteIdentifier,
-			} );
-			if ( ! cancelled ) {
-				handoffUrlRef.current = url;
-			}
-		} )().catch( () => {
-			// Confirm falls back to fetching it.
-		} );
-
-		return () => {
-			cancelled = true;
-		};
-	}, [ wowFunnelSlug, wowFunnelDest, blueprintArchiveSiteIdentifier ] );
 
 	// Kick off the background transfer + blueprint-archive import as soon as the
 	// spec page mounts, so it runs while the user reviews the spec. A funnel run skips this:

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
@@ -6,7 +6,6 @@ import { act, render } from '@testing-library/react';
 import {
 	applyBlueprintSpec,
 	getSiteAdminUrl,
-	isAtomicTransferComplete,
 	startBlueprintArchiveImport,
 	waitForAtomicTransferComplete,
 	waitForBlueprintImportComplete,
@@ -98,13 +97,12 @@ jest.mock( 'calypso/landing/stepper/stores', () => ( {
 // The wow-funnel helpers stay real so the funnel's readiness rules are exercised; only the
 // requests they make are stubbed.
 jest.mock( 'calypso/landing/stepper/utils/blueprint-archive-import', () => ( {
-	applyBlueprintSpec: jest.fn( () => Promise.resolve( true ) ),
+	applyBlueprintSpec: jest.fn( () => Promise.resolve( { applied: true, adminUrl: null } ) ),
 	getBlueprintArchiveSiteIdentifier: jest.fn(
 		( { siteSlug, siteId }: { siteSlug?: string | null; siteId?: string | null } ) =>
 			siteSlug || ( siteId && String( siteId ) !== '0' ? String( siteId ) : null )
 	),
 	getSiteAdminUrl: jest.fn( () => Promise.resolve( 'https://example.wordpress.com/wp-admin/' ) ),
-	isAtomicTransferComplete: jest.fn( () => Promise.resolve( true ) ),
 	getSiteEditorUrl: jest.fn( () => 'https://example.wordpress.com/wp-admin/site-editor.php' ),
 	logBlueprintArchiveEvent: jest.fn(),
 	startBlueprintArchiveImport: jest.fn( () => Promise.resolve() ),
@@ -353,50 +351,35 @@ describe( 'SiteSpec blueprint archive import', () => {
 		expect( waitForBlueprintImportComplete ).not.toHaveBeenCalled();
 	} );
 
-	it( 'prefetches the hand-off URL while the customer is still answering', async () => {
-		renderSiteSpec();
-		// Let the mount effect settle.
-		await act( async () => {} );
-
-		// One status check, never the poll — waiting belongs to the processing step.
-		expect( isAtomicTransferComplete ).toHaveBeenCalledWith( 'example.wordpress.com' );
-		expect( waitForAtomicTransferComplete ).not.toHaveBeenCalled();
-		expect( getSiteAdminUrl ).toHaveBeenCalledTimes( 1 );
-
-		const siteSpecOptions = mockUseSiteSpec.mock.calls[ 0 ][ 0 ];
-		await act( async () => {
-			await siteSpecOptions.onSpecConfirm( { spec_id: 'spec-789' } );
+	it( 'uses the admin URL from the apply response, so confirm does not fetch it', async () => {
+		( applyBlueprintSpec as jest.Mock ).mockResolvedValueOnce( {
+			applied: true,
+			adminUrl: 'https://example.wpcomstaging.com/wp-admin/',
 		} );
+
+		await confirmSpec();
 
 		const pendingAction = mockSetPendingAction.mock.calls[ 0 ][ 0 ];
 		await expect( pendingAction() ).resolves.toEqual( {
 			redirectTo: 'https://example.wordpress.com/wp-admin/site-editor.php',
 		} );
 
-		// Still one: confirm spent the prefetched URL instead of paying for it again.
-		expect( getSiteAdminUrl ).toHaveBeenCalledTimes( 1 );
+		// The response already knew the admin base, so the extra /sites/<id> round trip is skipped
+		// — that request is the one this change exists to remove from the hand-off.
+		expect( getSiteAdminUrl ).not.toHaveBeenCalled();
 	} );
 
-	it( 'skips the prefetch while the site is still transferring', async () => {
-		// admin_url changes when a site goes Atomic, so a URL read now would name the old site.
-		( isAtomicTransferComplete as jest.Mock ).mockResolvedValueOnce( false );
+	it( 'falls back to fetching the admin URL when the response has none', async () => {
+		// A wpcom that predates the field. The hand-off must still work, just a round trip slower.
+		( applyBlueprintSpec as jest.Mock ).mockResolvedValueOnce( { applied: true, adminUrl: null } );
 
-		renderSiteSpec();
-		await act( async () => {} );
-
-		expect( getSiteAdminUrl ).not.toHaveBeenCalled();
-
-		const siteSpecOptions = mockUseSiteSpec.mock.calls[ 0 ][ 0 ];
-		await act( async () => {
-			await siteSpecOptions.onSpecConfirm( { spec_id: 'spec-789' } );
-		} );
+		await confirmSpec();
 
 		const pendingAction = mockSetPendingAction.mock.calls[ 0 ][ 0 ];
 		await expect( pendingAction() ).resolves.toEqual( {
 			redirectTo: 'https://example.wordpress.com/wp-admin/site-editor.php',
 		} );
 
-		// Fetched at confirm, once, now that the transfer is known to be done.
 		expect( getSiteAdminUrl ).toHaveBeenCalledTimes( 1 );
 	} );
 

--- a/client/landing/stepper/utils/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/blueprint-archive-import.ts
@@ -194,31 +194,6 @@ export async function waitForBlueprintImportComplete(
 }
 
 /**
- * One-shot check of whether a site's Atomic transfer has already completed.
- *
- * Distinct from waitForAtomicTransferComplete(): a caller that must not block — a prefetch
- * speculating on work it may not need — wants an answer now, not a poll that can run for minutes.
- *
- * A missing transfer, an in-flight one, or a transient error all read as `false`. This is an
- * optimisation hint only: `false` never means the transfer failed, so callers must fall back to
- * doing the work properly rather than treating it as a verdict.
- */
-export async function isAtomicTransferComplete( siteIdentifier: string ): Promise< boolean > {
-	try {
-		const transfer = ( await wpcom.req.get( {
-			path: `/sites/${ siteIdentifier }/atomic/transfers/latest`,
-			apiNamespace: 'wpcom/v2',
-		} ) ) as AtomicTransferResponse;
-
-		return Boolean(
-			transfer?.status && ATOMIC_TRANSFER_COMPLETE_STATES.includes( transfer.status )
-		);
-	} catch {
-		return false;
-	}
-}
-
-/**
  * Poll the canonical Atomic transfer status endpoint until the site's transfer
  * to Atomic completes. Resolves on a complete state; throws on a terminal
  * failure or timeout. A missing transfer (404 before the backup_import job
@@ -293,17 +268,37 @@ export async function waitForAtomicTransferComplete(
  * Resolves either way — a failure here costs the user personalization, not
  * their site, so it must never block the hand-off to the editor.
  */
+/**
+ * Result of applying a confirmed spec.
+ *
+ * `adminUrl` is the site's wp-admin base as the server resolved it at apply time. Null when the
+ * apply failed, or when wpcom has not yet deployed the field — callers must fall back rather than
+ * assume it is present.
+ */
+export interface ApplyBlueprintSpecResult {
+	applied: boolean;
+	adminUrl: string | null;
+}
+
+/**
+ * Apply a confirmed site spec, and hand back the admin URL the response already knows.
+ *
+ * The endpoint resolves the site's admin URL as part of its reply, so reading it here saves the
+ * caller a `/sites/<id>` round trip on the hand-off path — the one place the customer is watching a
+ * spinner. It is also necessarily current: admin_url changes when a site goes Atomic, and by the
+ * time a spec is applied the transfer has landed.
+ */
 export async function applyBlueprintSpec(
 	siteIdentifier: string,
 	specId: string,
 	blueprintSlug?: string | null
-): Promise< boolean > {
+): Promise< ApplyBlueprintSpecResult > {
 	if ( ! specId ) {
-		return false;
+		return { applied: false, adminUrl: null };
 	}
 
 	try {
-		await wpcom.req.post(
+		const response = ( await wpcom.req.post(
 			{
 				path: `/sites/${ siteIdentifier }/big-sky/apply-blueprint-spec`,
 				apiNamespace: 'wpcom/v2',
@@ -312,14 +307,19 @@ export async function applyBlueprintSpec(
 				spec_id: specId,
 				...( blueprintSlug ? { blueprint_id: blueprintSlug } : {} ),
 			}
-		);
-		return true;
+		) ) as { admin_url?: string };
+
+		return {
+			applied: true,
+			// Absent on a wpcom that predates the field; the caller fetches it the old way.
+			adminUrl: typeof response?.admin_url === 'string' ? response.admin_url : null,
+		};
 	} catch ( error ) {
 		logBlueprintArchiveEvent( 'apply_spec_error', {
 			site_identifier: siteIdentifier,
 			error: error instanceof Error ? error.message : String( error ),
 		} );
-		return false;
+		return { applied: false, adminUrl: null };
 	}
 }
 

--- a/client/landing/stepper/utils/test/blueprint-archive-import.ts
+++ b/client/landing/stepper/utils/test/blueprint-archive-import.ts
@@ -42,12 +42,34 @@ describe( 'applyBlueprintSpec', () => {
 		mockPost.mockReset();
 	} );
 
+	it( 'surfaces the admin URL the response carries, so the caller need not fetch it', async () => {
+		mockPost.mockResolvedValue( {
+			success: true,
+			admin_url: 'https://example.wpcomstaging.com/wp-admin/',
+		} );
+
+		await expect( applyBlueprintSpec( 'example.wordpress.com', 'spec-123' ) ).resolves.toEqual( {
+			applied: true,
+			adminUrl: 'https://example.wpcomstaging.com/wp-admin/',
+		} );
+	} );
+
+	it( 'reports a null admin URL when the field is absent, rather than inventing one', async () => {
+		// A wpcom that predates the field. The caller has to fall back, so this must not guess.
+		mockPost.mockResolvedValue( { success: true } );
+
+		await expect( applyBlueprintSpec( 'example.wordpress.com', 'spec-123' ) ).resolves.toEqual( {
+			applied: true,
+			adminUrl: null,
+		} );
+	} );
+
 	it( 'posts the spec and blueprint to the apply endpoint', async () => {
 		mockPost.mockResolvedValue( { success: true } );
 
 		await expect(
 			applyBlueprintSpec( 'example.wordpress.com', 'spec-123', 'coachava' )
-		).resolves.toBe( true );
+		).resolves.toEqual( { applied: true, adminUrl: null } );
 
 		expect( mockPost ).toHaveBeenCalledWith(
 			{
@@ -67,7 +89,10 @@ describe( 'applyBlueprintSpec', () => {
 	} );
 
 	it( 'skips the request without a spec id', async () => {
-		await expect( applyBlueprintSpec( '12345', '' ) ).resolves.toBe( false );
+		await expect( applyBlueprintSpec( '12345', '' ) ).resolves.toEqual( {
+			applied: false,
+			adminUrl: null,
+		} );
 
 		expect( mockPost ).not.toHaveBeenCalled();
 	} );
@@ -79,7 +104,10 @@ describe( 'applyBlueprintSpec', () => {
 	it( 'resolves false instead of throwing when the request fails', async () => {
 		mockPost.mockRejectedValue( new Error( 'nope' ) );
 
-		await expect( applyBlueprintSpec( '12345', 'spec-123', 'coachava' ) ).resolves.toBe( false );
+		await expect( applyBlueprintSpec( '12345', 'spec-123', 'coachava' ) ).resolves.toEqual( {
+			applied: false,
+			adminUrl: null,
+		} );
 	} );
 } );
 

--- a/client/landing/stepper/utils/wow-funnel.ts
+++ b/client/landing/stepper/utils/wow-funnel.ts
@@ -353,14 +353,21 @@ export async function waitForWowFunnelReady( {
 export async function getWowFunnelHandoffUrl( {
 	dest,
 	siteIdentifier,
+	adminUrl: knownAdminUrl,
 }: {
 	dest: WowFunnelDest;
 	siteIdentifier: string;
+	/**
+	 * The site's admin base, when the caller already has it — the apply-spec response carries it.
+	 * Supplying it skips a `/sites/<id>` round trip on the hand-off, which happens while the
+	 * customer is watching a spinner.
+	 */
+	adminUrl?: string | null;
 } ): Promise< string > {
 	switch ( dest ) {
 		case 'editor':
 		default: {
-			const adminUrl = await getSiteAdminUrl( siteIdentifier );
+			const adminUrl = knownAdminUrl ?? ( await getSiteAdminUrl( siteIdentifier ) );
 			// `p` opens the front page rather than whatever the editor last had; `canvasEdit`
 			// because a plain site-editor.php load stays in view mode.
 			return getSiteEditorUrl( adminUrl, { canvasEdit: true, path: '/' } );


### PR DESCRIPTION
Follow-up to #114087, which prefetched the hand-off URL during site-spec to avoid a
`/sites/<id>` round trip at confirm. This removes the need for the workaround.

### Why

The apply-spec endpoint already resolves the site's admin URL and returns it. The hand-off
was then fetching `/sites/<id>` to read the same value — a round trip on the one path where
the customer is watching a spinner.

The prefetch dodged that by resolving the URL early, behind a one-shot transfer check that
guarded against `admin_url` changing when a site goes Atomic. Reading it from the apply
response **removes** the problem instead of timing around it: the server resolves it after
the transfer has landed, so it cannot be stale.

Net effect is the same round trip saved, with less machinery and one fewer thing to get
wrong.

### What goes away

- `isAtomicTransferComplete()` — added solely to gate the prefetch
- the ref and mount effect that carried the prefetched value
- the staleness reasoning they existed to satisfy

`applyBlueprintSpec()` now returns `{ applied, adminUrl }` rather than a bare boolean.

### Deploy ordering

`adminUrl` is `null` when the field is absent — a wpcom that predates
Automattic/wpcom#239963 — and the caller falls back to fetching as before. Safe to land in
either order; it simply does nothing useful until the server side ships.

### Scope

This removes one round trip. It is not the whole post-confirm wait: on a production run
today, `applyBlueprintSpec` itself accounted for ~4s (the site's own writes place it at
14:54:35 -> 14:54:39, with the import long finished). The larger remaining cost is that
apply being awaited before the redirect is constructed at all, which is a separate change
with a real UX trade-off — the editor could paint before the styles land.

### Testing

site-spec and stepper utils suites: **133/133**. eslint clean.

New cover, replacing the two prefetch tests:

- the admin URL from the response is used, and `getSiteAdminUrl` is **not** called — that
  absent request is the whole point of the change
- when the response has no admin URL, the hand-off still works and falls back to fetching
- the helper surfaces the field when present, and reports `null` rather than inventing one
  when it is absent
