### PR TITLE
Site Builder: turn on the build-wow flag in wpcalypso

### DIFF
--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -28,7 +28,7 @@
 		"blackbox-userless-checkout": true,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/ai-site-builder-flow": true,
-		"calypso/ai-site-builder-build-wow": false,
+		"calypso/ai-site-builder-build-wow": true,
 		"calypso/all-domain-management": true,
 		"calypso/big-sky": true,
 		"calypso/domains-dataviews": true,


### PR DESCRIPTION
## Proposed Changes

* Set `calypso/ai-site-builder-build-wow` to `true` in `config/wpcalypso.json`.

## Why are these changes being made?

The build-wow site builder needs two flags: `site-spec` and `calypso/ai-site-builder-build-wow`. On wpcalypso the first one is already on and the second is off, so the flow still asks whether you are an Automattician and sends everyone else to the old builder.

That makes staging awkward to use. Today you have to add `?flags=calypso/ai-site-builder-build-wow` to every URL, or set a `flags` cookie by hand, and the flag is lost on any full page load such as the trip through checkout.

The server side stopped gating this path in wpcom #239196, so wpcalypso is where we can walk the flow the way a customer will get it. `stage` and `development` already have the flag on, so this also lines wpcalypso up with the environment progression in `config/README.md`.

Production stays off. #114076 is the PR that turns it on for customers.

## Testing Instructions

* On https://wpcalypso.wordpress.com, sign in with an account that is not an Automattician and a site on Personal or higher (build-wow transfers the site to Atomic, so a free site is not eligible).
* Start the AI site builder from onboarding. You should land on build-wow without passing any flag in the URL.
* On https://wordpress.com nothing changes, because the flag stays off in production.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] Have you written new tests for your changes? Not applicable, config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdyLS1pVHGAZa7avVEw7A8