### PR TITLE
Dashboard: fix the language crash on the Logs, Activity, and Backups pages

### DIFF
--- a/client/dashboard/agency/sites/site/activity.tsx
+++ b/client/dashboard/agency/sites/site/activity.tsx
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import { useDateRange } from '../../../app/hooks/use-date-range';
 import { useSiteTimezoneWithJetpackFallback } from '../../../app/hooks/use-site-timezone';
-import { useLocale } from '../../../app/locale';
+import { useIntlLocale } from '../../../app/locale';
 import { agencySiteActivityRoute, agencySiteRoute } from '../../../app/router/agency';
 import { Card, CardBody } from '../../../components/card';
 import InlineSupportLink from '../../../components/inline-support-link';
@@ -21,7 +21,7 @@ export default function AgencySiteActivity() {
 	const { data: site } = useSuspenseQuery( siteBySlugQuery( siteSlug ) );
 	const { gmtOffset, timezoneString } = useSiteTimezoneWithJetpackFallback( site );
 
-	const locale = useLocale();
+	const locale = useIntlLocale();
 	const searchParams = agencySiteActivityRoute.useSearch();
 
 	// Activity has no auto-refresh, but the shared DataViews props require this state.

--- a/client/dashboard/sites/backups/backups-page.tsx
+++ b/client/dashboard/sites/backups/backups-page.tsx
@@ -4,7 +4,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { __ } from '@wordpress/i18n';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useDateRange } from '../../app/hooks/use-date-range';
-import { useLocale } from '../../app/locale';
+import { useIntlLocale } from '../../app/locale';
 import { PerformanceTrackerStop } from '../../app/performance-tracking';
 import { PageHeader } from '../../components/page-header';
 import PageLayout from '../../components/page-layout';
@@ -40,7 +40,7 @@ export function BackupsPage( {
 	hasBackups = true,
 	extraNotices,
 }: BackupsPageProps ) {
-	const locale = useLocale();
+	const locale = useIntlLocale();
 	const backupState = useBackupState( site.ID );
 
 	const { data: siteSettings } = useSuspenseQuery( siteSettingsQuery( site.ID ) );

--- a/client/dashboard/sites/logs/index.tsx
+++ b/client/dashboard/sites/logs/index.tsx
@@ -7,7 +7,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState } from 'react';
 import { useDateRange } from '../../app/hooks/use-date-range';
-import { useLocale } from '../../app/locale';
+import { useIntlLocale } from '../../app/locale';
 import { Card, CardBody } from '../../components/card';
 import InlineSupportLink from '../../components/inline-support-link';
 import Notice from '../../components/notice';
@@ -75,7 +75,7 @@ function SiteLogsContent( {
 	gmtOffset: number;
 	timezoneString: string | undefined;
 } ) {
-	const locale = useLocale();
+	const locale = useIntlLocale();
 
 	const settingsUrl = site.options?.admin_url
 		? `${ site.options.admin_url }options-general.php`


### PR DESCRIPTION
Follow-up to #114118 (DOTMSD-1547).

## Proposed Changes

Apply the same fix (`useLocale` -> `useIntlLocale`) to the linked PR to site activity logs and backups pages, which was missed.

## Testing Instructions 

Follow the same instructions, but also test these pages:

- Site -> Logs -> Activity
- Site -> Backups