### PR TITLE
Themes: opt the blueprint CTA into the WoW fleet

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -189,9 +189,14 @@ function BlueprintCtaButton( {
 	// so the finished site is waiting the moment the customer pays; dest=site-spec hands them to
 	// the AI site-spec afterwards. The step falls back to the legacy Simple-site runner when the
 	// blueprint has no archive.
+	// from_wfm=1 opts this CTA into the WoW fleet: /sites/new hands out a
+	// pre-provisioned Atomic site instead of building one, so the customer skips
+	// the provision wait. Purely an opt-in hint — the server falls back to the
+	// ordinary funnel build when the fleet is disabled, empty, or contended.
 	const href = addQueryArgs( '/setup/onboarding/blueprint', {
 		blueprint: blueprintId,
 		wow_funnel: 'blueprint',
+		from_wfm: 1,
 		dest: 'site-spec',
 		ref: `theme-${ themeId }`,
 	} );


### PR DESCRIPTION
## What

Adds `from_wfm=1` to the Theme Sheet's **"Build a site with this blueprint"** CTA.

```diff
 const href = addQueryArgs( '/setup/onboarding/blueprint', {
 	blueprint: blueprintId,
 	wow_funnel: 'blueprint',
+	from_wfm: 1,
 	dest: 'site-spec',
 	ref: `theme-${ themeId }`,
 } );
```

## Why

The CTA already enters the blueprint WoW funnel, but never opted into the fleet — so everyone arriving from a theme page waited for an Atomic site to be provisioned, even with ready-built sites sitting in inventory. `/sites/new` reads `from_wfm` and claims a pre-provisioned site from the fleet manager instead of building one.

Both halves of the plumbing already exist, so this is only the opt-in:

- `getWowFunnelFromWfm()` in `client/landing/stepper/utils/wow-funnel.ts` reads the param
- `createSite` forwards it in options when a funnel slug is present (`packages/onboarding/src/cart/index.tsx`) — which this CTA sets, so the guard is satisfied

## Risk

Low. It stays an opt-in hint: wpcom falls back to the ordinary funnel build when the fleet is disabled, empty, or contended, and logs `fleet_claim_fell_back` so a silent fallback is visible. The flow on the Calypso side is identical either way.

The CTA is still behind the `themes/blueprint-cta` feature flag and gated to Automatticians.

## Testing

Prettier clean. No test covers this CTA's URL construction today, so there was nothing to update.

Verified against the manual funnel entry that carries the same params (`?wow_funnel=blueprint&blueprint=punk&from_wfm=1`): claims land instantly from the fleet, and the funnel marks show `claimed` → `import_queued` within ~2s instead of a full provision.