### PR TITLE
Purchases: promote a lone header action out of the overflow menu

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -265,68 +265,138 @@ function ProductLink( { purchase }: { purchase: Purchase } ) {
 	return null;
 }
 
-function PurchaseActionMenu( { purchase }: { purchase: Purchase } ) {
+interface PurchaseHeaderAction {
+	label: string;
+	href: string;
+	recordClick: () => void;
+}
+
+/**
+ * The quick actions offered in the page header, most prominent first. Empty for
+ * anyone but the purchase's owner.
+ */
+function usePurchaseHeaderActions( purchase: Purchase ): PurchaseHeaderAction[] {
 	const hasEnTranslation = useHasEnTranslation();
 	const { user } = useAuth();
-	const isOwner = String( user.ID ) === String( purchase.user_id );
-	// The purchase list gates its renewal link on these same two conditions.
-	const canBeRenewed = purchase.can_explicit_renew && isOwner;
+	const { recordTracksEvent } = useAnalytics();
+
+	// The purchase list gates its renewal link on ownership too.
+	if ( String( user.ID ) !== String( purchase.user_id ) ) {
+		return [];
+	}
+
+	const actions: PurchaseHeaderAction[] = [];
 	const upgradeAction = getHeaderUpgradeAction( purchase );
 	const storageUpgradeUrl = getSitePurchaseStorageUpgradeUrl( purchase );
-	const { recordTracksEvent } = useAnalytics();
-	const menuItems = [
-		upgradeAction && isOwner && (
-			<MenuItem
-				onClick={ () => {
-					recordTracksEvent( 'calypso_purchases_upgrade_plan', {
-						status: isExpiredOrRemoved( purchase ) ? 'expired' : 'active',
-						plan: purchase.product_name,
-					} );
-					upgradePurchase( upgradeAction.href );
-				} }
-			>
-				{ getUpgradeControlLabel( purchase, upgradeAction.title, hasEnTranslation ) }
-			</MenuItem>
-		),
-		isStorageUpgradeShown( purchase ) && storageUpgradeUrl && isOwner && (
-			<MenuItem
-				onClick={ () => {
-					recordTracksEvent( 'calypso_purchases_upgrade_storage', {
-						status: isExpiredOrRemoved( purchase ) ? 'expired' : 'active',
-						plan: purchase.product_name,
-					} );
-					upgradePurchase( storageUpgradeUrl );
-				} }
-			>
-				{ _x( 'Upgrade storage', 'Buy more storage space for the subscription.' ) }
-			</MenuItem>
-		),
-		canBeRenewed && (
-			<MenuItem
-				onClick={ () => {
-					recordTracksEvent( 'calypso_purchases_renew_now_click', {
-						product_slug: purchase.product_slug,
-						position: 'purchase-settings',
-					} );
-					renewPurchase( purchase );
-				} }
-			>
-				{ _x(
-					'Renew',
-					'Immediately pay for and receive another term of the subscription, extending the expiration date by another term.'
-				) }
-			</MenuItem>
-		),
-	].filter( Boolean );
 
-	if ( menuItems.length === 0 ) {
+	if ( upgradeAction ) {
+		actions.push( {
+			label: getUpgradeControlLabel( purchase, upgradeAction.title, hasEnTranslation ),
+			href: upgradeAction.href,
+			recordClick: () =>
+				recordTracksEvent( 'calypso_purchases_upgrade_plan', {
+					status: isExpiredOrRemoved( purchase ) ? 'expired' : 'active',
+					plan: purchase.product_name,
+				} ),
+		} );
+	}
+
+	if ( isStorageUpgradeShown( purchase ) && storageUpgradeUrl ) {
+		actions.push( {
+			label: _x( 'Upgrade storage', 'Buy more storage space for the subscription.' ),
+			href: storageUpgradeUrl,
+			recordClick: () =>
+				recordTracksEvent( 'calypso_purchases_upgrade_storage', {
+					status: isExpiredOrRemoved( purchase ) ? 'expired' : 'active',
+					plan: purchase.product_name,
+				} ),
+		} );
+	}
+
+	if ( purchase.can_explicit_renew ) {
+		actions.push( {
+			label: _x(
+				'Renew',
+				'Immediately pay for and receive another term of the subscription, extending the expiration date by another term.'
+			),
+			href: getRenewalUrlFromPurchase( purchase ),
+			recordClick: () =>
+				recordTracksEvent( 'calypso_purchases_renew_now_click', {
+					product_slug: purchase.product_slug,
+					position: 'purchase-settings',
+				} ),
+		} );
+	}
+
+	return actions;
+}
+
+function PurchaseActionMenu( { actions }: { actions: PurchaseHeaderAction[] } ) {
+	if ( actions.length === 0 ) {
 		return null;
 	}
 
 	return (
 		<DropdownMenu icon={ moreVertical } label={ __( 'Quick actions' ) }>
-			{ () => <MenuGroup>{ menuItems }</MenuGroup> }
+			{ () => (
+				<MenuGroup>
+					{ actions.map( ( action ) => (
+						<MenuItem
+							key={ action.label }
+							onClick={ () => {
+								action.recordClick();
+								window.location.href = action.href;
+							} }
+						>
+							{ action.label }
+						</MenuItem>
+					) ) }
+				</MenuGroup>
+			) }
 		</DropdownMenu>
+	);
+}
+
+/**
+ * The header's quick actions. The most prominent one is a button and the rest go
+ * behind the overflow menu, so a purchase with a single action never hides it
+ * in a menu of one.
+ */
+export function PurchaseHeaderActions( {
+	purchase,
+	planExpiryNoticeShowing,
+}: {
+	purchase: Purchase;
+	planExpiryNoticeShowing: boolean;
+} ) {
+	const actions = usePurchaseHeaderActions( purchase );
+	// While the plan-expiry notice is up it owns the call to action, so nothing is
+	// promoted out of the menu to compete with it.
+	const promotedAction = planExpiryNoticeShowing ? undefined : actions[ 0 ];
+	// Email plans surface every action in the list below, so an overflow menu
+	// would only duplicate them.
+	const overflowActions = isEmailPlanManagementEnabled( purchase )
+		? []
+		: actions.filter( ( action ) => action !== promotedAction );
+
+	return (
+		<HStack justify="space-between">
+			{ promotedAction && (
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					href={ promotedAction.href }
+					onClick={ promotedAction.recordClick }
+				>
+					{ promotedAction.label }
+				</Button>
+			) }
+			{ overflowActions.length > 0 && (
+				<PageHeader.ActionMenu>
+					<PurchaseActionMenu actions={ overflowActions } />
+				</PageHeader.ActionMenu>
+			) }
+		</HStack>
 	);
 }
 
@@ -1522,8 +1592,6 @@ export default function PurchaseSettings() {
 	const formattedRenewal = useFormattedTime( purchase.renew_date ?? '' );
 	const formattedParentExpiry = useFormattedTime( parentPurchase?.expiry_date ?? '' );
 	const formattedParentRenewal = useFormattedTime( parentPurchase?.renew_date ?? '' );
-	const hasEnTranslation = useHasEnTranslation();
-	const upgradeAction = getHeaderUpgradeAction( purchase );
 	// During the expiration grace period, we don't want to display the
 	// purchase.renew_date from the server even if there is an upcoming
 	// auto-renewal attempt (since we want to communicate the urgency of the
@@ -1571,18 +1639,10 @@ export default function PurchaseSettings() {
 	const isSmallViewport = useViewportMatch( 'medium', '<' );
 	const columns = isSmallViewport ? 1 : 2;
 	const spacing = isSmallViewport ? SPACING.SMALL : SPACING.DEFAULT;
-	const isCurrentPurchaseOwner = String( user.ID ) === String( purchase.user_id );
-	const canHeaderUpgrade = Boolean( upgradeAction );
-	// While the plan-expiry notice is up, keep the header on the one thing that
-	// needs doing. The quick-actions menu still holds everything else.
-	const shouldShowHeaderUpgradeAction =
-		canHeaderUpgrade && isCurrentPurchaseOwner && ! planExpiryNoticeShowing;
-	const shouldShowHeaderActionMenu =
-		isCurrentPurchaseOwner && ( canHeaderUpgrade || purchase.can_explicit_renew );
-	const shouldShowHeaderActions =
-		site?.options?.admin_url &&
-		! isCentennial &&
-		( shouldShowHeaderUpgradeAction || shouldShowHeaderActionMenu );
+	const hasHeaderActions = usePurchaseHeaderActions( purchase ).length > 0;
+	const shouldShowHeaderActions = Boolean(
+		site?.options?.admin_url && ! isCentennial && hasHeaderActions
+	);
 
 	// Email plans order the overview cards as Renews, Renewal price, Mailbox, Site;
 	// every other purchase keeps Site, Owner, Renews, Price. Extract the two cards
@@ -1640,20 +1700,10 @@ export default function PurchaseSettings() {
 						}
 						actions={
 							shouldShowHeaderActions && (
-								<HStack justify="space-between">
-									{ shouldShowHeaderUpgradeAction && upgradeAction && (
-										<Button __next40pxDefaultSize variant="primary" href={ upgradeAction.href }>
-											{ getUpgradeControlLabel( purchase, upgradeAction.title, hasEnTranslation ) }
-										</Button>
-									) }
-									{ /* Email plans surface every action in the list below, so the
-									     quick-actions menu would only duplicate them. */ }
-									{ shouldShowHeaderActionMenu && ! isEmailPlanManagementEnabled( purchase ) && (
-										<PageHeader.ActionMenu>
-											<PurchaseActionMenu purchase={ purchase } />
-										</PageHeader.ActionMenu>
-									) }
-								</HStack>
+								<PurchaseHeaderActions
+									purchase={ purchase }
+									planExpiryNoticeShowing={ planExpiryNoticeShowing }
+								/>
 							)
 						}
 						description={

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/purchase-header-actions.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/purchase-header-actions.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from '../../../../test-utils';
 import { PurchaseHeaderActions } from '../index';
@@ -60,7 +60,11 @@ describe( '<PurchaseHeaderActions />', () => {
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'Quick actions' } ) );
 
-		expect( screen.getByRole( 'menuitem', { name: 'Renew' } ) ).toBeVisible();
+		// The menu's popover fades in from opacity 0, so give it a frame to become
+		// visible rather than asserting on the animation's first tick.
+		await waitFor( () =>
+			expect( screen.getByRole( 'menuitem', { name: 'Renew' } ) ).toBeVisible()
+		);
 		// The promoted action is not repeated in the menu.
 		expect( screen.queryByRole( 'menuitem', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
 	} );

--- a/client/dashboard/me/billing-purchases/purchase-settings/test/purchase-header-actions.test.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/test/purchase-header-actions.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from '../../../../test-utils';
+import { PurchaseHeaderActions } from '../index';
+import type { Purchase } from '@automattic/api-core';
+
+// The rendering wrapper's default user has ID 1, so a purchase owned by user 1
+// belongs to the current user.
+function makeDomain( overrides: Partial< Purchase > = {} ): Purchase {
+	return {
+		ID: 1,
+		user_id: 1,
+		product_name: 'example.com',
+		product_slug: 'domain_reg',
+		site_slug: 'example.com',
+		meta: 'example.com',
+		is_domain: true,
+		is_plan: false,
+		is_upgradable: false,
+		is_jetpack_plan_or_product: false,
+		is_plan_type_downgradable: false,
+		is_trial_plan: false,
+		is_woo_hosted_product: false,
+		can_explicit_renew: true,
+		subscription_status: 'active',
+		expiry_status: 'manual-renew',
+		...overrides,
+	} as Purchase;
+}
+
+// A plan that can both be upgraded and renewed, so it has two header actions.
+function makePlan( overrides: Partial< Purchase > = {} ): Purchase {
+	return makeDomain( {
+		product_name: 'WordPress.com Personal',
+		product_slug: 'personal-bundle',
+		meta: undefined,
+		is_domain: false,
+		is_plan: true,
+		is_upgradable: true,
+		...overrides,
+	} );
+}
+
+describe( '<PurchaseHeaderActions />', () => {
+	test( 'promotes a lone action to a primary button rather than burying it in the menu', () => {
+		render( <PurchaseHeaderActions purchase={ makeDomain() } planExpiryNoticeShowing={ false } /> );
+
+		expect( screen.getByRole( 'link', { name: 'Renew' } ) ).toHaveClass( 'is-primary' );
+		expect( screen.queryByRole( 'button', { name: 'Quick actions' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'promotes the first of several actions and overflows the rest', async () => {
+		render( <PurchaseHeaderActions purchase={ makePlan() } planExpiryNoticeShowing={ false } /> );
+
+		expect( screen.getByRole( 'link', { name: 'Upgrade' } ) ).toHaveClass( 'is-primary' );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'Quick actions' } ) );
+
+		expect( screen.getByRole( 'menuitem', { name: 'Renew' } ) ).toBeVisible();
+		// The promoted action is not repeated in the menu.
+		expect( screen.queryByRole( 'menuitem', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
+	} );
+
+	test( 'stands down to the menu while the plan-expiry notice owns the call to action', () => {
+		render( <PurchaseHeaderActions purchase={ makeDomain() } planExpiryNoticeShowing /> );
+
+		expect( screen.queryByRole( 'link', { name: 'Renew' } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Quick actions' } ) ).toBeVisible();
+	} );
+
+	test( 'offers nothing to someone who does not own the purchase', () => {
+		render(
+			<PurchaseHeaderActions
+				purchase={ makeDomain( { user_id: 2 } ) }
+				planExpiryNoticeShowing={ false }
+			/>
+		);
+
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/DOTMSD-1427/

## Proposed Changes

This creates a more consistent action for the purchases header. A single primary button when only one action exists, a primary button and a menu when there are more than one action, and only a menu if other notice-based actions are shown on the page.

| Before | After |
| ----------- | ----------- |
| <img width="1454" height="646" alt="CleanShot 2026-09-09 at 13 52 17@2x" src="https://github.com/user-attachments/assets/a4e5fd31-49e3-40c4-b80c-7918bce2bce0" /> | <img width="1500" height="640" alt="CleanShot 2026-09-09 at 13 52 10@2x" src="https://github.com/user-attachments/assets/9b1b6425-0f75-477c-b1e4-587708cbd577" /> |
| <img width="1422" height="310" alt="CleanShot 2026-09-09 at 13 50 31@2x" src="https://github.com/user-attachments/assets/6dc58e8f-4ae5-41c6-9a5d-ee92dab3d327" /> | <img width="1416" height="328" alt="CleanShot 2026-09-09 at 13 50 53@2x" src="https://github.com/user-attachments/assets/07e61ec5-a61a-4912-a458-8f80178d1e5b" /> |
| <img width="1406" height="366" alt="CleanShot 2026-09-09 at 13 50 05@2x" src="https://github.com/user-attachments/assets/a1c44410-003e-46ee-bcf3-0d858f2d69ee" /> | <img width="1422" height="380" alt="CleanShot 2026-09-09 at 13 51 10@2x" src="https://github.com/user-attachments/assets/9f01cac9-b0fa-4393-ab8f-a772ea58344d" /> |
| <img width="1406" height="472" alt="CleanShot 2026-09-09 at 13 50 20@2x" src="https://github.com/user-attachments/assets/a39fa061-43fe-4d14-bffc-1ee2b41bbf9d" /> | <img width="1448" height="480" alt="CleanShot 2026-09-09 at 13 51 28@2x" src="https://github.com/user-attachments/assets/4bce3317-1adc-416f-8b31-58c1f2ca710c" /> |


* Build the purchase page's header actions (Upgrade, Upgrade storage, Renew) as one ordered list, then promote the first one to a primary button and put the rest in the overflow menu. A purchase with a single action no longer hides it behind a three-dot menu of one.
* Stop offering the upgrade action twice — it previously appeared both as the header button and as a menu item.
* Surface the storage upgrade when it is the only action available. The old visibility check only looked at the plan upgrade and renewal, so the menu was never mounted in that case even though it had an item to show.
* Extract `PurchaseHeaderActions` so the promotion rule can be unit tested.

Unchanged: while a plan-expiry notice is showing, nothing is promoted out of the menu — the notice owns the call to action. Email plans still get no overflow menu, since the action list further down the page repeats every entry.

## Why are these changes being made?

Only the upgrade action was ever promoted to a button, so the most common single-action purchase — a domain that can only be renewed — buried "Renew" in an ellipsis menu. On mobile that reads as a floating three-dot menu with no visible context.

Rolling the three actions into one list also removes the split between the header's visibility check and the menu's own item list, which were two independent sources of truth that could disagree.

## Testing Instructions

1. Go to the Dashboard purchase management page for a domain that can be renewed and has no upgrade path (`/me/purchases/<id>`).
2. Confirm "Renew" now renders as a primary button in the header, with no three-dot menu beside it. Check at a narrow viewport too.
3. Open a plan that can be both upgraded and renewed. Confirm the header shows the "Upgrade" button plus a three-dot menu, and that the menu contains "Renew" but no longer repeats "Upgrade".
4. Open a purchase with an expiry notice showing. Confirm the header still stands down to the menu only.
5. Open a purchase owned by another user and confirm no header actions appear.

`yarn test-client client/dashboard/me/billing-purchases` — 21 suites, 163 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)