### PR TITLE
Pricing grid: fix alignment of components

### DIFF
--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -238,12 +238,21 @@ body.is-section-plans .layout__content #plans .main {
 /**
  * Adjust card sizes for 3/4 columns to align with the container
  */
-body.is-section-plans .plan-features-2023-grid__table {
+body.is-section-plans .plan-features-2023-grid__content {
        &.has-3-cols,
        &.has-4-cols {
-               max-width: none;
-        }
- }
+               .plan-features-2023-grid__table {
+                       max-width: none;
+               }
+
+               .plan-features-2023-grid__desktop-view,
+               .plan-features-2023-grid__tablet-view {
+                       .plan-features-2023-grid__table-item {
+                               max-width: none;
+                       }
+               }
+       }
+}
 
 body.is-section-stepper,
 body.is-section-signup {

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -239,19 +239,18 @@ body.is-section-plans .layout__content #plans .main {
  * Adjust card sizes for 3/4 columns to align with the container
  */
 body.is-section-plans .plan-features-2023-grid__content {
-       &.has-3-cols,
-       &.has-4-cols {
-               .plan-features-2023-grid__table {
-                       max-width: none;
-               }
-
-               .plan-features-2023-grid__desktop-view,
-               .plan-features-2023-grid__tablet-view {
-                       .plan-features-2023-grid__table-item {
-                               max-width: none;
-                       }
-               }
-       }
+	&.has-3-cols,
+	&.has-4-cols {
+		.plan-features-2023-grid__table {
+			max-width: none;
+		}
+		.plan-features-2023-grid__desktop-view,
+		.plan-features-2023-grid__tablet-view {
+			.plan-features-2023-grid__table-item {
+				max-width: none;
+			}
+		}
+	}
 }
 
 body.is-section-stepper,

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -234,6 +234,17 @@ body.is-section-plans .layout__content #plans .main {
 	}
 }
 
+
+/**
+ * Adjust card sizes for 3/4 columns to align with the container
+ */
+body.is-section-plans .plan-features-2023-grid__table {
+       &.has-3-cols,
+       &.has-4-cols {
+               max-width: none;
+        }
+ }
+
 body.is-section-stepper,
 body.is-section-signup {
 	.step-wrapper__header {

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -4,6 +4,7 @@
 @import "@automattic/typography/styles/variables";
 @import "calypso/assets/stylesheets/shared/mixins/breakpoints";
 @import "@automattic/plans-grid-next/src/media-queries";
+@import "@automattic/plans-grid-next/src/variables";
 @import "./media-queries";
 
 $plan-features-header-banner-height: 20px;
@@ -205,12 +206,30 @@ body.is-section-plans .layout__content .main {
 		.is-2023-pricing-grid .plans-wrapper {
 			margin: 0;
 		}
+
+		.plans-features-main > * > .plans-features-main__plan-type-selector-layout .plan-type-selector {
+			width: 100%;
+			max-width: $mobile-card-max-width;
+		}
+
+		// Once stuck, the selector spans the viewport instead.
+		.plans-features-main > .is-sticky-plan-type-selector > .plans-features-main__plan-type-selector-layout .plan-type-selector {
+			max-width: none;
+		}
 	}
 }
 body.is-section-plans .layout__content #plans .main {
 	@include plan-type-selector-custom-mobile-breakpoint {
 		.is-2023-pricing-grid .plans-wrapper {
 			padding: 17px;
+		}
+
+		.plans-features-main > * > .plans-features-main__plan-type-selector-layout {
+			padding-inline: 17px;
+		}
+
+		.plans-features-main > .is-sticky-plan-type-selector > .plans-features-main__plan-type-selector-layout {
+			padding-inline: 0;
 		}
 	}
 }

--- a/packages/plans-grid-next/src/_shared.scss
+++ b/packages/plans-grid-next/src/_shared.scss
@@ -1,9 +1,7 @@
 @import "@automattic/onboarding/styles/mixins";
 @import "./mixins";
 @import "./media-queries";
-
-$table-cell-max-width: 344px;
-$mobile-card-max-width: 440px;
+@import "./variables";
 
 /*********************************
  * Storage Add-On Dropdown parts *

--- a/packages/plans-grid-next/src/_variables.scss
+++ b/packages/plans-grid-next/src/_variables.scss
@@ -1,0 +1,2 @@
+$table-cell-max-width: 344px;
+$mobile-card-max-width: 440px;


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes MARTECH-3028

## Proposed Changes

* Update some pricing grid elements to align better with the surrounding elements.

||Before|After|
|---|---|---|
|Desktop|<img width="1277" height="859" alt="Screenshot 2026-09-08 at 20 47 17" src="https://github.com/user-attachments/assets/0a56ea38-51f1-4eca-aba3-2d36c1fa9479" />|<img width="1277" height="859" alt="Screenshot 2026-09-08 at 20 46 48" src="https://github.com/user-attachments/assets/3b32105f-77a6-4e53-82f6-2c369590db30" />|
|Mobile|<img width="483" height="468" alt="Screenshot 2026-09-08 at 20 47 39" src="https://github.com/user-attachments/assets/19b5b0d5-22c3-4e2f-9728-31e4daf6d333" />|<img width="483" height="468" alt="Screenshot 2026-09-08 at 20 47 45" src="https://github.com/user-attachments/assets/2467c222-3bf4-41de-b0c8-0fda85b5bb9c" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* We want to improve the visual presentation of the pricing grid.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a Business site /plans page.
* Confirm it shows thee plans in the grid and that they're aligned with the parent container.
* Switch to a mobile view and check that the interval selector has the same width as a plan card.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
