### PR TITLE
Reader: Refresh /mine and /list API calls on window focus

### DIFF
--- a/client/reader/data/site-subscriptions/test/use-site-subscriptions.test.tsx
+++ b/client/reader/data/site-subscriptions/test/use-site-subscriptions.test.tsx
@@ -4,6 +4,7 @@
 import {
 	getSiteSubscriptionsQueryKey,
 	patchSiteSubscription,
+	refetchSeenCounts,
 	type SiteSubscriptionsInfiniteData,
 } from '@automattic/api-queries';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -237,5 +238,44 @@ describe( 'subscriptions hooks', () => {
 
 	it( 'does not export hook or function names containing Reader', () => {
 		expect( Object.keys( selectors ).filter( ( name ) => /Reader/.test( name ) ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'useSiteSubscriptions refetchOnMount', () => {
+	afterEach( () => nock.cleanAll() );
+
+	const mockFollowing = () =>
+		nock( BASE )
+			.get( '/rest/v1.2/read/following/mine' )
+			.query( true )
+			.reply( 200, { subscriptions: [], total_subscriptions: 0, page: 1, number: 100 } );
+
+	it( 'refetches stale seen counts on mount when requested', async () => {
+		const queryClient = makeQueryClient();
+		queryClient.setQueryData( getSiteSubscriptionsQueryKey(), makeData( [ makeFollow() ] ), {
+			updatedAt: Date.now() - 31_000,
+		} );
+		const request = mockFollowing();
+
+		renderHook( () => useSiteSubscriptions( {}, { refetchOnMount: refetchSeenCounts } ), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		await waitFor( () => expect( request.isDone() ).toBe( true ) );
+	} );
+
+	it( 'does not refetch fresh seen counts on mount', () => {
+		const queryClient = makeQueryClient();
+		queryClient.setQueryData( getSiteSubscriptionsQueryKey(), makeData( [ makeFollow() ] ), {
+			updatedAt: Date.now() - 1_000,
+		} );
+		const request = mockFollowing();
+
+		renderHook( () => useSiteSubscriptions( {}, { refetchOnMount: refetchSeenCounts } ), {
+			wrapper: makeWrapper( queryClient ),
+		} );
+
+		expect( queryClient.isFetching() ).toBe( 0 );
+		expect( request.isDone() ).toBe( false );
 	} );
 } );

--- a/client/reader/data/site-subscriptions/use-site-subscriptions.ts
+++ b/client/reader/data/site-subscriptions/use-site-subscriptions.ts
@@ -13,23 +13,28 @@ interface UseSiteSubscriptionsOptions {
 	enabled?: boolean;
 }
 
-export const useSiteSubscriptions = ( {
-	fetchAllPages = false,
-	enabled = true,
-}: UseSiteSubscriptionsOptions = {} ) => {
+interface UseSiteSubscriptionsQueryOptions {
+	refetchOnMount?: ReturnType< typeof siteSubscriptionsQuery >[ 'refetchOnMount' ];
+}
+
+export const useSiteSubscriptions = (
+	{ fetchAllPages = false, enabled = true }: UseSiteSubscriptionsOptions = {},
+	queryOptions?: UseSiteSubscriptionsQueryOptions
+) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const isEnabled = enabled && isLoggedIn;
 	const query = useInfiniteQuery( {
 		...siteSubscriptionsQuery(),
+		...queryOptions,
 		enabled: isEnabled,
 	} );
-	const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = query;
+	const { data, fetchNextPage, hasNextPage, isFetching } = query;
 
 	useEffect( () => {
-		if ( fetchAllPages && isEnabled && hasNextPage && ! isFetchingNextPage ) {
+		if ( fetchAllPages && isEnabled && hasNextPage && ! isFetching ) {
 			fetchNextPage( { cancelRefetch: false } );
 		}
-	}, [ fetchAllPages, isEnabled, hasNextPage, isFetchingNextPage, fetchNextPage ] );
+	}, [ fetchAllPages, isEnabled, hasNextPage, isFetching, fetchNextPage ] );
 
 	return Object.assign( {}, query, {
 		subscriptions: getSiteSubscriptionsFromData( data ),

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -1,6 +1,6 @@
 import 'calypso/my-sites/sidebar/style.scss'; // Copy styles from the My Sites sidebar.
 import './style.scss';
-import { readSubscribedListsQuery } from '@automattic/api-queries';
+import { readSubscribedListsQuery, refetchSeenCounts } from '@automattic/api-queries';
 import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useQuery } from '@tanstack/react-query';
@@ -99,7 +99,7 @@ const TrackingKeys = {
  * Loads every page of the shared site-subscriptions query once for the whole sidebar.
  */
 function SyncAllSiteSubscriptions() {
-	useSiteSubscriptions( { fetchAllPages: true } );
+	useSiteSubscriptions( { fetchAllPages: true }, { refetchOnMount: refetchSeenCounts } );
 	return null;
 }
 
@@ -378,7 +378,10 @@ export class ReaderSidebar extends Component {
 
 function withSubscribedLists( WrappedComponent ) {
 	return function WithSubscribedLists( props ) {
-		const { data } = useQuery( readSubscribedListsQuery() );
+		const { data } = useQuery( {
+			...readSubscribedListsQuery(),
+			refetchOnMount: refetchSeenCounts,
+		} );
 		const collator = useSelector( getCurrentIntlCollator );
 		const subscribedLists = useMemo( () => {
 			if ( ! data?.lists ) {

--- a/packages/api-queries/src/__tests__/read-follows.test.tsx
+++ b/packages/api-queries/src/__tests__/read-follows.test.tsx
@@ -1,4 +1,5 @@
 import {
+	focusManager,
 	QueryClient,
 	QueryClientProvider,
 	useInfiniteQuery,
@@ -179,6 +180,57 @@ describe( 'siteSubscriptionsQuery', () => {
 			[ 1, 2, 3 ]
 		);
 	} );
+} );
+
+describe( 'siteSubscriptionsQuery freshness', () => {
+	const page = { subscriptions: [], total_subscriptions: 0, page: 1, number: 100 };
+	const mockFollowing = () =>
+		nock( BASE ).get( '/rest/v1.2/read/following/mine' ).query( true ).reply( 200, page );
+
+	afterEach( () => {
+		focusManager.setFocused( undefined );
+		nock.cleanAll();
+	} );
+
+	it( 'refetches on window focus when data is older than the seen-count max age', async () => {
+		const client = newClient();
+		seedStaleSubscriptionData( client, 31_000 );
+		const request = mockFollowing();
+
+		renderHook( () => useInfiniteQuery( siteSubscriptionsQuery() ), {
+			wrapper: makeWrapper( client ),
+		} );
+		await focus();
+
+		await waitFor( () => expect( request.isDone() ).toBe( true ) );
+	} );
+
+	it( 'does not refetch on window focus when data is fresh', async () => {
+		const client = newClient();
+		seedStaleSubscriptionData( client, 1_000 );
+		const request = mockFollowing();
+
+		renderHook( () => useInfiniteQuery( siteSubscriptionsQuery() ), {
+			wrapper: makeWrapper( client ),
+		} );
+		await focus();
+
+		expect( client.isFetching() ).toBe( 0 );
+		expect( request.isDone() ).toBe( false );
+	} );
+
+	async function focus() {
+		await act( async () => {
+			focusManager.setFocused( false );
+			focusManager.setFocused( true );
+		} );
+	}
+
+	function seedStaleSubscriptionData( client: QueryClient, ageMs: number ) {
+		return client.setQueryData( getSiteSubscriptionsQueryKey(), makeData( [] ), {
+			updatedAt: Date.now() - ageMs,
+		} );
+	}
 } );
 
 describe( 'follow selectors and cache helpers', () => {

--- a/packages/api-queries/src/__tests__/read-lists.test.tsx
+++ b/packages/api-queries/src/__tests__/read-lists.test.tsx
@@ -1,6 +1,16 @@
-import { QueryClient } from '@tanstack/react-query';
+import { focusManager, QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import nock from 'nock';
 import { patchListsSeenCount, readSubscribedListsQuery } from '../read-lists';
 import type { ReadList, ReadSubscribedListsResponse } from '@automattic/api-core';
+import type { ReactNode } from 'react';
+
+const BASE = 'https://public-api.wordpress.com';
+
+const makeWrapper = ( client: QueryClient ) =>
+	function Wrapper( { children }: { children: ReactNode } ) {
+		return <QueryClientProvider client={ client }>{ children }</QueryClientProvider>;
+	};
 
 const newClient = () => new QueryClient( { defaultOptions: { queries: { retry: false } } } );
 
@@ -16,13 +26,55 @@ const makeList = ( overrides: Partial< ReadList > = {} ): ReadList => ( {
 	...overrides,
 } );
 
-const setData = ( client: QueryClient, lists: ReadList[] ) =>
-	client.setQueryData< ReadSubscribedListsResponse >( readSubscribedListsQuery().queryKey, {
-		lists,
-	} );
+const setData = ( client: QueryClient, lists: ReadList[], updatedAt?: number ) =>
+	client.setQueryData< ReadSubscribedListsResponse >(
+		readSubscribedListsQuery().queryKey,
+		{ lists },
+		{ updatedAt }
+	);
 
 const getData = ( client: QueryClient ) =>
 	client.getQueryData< ReadSubscribedListsResponse >( readSubscribedListsQuery().queryKey );
+
+describe( 'readSubscribedListsQuery freshness', () => {
+	const mockLists = () =>
+		nock( BASE ).get( '/rest/v1.2/read/lists' ).query( true ).reply( 200, { lists: [] } );
+
+	afterEach( () => {
+		focusManager.setFocused( undefined );
+		nock.cleanAll();
+	} );
+
+	it( 'refetches on window focus when data is older than the seen-count max age', async () => {
+		const client = newClient();
+		setData( client, [], Date.now() - 31_000 );
+		const request = mockLists();
+
+		renderHook( () => useQuery( readSubscribedListsQuery() ), { wrapper: makeWrapper( client ) } );
+		await focus();
+
+		await waitFor( () => expect( request.isDone() ).toBe( true ) );
+	} );
+
+	it( 'does not refetch on window focus when data is fresh', async () => {
+		const client = newClient();
+		setData( client, [], Date.now() - 1_000 );
+		const request = mockLists();
+
+		renderHook( () => useQuery( readSubscribedListsQuery() ), { wrapper: makeWrapper( client ) } );
+		await focus();
+
+		expect( client.isFetching() ).toBe( 0 );
+		expect( request.isDone() ).toBe( false );
+	} );
+
+	async function focus() {
+		await act( async () => {
+			focusManager.setFocused( false );
+			focusManager.setFocused( true );
+		} );
+	}
+} );
 
 describe( 'patchListsSeenCount', () => {
 	it( 'does not patch when the subscribed lists query has no cached data', () => {

--- a/packages/api-queries/src/__tests__/read-seen-posts.test.tsx
+++ b/packages/api-queries/src/__tests__/read-seen-posts.test.tsx
@@ -9,6 +9,7 @@ import {
 	markReaderPostsAsUnseenMutation,
 	markReaderWpcomPostsAsSeenMutation,
 	markReaderWpcomPostsAsUnseenMutation,
+	refetchSeenCounts,
 } from '../read-seen-posts';
 import type { ReactNode } from 'react';
 
@@ -38,6 +39,29 @@ beforeEach( () => {
 } );
 
 afterEach( () => nock.cleanAll() );
+
+describe( 'refetchSeenCounts', () => {
+	const getQuery = ( client: QueryClient, updatedAt: number ) => {
+		client.setQueryData( [ 'x' ], 'data', { updatedAt } );
+		return client.getQueryCache().find( { queryKey: [ 'x' ] } )!;
+	};
+
+	it( 'returns false when counts are younger than the max age', () => {
+		const query = getQuery( newClient(), Date.now() - 1_000 );
+		expect( refetchSeenCounts( query ) ).toBe( false );
+	} );
+
+	it( "returns 'always' when counts are older than the max age", () => {
+		const query = getQuery( newClient(), Date.now() - 31_000 );
+		expect( refetchSeenCounts( query ) ).toBe( 'always' );
+	} );
+
+	it( "returns 'always' for fresh but invalidated counts", () => {
+		const query = getQuery( newClient(), Date.now() - 1_000 );
+		query.invalidate();
+		expect( refetchSeenCounts( query ) ).toBe( 'always' );
+	} );
+} );
 
 describe( 'markReaderPostsAsSeenMutation', () => {
 	it( 'posts to /seen-posts/seen/new and decrements the feed subscription unseen_count', async () => {

--- a/packages/api-queries/src/read-follows.ts
+++ b/packages/api-queries/src/read-follows.ts
@@ -21,6 +21,7 @@ import {
 	type InfiniteData,
 	type QueryClient,
 } from '@tanstack/react-query';
+import { seenCountQueryOptions } from './read-seen-posts';
 
 // The /read/following/mine endpoint paginates by walking raw subscription rows
 // with offset = (page - 1) * limit, and caps `limit` at 100 server-side
@@ -31,7 +32,6 @@ import {
 // offset) will paginate incorrectly.
 const ITEMS_PER_PAGE = 100;
 const MAX_ITEMS = 2000;
-const STALE_TIME = 60 * 60 * 1000;
 const MAX_PAGES_TO_FETCH = MAX_ITEMS / ITEMS_PER_PAGE;
 
 export type SiteSubscriptionsInfiniteData = InfiniteData< SiteSubscriptionsPage, number >;
@@ -73,8 +73,8 @@ export const siteSubscriptionsQuery = () =>
 			// empty page.
 			return lastPage.subscriptions.length === 0 ? undefined : allPages.length + 1;
 		},
-		staleTime: STALE_TIME,
 		meta: { persist: true },
+		...seenCountQueryOptions,
 	} );
 
 export const getSiteSubscriptionsFromData = (

--- a/packages/api-queries/src/read-lists.ts
+++ b/packages/api-queries/src/read-lists.ts
@@ -10,12 +10,13 @@ import {
 	type ReadSubscribedListsResponse,
 } from '@automattic/api-core';
 import { mutationOptions, queryOptions, type QueryClient } from '@tanstack/react-query';
+import { seenCountQueryOptions } from './read-seen-posts';
 
 export const readSubscribedListsQuery = () =>
 	queryOptions( {
 		queryKey: [ 'read', 'lists', 'subscribed' ],
-		staleTime: 1000 * 60 * 5, // 5 minutes — lists change infrequently
 		queryFn: () => fetchReadSubscribedLists(),
+		...seenCountQueryOptions,
 	} );
 
 export const readListQuery = ( owner: string, slug: string ) =>

--- a/packages/api-queries/src/read-seen-posts.ts
+++ b/packages/api-queries/src/read-seen-posts.ts
@@ -9,9 +9,26 @@ import {
 	type ReadSeenPostsFeedParams,
 	type ReadSeenPostsResponse,
 } from '@automattic/api-core';
-import { mutationOptions, type QueryClient } from '@tanstack/react-query';
+import { mutationOptions, type Query, type QueryClient } from '@tanstack/react-query';
 import { patchSubscriptionSeenCount } from './read-follows';
 import { patchListsSeenCount } from './read-lists';
+
+/**
+ * Query options for fetching unseen counts, including a stale time and a refetch strategy on window focus.
+ */
+export const seenCountQueryOptions = {
+	staleTime: 60 * 60 * 1000, // 1 hour.
+	refetchOnWindowFocus: refetchSeenCounts,
+} as const;
+
+/**
+ * Refetches unseen counts on focus / sidebar mount if the counts are stale.
+ */
+export function refetchSeenCounts( query: Pick< Query, 'isStaleByTime' > ): 'always' | false {
+	const SEEN_COUNT_MAX_AGE_IN_MS = 30 * 1000;
+
+	return query.isStaleByTime( SEEN_COUNT_MAX_AGE_IN_MS ) ? 'always' : false;
+}
 
 export const markReaderPostsAsSeenMutation = ( queryClient: QueryClient ) =>
 	mutationOptions< ReadSeenPostsResponse, Error, ReadSeenPostsFeedParams >( {


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: https://linear.app/a8c/issue/READ-611

## Proposed Changes

* Refetch `siteSubscriptionsQuery` and `readSubscribedListsQuery` on window focus when cached counts are older than 30s, via a shared `seenCountQueryOptions` (1h `staleTime` + `refetchSeenCounts` predicate).
* Apply the same predicate as `refetchOnMount` on the sidebar's two observers so a reload refreshes counts restored from the persisted cache.

## Why are these changes being made?

Marking posts as seen only patched the current tab's cache. Other tabs never refetched: the queries sat inside their `staleTime`, so neither focus nor reload triggered a request. 
## Testing Instructions

1. Log in as a user with seen-posts enabled (e.g. following a P2) and open `/reader` in two tabs, A and B. Note the unseen badge on a followed site in both sidebars.
2. In A, mark a post as seen. A's badge decrements.
3. Wait 30s, switch to B. B's badge updates without a reload. Network tab shows `read/following/mine` and `read/lists` requests.
4. Switch A → B again within 30s. No request is made.
5. In A, "Mark all as seen". Wait 30s, reload B. B shows the updated counts.
6. With a user following more than 100 sites, reload `/reader` and confirm the sidebar loads all follows (multiple `read/following/mine` pages), not just the first 100.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?