### PR TITLE
Purchase settings: correct the pending-renewal comment

### DIFF
--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -395,9 +395,12 @@ export function CancelOrRemoveActionButton( { purchase }: { purchase: Purchase }
 	// When a refund is available with auto-renew still on, the refund path is
 	// surfaced inside the cancel flow via RefundEligibilityNotice instead of
 	// a second CTA here.
-	// Verified against wpcom-billing backend — cancel / disable-auto-renew /
-	// delete endpoints all accept the call in pending-renewal state, so we
-	// don't need to special-case it.
+	// Verified against wpcom-billing backend: disable-auto-renew always accepts
+	// the call. cancel / delete accept it while a renewal is queued but not yet
+	// attempted at the registrar (the backend deletes the pending-renewal flag)
+	// and reject it only while an attempt is due or running,
+	// with a domain-pending-async-renewal error the cancel flow already shows.
+	// No special-casing is needed here.
 	const showCancel =
 		! isBundledWithPlan &&
 		autoRenewOn &&


### PR DESCRIPTION
Related to #DOMENG-383

This is a comment-only change. The old comment said the cancel, disable-auto-renew and delete endpoints all accept the call in pending-renewal state. That was wrong. The backend rejected cancel and delete with a `domain-pending-async-renewal` error whenever the pending-renewal flag was set. The new comment states the real behavior. Disable-auto-renew always accepts the call. Cancel and delete accept it while a renewal is queued but not yet attempted at the registrar, and reject it only while a registrar attempt is due or running. The cancel flow already shows that error, so this page still needs no special-casing.

The wpcom PRs 240455-ghe-Automattic/wpcom and 240456-ghe-Automattic/wpcom carry the behavior change. Merge this PR only after both of them deploy. No code changes here.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01Rnrg2mZeXzvHgKvH6qWeyP

