### PR TITLE
Reader: site subscription; update badge to wp-ui

### DIFF
--- a/client/blocks/reader-site-subscription/details.tsx
+++ b/client/blocks/reader-site-subscription/details.tsx
@@ -1,8 +1,9 @@
 import './styles.scss';
 import page from '@automattic/calypso-router';
-import { Badge, TimeSince } from '@automattic/components';
+import { TimeSince } from '@automattic/components';
 import { SubscriptionManager, Reader } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
+import { Badge, Stack } from '@wordpress/ui';
 import { fixMe, useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { SiteIcon } from 'calypso/blocks/site-icon';
@@ -299,10 +300,10 @@ const SiteSubscriptionDetails = ( {
 						{ paymentPlans.length === 0 && (
 							<dl className="site-subscription-info__list">
 								<dt>{ translate( 'Status' ) }</dt>
-								<dd>
-									<Badge type="success">{ translate( 'Active' ) }</Badge>
+								<Stack render={ <dd /> } align="center" gap="sm">
+									<Badge intent="stable">{ translate( 'Active' ) }</Badge>
 									{ translate( 'Free subscriber' ) }
-								</dd>
+								</Stack>
 							</dl>
 						) }
 						{ paymentPlans &&

--- a/client/blocks/reader-site-subscription/styles.scss
+++ b/client/blocks/reader-site-subscription/styles.scss
@@ -152,16 +152,6 @@
 		&__loading {
 			margin-bottom: 20px;
 		}
-
-		.badge {
-			margin: 0 8px 0 0;
-			border-radius: 4px;
-			font-size: rem(12px);
-		}
-		.badge--success {
-			background-color: $studio-green-5;
-			color: $studio-green-100;
-		}
 	}
 
 	&__unsubscribe-button.components-button {


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Part of NL-900

Related to https://github.com/Automattic/wp-calypso/issues/113835

## Proposed Changes

* Update old a8c Badge component to the latest design system [Badge](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-badge--docs) and use [Stack](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-stack--docs) rather than CSS to position elements.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See `http://calypso.localhost:3000/reader/site/subscription/SUBSCRIPTION_ID`

### Before
<img width="261" height="204" alt="Screenshot 2026-09-09 at 14 18 12" src="https://github.com/user-attachments/assets/a3142dca-e8e5-43f3-bd99-5b010630be17" />

### After
<img width="269" height="213" alt="Screenshot 2026-09-09 at 14 18 08" src="https://github.com/user-attachments/assets/06643488-7e55-4856-a1af-e3edba901cc7" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
