### PR TITLE
Tracks: rename the remaining camelCase event props to snake_case

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/products-overview/product-action-panel/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/products-overview/product-action-panel/index.tsx
@@ -43,7 +43,7 @@ export default function ProductActionPanel( {
 			onSearchQueryChange( searchQuery );
 			dispatch(
 				recordTracksEvent( 'calypso_a4a_marketplace_products_overview_input_search', {
-					searchQuery,
+					search_query: searchQuery,
 				} )
 			);
 		},

--- a/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
+++ b/client/a8c-for-agencies/sections/signup/signup-v2/components/multi-step-form/contact-form/index.tsx
@@ -154,7 +154,7 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 			if ( isDeniedNonUniqueDomain( agencyUrl, nonUniqueDomains ) ) {
 				dispatch(
 					recordTracksEvent( 'calypso_a4a_agency_signup_form_non_unique_domain_skipped', {
-						agencyUrl,
+						agency_url: agencyUrl,
 					} )
 				);
 				setIsProceeding( false );
@@ -173,7 +173,7 @@ const SignupContactForm = ( { onContinue, initialFormData, withEmail = false }: 
 						recordTracksEvent(
 							'calypso_a4a_agency_signup_form_duplicate_agency_warning_dialog_view',
 							{
-								agencyUrl,
+								agency_url: agencyUrl,
 							}
 						)
 					);

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -58,7 +58,7 @@ function configureSitesContext( context: Context ) {
 				path={ context.path }
 				properties={ {
 					category: context.params.category,
-					siteUrl: context.params.siteUrl,
+					site_url: context.params.siteUrl,
 					feature: context.params.feature,
 				} }
 			/>

--- a/client/a8c-for-agencies/sections/sites/sites-notifications/jetpack-site-connected.tsx
+++ b/client/a8c-for-agencies/sections/sites/sites-notifications/jetpack-site-connected.tsx
@@ -75,7 +75,7 @@ export default function JetpackSiteConnected() {
 			dispatch( successNotice( successNotification ) );
 			dispatch(
 				recordTracksEvent( eventName, {
-					siteUrl: mostRecentConnectedSite,
+					site_url: mostRecentConnectedSite,
 				} )
 			);
 		}

--- a/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
+++ b/client/a8c-for-agencies/sections/woopayments/primary/woopayments-site-setup/index.tsx
@@ -38,8 +38,8 @@ const WooPaymentsSiteSetup = ( { siteId }: { siteId: string } ) => {
 		dispatch(
 			recordTracksEvent( 'calypso_a4a_woopayments_site_setup_install_plugin_click', {
 				status: isInstalled ? 'installed' : 'not_installed',
-				woocommerceStatus,
-				woocommercePaymentsStatus,
+				woocommerce_status: woocommerceStatus,
+				woocommerce_payments_status: woocommercePaymentsStatus,
 			} )
 		);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
@@ -104,11 +104,13 @@ const getNewsLetterPlanCreated: TaskAction = ( task, flow, context ) => {
 		...task,
 		actionDispatch: () => {
 			completePaidNewsletterTask( siteSlug, queryClient );
-			site?.ID
-				? setShowPlansModal( true )
-				: window.location.assign(
-						`/earn/payments/${ siteSlug }?launchpad=add-product${ ADD_TIER_PLAN_HASH }`
-				  );
+			if ( site?.ID ) {
+				setShowPlansModal( true );
+			} else {
+				window.location.assign(
+					`/earn/payments/${ siteSlug }?launchpad=add-product${ ADD_TIER_PLAN_HASH }`
+				);
+			}
 		},
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
@@ -30,7 +30,7 @@ const getPlanTaskSubtitle = (
 					onClick={ ( event ) => {
 						event.stopPropagation();
 						recordGlobalStylesGattingPlanSelectedResetStylesEvent( task, flow, context, {
-							displayGlobalStylesWarning,
+							display_global_styles_warning: displayGlobalStylesWarning,
 						} );
 					} }
 				/>
@@ -54,7 +54,7 @@ export const getPlanSelectedTask: TaskAction = ( task, flow, context ): Task => 
 		actionDispatch: () => {
 			if ( displayGlobalStylesWarning ) {
 				recordGlobalStylesGattingPlanSelectedResetStylesEvent( task, flow, context, {
-					displayGlobalStylesWarning,
+					display_global_styles_warning: displayGlobalStylesWarning,
 				} );
 			}
 		},

--- a/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-store/hooks/use-store-item-info.tsx
@@ -254,7 +254,7 @@ export const useStoreItemInfo = ( {
 				// "Manage plan/Subscription" URL (`/me/purchases/:site/:productId`) - handled by getCheckoutURL.
 				if ( getIsOwned( item ) || getIsIncludedInPlan( item ) ) {
 					recordTracksEvent( 'calypso_pricing_manage_owned_product_click', {
-						productSlug: item.productSlug,
+						product_slug: item.productSlug,
 					} );
 					return;
 				}
@@ -272,7 +272,7 @@ export const useStoreItemInfo = ( {
 
 			if ( item.type === 'item-type-plan' ) {
 				recordTracksEvent( 'calypso_pricing_purchase_bundle_click', {
-					productSlug: item.productSlug,
+					product_slug: item.productSlug,
 				} );
 				return;
 			}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTCOM-18520/camelcase-prop-keys-reject-the-whole-event-a-fifth-loss-class-and-this

## Proposed Changes

**Renames the last camelCase Tracks prop keys to snake_case, finishing what #114203 started.**

- A4A: `site_url` on the sites page view and the Jetpack-connected notice, `search_query` on marketplace search, `agency_url` on signup, `woocommerce_status` / `woocommerce_payments_status` on WooPayments setup.
- Jetpack plans (`product_slug`) and the Launchpad global-styles task (`display_global_styles_warning`).
- One unrelated hunk: the Launchpad newsletter task used a ternary as a statement, which fails `no-unused-expressions`. The Code style check lints whole files in the diff, so it had to go.

## Why are these changes being made?

Tracks only accepts prop keys made of lowercase letters, digits and underscores. One camelCase key throws away the **whole event**, not just that key. #114203 fixed the highest-volume call sites; these eight event names were in the same audit but their call sites hadn’t been located yet, so they were left behind and are still at 100% loss.

The largest is `calypso_page_view` on the A4A sites dashboard — 899 page views a week discarded because one of the three properties is `siteUrl`. It hides well: the other 8.6M `calypso_page_view` rows are fine, so the event looks healthy.

## Testing Instructions

1. `yarn start`, open the browser network tab and filter for `pixel.wp.com`.
2. Go to the A4A sites dashboard and open a site’s Jetpack Backup tab.
3. Check the `calypso_page_view` pixel: the property is `site_url`, no camelCase keys.
