### PR TITLE
Dark mode: remap neutral interactive tokens so TabPanel tabs are readable

### DIFF
--- a/client/lib/color-scheme/dark-theme.scss
+++ b/client/lib/color-scheme/dark-theme.scss
@@ -82,8 +82,6 @@ This mixin generates alias variables for a color palette. For example, the
 	--wpds-color-foreground-interactive-brand: var( --wp-components-color-accent );
 	--wpds-color-foreground-interactive-brand-active: var( --wp-components-color-accent-darker-20 );
 	--wpds-color-stroke-focus: var( --wp-components-color-accent );
-	// `@wordpress/theme` ships light-only neutral interactive tokens. TabPanel
-	// tabs read them directly, so remap them for dark surfaces.
 	--wpds-color-foreground-interactive-neutral: var( --wp-components-color-foreground );
 	--wpds-color-foreground-interactive-neutral-active: var( --wp-components-color-foreground );
 	--wpds-color-background-interactive-neutral-weak-active: var( --wp-components-color-gray-200 );

--- a/client/lib/color-scheme/dark-theme.scss
+++ b/client/lib/color-scheme/dark-theme.scss
@@ -82,6 +82,11 @@ This mixin generates alias variables for a color palette. For example, the
 	--wpds-color-foreground-interactive-brand: var( --wp-components-color-accent );
 	--wpds-color-foreground-interactive-brand-active: var( --wp-components-color-accent-darker-20 );
 	--wpds-color-stroke-focus: var( --wp-components-color-accent );
+	// `@wordpress/theme` ships light-only neutral interactive tokens. TabPanel
+	// tabs read them directly, so remap them for dark surfaces.
+	--wpds-color-foreground-interactive-neutral: var( --wp-components-color-foreground );
+	--wpds-color-foreground-interactive-neutral-active: var( --wp-components-color-foreground );
+	--wpds-color-background-interactive-neutral-weak-active: var( --wp-components-color-gray-200 );
 	--wp-components-color-gray-800: #e0e0e0;
 	--wp-components-color-gray-700: #bdbdbd;
 	--wp-components-color-gray-600: #8a8a8a;


### PR DESCRIPTION

Fixes https://linear.app/a8c/issue/DOTMSD-1562/dns-records-email-setup-tab-labels-unreadable-in-dark-mode

## Proposed Changes

* Remap `--wpds-color-foreground-interactive-neutral` and `--wpds-color-foreground-interactive-neutral-active` to `--wp-components-color-foreground` in the shared dark theme token mixin.
* Remap `--wpds-color-background-interactive-neutral-weak-active` (vertical TabPanel active tab background) to `--wp-components-color-gray-200`.

## Why are these changes being made?

`@wordpress/theme` ships these tokens as light-only values (`#1e1e1e` text, `#ededed` background). `TabPanel` tabs read them directly, so in dark mode the tab labels in the DNS records **Email setup** card (Google Workspace / iCloud Mail / Office 365 / Zoho Mail) rendered dark-on-dark and were unreadable. The shared dark theme already remaps the `interactive-brand` and `stroke-focus` tokens the same way; this adds the neutral ones next to them.

Only two components consume these tokens in `@wordpress/components`: `TabPanel` tabs and the `Notice` dismiss button, which the dashboard dark theme already overrides by class.

## Testing Instructions

1. Set color scheme to **Dark** at `/me/preferences/appearance`.
2. Open a domain's DNS page, e.g. `/domains/<domain>/dns`, and scroll to **Email setup**.
3. Tab labels are legible (`#e0e0e0`), hover/focus keeps the same color, and the active tab underline is unchanged.
4. Narrow the viewport so the tabs stack vertically: the active tab gets a subtle `#3a3a3a` background instead of a bright `#ededed` one.
5. Switch back to **Light**: no change.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1282" height="861" alt="Email setup tabs unreadable in dark mode" src="https://github.com/user-attachments/assets/b928d96a-ad95-44b7-8020-0ed8f363015e" /> | <img width="1282" height="861" alt="Email setup tabs readable in dark mode" src="https://github.com/user-attachments/assets/de61fcce-0b92-4e15-9a96-0b17fef1b8c2" /> |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?

<!--
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KsAGDP3bXfj6t81rxJB6JJ
!-->