### PR TITLE
Domains: read the raw Purchase in domain-management

### DIFF
--- a/client/lib/domains/resolve-domain-status.tsx
+++ b/client/lib/domains/resolve-domain-status.tsx
@@ -10,7 +10,8 @@ import moment from 'moment';
 import { useMyDomainInputMode } from 'calypso/components/domains/connect-domain-step/constants';
 import { isExpiringSoon } from 'calypso/lib/domains/utils/is-expiring-soon';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils/is-recently-registered';
-import { shouldRenderExpiringCreditCard, handleRenewNowClick } from 'calypso/lib/purchases';
+import { handleRenewNowClick } from 'calypso/lib/purchases';
+import { shouldRenderExpiringCreditCard } from 'calypso/me/purchases/lib/raw-purchase-helpers';
 import {
 	domainManagementEdit,
 	domainManagementEditContactInfo,
@@ -19,7 +20,7 @@ import {
 } from 'calypso/my-sites/domains/paths';
 import { transferStatus, type as domainTypes, gdprConsentStatus } from './constants';
 import type { ResponseDomain } from './types';
-import type { Purchase } from 'calypso/lib/purchases/types';
+import type { Purchase } from '@automattic/api-core';
 import type { CalypsoDispatch } from 'calypso/state/types';
 import type { I18N, TranslateResult } from 'i18n-calypso';
 
@@ -54,8 +55,6 @@ export type ResolveDomainStatusOptionsBag = {
 
 export function resolveDomainStatus(
 	domain: ResponseDomain,
-	// Temporary bridge (SHILL-2256): callers still pass the camelCase Purchase,
-	// so the renewal handlers below are given `purchase.rawPurchase`.
 	purchase: Purchase | null = null,
 	translate: I18N[ 'translate' ],
 	dispatch: CalypsoDispatch,
@@ -322,9 +321,7 @@ export function resolveDomainStatus(
 											a: (
 												<Button
 													plain
-													onClick={ () =>
-														dispatch( handleRenewNowClick( purchase.rawPurchase, siteSlug ) )
-													}
+													onClick={ () => dispatch( handleRenewNowClick( purchase, siteSlug ) ) }
 												/>
 											),
 										},
@@ -353,9 +350,7 @@ export function resolveDomainStatus(
 											a: (
 												<Button
 													plain
-													onClick={ () =>
-														dispatch( handleRenewNowClick( purchase.rawPurchase, siteSlug ) )
-													}
+													onClick={ () => dispatch( handleRenewNowClick( purchase, siteSlug ) ) }
 												/>
 											),
 										},
@@ -408,9 +403,7 @@ export function resolveDomainStatus(
 									a: (
 										<Button
 											plain
-											onClick={ () =>
-												dispatch( handleRenewNowClick( purchase.rawPurchase, siteSlug ) )
-											}
+											onClick={ () => dispatch( handleRenewNowClick( purchase, siteSlug ) ) }
 										/>
 									),
 								},

--- a/client/me/purchases/lib/raw-purchase-helpers.ts
+++ b/client/me/purchases/lib/raw-purchase-helpers.ts
@@ -351,6 +351,16 @@ export function creditCardHasAlreadyExpired( purchase: Purchase ): boolean {
 	return moment( creditCard.expiryDate, 'MM/YY' ).isBefore( moment(), 'months' );
 }
 
+export function shouldRenderExpiringCreditCard( purchase: Purchase ): boolean {
+	return (
+		! isExpiredOrRemoved( purchase ) &&
+		! isExpiring( purchase ) &&
+		! isPurchaseOneTimePurchase( purchase ) &&
+		! isIncludedWithPlan( purchase ) &&
+		creditCardExpiresBeforeSubscription( purchase )
+	);
+}
+
 export function showCreditCardExpiringWarning( purchase: Purchase ): boolean {
 	return (
 		! isIncludedWithPlan( purchase ) &&
@@ -362,6 +372,33 @@ export function showCreditCardExpiringWarning( purchase: Purchase ): boolean {
 
 export function getRenewalPriceInSmallestUnit( purchase: Purchase ): number {
 	return purchase.sale_amount_integer || purchase.price_integer;
+}
+
+/**
+ * Whether to offer the user a cancellation flow for this purchase.
+ *
+ * This is the client-side derivation the legacy pages have always used; it is
+ * deliberately not the server's `is_cancelable` flag, which answers a narrower
+ * question.
+ */
+export function isCancelable( purchase: Purchase ): boolean {
+	if ( isIncludedWithPlan( purchase ) ) {
+		return false;
+	}
+
+	if ( purchase.pending_transfer ) {
+		return false;
+	}
+
+	if ( isExpiredOrRemoved( purchase ) ) {
+		return false;
+	}
+
+	if ( hasAmountAvailableToRefund( purchase ) ) {
+		return true;
+	}
+
+	return purchase.can_disable_auto_renew;
 }
 
 export function canAutoRenewBeTurnedOff( purchase: Purchase ): boolean {

--- a/client/me/purchases/lib/raw-purchase-helpers.ts
+++ b/client/me/purchases/lib/raw-purchase-helpers.ts
@@ -374,33 +374,6 @@ export function getRenewalPriceInSmallestUnit( purchase: Purchase ): number {
 	return purchase.sale_amount_integer || purchase.price_integer;
 }
 
-/**
- * Whether to offer the user a cancellation flow for this purchase.
- *
- * This is the client-side derivation the legacy pages have always used; it is
- * deliberately not the server's `is_cancelable` flag, which answers a narrower
- * question.
- */
-export function isCancelable( purchase: Purchase ): boolean {
-	if ( isIncludedWithPlan( purchase ) ) {
-		return false;
-	}
-
-	if ( purchase.pending_transfer ) {
-		return false;
-	}
-
-	if ( isExpiredOrRemoved( purchase ) ) {
-		return false;
-	}
-
-	if ( hasAmountAvailableToRefund( purchase ) ) {
-		return true;
-	}
-
-	return purchase.can_disable_auto_renew;
-}
-
 export function canAutoRenewBeTurnedOff( purchase: Purchase ): boolean {
 	if ( isIncludedWithPlan( purchase ) ) {
 		return false;

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { transferStatus, type as domainType } from 'calypso/lib/domains/constants';
-import { isCancelable } from 'calypso/me/purchases/lib/raw-purchase-helpers';
 import { cancelPurchase } from 'calypso/me/purchases/paths';
 import RemovePurchase from 'calypso/me/purchases/remove-purchase';
 import { getCancelPurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
@@ -71,7 +70,7 @@ const DomainDeleteInfoCard = ( {
 		);
 	}
 
-	if ( ! isCancelable( purchase ) ) {
+	if ( ! purchase.is_cancelable ) {
 		return null;
 	}
 

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/delete/index.tsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { transferStatus, type as domainType } from 'calypso/lib/domains/constants';
-import { isCancelable, isRemovable } from 'calypso/lib/purchases';
+import { isCancelable } from 'calypso/me/purchases/lib/raw-purchase-helpers';
 import { cancelPurchase } from 'calypso/me/purchases/paths';
 import RemovePurchase from 'calypso/me/purchases/remove-purchase';
 import { getCancelPurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
@@ -53,14 +53,14 @@ const DomainDeleteInfoCard = ( {
 			hasLoadedSites
 			hasLoadedUserPurchasesFromServer
 			site={ selectedSite }
-			purchase={ purchase.rawPurchase }
+			purchase={ purchase }
 			className={ removePurchaseClassName }
 		>
 			{ buttonLabel }
 		</RemovePurchase>
 	);
 
-	if ( isRemovable( purchase ) ) {
+	if ( purchase.is_removable ) {
 		return (
 			<DomainInfoCard
 				type="custom"
@@ -76,8 +76,8 @@ const DomainDeleteInfoCard = ( {
 	}
 
 	const link = config.isEnabled( 'calypso/all-domain-management' )
-		? cancelPurchase( selectedSite.slug, purchase.id )
-		: getCancelPurchaseUrlFor( selectedSite.slug, purchase.id );
+		? cancelPurchase( selectedSite.slug, purchase.ID )
+		: getCancelPurchaseUrlFor( selectedSite.slug, purchase.ID );
 
 	return (
 		<DomainInfoCard

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/types.tsx
@@ -1,7 +1,7 @@
 import ActionCard from 'calypso/components/action-card';
+import type { Purchase } from '@automattic/api-core';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
-import type { Purchase } from 'calypso/lib/purchases/types';
 import type { TranslateResult } from 'i18n-calypso';
 
 type ActionCardPropsBase = {

--- a/client/my-sites/domains/domain-management/list/use-purchase-actions.ts
+++ b/client/my-sites/domains/domain-management/list/use-purchase-actions.ts
@@ -1,50 +1,40 @@
+import { userPurchasesQuery } from '@automattic/api-queries';
 import { DomainStatusPurchaseActions, ResponseDomain } from '@automattic/domains-table';
-import { useQueryUserPurchases } from 'calypso/components/data/query-user-purchases';
+import { useQuery } from '@tanstack/react-query';
+import { handleRenewNowClick } from 'calypso/lib/purchases';
 import {
-	handleRenewNowClick,
 	monthsUntilCardExpires,
 	shouldRenderExpiringCreditCard,
-} from 'calypso/lib/purchases';
-import { useDispatch, useSelector } from 'calypso/state';
-import { getUserPurchases } from 'calypso/state/purchases/selectors';
+} from 'calypso/me/purchases/lib/raw-purchase-helpers';
+import { useDispatch } from 'calypso/state';
 
 export const usePurchaseActions = () => {
-	useQueryUserPurchases();
-
 	const dispatch = useDispatch();
-	const purchases = useSelector( getUserPurchases );
+	const { data: purchases } = useQuery( userPurchasesQuery() );
+
+	const findPurchase = ( domain: ResponseDomain ) =>
+		purchases?.find( ( p ) => Number( p.ID ) === parseInt( domain.subscriptionId ?? '', 10 ) );
 
 	const isCreditCardExpiring = ( domain: ResponseDomain ) => {
-		const purchase = purchases?.find(
-			( p ) => p.id === parseInt( domain.subscriptionId ?? '', 10 )
-		);
+		const purchase = findPurchase( domain );
 
 		return purchase ? shouldRenderExpiringCreditCard( purchase ) : false;
 	};
 
 	const isPurchasedDomain = ( domain: ResponseDomain ) => {
-		const purchase = purchases?.find(
-			( p ) => p.id === parseInt( domain.subscriptionId ?? '', 10 )
-		);
-		return !! purchase;
+		return !! findPurchase( domain );
 	};
 
 	const monthsUtilCreditCardExpires = ( domain: ResponseDomain ) => {
-		const purchase = purchases?.find(
-			( p ) => p.id === parseInt( domain.subscriptionId ?? '', 10 )
-		);
+		const purchase = findPurchase( domain );
 
 		return purchase ? monthsUntilCardExpires( purchase ) : null;
 	};
 
 	const onRenewNowClick = ( siteSlug: string, domain: ResponseDomain ) => {
-		const purchase = purchases?.find(
-			( p ) => p.id === parseInt( domain.subscriptionId ?? '', 10 )
-		);
+		const purchase = findPurchase( domain );
 		if ( purchase ) {
-			// Temporary bridge (SHILL-2256): this hook still reads the camelCase
-			// Purchase from Redux. Remove once it reads the raw shape.
-			dispatch( handleRenewNowClick( purchase.rawPurchase, siteSlug ) );
+			dispatch( handleRenewNowClick( purchase, siteSlug ) );
 		}
 	};
 

--- a/client/my-sites/domains/domain-management/security/index.jsx
+++ b/client/my-sites/domains/domain-management/security/index.jsx
@@ -1,13 +1,14 @@
+import { purchaseQuery } from '@automattic/api-queries';
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import { CompactCard, MaterialIcon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { ECOMMERCE, FORMS } from '@automattic/urls';
+import { useQuery } from '@tanstack/react-query';
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Main from 'calypso/components/main';
 import SupportButton from 'calypso/components/support-button';
 import VerticalNav from 'calypso/components/vertical-nav';
@@ -19,11 +20,6 @@ import Header from 'calypso/my-sites/domains/domain-management/components/header
 import RenewButton from 'calypso/my-sites/domains/domain-management/edit/card/renew-button';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
-import {
-	getByPurchaseId,
-	isFetchingSitePurchases,
-	hasLoadedSitePurchasesFromServer,
-} from 'calypso/state/purchases/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 import './style.scss';
@@ -103,12 +99,9 @@ class Security extends Component {
 							'We have disabled HTTPS encryption because your domain has expired and is no longer active. Renew your domain to reactivate it and turn on HTTPS encryption.'
 						) }
 					</p>
-					{ selectedSite.ID && ! purchase && <QuerySitePurchases siteId={ selectedSite.ID } /> }
 					<RenewButton
 						primary
-						// Temporary bridge (SHILL-2256): this page still reads the camelCase
-						// Purchase from Redux. Remove once it reads the raw shape.
-						purchase={ purchase?.rawPurchase ?? null }
+						purchase={ purchase }
 						selectedSite={ selectedSite }
 						subscriptionId={ parseInt( domain.subscriptionId, 10 ) }
 						redemptionProduct={ domain.isRedeemable ? this.props.redemptionProduct : null }
@@ -198,21 +191,27 @@ class Security extends Component {
 	}
 }
 
+const SecurityWithPurchase = ( props ) => {
+	const subscriptionId = props.domain?.subscriptionId
+		? parseInt( props.domain.subscriptionId, 10 )
+		: undefined;
+	const { data: purchase } = useQuery( {
+		...purchaseQuery( subscriptionId ),
+		enabled: Boolean( subscriptionId ),
+	} );
+
+	return <Security { ...props } purchase={ purchase ?? null } />;
+};
+
 export default connect(
 	( state, ownProps ) => {
-		const domain = ownProps.domains && getSelectedDomain( ownProps );
-		const { subscriptionId } = domain || {};
-
 		return {
 			currentRoute: getCurrentRoute( state ),
-			domain,
-			purchase: subscriptionId ? getByPurchaseId( state, parseInt( subscriptionId, 10 ) ) : null,
-			isLoadingPurchase:
-				isFetchingSitePurchases( state ) && ! hasLoadedSitePurchasesFromServer( state ),
+			domain: ownProps.domains && getSelectedDomain( ownProps ),
 			redemptionProduct: getProductBySlug( state, 'domain_redemption' ),
 		};
 	},
 	{
 		recordTracksEvent,
 	}
-)( localize( Security ) );
+)( localize( SecurityWithPurchase ) );

--- a/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/registered-domain-details.tsx
@@ -4,7 +4,7 @@ import { Button } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { getRenewalPrice, isExpiring, isExpiredOrRemoved } from 'calypso/lib/purchases';
+import { isExpiring, isExpiredOrRemoved } from 'calypso/me/purchases/lib/raw-purchase-helpers';
 import AutoRenewToggle from 'calypso/me/purchases/manage-purchase/auto-renew-toggle';
 import { managePurchase } from 'calypso/me/purchases/paths';
 import RenewButton from 'calypso/my-sites/domains/domain-management/edit/card/renew-button';
@@ -75,9 +75,9 @@ const RegisteredDomainDetails = ( {
 
 		if ( purchase && selectedSite.ID ) {
 			const renewalPrice =
-				getRenewalPrice( purchase ) +
+				( purchase.sale_amount || purchase.amount ) +
 				( domain.isRedeemable && redemptionProduct ? redemptionProduct.cost : 0 );
-			const currencyCode = purchase.currencyCode;
+			const currencyCode = purchase.currency_code;
 			formattedPrice = formatCurrency( renewalPrice, currencyCode, { stripZeros: true } ) ?? '';
 		}
 
@@ -100,7 +100,7 @@ const RegisteredDomainDetails = ( {
 				<AutoRenewToggle
 					planName={ selectedSite.plan?.product_name_short }
 					siteDomain={ selectedSite.domain }
-					purchase={ purchase.rawPurchase }
+					purchase={ purchase }
 					withTextStatus
 					toggleSource="registered-domain-status"
 				/>
@@ -131,9 +131,7 @@ const RegisteredDomainDetails = ( {
 
 		return (
 			<RenewButton
-				// Temporary bridge (SHILL-2256): this card still reads the camelCase
-				// Purchase from Redux. Remove once it reads the raw shape.
-				purchase={ purchase?.rawPurchase ?? null }
+				purchase={ purchase }
 				selectedSite={ selectedSite }
 				subscriptionId={ parseInt( domain.subscriptionId ?? '', 10 ) }
 				tracksProps={ { source: 'registered-domain-status', domain_status: 'active' } }

--- a/client/my-sites/domains/domain-management/settings/cards/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/types.tsx
@@ -1,7 +1,7 @@
+import type { Purchase } from '@automattic/api-core';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { UpdateNameServersReponse } from 'calypso/data/domains/nameservers/types';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
-import type { Purchase } from 'calypso/lib/purchases/types';
 
 export type DetailsCardProps = {
 	domain: ResponseDomain;

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -1,12 +1,13 @@
+import { purchaseQuery } from '@automattic/api-queries';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { isSubdomain } from '@automattic/domain-search';
+import { useQuery } from '@tanstack/react-query';
 import { useEffect, useState } from '@wordpress/element';
 import { Icon, info } from '@wordpress/icons';
 import { removeQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import Accordion from 'calypso/components/domains/accordion';
 import {
 	modeType,
@@ -48,11 +49,6 @@ import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getDomainDns } from 'calypso/state/domains/dns/selectors';
 import { requestWhois, verifyIcannEmail } from 'calypso/state/domains/management/actions';
 import { getWhoisData } from 'calypso/state/domains/management/selectors';
-import {
-	getByPurchaseId,
-	isFetchingSitePurchases,
-	hasLoadedSitePurchasesFromServer,
-} from 'calypso/state/purchases/selectors';
 import { canAnySiteConnectDomains } from 'calypso/state/selectors/can-any-site-connect-domains';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import { IAppState } from 'calypso/state/types';
@@ -78,13 +74,11 @@ const Settings = ( {
 	domain,
 	domains,
 	isFetchingNameservers,
-	isLoadingPurchase,
 	isLoadingNameservers,
 	isUpdatingNameservers,
 	loadingNameserversError,
 	nameservers,
 	dns,
-	purchase,
 	requestWhois,
 	selectedDomainName,
 	selectedSite,
@@ -94,6 +88,23 @@ const Settings = ( {
 }: SettingsPageProps ) => {
 	const translate = useTranslate();
 	const contactInformation = findRegistrantWhois( whoisData );
+	const currentUserId = useSelector( getCurrentUserId );
+	// `domain` above is resolved with `isSiteRedirect: true`, but the purchase
+	// has always been looked up from the domain without it, so site redirects
+	// never get one.
+	const purchaseDomain = domains ? getSelectedDomain( { domains, selectedDomainName } ) : undefined;
+	const subscriptionId = purchaseDomain?.subscriptionId
+		? parseInt( purchaseDomain.subscriptionId, 10 )
+		: undefined;
+	const { data: domainPurchase, isPending } = useQuery( {
+		...purchaseQuery( subscriptionId as number ),
+		enabled: Boolean( subscriptionId ),
+	} );
+	// A disabled query stays `pending` forever, so a domain without a
+	// subscription must not read as perpetually loading.
+	const isLoadingPurchase = Boolean( subscriptionId ) && isPending;
+	const purchase =
+		domainPurchase && Number( domainPurchase.user_id ) === currentUserId ? domainPurchase : null;
 
 	const queryParams = new URLSearchParams( window.location.search );
 
@@ -817,7 +828,6 @@ const Settings = ( {
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<Main wideLayout className="domain-settings-page">
-			{ selectedSite?.ID && <QuerySitePurchases siteId={ selectedSite?.ID } /> }
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
 			{ renderHeader() }
 			<TwoColumnsLayout content={ renderMainContent() } sidebar={ renderSettingsCards() } />
@@ -827,19 +837,10 @@ const Settings = ( {
 
 export default connect(
 	( state: IAppState, ownProps: SettingsPageProps ): SettingsPageConnectedProps => {
-		const domain = ownProps.domains && getSelectedDomain( ownProps );
-		const subscriptionId = domain && domain.subscriptionId;
-		const currentUserId = getCurrentUserId( state );
-		const purchase = subscriptionId
-			? getByPurchaseId( state, parseInt( subscriptionId, 10 ) )
-			: null;
 		return {
 			whoisData: getWhoisData( state, ownProps.selectedDomainName ),
 			currentRoute: getCurrentRoute( state ),
 			domain: getSelectedDomain( { ...ownProps, isSiteRedirect: true } ),
-			isLoadingPurchase:
-				isFetchingSitePurchases( state ) || ! hasLoadedSitePurchasesFromServer( state ),
-			purchase: purchase && purchase.userId === currentUserId ? purchase : null,
 			dns: getDomainDns( state, ownProps.selectedDomainName ),
 		};
 	},

--- a/client/my-sites/domains/domain-management/settings/settings-header.tsx
+++ b/client/my-sites/domains/domain-management/settings/settings-header.tsx
@@ -13,9 +13,9 @@ import TransferConnectedDomainNudge from 'calypso/my-sites/domains/domain-manage
 import { useSelector, useDispatch } from 'calypso/state';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, hasReceivedRemotePreferences } from 'calypso/state/preferences/selectors';
+import type { Purchase } from '@automattic/api-core';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
-import type { Purchase } from 'calypso/lib/purchases/types';
 import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';

--- a/client/my-sites/domains/domain-management/settings/types.tsx
+++ b/client/my-sites/domains/domain-management/settings/types.tsx
@@ -2,7 +2,6 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { UpdateNameServersReponse } from 'calypso/data/domains/nameservers/types';
 import type { DnsRequest, ResponseDomain } from 'calypso/lib/domains/types';
-import type { Purchase } from 'calypso/lib/purchases/types';
 
 export type WhoisData = {
 	fname: string;
@@ -32,8 +31,6 @@ export type SettingsPagePassedProps = {
 export type SettingsPageConnectedProps = {
 	currentRoute: string;
 	domain: ResponseDomain | undefined;
-	isLoadingPurchase: boolean;
-	purchase: Purchase | null;
 	whoisData: WhoisData[];
 	dns: DnsRequest;
 };


### PR DESCRIPTION
Related to SHILL-2256

## Proposed changes

Moves the domain-management settings, security and domains-list purchase reads off the camelCase `Purchase` produced by the data-stores assembler and onto the raw snake_case `Purchase` from `@automattic/api-core`, fetched with TanStack Query instead of the Redux purchase selectors. This removes the last temporary `.rawPurchase` bridges in app code — the only assembler use left is the root assembly point itself.

* Convert `client/lib/domains/resolve-domain-status.tsx` to the raw shape, deleting its three `handleRenewNowClick( purchase.rawPurchase, … )` bridges. It has only three callers and two of them pass `null`, so nothing else had to move.
* Move the settings page's purchase fetch out of `mapStateToProps` and into the component as `purchaseQuery( subscriptionId )`, with the usual disabled-query loading gate. `SettingsHeader`, `DetailsCardProps` and the domain info card types now carry the raw `Purchase`.
* Convert the `security` page the same way, adding a small function-component wrapper between `connect` and the still-class component to run the hook. Its `isLoadingPurchase` prop was unused and is gone.
* Replace `getUserPurchases` + `useQueryUserPurchases()` in `usePurchaseActions` with `useQuery( userPurchasesQuery() )`, coercing `Number( p.ID )` at the subscription-id comparison since raw IDs can arrive as strings.
* Read `purchase.is_removable`, `purchase.is_cancelable` and `purchase.ID` directly in the domain delete card, replacing the client-side `isRemovable` / `isCancelable` re-derivations, and inline the renewal price in `registered-domain-details` as `sale_amount || amount`.
* Add a raw port of `shouldRenderExpiringCreditCard` to `client/me/purchases/lib/raw-purchase-helpers.ts`.
* Remove the now-redundant `<QuerySitePurchases />` fetch triggers from the settings and security pages.

## Why are these changes being made?

The data-stores assembler (`createPurchaseObject`) exists only to rename the API's snake_case purchase fields into camelCase, which means every purchase-rendering surface carries a duplicate `Purchase` type and an extra transformation the backend never asked for. SHILL-2256 removes it; the assembler stays alive until the last consumer migrates, so the work is landing page by page. This slice finishes the domain-management cluster, which was the last place still bridging raw purchases back into the camelCase shape with `purchase.rawPurchase`.

One detail is worth calling out for review. The settings page still derives the subscription id from `getSelectedDomain( { domains, selectedDomainName } )` rather than from the `domain` prop. The old `mapStateToProps` resolved the domain twice: once without `isSiteRedirect` for the purchase lookup, and once with it for the `domain` prop. The consequence is that site redirects have never resolved a purchase there, so `DomainDeleteInfoCard` silently returns `null` for them. Reading `domain.subscriptionId` would have quietly enabled the delete card for site redirects, which is a behaviour change that does not belong in a type migration.

The `<QuerySitePurchases />` removals are safe: the only Redux purchase selector left anywhere in that tree is `willAtomicSiteRevertAfterPurchaseDeactivation` (reached through `RemovePurchase` → `CancelPurchaseForm`), and for a domain purchase it returns `false` whether or not `state.purchases` is populated, because domain products are never Atomic-supported.

## Testing instructions

No test files exist for the touched components, so no new coverage was added. The surrounding suites confirm nothing regressed (43 suites / 269 tests):

TC:
```
yarn test-client client/lib/domains client/my-sites/domains client/me/purchases/lib client/sites
```

Manual testing:

* Use a Simple site with a registered domain you own.
* Go to **Domains → {domain} → Settings**. Confirm the "Registered until" / "Registered on" dates, the auto-renew toggle and its "We will attempt to renew on {date} for {price}" text, and the **Renew** and **Payment details** buttons all render as before.
* Toggle auto-renew off and on and confirm the toggle text updates.
* Click **Renew** and confirm checkout opens with the domain in the cart at the correct price.
* Scroll to the sidebar and confirm the **Delete** card appears with the right copy, and that opening it shows the cancellation dialog. For a domain that is not removable, confirm the card links to the cancel-purchase page instead.
* Confirm the status notices at the top of the page (expiring soon, expired, credit card expiring) still render, and that their inline "renew" links start a renewal.
* On an expired domain's **Security** page (HTTPS disabled notice), confirm the reactivate/renew button shows the correct price and starts a renewal.
* On **Domains** (the bulk list) and the site **Overview** page's active domains card, confirm the expiring-credit-card and renewal statuses still show and that **Renew now** works.
* Regression check: open a site redirect's settings page and confirm it behaves exactly as on trunk (no delete card).

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
