### PR TITLE
A4A Marketplace: swap 3rd-party featured extensions for Woo-owned ones

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/hooks/use-product-and-plans.tsx
@@ -83,11 +83,11 @@ const getDisplayableFeaturedProducts = (
 ) => {
 	const featuredProductSlugs = [
 		'woocommerce-woopayments',
-		'woocommerce-constellation',
-		'woocommerce-dynamic-pricing',
-		'woocommerce-rental-products',
-		'woocommerce-smart-coupons',
-		'woocommerce-variation-swatches-and-photos',
+		'woocommerce-composite-products',
+		'woocommerce-table-rate-shipping',
+		'woocommerce-gift-cards',
+		'woocommerce-points-and-rewards',
+		'woocommerce-shipment-tracking',
 	]; // For now, we hardcode this until we understand how we want pick featured products.
 
 	// We do it this way to ensure we follow the same order as the featuredProductSlugs.


### PR DESCRIPTION
Fixes A4A-3321

## Proposed Changes

* Replace the five 3rd-party extensions in the Marketplace "Featured products" section (Constellation, Dynamic Pricing, Rental Products, Smart Coupons, Variation Swatches and Photos) with the top-selling Woo-owned ones: Composite Products, Table Rate Shipping, Gift Cards, Points and Rewards, Shipment Tracking.
* WooPayments stays in first position.

## Why are these changes being made?

* We don't have a clear strategy for 3rd-party extensions in the A4A Marketplace yet, so we're pulling them out of the featured section and promoting Woo-owned extensions with proven sales instead.

## Testing Instructions

* Go to Marketplace > Overview (`/marketplace/products`).
* Confirm the "Featured products" section shows WooPayments, Composite Products, Table Rate Shipping, Gift Cards, Points and Rewards, and Shipment Tracking, in that order.
* Confirm each card links to the right product and is attributed to WooCommerce.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01HiiTrM4BT1TTsnBbPk12BG
