### PR TITLE
Site Spec: stop reloading the widget on every render

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -6,7 +6,7 @@ import { useQuery as useReactQuery } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
@@ -594,6 +594,30 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 		blueprintArchiveSiteIdentifier,
 	] );
 
+	// useSiteSpec re-initialises the widget whenever this object's identity changes, the same
+	// way it does for the handlers above. Built inline in the JSX it was a fresh object on
+	// every render, so the widget tore down and reloaded each time.
+	const siteSpecConfig = useMemo( () => {
+		if ( activeFlow === 'build-wow' ) {
+			return getBuildWowSiteSpecConfig( {
+				siteSlug: queryParams.get( 'siteSlug' ),
+				siteId: queryParams.get( 'siteId' ),
+				ref: queryParams.get( 'ref' ),
+				source: querySource,
+			} );
+		}
+		if ( activeFlow === 'early-provision' ) {
+			return getEarlyProvisionSiteSpecConfig();
+		}
+		if ( activeFlow === 'ciab' ) {
+			return getCiabSiteSpecConfig();
+		}
+		if ( shouldImportBlueprint ) {
+			return getBlueprintSiteSpecConfig( { blueprintId: blueprintArchiveSlug } );
+		}
+		return undefined;
+	}, [ activeFlow, shouldImportBlueprint, blueprintArchiveSlug, querySource, queryParams ] );
+
 	if ( buildWowRequested && isLoadingAutomattician ) {
 		return <DocumentHead title={ translate( 'Build Your Site with AI' ) } />;
 	}
@@ -607,35 +631,28 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 	} else if ( activeFlow === 'build-wow' ) {
 		siteSpecStep = (
 			<SiteSpecContainer
-				siteSpecConfig={ getBuildWowSiteSpecConfig( {
-					siteSlug: queryParams.get( 'siteSlug' ),
-					siteId: queryParams.get( 'siteId' ),
-					ref: queryParams.get( 'ref' ),
-					source: querySource,
-				} ) }
+				siteSpecConfig={ siteSpecConfig }
 				onSpecConfirm={ handleBuildWowSpecConfirm }
 			/>
 		);
 	} else if ( activeFlow === 'early-provision' ) {
 		siteSpecStep = (
 			<SiteSpecContainer
-				siteSpecConfig={ getEarlyProvisionSiteSpecConfig() }
+				siteSpecConfig={ siteSpecConfig }
 				onSpecConfirm={ handleEarlyProvisionSpecConfirm }
 			/>
 		);
 	} else if ( shouldImportBlueprint ) {
 		siteSpecStep = (
 			<SiteSpecContainer
-				siteSpecConfig={ getBlueprintSiteSpecConfig( {
-					blueprintId: blueprintArchiveSlug,
-				} ) }
+				siteSpecConfig={ siteSpecConfig }
 				onSpecConfirm={ handleBlueprintArchiveSpecConfirm }
 			/>
 		);
 	} else if ( activeFlow === 'ciab' ) {
 		siteSpecStep = (
 			<SiteSpecContainer
-				siteSpecConfig={ getCiabSiteSpecConfig() }
+				siteSpecConfig={ siteSpecConfig }
 				onMessage={ handleCiabMessage }
 				onSpecConfirm={ handleCiabSpecConfirm }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
@@ -303,6 +303,24 @@ describe( 'SiteSpec early provisioning step', () => {
 		expect( window.location.href ).toBe( '' );
 	} );
 
+	it( 'keeps the widget config stable across re-renders', () => {
+		mockQueryParams = new URLSearchParams( 'build_wow=1&siteSlug=example.wordpress.com' );
+
+		const { rerender } = render(
+			<SiteSpec navigation={ navigation } stepName="site-spec" flow="ai-site-builder-spec" />
+		);
+		rerender(
+			<SiteSpec navigation={ navigation } stepName="site-spec" flow="ai-site-builder-spec" />
+		);
+
+		// useSiteSpec tears down and reloads the widget whenever the config identity changes,
+		// so a config rebuilt on every render restarts the whole load.
+		expect( mockUseSiteSpec.mock.calls.length ).toBeGreaterThan( 1 );
+		expect( mockUseSiteSpec.mock.calls[ 1 ][ 0 ].siteSpecConfig ).toBe(
+			mockUseSiteSpec.mock.calls[ 0 ][ 0 ].siteSpecConfig
+		);
+	} );
+
 	it( 'goes straight to the error step when build_wow has no target site', () => {
 		mockQueryParams = new URLSearchParams( 'build_wow=1' );
 

--- a/client/lib/site-spec/script-loader.ts
+++ b/client/lib/site-spec/script-loader.ts
@@ -163,15 +163,17 @@ async function loadResource( type: ResourceType ): Promise< void > {
 }
 
 /**
- * Loads both SiteSpec CSS and JavaScript resources in the correct order.
+ * Loads both SiteSpec CSS and JavaScript resources.
+ *
+ * Requested together: the script is by far the larger download and the stylesheet is
+ * not needed until the widget renders, so waiting for the CSS first only delays the
+ * script by a round trip.
  * @async
  * @returns Promise that resolves when both resources are loaded
  * @throws {Error} When resource URLs are not configured or loading fails
  */
 export async function loadSiteSpecScriptAndCSS(): Promise< void > {
-	await loadResource( 'css' );
-	await loadResource( 'script' );
-	return;
+	await Promise.all( [ loadResource( 'css' ), loadResource( 'script' ) ] );
 }
 
 /**

--- a/client/lib/site-spec/test/script-loader.ts
+++ b/client/lib/site-spec/test/script-loader.ts
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ */
+import { loadSiteSpecScriptAndCSS, resetSiteSpecScriptState } from '../script-loader';
+import { getSiteSpecUrlByType } from '../utils';
+
+jest.mock( '../utils', () => ( {
+	getSiteSpecUrlByType: jest.fn(),
+} ) );
+
+const mockGetUrl = getSiteSpecUrlByType as jest.Mock;
+
+const SCRIPT_URL = 'https://widgets.example.test/site-spec/index.js';
+const CSS_URL = 'https://widgets.example.test/site-spec/style.css';
+
+/**
+ * The loader resolves on the elements' onload, which jsdom never fires for a real URL.
+ */
+function settle( selector: string, event: 'load' | 'error' ) {
+	const element = document.head.querySelector( selector );
+	if ( ! element ) {
+		throw new Error( `expected ${ selector } in the document` );
+	}
+	( element as HTMLElement )[ event === 'load' ? 'onload' : 'onerror' ]?.( new Event( event ) );
+}
+
+describe( 'loadSiteSpecScriptAndCSS', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		resetSiteSpecScriptState();
+		document.head.innerHTML = '';
+		mockGetUrl.mockImplementation( ( type: string ) =>
+			type === 'script' ? SCRIPT_URL : CSS_URL
+		);
+	} );
+
+	it( 'requests the script without waiting for the stylesheet', async () => {
+		const pending = loadSiteSpecScriptAndCSS();
+
+		// Both tags are in the document before either has loaded. The script is the far
+		// larger download, so serialising it behind the CSS costs a round trip.
+		expect( document.head.querySelector( `script[src="${ SCRIPT_URL }"]` ) ).toBeTruthy();
+		expect( document.head.querySelector( `link[href="${ CSS_URL }"]` ) ).toBeTruthy();
+
+		settle( `link[href="${ CSS_URL }"]`, 'load' );
+		settle( `script[src="${ SCRIPT_URL }"]`, 'load' );
+
+		await expect( pending ).resolves.toBeUndefined();
+	} );
+
+	it( 'rejects when the script fails to load', async () => {
+		// The assertion is attached before the events fire: the promise rejects synchronously
+		// from onerror, and an unattached rejection takes the whole suite down.
+		const failed = expect( loadSiteSpecScriptAndCSS() ).rejects.toThrow( SCRIPT_URL );
+
+		settle( `link[href="${ CSS_URL }"]`, 'load' );
+		settle( `script[src="${ SCRIPT_URL }"]`, 'error' );
+
+		await failed;
+	} );
+
+	it( 'rejects when the stylesheet fails to load', async () => {
+		const failed = expect( loadSiteSpecScriptAndCSS() ).rejects.toThrow( CSS_URL );
+
+		settle( `link[href="${ CSS_URL }"]`, 'error' );
+
+		await failed;
+	} );
+
+	it( 'throws when a resource URL is not configured', async () => {
+		mockGetUrl.mockReturnValue( null );
+
+		await expect( loadSiteSpecScriptAndCSS() ).rejects.toThrow( 'URL not configured' );
+	} );
+} );


### PR DESCRIPTION
Part of BIGR-965.

## Proposed Changes

* Build the Site Spec widget's config object once, in a `useMemo`, instead of rebuilding it inline in the JSX on every render.
* Ask for the widget's script and stylesheet at the same time instead of waiting for the stylesheet first.
* Add tests for `client/lib/site-spec/script-loader.ts`, which had none.

## Why are these changes being made?

Both are about how long the Site Spec widget takes to appear. That matters more now that the AI theme generation flow is becoming the default after checkout, because the widget is the first thing the customer waits for on that page.

`useSiteSpec` reloads the widget whenever the config object it is given changes identity. The step already keeps its callbacks referentially stable for exactly this reason, and says so in a comment. But the config was built inline in the JSX, so it was a brand new object on every render and defeated that. Each render tore the widget down, cleared the loader's state, and started the load again.

The loader waited for the stylesheet to finish before it even asked for the script. The script is about 400 KB compressed and the stylesheet about 22 KB, so that put a round trip plus the stylesheet transfer in front of the download that actually matters. Nothing needs the stylesheet before the widget renders.

Neither change affects what the widget does or what any flow shows.

## Testing Instructions

* Run `yarn test-client` on `client/lib/site-spec` and `client/landing/stepper/declarative-flow/internals/steps-repository/site-spec`.
* Both new tests fail without the change, so they are worth checking against trunk: the config test compares object identity across two renders, and the loader test asserts the script tag is in the document before the stylesheet has loaded.
* Open a Site Spec page (for example `/setup/ai-site-builder-spec/site-spec?build_wow=1&siteSlug=<site>`) and confirm the interview loads and works as before.
* In the network panel, confirm the script and stylesheet requests start together rather than one after the other.
* Confirm the widget is not repeatedly torn down and re-created: with the change there should be one request for each asset, not one per render.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjGodJbYNFJw9bjFxdrXEt
