### PR TITLE
Add experimental Get Help labels to help entry points

### DIFF
--- a/client/dashboard/app/omnibar/plugin-help-center.tsx
+++ b/client/dashboard/app/omnibar/plugin-help-center.tsx
@@ -10,6 +10,7 @@ import { withSiteContext } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
+import { useExperiment } from 'calypso/lib/explat';
 import { useAnalytics } from '../analytics';
 import { useHelpCenter } from '../help-center';
 import { adminBarIcon } from './admin-bar-icon';
@@ -127,6 +128,13 @@ export function useHelpCenterPlugin( {
 	const { isShown: isHelpCenterShown, setShowHelpCenter } = useHelpCenter();
 	const { recordTracksEvent } = useAnalytics();
 	const { data: omnibarSiteId } = useQuery( omnibarSiteIdQuery() );
+	// Load the assignment where the entry point renders, so ExPlat exposure covers
+	// everyone who sees it, not only users who open the Help Center.
+	const [ isLoadingGetHelpAssignment, getHelpChatForwardAssignment ] = useExperiment(
+		'calypso_help_center_get_help_chat_forward'
+	);
+	const showGetHelpLabel =
+		! isLoadingGetHelpAssignment && getHelpChatForwardAssignment?.variationName === 'treatment';
 
 	const helpNode = adminBarNodes.find( ( node ) => node.id === AGENTS_MANAGER_NODE_ID );
 
@@ -142,6 +150,7 @@ export function useHelpCenterPlugin( {
 		return {
 			id: helpNode.id,
 			label: helpNode.meta?.menu_title,
+			title: showGetHelpLabel ? __( 'Get Help' ) : undefined,
 			icon: adminBarIcon( helpNode.meta?.icon, 'omnibar__help-icon' ),
 			tooltip: helpNode.meta?.menu_title,
 			// Disconnected sites get a link instead of a dropdown, opened in a new tab as in wp-admin.
@@ -154,6 +163,7 @@ export function useHelpCenterPlugin( {
 	return {
 		id: 'help-center',
 		label: __( 'Help' ),
+		title: showGetHelpLabel ? __( 'Get Help' ) : undefined,
 		icon: adminBarIcon( 'help', 'omnibar__help-icon' ),
 		onClick: () => setShowHelpCenter( ! isHelpCenterShown ),
 	};

--- a/client/dashboard/app/omnibar/test/plugin-help-center.test.tsx
+++ b/client/dashboard/app/omnibar/test/plugin-help-center.test.tsx
@@ -8,6 +8,7 @@ import {
 	openAgentsManagerChat,
 } from '@automattic/agents-manager';
 import { render, renderHook } from '@testing-library/react';
+import { useExperiment } from 'calypso/lib/explat';
 import { useHelpCenter } from '../../help-center';
 import { useHelpCenterPlugin } from '../plugin-help-center';
 import type { AdminBarNode, OmnibarNode } from '@automattic/omnibar';
@@ -26,6 +27,7 @@ jest.mock( '@automattic/i18n-utils', () => ( {
 	localizeUrl: jest.fn( ( url ) => `${ url }?l=fr` ),
 } ) );
 jest.mock( '@tanstack/react-query', () => ( { useQuery: jest.fn( () => ( { data: 7 } ) ) } ) );
+jest.mock( 'calypso/lib/explat', () => ( { useExperiment: jest.fn() } ) );
 jest.mock( '../../analytics', () => ( {
 	useAnalytics: jest.fn( () => ( { recordTracksEvent: jest.fn() } ) ),
 } ) );
@@ -41,6 +43,7 @@ const mockGetChatRoute = getAgentsManagerChatRoute as jest.MockedFunction<
 >;
 const mockUseHelpCenter = useHelpCenter as jest.MockedFunction< typeof useHelpCenter >;
 const setShowHelpCenter = jest.fn();
+const mockUseExperiment = jest.mocked( useExperiment );
 
 const ICON = 'help';
 
@@ -90,12 +93,63 @@ const childrenOf = ( n: OmnibarNode | undefined, id: string ) =>
 describe( 'useHelpCenterPlugin', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockUseExperiment.mockReturnValue( [ false, null ] );
 		mockIsChatVisible.mockReturnValue( false );
 		mockGetChatRoute.mockReturnValue( undefined );
 		mockUseHelpCenter.mockReturnValue( {
 			isShown: false,
 			setShowHelpCenter,
 		} as unknown as ReturnType< typeof useHelpCenter > );
+	} );
+
+	it.each( [
+		{ entryPoint: 'agents manager', adminBarNodes: HELP_NODES },
+		{ entryPoint: 'legacy help center', adminBarNodes: [] },
+	] )( 'keeps the control $entryPoint icon-only', ( { adminBarNodes } ) => {
+		mockUseExperiment.mockReturnValue( [
+			false,
+			{
+				experimentName: 'calypso_help_center_get_help_chat_forward',
+				variationName: 'control',
+				retrievedTimestamp: 0,
+				ttl: 60,
+			},
+		] );
+
+		expect( renderPlugin( adminBarNodes ).title ).toBeUndefined();
+	} );
+
+	it.each( [
+		{ adminBarNodes: HELP_NODES, title: 'Get Help' },
+		{ adminBarNodes: [], title: 'Get Help' },
+	] )( 'shows the treatment title "$title"', ( { adminBarNodes, title } ) => {
+		mockUseExperiment.mockReturnValue( [
+			false,
+			{
+				experimentName: 'calypso_help_center_get_help_chat_forward',
+				variationName: 'treatment',
+				retrievedTimestamp: 0,
+				ttl: 60,
+			},
+		] );
+
+		expect( renderPlugin( adminBarNodes ).title ).toBe( title );
+		expect( mockUseExperiment ).toHaveBeenCalledWith( 'calypso_help_center_get_help_chat_forward' );
+	} );
+
+	it.each( [
+		{ entryPoint: 'agents manager', adminBarNodes: HELP_NODES },
+		{ entryPoint: 'legacy help center', adminBarNodes: [] },
+	] )( 'keeps the $entryPoint icon-only until the assignment loads', ( { adminBarNodes } ) => {
+		mockUseExperiment.mockReturnValue( [ true, null ] );
+		const { result, rerender } = renderHook( () => useHelpCenterPlugin( { adminBarNodes } ) );
+
+		expect( result.current.title ).toBeUndefined();
+
+		mockUseExperiment.mockReturnValue( [ false, null ] );
+		rerender();
+
+		expect( result.current.title ).toBeUndefined();
 	} );
 
 	it( 'takes its id, label and tooltip from the admin bar node', () => {

--- a/client/layout/masterbar/masterbar-agents-manager/index.jsx
+++ b/client/layout/masterbar/masterbar-agents-manager/index.jsx
@@ -6,12 +6,14 @@ import {
 	openAgentsManagerChat,
 } from '@automattic/agents-manager';
 import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
+import { HELP_CENTER_GET_HELP_CHAT_FORWARD_EXPERIMENT } from '@automattic/data-stores/src/help-center/constants';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useSelect as useDateStoreSelect } from '@wordpress/data';
 import { Icon, comment, backup, page, video, rss } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { useHelpCenterSite } from 'calypso/layout/use-help-center-site';
+import { useExperiment } from 'calypso/lib/explat';
 import { getSectionName } from 'calypso/state/ui/selectors';
 import Item from '../item';
 import HelpIcon from './help-icon';
@@ -21,6 +23,11 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 	const translate = useTranslate();
 	const sectionName = useSelector( getSectionName );
 	const { siteId, siteContextSource } = useHelpCenterSite();
+	const [ isLoadingGetHelpAssignment, getHelpChatForwardAssignment ] = useExperiment(
+		HELP_CENTER_GET_HELP_CHAT_FORWARD_EXPERIMENT
+	);
+	const showGetHelpLabel =
+		! isLoadingGetHelpAssignment && getHelpChatForwardAssignment?.variationName === 'treatment';
 
 	const agentsManagerVisible = useDateStoreSelect(
 		( select ) => select( AGENTS_MANAGER_STORE ).getAgentsManagerState().isOpen,
@@ -165,7 +172,11 @@ const MasterbarAgentsManager = ( { tooltip } ) => {
 			subItems={ menuItems }
 			openSubMenuOnClick
 			closeSubMenuOnItemClick
-		/>
+		>
+			{ showGetHelpLabel && (
+				<span className="masterbar__item-help-label">{ translate( 'Get Help' ) }</span>
+			) }
+		</Item>
 	);
 };
 

--- a/client/layout/masterbar/masterbar-help-center/index.jsx
+++ b/client/layout/masterbar/masterbar-help-center/index.jsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent, withSiteContext } from '@automattic/calypso-analytics';
 import { HelpCenter } from '@automattic/data-stores';
+import { HELP_CENTER_GET_HELP_CHAT_FORWARD_EXPERIMENT } from '@automattic/data-stores/src/help-center/constants';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { usePrevious } from '@wordpress/compose';
 import {
@@ -40,7 +41,13 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
 		'calypso_help_center_menu_popover_increase_exposure'
 	);
+	const [ isLoadingGetHelpAssignment, getHelpChatForwardAssignment ] = useExperiment(
+		HELP_CENTER_GET_HELP_CHAT_FORWARD_EXPERIMENT
+	);
 	const { setShowHelpCenter, setNavigateToRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
+
+	const showGetHelpLabel =
+		! isLoadingGetHelpAssignment && getHelpChatForwardAssignment?.variationName === 'treatment';
 
 	// Check if the new menu panel feature is enabled (both feature flag AND query param must be true)
 	const isMenuPanelExperimentEnabled =
@@ -215,7 +222,11 @@ const MasterbarHelpCenter = ( { tooltip } ) => {
 				icon={ <HelpCenterIcon hasUnread={ unreadCount > 0 } /> }
 				subItems={ isMenuPanelExperimentEnabled ? menuItems : undefined }
 				openSubMenuOnClick={ isMenuPanelExperimentEnabled }
-			/>
+			>
+				{ showGetHelpLabel && (
+					<span className="masterbar__item-help-label">{ translate( 'Get Help' ) }</span>
+				) }
+			</Item>
 		</>
 	);
 };

--- a/client/layout/masterbar/style.scss
+++ b/client/layout/masterbar/style.scss
@@ -1082,7 +1082,8 @@ body.is-mobile-app-view {
 	line-height: 24px;
 }
 
-.masterbar__item-reader-label {
+.masterbar__item-reader-label,
+.masterbar__item-help-label {
 	padding-left: 6px;
 }
 

--- a/packages/data-stores/src/help-center/constants.ts
+++ b/packages/data-stores/src/help-center/constants.ts
@@ -2,3 +2,6 @@ export const STORE_KEY = 'automattic/help-center';
 export const PREFERENCES_KEY = 'logged_out_help_center_preferences_';
 // Set by the wpcom launcher on the pricing page so the assistant greets visitors as a pre-sales guide.
 export const PLANS_PRESALES_LAUNCHER_CONTEXT = 'plans-presales';
+
+export const HELP_CENTER_GET_HELP_CHAT_FORWARD_EXPERIMENT =
+	'calypso_help_center_get_help_chat_forward';


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18463/odie-usage-experiment-get-help-label-on-the-help-entry-point-masterbar

## Proposed changes

**Show translated “Get Help” labels beside help icons for experiment treatment users.**

- Cover classic masterbar and dashboard entry points for Help Center and Agents Manager.
- Keep control and loading states icon-only, and reuse masterbar label spacing.
- Verify dashboard treatment copy without introducing a banned runtime dependency.

## Why

Icon-only help entry points provide no visible text explaining their purpose. This experiment tests whether explicit wording makes help easier to discover and increases usage.

## Testing

1. Assign your account to `treatment` in `calypso_help_center_get_help_chat_forward`. Open classic Calypso and the dashboard with Help Center and Agents Manager; confirm “Get Help” appears and opens the expected help interface.
2. Switch to `control` and reload; confirm entry points remain icon-only.