### PR TITLE
Onboarding: route the AI build through build-wow on Premium and Business only

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/ai-site-builder-onboarding/test/ai-site-builder-onboarding.test.ts
+++ b/client/landing/stepper/declarative-flow/flows/ai-site-builder-onboarding/test/ai-site-builder-onboarding.test.ts
@@ -252,20 +252,29 @@ describe( 'ai-site-builder-onboarding flow', () => {
 				expect( redirectTo.searchParams.get( 'spec_id' ) ).toBe( 'spec-42' );
 			} );
 
-			it.each( [
-				'personal-bundle',
-				'value_bundle',
-				'business-bundle-monthly',
-				'ecommerce-bundle-2y',
-			] )( 'is used for the %s plan', async ( productSlug ) => {
-				setPlan( productSlug );
+			it.each( [ 'value_bundle', 'business-bundle-monthly' ] )(
+				'is used for the %s plan',
+				async ( productSlug ) => {
+					setPlan( productSlug );
 
-				await runProcessingSubmit();
+					await runProcessingSubmit();
 
-				expect( new URL( getRedirectTo(), 'https://wordpress.com' ).pathname ).toBe(
-					'/setup/ai-site-builder-spec/site-spec'
-				);
-			} );
+					expect( new URL( getRedirectTo(), 'https://wordpress.com' ).pathname ).toBe(
+						'/setup/ai-site-builder-spec/site-spec'
+					);
+				}
+			);
+
+			it.each( [ 'personal-bundle', 'ecommerce-bundle-2y' ] )(
+				'is not used for the %s plan',
+				async ( productSlug ) => {
+					setPlan( productSlug );
+
+					await runProcessingSubmit();
+
+					expect( new URL( getRedirectTo() ).pathname ).toBe( '/wp-admin/site-editor.php' );
+				}
+			);
 
 			it( 'is not used when the swap flag is off', async () => {
 				isEnabled.mockImplementation(

--- a/client/landing/stepper/utils/build-wow-plans.ts
+++ b/client/landing/stepper/utils/build-wow-plans.ts
@@ -1,14 +1,11 @@
-import { isBusinessPlan, isPersonalPlan, isPremiumPlan } from '@automattic/calypso-products';
+import { isBusinessPlan, isPremiumPlan } from '@automattic/calypso-products';
 
 /**
- * wpcom grants the underlying Big Sky feature to Commerce too, but the
- * post-checkout AI setup chooser only offers the AI build on Personal, Premium
- * and Business (a Commerce checkout skips the chooser and lands on My Home),
- * so build-wow routing matches that gate.
+ * Which plans route the AI build through build-wow. The post-checkout AI
+ * setup chooser offers "Create a custom design" on Personal and higher, but
+ * Personal stays on the legacy Big Sky builder and a Commerce checkout skips
+ * the chooser entirely, so only Premium and Business land on build-wow.
  */
 export function planSupportsBuildWow( planSlug: string | null | undefined ): boolean {
-	return (
-		!! planSlug &&
-		( isPersonalPlan( planSlug ) || isPremiumPlan( planSlug ) || isBusinessPlan( planSlug ) )
-	);
+	return !! planSlug && ( isPremiumPlan( planSlug ) || isBusinessPlan( planSlug ) );
 }

--- a/client/landing/stepper/utils/build-wow-plans.ts
+++ b/client/landing/stepper/utils/build-wow-plans.ts
@@ -1,22 +1,14 @@
-import {
-	isBusinessPlan,
-	isEcommercePlan,
-	isPersonalPlan,
-	isPremiumPlan,
-} from '@automattic/calypso-products';
+import { isBusinessPlan, isPersonalPlan, isPremiumPlan } from '@automattic/calypso-products';
 
 /**
- * build-wow transfers the site to Atomic. WordPress.com grants that feature to
- * Personal, Premium, Business and Commerce (the frozen client-side plan data
- * understates this), so only a plan outside those tiers falls back to the
- * legacy builder.
+ * wpcom grants the underlying Big Sky feature to Commerce too, but the
+ * post-checkout AI setup chooser only offers the AI build on Personal, Premium
+ * and Business (a Commerce checkout skips the chooser and lands on My Home),
+ * so build-wow routing matches that gate.
  */
 export function planSupportsBuildWow( planSlug: string | null | undefined ): boolean {
 	return (
 		!! planSlug &&
-		( isPersonalPlan( planSlug ) ||
-			isPremiumPlan( planSlug ) ||
-			isBusinessPlan( planSlug ) ||
-			isEcommercePlan( planSlug ) )
+		( isPersonalPlan( planSlug ) || isPremiumPlan( planSlug ) || isBusinessPlan( planSlug ) )
 	);
 }

--- a/client/landing/stepper/utils/test/build-wow-plans.ts
+++ b/client/landing/stepper/utils/test/build-wow-plans.ts
@@ -10,13 +10,17 @@ describe( 'planSupportsBuildWow', () => {
 		'business-bundle',
 		'business-bundle-monthly',
 		'business-bundle-3y',
-		'ecommerce-bundle',
-		'ecommerce-bundle-monthly',
-	] )( 'accepts the Atomic-capable plan %s', ( slug ) => {
+	] )( 'accepts the chooser-eligible plan %s', ( slug ) => {
 		expect( planSupportsBuildWow( slug ) ).toBe( true );
 	} );
 
-	it.each( [ 'free_plan', 'pro-plan', 'not-a-plan' ] )( 'rejects %s', ( slug ) => {
+	it.each( [
+		'free_plan',
+		'pro-plan',
+		'ecommerce-bundle',
+		'ecommerce-bundle-monthly',
+		'not-a-plan',
+	] )( 'rejects %s', ( slug ) => {
 		expect( planSupportsBuildWow( slug ) ).toBe( false );
 	} );
 

--- a/client/landing/stepper/utils/test/build-wow-plans.ts
+++ b/client/landing/stepper/utils/test/build-wow-plans.ts
@@ -2,21 +2,21 @@ import { planSupportsBuildWow } from '../build-wow-plans';
 
 describe( 'planSupportsBuildWow', () => {
 	it.each( [
-		'personal-bundle',
-		'personal-bundle-monthly',
 		'value_bundle',
 		'value_bundle_monthly',
 		'value_bundle-2y',
 		'business-bundle',
 		'business-bundle-monthly',
 		'business-bundle-3y',
-	] )( 'accepts the chooser-eligible plan %s', ( slug ) => {
+	] )( 'accepts the build-wow-eligible plan %s', ( slug ) => {
 		expect( planSupportsBuildWow( slug ) ).toBe( true );
 	} );
 
 	it.each( [
 		'free_plan',
 		'pro-plan',
+		'personal-bundle',
+		'personal-bundle-monthly',
 		'ecommerce-bundle',
 		'ecommerce-bundle-monthly',
 		'not-a-plan',


### PR DESCRIPTION
## Proposed Changes

* Narrow `planSupportsBuildWow` to Premium and Business, so those are the only plans routed through the build-wow AI theme generation flow.
* Update the predicate's unit test accordingly: the Personal and eCommerce bundles move to the rejected list.

## Why are these changes being made?

The intended behavior is: a Personal buyer still gets the post-checkout AI setup chooser and its "Create a custom design" button, but the click goes through the legacy Big Sky builder, not build-wow. That fallback already exists — `handleCustomDesignClick` in `setup-your-site-ai` submits `generate-theme` (build-wow) only when `planSupportsBuildWow` passes and otherwise submits `build-with-ai` (legacy Big Sky) — so narrowing the predicate is the whole change. The chooser gate (`showBigSkyChoice`, Personal and higher via `FEATURE_BIG_SKY`) is deliberately untouched.

Commerce is also excluded: a Commerce checkout skips the chooser entirely and lands on My Home (#113683, which would have widened that gate, was closed for later consideration), yet the predicate previously accepted eCommerce plans and routed a Commerce purchase in the `ai-site-builder-onboarding` flow into build-wow.

Net effect behind the `calypso/ai-site-builder-build-wow` flag: Premium and Business land on build-wow; Personal lands on the legacy Big Sky builder from both entry points (the chooser and the `ai-site-builder-onboarding` flow); Commerce keeps skipping AI setup.

This is a Calypso-side product gate only. wpcom still grants the Big Sky feature to Personal and higher; if the build-wow endpoint should also refuse Personal sites server-side (someone entering the spec flow by URL), that enforcement is a separate wpcom change.

## Testing Instructions

* `yarn test-client client/landing/stepper/utils/test/build-wow-plans.ts`
* With `calypso/ai-site-builder-build-wow` and `site-spec` enabled, buy a **Personal** plan through `/setup/onboarding`: the post-checkout chooser still renders, and "Create a custom design" lands on the legacy Big Sky builder rather than the build-wow site spec. **Premium** and **Business** land on the build-wow spec.
* Same flags, `/setup/ai-site-builder-onboarding` with a **Commerce** plan: after checkout the flow lands on the legacy site editor destination, not the build-wow spec.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01278Qg8Hc9tWbsMbPDuhsrj
