### PR TITLE
Domains: space the diagnostics dismiss action from the notice above it

### DIFF
--- a/client/dashboard/domains/domain-diagnostics/index.tsx
+++ b/client/dashboard/domains/domain-diagnostics/index.tsx
@@ -125,7 +125,7 @@ export default function DomainDiagnostics() {
 		const recordsToCheck = [ 'spf', 'dkim1', 'dkim2', 'dmarc' ];
 
 		return (
-			<VStack>
+			<VStack spacing={ 6 }>
 				<VStack as="ul" spacing={ 2 }>
 					{ recordsToCheck.map( renderDiagnosticForRecord ) }
 				</VStack>


### PR DESCRIPTION
Fixes DOMAINS-2307

## Proposed Changes

* Give the domain diagnostics content a `spacing={ 6 }` `VStack` (24px, the dashboard's usual section rhythm) instead of the default `2` (8px), so the actions are no longer glued to the notice above them.

## Why are these changes being made?

On **Domains → {domain} → Diagnostics**, the "Dismiss this notice" / "Fix DNS issues automatically" buttons sat only 8px below the "Missing or invalid DNS records" warning, reading as part of the notice rather than as separate actions.

The copy fix originally bundled here (the missing space before the "Learn more" link, which only reproduces under machine page-translation) is held back for now, so this PR carries no string changes.

## Testing Instructions

1. Go to a domain with email DNS issues → **Domains → {domain} → Diagnostics** (`/domains/{domain}/diagnostics`).
2. Confirm the "Dismiss this notice" / "Fix DNS issues automatically" buttons now sit 24px below the warning notice rather than 8px.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014B9XkV4JLGFi3U98hxPMLu
