### PR TITLE
Reader: clean up Lists

### DIFF
--- a/client/reader/index.ts
+++ b/client/reader/index.ts
@@ -145,14 +145,49 @@ export default async function (): Promise< void > {
 	page( '/reader/feeds/lookup/*', redirectLoggedOutToSignup, feedLookup );
 
 	// Lists
-	page( '/reader/list/:user/:list/edit/items', sidebar, editListItems, makeLayout, clientRender );
-	page( '/reader/list/:user/:list/edit', sidebar, editList, makeLayout, clientRender );
+	page(
+		'/reader/list/:user/:list/edit/items',
+		redirectLoggedOutToSignup,
+		sidebar,
+		editListItems,
+		makeLayout,
+		clientRender
+	);
+	page(
+		'/reader/list/:user/:list/edit',
+		redirectLoggedOutToSignup,
+		sidebar,
+		editList,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/reader/list/new', sidebar, createList, makeLayout, clientRender );
+	page(
+		'/reader/list/new',
+		redirectLoggedOutToSignup,
+		sidebar,
+		createList,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/reader/list/:user/:list/export', sidebar, exportList, makeLayout, clientRender );
+	page(
+		'/reader/list/:user/:list/export',
+		redirectLoggedOutToSignup,
+		sidebar,
+		exportList,
+		makeLayout,
+		clientRender
+	);
 
-	page( '/reader/list/:user/:list/delete', sidebar, deleteList, makeLayout, clientRender );
+	page(
+		'/reader/list/:user/:list/delete',
+		redirectLoggedOutToSignup,
+		sidebar,
+		deleteList,
+		makeLayout,
+		clientRender
+	);
 
 	page(
 		[ '/reader/list/:user/:list', '/reader/list/:user/:list/:view' ],

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -6,12 +6,14 @@ import {
 } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import ReaderExportButton from 'calypso/blocks/reader-export-button';
 import { READER_EXPORT_TYPE_LIST } from 'calypso/blocks/reader-export-button/constants';
 import EmptyContent from 'calypso/components/empty-content';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
@@ -139,7 +141,16 @@ function ReaderListCreate() {
 		<ReaderMain>
 			<NavigationHeader
 				title={ translate( 'Create List' ) }
-				subtitle={ translate( 'Lists let you organize multiple sites into custom feeds.' ) }
+				subtitle={
+					<>
+						{ translate( 'Lists let you organize multiple sites into custom feeds.' ) }{ ' ' }
+						<InlineSupportLink
+							supportPostId={ 92023 }
+							supportLink={ localizeUrl( 'https://wordpress.com/support/reader/reader-lists/' ) }
+							showIcon={ false }
+						/>
+					</>
+				}
 			/>
 			<ListForm isCreateForm isSubmissionDisabled={ isCreatingList } onSubmit={ handleSubmit } />
 		</ReaderMain>

--- a/client/reader/list-manage/index.jsx
+++ b/client/reader/list-manage/index.jsx
@@ -141,16 +141,22 @@ function ReaderListCreate() {
 		<ReaderMain>
 			<NavigationHeader
 				title={ translate( 'Create List' ) }
-				subtitle={
-					<>
-						{ translate( 'Lists let you organize multiple sites into custom feeds.' ) }{ ' ' }
-						<InlineSupportLink
-							supportPostId={ 92023 }
-							supportLink={ localizeUrl( 'https://wordpress.com/support/reader/reader-lists/' ) }
-							showIcon={ false }
-						/>
-					</>
-				}
+				subtitle={ translate(
+					'Lists let you organize multiple sites into custom feeds. {{learnMoreLink}}Learn more{{/learnMoreLink}}',
+					{
+						components: {
+							learnMoreLink: (
+								<InlineSupportLink
+									supportPostId={ 92023 }
+									supportLink={ localizeUrl(
+										'https://wordpress.com/support/reader/reader-lists/'
+									) }
+									showIcon={ false }
+								/>
+							),
+						},
+					}
+				) }
 			/>
 			<ListForm isCreateForm isSubmissionDisabled={ isCreatingList } onSubmit={ handleSubmit } />
 		</ReaderMain>

--- a/client/reader/list/components/list-header/index.tsx
+++ b/client/reader/list/components/list-header/index.tsx
@@ -84,7 +84,7 @@ const ReaderListHeader = ( props: ReaderListHeaderProps ) => {
 					{ description }
 					{ description && createdBy && (
 						<span className="list-stream__header-separator" aria-hidden="true">
-							{ ' · ' }
+							{ ' – ' }
 						</span>
 					) }
 					{ createdBy }

--- a/client/reader/list/components/list-header/index.tsx
+++ b/client/reader/list/components/list-header/index.tsx
@@ -54,17 +54,7 @@ const ReaderListHeader = ( props: ReaderListHeaderProps ) => {
 		readListItemsQuery( list?.owner ?? '', list?.slug ?? '' )
 	);
 	const totalItems = listItemsData?.total_items;
-	const isOwnedByCurrentUser = Boolean(
-		currentUser && list && list.owner === currentUser.username
-	);
-
-	const formattedTitle = (
-		<AutoDirection>
-			<span>{ list?.title }</span>
-		</AutoDirection>
-	);
-
-	const createdBy = list && ! isOwnedByCurrentUser && (
+	const createdBy = list && ! list.is_owner && (
 		<span className="list-stream__header-created-by">
 			{ translate( 'Created by {{ownerLink}}%(owner)s{{/ownerLink}}', {
 				args: { owner: list.owner },
@@ -81,16 +71,18 @@ const ReaderListHeader = ( props: ReaderListHeaderProps ) => {
 		createdBy || description ? (
 			<AutoDirection>
 				<span>
-					{ description }
-					{ description && createdBy && (
-						<span className="list-stream__header-separator" aria-hidden="true">
-							{ ' – ' }
-						</span>
-					) }
+					{ description && <span>{ description }</span> }
+					{ description && createdBy && ' – ' }
 					{ createdBy }
 				</span>
 			</AutoDirection>
 		) : undefined;
+
+	const formattedTitle = (
+		<AutoDirection>
+			<span>{ list?.title }</span>
+		</AutoDirection>
+	);
 
 	const listBaseUrl =
 		list?.owner && list?.slug ? `/reader/list/${ list.owner }/${ list.slug }` : '';

--- a/client/reader/list/components/list-header/index.tsx
+++ b/client/reader/list/components/list-header/index.tsx
@@ -23,7 +23,6 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { useRecordReaderTracksEvent } from 'calypso/state/reader/analytics/useRecordReaderTracksEvent';
 import type { AppState } from 'calypso/types';
-import type { JSX } from 'react';
 
 interface ReaderListHeaderProps {
 	list?: ReaderList;
@@ -55,30 +54,40 @@ const ReaderListHeader = ( props: ReaderListHeaderProps ) => {
 		readListItemsQuery( list?.owner ?? '', list?.slug ?? '' )
 	);
 	const totalItems = listItemsData?.total_items;
-	let title: string | JSX.Element | undefined = list?.title;
-	if ( list ) {
-		// Show author name in parentheses if the list is owned by someone other than the current user
-		const isOwnedByCurrentUser = currentUser && list.owner === currentUser.username;
-		title = isOwnedByCurrentUser ? (
-			title
-		) : (
-			<>
-				{ title } (<a href={ `/reader/users/${ list.owner }` }>{ list.owner }</a>)
-			</>
-		);
-	}
+	const isOwnedByCurrentUser = Boolean(
+		currentUser && list && list.owner === currentUser.username
+	);
 
 	const formattedTitle = (
 		<AutoDirection>
-			<span>{ title }</span>
+			<span>{ list?.title }</span>
 		</AutoDirection>
 	);
 
-	const formattedDescription = (
+	const createdBy = list && ! isOwnedByCurrentUser && (
+		<span className="list-stream__header-created-by">
+			{ translate( 'Created by {{ownerLink}}%(owner)s{{/ownerLink}}', {
+				args: { owner: list.owner },
+				components: {
+					ownerLink: <a href={ `/reader/users/${ list.owner }` } />,
+				},
+			} ) }
+		</span>
+	);
+
+	const description = list?.description && (
 		<AutoDirection>
-			<span>{ list?.description }</span>
+			<span className="list-stream__header-description">{ list.description }</span>
 		</AutoDirection>
 	);
+
+	const formattedSubtitle =
+		createdBy || description ? (
+			<>
+				{ createdBy }
+				{ description }
+			</>
+		) : undefined;
 
 	const listBaseUrl =
 		list?.owner && list?.slug ? `/reader/list/${ list.owner }/${ list.slug }` : '';
@@ -140,7 +149,7 @@ const ReaderListHeader = ( props: ReaderListHeaderProps ) => {
 	return (
 		<>
 			<AutoDirection>
-				<NavigationHeader title={ formattedTitle } subtitle={ formattedDescription }>
+				<NavigationHeader title={ formattedTitle } subtitle={ formattedSubtitle }>
 					{ list?.is_public === false && (
 						<div
 							className="list-stream__header-title-privacy"

--- a/client/reader/list/components/list-header/index.tsx
+++ b/client/reader/list/components/list-header/index.tsx
@@ -75,18 +75,21 @@ const ReaderListHeader = ( props: ReaderListHeaderProps ) => {
 		</span>
 	);
 
-	const description = list?.description && (
-		<AutoDirection>
-			<span className="list-stream__header-description">{ list.description }</span>
-		</AutoDirection>
-	);
+	const description = list?.description;
 
 	const formattedSubtitle =
 		createdBy || description ? (
-			<>
-				{ createdBy }
-				{ description }
-			</>
+			<AutoDirection>
+				<span>
+					{ description }
+					{ description && createdBy && (
+						<span className="list-stream__header-separator" aria-hidden="true">
+							{ ' · ' }
+						</span>
+					) }
+					{ createdBy }
+				</span>
+			</AutoDirection>
 		) : undefined;
 
 	const listBaseUrl =

--- a/client/reader/list/components/list-header/style.scss
+++ b/client/reader/list/components/list-header/style.scss
@@ -82,31 +82,20 @@
 	}
 }
 
-.list-stream__header-created-by {
-	display: block;
-	color: var( --color-neutral-40 );
-	font-size: 12px;
-	margin-top: 2px;
+.list-stream__header-created-by a {
+	color: inherit;
+	text-decoration: none;
 
-	a {
-		color: inherit;
-		text-decoration: none;
+	&:hover {
+		color: var( --color-text-subtle );
+		text-decoration: underline;
+	}
 
+	@include ui-mixins.when-dark-theme {
 		&:hover {
-			color: var( --color-text-subtle );
-			text-decoration: underline;
-		}
-
-		@include ui-mixins.when-dark-theme {
-			&:hover {
-				color: var( --color-link );
-			}
+			color: var( --color-link );
 		}
 	}
-}
-
-.list-stream__header-description {
-	display: block;
 }
 
 .is-reader-page {

--- a/client/reader/list/components/list-header/style.scss
+++ b/client/reader/list/components/list-header/style.scss
@@ -1,6 +1,6 @@
-@use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
+@use 'calypso/assets/stylesheets/shared/mixins/dark-theme' as ui-mixins;
 
-@import "calypso/assets/stylesheets/shared/functions/z-index";
+@import 'calypso/assets/stylesheets/shared/functions/z-index';
 
 .list-stream__header-title-privacy {
 	margin-inline-start: 2px;
@@ -19,27 +19,27 @@
 	align-items: stretch;
 	display: flex;
 	margin-inline-start: auto;
-	z-index: z-index("root", ".list-stream__header-follow");
+	z-index: z-index( 'root', '.list-stream__header-follow' );
 
 	.follow-button {
 		padding: 0;
-		z-index: z-index(".list-stream__header-follow", ".follow-button");
+		z-index: z-index( '.list-stream__header-follow', '.follow-button' );
 
 		.gridicon {
-			fill: var(--color-link);
+			fill: var( --color-link );
 		}
 
 		.follow-button__label {
-			color: var(--color-link);
+			color: var( --color-link );
 		}
 
 		&.is-following {
 			.gridicon {
-				fill: var(--color-success);
+				fill: var( --color-success );
 			}
 
 			.follow-button__label {
-				color: var(--color-success);
+				color: var( --color-success );
 			}
 		}
 	}
@@ -52,7 +52,7 @@
 	.follow-button,
 	.follow-button__label {
 		color: transparent;
-		background-color: var(--color-neutral-0);
+		background-color: var( --color-neutral-0 );
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }
@@ -61,7 +61,7 @@
 	margin-inline-start: auto;
 
 	.list-stream__header-action-icon .gridicon {
-		fill: var(--color-neutral-dark);
+		fill: var( --color-neutral-dark );
 	}
 
 	@include ui-mixins.when-dark-theme {
@@ -82,19 +82,34 @@
 	}
 }
 
-.is-reader-page {
-	.formatted-header__title {
-		a {
-			text-decoration-color: transparent;
-			color: var(--color-text);
-			transition: 0.25s;
+.list-stream__header-created-by {
+	display: block;
+	color: var( --color-neutral-40 );
+	font-size: 12px;
+	margin-top: 2px;
 
+	a {
+		color: inherit;
+		text-decoration: none;
+
+		&:hover {
+			color: var( --color-text-subtle );
+			text-decoration: underline;
+		}
+
+		@include ui-mixins.when-dark-theme {
 			&:hover {
-				text-decoration-color: initial;
+				color: var( --color-link );
 			}
 		}
 	}
+}
 
+.list-stream__header-description {
+	display: block;
+}
+
+.is-reader-page {
 	.list-stream__nav {
 		.section-nav-tab__link {
 			padding-top: 0; // Removing padding from top of tabs to make the view more compact.

--- a/client/reader/list/components/list-header/style.scss
+++ b/client/reader/list/components/list-header/style.scss
@@ -1,6 +1,6 @@
-@use 'calypso/assets/stylesheets/shared/mixins/dark-theme' as ui-mixins;
+@use "calypso/assets/stylesheets/shared/mixins/dark-theme" as ui-mixins;
 
-@import 'calypso/assets/stylesheets/shared/functions/z-index';
+@import "calypso/assets/stylesheets/shared/functions/z-index";
 
 .list-stream__header-title-privacy {
 	margin-inline-start: 2px;
@@ -19,27 +19,27 @@
 	align-items: stretch;
 	display: flex;
 	margin-inline-start: auto;
-	z-index: z-index( 'root', '.list-stream__header-follow' );
+	z-index: z-index("root", ".list-stream__header-follow");
 
 	.follow-button {
 		padding: 0;
-		z-index: z-index( '.list-stream__header-follow', '.follow-button' );
+		z-index: z-index(".list-stream__header-follow", ".follow-button");
 
 		.gridicon {
-			fill: var( --color-link );
+			fill: var(--color-link);
 		}
 
 		.follow-button__label {
-			color: var( --color-link );
+			color: var(--color-link);
 		}
 
 		&.is-following {
 			.gridicon {
-				fill: var( --color-success );
+				fill: var(--color-success);
 			}
 
 			.follow-button__label {
-				color: var( --color-success );
+				color: var(--color-success);
 			}
 		}
 	}
@@ -52,7 +52,7 @@
 	.follow-button,
 	.follow-button__label {
 		color: transparent;
-		background-color: var( --color-neutral-0 );
+		background-color: var(--color-neutral-0);
 		animation: loading-fade 1.6s ease-in-out infinite;
 	}
 }
@@ -61,7 +61,7 @@
 	margin-inline-start: auto;
 
 	.list-stream__header-action-icon .gridicon {
-		fill: var( --color-neutral-dark );
+		fill: var(--color-neutral-dark);
 	}
 
 	@include ui-mixins.when-dark-theme {
@@ -87,13 +87,13 @@
 	text-decoration: none;
 
 	&:hover {
-		color: var( --color-text-subtle );
+		color: var(--color-text-subtle);
 		text-decoration: underline;
 	}
 
 	@include ui-mixins.when-dark-theme {
 		&:hover {
-			color: var( --color-link );
+			color: var(--color-link);
 		}
 	}
 }

--- a/client/reader/list/components/list-header/test/index.test.tsx
+++ b/client/reader/list/components/list-header/test/index.test.tsx
@@ -89,7 +89,7 @@ describe( 'ReaderListHeader', () => {
 		expect( screen.getByText( /Created by/ ) ).toBeVisible();
 		expect( screen.getByText( 'otheruser' ) ).toBeVisible();
 		expect( screen.getByText( 'A test list' ).closest( 'p' ) ).toHaveTextContent(
-			'A test list · Created by otheruser'
+			'A test list – Created by otheruser'
 		);
 	} );
 

--- a/client/reader/list/components/list-header/test/index.test.tsx
+++ b/client/reader/list/components/list-header/test/index.test.tsx
@@ -82,16 +82,27 @@ describe( 'ReaderListHeader', () => {
 		expect( screen.getByText( 'A test list' ) ).toBeVisible();
 	} );
 
-	test( 'shows owner name when list is not owned by current user', () => {
+	test( 'shows a Created by line when list is not owned by current user', () => {
 		renderReaderListHeader( { list: { ...defaultList, owner: 'otheruser', is_owner: false } } );
 
+		expect( screen.getByRole( 'heading', { name: 'My List' } ) ).toBeVisible();
+		expect( screen.getByText( /Created by/ ) ).toBeVisible();
 		expect( screen.getByText( 'otheruser' ) ).toBeVisible();
 	} );
 
-	test( 'does not show owner name when list is owned by current user', () => {
+	test( 'does not show a Created by line when list is owned by current user', () => {
 		renderReaderListHeader();
 
-		expect( screen.queryByText( /\(/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( /Created by/ ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'test_user' ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'does not render a subtitle when there is nothing to show', () => {
+		const { container } = renderReaderListHeader( {
+			list: { ...defaultList, description: '' },
+		} );
+
+		expect( container.querySelector( '.formatted-header__subtitle' ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'shows lock icon for private lists', () => {

--- a/client/reader/list/components/list-header/test/index.test.tsx
+++ b/client/reader/list/components/list-header/test/index.test.tsx
@@ -85,9 +85,6 @@ describe( 'ReaderListHeader', () => {
 	test( 'shows a Created by line when list is not owned by current user', () => {
 		renderReaderListHeader( { list: { ...defaultList, owner: 'otheruser', is_owner: false } } );
 
-		expect( screen.getByRole( 'heading', { name: 'My List' } ) ).toBeVisible();
-		expect( screen.getByText( /Created by/ ) ).toBeVisible();
-		expect( screen.getByText( 'otheruser' ) ).toBeVisible();
 		expect( screen.getByText( 'A test list' ).closest( 'p' ) ).toHaveTextContent(
 			'A test list – Created by otheruser'
 		);

--- a/client/reader/list/components/list-header/test/index.test.tsx
+++ b/client/reader/list/components/list-header/test/index.test.tsx
@@ -88,6 +88,9 @@ describe( 'ReaderListHeader', () => {
 		expect( screen.getByRole( 'heading', { name: 'My List' } ) ).toBeVisible();
 		expect( screen.getByText( /Created by/ ) ).toBeVisible();
 		expect( screen.getByText( 'otheruser' ) ).toBeVisible();
+		expect( screen.getByText( 'A test list' ).closest( 'p' ) ).toHaveTextContent(
+			'A test list · Created by otheruser'
+		);
 	} );
 
 	test( 'does not show a Created by line when list is owned by current user', () => {

--- a/client/reader/sidebar/reader-sidebar-lists/index.tsx
+++ b/client/reader/sidebar/reader-sidebar-lists/index.tsx
@@ -10,6 +10,21 @@ import ReaderUnreadCount from 'calypso/layout/sidebar/reader-unread-count';
 import MoreMenuActions from '../more-menu-actions';
 import ReaderSidebarListsList from './list';
 
+const RECOMMENDED_BLOGS_SLUG = 'recommended-blogs';
+
+// The backend auto-creates a Recommended Blogs list for every user, so a brand
+// new account would otherwise see it as its only list. Hide it until the user
+// has either recommended something or created another list.
+function hideEmptyRecommendedBlogsPlaceholder( lists?: ReadList[] ): ReadList[] | undefined {
+	if ( lists?.length !== 1 ) {
+		return lists;
+	}
+	const [ list ] = lists;
+	const isEmptyOwnRecommendedBlogs =
+		list.slug === RECOMMENDED_BLOGS_SLUG && list.is_owner && ! list.feeds?.length;
+	return isEmptyOwnRecommendedBlogs ? [] : lists;
+}
+
 interface ReaderSidebarListsProps {
 	lists?: ReadList[];
 	path: string;
@@ -20,7 +35,7 @@ interface ReaderSidebarListsProps {
 }
 
 const ReaderSidebarLists = ( {
-	lists,
+	lists: allLists,
 	isOpen,
 	onClick,
 	path,
@@ -28,6 +43,7 @@ const ReaderSidebarLists = ( {
 }: ReaderSidebarListsProps ): JSX.Element => {
 	const translate = useTranslate();
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
+	const lists = hideEmptyRecommendedBlogsPlaceholder( allLists );
 	const isChildSelected = lists?.some( ( list ) =>
 		path.startsWith( `/reader/list/${ list.owner }/${ list.slug }` )
 	);

--- a/client/reader/sidebar/reader-sidebar-lists/test/index.test.tsx
+++ b/client/reader/sidebar/reader-sidebar-lists/test/index.test.tsx
@@ -33,7 +33,7 @@ jest.mock( '@automattic/api-queries', () => ( {
 
 function makeList(
 	ID: number,
-	feeds: { feed_id: number; unseen_count: number }[],
+	feeds: ReadList[ 'feeds' ],
 	overrides: Partial< ReadList > = {}
 ): ReadList {
 	return {
@@ -50,7 +50,7 @@ function makeList(
 }
 
 function makeRecommendedBlogsList(
-	feeds: { feed_id: number; unseen_count: number }[],
+	feeds: ReadList[ 'feeds' ],
 	overrides: Partial< ReadList > = {}
 ): ReadList {
 	return makeList( 99, feeds, {

--- a/client/reader/sidebar/reader-sidebar-lists/test/index.test.tsx
+++ b/client/reader/sidebar/reader-sidebar-lists/test/index.test.tsx
@@ -31,7 +31,11 @@ jest.mock( '@automattic/api-queries', () => ( {
 	} ),
 } ) );
 
-function makeList( ID: number, feeds: { feed_id: number; unseen_count: number }[] ): ReadList {
+function makeList(
+	ID: number,
+	feeds: { feed_id: number; unseen_count: number }[],
+	overrides: Partial< ReadList > = {}
+): ReadList {
 	return {
 		ID,
 		slug: `list-${ ID }`,
@@ -41,7 +45,19 @@ function makeList( ID: number, feeds: { feed_id: number; unseen_count: number }[
 		is_owner: true,
 		is_public: true,
 		feeds,
+		...overrides,
 	};
+}
+
+function makeRecommendedBlogsList(
+	feeds: { feed_id: number; unseen_count: number }[],
+	overrides: Partial< ReadList > = {}
+): ReadList {
+	return makeList( 99, feeds, {
+		slug: 'recommended-blogs',
+		title: 'Recommended Blogs',
+		...overrides,
+	} );
 }
 
 // The Count exposes no role/label, so scope to the header's own count element,
@@ -50,7 +66,51 @@ function getHeaderCount( container: HTMLElement ): HTMLElement | null {
 	return container.querySelector( '.a8c-count' );
 }
 
+const RECOMMENDED_BLOGS_LINK = "View list 'Recommended Blogs'";
+
 describe( 'ReaderSidebarLists', () => {
+	describe( 'recommended blogs placeholder', () => {
+		it( 'hides an empty Recommended Blogs list when it is the only list', () => {
+			renderWithProvider(
+				<ReaderSidebarLists lists={ [ makeRecommendedBlogsList( [] ) ] } path="/reader" isOpen />
+			);
+
+			expect(
+				screen.queryByRole( 'link', { name: RECOMMENDED_BLOGS_LINK } )
+			).not.toBeInTheDocument();
+			expect( screen.getByRole( 'link', { name: 'Create new list' } ) ).toBeInTheDocument();
+		} );
+
+		it( 'shows the Recommended Blogs list once it has feeds', () => {
+			renderWithProvider(
+				<ReaderSidebarLists
+					lists={ [ makeRecommendedBlogsList( [ { feed_id: 10, unseen_count: 0 } ] ) ] }
+					path="/reader"
+					isOpen
+				/>
+			);
+
+			expect( screen.getByRole( 'link', { name: RECOMMENDED_BLOGS_LINK } ) ).toBeInTheDocument();
+		} );
+
+		it( 'shows an empty Recommended Blogs list alongside other lists', () => {
+			const lists = [ makeRecommendedBlogsList( [] ), makeList( 1, [] ) ];
+
+			renderWithProvider( <ReaderSidebarLists lists={ lists } path="/reader" isOpen /> );
+
+			expect( screen.getByRole( 'link', { name: RECOMMENDED_BLOGS_LINK } ) ).toBeInTheDocument();
+			expect( screen.getByRole( 'link', { name: "View list 'List 1'" } ) ).toBeInTheDocument();
+		} );
+
+		it( "shows another user's empty Recommended Blogs list", () => {
+			const lists = [ makeRecommendedBlogsList( [], { owner: 'alice', is_owner: false } ) ];
+
+			renderWithProvider( <ReaderSidebarLists lists={ lists } path="/reader" isOpen /> );
+
+			expect( screen.getByText( 'Recommended Blogs (alice)' ) ).toBeInTheDocument();
+		} );
+	} );
+
 	describe( 'unseen count', () => {
 		it( 'shows no header count when there are no lists', () => {
 			const { container } = renderWithProvider(

--- a/client/reader/test/index.ts
+++ b/client/reader/test/index.ts
@@ -97,21 +97,18 @@ describe( 'reader routes', () => {
 		expect( page ).toHaveBeenCalledWith( '/read/*', readerNotFound );
 	} );
 
-	it( 'requires a logged-in user for list management routes', async () => {
+	it.each( [
+		'/reader/list/new',
+		'/reader/list/:user/:list/edit',
+		'/reader/list/:user/:list/edit/items',
+		'/reader/list/:user/:list/export',
+		'/reader/list/:user/:list/delete',
+	] )( 'requires a logged-in user for %s', async ( path ) => {
 		await initReader();
 
-		const managementPaths = [
-			'/reader/list/new',
-			'/reader/list/:user/:list/edit',
-			'/reader/list/:user/:list/edit/items',
-			'/reader/list/:user/:list/export',
-			'/reader/list/:user/:list/delete',
-		];
-		for ( const path of managementPaths ) {
-			const call = jest.mocked( page ).mock.calls.find( ( [ route ] ) => route === path );
-			expect( call ).toBeDefined();
-			expect( call?.slice( 1 ) ).toContain( redirectLoggedOutToSignup );
-		}
+		const call = jest.mocked( page ).mock.calls.find( ( [ route ] ) => route === path );
+		expect( call ).toBeDefined();
+		expect( call?.slice( 1 ) ).toContain( redirectLoggedOutToSignup );
 	} );
 
 	it( 'keeps list viewing available to logged-out users', async () => {

--- a/client/reader/test/index.ts
+++ b/client/reader/test/index.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import page from '@automattic/calypso-router';
+import { redirectLoggedOutToSignup } from 'calypso/controller';
 import initReader from '../index';
 import { readerNotFound } from '../lib/reader-router';
 
@@ -94,5 +95,34 @@ describe( 'reader routes', () => {
 
 		expect( page ).toHaveBeenCalledWith( '/reader/*', readerNotFound );
 		expect( page ).toHaveBeenCalledWith( '/read/*', readerNotFound );
+	} );
+
+	it( 'requires a logged-in user for list management routes', async () => {
+		await initReader();
+
+		const managementPaths = [
+			'/reader/list/new',
+			'/reader/list/:user/:list/edit',
+			'/reader/list/:user/:list/edit/items',
+			'/reader/list/:user/:list/export',
+			'/reader/list/:user/:list/delete',
+		];
+		for ( const path of managementPaths ) {
+			const call = jest.mocked( page ).mock.calls.find( ( [ route ] ) => route === path );
+			expect( call ).toBeDefined();
+			expect( call?.slice( 1 ) ).toContain( redirectLoggedOutToSignup );
+		}
+	} );
+
+	it( 'keeps list viewing available to logged-out users', async () => {
+		await initReader();
+
+		const call = jest
+			.mocked( page )
+			.mock.calls.find(
+				( [ route ] ) => Array.isArray( route ) && route.includes( '/reader/list/:user/:list' )
+			);
+		expect( call ).toBeDefined();
+		expect( call?.slice( 1 ) ).not.toContain( redirectLoggedOutToSignup );
 	} );
 } );

--- a/client/reader/test/index.ts
+++ b/client/reader/test/index.ts
@@ -85,6 +85,13 @@ jest.mock( '../user-profile/controller', () => ( {
 	userProfile: jest.fn(),
 } ) );
 
+type RouteCall = [ string | string[], ...unknown[] ];
+
+// `page` is a bare jest.fn(), so its recorded calls are typed as an empty tuple.
+function registeredRoutes(): RouteCall[] {
+	return jest.mocked( page ).mock.calls as unknown as RouteCall[];
+}
+
 describe( 'reader routes', () => {
 	beforeEach( () => {
 		jest.mocked( page ).mockClear();
@@ -106,7 +113,7 @@ describe( 'reader routes', () => {
 	] )( 'requires a logged-in user for %s', async ( path ) => {
 		await initReader();
 
-		const call = jest.mocked( page ).mock.calls.find( ( [ route ] ) => route === path );
+		const call = registeredRoutes().find( ( [ route ] ) => route === path );
 		expect( call ).toBeDefined();
 		expect( call?.slice( 1 ) ).toContain( redirectLoggedOutToSignup );
 	} );
@@ -114,11 +121,9 @@ describe( 'reader routes', () => {
 	it( 'keeps list viewing available to logged-out users', async () => {
 		await initReader();
 
-		const call = jest
-			.mocked( page )
-			.mock.calls.find(
-				( [ route ] ) => Array.isArray( route ) && route.includes( '/reader/list/:user/:list' )
-			);
+		const call = registeredRoutes().find(
+			( [ route ] ) => Array.isArray( route ) && route.includes( '/reader/list/:user/:list' )
+		);
 		expect( call ).toBeDefined();
 		expect( call?.slice( 1 ) ).not.toContain( redirectLoggedOutToSignup );
 	} );


### PR DESCRIPTION
Addresses: CM-903

## Proposed Changes

* Hide the auto-created Recommended Blogs list from the sidebar Lists section when it is empty and the user has no other lists. It reappears as soon as the user recommends a blog or creates a list.
* Add a "Learn more" link to the subtitle on the Create List page. It opens the Reader Lists support doc in the Help Center.
* Replace the owner name in parentheses in the list title with a "Created by {owner}" line, linked to the owner's Reader profile. The description and the Created by line render as one subtitle, separated by an en dash when both are present. The list title is now the only content in the H1.
* Require a logged-in user for `/reader/list/new` and the list edit, edit items, export, and delete routes. Logged-out visitors are sent to signup with a redirect back, matching the other logged-in-only Reader routes. Viewing a list stays public.

## Why are these changes being made?

* The backend creates a Recommended Blogs list for every user on the first Reader load, so a brand new account sees "Recommended Blogs" as the first and only item under Lists. The name reads as blogs we recommend rather than blogs you recommend, and it makes the blank slate confusing. Hiding it until it has content or company keeps the feature intact for people who use it.
* The Create List page had no path to documentation.
* Appending the owner to the H1 mixed two ideas in the page title. A Created by line reads more naturally and gives the owner a proper link.
* The create and management forms rendered for logged-out visitors, who could fill them in only to fail on submit.

## Testing Instructions

Recommended Blogs in the sidebar

1. With a brand new account, or one with no lists and no recommended blogs, open `/reader` and expand Lists. Confirm only "Create new list" is shown.
2. Recommend a blog from a feed header. Confirm "Recommended Blogs" appears under Lists.
3. Alternatively, create a list. Confirm both the new list and "Recommended Blogs" appear.
4. Follow another user's Recommended Blogs list. Confirm it still shows in the sidebar even when empty.

Learn more link

1. Open `/reader/list/new`.
2. Confirm the subtitle ends with "Learn more" and that clicking it opens the "Create lists in Reader" doc in the Help Center panel.

Created by line

1. Open a public list owned by another user. Confirm the H1 is just the list title and the subtitle reads `{description} – Created by {owner}`, with the owner linked to `/reader/users/{owner}`.
2. Open one of your own lists. Confirm the subtitle shows only the description and no Created by line.
3. Open a list with no description owned by someone else. Confirm the subtitle is just "Created by {owner}" with no dash.
4. Check the header in dark mode.

Logged-out access

1. In an incognito window, open `/reader/list/new`. Confirm you are redirected to signup rather than shown the form.
2. Repeat for `/reader/list/{owner}/{slug}/edit`, `/edit/items`, `/export`, and `/delete`.
3. Still logged out, open a public list at `/reader/list/{owner}/{slug}`. Confirm it still renders.

Unit tests

```
yarn test-client client/reader/sidebar/reader-sidebar-lists
yarn test-client client/reader/list/components/list-header
yarn test-client client/reader/test/index.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
