### PR TITLE
Performance: merge Frontend and Backend into one page with tabs

### DIFF
--- a/client/dashboard/agency/sites/site-sidebar/index.tsx
+++ b/client/dashboard/agency/sites/site-sidebar/index.tsx
@@ -1,5 +1,4 @@
 import { agencySiteQuery, siteBySlugQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -20,7 +19,6 @@ export default function AgencySiteSidebar() {
 	const { data: fullSite } = useQuery( siteBySlugQuery( siteSlug ) );
 	const supportsPerformance = fullSite ? siteTypeSupportsFeature( fullSite, 'performance' ) : false;
 	const supportsMonitoring = fullSite ? siteTypeSupportsFeature( fullSite, 'monitoring' ) : false;
-	const isApmEnabled = isEnabled( 'performance/apm' );
 
 	return (
 		<VStack spacing={ 2 }>
@@ -38,25 +36,11 @@ export default function AgencySiteSidebar() {
 						>
 							{ __( 'Overview' ) }
 						</SidebarMenuItem>
-						{ supportsPerformance &&
-							( isApmEnabled ? (
-								<SidebarExpandableMenuItem
-									label={ __( 'Performance' ) }
-									icon={ chartBar }
-									to={ `/sites/${ siteSlug }/performance` }
-								>
-									<SidebarMenuItem to={ `/sites/${ siteSlug }/performance/frontend` }>
-										{ __( 'Frontend' ) }
-									</SidebarMenuItem>
-									<SidebarMenuItem to={ `/sites/${ siteSlug }/performance/backend` }>
-										{ __( 'Backend' ) }
-									</SidebarMenuItem>
-								</SidebarExpandableMenuItem>
-							) : (
-								<SidebarMenuItem icon={ chartBar } to={ `/sites/${ siteSlug }/performance` }>
-									{ __( 'Performance' ) }
-								</SidebarMenuItem>
-							) ) }
+						{ supportsPerformance && (
+							<SidebarMenuItem icon={ chartBar } to={ `/sites/${ siteSlug }/performance` }>
+								{ __( 'Performance' ) }
+							</SidebarMenuItem>
+						) }
 						{ site.has_backup && (
 							<SidebarMenuItem icon={ backup } to={ `/sites/${ siteSlug }/backups` }>
 								{ __( 'Backups' ) }

--- a/client/dashboard/app/router/agency.tsx
+++ b/client/dashboard/app/router/agency.tsx
@@ -23,7 +23,6 @@ import {
 	wooPaymentsLicensesQuery,
 	WOOPAYMENTS_PLUGIN,
 } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { createRoute, createLazyRoute, notFound, Outlet } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { hasApprovedDirectory } from '../../agency/partner-directory/lib';
@@ -872,7 +871,7 @@ export const agencySiteScanHistoryRoute = createRoute( {
 	)
 );
 
-// `/sites/$siteSlug/performance` – layout hosting the Frontend and Backend views
+// `/sites/$siteSlug/performance` - layout hosting the page speed and server response views
 const agencySitePerformanceRoute = createRoute( {
 	staticData: { requiresSiteTypeSupport: 'performance' },
 	head: () => ( { meta: [ { title: __( 'Performance' ) } ] } ),
@@ -895,9 +894,6 @@ const agencySitePerformanceIndexRoute = createRoute( {
 } );
 
 export const agencySitePerformanceFrontendRoute = createRoute( {
-	head: () => ( {
-		meta: [ { title: isEnabled( 'performance/apm' ) ? __( 'Frontend' ) : undefined } ],
-	} ),
 	getParentRoute: () => agencySitePerformanceRoute,
 	path: 'frontend',
 } ).lazy( () =>
@@ -909,7 +905,6 @@ export const agencySitePerformanceFrontendRoute = createRoute( {
 );
 
 export const agencySitePerformanceBackendRoute = createRoute( {
-	head: () => ( { meta: [ { title: __( 'Backend' ) } ] } ),
 	getParentRoute: () => agencySitePerformanceRoute,
 	path: 'backend',
 } );

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -623,13 +623,6 @@ export const sitePerformanceIndexRoute = createRoute( {
 } );
 
 export const sitePerformanceFrontendRoute = createRoute( {
-	head: () => ( {
-		meta: [
-			{
-				title: isEnabled( 'performance/apm' ) ? __( 'Frontend' ) : undefined,
-			},
-		],
-	} ),
 	getParentRoute: () => sitePerformanceRoute,
 	path: 'frontend',
 } ).lazy( () =>
@@ -641,13 +634,6 @@ export const sitePerformanceFrontendRoute = createRoute( {
 );
 
 export const sitePerformanceBackendRoute = createRoute( {
-	head: () => ( {
-		meta: [
-			{
-				title: __( 'Backend' ),
-			},
-		],
-	} ),
 	getParentRoute: () => sitePerformanceRoute,
 	path: 'backend',
 } );

--- a/client/dashboard/sites/performance/backend/backend-status.tsx
+++ b/client/dashboard/sites/performance/backend/backend-status.tsx
@@ -48,7 +48,7 @@ export default function BackendStatusNotice( {
 				variant="error"
 				title={ sprintf(
 					/* translators: %s is the average response time. */
-					__( 'Backend is slow — avg %s' ),
+					__( 'Server response is slow — avg %s' ),
 					formatted
 				) }
 			>
@@ -65,7 +65,7 @@ export default function BackendStatusNotice( {
 				variant="warning"
 				title={ sprintf(
 					/* translators: %s is the average response time. */
-					__( 'Backend needs improvement — avg %s' ),
+					__( 'Server response needs improvement — avg %s' ),
 					formatted
 				) }
 			>
@@ -81,7 +81,7 @@ export default function BackendStatusNotice( {
 			variant="success"
 			title={ sprintf(
 				/* translators: %s is the average response time. */
-				__( 'Healthy backend — avg %s' ),
+				__( 'Healthy server response — avg %s' ),
 				formatted
 			) }
 		>

--- a/client/dashboard/sites/performance/backend/index.tsx
+++ b/client/dashboard/sites/performance/backend/index.tsx
@@ -8,16 +8,14 @@ import {
 	privateApis,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { __ } from '@wordpress/i18n';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { useMemo } from 'react';
 import { Card } from '../../../components/card';
-import { PageHeader } from '../../../components/page-header';
-import PageLayout from '../../../components/page-layout';
 import UpsellCallout from '../../hosting-feature-gated-with-callout/upsell';
 import { hasBackendAccess } from '../backend-access';
 import { getBackendCalloutProps } from '../backend-callout';
 import { VIEWPORT_BREAKPOINTS } from '../constants';
+import PerformancePage from '../performance-page';
 import { mergeAggregates } from './aggregate';
 import BackendEmptyState from './backend-empty-state';
 import BackendStatusNotice from './backend-status';
@@ -168,22 +166,19 @@ export default function SitePerformanceBackend( {
 	const [ timeframe, setTimeframe ] = usePersistedTimeframe();
 
 	return (
-		<PageLayout
-			header={
-				<PageHeader
-					title={ __( 'Backend' ) }
-					description={
-						userHasBackendAccess ? <BackendSubtitle capturing={ apmEnabled } /> : undefined
-					}
-					actions={
-						userHasBackendAccess ? (
-							<HStack spacing={ 2 } justify="flex-end" expanded={ false }>
-								<TimeframeSelector value={ timeframe } onChange={ setTimeframe } />
-								{ ! apmEnabled && <StartCapturingButton site={ site } /> }
-							</HStack>
-						) : undefined
-					}
-				/>
+		<PerformancePage
+			siteSlug={ siteSlug }
+			tab="backend"
+			description={
+				userHasBackendAccess ? <BackendSubtitle capturing={ apmEnabled } /> : undefined
+			}
+			actions={
+				userHasBackendAccess ? (
+					<HStack spacing={ 2 } justify="flex-end" expanded={ false }>
+						<TimeframeSelector value={ timeframe } onChange={ setTimeframe } />
+						{ ! apmEnabled && <StartCapturingButton site={ site } /> }
+					</HStack>
+				) : undefined
 			}
 		>
 			{ userHasBackendAccess ? (
@@ -191,6 +186,6 @@ export default function SitePerformanceBackend( {
 			) : (
 				<UpsellCallout site={ site } { ...getBackendCalloutProps() } />
 			) }
-		</PageLayout>
+		</PerformancePage>
 	);
 }

--- a/client/dashboard/sites/performance/backend/test/index.test.tsx
+++ b/client/dashboard/sites/performance/backend/test/index.test.tsx
@@ -242,7 +242,7 @@ describe( '<SitePerformanceBackend>', () => {
 		// but one of these three titles must always appear with the formatted avg.
 		expect(
 			await screen.findByText(
-				/(Healthy backend|Backend needs improvement|Backend is slow) — avg /
+				/(Healthy server response|Server response needs improvement|Server response is slow) — avg /
 			)
 		).toBeVisible();
 	} );
@@ -257,7 +257,9 @@ describe( '<SitePerformanceBackend>', () => {
 		await screen.findByRole( 'heading', { name: 'Response time breakdown' } );
 
 		expect(
-			screen.queryByText( /(Healthy backend|Backend needs improvement|Backend is slow) — avg / )
+			screen.queryByText(
+				/(Healthy server response|Server response needs improvement|Server response is slow) — avg /
+			)
 		).not.toBeInTheDocument();
 	} );
 

--- a/client/dashboard/sites/performance/frontend/index.tsx
+++ b/client/dashboard/sites/performance/frontend/index.tsx
@@ -6,10 +6,9 @@ import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useEffect, useState, useMemo } from 'react';
 import { useAnalytics } from '../../../app/analytics';
 import { sitePerformanceFrontendRoute } from '../../../app/router/sites';
-import { PageHeader } from '../../../components/page-header';
-import PageLayout from '../../../components/page-layout';
 import DeviceToggle from '../device-toggle';
 import PageSelector from '../page-selector';
+import PerformancePage from '../performance-page';
 import Report from '../report';
 import ReportErrorNotice from '../report-error-notice';
 import ReportLoading from '../report-loading';
@@ -114,43 +113,38 @@ export default function SitePerformanceFrontend( { siteSlug }: { siteSlug: strin
 	};
 
 	return (
-		<PageLayout
-			header={
-				<PageHeader
-					description={
-						<Subtitle timestamp={ currentReport?.timestamp } onClick={ handleReportRefetch } />
-					}
-					actions={
-						<HStack>
-							<PageSelector
-								siteUrl={ site.URL }
-								currentPage={ currentPage }
-								pages={ pagesData || [] }
-								onChange={ ( pageId ) => {
-									setRunNewReport( false );
-									recordTracksEvent(
-										'calypso_dashboard_performance_profiler_page_selector_change',
-										{
-											is_home: pageId === '0',
-										}
-									);
+		<PerformancePage
+			siteSlug={ siteSlug }
+			tab="frontend"
+			description={
+				<Subtitle timestamp={ currentReport?.timestamp } onClick={ handleReportRefetch } />
+			}
+			actions={
+				<HStack>
+					<PageSelector
+						siteUrl={ site.URL }
+						currentPage={ currentPage }
+						pages={ pagesData || [] }
+						onChange={ ( pageId ) => {
+							setRunNewReport( false );
+							recordTracksEvent( 'calypso_dashboard_performance_profiler_page_selector_change', {
+								is_home: pageId === '0',
+							} );
 
-									navigate( {
-										to: `/sites/${ siteSlug }/performance/frontend`,
-										search: ( prev: Record< string, string > ) => ( {
-											...prev,
-											page_id: Number( pageId ),
-										} ),
-									} );
-								} }
-							/>
-							<DeviceToggle value={ deviceToggle } onChange={ setDeviceToggle } />
-						</HStack>
-					}
-				/>
+							navigate( {
+								to: `/sites/${ siteSlug }/performance/frontend`,
+								search: ( prev: Record< string, string > ) => ( {
+									...prev,
+									page_id: Number( pageId ),
+								} ),
+							} );
+						} }
+					/>
+					<DeviceToggle value={ deviceToggle } onChange={ setDeviceToggle } />
+				</HStack>
 			}
 		>
 			{ renderContent() }
-		</PageLayout>
+		</PerformancePage>
 	);
 }

--- a/client/dashboard/sites/performance/performance-page.tsx
+++ b/client/dashboard/sites/performance/performance-page.tsx
@@ -1,0 +1,66 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useRouter } from '@tanstack/react-router';
+import { privateApis } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+import { PageHeader } from '../../components/page-header';
+import PageLayout from '../../components/page-layout';
+
+export type PerformanceTab = 'frontend' | 'backend';
+
+const { unlock } = __dangerousOptInToUnstableAPIsOnlyForCoreModules(
+	'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+	'@wordpress/components'
+);
+
+const { Tabs } = unlock( privateApis );
+
+/**
+ * Shared shell for the two Performance views. Each view keeps its own route so
+ * it stays deep-linkable, but they share one page title and one tab bar so they
+ * read as a single page.
+ */
+export default function PerformancePage( {
+	siteSlug,
+	tab,
+	description,
+	actions,
+	children,
+}: {
+	siteSlug: string;
+	tab: PerformanceTab;
+	description?: React.ReactNode;
+	actions?: React.ReactNode;
+	children: React.ReactNode;
+} ) {
+	const router = useRouter();
+
+	const header = (
+		<PageHeader title={ __( 'Performance' ) } description={ description } actions={ actions } />
+	);
+
+	// Without APM there is only one view, so a tab bar would be noise.
+	if ( ! isEnabled( 'performance/apm' ) ) {
+		return <PageLayout header={ header }>{ children }</PageLayout>;
+	}
+
+	const handleSelect = ( name: string ) => {
+		const next = name as PerformanceTab;
+		if ( next === tab ) {
+			return;
+		}
+		router.navigate( { to: `/sites/${ siteSlug }/performance/${ next }` } );
+	};
+
+	return (
+		<PageLayout header={ header }>
+			<Tabs selectedTabId={ tab } onSelect={ handleSelect }>
+				<Tabs.TabList>
+					<Tabs.Tab tabId="frontend">{ __( 'Page speed' ) }</Tabs.Tab>
+					<Tabs.Tab tabId="backend">{ __( 'Server response' ) }</Tabs.Tab>
+				</Tabs.TabList>
+				<Tabs.TabPanel tabId={ tab }>{ children }</Tabs.TabPanel>
+			</Tabs>
+		</PageLayout>
+	);
+}

--- a/client/dashboard/sites/performance/test/performance-page.test.tsx
+++ b/client/dashboard/sites/performance/test/performance-page.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { isEnabled } from '@automattic/calypso-config';
+import { screen } from '@testing-library/react';
+import { render } from '../../../test-utils';
+import PerformancePage from '../performance-page';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const fn = jest.fn( () => '' );
+	return Object.assign( fn, { __esModule: true, default: fn, isEnabled: jest.fn() } );
+} );
+
+const mockedIsEnabled = isEnabled as jest.MockedFunction< typeof isEnabled >;
+
+describe( '<PerformancePage>', () => {
+	test( 'renders one page title and both tabs, with the current tab selected', async () => {
+		mockedIsEnabled.mockReturnValue( true );
+
+		render(
+			<PerformancePage siteSlug="test-site.wordpress.com" tab="backend">
+				<div>Server response content</div>
+			</PerformancePage>
+		);
+
+		expect( await screen.findByRole( 'heading', { name: 'Performance', level: 1 } ) ).toBeVisible();
+		expect( screen.getByRole( 'tab', { name: 'Page speed' } ) ).toBeVisible();
+		expect( screen.getByRole( 'tab', { name: 'Server response' } ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+		expect( screen.getByText( 'Server response content' ) ).toBeVisible();
+	} );
+
+	test( 'hides the tabs when APM is disabled', async () => {
+		mockedIsEnabled.mockReturnValue( false );
+
+		render(
+			<PerformancePage siteSlug="test-site.wordpress.com" tab="frontend">
+				<div>Page speed content</div>
+			</PerformancePage>
+		);
+
+		expect( await screen.findByText( 'Page speed content' ) ).toBeVisible();
+		expect( screen.queryByRole( 'tab' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/dashboard/sites/site-sidebar/index.tsx
+++ b/client/dashboard/sites/site-sidebar/index.tsx
@@ -1,6 +1,5 @@
 import { HostingFeatures } from '@automattic/api-core';
 import { siteBySlugQuery } from '@automattic/api-queries';
-import { isEnabled } from '@automattic/calypso-config';
 import { isSupportSession } from '@automattic/calypso-support-session';
 import { useQuery } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
@@ -71,7 +70,6 @@ export default function SiteSidebar() {
 function SiteMenuSidebar( { site }: { site: Site } ) {
 	const siteSlug = site.slug;
 	const siteTypeSupports = getSiteTypeFeatureSupports( site );
-	const isApmEnabled = isEnabled( 'performance/apm' );
 
 	if ( isSiteMigrationInProgress( site ) && ! isSupportSession() ) {
 		return null;
@@ -146,26 +144,11 @@ function SiteMenuSidebar( { site }: { site: Site } ) {
 					{ __( 'Backups' ) }
 				</SidebarMenuItem>
 			) }
-			{ isAvailable( sitePerformanceRoute ) &&
-				siteTypeSupports.performance &&
-				( isApmEnabled ? (
-					<SidebarExpandableMenuItem
-						label={ __( 'Performance' ) }
-						icon={ chartBar }
-						to={ `/sites/${ siteSlug }/performance` }
-					>
-						<SidebarMenuItem to={ `/sites/${ siteSlug }/performance/frontend` }>
-							{ __( 'Frontend' ) }
-						</SidebarMenuItem>
-						<SidebarMenuItem to={ `/sites/${ siteSlug }/performance/backend` }>
-							{ __( 'Backend' ) }
-						</SidebarMenuItem>
-					</SidebarExpandableMenuItem>
-				) : (
-					<SidebarMenuItem icon={ chartBar } to={ `/sites/${ siteSlug }/performance` }>
-						{ __( 'Performance' ) }
-					</SidebarMenuItem>
-				) ) }
+			{ isAvailable( sitePerformanceRoute ) && siteTypeSupports.performance && (
+				<SidebarMenuItem icon={ chartBar } to={ `/sites/${ siteSlug }/performance` }>
+					{ __( 'Performance' ) }
+				</SidebarMenuItem>
+			) }
 			{ isAvailable( siteMonitoringRoute ) && siteTypeSupports.monitoring && (
 				<SidebarMenuItem icon={ pending } to={ `/sites/${ siteSlug }/monitoring` }>
 					{ __( 'Monitoring' ) }


### PR DESCRIPTION
Fixes DSGCOM-554

<img width="1223" height="656" alt="Captura de Tela 2026-09-08 às 12 23 51" src="https://github.com/user-attachments/assets/1c44d867-7f0c-4e56-824e-354b695063a7" />

## Proposed Changes

* Merge the Performance "Frontend" and "Backend" views into one page with "Page speed" and "Server response" tabs.
* Sidebar goes back to a single "Performance" item; the expandable Frontend/Backend submenu is removed (both the site and agency sidebars).
* Each tab keeps its own route, so `/performance/frontend` and `/performance/backend/*` stay deep-linkable and the backend sub-tabs and request drill-down are untouched.
* Backend status notices now say "Server response is slow / needs improvement / Healthy server response" instead of "Backend ...".
* Behind the `performance/apm` flag: with it off (production today) the page renders exactly as it does now, with no tab bar.

## Why are these changes being made?

"Frontend" and "Backend" are developer terms, and splitting them into two sidebar items made it look like two unrelated features rather than two views of the same thing.

## Testing Instructions

1. Run the dashboard locally (`yarn start-dashboard`), which has `performance/apm` enabled.
2. Open `/sites/<slug>/performance` on a Business or Commerce site. The sidebar shows one "Performance" item, and the page has a single "Performance" title with "Page speed" and "Server response" tabs.
3. Switch tabs. The URL alternates between `/performance/frontend` and `/performance/backend`, the header actions swap (page + device selectors vs timeframe + Start capturing), and browser back/forward works.
4. On "Server response", open a slow request. The drill-down page has no tab bar and its breadcrumb reads `Performance > Request`.
5. On a Free or Personal site, the "Server response" tab is still there and shows the upsell.
6. Set `"performance/apm": false` in `config/dashboard-development.json` and reload. The sidebar and page match production: one item, no tab bar.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
