### PR TITLE
Pricing grid: restore custom features/plans for pricing intents

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -1439,7 +1439,10 @@ const PlansFeaturesMain = ( {
 					intent={ intent }
 					isPlansGridRedesign={ usePlansGridRedesign }
 					showDifferentiatorHeader={
-						showDifferentiatorHeader || showPlansGridRedesignDifferentiatorHeader
+						// The "Paid plans include:" strip is part of the pricing-differentiation
+						// presentation, so an intent that curates its own grid does not get it.
+						( showDifferentiatorHeader || showPlansGridRedesignDifferentiatorHeader ) &&
+						! hasTailoredFeatureList( intent )
 					}
 				/>
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -1439,10 +1439,7 @@ const PlansFeaturesMain = ( {
 					intent={ intent }
 					isPlansGridRedesign={ usePlansGridRedesign }
 					showDifferentiatorHeader={
-						// The "Paid plans include:" strip is part of the pricing-differentiation
-						// presentation, so an intent that curates its own grid does not get it.
-						( showDifferentiatorHeader || showPlansGridRedesignDifferentiatorHeader ) &&
-						! hasTailoredFeatureList( intent )
+						showDifferentiatorHeader || showPlansGridRedesignDifferentiatorHeader
 					}
 				/>
 				{ ! isPlansGridReady && <Spinner size={ 30 } /> }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -1270,7 +1270,10 @@ const PlansFeaturesMain = ( {
 		featureGroupMapForComparisonGrid = getWooExpressFeaturesGroupedForComparisonGrid();
 	} else {
 		featureGroupMapForComparisonGrid = getPlanFeaturesGroupedForComparisonGrid( {
-			isExperimentVariant,
+			// The row set has to match the feature lists the comparison grid is built from, which a
+			// curated intent keeps for itself. Leaving this un-gated pairs experiment rows and group
+			// titles with a control list.
+			isExperimentVariant: isExperimentVariant && ! hasTailoredFeatureList( intent ),
 		} );
 	}
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -44,6 +44,7 @@ import {
 	useGridPlansForComparisonGrid,
 	useGridPlanForSpotlight,
 	usePlanBillingPeriod,
+	hasTailoredFeatureList,
 } from '@automattic/plans-grid-next';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import styled from '@emotion/styled';
@@ -1280,9 +1281,13 @@ const PlansFeaturesMain = ( {
 		featureGroupMapForFeaturesGrid = getWooExpressFeaturesGroupedForFeaturesGrid();
 	} else if ( intent === 'plans-wordpress-hosting' ) {
 		featureGroupMapForFeaturesGrid = getWordPressHostingFeaturesGroupedForFeaturesGrid();
-	} else if ( useVar42NoAiFeatures || usePlansGridRedesignFeatures ) {
+	} else if (
+		( useVar42NoAiFeatures || usePlansGridRedesignFeatures ) &&
+		! hasTailoredFeatureList( intent )
+	) {
 		// Stacked rollout variant should render a single, ordered list (no grouping),
 		// otherwise features get scattered across groups causing gaps and can be filtered out.
+		// Skipped for intents that curate their own feature list, whose grouping is theirs too.
 		const featureGroups = getPlanFeaturesGroupedForFeaturesGrid();
 		featureGroupMapForFeaturesGrid = Object.fromEntries(
 			Object.entries( featureGroups ).reverse()

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -255,37 +255,6 @@ describe( 'PlansFeaturesMain', () => {
 		} );
 	} );
 
-	describe( 'differentiator header', () => {
-		// The "Paid plans include:" strip belongs to the pricing-differentiation presentation, so it
-		// must not appear on a grid an intent curates for itself.
-		const enableDifferentiatorHeader = () =>
-			usePlansGridRedesignExperiment.mockImplementation( () => ( {
-				isLoading: false,
-				variant: 'six_plan_new_features',
-				usePlansGridRedesign: true,
-				showDifferentiatorHeader: true,
-				showEnterpriseBottomCard: false,
-				showWooCommerceBottomCard: false,
-				isExperimentEligible: true,
-			} ) );
-
-		test( 'renders the strip for an intent with no curated grid of its own', () => {
-			enableDifferentiatorHeader();
-
-			renderWithProvider( <PlansFeaturesMain { ...props } intent="plans-default-wpcom" /> );
-
-			expect( screen.getByText( 'Paid plans include:' ) ).toBeInTheDocument();
-		} );
-
-		test( 'omits the strip for an intent that curates its own grid', () => {
-			enableDifferentiatorHeader();
-
-			renderWithProvider( <PlansFeaturesMain { ...props } intent="plans-newsletter" /> );
-
-			expect( screen.queryByText( 'Paid plans include:' ) ).not.toBeInTheDocument();
-		} );
-	} );
-
 	describe( 'PlansFeaturesMain. Plan exclusion props', () => {
 		test( 'Should render <PlanFeatures /> removing the free plan when hideFreePlan prop is present, regardless of its position', () => {
 			renderWithProvider( <PlansFeaturesMain { ...props } hideFreePlan /> );

--- a/client/my-sites/plans-features-main/test/index.jsx
+++ b/client/my-sites/plans-features-main/test/index.jsx
@@ -255,6 +255,37 @@ describe( 'PlansFeaturesMain', () => {
 		} );
 	} );
 
+	describe( 'differentiator header', () => {
+		// The "Paid plans include:" strip belongs to the pricing-differentiation presentation, so it
+		// must not appear on a grid an intent curates for itself.
+		const enableDifferentiatorHeader = () =>
+			usePlansGridRedesignExperiment.mockImplementation( () => ( {
+				isLoading: false,
+				variant: 'six_plan_new_features',
+				usePlansGridRedesign: true,
+				showDifferentiatorHeader: true,
+				showEnterpriseBottomCard: false,
+				showWooCommerceBottomCard: false,
+				isExperimentEligible: true,
+			} ) );
+
+		test( 'renders the strip for an intent with no curated grid of its own', () => {
+			enableDifferentiatorHeader();
+
+			renderWithProvider( <PlansFeaturesMain { ...props } intent="plans-default-wpcom" /> );
+
+			expect( screen.getByText( 'Paid plans include:' ) ).toBeInTheDocument();
+		} );
+
+		test( 'omits the strip for an intent that curates its own grid', () => {
+			enableDifferentiatorHeader();
+
+			renderWithProvider( <PlansFeaturesMain { ...props } intent="plans-newsletter" /> );
+
+			expect( screen.queryByText( 'Paid plans include:' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
 	describe( 'PlansFeaturesMain. Plan exclusion props', () => {
 		test( 'Should render <PlanFeatures /> removing the free plan when hideFreePlan prop is present, regardless of its position', () => {
 			renderWithProvider( <PlansFeaturesMain { ...props } hideFreePlan /> );

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -27,6 +27,7 @@ import {
 	forwardRef,
 } from 'react';
 import { useInView } from 'react-intersection-observer';
+import { hasTailoredFeatureList } from '../../constants';
 import { plansGridMediumLarge } from '../../css-mixins';
 import PlansGridContextProvider, { usePlansGridContext } from '../../grid-context';
 import useGridSize from '../../hooks/use-grid-size';
@@ -934,16 +935,22 @@ const FeatureGroup = ( {
 	};
 	plansLength: number;
 } ) => {
-	const { allFeaturesList, isExperimentVariant } = usePlansGridContext();
+	const { allFeaturesList, intent, isExperimentVariant } = usePlansGridContext();
 	const [ firstSetOfFeatures ] = Object.keys( featureGroupMap );
 	const [ visibleFeatureGroups, setVisibleFeatureGroups ] = useState< string[] >( [
 		firstSetOfFeatures,
 	] );
 	const features = featureGroup.getFeatures();
 
+	// Row titles follow the list: the experiment copy renames features the experiment override
+	// lists, so pairing it with a curated list mistitles the rows.
 	const featureObjects = filterUnusedFeaturesObject(
 		visibleGridPlans,
-		getPlanFeaturesObject( allFeaturesList, features, isExperimentVariant )
+		getPlanFeaturesObject(
+			allFeaturesList,
+			features,
+			isExperimentVariant && ! hasTailoredFeatureList( intent )
+		)
 	);
 
 	const isHiddenInMobile = ! visibleFeatureGroups.includes( featureGroup.slug );

--- a/packages/plans-grid-next/src/constants.ts
+++ b/packages/plans-grid-next/src/constants.ts
@@ -4,6 +4,7 @@ import {
 	TERM_MONTHLY,
 	TERM_TRIENNIALLY,
 } from '@automattic/calypso-products';
+import type { PlansIntent } from './types';
 
 export const EFFECTIVE_TERMS_LIST = < const >[
 	TERM_MONTHLY,
@@ -11,3 +12,34 @@ export const EFFECTIVE_TERMS_LIST = < const >[
 	TERM_BIENNIALLY,
 	TERM_TRIENNIALLY,
 ];
+
+/**
+ * Intents whose feature list is curated for one product surface: a newsletter site, a P2 workspace,
+ * a Woo Express trial, the hosting funnel.
+ *
+ * The pricing-differentiation feature lists (`useVar42NoAiFeatures`,
+ * `usePlansGridRedesignFeatures`) are the default presentation for a site, so they are checked
+ * before every intent branch in usePlanFeaturesForGridPlans. Without this list they would shadow
+ * the curated lists entirely, leaving the choice of grid up to how old the site is -- a site with
+ * the gating flag would see the differentiation list on the P2 plans page while an older workspace
+ * saw the P2 one. An intent is a deliberate statement about the surface, so it wins.
+ *
+ * `plans-blog-onboarding` is included for completeness: no flow produces it today (see the note on
+ * PlansIntent), but its branch is still wired up.
+ */
+export const TAILORED_FEATURE_LIST_INTENTS: readonly PlansIntent[] = [
+	'plans-blog-onboarding',
+	'plans-newsletter',
+	'plans-p2',
+	'plans-woocommerce',
+	'plans-wordpress-hosting',
+];
+
+/**
+ * Whether the given intent curates its own feature list, and so must not be overridden by the
+ * pricing-differentiation lists.
+ * @param intent The resolved plans intent, if any.
+ */
+export function hasTailoredFeatureList( intent?: PlansIntent | null ): boolean {
+	return !! intent && TAILORED_FEATURE_LIST_INTENTS.includes( intent );
+}

--- a/packages/plans-grid-next/src/hooks/data-store/test/use-plan-features-for-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/test/use-plan-features-for-grid-plans.tsx
@@ -11,67 +11,125 @@ jest.mock( 'i18n-calypso', () => ( {
 	useRtl: () => false,
 } ) );
 
-// Only the plan-constants lookup is stubbed; the FEATURE_* constants and helpers stay real so the
-// branch under test is the real one.
-jest.mock( '@automattic/calypso-products', () => ( {
-	...jest.requireActual( '@automattic/calypso-products' ),
-	applyTestFiltersToPlansList: () => ( {
-		getVar42NoAiSignupWpcomFeatures: () => [ 'differentiation-feature' ],
-		getNewsletterSignupFeatures: () => [ 'newsletter-feature' ],
-		get2023PricingGridSignupWpcomFeatures: () => [ 'default-feature' ],
-		get2023PricingGridSignupJetpackFeatures: () => [],
-		// The transform only walks wpcomFeatures when the plan has at least one annual-only
-		// feature, so a non-empty list is needed for anything to come back at all.
-		getAnnualPlansOnlyFeatures: () => [ 'annual-only-feature' ],
-	} ),
-} ) );
+// Only the plan-constants lookup is stubbed; the FEATURE_* constants and the plan-type predicates
+// stay real so the branches under test are the real ones.
+jest.mock( '@automattic/calypso-products', () => {
+	const actual = jest.requireActual( '@automattic/calypso-products' );
 
+	return {
+		...actual,
+		applyTestFiltersToPlansList: () => ( {
+			// Each list carries a marker slug identifying it, plus one real feature that earns a
+			// pricing-differentiation pill, so one fixture covers both the list choice and the
+			// presentation that comes with it.
+			getVar42NoAiSignupWpcomFeatures: () => [
+				'differentiation-feature',
+				actual.FEATURE_SIMPLE_PAYMENTS,
+			],
+			getNewsletterSignupFeatures: () => [ 'newsletter-feature', actual.FEATURE_SIMPLE_PAYMENTS ],
+			get2023PricingGridSignupWpcomFeatures: () => [
+				'default-feature',
+				actual.FEATURE_SIMPLE_PAYMENTS,
+			],
+			get2023PricingGridSignupJetpackFeatures: () => [],
+			// The transform only walks wpcomFeatures when the plan has at least one annual-only
+			// feature, so a non-empty list is needed for anything to come back at all.
+			getAnnualPlansOnlyFeatures: () => [ 'annual-only-feature' ],
+		} ),
+	};
+} );
+
+import { FEATURE_SIMPLE_PAYMENTS } from '@automattic/calypso-products';
 import { renderHook } from '@testing-library/react';
 import usePlanFeaturesForGridPlans from '../use-plan-features-for-grid-plans';
 import type { GridPlan, PlansIntent } from '../../../types';
 import type { FeatureList } from '@automattic/calypso-products';
 
+// Premium, because getPricingDifferentiationFeatureBadgeText() pills FEATURE_SIMPLE_PAYMENTS as
+// "New" on premium plans.
 const PREMIUM = 'value_bundle';
 
+const feature = ( slug: string ) => ( { getSlug: () => slug, getTitle: () => slug } );
+
 const ALL_FEATURES = {
-	'differentiation-feature': { getSlug: () => 'differentiation-feature', getTitle: () => 'D' },
-	'newsletter-feature': { getSlug: () => 'newsletter-feature', getTitle: () => 'N' },
-	'default-feature': { getSlug: () => 'default-feature', getTitle: () => 'F' },
+	'differentiation-feature': feature( 'differentiation-feature' ),
+	'newsletter-feature': feature( 'newsletter-feature' ),
+	'default-feature': feature( 'default-feature' ),
+	[ FEATURE_SIMPLE_PAYMENTS ]: feature( FEATURE_SIMPLE_PAYMENTS ),
 } as unknown as FeatureList;
 
 const GRID_PLANS = [ { planSlug: PREMIUM } ] as Omit< GridPlan, 'features' >[];
 
-function slugsFor( intent?: PlansIntent, useVar42NoAiFeatures = true ) {
+function featuresFor( intent?: PlansIntent ) {
 	const { result } = renderHook( () =>
 		usePlanFeaturesForGridPlans( {
 			gridPlans: GRID_PLANS,
 			allFeaturesList: ALL_FEATURES,
 			intent,
-			useVar42NoAiFeatures,
+			useVar42NoAiFeatures: true,
+			showPricingDifferentiationFeaturePills: true,
+			isExperimentVariant: true,
 		} )
 	);
 
-	return result.current[ PREMIUM ].wpcomFeatures.map( ( feature ) => feature.getSlug() );
+	return result.current[ PREMIUM ].wpcomFeatures;
 }
+
+const slugsFor = ( intent?: PlansIntent ) => featuresFor( intent ).map( ( f ) => f.getSlug() );
 
 describe( 'usePlanFeaturesForGridPlans feature-list precedence', () => {
 	it( 'uses the pricing-differentiation list when no intent curates its own', () => {
-		expect( slugsFor( undefined ) ).toEqual( [ 'differentiation-feature' ] );
+		expect( slugsFor( undefined ) ).toEqual( [
+			'differentiation-feature',
+			FEATURE_SIMPLE_PAYMENTS,
+		] );
 	} );
 
 	it( 'keeps a curated intent list even when the differentiation list is enabled', () => {
 		// The regression this guards: the differentiation branch is checked first, so before
 		// TAILORED_FEATURE_LIST_INTENTS it shadowed every intent branch, and which grid a
 		// newsletter site saw depended on whether it carried the gating flag.
-		expect( slugsFor( 'plans-newsletter' ) ).toEqual( [ 'newsletter-feature' ] );
+		expect( slugsFor( 'plans-newsletter' ) ).toEqual( [
+			'newsletter-feature',
+			FEATURE_SIMPLE_PAYMENTS,
+		] );
 	} );
 
 	it( 'falls back to the default list for a curated intent with no list of its own', () => {
 		// plans-p2 and plans-woocommerce share the default list rather than defining one.
-		expect( slugsFor( 'plans-p2' ) ).toEqual( [ 'default-feature' ] );
+		expect( slugsFor( 'plans-p2' ) ).toEqual( [ 'default-feature', FEATURE_SIMPLE_PAYMENTS ] );
 	} );
 
 	it( 'leaves non-curated intents on the differentiation list', () => {
-		expect( slugsFor( 'plans-upgrade' ) ).toEqual( [ 'differentiation-feature' ] );
+		expect( slugsFor( 'plans-upgrade' ) ).toEqual( [
+			'differentiation-feature',
+			FEATURE_SIMPLE_PAYMENTS,
+		] );
+	} );
+} );
+
+describe( 'usePlanFeaturesForGridPlans differentiation presentation', () => {
+	const badgeFor = ( intent?: PlansIntent ) =>
+		featuresFor( intent ).find( ( f ) => f.getSlug() === FEATURE_SIMPLE_PAYMENTS )?.badgeText;
+
+	const lastFeatureMarked = ( intent?: PlansIntent ) => {
+		const features = featuresFor( intent );
+
+		return !! features[ features.length - 1 ].isExperimentLastFeature;
+	};
+
+	it( 'pills a feature and marks the last one when the differentiation list is in use', () => {
+		expect( badgeFor( undefined ) ).toBe( 'New' );
+		expect( lastFeatureMarked( undefined ) ).toBe( true );
+	} );
+
+	it( 'drops the pills on a curated list', () => {
+		// The pills and the stacked layout's trailing margin belong to the differentiation
+		// presentation; on a curated list they would decorate a grid that is not part of it.
+		expect( badgeFor( 'plans-newsletter' ) ).toBeUndefined();
+	} );
+
+	it( 'drops the last-feature margin marker on a curated list', () => {
+		expect( lastFeatureMarked( 'plans-newsletter' ) ).toBe( false );
 	} );
 } );

--- a/packages/plans-grid-next/src/hooks/data-store/test/use-plan-features-for-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/test/use-plan-features-for-grid-plans.tsx
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( text: string ) => text,
+	translate: ( text: string ) => text,
+	// requireActual( calypso-products ) below reaches @automattic/components, which localizes a
+	// class component at module scope.
+	localize: ( component: unknown ) => component,
+	useRtl: () => false,
+} ) );
+
+// Only the plan-constants lookup is stubbed; the FEATURE_* constants and helpers stay real so the
+// branch under test is the real one.
+jest.mock( '@automattic/calypso-products', () => ( {
+	...jest.requireActual( '@automattic/calypso-products' ),
+	applyTestFiltersToPlansList: () => ( {
+		getVar42NoAiSignupWpcomFeatures: () => [ 'differentiation-feature' ],
+		getNewsletterSignupFeatures: () => [ 'newsletter-feature' ],
+		get2023PricingGridSignupWpcomFeatures: () => [ 'default-feature' ],
+		get2023PricingGridSignupJetpackFeatures: () => [],
+		// The transform only walks wpcomFeatures when the plan has at least one annual-only
+		// feature, so a non-empty list is needed for anything to come back at all.
+		getAnnualPlansOnlyFeatures: () => [ 'annual-only-feature' ],
+	} ),
+} ) );
+
+import { renderHook } from '@testing-library/react';
+import usePlanFeaturesForGridPlans from '../use-plan-features-for-grid-plans';
+import type { GridPlan, PlansIntent } from '../../../types';
+import type { FeatureList } from '@automattic/calypso-products';
+
+const PREMIUM = 'value_bundle';
+
+const ALL_FEATURES = {
+	'differentiation-feature': { getSlug: () => 'differentiation-feature', getTitle: () => 'D' },
+	'newsletter-feature': { getSlug: () => 'newsletter-feature', getTitle: () => 'N' },
+	'default-feature': { getSlug: () => 'default-feature', getTitle: () => 'F' },
+} as unknown as FeatureList;
+
+const GRID_PLANS = [ { planSlug: PREMIUM } ] as Omit< GridPlan, 'features' >[];
+
+function slugsFor( intent?: PlansIntent, useVar42NoAiFeatures = true ) {
+	const { result } = renderHook( () =>
+		usePlanFeaturesForGridPlans( {
+			gridPlans: GRID_PLANS,
+			allFeaturesList: ALL_FEATURES,
+			intent,
+			useVar42NoAiFeatures,
+		} )
+	);
+
+	return result.current[ PREMIUM ].wpcomFeatures.map( ( feature ) => feature.getSlug() );
+}
+
+describe( 'usePlanFeaturesForGridPlans feature-list precedence', () => {
+	it( 'uses the pricing-differentiation list when no intent curates its own', () => {
+		expect( slugsFor( undefined ) ).toEqual( [ 'differentiation-feature' ] );
+	} );
+
+	it( 'keeps a curated intent list even when the differentiation list is enabled', () => {
+		// The regression this guards: the differentiation branch is checked first, so before
+		// TAILORED_FEATURE_LIST_INTENTS it shadowed every intent branch, and which grid a
+		// newsletter site saw depended on whether it carried the gating flag.
+		expect( slugsFor( 'plans-newsletter' ) ).toEqual( [ 'newsletter-feature' ] );
+	} );
+
+	it( 'falls back to the default list for a curated intent with no list of its own', () => {
+		// plans-p2 and plans-woocommerce share the default list rather than defining one.
+		expect( slugsFor( 'plans-p2' ) ).toEqual( [ 'default-feature' ] );
+	} );
+
+	it( 'leaves non-curated intents on the differentiation list', () => {
+		expect( slugsFor( 'plans-upgrade' ) ).toEqual( [ 'differentiation-feature' ] );
+	} );
+} );

--- a/packages/plans-grid-next/src/hooks/data-store/test/use-plan-features-for-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/test/use-plan-features-for-grid-plans.tsx
@@ -11,125 +11,67 @@ jest.mock( 'i18n-calypso', () => ( {
 	useRtl: () => false,
 } ) );
 
-// Only the plan-constants lookup is stubbed; the FEATURE_* constants and the plan-type predicates
-// stay real so the branches under test are the real ones.
-jest.mock( '@automattic/calypso-products', () => {
-	const actual = jest.requireActual( '@automattic/calypso-products' );
+// Only the plan-constants lookup is stubbed; the FEATURE_* constants and helpers stay real so the
+// branch under test is the real one.
+jest.mock( '@automattic/calypso-products', () => ( {
+	...jest.requireActual( '@automattic/calypso-products' ),
+	applyTestFiltersToPlansList: () => ( {
+		getVar42NoAiSignupWpcomFeatures: () => [ 'differentiation-feature' ],
+		getNewsletterSignupFeatures: () => [ 'newsletter-feature' ],
+		get2023PricingGridSignupWpcomFeatures: () => [ 'default-feature' ],
+		get2023PricingGridSignupJetpackFeatures: () => [],
+		// The transform only walks wpcomFeatures when the plan has at least one annual-only
+		// feature, so a non-empty list is needed for anything to come back at all.
+		getAnnualPlansOnlyFeatures: () => [ 'annual-only-feature' ],
+	} ),
+} ) );
 
-	return {
-		...actual,
-		applyTestFiltersToPlansList: () => ( {
-			// Each list carries a marker slug identifying it, plus one real feature that earns a
-			// pricing-differentiation pill, so one fixture covers both the list choice and the
-			// presentation that comes with it.
-			getVar42NoAiSignupWpcomFeatures: () => [
-				'differentiation-feature',
-				actual.FEATURE_SIMPLE_PAYMENTS,
-			],
-			getNewsletterSignupFeatures: () => [ 'newsletter-feature', actual.FEATURE_SIMPLE_PAYMENTS ],
-			get2023PricingGridSignupWpcomFeatures: () => [
-				'default-feature',
-				actual.FEATURE_SIMPLE_PAYMENTS,
-			],
-			get2023PricingGridSignupJetpackFeatures: () => [],
-			// The transform only walks wpcomFeatures when the plan has at least one annual-only
-			// feature, so a non-empty list is needed for anything to come back at all.
-			getAnnualPlansOnlyFeatures: () => [ 'annual-only-feature' ],
-		} ),
-	};
-} );
-
-import { FEATURE_SIMPLE_PAYMENTS } from '@automattic/calypso-products';
 import { renderHook } from '@testing-library/react';
 import usePlanFeaturesForGridPlans from '../use-plan-features-for-grid-plans';
 import type { GridPlan, PlansIntent } from '../../../types';
 import type { FeatureList } from '@automattic/calypso-products';
 
-// Premium, because getPricingDifferentiationFeatureBadgeText() pills FEATURE_SIMPLE_PAYMENTS as
-// "New" on premium plans.
 const PREMIUM = 'value_bundle';
 
-const feature = ( slug: string ) => ( { getSlug: () => slug, getTitle: () => slug } );
-
 const ALL_FEATURES = {
-	'differentiation-feature': feature( 'differentiation-feature' ),
-	'newsletter-feature': feature( 'newsletter-feature' ),
-	'default-feature': feature( 'default-feature' ),
-	[ FEATURE_SIMPLE_PAYMENTS ]: feature( FEATURE_SIMPLE_PAYMENTS ),
+	'differentiation-feature': { getSlug: () => 'differentiation-feature', getTitle: () => 'D' },
+	'newsletter-feature': { getSlug: () => 'newsletter-feature', getTitle: () => 'N' },
+	'default-feature': { getSlug: () => 'default-feature', getTitle: () => 'F' },
 } as unknown as FeatureList;
 
 const GRID_PLANS = [ { planSlug: PREMIUM } ] as Omit< GridPlan, 'features' >[];
 
-function featuresFor( intent?: PlansIntent ) {
+function slugsFor( intent?: PlansIntent, useVar42NoAiFeatures = true ) {
 	const { result } = renderHook( () =>
 		usePlanFeaturesForGridPlans( {
 			gridPlans: GRID_PLANS,
 			allFeaturesList: ALL_FEATURES,
 			intent,
-			useVar42NoAiFeatures: true,
-			showPricingDifferentiationFeaturePills: true,
-			isExperimentVariant: true,
+			useVar42NoAiFeatures,
 		} )
 	);
 
-	return result.current[ PREMIUM ].wpcomFeatures;
+	return result.current[ PREMIUM ].wpcomFeatures.map( ( feature ) => feature.getSlug() );
 }
-
-const slugsFor = ( intent?: PlansIntent ) => featuresFor( intent ).map( ( f ) => f.getSlug() );
 
 describe( 'usePlanFeaturesForGridPlans feature-list precedence', () => {
 	it( 'uses the pricing-differentiation list when no intent curates its own', () => {
-		expect( slugsFor( undefined ) ).toEqual( [
-			'differentiation-feature',
-			FEATURE_SIMPLE_PAYMENTS,
-		] );
+		expect( slugsFor( undefined ) ).toEqual( [ 'differentiation-feature' ] );
 	} );
 
 	it( 'keeps a curated intent list even when the differentiation list is enabled', () => {
 		// The regression this guards: the differentiation branch is checked first, so before
 		// TAILORED_FEATURE_LIST_INTENTS it shadowed every intent branch, and which grid a
 		// newsletter site saw depended on whether it carried the gating flag.
-		expect( slugsFor( 'plans-newsletter' ) ).toEqual( [
-			'newsletter-feature',
-			FEATURE_SIMPLE_PAYMENTS,
-		] );
+		expect( slugsFor( 'plans-newsletter' ) ).toEqual( [ 'newsletter-feature' ] );
 	} );
 
 	it( 'falls back to the default list for a curated intent with no list of its own', () => {
 		// plans-p2 and plans-woocommerce share the default list rather than defining one.
-		expect( slugsFor( 'plans-p2' ) ).toEqual( [ 'default-feature', FEATURE_SIMPLE_PAYMENTS ] );
+		expect( slugsFor( 'plans-p2' ) ).toEqual( [ 'default-feature' ] );
 	} );
 
 	it( 'leaves non-curated intents on the differentiation list', () => {
-		expect( slugsFor( 'plans-upgrade' ) ).toEqual( [
-			'differentiation-feature',
-			FEATURE_SIMPLE_PAYMENTS,
-		] );
-	} );
-} );
-
-describe( 'usePlanFeaturesForGridPlans differentiation presentation', () => {
-	const badgeFor = ( intent?: PlansIntent ) =>
-		featuresFor( intent ).find( ( f ) => f.getSlug() === FEATURE_SIMPLE_PAYMENTS )?.badgeText;
-
-	const lastFeatureMarked = ( intent?: PlansIntent ) => {
-		const features = featuresFor( intent );
-
-		return !! features[ features.length - 1 ].isExperimentLastFeature;
-	};
-
-	it( 'pills a feature and marks the last one when the differentiation list is in use', () => {
-		expect( badgeFor( undefined ) ).toBe( 'New' );
-		expect( lastFeatureMarked( undefined ) ).toBe( true );
-	} );
-
-	it( 'drops the pills on a curated list', () => {
-		// The pills and the stacked layout's trailing margin belong to the differentiation
-		// presentation; on a curated list they would decorate a grid that is not part of it.
-		expect( badgeFor( 'plans-newsletter' ) ).toBeUndefined();
-	} );
-
-	it( 'drops the last-feature margin marker on a curated list', () => {
-		expect( lastFeatureMarked( 'plans-newsletter' ) ).toBe( false );
+		expect( slugsFor( 'plans-upgrade' ) ).toEqual( [ 'differentiation-feature' ] );
 	} );
 } );

--- a/packages/plans-grid-next/src/hooks/data-store/test/use-restructured-plan-features-for-comparison-grid.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/test/use-restructured-plan-features-for-comparison-grid.tsx
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock( 'i18n-calypso', () => ( {
+	useTranslate: () => ( text: string ) => text,
+	translate: ( text: string ) => text,
+	// requireActual( calypso-products ) below reaches @automattic/components, which localizes a
+	// class component at module scope.
+	localize: ( component: unknown ) => component,
+	useRtl: () => false,
+} ) );
+
+jest.mock( '@automattic/calypso-products', () => {
+	const actual = jest.requireActual( '@automattic/calypso-products' );
+
+	return {
+		...actual,
+		applyTestFiltersToPlansList: () => ( {
+			get2023PlanComparisonFeatureOverrideForExperiment: () => [ 'experiment-feature' ],
+			get2023PlanComparisonFeatureOverride: () => [ 'control-feature' ],
+			get2023PricingGridSignupWpcomFeatures: () => [ 'default-feature' ],
+			get2023PricingGridSignupJetpackFeatures: () => [],
+			get2023PlanComparisonJetpackFeatureOverride: () => [],
+			getVar42NoAiSignupWpcomFeatures: () => [ 'differentiation-feature' ],
+			getAnnualPlansOnlyFeatures: () => [ 'annual-only-feature' ],
+			// Stands in for the real per-plan labels, which say "Free support" under the experiment
+			// and "Support from our expert team" otherwise (plans-list.tsx).
+			getPlanComparisonFeatureLabels: ( { isExperimentVariant } = {} ) => ( {
+				support: isExperimentVariant ? 'experiment copy' : 'control copy',
+			} ),
+		} ),
+	};
+} );
+
+import { renderHook } from '@testing-library/react';
+import useRestructuredPlanFeaturesForComparisonGrid from '../use-restructured-plan-features-for-comparison-grid';
+import type { GridPlan, PlansIntent } from '../../../types';
+import type { FeatureList } from '@automattic/calypso-products';
+
+const PREMIUM = 'value_bundle';
+
+const feature = ( slug: string ) => ( { getSlug: () => slug, getTitle: () => slug } );
+
+const ALL_FEATURES = {
+	'experiment-feature': feature( 'experiment-feature' ),
+	'control-feature': feature( 'control-feature' ),
+	'default-feature': feature( 'default-feature' ),
+	'differentiation-feature': feature( 'differentiation-feature' ),
+} as unknown as FeatureList;
+
+const GRID_PLANS = [ { planSlug: PREMIUM } ] as Omit< GridPlan, 'features' >[];
+
+function comparisonFor( intent?: PlansIntent ) {
+	const { result } = renderHook( () =>
+		useRestructuredPlanFeaturesForComparisonGrid( {
+			gridPlans: GRID_PLANS,
+			allFeaturesList: ALL_FEATURES,
+			intent,
+			useVar42NoAiFeatures: true,
+			isExperimentVariant: true,
+		} )
+	);
+
+	return result.current[ PREMIUM ];
+}
+
+describe( 'useRestructuredPlanFeaturesForComparisonGrid', () => {
+	it( 'uses the experiment override and its labels when no intent curates its own list', () => {
+		const { wpcomFeatures, comparisonGridFeatureLabels } = comparisonFor( undefined );
+
+		expect( wpcomFeatures.map( ( f ) => f.getSlug() ) ).toEqual( [ 'experiment-feature' ] );
+		expect( comparisonGridFeatureLabels ).toEqual( { support: 'experiment copy' } );
+	} );
+
+	it( 'labels a curated list with the control copy', () => {
+		// The list and its labels have to come from the same side: experiment copy describes the
+		// features the experiment override lists, so on a control list it mislabels the rows.
+		const { wpcomFeatures, comparisonGridFeatureLabels } = comparisonFor( 'plans-newsletter' );
+
+		expect( wpcomFeatures.map( ( f ) => f.getSlug() ) ).toEqual( [ 'control-feature' ] );
+		expect( comparisonGridFeatureLabels ).toEqual( { support: 'control copy' } );
+	} );
+} );

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
@@ -286,6 +286,10 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 		 * The pricing-differentiation lists are the default presentation, not an override: an intent
 		 * that curates its own list keeps it. Checked here rather than by reordering the branches
 		 * below, so the relative order of the intent branches themselves is untouched.
+		 *
+		 * This also governs the presentation that belongs with those lists -- the feature pills and
+		 * the trailing margin of the stacked layout -- so a curated list is not left half-dressed in
+		 * differentiation styling.
 		 */
 		const useDifferentiationFeatures = ! hasTailoredFeatureList( intent );
 
@@ -484,11 +488,12 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 
 						const featureSlug = feature.getSlug();
 
-						const badgeText = showPricingDifferentiationFeaturePills
-							? getPricingDifferentiationFeatureBadgeText( planSlug, featureSlug, translate, {
-									suppressAiPills: useVar42NoAiFeatures,
-							  } )
-							: undefined;
+						const badgeText =
+							showPricingDifferentiationFeaturePills && useDifferentiationFeatures
+								? getPricingDifferentiationFeatureBadgeText( planSlug, featureSlug, translate, {
+										suppressAiPills: useVar42NoAiFeatures,
+								  } )
+								: undefined;
 
 						wpcomFeaturesTransformed.push( {
 							...feature,
@@ -500,6 +505,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 
 					if (
 						wpcomFeaturesTransformed.length > 0 &&
+						useDifferentiationFeatures &&
 						( isExperimentVariant || usePlansGridRedesignFeatures )
 					) {
 						const lastIndex = wpcomFeaturesTransformed.length - 1;

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
@@ -286,10 +286,6 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 		 * The pricing-differentiation lists are the default presentation, not an override: an intent
 		 * that curates its own list keeps it. Checked here rather than by reordering the branches
 		 * below, so the relative order of the intent branches themselves is untouched.
-		 *
-		 * This also governs the presentation that belongs with those lists -- the feature pills and
-		 * the trailing margin of the stacked layout -- so a curated list is not left half-dressed in
-		 * differentiation styling.
 		 */
 		const useDifferentiationFeatures = ! hasTailoredFeatureList( intent );
 
@@ -488,12 +484,11 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 
 						const featureSlug = feature.getSlug();
 
-						const badgeText =
-							showPricingDifferentiationFeaturePills && useDifferentiationFeatures
-								? getPricingDifferentiationFeatureBadgeText( planSlug, featureSlug, translate, {
-										suppressAiPills: useVar42NoAiFeatures,
-								  } )
-								: undefined;
+						const badgeText = showPricingDifferentiationFeaturePills
+							? getPricingDifferentiationFeatureBadgeText( planSlug, featureSlug, translate, {
+									suppressAiPills: useVar42NoAiFeatures,
+							  } )
+							: undefined;
 
 						wpcomFeaturesTransformed.push( {
 							...feature,
@@ -505,7 +500,6 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 
 					if (
 						wpcomFeaturesTransformed.length > 0 &&
-						useDifferentiationFeatures &&
 						( isExperimentVariant || usePlansGridRedesignFeatures )
 					) {
 						const lastIndex = wpcomFeaturesTransformed.length - 1;

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
@@ -35,6 +35,7 @@ import {
 } from '@automattic/calypso-products';
 import { useMemo } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
+import { hasTailoredFeatureList } from '../../constants';
 import getPlanFeaturesObject from '../../lib/get-plan-features-object';
 import useHighlightedFeatures from './use-highlighted-features';
 import type {
@@ -281,6 +282,13 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 	const translate = useTranslate();
 	const highlightedFeatures = useHighlightedFeatures( { intent: intent ?? null, isInSignup } );
 	return useMemo( () => {
+		/*
+		 * The pricing-differentiation lists are the default presentation, not an override: an intent
+		 * that curates its own list keeps it. Checked here rather than by reordering the branches
+		 * below, so the relative order of the intent branches themselves is untouched.
+		 */
+		const useDifferentiationFeatures = ! hasTailoredFeatureList( intent );
+
 		return gridPlans.reduce(
 			( acc, gridPlan ) => {
 				const planSlug = gridPlan.planSlug;
@@ -290,7 +298,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 				let wpcomFeatures: FeatureObject[] = [];
 				let jetpackFeatures: FeatureObject[] = [];
 
-				if ( usePlansGridRedesignFeatures ) {
+				if ( usePlansGridRedesignFeatures && useDifferentiationFeatures ) {
 					const featureSlugs =
 						planConstantObj?.getVar42NoAiSignupWpcomFeatures?.() ??
 						planConstantObj?.get2023PricingGridSignupWpcomFeatures?.() ??
@@ -307,7 +315,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 						planConstantObj.get2023PricingGridSignupJetpackFeatures?.() ?? [],
 						true
 					);
-				} else if ( useVar42NoAiFeatures ) {
+				} else if ( useVar42NoAiFeatures && useDifferentiationFeatures ) {
 					wpcomFeatures = getPlanFeaturesObject(
 						allFeaturesList,
 						planConstantObj?.getVar42NoAiSignupWpcomFeatures?.() ??
@@ -402,7 +410,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 					);
 				}
 
-				if ( usePlansGridRedesignFeatures ) {
+				if ( usePlansGridRedesignFeatures && useDifferentiationFeatures ) {
 					wpcomFeatures = applyPlansGridRedesignFeatureTitleOverrides(
 						wpcomFeatures,
 						planSlug,

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-features-for-grid-plans.ts
@@ -500,6 +500,7 @@ const usePlanFeaturesForGridPlans: UsePlanFeaturesForGridPlans = ( {
 
 					if (
 						wpcomFeaturesTransformed.length > 0 &&
+						useDifferentiationFeatures &&
 						( isExperimentVariant || usePlansGridRedesignFeatures )
 					) {
 						const lastIndex = wpcomFeaturesTransformed.length - 1;

--- a/packages/plans-grid-next/src/hooks/data-store/use-restructured-plan-features-for-comparison-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-restructured-plan-features-for-comparison-grid.ts
@@ -6,6 +6,7 @@ import {
 	FEATURE_CUSTOM_DOMAIN,
 } from '@automattic/calypso-products';
 import { useMemo } from '@wordpress/element';
+import { hasTailoredFeatureList } from '../../constants';
 import getPlanFeaturesObject from '../../lib/get-plan-features-object';
 import usePlanFeaturesForGridPlans from './use-plan-features-for-grid-plans';
 import type {
@@ -61,6 +62,8 @@ const useRestructuredPlanFeaturesForComparisonGrid: UseRestructuredPlanFeaturesF
 		} );
 
 		return useMemo( () => {
+			// An intent that curates its own comparison list keeps it; see TAILORED_FEATURE_LIST_INTENTS.
+			const useDifferentiationFeatures = ! hasTailoredFeatureList( intent );
 			let previousPlan = null;
 			const planFeatureMap: Record< string, PlanFeaturesForGridPlan > = {};
 
@@ -75,6 +78,7 @@ const useRestructuredPlanFeaturesForComparisonGrid: UseRestructuredPlanFeaturesF
 				// Plans differentiators (non-control): use experiment comparison override when present.
 				if (
 					isExperimentVariant &&
+					useDifferentiationFeatures &&
 					planConstantObj.get2023PlanComparisonFeatureOverrideForExperiment?.()?.length
 				) {
 					wpcomFeatures = getPlanFeaturesObject(
@@ -124,6 +128,7 @@ const useRestructuredPlanFeaturesForComparisonGrid: UseRestructuredPlanFeaturesF
 				let jetpackFeatures;
 				if (
 					isExperimentVariant &&
+					useDifferentiationFeatures &&
 					planConstantObj.get2023PlanComparisonJetpackFeatureOverrideForExperiment
 				) {
 					jetpackFeatures = getPlanFeaturesObject(

--- a/packages/plans-grid-next/src/hooks/data-store/use-restructured-plan-features-for-comparison-grid.ts
+++ b/packages/plans-grid-next/src/hooks/data-store/use-restructured-plan-features-for-comparison-grid.ts
@@ -214,8 +214,10 @@ const useRestructuredPlanFeaturesForComparisonGrid: UseRestructuredPlanFeaturesF
 						...previousPlanFeatures.jetpackFeatures,
 					],
 					storageFeature: planFeaturesForGridPlans[ planSlug ].storageFeature,
+					// Labels follow the list: the experiment copy describes features the experiment
+					// override lists, so pairing it with a curated list mislabels the rows.
 					comparisonGridFeatureLabels: planConstantObj.getPlanComparisonFeatureLabels?.( {
-						isExperimentVariant,
+						isExperimentVariant: isExperimentVariant && useDifferentiationFeatures,
 					} ),
 				};
 

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -3,7 +3,11 @@ import FeaturesGrid from './components/features-grid';
 import PlanButton from './components/plan-button';
 import PlanTypeSelector from './components/plan-type-selector';
 import { Plans2023Tooltip } from './components/plans-2023-tooltip';
-import { EFFECTIVE_TERMS_LIST } from './constants';
+import {
+	EFFECTIVE_TERMS_LIST,
+	TAILORED_FEATURE_LIST_INTENTS,
+	hasTailoredFeatureList,
+} from './constants';
 import useGridPlanForSpotlight from './hooks/data-store/use-grid-plan-for-spotlight';
 import useGridPlans, { usePlanTypesWithIntent } from './hooks/data-store/use-grid-plans';
 import useGridPlansForComparisonGrid from './hooks/data-store/use-grid-plans-for-comparison-grid';
@@ -52,7 +56,7 @@ export {
 /**
  * Constants
  */
-export { EFFECTIVE_TERMS_LIST };
+export { EFFECTIVE_TERMS_LIST, TAILORED_FEATURE_LIST_INTENTS, hasTailoredFeatureList };
 
 /**
  * Plan pricing utilities


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes MARTECH-3024

## Proposed Changes

* Display the custom grids for pricing intents.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* The pricing intents stopped showing their specific plans and features.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open /setup/onboarding/plans?intent=default_hosting and compare with production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
