### PR TITLE
Pricing grid redesign: display Enterprise/Commerce plans as normal cards on the /plans page

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-plans-grid-redesign-experiment.test.ts
@@ -310,4 +310,67 @@ describe( 'usePlansGridRedesignExperiment', () => {
 			showWooCommerceBottomCard: true,
 		} );
 	} );
+
+	test( 'keeps the Enterprise card in the grid on logged-in plans pages for five_plan_new_description', () => {
+		mockSite( { isGatingBusinessQ1: true } );
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'five_plan_new_description' } ] );
+
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: null,
+				isInSignup: false,
+				siteId: 123,
+			} )
+		);
+
+		expect( result.current ).toEqual( {
+			...CONTROL_RESULT,
+			variant: 'five_plan_new_description',
+			usePlansGridRedesign: true,
+			usePlansGridRedesignNewDescription: true,
+			showEnterpriseBottomCard: false,
+		} );
+	} );
+
+	test( 'keeps the WooCommerce card in the grid on logged-in plans pages for four_plan_new_description', () => {
+		mockSite( { isGatingBusinessQ1: true } );
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'four_plan_new_description' } ] );
+
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: null,
+				isInSignup: false,
+				siteId: 123,
+			} )
+		);
+
+		expect( result.current ).toEqual( {
+			...CONTROL_RESULT,
+			variant: 'four_plan_new_description',
+			usePlansGridRedesign: true,
+			usePlansGridRedesignNewDescription: true,
+			showWooCommerceBottomCard: false,
+		} );
+	} );
+
+	test( 'hides the differentiator header on logged-in plans pages for six_plan_new_features', () => {
+		mockSite( { isGatingBusinessQ1: true } );
+		mockUseExperiment.mockReturnValue( [ false, { variationName: 'six_plan_new_features' } ] );
+
+		const { result } = renderHook( () =>
+			usePlansGridRedesignExperiment( {
+				flowName: null,
+				isInSignup: false,
+				siteId: 123,
+			} )
+		);
+
+		expect( result.current ).toEqual( {
+			...CONTROL_RESULT,
+			variant: 'six_plan_new_features',
+			usePlansGridRedesign: true,
+			showDifferentiatorHeader: false,
+			usePlansGridRedesignFeatures: true,
+		} );
+	} );
 } );

--- a/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plans-grid-redesign-experiment.ts
@@ -30,7 +30,7 @@ type PlansGridRedesignExperimentResult = {
 	 */
 	usePlansGridRedesignNewDescription: boolean;
 	/**
-	 * When true, show the differentiator header (4 bullet points).
+	 * When true, show the differentiator header (4 bullet points). Signup only.
 	 */
 	showDifferentiatorHeader: boolean;
 	/**
@@ -38,11 +38,13 @@ type PlansGridRedesignExperimentResult = {
 	 */
 	usePlansGridRedesignFeatures: boolean;
 	/**
-	 * When true, show the Enterprise/VIP card at the bottom.
+	 * When true, show the Enterprise/VIP card at the bottom. Signup only; the
+	 * logged-in plans page renders it as a regular column instead.
 	 */
 	showEnterpriseBottomCard: boolean;
 	/**
-	 * When true, show the WooCommerce card at the bottom.
+	 * When true, show the WooCommerce card at the bottom. Signup only; the
+	 * logged-in plans page renders it as a regular column instead.
 	 */
 	showWooCommerceBottomCard: boolean;
 	/**
@@ -110,10 +112,13 @@ function usePlansGridRedesignExperiment( {
 		variant,
 		usePlansGridRedesign,
 		usePlansGridRedesignNewDescription,
-		showDifferentiatorHeader: usePlansGridRedesign && variant === 'six_plan_new_features',
+		showDifferentiatorHeader:
+			usePlansGridRedesign && isInSignup && variant === 'six_plan_new_features',
 		usePlansGridRedesignFeatures: usePlansGridRedesign && variant === 'six_plan_new_features',
-		showEnterpriseBottomCard: usePlansGridRedesign && variant === 'five_plan_new_description',
-		showWooCommerceBottomCard: usePlansGridRedesign && variant === 'four_plan_new_description',
+		showEnterpriseBottomCard:
+			usePlansGridRedesign && isInSignup && variant === 'five_plan_new_description',
+		showWooCommerceBottomCard:
+			usePlansGridRedesign && isInSignup && variant === 'four_plan_new_description',
 		isExperimentEligible: isEligible,
 	};
 }


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes MARTECH-3066

## Proposed Changes

* For the experiment variants with 5 and 4 cards where the Enterprise or Commerce cards are shown on the bottom during signup, the cards should be shown as normal on the /plans page.

|Before: new features|<img width="1287" height="720" alt="Screenshot 2026-09-08 at 23 59 53" src="https://github.com/user-attachments/assets/2d7caa48-b93a-4e7b-b6a2-f82013bd0653" />|
|---|---|
|Before: five plans|<img width="628" height="699" alt="Screenshot 2026-09-08 at 22 49 46" src="https://github.com/user-attachments/assets/d8a4c82b-2c6d-4c1e-9e22-1d767e8be527" />|
|Before: four plans|<img width="628" height="699" alt="Screenshot 2026-09-08 at 23 58 22" src="https://github.com/user-attachments/assets/96dba00f-615d-48a7-a05f-659a9330ab85" />|
|After|<img width="1287" height="728" alt="Screenshot 2026-09-09 at 00 25 29" src="https://github.com/user-attachments/assets/0494b6b7-b666-47fc-84d1-9c3b6daa89ef" />|


## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Showing the cards at the bottom doesn't work well on /plans page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On a new site with Business plan, check the /plans page with `six_plan_new_features`, `five_plan_new_description` and `four_plan_new_description` variants.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
