### PR TITLE
Tracks: send camelCase event props as snake_case keys

### DIFF
--- a/client/components/locale-suggestions/index.jsx
+++ b/client/components/locale-suggestions/index.jsx
@@ -56,8 +56,8 @@ export class LocaleSuggestions extends Component {
 
 	recordLocaleSuggestionClick = ( locale ) => {
 		this.props.recordTracksEvent( 'calypso_locale_suggestion_click', {
-			sourceLocale: getLocaleSlug(),
-			targetLocale: locale?.locale,
+			source_locale: getLocaleSlug(),
+			target_locale: locale?.locale,
 			path: this.props.path,
 		} );
 	};

--- a/client/dashboard/emails/add-mailbox/components/cart.tsx
+++ b/client/dashboard/emails/add-mailbox/components/cart.tsx
@@ -72,8 +72,8 @@ export const Cart = ( {
 								type="submit"
 								onClick={ () => {
 									recordTracksEvent( 'calypso_dashboard_emails_add_mailbox_add_to_cart_click', {
-										domainName,
-										mailboxCount: totalItems,
+										domain_name: domainName,
+										mailbox_count: totalItems,
 										provider,
 									} );
 								} }

--- a/client/dashboard/emails/add-mailbox/index.tsx
+++ b/client/dashboard/emails/add-mailbox/index.tsx
@@ -89,8 +89,8 @@ const AddProfessionalEmail = () => {
 					? 'calypso_dashboard_emails_add_mailbox_validation_failure'
 					: 'calypso_dashboard_emails_setup_mailbox_validation_failure',
 				{
-					domainName,
-					mailboxCount: mailboxEntities.length,
+					domain_name: domainName,
+					mailbox_count: mailboxEntities.length,
 					provider,
 					reason: validated ? 'user_cannot_add_email' : 'validation_failed',
 				}
@@ -125,8 +125,8 @@ const AddProfessionalEmail = () => {
 
 	const removeForm = ( index: number ) => {
 		recordTracksEvent( 'calypso_dashboard_emails_add_mailbox_remove_mailbox_click', {
-			domainName,
-			mailboxCount: mailboxEntities.length,
+			domain_name: domainName,
+			mailbox_count: mailboxEntities.length,
 			provider,
 		} );
 
@@ -172,8 +172,8 @@ const AddProfessionalEmail = () => {
 										? 'calypso_dashboard_emails_add_mailbox_back_to_emails_click'
 										: 'calypso_dashboard_emails_setup_mailbox_back_to_emails_click',
 									{
-										domainName,
-										mailboxCount: mailboxEntities.length,
+										domain_name: domainName,
+										mailbox_count: mailboxEntities.length,
 										provider,
 									}
 								);
@@ -225,8 +225,8 @@ const AddProfessionalEmail = () => {
 									recordTracksEvent(
 										'calypso_dashboard_emails_add_mailbox_add_another_mailbox_click',
 										{
-											domainName,
-											mailboxCount: mailboxEntities.length,
+											domain_name: domainName,
+											mailbox_count: mailboxEntities.length,
 											provider,
 										}
 									);
@@ -249,7 +249,7 @@ const AddProfessionalEmail = () => {
 									recordTracksEvent(
 										'calypso_dashboard_emails_setup_mailbox_complete_setup_click',
 										{
-											domainName,
+											domain_name: domainName,
 										}
 									);
 								} }

--- a/client/dashboard/emails/hooks/use-add-to-cart.ts
+++ b/client/dashboard/emails/hooks/use-add-to-cart.ts
@@ -77,8 +77,8 @@ export const useAddToCart = () => {
 			.actions.addProductsToCart( [ getCartItems( mailboxOperations.mailboxes, emailProperties ) ] )
 			.then( () => {
 				recordTracksEvent( 'calypso_dashboard_emails_add_mailbox_add_to_cart_success', {
-					domainName,
-					mailboxCount: mailboxOperations.mailboxes.length,
+					domain_name: domainName,
+					mailbox_count: mailboxOperations.mailboxes.length,
 					provider,
 				} );
 
@@ -87,8 +87,8 @@ export const useAddToCart = () => {
 			.finally( onFinally )
 			.catch( ( error: CartActionError ) => {
 				recordTracksEvent( 'calypso_dashboard_emails_add_mailbox_add_to_cart_failure', {
-					domainName,
-					mailboxCount: mailboxOperations.mailboxes.length,
+					domain_name: domainName,
+					mailbox_count: mailboxOperations.mailboxes.length,
 					provider,
 					error: error.message,
 				} );

--- a/client/jetpack-connect/disclaimer.jsx
+++ b/client/jetpack-connect/disclaimer.jsx
@@ -15,12 +15,20 @@ export function useDisclaimerText( props ) {
 		buttonText,
 	} = props;
 
+	const disclaimerTracksProps = {
+		company_name: companyName,
+		is_woo_jpc: isWooJPC,
+		site_name: siteName,
+		from,
+		button_text: buttonText,
+	};
+
 	const detailsLink = (
 		<a
 			target="_blank"
 			rel="noopener noreferrer"
 			onClick={ () => {
-				props.recordTracksEvent( 'calypso_jpc_disclaimer_link_click', { ...props } );
+				props.recordTracksEvent( 'calypso_jpc_disclaimer_link_click', disclaimerTracksProps );
 			} }
 			href={ localizeUrl( 'https://jetpack.com/support/what-data-does-jetpack-sync/' ) }
 			className="jetpack-connect__sso-actions-modal-link"
@@ -35,9 +43,7 @@ export function useDisclaimerText( props ) {
 				rel="noopener noreferrer"
 				className="jetpack-connect__sso-actions-modal-link"
 				onClick={ () => {
-					props.recordTracksEvent( 'calypso_jpc_disclaimer_tos_link_click', {
-						...props,
-					} );
+					props.recordTracksEvent( 'calypso_jpc_disclaimer_tos_link_click', disclaimerTracksProps );
 				} }
 			/>
 		);
@@ -48,9 +54,10 @@ export function useDisclaimerText( props ) {
 				rel="noopener noreferrer"
 				className="jetpack-connect__sso-actions-modal-link"
 				onClick={ () => {
-					props.recordTracksEvent( 'calypso_jpc_disclaimer_sync_data_link_click', {
-						...props,
-					} );
+					props.recordTracksEvent(
+						'calypso_jpc_disclaimer_sync_data_link_click',
+						disclaimerTracksProps
+					);
 				} }
 			/>
 		);

--- a/client/landing/subscriptions/tracks/use-record-view-feed-button-clicked.tsx
+++ b/client/landing/subscriptions/tracks/use-record-view-feed-button-clicked.tsx
@@ -3,12 +3,20 @@ import useRecordSubscriptionsTracksEvent from './use-record-subscriptions-tracks
 const useRecordViewFeedButtonClicked = () => {
 	const recordSubscriptionsTracksEvent = useRecordSubscriptionsTracksEvent();
 
-	const recordViewFeedButtonClicked = ( tracksProps: {
+	const recordViewFeedButtonClicked = ( {
+		blogId,
+		feedId,
+		source,
+	}: {
 		blogId: string | null;
 		feedId: string;
 		source?: string;
 	} ) => {
-		recordSubscriptionsTracksEvent( 'calypso_subscriptions_view_feed_button_clicked', tracksProps );
+		recordSubscriptionsTracksEvent( 'calypso_subscriptions_view_feed_button_clicked', {
+			blog_id: blogId,
+			feed_id: feedId,
+			source,
+		} );
 	};
 
 	return recordViewFeedButtonClicked;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18520/camelcase-prop-keys-reject-the-whole-event-a-fifth-loss-class-and-this

## Proposed Changes

**Renames camelCase Tracks prop keys to snake_case at 19 call sites, so the events stop being thrown away at ingest.**

- Dashboard emails add/setup mailbox (`domain_name`, `mailbox_count`), locale suggestions (`source_locale`, `target_locale`), subscriptions view-feed (`blog_id`, `feed_id`).
- The jetpack-connect disclaimer passed `{ ...props }` to Tracks, sending the bound `recordTracksEvent` function itself as a prop key — replaced with an explicit props object.

## Why are these changes being made?

Tracks only accepts prop keys made of lowercase letters, digits and underscores. Send one camelCase key and it throws away the **whole event**, not just that key. These call sites have been at 100% loss since they shipped — the entire Dashboard emails “add mailbox” purchase funnel has never produced a single usable event.

Object shorthand is what hides it: `{ domainName }` looks like a variable, but it becomes a prop key. Found by the reject-side audit in [DOTCOM-18360](https://linear.app/a8c/issue/DOTCOM-18360).

## Testing Instructions

1. `yarn start`, open the browser network tab and filter for `pixel.wp.com`.
2. Go to a site’s Emails → Add mailbox, fill a mailbox and click Continue.
3. Check the `calypso_dashboard_emails_add_mailbox_add_to_cart_click` pixel: props are `domain_name` and `mailbox_count`, no camelCase keys.
