### PR TITLE
A4A Referrals: strip whitespace from the client email in referral checkout

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/checkout/request-client-payment.tsx
@@ -101,7 +101,7 @@ function RequestClientPayment( { checkoutItems, termPricing }: Props ) {
 	const { onClearCart } = useShoppingCart();
 
 	const onEmailChange = ( value: string ) => {
-		setEmail( value );
+		setEmail( value.trim() );
 		if ( validationError.email ) {
 			setValidationError( { email: undefined } );
 		}


### PR DESCRIPTION
Fixes A4A-3198

## Proposed Changes

* Trim the client email as it is entered in the referral checkout form, so leading/trailing whitespace never reaches validation or the request payload.

## Why are these changes being made?

* Pasting an email with a trailing space failed `emailValidator.validate()`, so the form showed “Please provide correct email address” next to an address that looked correct, and the referral could not be sent.

## Testing Instructions

* Go to the marketplace, add a product to the cart, and choose “Refer to client”.
* Paste an email with leading/trailing spaces (e.g. `" client@example.com "`) into the client’s email address field. The spaces should be stripped as you paste.
* Send the referral and confirm it goes through without a validation error.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01HiiTrM4BT1TTsnBbPk12BG
