### PR TITLE
Marketplace: read the uploaded plugin slug from the error data

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/test/use-product-install.tsx
@@ -268,8 +268,7 @@ describe( 'useProductInstall', () => {
 				{},
 				withReplaceCandidate( {
 					error: 'folder_exists',
-					plugin_slug: 'hello-dolly',
-					plugin_version: '2.0',
+					data: { plugin_slug: 'hello-dolly', plugin_version: '2.0' },
 				} )
 			);
 
@@ -284,7 +283,7 @@ describe( 'useProductInstall', () => {
 		it( 'keeps the existing rejection when the backend slug is missing', () => {
 			const { result } = renderProductInstall(
 				{},
-				withReplaceCandidate( { error: 'folder_exists', plugin_version: '2.0' } )
+				withReplaceCandidate( { error: 'folder_exists', data: { plugin_version: '2.0' } } )
 			);
 
 			expect( result.current.error ).toEqual( { type: 'rejected-upload', reason: 'exists' } );
@@ -295,8 +294,7 @@ describe( 'useProductInstall', () => {
 				{},
 				withUploadError( {
 					error: 'folder_exists',
-					plugin_slug: 'hello-dolly',
-					plugin_version: '2.0',
+					data: { plugin_slug: 'hello-dolly', plugin_version: '2.0' },
 				} )
 			);
 

--- a/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/use-product-install.tsx
@@ -201,7 +201,7 @@ export function useProductInstall( {
 	const uploadedPluginSlug = useSelector( ( state ) =>
 		getUploadedPluginId( state, siteId )
 	) as string;
-	const uploadErrorPluginSlug = pluginUploadError?.plugin_slug;
+	const uploadErrorPluginSlug = pluginUploadError?.data?.plugin_slug;
 	const pluginUploadFile = useSelector( ( state ) => getPluginUploadFile( state, siteId ) );
 	const pluginUploadComplete = useSelector( ( state ) => isPluginUploadComplete( state, siteId ) );
 	// A zip upload that brought the site to Atomic. Its plugin arrives with the transfer rather than
@@ -394,7 +394,7 @@ export function useProductInstall( {
 				type: 'plugin-exists',
 				pluginSlug: uploadErrorPluginSlug,
 				installedVersion: existingPlugin?.version,
-				uploadedVersion: pluginUploadError?.plugin_version,
+				uploadedVersion: pluginUploadError?.data?.plugin_version,
 			};
 		}
 		if ( pluginExists ) {

--- a/client/state/selectors/get-plugin-upload-error.js
+++ b/client/state/selectors/get-plugin-upload-error.js
@@ -5,7 +5,7 @@ import 'calypso/state/plugins/init';
  * null if currently no error.
  * @param {Object} state Global state tree
  * @param {number} siteId the site ID
- * @returns {null|{error?: string, message?: string, statusCode?: number, plugin_slug?: string, plugin_version?: string}} Error from upload, if any
+ * @returns {null|{error?: string, message?: string, statusCode?: number, data?: {plugin_slug?: string, plugin_version?: string, plugin_name?: string}}} Error from upload, if any
  */
 export default function getPluginUploadError( state, siteId ) {
 	return state.plugins.upload.uploadError?.[ siteId ] ?? null;


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18493/read-the-plugin-slug-from-errordata-in-the-marketplace-install-flow

## Proposed Changes

**The marketplace install screen was looking for the uploaded plugin's slug in a place the API can never put it, so the “replace it instead” offer could never appear.**

- Reads `plugin_slug` and `plugin_version` from `error.data`, where the API actually sends them.
- Test fixtures moved to the real nested shape — the old top-level mock is why the mismatch survived review.

## Why are these changes being made?

Upload a zip for a plugin you already have and you get “Destination folder already exists.” and a dead end that tells you to go do it in wp-admin. That screen was meant to offer to replace the plugin instead, but the client reads the plugin's name from the wrong part of the error response, so the offer never shows. This is the client half of [DOTCOM-18352](https://linear.app/a8c/issue/DOTCOM-18352); the backend half sends the field.

Safe to land first. While the field is absent the offer stays hidden and customers get exactly today's screen.

## Testing Instructions

1. `yarn start`, open a site's Plugins page and install any plugin.
2. Upload a zip of that same plugin.
3. The upload is rejected with the existing screen — unchanged, since the backend does not send the slug yet.
4. `yarn test-client client/my-sites/marketplace/pages/marketplace-product-install` to see the replace offer render against the real error shape.
