### PR TITLE
Domain search: show the bundle card beside the featured .com on bare-term searches (DOMAINS-2238)

### DIFF
--- a/packages/api-core/src/domain-suggestions/__tests__/fetchers.test.ts
+++ b/packages/api-core/src/domain-suggestions/__tests__/fetchers.test.ts
@@ -68,6 +68,48 @@ describe( 'fetchBundleMetadata', () => {
 		expect( scope.isDone() ).toBe( true );
 	} );
 
+	it( 'sends the plain suggestion defaults so the wrapped request matches the plain one', async () => {
+		const scope = nock( BASE )
+			.get( '/rest/v1.1/domains/suggestions' )
+			.query(
+				( query ) =>
+					query.with_bundles === '1' &&
+					query.include_wordpressdotcom === 'false' &&
+					query.include_dotblogsubdomain === 'false' &&
+					query.only_wordpressdotcom === 'false' &&
+					query.quantity === '5' &&
+					query.vendor === 'variation2_front' &&
+					query.query === 'example'
+			)
+			.reply( 200, { domain_suggestions: [], bundle_suggestion: null, bundle_triggers: [] } );
+
+		await fetchBundleMetadata( 'example' );
+
+		expect( scope.isDone() ).toBe( true );
+	} );
+
+	it( 'forwards caller params over the defaults', async () => {
+		const scope = nock( BASE )
+			.get( '/rest/v1.1/domains/suggestions' )
+			.query(
+				( query ) =>
+					query.with_bundles === '1' &&
+					query.quantity === '30' &&
+					query.vendor === 'ciab' &&
+					query.exact_sld_matches_only === 'true' &&
+					query.query === 'example'
+			)
+			.reply( 200, { domain_suggestions: [], bundle_suggestion: null, bundle_triggers: [] } );
+
+		await fetchBundleMetadata( 'example', {
+			quantity: 30,
+			vendor: 'ciab',
+			exact_sld_matches_only: true,
+		} );
+
+		expect( scope.isDone() ).toBe( true );
+	} );
+
 	it( 'normalises a missing bundle suggestion to null and missing triggers to []', async () => {
 		nock( BASE ).get( '/rest/v1.1/domains/suggestions' ).query( true ).reply( 200, {
 			domain_suggestions: [],

--- a/packages/api-core/src/domain-suggestions/fetchers.ts
+++ b/packages/api-core/src/domain-suggestions/fetchers.ts
@@ -7,20 +7,20 @@ import type {
 	FreeDomainSuggestion,
 } from './types';
 
+const DEFAULT_DOMAIN_SUGGESTION_QUERY = {
+	include_wordpressdotcom: false,
+	include_dotblogsubdomain: false,
+	only_wordpressdotcom: false,
+	quantity: 5,
+	vendor: 'variation2_front',
+};
+
 export async function fetchDomainSuggestions(
 	search: string,
 	domainSuggestionQuery: Partial< DomainSuggestionQuery > = {}
 ): Promise< DomainSuggestion[] > {
-	const defaultDomainSuggestionQuery = {
-		include_wordpressdotcom: false,
-		include_dotblogsubdomain: false,
-		only_wordpressdotcom: false,
-		quantity: 5,
-		vendor: 'variation2_front',
-	};
-
 	const suggestions: DomainSuggestion[] = await wpcom.req.get( '/domains/suggestions', {
-		...defaultDomainSuggestionQuery,
+		...DEFAULT_DOMAIN_SUGGESTION_QUERY,
 		...domainSuggestionQuery,
 		query: search.trim().toLocaleLowerCase(),
 		apiVersion: '1.1',
@@ -90,10 +90,16 @@ export async function fetchAvailableTlds( search?: string, vendor?: string ): Pr
  * normalises a missing suggestion to `null` and missing triggers to `[]`. The
  * frontend `domain-bundling` flag additionally gates whether the query runs at
  * all (see the `bundleMetadataQuery` consumers).
+ * `params` are the plain suggestions request's params, so the backend sees the
+ * same list the client renders (DOMAINS-2238).
  * @param search The domain search query (an SLD or FQDN).
+ * @param params The plain suggestions request's params.
  * @returns The bundle suggestion (or null) and the trigger TLDs (or []).
  */
-export async function fetchBundleMetadata( search: string ): Promise< BundleMetadata > {
+export async function fetchBundleMetadata(
+	search: string,
+	params: Partial< DomainSuggestionQuery > = {}
+): Promise< BundleMetadata > {
 	const response: {
 		bundle_suggestion?: BundleSuggestion | null;
 		bundle_triggers?: string[];
@@ -103,8 +109,9 @@ export async function fetchBundleMetadata( search: string ): Promise< BundleMeta
 			path: '/domains/suggestions',
 		},
 		{
+			...DEFAULT_DOMAIN_SUGGESTION_QUERY,
+			...params,
 			query: search.trim().toLocaleLowerCase(),
-			vendor: 'variation2_front',
 			with_bundles: 1,
 		}
 	);

--- a/packages/api-queries/src/domains.ts
+++ b/packages/api-queries/src/domains.ts
@@ -50,11 +50,16 @@ export const freeSuggestionQuery = (
 // `with_bundles=1` `/domains/suggestions` call, so they share a query key and
 // React Query dedupes them to a single network request even when both consumers
 // are enabled on the same query. The two exports below spread this query and add
-// a `select` picking their half of the response.
-export const bundleMetadataQuery = ( query: string ) =>
+// a `select` picking their half of the response. `params` mirror the plain
+// suggestions request so the two lists match (DOMAINS-2238); they are part of
+// the key because a different filter is a different list.
+export const bundleMetadataQuery = (
+	query: string,
+	params: Partial< DomainSuggestionQuery > = {}
+) =>
 	queryOptions( {
-		queryKey: [ 'domain-bundle-metadata', query ],
-		queryFn: () => fetchBundleMetadata( query ),
+		queryKey: [ 'domain-bundle-metadata', query, params ],
+		queryFn: () => fetchBundleMetadata( query, params ),
 		meta: { persist: false },
 	} );
 
@@ -63,13 +68,19 @@ export const bundleMetadataQuery = ( query: string ) =>
 const selectBundleSuggestion = ( data: BundleMetadata ) => data.bundle_suggestion;
 const selectBundleTriggers = ( data: BundleMetadata ) => data.bundle_triggers;
 
-export const bundleSuggestionQuery = ( query: string ) => ( {
-	...bundleMetadataQuery( query ),
+export const bundleSuggestionQuery = (
+	query: string,
+	params: Partial< DomainSuggestionQuery > = {}
+) => ( {
+	...bundleMetadataQuery( query, params ),
 	select: selectBundleSuggestion,
 } );
 
-export const bundleTriggersQuery = ( query: string ) => ( {
-	...bundleMetadataQuery( query ),
+export const bundleTriggersQuery = (
+	query: string,
+	params: Partial< DomainSuggestionQuery > = {}
+) => ( {
+	...bundleMetadataQuery( query, params ),
 	select: selectBundleTriggers,
 } );
 

--- a/packages/domain-search/src/hooks/test/bundle-metadata-shared-request.tsx
+++ b/packages/domain-search/src/hooks/test/bundle-metadata-shared-request.tsx
@@ -3,9 +3,13 @@
  */
 import { renderHook, waitFor } from '@testing-library/react';
 import nock from 'nock';
+import qs from 'qs';
 import { buildAvailability } from '../../test-helpers/factories/availability';
 import { mockGetAvailabilityQuery } from '../../test-helpers/queries/availability';
-import { mockGetSuggestionsQuery } from '../../test-helpers/queries/suggestions';
+import {
+	mockGetBundleMetadataQuery,
+	mockGetSuggestionsQuery,
+} from '../../test-helpers/queries/suggestions';
 import { queryClient, TestDomainSearch } from '../../test-helpers/renderer';
 import { useInlineBundles } from '../use-inline-bundles';
 import { useSuggestionsList } from '../use-suggestions-list';
@@ -47,7 +51,22 @@ describe( 'bundle metadata shared request', () => {
 		let withBundlesCallCount = 0;
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.1/domains/suggestions' )
-			.query( { vendor: 'variation2_front', with_bundles: 1, query: 'flowers.com' } )
+			.query(
+				qs.stringify(
+					{
+						include_wordpressdotcom: false,
+						include_dotblogsubdomain: false,
+						only_wordpressdotcom: false,
+						quantity: 30,
+						vendor: 'variation2_front',
+						exact_sld_matches_only: false,
+						include_internal_move_eligible: false,
+						query: 'flowers.com',
+						with_bundles: 1,
+					},
+					{ arrayFormat: 'brackets' }
+				)
+			)
 			.reply( 200, () => {
 				withBundlesCallCount++;
 				return { bundle_suggestion: TEST_BUNDLE, bundle_triggers: [ 'com' ] };
@@ -74,5 +93,35 @@ describe( 'bundle metadata shared request', () => {
 
 		expect( result.current.suggestions.bundleSuggestion?.sld ).toBe( 'flowers' );
 		expect( withBundlesCallCount ).toBe( 1 );
+	} );
+
+	// DOMAINS-2238: the backend anchors a bare-term bundle on its own suggestion
+	// list, so the wrapped request must carry the plain request's params — a TLD
+	// filter here changes which list the backend walks.
+	it( 'sends the plain suggestion params, including the TLD filter, on the with_bundles request', async () => {
+		mockGetSuggestionsQuery( {
+			params: { query: 'flowers', tlds: [ 'com', 'net' ] },
+			suggestions: [],
+		} );
+
+		const scope = mockGetBundleMetadataQuery( {
+			params: { query: 'flowers', tlds: [ 'com', 'net' ] },
+			bundleSuggestion: null,
+			bundleTriggers: [ 'com' ],
+		} );
+
+		const { result } = renderHook( () => useInlineBundles(), {
+			wrapper: ( { children } ) => (
+				<TestDomainSearch
+					query="flowers"
+					config={ { showBundleSuggestions: true, allowedTlds: [ 'com', 'net' ] } }
+				>
+					{ children }
+				</TestDomainSearch>
+			),
+		} );
+
+		await waitFor( () => expect( result.current.bundleTriggers ).toEqual( [ 'com' ] ) );
+		expect( scope.isDone() ).toBe( true );
 	} );
 } );

--- a/packages/domain-search/src/hooks/test/bundle-metadata-shared-request.tsx
+++ b/packages/domain-search/src/hooks/test/bundle-metadata-shared-request.tsx
@@ -124,4 +124,57 @@ describe( 'bundle metadata shared request', () => {
 		await waitFor( () => expect( result.current.bundleTriggers ).toEqual( [ 'com' ] ) );
 		expect( scope.isDone() ).toBe( true );
 	} );
+
+	// DOMAINS-2238: because the wrapped request carries the plain params, those
+	// params are part of the `domain-bundle-metadata` key. Two TLD filters on one
+	// term are two different backend lists, so they must not share a cache entry.
+	// Both trees stay mounted for the whole test: `staleTime: Infinity` means a
+	// shared key would serve the second tree from the first tree's entry and leave
+	// the second interceptor unconsumed.
+	it( 'keeps separate cache entries for one query under two param sets', async () => {
+		mockGetSuggestionsQuery( { params: { query: 'flowers', tlds: [ 'com' ] }, suggestions: [] } );
+		mockGetSuggestionsQuery( {
+			params: { query: 'flowers', tlds: [ 'com', 'net' ] },
+			suggestions: [],
+		} );
+
+		const comScope = mockGetBundleMetadataQuery( {
+			params: { query: 'flowers', tlds: [ 'com' ] },
+			bundleTriggers: [ 'com' ],
+		} );
+		const comNetScope = mockGetBundleMetadataQuery( {
+			params: { query: 'flowers', tlds: [ 'com', 'net' ] },
+			bundleTriggers: [ 'com', 'net' ],
+		} );
+
+		const com = renderHook( () => useInlineBundles(), {
+			wrapper: ( { children } ) => (
+				<TestDomainSearch
+					query="flowers"
+					config={ { showBundleSuggestions: true, allowedTlds: [ 'com' ] } }
+				>
+					{ children }
+				</TestDomainSearch>
+			),
+		} );
+
+		const comNet = renderHook( () => useInlineBundles(), {
+			wrapper: ( { children } ) => (
+				<TestDomainSearch
+					query="flowers"
+					config={ { showBundleSuggestions: true, allowedTlds: [ 'com', 'net' ] } }
+				>
+					{ children }
+				</TestDomainSearch>
+			),
+		} );
+
+		await waitFor( () => {
+			expect( com.result.current.bundleTriggers ).toEqual( [ 'com' ] );
+			expect( comNet.result.current.bundleTriggers ).toEqual( [ 'com', 'net' ] );
+		} );
+
+		expect( comScope.isDone() ).toBe( true );
+		expect( comNetScope.isDone() ).toBe( true );
+	} );
 } );

--- a/packages/domain-search/src/hooks/test/use-suggestions-list.tsx
+++ b/packages/domain-search/src/hooks/test/use-suggestions-list.tsx
@@ -42,8 +42,8 @@ describe( 'useSuggestionsList — bundle suggestions', () => {
 		queryClient.clear();
 	} );
 
-	// The top bundle card is the FQDN path, so bundleSuggestion is only fetched
-	// for an FQDN query (a bare-term search shows inline bundle rows instead).
+	// The bundle query runs for every query shape (DOMAINS-2238); the FQDN case
+	// keeps its own coverage here.
 	it( 'surfaces a bundle suggestion for an FQDN query when showBundleSuggestions is on', async () => {
 		mockGetSuggestionsQuery( { params: { query: 'test.com' }, suggestions: [] } );
 		mockGetBundleSuggestionQuery( {
@@ -58,13 +58,35 @@ describe( 'useSuggestionsList — bundle suggestions', () => {
 		expect( result.current.bundleSuggestion?.domains.length ).toBeGreaterThan( 0 );
 	} );
 
-	it( 'does not surface a bundle suggestion for a bare-term query', async () => {
+	// DOMAINS-2238: the backend anchors a bare-term bundle on its own suggestion
+	// list, so the query runs for bare terms too.
+	it( 'surfaces a bundle suggestion for a bare-term query when the backend anchors one', async () => {
 		mockGetSuggestionsQuery( { params: { query: 'test' }, suggestions: [] } );
+		mockGetBundleSuggestionQuery( {
+			params: { query: 'test' },
+			bundleSuggestion: TEST_BUNDLE_SUGGESTION,
+		} );
 
 		const { result } = renderUseSuggestionsList( { showBundleSuggestions: true } );
 
-		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
-		expect( result.current.bundleSuggestion ).toBeUndefined();
+		await waitFor( () => expect( result.current.bundleSuggestion ).toBeTruthy() );
+		expect( result.current.bundleSuggestion?.sld ).toBe( 'test' );
+		expect( result.current.isLoadingBundleSuggestion ).toBe( false );
+	} );
+
+	it( 'reports the bundle request as loading while it is in flight', async () => {
+		mockGetSuggestionsQuery( { params: { query: 'test' }, suggestions: [] } );
+		mockGetBundleSuggestionQuery( {
+			params: { query: 'test' },
+			bundleSuggestion: TEST_BUNDLE_SUGGESTION,
+			delayMs: 100,
+		} );
+
+		const { result } = renderUseSuggestionsList( { showBundleSuggestions: true } );
+
+		expect( result.current.isLoadingBundleSuggestion ).toBe( true );
+		await waitFor( () => expect( result.current.isLoadingBundleSuggestion ).toBe( false ) );
+		expect( result.current.bundleSuggestion?.sld ).toBe( 'test' );
 	} );
 
 	it( 'does not surface a bundle suggestion when the flag is off', async () => {
@@ -74,5 +96,6 @@ describe( 'useSuggestionsList — bundle suggestions', () => {
 
 		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
 		expect( result.current.bundleSuggestion ).toBeUndefined();
+		expect( result.current.isLoadingBundleSuggestion ).toBe( false );
 	} );
 } );

--- a/packages/domain-search/src/hooks/use-suggestions-list.ts
+++ b/packages/domain-search/src/hooks/use-suggestions-list.ts
@@ -43,16 +43,15 @@ export const useSuggestionsList = () => {
 		enabled: config.skippable && ! isFqdn,
 	} );
 
-	// The top bundle card is the FQDN path: a bare-term search shows inline
-	// bundle rows instead (see useInlineBundles), and the backend returns no
-	// bundle_suggestion for a bare term anyway, so this query stays gated to
-	// FQDN queries. It shares a query key with useInlineBundles' bundleTriggers
-	// (see api-queries domains.ts), so the two dedupe to a single request even
-	// when both are enabled on the same FQDN query.
+	// The bundle card is keyed on the featured suggestion, not the typed query
+	// (DOMAINS-2238): the backend anchors a bare-term bundle on the first
+	// trigger-TLD suggestion in its list, so the query runs for every query
+	// shape. It shares a query key with useInlineBundles' bundleTriggers (see
+	// api-queries domains.ts), so the two dedupe to a single request.
 	// Still gated behind the frontend `domain-bundling` flag (config.showBundleSuggestions).
-	const { data: bundleSuggestion } = useQuery( {
+	const { data: bundleSuggestion, isLoading: isLoadingBundleSuggestion } = useQuery( {
 		...queries.bundleSuggestion( query ),
-		enabled: config.showBundleSuggestions && isFqdn,
+		enabled: config.showBundleSuggestions,
 	} );
 
 	const { isLoading: isLoadingQueryAvailability, data: fqdnAvailability } = useQuery( {
@@ -132,5 +131,6 @@ export const useSuggestionsList = () => {
 		featuredSuggestions,
 		regularSuggestions,
 		bundleSuggestion,
+		isLoadingBundleSuggestion,
 	};
 };

--- a/packages/domain-search/src/page/context.ts
+++ b/packages/domain-search/src/page/context.ts
@@ -145,20 +145,25 @@ export const useDomainSearchContextValue = ( {
 			? normalizedConfig.allowedTlds
 			: undefined;
 
+		// One params object for the plain suggestions request and the wrapped
+		// with_bundles request: the backend anchors a bare-term bundle on its own
+		// suggestion list (DOMAINS-2238), so both requests must see the same list.
+		const suggestionParams = {
+			quantity: 30,
+			vendor: normalizedConfig.vendor,
+			tlds: filter.tlds.length > 0 ? filter.tlds : allowedTlds,
+			exact_sld_matches_only: filter.exactSldMatchesOnly,
+			include_internal_move_eligible: normalizedConfig.includeOwnedDomainInSuggestions,
+			site_slug: currentSiteUrl,
+		};
+
 		return {
 			...DEFAULT_CONTEXT_VALUE,
 			events: normalizedEvents,
 			config: normalizedConfig,
 			queries: {
 				domainSuggestions: ( query ) => ( {
-					...domainSuggestionsQuery( query, {
-						quantity: 30,
-						vendor: normalizedConfig.vendor,
-						tlds: filter.tlds.length > 0 ? filter.tlds : allowedTlds,
-						exact_sld_matches_only: filter.exactSldMatchesOnly,
-						include_internal_move_eligible: normalizedConfig.includeOwnedDomainInSuggestions,
-						site_slug: currentSiteUrl,
-					} ),
+					...domainSuggestionsQuery( query, suggestionParams ),
 					enabled: false,
 					staleTime: Infinity,
 					refetchOnMount: false,
@@ -175,14 +180,14 @@ export const useDomainSearchContextValue = ( {
 					refetchOnWindowFocus: false,
 				} ),
 				bundleSuggestion: ( query ) => ( {
-					...bundleSuggestionQuery( query ),
+					...bundleSuggestionQuery( query, suggestionParams ),
 					enabled: false,
 					staleTime: Infinity,
 					refetchOnMount: false,
 					refetchOnWindowFocus: false,
 				} ),
 				bundleTriggers: ( query ) => ( {
-					...bundleTriggersQuery( query ),
+					...bundleTriggersQuery( query, suggestionParams ),
 					enabled: false,
 					staleTime: Infinity,
 					refetchOnMount: false,

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -2,7 +2,7 @@ import { useIsMutating, useMutation } from '@tanstack/react-query';
 import { __experimentalVStack as VStack } from '@wordpress/components';
 import { chevronDown, chevronUp, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { BundleCard } from '../components/bundle-card';
 import { Cart } from '../components/cart';
 import { FeaturedSearchResults } from '../components/featured-search-results';
@@ -17,6 +17,7 @@ import { useInlineBundles } from '../hooks/use-inline-bundles';
 import { useIsCurrentMutation } from '../hooks/use-is-current-mutation';
 import { useRequestTracking } from '../hooks/use-request-tracking';
 import { useSuggestionsList } from '../hooks/use-suggestions-list';
+import { DomainSuggestion } from '../ui';
 import { DOMAIN_BUNDLE_UNAVAILABLE_ERROR_CODE } from './constants';
 import { useDomainSearch } from './context';
 import type { InlineBundleEntry } from '../hooks/use-inline-bundles';
@@ -146,18 +147,51 @@ export const ResultsPage = () => {
 		featuredSuggestions,
 		regularSuggestions,
 		bundleSuggestion,
+		isLoadingBundleSuggestion,
 	} = useSuggestionsList();
 	// Hoisted here (rather than called inside SearchResults) so the featured-trigger
 	// inline rows and the regular-list inline rows share a single hook instance,
 	// and thus one set of bundle requests.
 	const { getInlineBundle } = useInlineBundles();
-	// The top BundleCard is the FQDN path only; a bare-term search shows inline
-	// bundle rows beneath trigger suggestions instead (see useInlineBundles).
 	const isFqdn = isFqdnQuery( query );
+
+	// On an FQDN query the top BundleCard is keyed on the typed domain, as
+	// before. On a bare-term query it is keyed on the featured Recommended
+	// suggestion (DOMAINS-2238): the backend anchors the bundle on the first
+	// trigger-TLD suggestion in its list, and the card renders only when that
+	// primary is the Recommended card, so an anchor the client filtered out or
+	// reordered is ignored.
+	const recommendedFqdn = featuredSuggestions
+		.find( ( { reason } ) => reason === 'recommended' )
+		?.suggestion.toLowerCase();
+	const bundlePrimaryFqdn =
+		bundleSuggestion && bundleSuggestion.domains.length > 0
+			? getBundlePrimaryDomain( bundleSuggestion ).domain.toLowerCase()
+			: undefined;
+	const bundleMatchesRecommended =
+		bundlePrimaryFqdn !== undefined && bundlePrimaryFqdn === recommendedFqdn;
 	// A failed add keeps the card mounted (with an error notice) rather than
 	// hiding it, so the user sees the failure instead of the offer silently
 	// vanishing. See bundleErrorMessage above.
-	const visibleBundleSuggestion = isFqdn ? bundleSuggestion : undefined;
+	const visibleBundleSuggestion = isFqdn || bundleMatchesRecommended ? bundleSuggestion : undefined;
+
+	// While the wrapped request is in flight on a bare-term search, the right
+	// slot shows a placeholder instead of best-alternative, so the row does not
+	// render best-alternative and then swap it for the bundle card.
+	const showBundleSlotPlaceholder =
+		! isFqdn &&
+		config.showBundleSuggestions &&
+		isLoadingBundleSuggestion &&
+		recommendedFqdn !== undefined;
+
+	// The bundle card (or its placeholder) takes the best-alternative slot on a
+	// bare-term search. An FQDN search has one featured card, so nothing is dropped.
+	const bundleTakesRightSlot =
+		! isFqdn && ( !! visibleBundleSuggestion || showBundleSlotPlaceholder );
+	const renderedFeaturedSuggestions = bundleTakesRightSlot
+		? featuredSuggestions.filter( ( { reason } ) => reason !== 'best-alternative' )
+		: featuredSuggestions;
+
 	const numberOfInitialVisibleSuggestions =
 		config.numberOfDomainsResultsPerPage - featuredSuggestions.length;
 
@@ -166,10 +200,7 @@ export const ResultsPage = () => {
 	// inline bundle offer, which the regular list would otherwise own. Derive one
 	// row per featured trigger that has (or is fetching) a bundle, rendered below
 	// the featured section.
-	const visibleBundlePrimaryFqdn =
-		visibleBundleSuggestion && visibleBundleSuggestion.domains.length > 0
-			? getBundlePrimaryDomain( visibleBundleSuggestion ).domain.toLowerCase()
-			: undefined;
+	const visibleBundlePrimaryFqdn = visibleBundleSuggestion ? bundlePrimaryFqdn : undefined;
 
 	const featuredInlineBundles = featuredSuggestions
 		.map( ( { suggestion } ) => {
@@ -229,6 +260,29 @@ export const ResultsPage = () => {
 
 	const showCompactBanner = !! slots?.BeforeResults;
 
+	// One child expression, never an array: FeaturedSearchResults treats a null
+	// child as "no trailing card" when deciding the single-card layout.
+	let bundleSlot: ReactNode = null;
+	if ( visibleBundleSuggestion ) {
+		bundleSlot = (
+			<BundleCard
+				suggestion={ visibleBundleSuggestion }
+				onAddToCart={ ( bundle ) => {
+					addBundleToCart( { bundle, query } );
+				} }
+				isAddedToCart={ visibleBundleSuggestion.domains.every( ( { domain } ) =>
+					cart.hasItem( domain )
+				) }
+				onContinue={ events.onContinue }
+				isBusy={ isAddingBundle }
+				disabled={ isMutating }
+				errorMessage={ bundleErrorMessage }
+			/>
+		);
+	} else if ( showBundleSlotPlaceholder ) {
+		bundleSlot = <DomainSuggestion.Featured.Placeholder />;
+	}
+
 	return (
 		<VStack spacing={ 8 } className="domain-search--results">
 			{ /* Desktop in-flow SearchBar. CSS-hidden on mobile (the persistent
@@ -265,22 +319,8 @@ export const ResultsPage = () => {
 				{ isLoadingSuggestions ? (
 					<FeaturedSearchResults.Placeholder />
 				) : (
-					<FeaturedSearchResults suggestions={ featuredSuggestions }>
-						{ visibleBundleSuggestion && (
-							<BundleCard
-								suggestion={ visibleBundleSuggestion }
-								onAddToCart={ ( bundle ) => {
-									addBundleToCart( { bundle, query } );
-								} }
-								isAddedToCart={ visibleBundleSuggestion.domains.every( ( { domain } ) =>
-									cart.hasItem( domain )
-								) }
-								onContinue={ events.onContinue }
-								isBusy={ isAddingBundle }
-								disabled={ isMutating }
-								errorMessage={ bundleErrorMessage }
-							/>
-						) }
+					<FeaturedSearchResults suggestions={ renderedFeaturedSuggestions }>
+						{ bundleSlot }
 					</FeaturedSearchResults>
 				) }
 				{ /* Inline bundle offers for triggers promoted into the featured section.

--- a/packages/domain-search/src/page/results.tsx
+++ b/packages/domain-search/src/page/results.tsx
@@ -156,44 +156,57 @@ export const ResultsPage = () => {
 	const isFqdn = isFqdnQuery( query );
 
 	// On an FQDN query the top BundleCard is keyed on the typed domain, as
-	// before. On a bare-term query it is keyed on the featured Recommended
-	// suggestion (DOMAINS-2238): the backend anchors the bundle on the first
-	// trigger-TLD suggestion in its list, and the card renders only when that
-	// primary is the Recommended card, so an anchor the client filtered out or
-	// reordered is ignored.
+	// before. On a bare-term query it is keyed on the featured row
+	// (DOMAINS-2238): the backend anchors the bundle on the first trigger-TLD
+	// suggestion in its list, and the card renders only when that primary is
+	// the Recommended or Best alternative card, so an anchor the client
+	// filtered out or reordered is ignored. The .com is not always Recommended:
+	// a .blog often leads a bare-term list with the .com as Best alternative.
 	const recommendedFqdn = featuredSuggestions
 		.find( ( { reason } ) => reason === 'recommended' )
 		?.suggestion.toLowerCase();
+	const featuredFqdns = featuredSuggestions.map( ( { suggestion } ) => suggestion.toLowerCase() );
 	const bundlePrimaryFqdn =
 		bundleSuggestion && bundleSuggestion.domains.length > 0
 			? getBundlePrimaryDomain( bundleSuggestion ).domain.toLowerCase()
 			: undefined;
-	const bundleMatchesRecommended =
-		bundlePrimaryFqdn !== undefined && bundlePrimaryFqdn === recommendedFqdn;
+	const bundleMatchesFeatured =
+		bundlePrimaryFqdn !== undefined && featuredFqdns.includes( bundlePrimaryFqdn );
 	// A failed add keeps the card mounted (with an error notice) rather than
 	// hiding it, so the user sees the failure instead of the offer silently
 	// vanishing. See bundleErrorMessage above.
-	const visibleBundleSuggestion = isFqdn || bundleMatchesRecommended ? bundleSuggestion : undefined;
+	const visibleBundleSuggestion = isFqdn || bundleMatchesFeatured ? bundleSuggestion : undefined;
 
 	// While the wrapped request is in flight on a bare-term search, the right
-	// slot shows a placeholder instead of best-alternative, so the row does not
-	// render best-alternative and then swap it for the bundle card.
+	// slot shows a placeholder instead of Best alternative, so the row does not
+	// render Best alternative and then swap it for the bundle card.
 	const showBundleSlotPlaceholder =
 		! isFqdn &&
 		config.showBundleSuggestions &&
 		isLoadingBundleSuggestion &&
 		recommendedFqdn !== undefined;
 
-	// The bundle card (or its placeholder) takes the best-alternative slot on a
-	// bare-term search. An FQDN search has one featured card, so nothing is dropped.
+	// The bundle card (or its placeholder) takes the Best alternative slot on a
+	// bare-term search. The displaced suggestion is still purchasable on its
+	// own, so once the card is visible it leads the regular list instead of
+	// leaving the page — when a .blog is Recommended, the displaced card is the
+	// .com itself. While the placeholder shows it is withheld, so it does not
+	// jump from the list back into the featured row if no bundle arrives.
 	const bundleTakesRightSlot =
 		! isFqdn && ( !! visibleBundleSuggestion || showBundleSlotPlaceholder );
-	const renderedFeaturedSuggestions = bundleTakesRightSlot
-		? featuredSuggestions.filter( ( { reason } ) => reason !== 'best-alternative' )
+	const displacedSuggestion = bundleTakesRightSlot
+		? featuredSuggestions.find( ( { reason } ) => reason === 'best-alternative' )?.suggestion
+		: undefined;
+	const renderedFeaturedSuggestions = displacedSuggestion
+		? featuredSuggestions.filter( ( { suggestion } ) => suggestion !== displacedSuggestion )
 		: featuredSuggestions;
+	const renderedRegularSuggestions =
+		displacedSuggestion && visibleBundleSuggestion
+			? [ displacedSuggestion, ...regularSuggestions ]
+			: regularSuggestions;
 
 	const numberOfInitialVisibleSuggestions =
-		config.numberOfDomainsResultsPerPage - featuredSuggestions.length;
+		config.numberOfDomainsResultsPerPage - renderedFeaturedSuggestions.length;
 
 	// A trigger domain promoted into the featured section (e.g. the bare-term
 	// search `example` surfaces `example.com` as a featured card) still needs its
@@ -338,9 +351,11 @@ export const ResultsPage = () => {
 					<SearchResults.Placeholder />
 				) : (
 					<SearchResults
-						suggestions={ regularSuggestions }
+						suggestions={ renderedRegularSuggestions }
 						numberOfInitialVisibleSuggestions={ numberOfInitialVisibleSuggestions }
-						getInlineBundle={ getInlineBundle }
+						getInlineBundle={ ( fqdn ) =>
+							fqdn.toLowerCase() === visibleBundlePrimaryFqdn ? undefined : getInlineBundle( fqdn )
+						}
 					/>
 				) }
 			</VStack>

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -7,6 +7,7 @@ import { buildFreeSuggestion, buildSuggestion } from '../../test-helpers/factori
 import { mockGetAvailabilityQuery } from '../../test-helpers/queries/availability';
 import {
 	mockGetBundleForDomainQuery,
+	mockGetBundleMetadataQuery,
 	mockGetBundleSuggestionQuery,
 	mockGetBundleTriggersQuery,
 	mockGetFreeSuggestionQuery,
@@ -1574,6 +1575,185 @@ describe( 'ResultsPage', () => {
 			// The top BundleCard is the single offer...
 			expect( await findBundleMember( 'flowers.net' ) ).toBeInTheDocument();
 			// ...with no inline row duplicating the flowers.com primary.
+			expect( container.querySelector( '.inline-bundle-row' ) ).toBeNull();
+			expect(
+				container.querySelector( '.domain-search--results__featured-inline-bundles' )
+			).toBeNull();
+		} );
+	} );
+
+	describe( 'bundle card on a bare-term search', () => {
+		// DOMAINS-2238: the backend anchors a bare-term bundle on the first
+		// trigger-TLD suggestion in its list. The card renders beside the
+		// Recommended card, in the slot best-alternative used to occupy.
+		const flowersBundle: BundleSuggestion = {
+			sld: 'flowers',
+			domains: [
+				{
+					domain: 'flowers.com',
+					cost: '$22.00',
+					raw_price: 22,
+					product_slug: 'domain_reg',
+					role: 'primary',
+				},
+				{
+					domain: 'flowers.net',
+					cost: '$18.00',
+					raw_price: 18,
+					product_slug: 'domain_reg',
+					role: 'companion',
+				},
+			],
+			bundle_price: 36,
+			original_price: 44,
+			discount_percent: 18,
+			category: 'business',
+			bundle_id: 'flowers-bundle',
+			bundle_group_id: 'v1.flowers.deadbeef',
+			catalogue_version: '1',
+		};
+
+		const flowersSuggestions = [
+			buildSuggestion( { domain_name: 'flowers.com' } ),
+			buildSuggestion( { domain_name: 'flowers.net' } ),
+			buildSuggestion( { domain_name: 'flowers.org' } ),
+		];
+
+		it( 'renders the bundle card beside the recommended suggestion and drops best-alternative', async () => {
+			const onBundleShown = jest.fn();
+			mockGetSuggestionsQuery( { params: { query: 'flowers' }, suggestions: flowersSuggestions } );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'flowers' },
+				bundleSuggestion: flowersBundle,
+			} );
+
+			render(
+				<TestDomainSearch
+					config={ { showBundleSuggestions: true } }
+					events={ { onBundleShown } }
+					query="flowers"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await findBundleCta() ).toBeInTheDocument();
+			expect( await screen.findByTitle( 'flowers.com' ) ).toHaveTextContent( 'Recommended' );
+			expect( screen.queryByText( 'Best alternative' ) ).not.toBeInTheDocument();
+			// The regular list is untouched.
+			expect( await screen.findByTitle( 'flowers.org' ) ).toBeInTheDocument();
+
+			await waitFor( () => {
+				expect( onBundleShown ).toHaveBeenCalledTimes( 1 );
+			} );
+			expect( onBundleShown ).toHaveBeenCalledWith(
+				expect.objectContaining( { sld: 'flowers' } ),
+				'card'
+			);
+		} );
+
+		it( 'keeps best-alternative when the bundle primary is not the recommended suggestion', async () => {
+			mockGetSuggestionsQuery( { params: { query: 'flowers' }, suggestions: flowersSuggestions } );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'flowers' },
+				bundleSuggestion: {
+					...flowersBundle,
+					sld: 'getflowers',
+					domains: [
+						{ ...flowersBundle.domains[ 0 ], domain: 'getflowers.com' },
+						{ ...flowersBundle.domains[ 1 ], domain: 'getflowers.net' },
+					],
+				},
+			} );
+
+			render(
+				<TestDomainSearch config={ { showBundleSuggestions: true } } query="flowers">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByText( 'Best alternative' ) ).toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'keeps best-alternative when the backend returns no bundle', async () => {
+			mockGetSuggestionsQuery( { params: { query: 'flowers' }, suggestions: flowersSuggestions } );
+			mockGetBundleSuggestionQuery( { params: { query: 'flowers' }, bundleSuggestion: null } );
+
+			render(
+				<TestDomainSearch config={ { showBundleSuggestions: true } } query="flowers">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByText( 'Best alternative' ) ).toBeInTheDocument();
+			expect( screen.queryByRole( 'button', { name: 'Get bundle' } ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'shows a placeholder in the right slot while the bundle request is in flight', async () => {
+			mockGetSuggestionsQuery( { params: { query: 'flowers' }, suggestions: flowersSuggestions } );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'flowers' },
+				bundleSuggestion: flowersBundle,
+				delayMs: 300,
+			} );
+
+			render(
+				<TestDomainSearch config={ { showBundleSuggestions: true } } query="flowers">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			// Suggestions have landed; the bundle has not.
+			expect( await screen.findByTitle( 'flowers.com' ) ).toHaveTextContent( 'Recommended' );
+			expect( screen.getAllByLabelText( 'Loading featured domain suggestion' ) ).toHaveLength( 1 );
+			expect( screen.queryByText( 'Best alternative' ) ).not.toBeInTheDocument();
+
+			// The bundle lands: the placeholder becomes the card.
+			expect( await findBundleCta() ).toBeInTheDocument();
+			expect(
+				screen.queryByLabelText( 'Loading featured domain suggestion' )
+			).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Best alternative' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'does not render a placeholder or drop best-alternative when bundles are disabled', async () => {
+			mockGetSuggestionsQuery( { params: { query: 'flowers' }, suggestions: flowersSuggestions } );
+
+			render(
+				<TestDomainSearch config={ { showBundleSuggestions: false } } query="flowers">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await screen.findByText( 'Best alternative' ) ).toBeInTheDocument();
+			expect(
+				screen.queryByLabelText( 'Loading featured domain suggestion' )
+			).not.toBeInTheDocument();
+		} );
+
+		it( 'shows only the card and no inline row when the trigger is already in the cart', async () => {
+			mockGetSuggestionsQuery( { params: { query: 'flowers' }, suggestions: flowersSuggestions } );
+			mockGetBundleMetadataQuery( {
+				params: { query: 'flowers' },
+				bundleSuggestion: flowersBundle,
+				bundleTriggers: [ 'com' ],
+			} );
+			mockGetBundleForDomainQuery( { fqdn: 'flowers.com', bundleSuggestion: flowersBundle } );
+
+			const { container } = render(
+				<TestDomainSearch
+					cart={ buildCart( {
+						items: [ buildCartItem( { domain: 'flowers', tld: 'com' } ) ],
+					} ) }
+					config={ { showBundleSuggestions: true } }
+					query="flowers"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await findBundleMember( 'flowers.net' ) ).toBeInTheDocument();
 			expect( container.querySelector( '.inline-bundle-row' ) ).toBeNull();
 			expect(
 				container.querySelector( '.domain-search--results__featured-inline-bundles' )

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1640,7 +1640,10 @@ describe( 'ResultsPage', () => {
 			expect( await findBundleCta() ).toBeInTheDocument();
 			expect( await screen.findByTitle( 'flowers.com' ) ).toHaveTextContent( 'Recommended' );
 			expect( screen.queryByText( 'Best alternative' ) ).not.toBeInTheDocument();
-			// The regular list is untouched.
+			// The displaced best-alternative leads the regular list instead of leaving the page.
+			expect( await screen.findByTitle( 'flowers.net' ) ).not.toHaveTextContent(
+				'Best alternative'
+			);
 			expect( await screen.findByTitle( 'flowers.org' ) ).toBeInTheDocument();
 
 			await waitFor( () => {
@@ -1652,7 +1655,7 @@ describe( 'ResultsPage', () => {
 			);
 		} );
 
-		it( 'keeps best-alternative when the bundle primary is not the recommended suggestion', async () => {
+		it( 'keeps best-alternative when the bundle primary is not a featured suggestion', async () => {
 			mockGetSuggestionsQuery( { params: { query: 'flowers' }, suggestions: flowersSuggestions } );
 			mockGetBundleSuggestionQuery( {
 				params: { query: 'flowers' },
@@ -1708,6 +1711,7 @@ describe( 'ResultsPage', () => {
 			expect( await screen.findByTitle( 'flowers.com' ) ).toHaveTextContent( 'Recommended' );
 			expect( screen.getAllByLabelText( 'Loading featured domain suggestion' ) ).toHaveLength( 1 );
 			expect( screen.queryByText( 'Best alternative' ) ).not.toBeInTheDocument();
+			expect( screen.queryByTitle( 'flowers.net' ) ).not.toBeInTheDocument();
 
 			// The bundle lands: the placeholder becomes the card.
 			expect( await findBundleCta() ).toBeInTheDocument();
@@ -1734,6 +1738,74 @@ describe( 'ResultsPage', () => {
 
 		it( 'shows only the card and no inline row when the trigger is already in the cart', async () => {
 			mockGetSuggestionsQuery( { params: { query: 'flowers' }, suggestions: flowersSuggestions } );
+			mockGetBundleMetadataQuery( {
+				params: { query: 'flowers' },
+				bundleSuggestion: flowersBundle,
+				bundleTriggers: [ 'com' ],
+			} );
+			mockGetBundleForDomainQuery( { fqdn: 'flowers.com', bundleSuggestion: flowersBundle } );
+
+			const { container } = render(
+				<TestDomainSearch
+					cart={ buildCart( {
+						items: [ buildCartItem( { domain: 'flowers', tld: 'com' } ) ],
+					} ) }
+					config={ { showBundleSuggestions: true } }
+					query="flowers"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await findBundleMember( 'flowers.net' ) ).toBeInTheDocument();
+			expect( container.querySelector( '.inline-bundle-row' ) ).toBeNull();
+			expect(
+				container.querySelector( '.domain-search--results__featured-inline-bundles' )
+			).toBeNull();
+		} );
+
+		it( 'renders the bundle card when the primary is the best-alternative suggestion and moves it to the top of the regular list', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'flowers' },
+				suggestions: [
+					buildSuggestion( { domain_name: 'flowers.blog' } ),
+					buildSuggestion( { domain_name: 'flowers.com' } ),
+					buildSuggestion( { domain_name: 'flowers.org' } ),
+				],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'flowers' },
+				bundleSuggestion: flowersBundle,
+			} );
+
+			render(
+				<TestDomainSearch config={ { showBundleSuggestions: true } } query="flowers">
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			expect( await findBundleCta() ).toBeInTheDocument();
+			expect( screen.getByTitle( 'flowers.blog' ) ).toHaveTextContent( 'Recommended' );
+			expect( screen.queryByText( 'Best alternative' ) ).not.toBeInTheDocument();
+
+			// flowers.org is regular-only, so its role="list" ancestor is the regular list.
+			const regularList = screen.getByTitle( 'flowers.org' ).closest( '[role="list"]' );
+			const regularTitles = Array.from(
+				regularList?.querySelectorAll( '[role="listitem"][title]' ) ?? []
+			).map( ( element ) => element.getAttribute( 'title' ) );
+			expect( regularTitles[ 0 ] ).toBe( 'flowers.com' );
+			expect( regularTitles ).toContain( 'flowers.org' );
+		} );
+
+		it( 'does not offer an inline row for the displaced primary that the card already shows', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'flowers' },
+				suggestions: [
+					buildSuggestion( { domain_name: 'flowers.blog' } ),
+					buildSuggestion( { domain_name: 'flowers.com' } ),
+					buildSuggestion( { domain_name: 'flowers.org' } ),
+				],
+			} );
 			mockGetBundleMetadataQuery( {
 				params: { query: 'flowers' },
 				bundleSuggestion: flowersBundle,

--- a/packages/domain-search/src/page/test/results.tsx
+++ b/packages/domain-search/src/page/test/results.tsx
@@ -1655,6 +1655,35 @@ describe( 'ResultsPage', () => {
 			);
 		} );
 
+		// The page size counts the featured cards that actually render, so the card
+		// the bundle displaces frees a slot in the list below.
+		it( 'counts only the rendered featured cards against the page size', async () => {
+			mockGetSuggestionsQuery( {
+				params: { query: 'flowers' },
+				suggestions: [ ...flowersSuggestions, buildSuggestion( { domain_name: 'flowers.info' } ) ],
+			} );
+			mockGetBundleSuggestionQuery( {
+				params: { query: 'flowers' },
+				bundleSuggestion: flowersBundle,
+			} );
+
+			render(
+				<TestDomainSearch
+					config={ { showBundleSuggestions: true, numberOfDomainsResultsPerPage: 3 } }
+					query="flowers"
+				>
+					<ResultsPage />
+				</TestDomainSearch>
+			);
+
+			// One featured card renders, so the list shows 3 - 1 = 2 rows: the
+			// displaced flowers.net and flowers.org. flowers.info waits behind
+			// "Show more results".
+			expect( await screen.findByTitle( 'flowers.net' ) ).toBeInTheDocument();
+			expect( screen.getByTitle( 'flowers.org' ) ).toBeInTheDocument();
+			expect( screen.queryByTitle( 'flowers.info' ) ).not.toBeInTheDocument();
+		} );
+
 		it( 'keeps best-alternative when the bundle primary is not a featured suggestion', async () => {
 			mockGetSuggestionsQuery( { params: { query: 'flowers' }, suggestions: flowersSuggestions } );
 			mockGetBundleSuggestionQuery( {

--- a/packages/domain-search/src/test-helpers/queries/suggestions.ts
+++ b/packages/domain-search/src/test-helpers/queries/suggestions.ts
@@ -43,32 +43,51 @@ export const mockGetSuggestionsQuery = ( {
 // the other half of the payload is silently absent. When a test needs both
 // fields on the same query, use this combined helper instead.
 export const mockGetBundleMetadataQuery = ( {
-	params,
+	params: rawParams,
 	bundleSuggestion = null,
 	bundleTriggers = [],
+	delayMs,
 }: {
 	params: Partial< DomainSuggestionQuery >;
 	bundleSuggestion?: BundleSuggestion | null;
 	bundleTriggers?: string[];
+	/** Hold the reply so a test can observe the in-flight state. */
+	delayMs?: number;
 } ) => {
-	return nock( 'https://public-api.wordpress.com' )
+	// The wrapped request carries the plain request's params plus with_bundles
+	// (DOMAINS-2238), so the expected query mirrors mockGetSuggestionsQuery.
+	const params = {
+		include_wordpressdotcom: false,
+		include_dotblogsubdomain: false,
+		only_wordpressdotcom: false,
+		quantity: 30,
+		vendor: 'variation2_front',
+		exact_sld_matches_only: false,
+		include_internal_move_eligible: false,
+		...rawParams,
+		with_bundles: 1,
+	};
+
+	const request = nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.1/domains/suggestions' )
-		.query( {
-			vendor: 'variation2_front',
-			with_bundles: 1,
-			...params,
-		} )
-		.reply( 200, { bundle_suggestion: bundleSuggestion, bundle_triggers: bundleTriggers } );
+		.query( qs.stringify( params, { arrayFormat: 'brackets' } ) );
+
+	return ( delayMs ? request.delay( delayMs ) : request ).reply( 200, {
+		bundle_suggestion: bundleSuggestion,
+		bundle_triggers: bundleTriggers,
+	} );
 };
 
 export const mockGetBundleSuggestionQuery = ( {
 	params,
 	bundleSuggestion,
+	delayMs,
 }: {
 	params: Partial< DomainSuggestionQuery >;
 	bundleSuggestion: BundleSuggestion | null;
+	delayMs?: number;
 } ) => {
-	return mockGetBundleMetadataQuery( { params, bundleSuggestion } );
+	return mockGetBundleMetadataQuery( { params, bundleSuggestion, delayMs } );
 };
 
 export const mockGetBundleTriggersQuery = ( {


### PR DESCRIPTION
Related to #DOMAINS-2238

Backend: 239966-ghe-Automattic/wpcom

## Proposed Changes

Render bundle cards on every query, not just FQDN queries. On a bare-term search, the bundle card renders in the right featured slot when the bundle primary matches either the Recommended or "Best alternative" featured suggestions. FQDN searches are unchanged.

<img width="1568" height="1125" alt="domains-2238-bundle-card-scenarios" src="https://github.com/user-attachments/assets/2a7302f0-40cd-48c8-84a6-b266ff2eabdc" />


## Why are these changes being made?

Product wants the bundle offer beside the featured `.com` on every search. Until now the card only rendered when the user typed a full domain name. A bare-term search offered the bundle only as an inline row after a cart add.

The two requests must carry the same params. The backend picks the bundle anchor from its own suggestion list, so a different `quantity`, `vendor`, or TLD filter makes it walk a different list than the one the client renders.

## Testing Instructions

<details>
<summary>Joint test plan (frontend + backend)</summary>

## Testing both PRs together

The backend PR is `239966-ghe-Automattic/wpcom`. The frontend PR is `Automattic/wp-calypso#114175`. Each PR is safe alone; the visible change needs both.

### Setup

1. On your sandbox, check out the wpcom PR branch.
2. Route `public-api.wordpress.com` to your sandbox as you normally do for sandbox testing.
3. In Calypso, check out the frontend PR branch and run `yarn start`.
4. Open `http://calypso.localhost:3000/start/domain/domain-only`.

Pick a search term whose `.com`, `.net`, and `.blog` are all unregistered. `quokkalumberyard` worked on 2026-08-27. Check availability first if in doubt.

### Cases

| # | Do | Expect |
|---|---|---|
| 1 | Search `quokkalumberyard` | Featured row shows the Recommended card (`quokkalumberyard.blog` on 2026-09-08) and a loading placeholder, then the "Protect your Name" bundle card with `quokkalumberyard.com` as its primary. No "Best alternative" card. `quokkalumberyard.com` is the first row of the list below the featured row. |
| 2 | Search `wordpress` | Featured row shows Recommended and Best alternative. No bundle card. |
| 3 | Search `quokkalumberyard.com` | Unchanged: exact match beside the bundle card. |
| 4 | On the case 1 results, add `quokkalumberyard.com` to the cart from its row below the featured row | The bundle card stays. No inline bundle row appears anywhere on the page. |
| 5 | On the case 1 results, filter TLDs to exclude `.com` | No bundle card. Recommended and Best alternative both render. |
| 6 | Repeat case 1 in a private window, logged out | Same as case 1. |

### Backend alone

From a machine with the sandbox hosts entry:

```
curl -s 'https://public-api.wordpress.com/rest/v1.1/domains/suggestions?query=quokkalumberyard&vendor=variation2_front&quantity=30&with_bundles=1' | jq '.bundle_suggestion.domains[0].domain, [.domain_suggestions[].domain_name][0:3]'
```

Expect the bundle primary to be a `.com` that appears in `domain_suggestions`. Repeat with `query=quokkalumberyard.net` and expect `bundle_suggestion` to be `null`.

### Unit

wpcom, on the sandbox:

```
sb-run-tests domain DomainSuggestionsBundleAnchorTest
sb-run-tests domain DomainSuggestionsWithBundlesTest
sb-run-tests domain DomainSuggestionsBundleTriggersTest
```

Calypso, locally:

```
yarn test-packages packages/domain-search packages/api-core/src/domain-suggestions packages/api-queries
```

</details>

<details>
<summary>Unit tests for this PR alone</summary>

```
yarn test-packages packages/domain-search packages/api-core/src/domain-suggestions packages/api-queries
yarn tsc --noEmit -p packages/api-core/tsconfig.json
yarn tsc --noEmit -p packages/api-queries/tsconfig.json
yarn tsc --noEmit -p packages/domain-search/tsconfig.json
```

</details>

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01Qjasb1xFQnePFLPtZLghaE

