### PR TITLE
Site Builder: allow build-wow access through its feature flag

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -139,7 +139,7 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 	const buildWowRequested = queryParams.get( 'build_wow' ) === '1';
 	const { data: isAutomattician, isLoading: isLoadingAutomattician } = useReactQuery( {
 		...isAutomatticianQuery(),
-		enabled: buildWowRequested,
+		enabled: buildWowRequested && ! isBuildWowEnabled( queryParams ),
 	} );
 	const shouldBuildWow = isBuildWowEnabled( queryParams, isAutomattician === true );
 	const activeFlow = getActiveFlow( { shouldBuildWow, shouldProvisionAtomicSite, isCiab } );
@@ -555,7 +555,7 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 		blueprintArchiveSiteIdentifier,
 	] );
 
-	if ( buildWowRequested && isLoadingAutomattician ) {
+	if ( buildWowRequested && ! shouldBuildWow && isLoadingAutomattician ) {
 		return <DocumentHead title={ translate( 'Build Your Site with AI' ) } />;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/index.tsx
@@ -136,12 +136,16 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 	const shouldEarlyProvisionSite = queryParams.get( 'early_provision_site' ) === '1';
 	const shouldProvisionAtomicSite =
 		shouldEarlyProvisionSite || queryParams.get( 'provision_target' ) === 'wpcom-atomic';
-	const buildWowRequested = queryParams.get( 'build_wow' ) === '1';
+	const isBuildWowFlagged = config.isEnabled( 'calypso/ai-site-builder-build-wow' );
+	const needsAutomatticianCheck = queryParams.get( 'build_wow' ) === '1' && ! isBuildWowFlagged;
 	const { data: isAutomattician, isLoading: isLoadingAutomattician } = useReactQuery( {
 		...isAutomatticianQuery(),
-		enabled: buildWowRequested && ! isBuildWowEnabled( queryParams ),
+		enabled: needsAutomatticianCheck,
 	} );
-	const shouldBuildWow = isBuildWowEnabled( queryParams, isAutomattician === true );
+	const shouldBuildWow = isBuildWowEnabled(
+		queryParams,
+		isBuildWowFlagged || isAutomattician === true
+	);
 	const activeFlow = getActiveFlow( { shouldBuildWow, shouldProvisionAtomicSite, isCiab } );
 	const atomicProvisionSpecId = shouldProvisionAtomicSite ? queryParams.get( 'spec_id' ) ?? '' : '';
 	const buildWowSpecId = shouldBuildWow ? queryParams.get( 'spec_id' ) ?? '' : '';
@@ -555,7 +559,7 @@ const SiteSpec: StepType = function SiteSpec( { navigation } ) {
 		blueprintArchiveSiteIdentifier,
 	] );
 
-	if ( buildWowRequested && ! shouldBuildWow && isLoadingAutomattician ) {
+	if ( needsAutomatticianCheck && isLoadingAutomattician ) {
 		return <DocumentHead title={ translate( 'Build Your Site with AI' ) } />;
 	}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
@@ -17,18 +17,26 @@ import { EARLY_PROVISION_TARGET_WPCOM_ATOMIC } from '../early-provisioning';
 import SiteSpec from '../index';
 
 let mockQueryParams = new URLSearchParams();
+let mockBuildWowEnabled = false;
 
 jest.mock( '@automattic/calypso-config', () => {
 	return {
 		__esModule: true,
-		default: jest.fn( ( key: string ) => {
-			const values: Record< string, string > = {
-				wpcom_signup_id: 'signup-id',
-				wpcom_signup_key: 'signup-key',
-			};
+		default: Object.assign(
+			jest.fn( ( key: string ) => {
+				const values: Record< string, string > = {
+					wpcom_signup_id: 'signup-id',
+					wpcom_signup_key: 'signup-key',
+				};
 
-			return values[ key ];
-		} ),
+				return values[ key ];
+			} ),
+			{
+				isEnabled: jest.fn(
+					( flag: string ) => flag === 'calypso/ai-site-builder-build-wow' && mockBuildWowEnabled
+				),
+			}
+		),
 	};
 } );
 
@@ -137,6 +145,7 @@ describe( 'SiteSpec early provisioning step', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockBuildWowEnabled = false;
 		window.sessionStorage.clear();
 		mockQueryParams = new URLSearchParams( 'early_provision_site=1&source=vega' );
 		mockUseReactQuery.mockReturnValue( {
@@ -245,7 +254,28 @@ describe( 'SiteSpec early provisioning step', () => {
 		);
 	} );
 
-	it( 'ignores build-wow Site Spec routing for non-Automatticians', () => {
+	it( 'loads build-wow for non-Automatticians without waiting for staff status when the feature is enabled', () => {
+		mockBuildWowEnabled = true;
+		mockQueryParams = new URLSearchParams( 'build_wow=1&siteSlug=example.wordpress.com' );
+		mockUseReactQuery.mockReturnValue( { data: undefined, isLoading: true } );
+
+		const { rerender } = renderSiteSpec();
+
+		expect( mockUseSiteSpec.mock.calls[ 0 ][ 0 ].siteSpecConfig ).toEqual( {
+			agentId: 'build-wow-site-spec',
+		} );
+
+		mockUseReactQuery.mockReturnValue( { data: false, isLoading: false } );
+		rerender(
+			<SiteSpec navigation={ navigation } stepName="site-spec" flow="ai-site-builder-spec" />
+		);
+
+		expect( mockUseSiteSpec.mock.calls.at( -1 )[ 0 ].siteSpecConfig ).toEqual( {
+			agentId: 'build-wow-site-spec',
+		} );
+	} );
+
+	it( 'ignores build-wow Site Spec routing for non-Automatticians when the feature is disabled', () => {
 		mockQueryParams = new URLSearchParams( 'build_wow=1&siteSlug=example.wordpress.com' );
 		mockUseReactQuery.mockReturnValue( {
 			data: false,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx
@@ -254,23 +254,17 @@ describe( 'SiteSpec early provisioning step', () => {
 		);
 	} );
 
-	it( 'loads build-wow for non-Automatticians without waiting for staff status when the feature is enabled', () => {
+	it( 'loads build-wow for non-Automatticians without asking for staff status when the feature is enabled', () => {
 		mockBuildWowEnabled = true;
 		mockQueryParams = new URLSearchParams( 'build_wow=1&siteSlug=example.wordpress.com' );
-		mockUseReactQuery.mockReturnValue( { data: undefined, isLoading: true } );
+		mockUseReactQuery.mockReturnValue( { data: undefined, isLoading: false } );
 
-		const { rerender } = renderSiteSpec();
+		renderSiteSpec();
 
-		expect( mockUseSiteSpec.mock.calls[ 0 ][ 0 ].siteSpecConfig ).toEqual( {
-			agentId: 'build-wow-site-spec',
-		} );
-
-		mockUseReactQuery.mockReturnValue( { data: false, isLoading: false } );
-		rerender(
-			<SiteSpec navigation={ navigation } stepName="site-spec" flow="ai-site-builder-spec" />
+		expect( mockUseReactQuery ).toHaveBeenCalledWith(
+			expect.objectContaining( { enabled: false } )
 		);
-
-		expect( mockUseSiteSpec.mock.calls.at( -1 )[ 0 ].siteSpecConfig ).toEqual( {
+		expect( mockUseSiteSpec.mock.calls[ 0 ][ 0 ].siteSpecConfig ).toEqual( {
 			agentId: 'build-wow-site-spec',
 		} );
 	} );
@@ -284,6 +278,9 @@ describe( 'SiteSpec early provisioning step', () => {
 
 		renderSiteSpec();
 
+		expect( mockUseReactQuery ).toHaveBeenCalledWith(
+			expect.objectContaining( { enabled: true } )
+		);
 		const siteSpecOptions = mockUseSiteSpec.mock.calls[ 0 ][ 0 ];
 		expect( siteSpecOptions.siteSpecConfig ).toBeUndefined();
 		expect( siteSpecOptions.onSpecConfirm ).toBeUndefined();

--- a/client/landing/stepper/utils/build-wow.ts
+++ b/client/landing/stepper/utils/build-wow.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { addQueryArgs } from '@wordpress/url';
 import { logToLogstash } from 'calypso/lib/logstash';
 import wpcom from 'calypso/lib/wp';
@@ -53,7 +54,10 @@ export function isBuildWowEnabled(
 	queryParams: URLSearchParams,
 	isAutomattician = false
 ): boolean {
-	return isAutomattician && queryParams.get( 'build_wow' ) === BUILD_WOW_QUERY_VALUE;
+	return (
+		( isAutomattician || config.isEnabled( 'calypso/ai-site-builder-build-wow' ) ) &&
+		queryParams.get( 'build_wow' ) === BUILD_WOW_QUERY_VALUE
+	);
 }
 
 export function getBuildWowSiteIdentifier( {

--- a/client/landing/stepper/utils/build-wow.ts
+++ b/client/landing/stepper/utils/build-wow.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { addQueryArgs } from '@wordpress/url';
 import { logToLogstash } from 'calypso/lib/logstash';
 import wpcom from 'calypso/lib/wp';
@@ -52,12 +51,9 @@ type BigSkyPluginStatus = {
 
 export function isBuildWowEnabled(
 	queryParams: URLSearchParams,
-	isAutomattician = false
+	hasBuildWowAccess: boolean
 ): boolean {
-	return (
-		( isAutomattician || config.isEnabled( 'calypso/ai-site-builder-build-wow' ) ) &&
-		queryParams.get( 'build_wow' ) === BUILD_WOW_QUERY_VALUE
-	);
+	return hasBuildWowAccess && queryParams.get( 'build_wow' ) === BUILD_WOW_QUERY_VALUE;
 }
 
 export function getBuildWowSiteIdentifier( {

--- a/client/landing/stepper/utils/test/build-wow.ts
+++ b/client/landing/stepper/utils/test/build-wow.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import wpcom from 'calypso/lib/wp';
 import {
 	getBuildWowGraph,
@@ -7,6 +8,10 @@ import {
 	isBuildWowSiteEditorReady,
 	requestBuildWowSite,
 } from '../build-wow';
+
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: jest.fn(),
+} ) );
 
 jest.mock( 'calypso/lib/logstash', () => ( {
 	logToLogstash: jest.fn( () => Promise.resolve() ),
@@ -23,7 +28,20 @@ jest.mock( 'calypso/lib/wp', () => ( {
 } ) );
 
 describe( 'build-wow utilities', () => {
-	it( 'detects the build_wow query parameter', () => {
+	beforeEach( () => {
+		jest.mocked( config.isEnabled ).mockReturnValue( false );
+	} );
+
+	it( 'allows non-Automatticians when the build-wow feature is enabled', () => {
+		jest
+			.mocked( config.isEnabled )
+			.mockImplementation( ( flag ) => flag === 'calypso/ai-site-builder-build-wow' );
+		expect( isBuildWowEnabled( new URLSearchParams( 'build_wow=1' ) ) ).toBe( true );
+		expect( isBuildWowEnabled( new URLSearchParams( 'build_wow=0' ) ) ).toBe( false );
+		expect( isBuildWowEnabled( new URLSearchParams() ) ).toBe( false );
+	} );
+
+	it( 'requires staff status and the build_wow query parameter when the feature is disabled', () => {
 		expect( isBuildWowEnabled( new URLSearchParams( 'build_wow=1' ), true ) ).toBe( true );
 		expect( isBuildWowEnabled( new URLSearchParams( 'build_wow=1' ), false ) ).toBe( false );
 		expect( isBuildWowEnabled( new URLSearchParams( 'build_wow=0' ), true ) ).toBe( false );

--- a/client/landing/stepper/utils/test/build-wow.ts
+++ b/client/landing/stepper/utils/test/build-wow.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import wpcom from 'calypso/lib/wp';
 import {
 	getBuildWowGraph,
@@ -8,10 +7,6 @@ import {
 	isBuildWowSiteEditorReady,
 	requestBuildWowSite,
 } from '../build-wow';
-
-jest.mock( '@automattic/calypso-config', () => ( {
-	isEnabled: jest.fn(),
-} ) );
 
 jest.mock( 'calypso/lib/logstash', () => ( {
 	logToLogstash: jest.fn( () => Promise.resolve() ),
@@ -28,20 +23,7 @@ jest.mock( 'calypso/lib/wp', () => ( {
 } ) );
 
 describe( 'build-wow utilities', () => {
-	beforeEach( () => {
-		jest.mocked( config.isEnabled ).mockReturnValue( false );
-	} );
-
-	it( 'allows non-Automatticians when the build-wow feature is enabled', () => {
-		jest
-			.mocked( config.isEnabled )
-			.mockImplementation( ( flag ) => flag === 'calypso/ai-site-builder-build-wow' );
-		expect( isBuildWowEnabled( new URLSearchParams( 'build_wow=1' ) ) ).toBe( true );
-		expect( isBuildWowEnabled( new URLSearchParams( 'build_wow=0' ) ) ).toBe( false );
-		expect( isBuildWowEnabled( new URLSearchParams() ) ).toBe( false );
-	} );
-
-	it( 'requires staff status and the build_wow query parameter when the feature is disabled', () => {
+	it( 'detects the build_wow query parameter', () => {
 		expect( isBuildWowEnabled( new URLSearchParams( 'build_wow=1' ), true ) ).toBe( true );
 		expect( isBuildWowEnabled( new URLSearchParams( 'build_wow=1' ), false ) ).toBe( false );
 		expect( isBuildWowEnabled( new URLSearchParams( 'build_wow=0' ), true ) ).toBe( false );


### PR DESCRIPTION
## Proposed Changes

Allow non-Automatticians into the shared build-wow Site Spec flow when `calypso/ai-site-builder-build-wow` is enabled, and skip the staff-status query and loading wait in that case. Keep the existing Automattician restriction when the flag is disabled.

## Why are these changes being made?

The custom-design card and Sites dashboard’s **Create a site → Create with AI** path already route into build-wow where the feature is enabled, but the shared Site Spec gate still excludes non-Automatticians. Reusing the existing flag makes those paths available in staging and local development without hardcoding environments or changing production configuration.

## Testing Instructions

1. With `calypso/ai-site-builder-build-wow` enabled, use a non-Automattician account and an Atomic-capable plan. Follow either the custom-design card or **Sites → Create a site → Create with AI** through checkout. Verify that the build-wow Site Spec interview loads without waiting for staff status.
2. With the flag disabled, verify that a non-Automattician visiting `/setup/ai-site-builder-spec/site-spec?build_wow=1&siteSlug=<site-slug>` does not enter build-wow. Verify that an Automattician can still enter it.
3. Run the focused suites:

```sh
yarn test-client --runInBand client/landing/stepper/utils/test/build-wow.ts client/landing/stepper/declarative-flow/internals/steps-repository/site-spec/test/index.test.tsx client/landing/stepper/declarative-flow/internals/steps-repository/setup-your-site-ai/test/index.test.tsx client/landing/stepper/declarative-flow/flows/ai-site-builder-onboarding/test/ai-site-builder-onboarding.test.ts
```

Validation: all 57 tests across four suites pass; ESLint passes for the four changed files. `yarn typecheck-client` exceeds the default 4 GB Node heap. With an 8 GB heap it reports 35 errors outside the changed files, including stale package declarations and an existing untracked test. Repeating the check with the four changed files supplied from the parent commit through a read-only overlay produces byte-for-byte identical diagnostics; this change adds no type errors. Browser and backend permission checks have not been performed.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
