### PR TITLE
Monetize: return to the page an upsell started from after checkout

### DIFF
--- a/client/my-sites/earn/ads/test/wrapper.tsx
+++ b/client/my-sites/earn/ads/test/wrapper.tsx
@@ -22,7 +22,15 @@ const renderWrapper = ( {
 			initialState: {
 				currentUser: { capabilities: { 1: { manage_options: manageOptions } } },
 				sites: {
-					items: { 1: { ID: 1, slug: 'example.wordpress.com', options: {}, ...site } },
+					items: {
+						1: {
+							ID: 1,
+							slug: 'example.wordpress.com',
+							URL: 'https://example.wordpress.com',
+							options: {},
+							...site,
+						},
+					},
 					features,
 				},
 				ui: { selectedSiteId: 1 },
@@ -33,7 +41,17 @@ const renderWrapper = ( {
 
 const notAuthorized = 'You are not authorized to view this page';
 
+const upgradeUrl = () =>
+	new URL(
+		screen.getByRole( 'link', { name: 'Upgrade' } ).getAttribute( 'href' ),
+		window.location.origin
+	);
+
 describe( 'AdsWrapper', () => {
+	beforeEach( () => {
+		window.history.pushState( {}, '', '/earn/ads-settings/example.wordpress.com' );
+	} );
+
 	it( 'only offers the WordAds upgrade to users who can upgrade the site', () => {
 		const { unmount } = renderWrapper( { manageOptions: false } );
 		expect( screen.queryByRole( 'link', { name: 'Upgrade' } ) ).not.toBeInTheDocument();
@@ -42,6 +60,66 @@ describe( 'AdsWrapper', () => {
 		unmount();
 		renderWrapper();
 		expect( screen.getByRole( 'link', { name: 'Upgrade' } ) ).toBeVisible();
+	} );
+
+	// Without these, checkout drops the user on the generic thank-you page with no
+	// way back to the ads dashboard they were setting up.
+	it( 'sends the user back to the ads page after checkout', () => {
+		renderWrapper();
+
+		const url = upgradeUrl();
+		expect( url.pathname ).toBe( '/checkout/example.wordpress.com/value_bundle' );
+		expect( url.searchParams.get( 'redirect_to' ) ).toBe(
+			'/earn/ads-settings/example.wordpress.com'
+		);
+		expect( url.searchParams.get( 'cancel_to' ) ).toBe(
+			'/earn/ads-settings/example.wordpress.com'
+		);
+	} );
+
+	it( 'sends a Jetpack site back to the ads page after checkout', () => {
+		renderWrapper( { site: { jetpack: true } } );
+
+		const url = upgradeUrl();
+		expect( url.pathname ).toBe( '/checkout/example.wordpress.com/jetpack_security_daily' );
+		expect( url.searchParams.get( 'redirect_to' ) ).toBe(
+			'/earn/ads-settings/example.wordpress.com'
+		);
+	} );
+
+	// The plans page forwards `redirect_to` to checkout, but has no use for
+	// `cancel_to`.
+	it( 'sends a site on an ineligible plan back to the ads page after checkout', () => {
+		renderWithProvider(
+			<AdsWrapper section="ads-earnings">
+				<div />
+			</AdsWrapper>,
+			{
+				initialState: {
+					currentUser: { capabilities: { 1: { manage_options: true } } },
+					sites: {
+						items: {
+							1: {
+								ID: 1,
+								slug: 'example.wordpress.com',
+								URL: 'https://example.wordpress.com',
+								options: { wordads: true },
+							},
+						},
+						features: { 1: { data: { active: [] } } },
+					},
+					ui: { selectedSiteId: 1 },
+					wordads: { status: { 1: { status: 'ineligible' } } },
+				},
+				reducers: { ui: uiReducer, wordads: wordadsReducer },
+			}
+		);
+
+		const url = upgradeUrl();
+		expect( url.pathname ).toBe( '/plans/example.wordpress.com' );
+		expect( url.searchParams.get( 'redirect_to' ) ).toBe(
+			'/earn/ads-settings/example.wordpress.com'
+		);
 	} );
 
 	// An unloaded feature list is indistinguishable from an absent feature, so

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -6,6 +6,7 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
+import { addQueryArgs } from '@wordpress/url';
 import clsx from 'clsx';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { ReactNode } from 'react';
@@ -42,6 +43,7 @@ import {
 	getWordAdsSuccessForSite,
 } from 'calypso/state/wordads/approve/selectors';
 import { isSiteWordadsUnsafe } from 'calypso/state/wordads/status/selectors';
+import { getUpsellCheckoutQueryArgs, getUpsellReturnUrl } from '../upsell-return-url';
 
 import './style.scss';
 import 'calypso/my-sites/stats/stats-module/style.scss';
@@ -303,7 +305,7 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 				translate( 'Instantly enroll into the WordAds network.' ),
 				translate( 'Earn money from your content and traffic.' ),
 			],
-			href: buildCheckoutURL( siteSlug as string, PLAN_PREMIUM ),
+			href: buildCheckoutURL( siteSlug as string, PLAN_PREMIUM, getUpsellCheckoutQueryArgs() ),
 			tracksClickName: 'calypso_upgrade_nudge_cta_click',
 			learnMoreUrl: 'https://wordads.co/',
 			fitToContent: true,
@@ -315,7 +317,10 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 			body: translate(
 				'Make money each time someone visits your site by displaying ads on all your posts and pages.'
 			),
-			href: `/checkout/${ siteSlug }/${ PLAN_JETPACK_SECURITY_DAILY }`,
+			href: addQueryArgs(
+				`/checkout/${ siteSlug }/${ PLAN_JETPACK_SECURITY_DAILY }`,
+				getUpsellCheckoutQueryArgs()
+			),
 			tracksClickName: 'calypso_upgrade_nudge_click',
 			ctaName: 'calypso_upgrade_nudge_impression',
 		} );
@@ -339,7 +344,11 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 	const renderContentWithUpsell = ( component: ReactNode ) => {
 		const allowedSections = [ 'ads-earnings', 'ads-payments' ];
 		const isAllowedSection = section && allowedSections.includes( section );
-		const url = `/plans/${ siteSlug }?feature=${ FEATURE_WORDADS_INSTANT }&plan=${ PLAN_PREMIUM }`;
+		const url = addQueryArgs( `/plans/${ siteSlug }`, {
+			feature: FEATURE_WORDADS_INSTANT,
+			plan: PLAN_PREMIUM,
+			redirect_to: getUpsellReturnUrl(),
+		} );
 		return (
 			<>
 				{ ! isWPForTeams &&

--- a/client/my-sites/earn/components/commission-fees.tsx
+++ b/client/my-sites/earn/components/commission-fees.tsx
@@ -1,10 +1,12 @@
 import { ExternalLink } from '@automattic/components';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { preventWidows } from 'calypso/lib/formatting';
 import { useSelector } from 'calypso/state';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getUpsellReturnUrl } from '../upsell-return-url';
 
 type CommissionFeesProps = {
 	className?: string;
@@ -34,7 +36,9 @@ const CommissionFees = ( {
 
 	const upgradeLinkHost = isJetpackNotAtomic
 		? 'https://jetpack.com/creator/#pricing'
-		: `https://wordpress.com/plans/${ siteSlug ? siteSlug : '' }`;
+		: addQueryArgs( `https://wordpress.com/plans/${ siteSlug ? siteSlug : '' }`, {
+				redirect_to: getUpsellReturnUrl(),
+		  } );
 
 	const upgradeLink =
 		commission === 0 || isPlan100YearPlan ? null : (

--- a/client/my-sites/earn/components/test/commission-fees.tsx
+++ b/client/my-sites/earn/components/test/commission-fees.tsx
@@ -1,0 +1,46 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { screen } from '@testing-library/react';
+import uiReducer from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import CommissionFees from '../commission-fees';
+
+const renderCommissionFees = ( site = {} ) =>
+	renderWithProvider( <CommissionFees commission={ 0.08 } siteSlug="example.wordpress.com" />, {
+		initialState: {
+			sites: {
+				items: { 1: { ID: 1, URL: 'https://example.wordpress.com', options: {}, ...site } },
+			},
+			ui: { selectedSiteId: 1 },
+		},
+		reducers: { ui: uiReducer },
+	} );
+
+describe( 'CommissionFees', () => {
+	// Without it, checkout drops the user on the generic thank-you page instead of
+	// the payment settings whose fee they set out to lower.
+	it( 'sends the user back to the page they upgraded from', () => {
+		window.history.pushState( {}, '', '/earn/payments/example.wordpress.com' );
+		renderCommissionFees();
+
+		const url = new URL(
+			screen.getByRole( 'link', { name: /Upgrade to lower/ } ).getAttribute( 'href' ) as string
+		);
+		expect( url.pathname ).toBe( '/plans/example.wordpress.com' );
+		expect( url.searchParams.get( 'redirect_to' ) ).toBe( '/earn/payments/example.wordpress.com' );
+	} );
+
+	it( 'offers no upgrade when there is no fee to lower', () => {
+		renderWithProvider( <CommissionFees commission={ 0 } siteSlug="example.wordpress.com" />, {
+			initialState: {
+				sites: { items: { 1: { ID: 1, URL: 'https://example.wordpress.com', options: {} } } },
+				ui: { selectedSiteId: 1 },
+			},
+			reducers: { ui: uiReducer },
+		} );
+
+		expect( screen.queryByRole( 'link', { name: /Upgrade to lower/ } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -47,6 +47,7 @@ import EarnSupportButton from './components/earn-support-button';
 import StatsSection from './components/stats';
 import { useEarnLaunchpadTasks } from './hooks/use-earn-launchpad-tasks';
 import EarnLaunchpad from './launchpad';
+import { getUpsellCheckoutQueryArgs, getUpsellReturnUrl } from './upsell-return-url';
 
 import './style.scss';
 
@@ -186,6 +187,7 @@ const Home = () => {
 						const url = addQueryArgs( `/plans/${ site?.slug }`, {
 							feature: FEATURE_SIMPLE_PAYMENTS,
 							plan: isNonAtomicJetpack ? PLAN_JETPACK_SECURITY_DAILY : PLAN_PREMIUM,
+							redirect_to: getUpsellReturnUrl(),
 						} );
 						/**
 						 * If the site is Simple, redirect to WP.com plans page even if it's a Jetpack Cloud site.
@@ -408,11 +410,16 @@ const Home = () => {
 							const annualPlanSlug = getYearlyPlanByMonthly( sitePlanSlug );
 							const planPath = annualPlanSlug || undefined;
 							if ( planPath ) {
-								page( `/checkout/${ site.slug }/${ planPath }` );
+								page(
+									addQueryArgs(
+										`/checkout/${ site.slug }/${ planPath }`,
+										getUpsellCheckoutQueryArgs()
+									)
+								);
 								return;
 							}
 						}
-						page( `/plans/${ site?.slug }` );
+						page( addQueryArgs( `/plans/${ site?.slug }`, { redirect_to: getUpsellReturnUrl() } ) );
 					},
 			  };
 
@@ -484,6 +491,7 @@ const Home = () => {
 							const url = addQueryArgs( `/plans/${ site?.slug }`, {
 								feature: FEATURE_WORDADS_INSTANT,
 								plan: PLAN_PREMIUM,
+								redirect_to: getUpsellReturnUrl(),
 							} );
 							/**
 							 * If the site is Simple, redirect to WP.com plans page even if it's a Jetpack Cloud site.

--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -6,6 +6,7 @@ import {
 import { Badge, Button, Card, CompactCard, Gridicon } from '@automattic/components';
 import { formatCurrency } from '@automattic/number-formatters';
 import { __experimentalHStack as HStack } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 import DOMPurify from 'dompurify';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -33,6 +34,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 import RecurringPaymentsPlanAddEditModal from '../components/add-edit-plan-modal';
 import FreePlanModal from '../components/free-plan-modal';
 import { Product } from '../types';
+import { getUpsellReturnUrl } from '../upsell-return-url';
 import {
 	ADD_NEW_PAYMENT_PLAN_HASH,
 	ADD_TIER_PLAN_HASH,
@@ -238,7 +240,9 @@ function ProductsList() {
 								text: translate( 'Upgrade' ),
 								isPrimary: true,
 								action: {
-									url: `/plans/${ site?.slug }`,
+									url: addQueryArgs( `/plans/${ site?.slug }`, {
+										redirect_to: getUpsellReturnUrl(),
+									} ),
 									onClick: trackUpgrade,
 									selfTarget: true,
 								},

--- a/client/my-sites/earn/memberships/test/products-list.tsx
+++ b/client/my-sites/earn/memberships/test/products-list.tsx
@@ -245,4 +245,35 @@ describe( 'ProductsList', () => {
 
 		expect( screen.getByText( 'Hidden from subscribers' ) ).toBeInTheDocument();
 	} );
+
+	// Without it, checkout drops the user on the generic thank-you page instead of
+	// the payment plans they were trying to add.
+	test( 'sends the user back to the payments page after upgrading', () => {
+		window.history.pushState( {}, '', '/earn/payments/example.wordpress.com' );
+		renderWithProvider( <ProductsList />, {
+			initialState: {
+				sites: {
+					items: { 1: { ID: 1, URL: 'https://example.wordpress.com' } },
+					// A loaded feature list without any of the Stripe-backed features is
+					// what puts the site behind the upsell.
+					features: { 1: { data: { active: [ 'wordads' ] } } },
+				},
+				ui: { selectedSiteId: 1 },
+				memberships: { productList: { items: {} }, settings: {} },
+				siteSettings: { items: {}, requesting: { 1: true }, saveRequests: {} },
+			},
+			reducers: {
+				ui: uiReducer,
+				memberships: membershipsReducer,
+				siteSettings: siteSettingsReducer,
+			},
+		} );
+
+		const url = new URL(
+			screen.getByRole( 'link', { name: 'Upgrade' } ).getAttribute( 'href' ),
+			window.location.origin
+		);
+		expect( url.pathname ).toBe( '/plans/example.wordpress.com' );
+		expect( url.searchParams.get( 'redirect_to' ) ).toBe( '/earn/payments/example.wordpress.com' );
+	} );
 } );

--- a/client/my-sites/earn/test/home.tsx
+++ b/client/my-sites/earn/test/home.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import page from '@automattic/calypso-router';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import membershipsReducer from 'calypso/state/memberships/reducer';
+import uiReducer from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import Home from '../home';
+
+jest.mock( '@automattic/calypso-router', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+// Requests stay pending: the cards under test read their state from Redux, not
+// from anything these would return.
+jest.mock( 'calypso/lib/wp', () => {
+	const pending = () => new Promise( () => {} );
+	return { __esModule: true, default: { req: { get: pending, post: pending } } };
+} );
+
+const mockedPage = page as unknown as jest.Mock;
+
+// A monthly plan has none of the monetization features, so every card that can
+// upsell does.
+const renderHome = () =>
+	renderWithProvider( <Home />, {
+		initialState: {
+			currentUser: { capabilities: { 1: { manage_options: true } } },
+			sites: {
+				items: { 1: { ID: 1, URL: 'https://example.wordpress.com', options: {} } },
+				features: { 1: { data: { active: [] } } },
+				plans: {
+					1: { data: [ { currentPlan: true, productSlug: 'personal-bundle-monthly' } ] },
+				},
+			},
+			ui: { selectedSiteId: 1 },
+			memberships: { productList: { items: {} }, settings: {} },
+		},
+		reducers: { ui: uiReducer, memberships: membershipsReducer },
+	} );
+
+const lastDestination = () => new URL( mockedPage.mock.lastCall[ 0 ], window.location.origin );
+
+describe( 'Earn home', () => {
+	beforeEach( () => {
+		mockedPage.mockClear();
+		window.history.pushState( {}, '', '/earn/example.wordpress.com' );
+	} );
+
+	// Without it, checkout drops the user on the generic thank-you page instead of
+	// the monetization tool they set out to use.
+	it( 'sends the user back to the Monetize page after every upgrade', async () => {
+		renderHome();
+
+		const upgrades = screen.getAllByRole( 'button', { name: 'Upgrade' } );
+		expect( upgrades ).toHaveLength( 3 );
+
+		for ( const upgrade of upgrades ) {
+			await userEvent.click( upgrade );
+			expect( lastDestination().searchParams.get( 'redirect_to' ) ).toBe(
+				'/earn/example.wordpress.com'
+			);
+		}
+	} );
+
+	// The plans page forwards `redirect_to` to checkout; a direct checkout link is
+	// expected to carry a cancel destination of its own too.
+	it( 'gives the checkout link a cancel destination', async () => {
+		renderHome();
+
+		// Refer a friend is the only card that skips the plans page, sending a
+		// monthly plan straight to checkout for its annual equivalent.
+		await userEvent.click( screen.getAllByRole( 'button', { name: 'Upgrade' } )[ 2 ] );
+
+		const destination = lastDestination();
+		expect( destination.pathname ).toBe( '/checkout/example.wordpress.com/personal-bundle' );
+		expect( destination.searchParams.get( 'cancel_to' ) ).toBe( '/earn/example.wordpress.com' );
+	} );
+} );

--- a/client/my-sites/earn/test/upsell-return-url.ts
+++ b/client/my-sites/earn/test/upsell-return-url.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+import { getUpsellCheckoutQueryArgs, getUpsellReturnUrl } from '../upsell-return-url';
+
+jest.mock( 'calypso/lib/jetpack/is-jetpack-cloud', () => jest.fn() );
+
+const mockedIsJetpackCloud = isJetpackCloud as jest.MockedFunction< typeof isJetpackCloud >;
+
+describe( 'getUpsellReturnUrl', () => {
+	beforeEach( () => {
+		mockedIsJetpackCloud.mockReturnValue( false );
+		window.history.pushState( {}, '', '/earn/payments/example.wordpress.com' );
+	} );
+
+	it( 'returns the current page as a relative URL', () => {
+		window.history.pushState(
+			{},
+			'',
+			'/earn/payments/example.wordpress.com?foo=bar#add-tier-plan'
+		);
+
+		expect( getUpsellReturnUrl() ).toBe(
+			'/earn/payments/example.wordpress.com?foo=bar#add-tier-plan'
+		);
+	} );
+
+	// Jetpack Cloud checkout runs on WordPress.com, where a relative path would
+	// resolve to a page that does not exist.
+	it( 'returns an absolute URL in Jetpack Cloud', () => {
+		mockedIsJetpackCloud.mockReturnValue( true );
+
+		expect( getUpsellReturnUrl() ).toBe(
+			'https://example.com/earn/payments/example.wordpress.com'
+		);
+	} );
+
+	it( 'pairs the return URL with a cancel destination for checkout links', () => {
+		expect( getUpsellCheckoutQueryArgs() ).toEqual( {
+			redirect_to: '/earn/payments/example.wordpress.com',
+			cancel_to: '/earn/payments/example.wordpress.com',
+		} );
+	} );
+
+	// `leaveCheckout` ignores an absolute `cancel_to`, so sending one would only
+	// look like the cancel destination was honoured.
+	it( 'omits the cancel destination in Jetpack Cloud', () => {
+		mockedIsJetpackCloud.mockReturnValue( true );
+
+		expect( getUpsellCheckoutQueryArgs() ).toEqual( {
+			redirect_to: 'https://example.com/earn/payments/example.wordpress.com',
+		} );
+	} );
+} );

--- a/client/my-sites/earn/upsell-return-url.ts
+++ b/client/my-sites/earn/upsell-return-url.ts
@@ -1,0 +1,31 @@
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
+
+/**
+ * The Monetize page the user is currently on, in the form checkout can redirect
+ * back to, so an upgrade started here returns to the tool that prompted it
+ * instead of the generic thank-you page.
+ *
+ * Jetpack Cloud sends people to checkout on WordPress.com, so Cloud needs an
+ * absolute URL — `cloud.jetpack.com` is one of the hosts checkout is allowed to
+ * redirect back to.
+ */
+export function getUpsellReturnUrl(): string {
+	return isJetpackCloud()
+		? window.location.href
+		: window.location.pathname + window.location.search + window.location.hash;
+}
+
+/**
+ * Query args for an upsell linking straight to `/checkout`, which is expected to
+ * carry both a post-purchase and a cancel destination.
+ *
+ * `cancel_to` is only honoured when it is relative (see `leaveCheckout`), so
+ * Jetpack Cloud gets none and keeps relying on `checkoutBackUrl`.
+ */
+export function getUpsellCheckoutQueryArgs(): Record< string, string > {
+	const returnUrl = getUpsellReturnUrl();
+
+	return isJetpackCloud()
+		? { redirect_to: returnUrl }
+		: { redirect_to: returnUrl, cancel_to: returnUrl };
+}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/MON-97/

## Proposed changes

This adds a `redirect_to` parameter to every upsell in the Monetize section, to return the user to a sensible page after Checkout.

* Add `client/my-sites/earn/upsell-return-url.ts` — `getUpsellReturnUrl()` for the current Monetize page, and `getUpsellCheckoutQueryArgs()` for links that go straight to `/checkout`.
* Attach `redirect_to` to the Collect PayPal payments, Earn ad revenue and Refer a friend cards on the Monetize home page.
* Attach `redirect_to` to the payment plans upsell on the Payment Settings page.
* Attach `redirect_to` to all three WordAds upsells (WordPress.com plan, Jetpack plan, and the ineligible-plan variant).
* Attach `redirect_to` to the “Upgrade to lower it” transaction-fee link.
* Add `cancel_to` alongside `redirect_to` on the three CTAs that link directly to `/checkout`, per the links guidelines in `client/dashboard/docs/links.md` and `client/my-sites/checkout/AGENTS.md`.
* Cover the new behaviour with unit tests for the helper and for all four components that render an upsell.

## Why are these changes being made?

Users that clicked an upsell nudge in the Monetize section were taken to plans, checkout, and then the generic plan-centric Thank You page, which only has actions to manage the purchase and manage the site. This effectively stranded the user away from the Monetize feature that drove their purchase.

## Testing instructions

TC:
```
yarn test-client client/my-sites/earn
```

Manual testing:
* Use a Simple site on a free plan so every Monetize card shows its upsell.
* Visit `/earn/<site>` and click Upgrade on “Collect PayPal payments”, then confirm the plans page URL carries `redirect_to=/earn/<site>` and that the checkout link it builds carries it too.
* Repeat from `/earn/payments/<site>` (payment plans upsell and the “Upgrade to lower it” fee link) and `/earn/ads-settings/<site>` (WordAds upsell) — each should carry the path you started from.
* Complete a purchase from one of them and confirm you land back on the Monetize page you started from instead of the generic thank-you page.
* On the WordAds upsell, exit checkout with the X and confirm `cancel_to` returns you to the ads page.
* Repeat the WordAds upsell check on a self-hosted Jetpack site (Jetpack plan variant) and, if available, from Jetpack Cloud’s `/monetize` to confirm the absolute return URL works.
