### PR TITLE
A4A: fix the Performance tab launch CTA link

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -15,6 +15,7 @@ import {
 	DeviceTabProvider,
 	useDeviceTab,
 } from 'calypso/hosting/performance/contexts/device-tab-context';
+import isA8CForAgencies from 'calypso/lib/a8c-for-agencies/is-a8c-for-agencies';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteLaunchGatingVariant } from 'calypso/lib/use-site-launch-gating-variant';
 import { TabType } from 'calypso/performance-profiler/components/header';
@@ -161,9 +162,11 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 	const [ isExperimentLoading, experimentVariant ] = useSiteLaunchGatingVariant();
 
 	// A free, already-public, or A4A dev site never qualifies, so skip the bridge
-	// and let the CTA redirect instantly.
+	// and let the CTA redirect instantly. A4A sends the CTA to WordPress.com
+	// instead, so the bridge never applies there either.
 	const isFreePlan = site?.plan?.is_free ?? false;
-	const canOfferPreLaunch = ! isSitePublic && ! site?.is_a4a_dev_site && ! isFreePlan;
+	const canOfferPreLaunch =
+		! isSitePublic && ! site?.is_a4a_dev_site && ! isFreePlan && ! isA8CForAgencies();
 	const [ isLaunchModalOpen, setIsLaunchModalOpen ] = useState( false );
 	const [ launchUrl, setLaunchUrl ] = useState( '' );
 
@@ -182,6 +185,15 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 	};
 
 	const onLaunchSiteClick = () => {
+		// A4A has no site settings of its own, so launching happens on WordPress.com.
+		if ( isA8CForAgencies() ) {
+			recordTracksEvent( 'calypso_performance_profiler_prepare_launch_cta_click' );
+			window.location.assign(
+				`https://wordpress.com/sites/${ site?.slug }/settings/site-visibility`
+			);
+			return;
+		}
+
 		if ( site?.is_a4a_dev_site ) {
 			recordTracksEvent( 'calypso_performance_profiler_prepare_launch_cta_click' );
 			page( `/sites/settings/site/${ site.slug }` );


### PR DESCRIPTION
Related https://linear.app/a8c/issue/A4A-3312/performance-tab-shows-launch-site-for-a-wordpresscom-site-that-is

## Proposed Changes

* Point the Performance tab's launch CTA at `wordpress.com/sites/<slug>/settings/site-visibility` when running in A4A, matching what A4A's own site actions already use. Previously A4A dev sites did an in-app `page.js` nav to `/sites/settings/site/<slug>`, which has no route in the A4A router, and every other site was sent to the `/start/launch-site` signup flow.
* Skip the pre-launch modal in A4A so it stops mounting and fetching on a path that can never open it.

## Why are these changes being made?

The A4A classic site details Performance tab renders Calypso's `SitePerformance`, whose launch CTA assumed a Calypso host. Neither destination exists in A4A, so the CTA was a dead link.

One related problem is deliberately out of scope. A4A's dev-site launch calls `\WPCOM\Lib\Launch_Site\set_status_launched()`, which writes only the `launch-status` blog option, while both launch REST endpoints also write `blog_public = 1` and `wpcom_public_coming_soon = 0`. A launched agency site therefore keeps its pre-launch `blog_public` and still reads as not public, so the tab keeps offering to launch a site that is already live. That is a wpcom-side gap and is handled separately.

## Testing Instructions

In A4A, open a site's details and go to the Performance tab. The site must be Atomic for the tab to appear.

1. On an unlaunched A4A dev site, confirm the "Launch your site to start measuring performance" notice shows.
2. Click "Prepare for launch" and confirm it opens `wordpress.com/sites/<slug>/settings/site-visibility`, with no pre-launch modal in between.
3. Repeat on an unlaunched regular A4A WPCOM site and confirm the CTA goes to the same place.
4. On a public A4A site, confirm the performance report still loads as before.
5. Outside A4A, open Performance on an unlaunched site and confirm the notice and its CTA behave exactly as they did before this PR.

```
yarn test-client client/hosting/performance
```

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnzYNuWRytFXcid17ShAnf
