### PR TITLE
Fix "inititate" typo in transfer initiate Tracks events

### DIFF
--- a/client/state/data-layer/wpcom/sites/atomic/software/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/software/index.js
@@ -28,13 +28,13 @@ const installSoftware = ( action ) => [
 ];
 
 const receiveInstallResponse = () => [
-	recordTracksEvent( 'calypso_atomic_software_install_inititate_success', {
+	recordTracksEvent( 'calypso_atomic_software_install_initiate_success', {
 		context: 'atomic_software_install',
 	} ),
 ];
 
 const receiveInstallError = ( action, error ) => [
-	recordTracksEvent( 'calypso_atomic_software_install_inititate_failure', {
+	recordTracksEvent( 'calypso_atomic_software_install_initiate_failure', {
 		context: 'atomic_software_install',
 		error: error.error,
 	} ),

--- a/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
@@ -54,14 +54,14 @@ const initiateAtomicTransfer = ( action ) =>
 	);
 
 const receiveResponse = ( action, transfer ) => [
-	recordTracksEvent( 'calypso_atomic_transfer_inititate_success', {
+	recordTracksEvent( 'calypso_atomic_transfer_initiate_success', {
 		context: 'atomic_transfer',
 	} ),
 	setLatestAtomicTransfer( action.siteId, transfer ),
 ];
 
 const receiveError = ( action, error ) => [
-	recordTracksEvent( 'calypso_atomic_transfer_inititate_failure', {
+	recordTracksEvent( 'calypso_atomic_transfer_initiate_failure', {
 		context: 'atomic_transfer',
 		error: error.error,
 	} ),

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/index.js
@@ -21,7 +21,7 @@ export const initiateTransferWithPluginZip = ( action ) => {
 	const { siteId, pluginZip } = action;
 
 	return [
-		recordTracksEvent( 'calypso_automated_transfer_inititate_transfer', {
+		recordTracksEvent( 'calypso_automated_transfer_initiate_transfer', {
 			context: 'plugin_upload',
 		} ),
 		http(
@@ -60,7 +60,7 @@ const showErrorNotice = ( error ) => {
 
 export const receiveError = ( { siteId }, error ) => {
 	return [
-		recordTracksEvent( 'calypso_automated_transfer_inititate_failure', {
+		recordTracksEvent( 'calypso_automated_transfer_initiate_failure', {
 			context: 'plugin_upload',
 			error: error.error,
 		} ),
@@ -75,7 +75,7 @@ export const receiveResponse = ( action, { success } ) => {
 	}
 
 	return [
-		recordTracksEvent( 'calypso_automated_transfer_inititate_success', {
+		recordTracksEvent( 'calypso_automated_transfer_initiate_success', {
 			context: 'plugin_upload',
 		} ),
 		fetchAutomatedTransferStatus( action.siteId ),

--- a/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
+++ b/client/state/data-layer/wpcom/sites/automated-transfer/initiate/test/index.js
@@ -53,7 +53,7 @@ describe( 'initiateTransferWithPluginZip', () => {
 	test( 'should dispatch a tracks call', () => {
 		const result = initiateTransferWithPluginZip( { siteId, pluginZip: 'foo' } );
 		expect( result[ 0 ] ).toEqual(
-			recordTracksEvent( 'calypso_automated_transfer_inititate_transfer', {
+			recordTracksEvent( 'calypso_automated_transfer_initiate_transfer', {
 				context: 'plugin_upload',
 			} )
 		);
@@ -69,7 +69,7 @@ describe( 'receiveResponse', () => {
 	test( 'should dispatch a tracks call', () => {
 		const result = receiveResponse( { siteId }, INITIATE_SUCCESS_RESPONSE );
 		expect( result[ 0 ] ).toEqual(
-			recordTracksEvent( 'calypso_automated_transfer_inititate_success', {
+			recordTracksEvent( 'calypso_automated_transfer_initiate_success', {
 				context: 'plugin_upload',
 			} )
 		);
@@ -83,7 +83,7 @@ describe( 'receiveResponse', () => {
 	test( 'should dispatch a tracks call on unsuccessful initiation', () => {
 		const result = receiveResponse( { siteId }, INITIATE_FAILURE_RESPONSE );
 		expect( result[ 0 ] ).toEqual(
-			recordTracksEvent( 'calypso_automated_transfer_inititate_failure', {
+			recordTracksEvent( 'calypso_automated_transfer_initiate_failure', {
 				context: 'plugin_upload',
 				error: 'api_success_false',
 			} )
@@ -105,7 +105,7 @@ describe( 'receiveError', () => {
 	test( 'should dispatch a tracks call', () => {
 		const result = receiveError( { siteId }, ERROR_RESPONSE );
 		expect( result[ 0 ] ).toEqual(
-			recordTracksEvent( 'calypso_automated_transfer_inititate_failure', {
+			recordTracksEvent( 'calypso_automated_transfer_initiate_failure', {
 				context: 'plugin_upload',
 				error: 'invalid_input',
 			} )


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18519/transfer-initiate-failure-tracks-events-are-misspelled-inititate

## Proposed Changes

**Fixes the "inititate" typo in nine Tracks event names recorded when a site transfer or software install starts, succeeds, or fails.**

- `calypso_automated_transfer_inititate_{transfer,success,failure}` → `..._initiate_...`, which merges the plugin path into the already correctly named theme path.
- Same rename for `calypso_atomic_transfer_inititate_*` and `calypso_atomic_software_install_inititate_*`.

## Why are these changes being made?

Two spellings of the same event exist in production and they cover different code paths: plugin transfers were recorded under the misspelled name, theme transfers under the correct one. Anyone querying the correct name sees theme transfers only and concludes plugin transfers never fail to start — over 27 Aug – 7 Sep that hid 31 sites' worth of failures. None of the misspelled events feed a funnel, so renaming them outright is safe.

## Testing Instructions

1. `yarn start`, open a site's Plugins page.
2. Upload an invalid zip as a plugin so the transfer fails to start.
3. In the browser console (or a Tracks debug view), confirm the recorded event is `calypso_automated_transfer_initiate_failure` with `context: plugin_upload`, and that no `inititate` event fires.
