### PR TITLE
Emails: keep add-forwarder inputs aligned when a validation error shows

### DIFF
--- a/client/dashboard/emails/add-forwarder/index.tsx
+++ b/client/dashboard/emails/add-forwarder/index.tsx
@@ -151,6 +151,7 @@ function AddEmailForwarder() {
 				id: 'email_address',
 				layout: {
 					type: 'row' as const,
+					alignment: 'start' as const,
 				},
 			},
 			'forwardingAddresses',


### PR DESCRIPTION

Fixes https://linear.app/a8c/issue/DOTDEV-456/email-inputs-become-misaligned-when-an-error-is-displayed

## Proposed Changes

* Set `alignment: 'start'` on the DataForm row layout that holds the **Email address** and **Domain** fields on `/emails/add-forwarder`.

## Why are these changes being made?

Displaying an error in the email it moves vertically the next text input breaking the alignment layout.

## Testing Instructions

1. Go to `/emails/add-forwarder` on an account with at least one domain eligible for forwarding.
2. Click into **Email address**, type a character, delete it, and tab out so the required-field error appears.
3. The **Domain** select stays aligned with the email input; only the error line extends below it.
4. Fill in the email address: the error disappears and the layout does not jump.

## Screenshots

| Before | After |
| --- | --- |
| <img width="1000" alt="Domain select shifted down next to the email field error" src="https://github.com/user-attachments/assets/35de4f76-22a0-4448-8483-d7271427890d" /> | <img width="1000" alt="Domain select aligned with the email field while the error shows" src="https://github.com/user-attachments/assets/730a2d5d-1b59-4586-823a-ebe6dc7da343" /> |

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes?

<!-- session_01KsAGDP3bXfj6t81rxJB6JJ -->
