### PR TITLE
Dashboard: keep SFTP/SSH reachable when a site is unreachable

### DIFF
--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -811,9 +811,8 @@ export const siteSettingsRoute = createRoute( {
 
 		queryClient.prefetchQuery( siteCurrentPlanQuery( site.ID ) );
 
-		// These requests are served by the site itself, so they fail while it is
-		// unreachable. Awaiting them would take down the settings routes that
-		// remain available in that state.
+		// Skip the settings fetch for sites we know can't reach Jetpack — it would
+		// fail and error the route, and SFTP/SSH doesn't need it anyway.
 		if ( site.__inaccessible_jetpack_error ) {
 			return;
 		}

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -811,8 +811,10 @@ export const siteSettingsRoute = createRoute( {
 
 		queryClient.prefetchQuery( siteCurrentPlanQuery( site.ID ) );
 
-		// Skip the settings fetch for sites we know can't reach Jetpack — it would
-		// fail and error the route, and SFTP/SSH doesn't need it anyway.
+		// The request below is answered by the site itself, so it fails while the
+		// site is broken, and that failure shows an error screen instead of the
+		// page. SFTP/SSH is the only settings page reachable then, and it doesn't
+		// need that data.
 		if ( site.__inaccessible_jetpack_error ) {
 			return;
 		}

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -810,6 +810,14 @@ export const siteSettingsRoute = createRoute( {
 		const site = await queryClient.ensureQueryData( siteBySlugQuery( siteSlug ) );
 
 		queryClient.prefetchQuery( siteCurrentPlanQuery( site.ID ) );
+
+		// These requests are served by the site itself, so they fail while it is
+		// unreachable. Awaiting them would take down the settings routes that
+		// remain available in that state.
+		if ( site.__inaccessible_jetpack_error ) {
+			return;
+		}
+
 		await Promise.all( [
 			queryClient.ensureQueryData( siteSettingsQuery( site.ID ) ),
 			hasHostingFeature( site, HostingFeatures.PRIMARY_DATA_CENTER ) &&
@@ -1351,7 +1359,10 @@ export const siteSettingsDefensiveModeRoute = createRoute( {
 );
 
 export const siteSettingsSftpSshRoute = createRoute( {
-	staticData: { requiresSiteTypeSupport: 'settingsServer' },
+	staticData: {
+		requiresSiteTypeSupport: 'settingsServer',
+		availableToInaccessibleJetpackSites: true,
+	},
 	head: () => ( {
 		meta: [
 			{

--- a/client/dashboard/app/router/sites.tsx
+++ b/client/dashboard/app/router/sites.tsx
@@ -811,10 +811,8 @@ export const siteSettingsRoute = createRoute( {
 
 		queryClient.prefetchQuery( siteCurrentPlanQuery( site.ID ) );
 
-		// The request below is answered by the site itself, so it fails while the
-		// site is broken, and that failure shows an error screen instead of the
-		// page. SFTP/SSH is the only settings page reachable then, and it doesn't
-		// need that data.
+		// SFTP/SSH is the only settings page reachable while the site is broken,
+		// and it doesn't need the data fetched below.
 		if ( site.__inaccessible_jetpack_error ) {
 			return;
 		}

--- a/client/dashboard/sites/critical-error/index.tsx
+++ b/client/dashboard/sites/critical-error/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, envelope, formatListBullets, help, wordpress } from '@wordpress/icons';
+import { Icon, envelope, file, formatListBullets, help, wordpress } from '@wordpress/icons';
 import { Fragment, useEffect } from 'react';
 import { useAnalytics } from '../../app/analytics';
 import { useHelpCenter } from '../../app/help-center';
@@ -20,7 +20,7 @@ import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { SectionHeader } from '../../components/section-header';
 import { Text } from '../../components/text';
-import { hasHostingFeature } from '../../utils/site-features';
+import { canAccessSftpSettings, hasHostingFeature } from '../../utils/site-features';
 import {
 	getJetpackCriticalErrorMessage,
 	getJetpackRecoverySessionErrors,
@@ -78,6 +78,7 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 		isAdmin &&
 		siteTypeSupportsFeature( site, 'logs' ) &&
 		hasHostingFeature( site, HostingFeatures.LOGS );
+	const canAccessSftp = canAccessSftpSettings( site );
 	const hasRecovered = ! isInJetpackCriticalErrorState( site );
 
 	useEffect( () => {
@@ -133,6 +134,25 @@ const SiteCriticalError = ( { siteSlug }: { siteSlug: string } ) => {
 					phpLogsLink: (
 						<Link to={ `/sites/${ siteSlug }/logs/php` } search={ { severity: 'Fatal error' } }>
 							{ __( 'Review the PHP logs' ) }
+						</Link>
+					),
+				}
+			),
+		} );
+	}
+	if ( canAccessSftp ) {
+		items.push( {
+			icon: file,
+			text: createInterpolateElement(
+				// translators: <sftpLink/> is a link to the SFTP/SSH settings page with the text "Connect over SFTP/SSH"
+				__( '<sftpLink/> to edit the files responsible for the error.' ),
+				{
+					sftpLink: (
+						<Link
+							to={ `/sites/${ siteSlug }/settings/sftp-ssh` }
+							onClick={ () => recordTracksEvent( 'calypso_dashboard_critical_error_sftp_click' ) }
+						>
+							{ __( 'Connect over SFTP/SSH' ) }
 						</Link>
 					),
 				}

--- a/client/dashboard/sites/overview/index.tsx
+++ b/client/dashboard/sites/overview/index.tsx
@@ -258,7 +258,7 @@ function SiteOverview( {
 			notices={
 				<SitesNoticeArbiter>
 					{ site.__inaccessible_jetpack_error && (
-						<InaccessibleJetpackNotice error={ site.__inaccessible_jetpack_error } />
+						<InaccessibleJetpackNotice error={ site.__inaccessible_jetpack_error } site={ site } />
 					) }
 					{ !! getEmailBlock( site ) && <EmailBlockNotice site={ site } /> }
 					{ isStorageWarningVisible && <StorageWarningBanner site={ site } /> }

--- a/client/dashboard/sites/settings-sftp-ssh/index.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/index.tsx
@@ -5,11 +5,9 @@ import {
 	siteSshAccessStatusQuery,
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
-import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { file } from '@wordpress/icons';
 import Breadcrumbs from '../../app/breadcrumbs';
-import { Notice } from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { hasHostingFeature } from '../../utils/site-features';
@@ -25,12 +23,7 @@ export default function SftpSshSettings( { siteSlug }: { siteSlug: string } ) {
 	const hasSftpFeature = hasHostingFeature( site, HostingFeatures.SFTP );
 	const hasSshFeature = hasHostingFeature( site, HostingFeatures.SSH );
 
-	const {
-		data: sftpUsers,
-		isError: hasSftpUsersError,
-		isFetching: isFetchingSftpUsers,
-		refetch: refetchSftpUsers,
-	} = useQuery( {
+	const { data: sftpUsers } = useQuery( {
 		...siteSftpUsersQuery( site.ID ),
 		enabled: hasSftpFeature,
 	} );
@@ -66,29 +59,12 @@ export default function SftpSshSettings( { siteSlug }: { siteSlug: string } ) {
 					'SFTP and SSH give you secure, direct access to your site’s filesystem—fast, reliable, and built for your workflow.'
 				) }
 			>
-				{ hasSftpUsersError && (
-					<Notice
-						variant="error"
-						actions={
-							<Button
-								variant="primary"
-								isBusy={ isFetchingSftpUsers }
-								onClick={ () => refetchSftpUsers() }
-							>
-								{ __( 'Try again' ) }
-							</Button>
-						}
-					>
-						{ __( 'We couldn’t load your SFTP/SSH credentials. Please try again.' ) }
-					</Notice>
+				{ sftpEnabled ? (
+					<SftpCard siteId={ site.ID } sftpUsers={ sftpUsers } />
+				) : (
+					<EnableSftpCard siteId={ site.ID } canUseSsh={ hasSshFeature } />
 				) }
-				{ ! hasSftpUsersError &&
-					( sftpEnabled ? (
-						<SftpCard siteId={ site.ID } sftpUsers={ sftpUsers } />
-					) : (
-						<EnableSftpCard siteId={ site.ID } canUseSsh={ hasSshFeature } />
-					) ) }
-				{ ! hasSftpUsersError && sftpEnabled && hasSshFeature && (
+				{ sftpEnabled && hasSshFeature && (
 					<SshCard
 						siteId={ site.ID }
 						sftpUsers={ sftpUsers }

--- a/client/dashboard/sites/settings-sftp-ssh/index.tsx
+++ b/client/dashboard/sites/settings-sftp-ssh/index.tsx
@@ -5,9 +5,11 @@ import {
 	siteSshAccessStatusQuery,
 } from '@automattic/api-queries';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { file } from '@wordpress/icons';
 import Breadcrumbs from '../../app/breadcrumbs';
+import { Notice } from '../../components/notice';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
 import { hasHostingFeature } from '../../utils/site-features';
@@ -23,7 +25,12 @@ export default function SftpSshSettings( { siteSlug }: { siteSlug: string } ) {
 	const hasSftpFeature = hasHostingFeature( site, HostingFeatures.SFTP );
 	const hasSshFeature = hasHostingFeature( site, HostingFeatures.SSH );
 
-	const { data: sftpUsers } = useQuery( {
+	const {
+		data: sftpUsers,
+		isError: hasSftpUsersError,
+		isFetching: isFetchingSftpUsers,
+		refetch: refetchSftpUsers,
+	} = useQuery( {
 		...siteSftpUsersQuery( site.ID ),
 		enabled: hasSftpFeature,
 	} );
@@ -59,12 +66,29 @@ export default function SftpSshSettings( { siteSlug }: { siteSlug: string } ) {
 					'SFTP and SSH give you secure, direct access to your site’s filesystem—fast, reliable, and built for your workflow.'
 				) }
 			>
-				{ sftpEnabled ? (
-					<SftpCard siteId={ site.ID } sftpUsers={ sftpUsers } />
-				) : (
-					<EnableSftpCard siteId={ site.ID } canUseSsh={ hasSshFeature } />
+				{ hasSftpUsersError && (
+					<Notice
+						variant="error"
+						actions={
+							<Button
+								variant="primary"
+								isBusy={ isFetchingSftpUsers }
+								onClick={ () => refetchSftpUsers() }
+							>
+								{ __( 'Try again' ) }
+							</Button>
+						}
+					>
+						{ __( 'We couldn’t load your SFTP/SSH credentials. Please try again.' ) }
+					</Notice>
 				) }
-				{ sftpEnabled && hasSshFeature && (
+				{ ! hasSftpUsersError &&
+					( sftpEnabled ? (
+						<SftpCard siteId={ site.ID } sftpUsers={ sftpUsers } />
+					) : (
+						<EnableSftpCard siteId={ site.ID } canUseSsh={ hasSshFeature } />
+					) ) }
+				{ ! hasSftpUsersError && sftpEnabled && hasSshFeature && (
 					<SshCard
 						siteId={ site.ID }
 						sftpUsers={ sftpUsers }

--- a/client/dashboard/sites/site/notices.tsx
+++ b/client/dashboard/sites/site/notices.tsx
@@ -9,7 +9,7 @@ import { canAccessSftpSettings } from '../../utils/site-features';
 import type { Site } from '@automattic/api-core';
 
 // `site` is optional because the site error boundary renders this notice when
-// the site request itself failed and there is no site to read.
+// even the WPCOM-only retry failed and there is no site object to read.
 export function InaccessibleJetpackNotice( { error, site }: { error: Error; site?: Site } ) {
 	useEffect( () => {
 		logToLogstash( {

--- a/client/dashboard/sites/site/notices.tsx
+++ b/client/dashboard/sites/site/notices.tsx
@@ -1,11 +1,16 @@
 import { JETPACK_SUPPORT_CONNECTION_ISSUES } from '@automattic/urls';
+import { Link } from '@tanstack/react-router';
 import { ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { Notice } from '../../components/notice';
+import { canAccessSftpSettings } from '../../utils/site-features';
+import type { Site } from '@automattic/api-core';
 
-export function InaccessibleJetpackNotice( { error }: { error: Error } ) {
+// `site` is optional because the site error boundary renders this notice when
+// the site request itself failed and there is no site to read.
+export function InaccessibleJetpackNotice( { error, site }: { error: Error; site?: Site } ) {
 	useEffect( () => {
 		logToLogstash( {
 			feature: 'calypso_client',
@@ -22,9 +27,16 @@ export function InaccessibleJetpackNotice( { error }: { error: Error } ) {
 			variant="error"
 			title={ __( 'Your Jetpack site cannot be reached at this time.' ) }
 			actions={
-				<ExternalLink href={ JETPACK_SUPPORT_CONNECTION_ISSUES }>
-					{ __( 'Troubleshoot your Jetpack connection' ) }
-				</ExternalLink>
+				<>
+					{ site && canAccessSftpSettings( site ) && (
+						<Link to={ `/sites/${ site.slug }/settings/sftp-ssh` }>
+							{ __( 'Connect over SFTP/SSH' ) }
+						</Link>
+					) }
+					<ExternalLink href={ JETPACK_SUPPORT_CONNECTION_ISSUES }>
+						{ __( 'Troubleshoot your Jetpack connection' ) }
+					</ExternalLink>
+				</>
 			}
 		>
 			{ error.message }

--- a/client/dashboard/sites/site/notices.tsx
+++ b/client/dashboard/sites/site/notices.tsx
@@ -8,8 +8,6 @@ import { Notice } from '../../components/notice';
 import { canAccessSftpSettings } from '../../utils/site-features';
 import type { Site } from '@automattic/api-core';
 
-// `site` is optional because the site error boundary renders this notice when
-// even the WPCOM-only retry failed and there is no site object to read.
 export function InaccessibleJetpackNotice( { error, site }: { error: Error; site?: Site } ) {
 	useEffect( () => {
 		logToLogstash( {
@@ -28,14 +26,14 @@ export function InaccessibleJetpackNotice( { error, site }: { error: Error; site
 			title={ __( 'Your Jetpack site cannot be reached at this time.' ) }
 			actions={
 				<>
+					<ExternalLink href={ JETPACK_SUPPORT_CONNECTION_ISSUES }>
+						{ __( 'Troubleshoot your Jetpack connection' ) }
+					</ExternalLink>
 					{ site && canAccessSftpSettings( site ) && (
 						<Link to={ `/sites/${ site.slug }/settings/sftp-ssh` }>
 							{ __( 'Connect over SFTP/SSH' ) }
 						</Link>
 					) }
-					<ExternalLink href={ JETPACK_SUPPORT_CONNECTION_ISSUES }>
-						{ __( 'Troubleshoot your Jetpack connection' ) }
-					</ExternalLink>
 				</>
 			}
 		>

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -33,8 +33,6 @@ export function hasHostingFeature( site: Site, feature: HostingFeatureSlug ) {
 	return hasPlanFeature( site, feature );
 }
 
-// Whether the user can reach the SFTP/SSH settings page. Both recovery surfaces
-// for an unreachable site link there, so they share one gate.
 export function canAccessSftpSettings( site: Site ) {
 	return (
 		!! site.capabilities?.manage_options &&

--- a/client/dashboard/utils/site-features.ts
+++ b/client/dashboard/utils/site-features.ts
@@ -1,4 +1,5 @@
-import { DotcomFeatures } from '@automattic/api-core';
+import { DotcomFeatures, HostingFeatures } from '@automattic/api-core';
+import { siteTypeSupportsFeature } from './site-type-feature-support';
 import type {
 	DotcomFeatureSlug,
 	HostingFeatureSlug,
@@ -30,6 +31,16 @@ export function hasHostingFeature( site: Site, feature: HostingFeatureSlug ) {
 		}
 	}
 	return hasPlanFeature( site, feature );
+}
+
+// Whether the user can reach the SFTP/SSH settings page. Both recovery surfaces
+// for an unreachable site link there, so they share one gate.
+export function canAccessSftpSettings( site: Site ) {
+	return (
+		!! site.capabilities?.manage_options &&
+		siteTypeSupportsFeature( site, 'settingsServer' ) &&
+		hasHostingFeature( site, HostingFeatures.SFTP )
+	);
 }
 
 export function hasJetpackModule( site: Site, module: `${ JetpackModuleSlug }` ) {


### PR DESCRIPTION
### Related issues

Resolves DOTDEV-457

## Proposed Changes

**Summary:**

- unblock SFTP/SSH settings page (`/sites/{site-slug}/settings/sftp-ssh`) when there's an error on the site 
- add links to the SFTP/SSH setting to relevant places in the Dashboard to make it easy for users to access the site files of the site that is erroring:

Overview page (`/sites/{site-slug}`):
<img width="1740" height="678" alt="CleanShot 2026-09-10 at 11 53 22@2x" src="https://github.com/user-attachments/assets/8586c7f9-ac8e-45a2-be87-495d7dca7a97" />

Critical error page (`/sites/{site-slug}/critical-error`):
<img width="1396" height="830" alt="CleanShot 2026-09-10 at 11 51 26@2x" src="https://github.com/user-attachments/assets/30d9c4e6-b60e-406a-ad1a-23162087c973" />

<details>
<summary>Details</summary>

* Allow the SFTP/SSH settings route for sites whose Jetpack connection is unreachable, via `availableToInaccessibleJetpackSites`.
* Return early from the `siteSettingsRoute` loader for an unreachable site, so the awaited site settings request (served by the site itself) can no longer take the route down.
* Add a "Connect over SFTP/SSH" entry to the critical error page's "What you can try next" list, between the PHP logs entry and contact support.
* Add an SFTP/SSH action link to `InaccessibleJetpackNotice`, so the overview page offers the same path for sites that never reach the critical error page.
* Add `canAccessSftpSettings()` so both surfaces share one gate.
</details>

## Why are these changes being made?

- allow users to access their site via SFTP/SSH even when the site is down due to some fatal error so they can self-serve and fix the issue themselves

<details>
<summary>Details</summary>

When a site hits a PHP fatal error, the Jetpack-proxied site request fails and the site is marked `__inaccessible_jetpack_error`. Every route that has not opted into `availableToInaccessibleJetpackSites` is then redirected to the overview and hidden from the sidebar. Settings is one of them, so the SFTP/SSH page is unreachable — the customer cannot get the credentials they need to edit the file that broke the site. Support can still reach the files, so these tickets are resolvable, but only by contacting support.

The hosting credential endpoints are served by WPCOM rather than the site, so they keep working while the site is down. This was verified against a site in a fatal error state: the page loaded and a password reset succeeded. Nothing outside the dashboard needs to change.

Two different states can leave a site unreachable, and only one of them redirects to the critical error page (it additionally requires `jetpack_recovery_mode_status`). A site that is inaccessible without that status stays on the overview, so both surfaces need the link.
</details>

## Testing Instructions

### Overview notice

Build the app with `yarn start-dashboard` and then access the dashboard at http://my.localhost:3000/.

1. Break an Atomic Business/Commerce site so it returns a fatal error, for example by adding a syntax error to the main file of an active plugin. You can use this simple sitee-breaking plugin as well if you like: https://drive.google.com/file/d/1KTWy7c0ob3_12b2atwRMxhvpai2Flf1O/view?usp=sharing.
2. Open the site in the dashboard. You land on the overview with an error notice.
3. Confirm the notice offers "Connect over SFTP/SSH" as its second action.
4. Follow the link and confirm the SFTP/SSH page loads, shows the existing username, and that "Reset password" returns a working password. If you haven't set up the connection before, it should be possible. Before this change the settings section was hidden from the sidebar and the page redirected to the overview.
5. Confirm the credentials work over SFTP, and that fixing the file brings the site back.

### Critical error page

Reaching this page for real needs `site.options.jetpack_recovery_mode_status` to be set on WPCOM as well as the site being unreachable, and the two tend to be mutually exclusive: the status reaches WPCOM through Jetpack sync, which is itself a request to the site, so a site that fatals on every request never reports it. The original PR for this page (#110174) says to simulate the state for the same reason.

The simplest way to view the page is to disable both redirects locally:

1. In `client/dashboard/app/router/sites.tsx`, comment out the redirect in `siteCriticalErrorRoute.beforeLoad`:

```js
// if ( ! isInJetpackCriticalErrorState( site ) ) {
// 	throw dashboardRedirect( { to: siteOverviewRoute.fullPath, params: { siteSlug } } );
// }
```

2. In `client/dashboard/sites/critical-error/index.tsx`, disable the effect that navigates away once the site looks recovered, which it does when the recovery status is missing:

```js
if ( false && hasRecovered ) {
```

3. Visit `/sites/<slug>/critical-error` for the broken site and confirm "Connect over SFTP/SSH" appears under "What you can try next", between "Review the PHP logs" and "Contact WordPress.com support". The new link should work as expected and lead to the SFTP/SSH settings page.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations?
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_01MdSyB1yCJYjJJ7Snapdt6i
