### PR TITLE
Unseen Posts: Update seen status of x-posts when visited from the feed

### DIFF
--- a/client/reader/stream/test/x-post.test.tsx
+++ b/client/reader/stream/test/x-post.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CrossPost } from '../x-post';
+import type { Post } from 'calypso/reader/data/post/cache';
+
+jest.mock( 'calypso/blocks/user-avatar', () => () => <div data-testid="user-avatar" /> );
+
+const post: Post = {
+	title: 'X-post: Test post',
+	site_URL: 'https://destination.example.com',
+	feed_item_ID: 200,
+	global_ID: 'x-post-global-id',
+	is_seen: false,
+};
+
+describe( 'CrossPost', () => {
+	it( 'marks the feed item as seen on opening its source post', async () => {
+		const user = userEvent.setup();
+		const requestMarkAsSeen = jest.fn();
+		const { container } = render(
+			<CrossPost
+				post={ post }
+				postKey={ { feedId: 100, postId: 200 } }
+				isSeenEnabled
+				requestMarkAsSeen={ requestMarkAsSeen }
+				handleClick={ jest.fn() }
+			/>
+		);
+		const article = container.querySelector( 'article' );
+
+		expect( article ).not.toBeNull();
+		await user.click( article! );
+
+		expect( requestMarkAsSeen ).toHaveBeenCalledWith( {
+			feedId: 100,
+			feedItemIds: [ 200 ],
+			globalIds: [ 'x-post-global-id' ],
+		} );
+	} );
+} );

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -8,11 +8,11 @@ import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 import UserAvatar from 'calypso/blocks/user-avatar';
 import { useFeedQuery } from 'calypso/reader/data/feed';
-import { useIsSeenEnabled } from 'calypso/reader/data/seen-posts';
+import { useIsSeenEnabled, useMarkAsSeenMutation } from 'calypso/reader/data/seen-posts';
 import { useSite } from 'calypso/reader/data/site';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
-class CrossPost extends PureComponent {
+export class CrossPost extends PureComponent {
 	static propTypes = {
 		post: PropTypes.object.isRequired,
 		isSelected: PropTypes.bool.isRequired,
@@ -24,6 +24,7 @@ class CrossPost extends PureComponent {
 		site: PropTypes.object,
 		feed: PropTypes.object,
 		isSeenEnabled: PropTypes.bool,
+		requestMarkAsSeen: PropTypes.func.isRequired,
 	};
 
 	cardRef = createRef();
@@ -70,8 +71,23 @@ class CrossPost extends PureComponent {
 		if ( ! event.defaultPrevented ) {
 			// some child handled it
 			event.preventDefault();
+			this.markAsSeen();
 			this.props.handleClick( this.props.xMetadata );
 		}
+	};
+
+	markAsSeen = () => {
+		const { isSeenEnabled, post, postKey, requestMarkAsSeen } = this.props;
+		const feedId = postKey?.feedId || post.feed_ID;
+		if ( ! isSeenEnabled || post.is_seen || ! feedId || ! post.feed_item_ID ) {
+			return;
+		}
+
+		requestMarkAsSeen( {
+			feedId,
+			feedItemIds: [ post.feed_item_ID ],
+			globalIds: post.global_ID ? [ post.global_ID ] : [],
+		} );
 	};
 
 	getSiteNameFromURL = ( siteURL ) => {
@@ -213,6 +229,7 @@ export default function CrossPostContainer( props ) {
 	const { site } = useSite( siteId );
 	const resolvedFeedId = feedId || site?.feed_ID;
 	const { data: feedFromSite } = useFeedQuery( feedFromKey ? undefined : resolvedFeedId );
+	const { mutate: requestMarkAsSeen } = useMarkAsSeenMutation();
 	const isSeenEnabled = useIsSeenEnabled( {
 		feedId: resolvedFeedId,
 		blogId: siteId,
@@ -225,6 +242,7 @@ export default function CrossPostContainer( props ) {
 			site={ site }
 			feed={ feedFromKey || feedFromSite }
 			isSeenEnabled={ isSeenEnabled }
+			requestMarkAsSeen={ requestMarkAsSeen }
 		/>
 	);
 }


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: https://linear.app/a8c/issue/READ-717

## Proposed Changes

Mark an x-post’s feed item as read when opening its source post.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

Visiting an x-post incorrectly marked the source post instead of the subscribed feed item.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

  * Open an unread x-post from Reader and confirm it becomes read.
  * Run `yarn test-client client/reader/stream/test/x-post.test.tsx`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
