### PR TITLE
Checkout: offer domain search when a domain can't be renewed

### DIFF
--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -4,6 +4,7 @@ import { JETPACK_CONTACT_SUPPORT, JETPACK_SUPPORT } from '@automattic/urls';
 import { useDisplayCartMessages } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
+import { NON_RENEWABLE_DOMAIN_ERROR_CODE } from 'calypso/my-sites/checkout/src/hooks/use-has-non-renewable-domain-error';
 import { WRONG_ACCOUNT_RENEWAL_ERROR_CODE } from 'calypso/my-sites/checkout/src/hooks/use-has-wrong-account-renewal-error';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useDispatch, useSelector } from 'calypso/state';
@@ -70,7 +71,10 @@ export default function CartMessages( {
  * and a way out. A notice for those would only repeat, in one line and with no
  * action attached, what the screen already says better.
  */
-const CART_ERROR_CODES_WITH_THEIR_OWN_SCREEN = [ WRONG_ACCOUNT_RENEWAL_ERROR_CODE ];
+const CART_ERROR_CODES_WITH_THEIR_OWN_SCREEN = [
+	WRONG_ACCOUNT_RENEWAL_ERROR_CODE,
+	NON_RENEWABLE_DOMAIN_ERROR_CODE,
+];
 
 function hasNoScreenOfItsOwn( message: ResponseCartMessage ): boolean {
 	return ! CART_ERROR_CODES_WITH_THEIR_OWN_SCREEN.includes( message.code );

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -117,6 +117,7 @@ import JetpackAkismetCheckoutSidebarPlanUpsell from './jetpack-akismet-checkout-
 import { LeaveCheckoutModal, useCheckoutLeaveModal } from './leave-checkout-modal';
 import { MobileCheckoutStickySummary } from './mobile-checkout-sticky-summary';
 import { mobileCheckoutStickySummaryRadioDotStyles } from './mobile-checkout-sticky-summary-styles';
+import { NonRenewableDomain, SearchForNewDomainButton } from './non-renewable-domain';
 import BeforeSubmitCheckoutHeader from './payment-method-step';
 import { PaymentMethodFilter } from './payment-methods-filter';
 import { getRefundWindowCopy } from './refund-policies';
@@ -432,6 +433,7 @@ export default function CheckoutMainContent( {
 	isRemovingProductFromCart,
 	areThereErrors,
 	isWrongAccountRenewal,
+	isNonRenewableDomain,
 	isInitialCartLoading,
 	customizedPreviousPath,
 	loadingHeader,
@@ -456,6 +458,7 @@ export default function CheckoutMainContent( {
 	isRemovingProductFromCart: boolean;
 	areThereErrors: boolean;
 	isWrongAccountRenewal: boolean;
+	isNonRenewableDomain: boolean;
 	isInitialCartLoading: boolean;
 	customizedPreviousPath?: string;
 	loadingHeader?: ReactNode;
@@ -708,6 +711,25 @@ export default function CheckoutMainContent( {
 					</WPCheckoutTitle>
 					<WrongAccountRenewal />
 					<CheckoutFormSubmit submitButton={ <LogInToCorrectAccountButton /> } />
+				</WPCheckoutMainContent>
+			</WPCheckoutWrapper>
+		);
+	}
+
+	// Same reasoning as above: the domain renewal was rejected, so the cart is
+	// empty, and "you have no items in your cart" explains none of it.
+	if ( isNonRenewableDomain ) {
+		debug( 'rendering non-renewable domain page' );
+		return (
+			<WPCheckoutWrapper>
+				<WPCheckoutSidebarContent></WPCheckoutSidebarContent>
+				<WPCheckoutMainContent isMobileCheckoutStickySummary={ isMobileCheckoutStickySummary }>
+					<PerformanceTrackerStop />
+					<WPCheckoutTitle className="checkout__main-title">
+						{ translate( 'Checkout' ) }
+					</WPCheckoutTitle>
+					<NonRenewableDomain />
+					<CheckoutFormSubmit submitButton={ <SearchForNewDomainButton /> } />
 				</WPCheckoutMainContent>
 			</WPCheckoutWrapper>
 		);

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -41,6 +41,7 @@ import { existingPayPalPPCPPrefix } from '../hooks/use-create-payment-methods/us
 import useCreatePaymentSubmittedAndProcessingCallback from '../hooks/use-create-payment-submitted-and-processing-callback';
 import useDetectedCountryCode from '../hooks/use-detected-country-code';
 import useGetThankYouUrl from '../hooks/use-get-thank-you-url';
+import { useHasNonRenewableDomainError } from '../hooks/use-has-non-renewable-domain-error';
 import { useHasWrongAccountRenewalError } from '../hooks/use-has-wrong-account-renewal-error';
 import { useMobileCheckoutStickySummaryExperiment } from '../hooks/use-mobile-checkout-sticky-summary-experiment';
 import usePrepareProductsForCart from '../hooks/use-prepare-products-for-cart';
@@ -399,6 +400,10 @@ export default function CheckoutMain( {
 	// rather than the generic empty cart page, because there is something the
 	// customer can do about it.
 	const isWrongAccountRenewal = useHasWrongAccountRenewalError( responseCart );
+
+	// Likewise for a domain renewal that arrived too late to be a renewal at
+	// all: the customer can still go and look for another domain.
+	const isNonRenewableDomain = useHasNonRenewableDomainError( responseCart );
 
 	const areThereErrors =
 		[ ...responseCartErrors, cartLoadingError, cartProductPrepError ].filter( isValueTruthy )
@@ -925,6 +930,7 @@ export default function CheckoutMain( {
 						isRemovingProductFromCart={ isRemovingProductFromCart }
 						areThereErrors={ areThereErrors }
 						isWrongAccountRenewal={ isWrongAccountRenewal }
+						isNonRenewableDomain={ isNonRenewableDomain }
 						isInitialCartLoading={ isInitialCartLoading }
 						addItemToCart={ addItemAndLog }
 						changeSelection={ changeSelection }

--- a/client/my-sites/checkout/src/components/non-renewable-domain.tsx
+++ b/client/my-sites/checkout/src/components/non-renewable-domain.tsx
@@ -1,0 +1,64 @@
+import page from '@automattic/calypso-router';
+import { Button, CheckoutStepBody } from '@automattic/composite-checkout';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { domainAddNew } from 'calypso/my-sites/domains/paths';
+import { useSelector, useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+export function NonRenewableDomain() {
+	const reduxDispatch = useDispatch();
+	useEffect( () => {
+		reduxDispatch( recordTracksEvent( 'calypso_checkout_non_renewable_domain' ) );
+	}, [ reduxDispatch ] );
+
+	return (
+		<CheckoutStepBody
+			stepId="non-renewable-domain"
+			isStepActive={ false }
+			isStepComplete
+			titleContent={ <NonRenewableDomainTitle /> }
+			completeStepContent={ <NonRenewableDomainExplanation /> }
+		/>
+	);
+}
+
+function NonRenewableDomainTitle() {
+	const translate = useTranslate();
+	return <>{ String( translate( 'This domain can no longer be renewed' ) ) }</>;
+}
+
+function NonRenewableDomainExplanation() {
+	const translate = useTranslate();
+	return (
+		<>
+			{ translate(
+				'Both the renewal period and the redemption period for this domain have ended, so there is nothing left to renew. It will be released back to the domain registry, after which anyone may be able to register it. You can search for another domain in the meantime.'
+			) }
+		</>
+	);
+}
+
+/**
+ * Sends the customer to domain search, which is the only thing left they can do
+ * about this domain.
+ */
+export function SearchForNewDomainButton() {
+	const translate = useTranslate();
+	const reduxDispatch = useDispatch();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	return (
+		<Button
+			buttonType="primary"
+			fullWidth
+			onClick={ () => {
+				reduxDispatch( recordTracksEvent( 'calypso_checkout_non_renewable_domain_search_click' ) );
+				page( domainAddNew( siteSlug ) );
+			} }
+		>
+			{ translate( 'Search for a new domain' ) }
+		</Button>
+	);
+}

--- a/client/my-sites/checkout/src/hooks/use-has-latched-cart-error.ts
+++ b/client/my-sites/checkout/src/hooks/use-has-latched-cart-error.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import type { ResponseCart } from '@automattic/shopping-cart';
+
+/**
+ * Whether the cart has reported `errorCode` at any point since this page
+ * loaded.
+ *
+ * Regular cart errors are transient: they are returned only by the request that
+ * caused them, so any later fetch of the cart (the cart refetches on window
+ * focus) would drop the error and leave behind an empty cart with no
+ * explanation of what went wrong. An error that checkout answers with a screen
+ * of its own therefore has to be latched: once we have seen the code we keep
+ * reporting it for the rest of the page's life.
+ */
+export function useHasLatchedCartError( responseCart: ResponseCart, errorCode: string ): boolean {
+	const isInCurrentCart = ( responseCart.messages?.errors ?? [] ).some(
+		( error ) => error.code === errorCode
+	);
+	const [ wasInAnyCart, setWasInAnyCart ] = useState( false );
+	useEffect( () => {
+		if ( isInCurrentCart ) {
+			setWasInAnyCart( true );
+		}
+	}, [ isInCurrentCart ] );
+	return isInCurrentCart || wasInAnyCart;
+}

--- a/client/my-sites/checkout/src/hooks/use-has-non-renewable-domain-error.ts
+++ b/client/my-sites/checkout/src/hooks/use-has-non-renewable-domain-error.ts
@@ -1,0 +1,18 @@
+import { useHasLatchedCartError } from './use-has-latched-cart-error';
+import type { ResponseCart } from '@automattic/shopping-cart';
+
+/**
+ * The cart error code returned when a domain renewal arrives after both the
+ * renewal and the redemption period have ended. Must match the code sent by the
+ * shopping cart backend.
+ */
+export const NON_RENEWABLE_DOMAIN_ERROR_CODE = 'renewal-domain-not-renewable';
+
+/**
+ * Whether the cart has rejected a domain renewal because the domain is out of
+ * time: it is past its renewal period and past its redemption period, so there
+ * is no longer anything to renew.
+ */
+export function useHasNonRenewableDomainError( responseCart: ResponseCart ): boolean {
+	return useHasLatchedCartError( responseCart, NON_RENEWABLE_DOMAIN_ERROR_CODE );
+}

--- a/client/my-sites/checkout/src/hooks/use-has-wrong-account-renewal-error.ts
+++ b/client/my-sites/checkout/src/hooks/use-has-wrong-account-renewal-error.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useHasLatchedCartError } from './use-has-latched-cart-error';
 import type { ResponseCart } from '@automattic/shopping-cart';
 
 /**
@@ -11,22 +11,7 @@ export const WRONG_ACCOUNT_RENEWAL_ERROR_CODE = 'renewal-wrong-account';
  * Whether the cart has rejected a renewal because it belongs to a different
  * WordPress.com account, which usually means the customer has more than one
  * account and followed a renewal link while signed in to the wrong one.
- *
- * Regular cart errors are transient: they are returned only by the request that
- * caused them, so any later fetch of the cart (the cart refetches on window
- * focus) would drop this one and leave behind an empty cart with no explanation
- * of what went wrong. Once we have seen the error we therefore keep reporting
- * it for the rest of the page's life.
  */
 export function useHasWrongAccountRenewalError( responseCart: ResponseCart ): boolean {
-	const isInCurrentCart = ( responseCart.messages?.errors ?? [] ).some(
-		( error ) => error.code === WRONG_ACCOUNT_RENEWAL_ERROR_CODE
-	);
-	const [ wasInAnyCart, setWasInAnyCart ] = useState( false );
-	useEffect( () => {
-		if ( isInCurrentCart ) {
-			setWasInAnyCart( true );
-		}
-	}, [ isInCurrentCart ] );
-	return isInCurrentCart || wasInAnyCart;
+	return useHasLatchedCartError( responseCart, WRONG_ACCOUNT_RENEWAL_ERROR_CODE );
 }

--- a/client/my-sites/checkout/src/test/non-renewable-domain.tsx
+++ b/client/my-sites/checkout/src/test/non-renewable-domain.tsx
@@ -1,0 +1,128 @@
+/**
+ * @jest-environment jsdom
+ */
+import page from '@automattic/calypso-router';
+import { CheckoutProvider } from '@automattic/composite-checkout';
+import { getEmptyResponseCart } from '@automattic/shopping-cart';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import uiReducer from 'calypso/state/ui/reducer';
+import { renderWithProvider, renderHookWithProvider } from 'calypso/test-helpers/testing-library';
+import { NonRenewableDomain, SearchForNewDomainButton } from '../components/non-renewable-domain';
+import {
+	useHasNonRenewableDomainError,
+	NON_RENEWABLE_DOMAIN_ERROR_CODE,
+} from '../hooks/use-has-non-renewable-domain-error';
+import type { ResponseCart } from '@automattic/shopping-cart';
+
+jest.mock( '@automattic/calypso-router', () => jest.fn() );
+
+function getCartWithErrorCodes( codes: string[] ): ResponseCart {
+	return {
+		...getEmptyResponseCart(),
+		messages: {
+			errors: codes.map( ( code ) => ( { code, message: 'Something went wrong' } ) ),
+		},
+	};
+}
+
+/**
+ * Both components are rendered inside checkout, so they rely on its theme and
+ * form state the same way every other step of the page does.
+ */
+function CheckoutWrapper( { children }: { children: React.ReactNode } ) {
+	return (
+		<CheckoutProvider paymentMethods={ [] } paymentProcessors={ {} }>
+			{ children }
+		</CheckoutProvider>
+	);
+}
+
+const withSelectedSite = {
+	initialState: {
+		sites: { items: { 12345: { ID: 12345, URL: 'https://example.wordpress.com' } } },
+		ui: { selectedSiteId: 12345 },
+	},
+	reducers: { ui: uiReducer },
+};
+
+describe( 'useHasNonRenewableDomainError', () => {
+	it( 'is false for a cart with no errors', () => {
+		const { result } = renderHookWithProvider( () =>
+			useHasNonRenewableDomainError( getEmptyResponseCart() )
+		);
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'is false for a cart with some other error', () => {
+		const { result } = renderHookWithProvider( () =>
+			useHasNonRenewableDomainError( getCartWithErrorCodes( [ 'renewal-domain-pending' ] ) )
+		);
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'is true for a cart with the non-renewable domain error', () => {
+		const { result } = renderHookWithProvider( () =>
+			useHasNonRenewableDomainError( getCartWithErrorCodes( [ NON_RENEWABLE_DOMAIN_ERROR_CODE ] ) )
+		);
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'stays true once the error has been seen, because cart errors are transient', () => {
+		const { result, rerender } = renderHookWithProvider(
+			( cart: ResponseCart ) => useHasNonRenewableDomainError( cart ),
+			{ initialProps: getCartWithErrorCodes( [ NON_RENEWABLE_DOMAIN_ERROR_CODE ] ) }
+		);
+		expect( result.current ).toBe( true );
+
+		// A later fetch of the cart (the cart refetches when the window regains
+		// focus) returns no messages at all.
+		rerender( getEmptyResponseCart() );
+		expect( result.current ).toBe( true );
+	} );
+} );
+
+describe( 'NonRenewableDomain', () => {
+	it( 'explains that the domain is past both its renewal and redemption periods', () => {
+		renderWithProvider(
+			<CheckoutWrapper>
+				<NonRenewableDomain />
+			</CheckoutWrapper>
+		);
+		expect( screen.getByText( 'This domain can no longer be renewed' ) ).toBeInTheDocument();
+		expect( screen.getByText( /redemption period/ ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'SearchForNewDomainButton', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'sends the customer to domain search for the selected site', async () => {
+		const user = userEvent.setup();
+		renderWithProvider(
+			<CheckoutWrapper>
+				<SearchForNewDomainButton />
+			</CheckoutWrapper>,
+			withSelectedSite
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Search for a new domain' } ) );
+
+		expect( page ).toHaveBeenCalledWith( '/domains/add/example.wordpress.com' );
+	} );
+
+	it( 'sends the customer to domain search with no site when checkout has none', async () => {
+		const user = userEvent.setup();
+		renderWithProvider(
+			<CheckoutWrapper>
+				<SearchForNewDomainButton />
+			</CheckoutWrapper>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Search for a new domain' } ) );
+
+		expect( page ).toHaveBeenCalledWith( '/domains/add' );
+	} );
+} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SHILL-2503/

## Proposed changes

When the cart rejects a domain renewal because the domain is past both its renewal and its redemption period, checkout now shows a screen explaining that and offering a domain search, instead of an empty cart with a red notice.

* Add `NonRenewableDomain` and `SearchForNewDomainButton` in `non-renewable-domain.tsx`, rendered ahead of the empty-cart branch in `checkout-main-content.tsx`.
* Add `useHasNonRenewableDomainError`, keyed on the `renewal-domain-not-renewable` code sent by the shopping cart backend.
* Extract the latching behaviour shared with the wrong-account screen into `useHasLatchedCartError`.
* Suppress the generic red notice for this code in `cart-messages.tsx`, since the screen says it better.
* Record `calypso_checkout_non_renewable_domain` on render and `calypso_checkout_non_renewable_domain_search_click` on the CTA.

## Why are these changes being made?

A customer following a renewal link for a domain that has run out of time got the least useful pair of things checkout can show: "You have no items in your cart", which is true but explains nothing, and a red notice repeating an untranslated backend string — "This domain can no longer be renewed - it might be available for registration soon." Neither says what happened or what to do about it.

This is the same shape of problem as SHILL-2497, and takes the same shape of fix: give the rejection a screen of its own that names what happened and offers the one action still available. For a domain past its redemption period that action is searching for a different domain, so the CTA goes to `domainAddNew( siteSlug )`, falling back to `/domains/add` when checkout has no selected site.

The error has to be latched. Cart errors are transient — returned only by the request that caused them — and `refetchOnWindowFocus` is on, so a tab refocus would drop the message and leave an unexplained empty cart behind. The wrong-account screen already worked around this; rather than copy the hook, the latching moved into `useHasLatchedCartError` and both screens now use it.

## Testing instructions

TC:
```
yarn test-client client/my-sites/checkout/src/test/non-renewable-domain.tsx client/my-sites/checkout/src/test/wrong-account-renewal.tsx
```

Both suites should pass — the second covers the hook refactor not having changed the existing screen's behaviour.

Manual testing:
* Requires Automattic/wpcom#240395 deployed to your sandbox, since that is what sends the `renewal-domain-not-renewable` code. Without it this screen never renders.
* Sandbox both wpcom and Calypso.
* Find a domain registration whose registry expiration date is past both the grace period and the redemption period that follows it, while its store subscription is still `active`.
* Visit its renewal checkout URL, e.g. `/checkout/domain_reg:<domain>/renew/<subscription_id>/<site_slug>`.
* **Expected:** a "This domain can no longer be renewed" screen with a "Search for a new domain" button, and no red error notice.
* Click the button and confirm it lands on domain search for the selected site.
* Refocus the tab (or switch away and back) and confirm the screen stays put rather than collapsing to the empty-cart page.
* Confirm the wrong-account renewal screen from SHILL-2497 still behaves the same, since it now shares the latching hook.
