### PR TITLE
Transfer wait: reword the dedicated server copy

### DIFF
--- a/client/components/transfer-wait/card.tsx
+++ b/client/components/transfer-wait/card.tsx
@@ -115,7 +115,7 @@ export default function TransferWaitCard( {
 					{
 						icon: 'time',
 						text: translate(
-							'Setting up usually takes about a minute — your site is getting its own dedicated server.'
+							'Setting up usually takes about a minute — your site is moving to a dedicated server.'
 						),
 					},
 					{

--- a/client/components/transfer-wait/copy.tsx
+++ b/client/components/transfer-wait/copy.tsx
@@ -8,7 +8,7 @@ import type { ReactNode } from 'react';
 export function useStageTitles(): Record< InstallStageKey, ReactNode > {
 	const translate = useTranslate();
 	return {
-		preparing: translate( 'Preparing a dedicated server for your site' ),
+		preparing: translate( 'Preparing a dedicated server' ),
 		moving: translate( 'Moving your site to its new server' ),
 		finishing: translate( 'Finishing up' ),
 	};
@@ -21,7 +21,7 @@ export function useStageSentences( isPluginInstall = true ): Record< InstallStag
 	const translate = useTranslate();
 	return {
 		preparing: translate(
-			'We’re {{strong}}preparing a dedicated server for your site{{/strong}}.',
+			'We’re {{strong}}preparing a dedicated server{{/strong}} for your site.',
 			{
 				components: { strong: <strong /> },
 			}

--- a/client/components/transfer-wait/test/card.tsx
+++ b/client/components/transfer-wait/test/card.tsx
@@ -18,9 +18,7 @@ describe( 'TransferWaitCard', () => {
 
 	it( 'narrates the preparing stage', () => {
 		render( <TransferWaitCard transferStatus={ transferStates.ACTIVE } fallbackStep={ 1 } /> );
-		expect( screen.getByRole( 'status' ).textContent ).toContain(
-			'preparing a dedicated server for your site'
-		);
+		expect( screen.getByRole( 'status' ).textContent ).toContain( 'preparing a dedicated server' );
 	} );
 	it( 'narrates the moving stage', () => {
 		render( <TransferWaitCard transferStatus={ transferStates.RELOCATING } fallbackStep={ 1 } /> );
@@ -55,7 +53,7 @@ describe( 'TransferWaitCard', () => {
 		render( <TransferWaitCard transferStatus={ transferStates.ACTIVE } fallbackStep={ 1 } /> );
 		expect( screen.getByRole( 'progressbar' ) ).toHaveAttribute(
 			'aria-label',
-			'Preparing a dedicated server for your site'
+			'Preparing a dedicated server'
 		);
 	} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/test/index.tsx
@@ -43,12 +43,10 @@ describe( 'ProcessingStep', () => {
 		render( { flow: TRANSFERRING_HOSTED_SITE_FLOW } );
 
 		expect( screen.getByText( 'Setting up your site' ) ).toBeVisible();
-		expect( screen.getByRole( 'status' ).textContent ).toContain(
-			'preparing a dedicated server for your site'
-		);
+		expect( screen.getByRole( 'status' ).textContent ).toContain( 'preparing a dedicated server' );
 		expect( screen.getByRole( 'progressbar' ) ).toHaveAttribute(
 			'aria-label',
-			'Preparing a dedicated server for your site'
+			'Preparing a dedicated server'
 		);
 	} );
 


### PR DESCRIPTION
## Proposed Changes

**Reword the transfer wait copy so it no longer sounds like the site gets its own VPS.**

- Checklist line: "your site is getting its own dedicated server" → "your site is moving to a dedicated server".
- Preparing stage title: "Preparing a dedicated server for your site" → "Preparing a dedicated server" (the narrated sentence keeps "for your site" outside the emphasized phrase).

## Why are these changes being made?

While a site moves to Atomic hosting, the wait screen said the site was "getting its own dedicated server". That reads as a promise of a private server of your own, which is not what happens. Feedback on the recap post asked for wording that describes the move without the ownership claim.

## Testing Instructions

1. `yarn start`, install a plugin from the marketplace on a Simple site (or start a hosted-site creation flow).
2. On the wait screen, check the stage title and the "Here's what to expect" list.
3. Copy reads "Preparing a dedicated server" and "your site is moving to a dedicated server".
