### PR TITLE
Onboarding: offer the post-checkout AI setup choice on Premium and Business only

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/post-checkout/post-checkout-onboarding.tsx
@@ -1,11 +1,5 @@
 import { siteBySlugQuery } from '@automattic/api-queries';
-import {
-	FEATURE_BIG_SKY,
-	isBusiness,
-	isEcommerce,
-	isPersonal,
-	isPremium,
-} from '@automattic/calypso-products';
+import { FEATURE_BIG_SKY, isBusiness, isEcommerce, isPremium } from '@automattic/calypso-products';
 import { SiteIntent } from '@automattic/data-stores/src/onboard';
 import { Step } from '@automattic/onboarding';
 import { useQuery } from '@tanstack/react-query';
@@ -62,7 +56,7 @@ const PostCheckoutOnboarding: StepType< {
 
 	const showBigSkyChoice =
 		!! site?.plan &&
-		( isPersonal( site.plan ) || isPremium( site.plan ) || isBusiness( site.plan ) ) &&
+		( isPremium( site.plan ) || isBusiness( site.plan ) ) &&
 		site.plan.features?.active?.includes( FEATURE_BIG_SKY );
 
 	const intent = useSelect(


### PR DESCRIPTION
## Proposed Changes

* Remove Personal from the `showBigSkyChoice` allowlist in `post-checkout-onboarding.tsx`, so the post-checkout AI setup chooser (`setup-your-site-ai`: Build with AI / start simple) is offered on Premium and Business checkouts only. A Personal purchase now goes straight to My Home after checkout, the same as Commerce and Free.

## Why are these changes being made?

The counterpart of #113683 (closed for later consideration): instead of widening the chooser gate to Commerce, narrow it so only Premium and Business get the AI build entry after checkout. The trailing `FEATURE_BIG_SKY` check is unchanged; wpcom still grants the feature more broadly, and this is a Calypso-side product gate only.

Note the sibling gate: `planSupportsBuildWow` (which picks build-wow over the legacy builder behind the `calypso/ai-site-builder-build-wow` flag, and routes checkout in the `ai-site-builder-onboarding` flow) still accepts Personal. #114213 aligns that predicate with the chooser gate on the Commerce side; if this PR lands, the predicate needs the same Personal narrowing in a follow-up.

## Testing Instructions

* Run `/setup/onboarding` and buy a **Personal** plan. Before: the post-checkout AI setup chooser renders. After: a brief processing screen, then `/home/:site`.
* Regression: **Premium** and **Business** purchases still show the chooser; **Commerce** and **Free** still go to My Home.
* `yarn test-client client/landing/stepper/declarative-flow/flows/onboarding/test/` — existing flow routing coverage (the chooser tests inject `postCheckoutBigSky` directly, so they are unaffected by the gate change).

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01278Qg8Hc9tWbsMbPDuhsrj
