### PR TITLE
Stats: escalate the Traffic tab preview banner dismiss, 30 days then for good

### DIFF
--- a/client/my-sites/stats/hooks/test/use-notice-visibility-mutation.tsx
+++ b/client/my-sites/stats/hooks/test/use-notice-visibility-mutation.tsx
@@ -4,12 +4,22 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import useNoticeVisibilityMutation from '../use-notice-visibility-mutation';
-import { noticesVisibilityQueryKey, NoticeRecords } from '../use-notice-visibility-query';
+import {
+	noticesVisibilityQueryKey,
+	NoticeRecords,
+	useNoticesVisibilityQuery,
+} from '../use-notice-visibility-query';
 
 const mockPost = jest.fn();
+const mockGet = jest.fn();
 jest.mock( 'calypso/lib/wp', () => ( {
 	__esModule: true,
-	default: { req: { post: ( ...args: unknown[] ) => mockPost( ...args ) } },
+	default: {
+		req: {
+			post: ( ...args: unknown[] ) => mockPost( ...args ),
+			get: ( ...args: unknown[] ) => mockGet( ...args ),
+		},
+	},
 } ) );
 
 const SITE_ID = 123;
@@ -36,7 +46,10 @@ describe( 'useNoticeVisibilityMutation', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
-		client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+		client = new QueryClient( {
+			defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+		} );
+		mockGet.mockResolvedValue( {} );
 		client.setQueryData< NoticeRecords >( noticesVisibilityQueryKey( SITE_ID ), {
 			premium_analytics_preview: visibleRecord,
 			tier_upgrade: visibleRecord,
@@ -100,6 +113,56 @@ describe( 'useNoticeVisibilityMutation', () => {
 			client.getQueryData< NoticeRecords >( noticesVisibilityQueryKey( SITE_ID ) )?.tier_upgrade
 		).toBe( visibleRecord );
 		expect( invalidate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'hides the notice even if the returned record claims it is shown', async () => {
+		mockPost.mockResolvedValue( {
+			updated: true,
+			notice: { show: true, status: 'postponed', postponed_count: 1, next_show_at: 1 },
+		} );
+		const { result } = renderMutation( client );
+
+		await result.current.mutateAsync( { status: 'postponed', postponedFor: THIRTY_DAYS } );
+
+		await waitFor( () =>
+			expect(
+				client.getQueryData< NoticeRecords >( noticesVisibilityQueryKey( SITE_ID ) )
+					?.premium_analytics_preview.show
+			).toBe( false )
+		);
+	} );
+
+	/**
+	 * A fetch already in flight resolves after the patch and would put the pre-dismissal record
+	 * back. Invalidating cancels it and refetches, which is how trunk always converged.
+	 */
+	it( 'refetches instead of patching while a fetch is in flight', async () => {
+		const invalidate = jest.spyOn( client, 'invalidateQueries' );
+		let answerStaleGet: ( payload: unknown ) => void = () => {};
+		mockGet
+			.mockReturnValueOnce( new Promise( ( resolve ) => ( answerStaleGet = resolve ) ) )
+			.mockResolvedValue( {
+				premium_analytics_preview: { show: false, status: 'postponed', postponed_count: 1 },
+			} );
+		mockPost.mockResolvedValue( {
+			updated: true,
+			notice: { status: 'postponed', postponed_count: 1, next_show_at: 1 },
+		} );
+		const { result: query } = renderHook( () => useNoticesVisibilityQuery( SITE_ID ), {
+			wrapper: ( { children } ) => (
+				<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
+			),
+		} );
+		client.refetchQueries( { queryKey: noticesVisibilityQueryKey( SITE_ID ) } );
+		await waitFor( () => expect( query.current.isFetching ).toBe( true ) );
+		const { result } = renderMutation( client );
+
+		await result.current.mutateAsync( { status: 'postponed', postponedFor: THIRTY_DAYS } );
+
+		expect( invalidate ).toHaveBeenCalledWith( { queryKey: noticesVisibilityQueryKey( SITE_ID ) } );
+		answerStaleGet( { premium_analytics_preview: true } );
+		await waitFor( () => expect( query.current.data?.premium_analytics_preview ).toBe( false ) );
+		expect( mockGet ).toHaveBeenCalledTimes( 2 );
 	} );
 
 	/**

--- a/client/my-sites/stats/hooks/test/use-notice-visibility-mutation.tsx
+++ b/client/my-sites/stats/hooks/test/use-notice-visibility-mutation.tsx
@@ -4,28 +4,16 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import useNoticeVisibilityMutation from '../use-notice-visibility-mutation';
-import {
-	noticesVisibilityQueryKey,
-	NoticeRecords,
-	useNoticesVisibilityQuery,
-} from '../use-notice-visibility-query';
+import { noticesVisibilityQueryKey } from '../use-notice-visibility-query';
 
 const mockPost = jest.fn();
-const mockGet = jest.fn();
 jest.mock( 'calypso/lib/wp', () => ( {
 	__esModule: true,
-	default: {
-		req: {
-			post: ( ...args: unknown[] ) => mockPost( ...args ),
-			get: ( ...args: unknown[] ) => mockGet( ...args ),
-		},
-	},
+	default: { req: { post: ( ...args: unknown[] ) => mockPost( ...args ) } },
 } ) );
 
 const SITE_ID = 123;
 const THIRTY_DAYS = 30 * 24 * 3600;
-
-const visibleRecord = { show: true, status: null, postponed_count: 0, next_show_at: null };
 
 const renderMutation = (
 	client: QueryClient,
@@ -46,18 +34,11 @@ describe( 'useNoticeVisibilityMutation', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
-		client = new QueryClient( {
-			defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
-		} );
-		mockGet.mockResolvedValue( {} );
-		client.setQueryData< NoticeRecords >( noticesVisibilityQueryKey( SITE_ID ), {
-			premium_analytics_preview: visibleRecord,
-			tier_upgrade: visibleRecord,
-		} as NoticeRecords );
+		client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+		mockPost.mockResolvedValue( { updated: true } );
 	} );
 
 	it( 'sends the hook arguments when the call passes nothing', async () => {
-		mockPost.mockResolvedValue( { updated: true } );
 		const { result } = renderMutation( client, 'postponed', THIRTY_DAYS );
 
 		await result.current.mutateAsync();
@@ -70,7 +51,6 @@ describe( 'useNoticeVisibilityMutation', () => {
 	} );
 
 	it( 'lets a call override the update, so one hook can escalate', async () => {
-		mockPost.mockResolvedValue( { updated: true } );
 		const { result } = renderMutation( client );
 
 		await result.current.mutateAsync( { status: 'postponed', postponedFor: THIRTY_DAYS } );
@@ -82,123 +62,16 @@ describe( 'useNoticeVisibilityMutation', () => {
 		] );
 	} );
 
-	it( 'writes the returned record into the cache as hidden, without a refetch', async () => {
+	it( 'refetches the notices once the write lands', async () => {
 		const invalidate = jest.spyOn( client, 'invalidateQueries' );
-		mockPost.mockResolvedValue( {
-			updated: true,
-			notice: {
-				id: 'premium_analytics_preview',
-				status: 'postponed',
-				dismissed_at: 1_700_000_000,
-				postponed_count: 1,
-				next_show_at: 1_700_000_000 + THIRTY_DAYS,
-			},
-		} );
 		const { result } = renderMutation( client );
 
-		await result.current.mutateAsync( { status: 'postponed', postponedFor: THIRTY_DAYS } );
-
-		await waitFor( () =>
-			expect(
-				client.getQueryData< NoticeRecords >( noticesVisibilityQueryKey( SITE_ID ) )
-					?.premium_analytics_preview
-			).toEqual( {
-				show: false,
-				status: 'postponed',
-				postponed_count: 1,
-				next_show_at: 1_700_000_000 + THIRTY_DAYS,
-			} )
-		);
-		expect(
-			client.getQueryData< NoticeRecords >( noticesVisibilityQueryKey( SITE_ID ) )?.tier_upgrade
-		).toBe( visibleRecord );
-		expect( invalidate ).not.toHaveBeenCalled();
-	} );
-
-	it( 'hides the notice even if the returned record claims it is shown', async () => {
-		mockPost.mockResolvedValue( {
-			updated: true,
-			notice: { show: true, status: 'postponed', postponed_count: 1, next_show_at: 1 },
-		} );
-		const { result } = renderMutation( client );
-
-		await result.current.mutateAsync( { status: 'postponed', postponedFor: THIRTY_DAYS } );
-
-		await waitFor( () =>
-			expect(
-				client.getQueryData< NoticeRecords >( noticesVisibilityQueryKey( SITE_ID ) )
-					?.premium_analytics_preview.show
-			).toBe( false )
-		);
-	} );
-
-	/**
-	 * A fetch already in flight resolves after the patch and would put the pre-dismissal record
-	 * back. Invalidating cancels it and refetches, which is how trunk always converged.
-	 */
-	it( 'refetches instead of patching while a fetch is in flight', async () => {
-		const invalidate = jest.spyOn( client, 'invalidateQueries' );
-		let answerStaleGet: ( payload: unknown ) => void = () => {};
-		mockGet
-			.mockReturnValueOnce( new Promise( ( resolve ) => ( answerStaleGet = resolve ) ) )
-			.mockResolvedValue( {
-				premium_analytics_preview: { show: false, status: 'postponed', postponed_count: 1 },
-			} );
-		mockPost.mockResolvedValue( {
-			updated: true,
-			notice: { status: 'postponed', postponed_count: 1, next_show_at: 1 },
-		} );
-		const { result: query } = renderHook( () => useNoticesVisibilityQuery( SITE_ID ), {
-			wrapper: ( { children } ) => (
-				<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
-			),
-		} );
-		client.refetchQueries( { queryKey: noticesVisibilityQueryKey( SITE_ID ) } );
-		await waitFor( () => expect( query.current.isFetching ).toBe( true ) );
-		const { result } = renderMutation( client );
-
-		await result.current.mutateAsync( { status: 'postponed', postponedFor: THIRTY_DAYS } );
-
-		expect( invalidate ).toHaveBeenCalledWith( { queryKey: noticesVisibilityQueryKey( SITE_ID ) } );
-		answerStaleGet( { premium_analytics_preview: true } );
-		await waitFor( () => expect( query.current.data?.premium_analytics_preview ).toBe( false ) );
-		expect( mockGet ).toHaveBeenCalledTimes( 2 );
-	} );
-
-	/**
-	 * A server predating the detail contract answers `{ updated }` alone. The refetch is what
-	 * hides the notice there, so it has to stay.
-	 */
-	it( 'falls back to a refetch when the response carries no record', async () => {
-		const invalidate = jest.spyOn( client, 'invalidateQueries' );
-		mockPost.mockResolvedValue( { updated: true } );
-		const { result } = renderMutation( client );
-
-		await result.current.mutateAsync( { status: 'postponed', postponedFor: THIRTY_DAYS } );
+		await result.current.mutateAsync( { status: 'dismissed' } );
 
 		await waitFor( () =>
 			expect( invalidate ).toHaveBeenCalledWith( {
 				queryKey: noticesVisibilityQueryKey( SITE_ID ),
 			} )
 		);
-		expect(
-			client.getQueryData< NoticeRecords >( noticesVisibilityQueryKey( SITE_ID ) )
-				?.premium_analytics_preview
-		).toBe( visibleRecord );
-	} );
-
-	it( 'does not seed a cache that was never fetched', async () => {
-		client.removeQueries( { queryKey: noticesVisibilityQueryKey( SITE_ID ) } );
-		const invalidate = jest.spyOn( client, 'invalidateQueries' );
-		mockPost.mockResolvedValue( {
-			updated: true,
-			notice: { status: 'dismissed', postponed_count: 1, next_show_at: null },
-		} );
-		const { result } = renderMutation( client );
-
-		await result.current.mutateAsync( { status: 'dismissed' } );
-
-		await waitFor( () => expect( invalidate ).toHaveBeenCalled() );
-		expect( client.getQueryData( noticesVisibilityQueryKey( SITE_ID ) ) ).toBeUndefined();
 	} );
 } );

--- a/client/my-sites/stats/hooks/test/use-notice-visibility-mutation.tsx
+++ b/client/my-sites/stats/hooks/test/use-notice-visibility-mutation.tsx
@@ -1,0 +1,141 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import useNoticeVisibilityMutation from '../use-notice-visibility-mutation';
+import { noticesVisibilityQueryKey, NoticeRecords } from '../use-notice-visibility-query';
+
+const mockPost = jest.fn();
+jest.mock( 'calypso/lib/wp', () => ( {
+	__esModule: true,
+	default: { req: { post: ( ...args: unknown[] ) => mockPost( ...args ) } },
+} ) );
+
+const SITE_ID = 123;
+const THIRTY_DAYS = 30 * 24 * 3600;
+
+const visibleRecord = { show: true, status: null, postponed_count: 0, next_show_at: null };
+
+const renderMutation = (
+	client: QueryClient,
+	status?: 'dismissed' | 'postponed',
+	seconds?: number
+) =>
+	renderHook(
+		() => useNoticeVisibilityMutation( SITE_ID, 'premium_analytics_preview', status, seconds ),
+		{
+			wrapper: ( { children } ) => (
+				<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
+			),
+		}
+	);
+
+describe( 'useNoticeVisibilityMutation', () => {
+	let client: QueryClient;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		client = new QueryClient( { defaultOptions: { mutations: { retry: false } } } );
+		client.setQueryData< NoticeRecords >( noticesVisibilityQueryKey( SITE_ID ), {
+			premium_analytics_preview: visibleRecord,
+			tier_upgrade: visibleRecord,
+		} as NoticeRecords );
+	} );
+
+	it( 'sends the hook arguments when the call passes nothing', async () => {
+		mockPost.mockResolvedValue( { updated: true } );
+		const { result } = renderMutation( client, 'postponed', THIRTY_DAYS );
+
+		await result.current.mutateAsync();
+
+		expect( mockPost ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				body: { id: 'premium_analytics_preview', status: 'postponed', postponed_for: THIRTY_DAYS },
+			} )
+		);
+	} );
+
+	it( 'lets a call override the update, so one hook can escalate', async () => {
+		mockPost.mockResolvedValue( { updated: true } );
+		const { result } = renderMutation( client );
+
+		await result.current.mutateAsync( { status: 'postponed', postponedFor: THIRTY_DAYS } );
+		await result.current.mutateAsync( { status: 'dismissed' } );
+
+		expect( mockPost.mock.calls.map( ( [ params ] ) => params.body ) ).toEqual( [
+			{ id: 'premium_analytics_preview', status: 'postponed', postponed_for: THIRTY_DAYS },
+			{ id: 'premium_analytics_preview', status: 'dismissed', postponed_for: 0 },
+		] );
+	} );
+
+	it( 'writes the returned record into the cache as hidden, without a refetch', async () => {
+		const invalidate = jest.spyOn( client, 'invalidateQueries' );
+		mockPost.mockResolvedValue( {
+			updated: true,
+			notice: {
+				id: 'premium_analytics_preview',
+				status: 'postponed',
+				dismissed_at: 1_700_000_000,
+				postponed_count: 1,
+				next_show_at: 1_700_000_000 + THIRTY_DAYS,
+			},
+		} );
+		const { result } = renderMutation( client );
+
+		await result.current.mutateAsync( { status: 'postponed', postponedFor: THIRTY_DAYS } );
+
+		await waitFor( () =>
+			expect(
+				client.getQueryData< NoticeRecords >( noticesVisibilityQueryKey( SITE_ID ) )
+					?.premium_analytics_preview
+			).toEqual( {
+				show: false,
+				status: 'postponed',
+				postponed_count: 1,
+				next_show_at: 1_700_000_000 + THIRTY_DAYS,
+			} )
+		);
+		expect(
+			client.getQueryData< NoticeRecords >( noticesVisibilityQueryKey( SITE_ID ) )?.tier_upgrade
+		).toBe( visibleRecord );
+		expect( invalidate ).not.toHaveBeenCalled();
+	} );
+
+	/**
+	 * A server predating the detail contract answers `{ updated }` alone. The refetch is what
+	 * hides the notice there, so it has to stay.
+	 */
+	it( 'falls back to a refetch when the response carries no record', async () => {
+		const invalidate = jest.spyOn( client, 'invalidateQueries' );
+		mockPost.mockResolvedValue( { updated: true } );
+		const { result } = renderMutation( client );
+
+		await result.current.mutateAsync( { status: 'postponed', postponedFor: THIRTY_DAYS } );
+
+		await waitFor( () =>
+			expect( invalidate ).toHaveBeenCalledWith( {
+				queryKey: noticesVisibilityQueryKey( SITE_ID ),
+			} )
+		);
+		expect(
+			client.getQueryData< NoticeRecords >( noticesVisibilityQueryKey( SITE_ID ) )
+				?.premium_analytics_preview
+		).toBe( visibleRecord );
+	} );
+
+	it( 'does not seed a cache that was never fetched', async () => {
+		client.removeQueries( { queryKey: noticesVisibilityQueryKey( SITE_ID ) } );
+		const invalidate = jest.spyOn( client, 'invalidateQueries' );
+		mockPost.mockResolvedValue( {
+			updated: true,
+			notice: { status: 'dismissed', postponed_count: 1, next_show_at: null },
+		} );
+		const { result } = renderMutation( client );
+
+		await result.current.mutateAsync( { status: 'dismissed' } );
+
+		await waitFor( () => expect( invalidate ).toHaveBeenCalled() );
+		expect( client.getQueryData( noticesVisibilityQueryKey( SITE_ID ) ) ).toBeUndefined();
+	} );
+} );

--- a/client/my-sites/stats/hooks/test/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/test/use-notice-visibility-query.ts
@@ -1,6 +1,9 @@
+import { QueryClient } from '@tanstack/react-query';
 import {
 	normalizeNoticeRecords,
 	normalizeNoticesVisibility,
+	noticesVisibilityQueryKey,
+	setNoticeHidden,
 	toNoticeRecord,
 	toNoticesVisibility,
 } from '../use-notice-visibility-query';
@@ -133,5 +136,57 @@ describe( 'normalizeNoticeRecords', () => {
 		expect( visibility.premium_analytics_preview ).toBe( false );
 		expect( visibility.tier_upgrade ).toBe( true );
 		expect( visibility.gdpr_cookie_consent ).toBe( false );
+	} );
+} );
+
+describe( 'setNoticeHidden', () => {
+	const read = ( client: QueryClient ) =>
+		client.getQueryData< ReturnType< typeof normalizeNoticeRecords > >(
+			noticesVisibilityQueryKey( 1 )
+		);
+
+	it( 'hides the notice from the record it already holds when no record is given', () => {
+		const client = new QueryClient();
+		client.setQueryData(
+			noticesVisibilityQueryKey( 1 ),
+			normalizeNoticeRecords( {
+				pricing_grid: { show: true, status: null, postponed_count: 2, next_show_at: null },
+				tier_upgrade: true,
+			} )
+		);
+
+		setNoticeHidden( client, 1, 'pricing_grid' );
+
+		expect( read( client )?.pricing_grid ).toEqual( {
+			show: false,
+			status: null,
+			postponed_count: 2,
+			next_show_at: null,
+		} );
+		expect( read( client )?.tier_upgrade.show ).toBe( true );
+	} );
+
+	it( 'applies the same inheritance rules a fetch would', () => {
+		const client = new QueryClient();
+		client.setQueryData(
+			noticesVisibilityQueryKey( 1 ),
+			normalizeNoticeRecords( { do_you_love_jetpack_stats: true, free_site_upgrade: true } )
+		);
+
+		setNoticeHidden( client, 1, 'do_you_love_jetpack_stats', {
+			status: 'postponed',
+			postponed_count: 1,
+			next_show_at: 1,
+		} );
+
+		expect( read( client )?.free_site_upgrade.show ).toBe( false );
+	} );
+
+	it( 'leaves a cache that was never fetched empty', () => {
+		const client = new QueryClient();
+
+		setNoticeHidden( client, 1, 'pricing_grid' );
+
+		expect( read( client ) ).toBeUndefined();
 	} );
 } );

--- a/client/my-sites/stats/hooks/test/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/test/use-notice-visibility-query.ts
@@ -166,22 +166,6 @@ describe( 'setNoticeHidden', () => {
 		expect( read( client )?.tier_upgrade.show ).toBe( true );
 	} );
 
-	it( 'applies the same inheritance rules a fetch would', () => {
-		const client = new QueryClient();
-		client.setQueryData(
-			noticesVisibilityQueryKey( 1 ),
-			normalizeNoticeRecords( { do_you_love_jetpack_stats: true, free_site_upgrade: true } )
-		);
-
-		setNoticeHidden( client, 1, 'do_you_love_jetpack_stats', {
-			status: 'postponed',
-			postponed_count: 1,
-			next_show_at: 1,
-		} );
-
-		expect( read( client )?.free_site_upgrade.show ).toBe( false );
-	} );
-
 	it( 'leaves a cache that was never fetched empty', () => {
 		const client = new QueryClient();
 

--- a/client/my-sites/stats/hooks/test/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/test/use-notice-visibility-query.ts
@@ -1,4 +1,9 @@
-import { normalizeNoticesVisibility } from '../use-notice-visibility-query';
+import {
+	normalizeNoticeRecords,
+	normalizeNoticesVisibility,
+	toNoticeRecord,
+	toNoticesVisibility,
+} from '../use-notice-visibility-query';
 
 const serverSaysVisible = {
 	free_site_upgrade: true,
@@ -45,5 +50,88 @@ describe( 'normalizeNoticesVisibility', () => {
 				commercial_site_upgrade: true,
 			} ).free_site_upgrade
 		).toBe( false );
+	} );
+} );
+
+describe( 'normalizeNoticeRecords', () => {
+	const detail = {
+		show: false,
+		status: 'postponed',
+		postponed_count: 1,
+		next_show_at: 1_800_000_000,
+	};
+
+	it( 'reads a detail record as the server sent it', () => {
+		expect(
+			normalizeNoticeRecords( { premium_analytics_preview: detail } ).premium_analytics_preview
+		).toEqual( detail );
+	} );
+
+	/**
+	 * An older server, or a Jetpack plugin without the details route, still answers with a flat
+	 * `{ id: bool }` map. It must land in the same shape, reading as never postponed, so the
+	 * banner keeps its single 30-day hold there instead of throwing.
+	 */
+	it( 'wraps a bare boolean as a record that was never postponed', () => {
+		const records = normalizeNoticeRecords( {
+			premium_analytics_preview: true,
+			tier_upgrade: false,
+		} );
+
+		expect( records.premium_analytics_preview ).toEqual( {
+			show: true,
+			status: null,
+			postponed_count: 0,
+			next_show_at: null,
+		} );
+		expect( records.tier_upgrade.show ).toBe( false );
+	} );
+
+	it( 'fills ids missing from the response with their defaults', () => {
+		const records = normalizeNoticeRecords( {} );
+
+		expect( records.tier_upgrade ).toEqual( {
+			show: true,
+			status: null,
+			postponed_count: 0,
+			next_show_at: null,
+		} );
+		expect( records.premium_analytics_preview.show ).toBe( false );
+		expect( normalizeNoticeRecords( null ) ).toEqual( records );
+	} );
+
+	it( 'keeps the legacy upsell inheritance for free_site_upgrade on detail records', () => {
+		const records = normalizeNoticeRecords( {
+			free_site_upgrade: { ...detail, show: true, postponed_count: 0 },
+			do_you_love_jetpack_stats: { ...detail, show: false },
+		} );
+
+		expect( records.free_site_upgrade.show ).toBe( false );
+	} );
+
+	it( 'discards malformed escalation fields rather than passing them on', () => {
+		const record = toNoticeRecord( {
+			show: 1,
+			status: 'expired',
+			postponed_count: 'two',
+			next_show_at: 'soon',
+		} );
+
+		expect( record ).toEqual( {
+			show: true,
+			status: null,
+			postponed_count: 0,
+			next_show_at: null,
+		} );
+	} );
+
+	it( 'reduces records to the flat map the rest of Stats reads', () => {
+		const visibility = toNoticesVisibility(
+			normalizeNoticeRecords( { premium_analytics_preview: detail, tier_upgrade: true } )
+		);
+
+		expect( visibility.premium_analytics_preview ).toBe( false );
+		expect( visibility.tier_upgrade ).toBe( true );
+		expect( visibility.gdpr_cookie_consent ).toBe( false );
 	} );
 } );

--- a/client/my-sites/stats/hooks/test/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/test/use-notice-visibility-query.ts
@@ -166,6 +166,39 @@ describe( 'setNoticeHidden', () => {
 		expect( read( client )?.tier_upgrade.show ).toBe( true );
 	} );
 
+	it.each( [ 'do_you_love_jetpack_stats', 'commercial_site_upgrade' ] as const )(
+		'hides the successor when %s is hidden, preserving its metadata',
+		( noticeId ) => {
+			const client = new QueryClient();
+			const records = normalizeNoticeRecords( {
+				[ noticeId ]: true,
+				free_site_upgrade: {
+					show: true,
+					status: 'postponed',
+					postponed_count: 2,
+					next_show_at: 1_700_000_000,
+				},
+				tier_upgrade: true,
+			} );
+			client.setQueryData( noticesVisibilityQueryKey( 1 ), records );
+
+			expect( records.free_site_upgrade.show ).toBe( true );
+
+			setNoticeHidden( client, 1, noticeId, {
+				status: 'postponed',
+				postponed_count: 1,
+				next_show_at: 1_800_000_000,
+			} );
+
+			expect( read( client )?.[ noticeId ].show ).toBe( false );
+			expect( read( client )?.free_site_upgrade ).toEqual( {
+				...records.free_site_upgrade,
+				show: false,
+			} );
+			expect( read( client )?.tier_upgrade ).toBe( records.tier_upgrade );
+		}
+	);
+
 	it( 'leaves a cache that was never fetched empty', () => {
 		const client = new QueryClient();
 

--- a/client/my-sites/stats/hooks/test/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/test/use-notice-visibility-query.ts
@@ -4,7 +4,6 @@ import {
 	normalizeNoticesVisibility,
 	noticesVisibilityQueryKey,
 	setNoticeHidden,
-	toNoticeRecord,
 	toNoticesVisibility,
 } from '../use-notice-visibility-query';
 
@@ -70,11 +69,6 @@ describe( 'normalizeNoticeRecords', () => {
 		).toEqual( detail );
 	} );
 
-	/**
-	 * An older server, or a Jetpack plugin without the details route, still answers with a flat
-	 * `{ id: bool }` map. It must land in the same shape, reading as never postponed, so the
-	 * banner keeps its single 30-day hold there instead of throwing.
-	 */
 	it( 'wraps a bare boolean as a record that was never postponed', () => {
 		const records = normalizeNoticeRecords( {
 			premium_analytics_preview: true,
@@ -113,12 +107,14 @@ describe( 'normalizeNoticeRecords', () => {
 	} );
 
 	it( 'discards malformed escalation fields rather than passing them on', () => {
-		const record = toNoticeRecord( {
-			show: 1,
-			status: 'expired',
-			postponed_count: 'two',
-			next_show_at: 'soon',
-		} );
+		const record = normalizeNoticeRecords( {
+			premium_analytics_preview: {
+				show: 1,
+				status: 'expired',
+				postponed_count: 'two',
+				next_show_at: 'soon',
+			},
+		} ).premium_analytics_preview;
 
 		expect( record ).toEqual( {
 			show: true,
@@ -145,7 +141,7 @@ describe( 'setNoticeHidden', () => {
 			noticesVisibilityQueryKey( 1 )
 		);
 
-	it( 'hides the notice from the record it already holds when no record is given', () => {
+	it( 'hides the notice, keeping the record it already holds', () => {
 		const client = new QueryClient();
 		client.setQueryData(
 			noticesVisibilityQueryKey( 1 ),
@@ -165,39 +161,6 @@ describe( 'setNoticeHidden', () => {
 		} );
 		expect( read( client )?.tier_upgrade.show ).toBe( true );
 	} );
-
-	it.each( [ 'do_you_love_jetpack_stats', 'commercial_site_upgrade' ] as const )(
-		'hides the successor when %s is hidden, preserving its metadata',
-		( noticeId ) => {
-			const client = new QueryClient();
-			const records = normalizeNoticeRecords( {
-				[ noticeId ]: true,
-				free_site_upgrade: {
-					show: true,
-					status: 'postponed',
-					postponed_count: 2,
-					next_show_at: 1_700_000_000,
-				},
-				tier_upgrade: true,
-			} );
-			client.setQueryData( noticesVisibilityQueryKey( 1 ), records );
-
-			expect( records.free_site_upgrade.show ).toBe( true );
-
-			setNoticeHidden( client, 1, noticeId, {
-				status: 'postponed',
-				postponed_count: 1,
-				next_show_at: 1_800_000_000,
-			} );
-
-			expect( read( client )?.[ noticeId ].show ).toBe( false );
-			expect( read( client )?.free_site_upgrade ).toEqual( {
-				...records.free_site_upgrade,
-				show: false,
-			} );
-			expect( read( client )?.tier_upgrade ).toBe( records.tier_upgrade );
-		}
-	);
 
 	it( 'leaves a cache that was never fetched empty', () => {
 		const client = new QueryClient();

--- a/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
@@ -1,11 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
-import {
-	NoticeRecords,
-	Notices,
-	noticesVisibilityQueryKey,
-	toNoticeRecord,
-} from './use-notice-visibility-query';
+import { Notices, noticesVisibilityQueryKey, setNoticeHidden } from './use-notice-visibility-query';
 
 type Status = 'dismissed' | 'postponed';
 
@@ -49,7 +44,7 @@ export default function useNoticeVisibilityMutation(
 	const queryClient = useQueryClient();
 	return useMutation( {
 		mutationKey: noticesVisibilityQueryKey( siteId ),
-		mutationFn: ( update?: NoticeUpdate ) =>
+		mutationFn: ( update: NoticeUpdate | void ) =>
 			dismissNotice(
 				siteId,
 				noticeId,
@@ -65,15 +60,17 @@ export default function useNoticeVisibilityMutation(
 		onSuccess: ( response ) => {
 			const queryKey = noticesVisibilityQueryKey( siteId );
 			const record = response?.notice;
-			if ( ! record || ! queryClient.getQueryData< NoticeRecords >( queryKey ) ) {
+			// A fetch already in flight would land after the patch and undo it; invalidating
+			// cancels that fetch and starts one that sees the write.
+			if (
+				! record ||
+				! queryClient.getQueryData( queryKey ) ||
+				queryClient.getQueryState( queryKey )?.fetchStatus === 'fetching'
+			) {
 				queryClient.invalidateQueries( { queryKey } );
 				return;
 			}
-			// The POST record carries no `show`, but a write that went through always hides the notice.
-			queryClient.setQueryData< NoticeRecords >( queryKey, ( records ) => ( {
-				...records,
-				[ noticeId ]: { ...toNoticeRecord( record ), show: false },
-			} ) );
+			setNoticeHidden( queryClient, siteId, noticeId, record );
 		},
 	} );
 }

--- a/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
@@ -1,15 +1,30 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
-import { Notices } from './use-notice-visibility-query';
+import {
+	NoticeRecords,
+	Notices,
+	noticesVisibilityQueryKey,
+	toNoticeRecord,
+} from './use-notice-visibility-query';
 
 type Status = 'dismissed' | 'postponed';
+
+export interface NoticeUpdate {
+	status: Status;
+	postponedFor?: number;
+}
+
+interface NoticeUpdateResponse {
+	updated?: boolean;
+	notice?: Record< string, unknown >;
+}
 
 export function dismissNotice(
 	siteId: number | null,
 	noticeId: keyof Notices,
 	status: Status,
 	postponedFor = 0
-): Promise< any > {
+): Promise< NoticeUpdateResponse > {
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
 		path: `/sites/${ siteId }/jetpack-stats-dashboard/notices`,
@@ -21,6 +36,10 @@ export function dismissNotice(
 	} );
 }
 
+/**
+ * The hook arguments are the default update; `mutate()` may pass a `NoticeUpdate` to override
+ * them per call, for notices whose next step depends on the saved record.
+ */
 export default function useNoticeVisibilityMutation(
 	siteId: number | null,
 	noticeId: keyof Notices,
@@ -29,18 +48,32 @@ export default function useNoticeVisibilityMutation(
 ) {
 	const queryClient = useQueryClient();
 	return useMutation( {
-		mutationKey: [ 'stats', 'notices-visibility', 'raw', siteId ],
-		mutationFn: () => dismissNotice( siteId, noticeId, status, postponedFor ),
+		mutationKey: noticesVisibilityQueryKey( siteId ),
+		mutationFn: ( update?: NoticeUpdate ) =>
+			dismissNotice(
+				siteId,
+				noticeId,
+				update?.status ?? status,
+				update?.postponedFor ?? postponedFor
+			),
 		retry: 1,
 		retryDelay: 3 * 1000, // 3 seconds
 		// Mutation-level rather than per-call: query-core only runs mutate()'s own
 		// callbacks while the calling component is still mounted, and consumers may
 		// navigate away before the retry succeeds. Not awaited, so callers chaining
 		// on mutateAsync() don't also wait out the refetch.
-		onSuccess: () => {
-			queryClient.invalidateQueries( {
-				queryKey: [ 'stats', 'notices-visibility', 'raw', siteId ],
-			} );
+		onSuccess: ( response ) => {
+			const queryKey = noticesVisibilityQueryKey( siteId );
+			const record = response?.notice;
+			if ( ! record || ! queryClient.getQueryData< NoticeRecords >( queryKey ) ) {
+				queryClient.invalidateQueries( { queryKey } );
+				return;
+			}
+			// The POST record carries no `show`, but a write that went through always hides the notice.
+			queryClient.setQueryData< NoticeRecords >( queryKey, ( records ) => ( {
+				...records,
+				[ noticeId ]: { ...toNoticeRecord( record ), show: false },
+			} ) );
 		},
 	} );
 }

--- a/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
@@ -1,25 +1,22 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
-import { Notices, noticesVisibilityQueryKey, setNoticeHidden } from './use-notice-visibility-query';
-
-type Status = 'dismissed' | 'postponed';
+import {
+	Notices,
+	NoticeDismissStatus,
+	noticesVisibilityQueryKey,
+} from './use-notice-visibility-query';
 
 export interface NoticeUpdate {
-	status: Status;
+	status: NoticeDismissStatus;
 	postponedFor?: number;
-}
-
-interface NoticeUpdateResponse {
-	updated?: boolean;
-	notice?: Record< string, unknown >;
 }
 
 export function dismissNotice(
 	siteId: number | null,
 	noticeId: keyof Notices,
-	status: Status,
+	status: NoticeDismissStatus,
 	postponedFor = 0
-): Promise< NoticeUpdateResponse > {
+): Promise< unknown > {
 	return wpcom.req.post( {
 		apiNamespace: 'wpcom/v2',
 		path: `/sites/${ siteId }/jetpack-stats-dashboard/notices`,
@@ -32,13 +29,13 @@ export function dismissNotice(
 }
 
 /**
- * The hook arguments are the default update; `mutate()` may pass a `NoticeUpdate` to override
- * them per call, for notices whose next step depends on the saved record.
+ * The hook arguments are the default update. `mutate()` may pass a `NoticeUpdate` for notices
+ * whose next step depends on the saved record; each field it omits falls back to the hook argument.
  */
 export default function useNoticeVisibilityMutation(
 	siteId: number | null,
 	noticeId: keyof Notices,
-	status: Status = 'dismissed',
+	status: NoticeDismissStatus = 'dismissed',
 	postponedFor = 0
 ) {
 	const queryClient = useQueryClient();
@@ -57,20 +54,8 @@ export default function useNoticeVisibilityMutation(
 		// callbacks while the calling component is still mounted, and consumers may
 		// navigate away before the retry succeeds. Not awaited, so callers chaining
 		// on mutateAsync() don't also wait out the refetch.
-		onSuccess: ( response ) => {
-			const queryKey = noticesVisibilityQueryKey( siteId );
-			const record = response?.notice;
-			// A fetch already in flight would land after the patch and undo it; invalidating
-			// cancels that fetch and starts one that sees the write.
-			if (
-				! record ||
-				! queryClient.getQueryData( queryKey ) ||
-				queryClient.getQueryState( queryKey )?.fetchStatus === 'fetching'
-			) {
-				queryClient.invalidateQueries( { queryKey } );
-				return;
-			}
-			setNoticeHidden( queryClient, siteId, noticeId, record );
+		onSuccess: () => {
+			queryClient.invalidateQueries( { queryKey: noticesVisibilityQueryKey( siteId ) } );
 		},
 	} );
 }

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -196,6 +196,9 @@ export const setNoticeHidden = (
 			? {
 					...records,
 					[ noticeId ]: { ...toNoticeRecord( record ?? records[ noticeId ] ), show: false },
+					...( noticeId === 'do_you_love_jetpack_stats' || noticeId === 'commercial_site_upgrade'
+						? { free_site_upgrade: { ...records.free_site_upgrade, show: false } }
+						: {} ),
 			  }
 			: records
 	);

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { QueryClient, useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import getDefaultQueryParams from './default-query-params';
 
@@ -172,12 +172,33 @@ const queryNotices = async function ( siteId: number | null ): Promise< NoticeRe
 	return normalizeNoticeRecords( payload );
 };
 
+// Calypso persists this cache for a week with no buster, so the shape change from a boolean
+// map to records needs its own key or an older build's entry is read as records.
 export const noticesVisibilityQueryKey = ( siteId: number | null ) => [
 	'stats',
 	'notices-visibility',
-	'raw',
+	'details',
 	siteId,
 ];
+
+/**
+ * Mark a notice hidden in the cache, from the record a write returned or the one already held.
+ * A cache that was never filled is left alone; only a fetch may seed it.
+ */
+export const setNoticeHidden = (
+	queryClient: QueryClient,
+	siteId: number | null,
+	noticeId: NoticeIdType,
+	record?: unknown
+) =>
+	queryClient.setQueryData< NoticeRecords >( noticesVisibilityQueryKey( siteId ), ( records ) =>
+		records
+			? normalizeNoticeRecords( {
+					...records,
+					[ noticeId ]: { ...toNoticeRecord( record ?? records[ noticeId ] ), show: false },
+			  } )
+			: records
+	);
 
 const useNoticesVisibilityQueryRaw = function < T >(
 	siteId: number | null,

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -193,10 +193,10 @@ export const setNoticeHidden = (
 ) =>
 	queryClient.setQueryData< NoticeRecords >( noticesVisibilityQueryKey( siteId ), ( records ) =>
 		records
-			? normalizeNoticeRecords( {
+			? {
 					...records,
 					[ noticeId ]: { ...toNoticeRecord( record ?? records[ noticeId ] ), show: false },
-			  } )
+			  }
 			: records
 	);
 

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -36,6 +36,15 @@ export const DEFAULT_NOTICES_VISIBILITY = {
 export type Notices = typeof DEFAULT_NOTICES_VISIBILITY;
 export type NoticeIdType = keyof Notices;
 
+export type NoticeStatus = 'dismissed' | 'postponed' | null;
+export interface NoticeRecord {
+	show: boolean;
+	status: NoticeStatus;
+	postponed_count: number;
+	next_show_at: number | null;
+}
+export type NoticeRecords = Record< NoticeIdType, NoticeRecord >;
+
 // These notices are mutually exclusive, so if one is active, the other should be hidden.
 // The IDs are sorted by priory from high to low.
 // `pricing_grid` is deliberately NOT in this group even though the grid trumps every
@@ -98,30 +107,86 @@ export const normalizeNoticesVisibility = (
 	return notices;
 };
 
-const queryNotices = async function ( siteId: number | null ): Promise< Notices > {
+const isNoticeRecord = ( value: unknown ): value is Partial< NoticeRecord > =>
+	typeof value === 'object' && value !== null;
+
+/**
+ * Both the flat map an older server answers with and a detail record land in one shape, so the
+ * escalation fields read as "never postponed" wherever the server cannot say otherwise.
+ */
+export const toNoticeRecord = ( value: unknown ): NoticeRecord => {
+	if ( ! isNoticeRecord( value ) ) {
+		return { show: !! value, status: null, postponed_count: 0, next_show_at: null };
+	}
+	return {
+		show: !! value.show,
+		status: value.status === 'dismissed' || value.status === 'postponed' ? value.status : null,
+		postponed_count: Number( value.postponed_count ) || 0,
+		next_show_at: typeof value.next_show_at === 'number' ? value.next_show_at : null,
+	};
+};
+
+export const normalizeNoticeRecords = (
+	payload: Record< string, unknown > | null | undefined
+): NoticeRecords => {
+	const records = {} as NoticeRecords;
+	const payloadVisibility: Record< string, boolean > = {};
+	for ( const [ noticeId, value ] of Object.entries( payload ?? {} ) ) {
+		records[ noticeId as NoticeIdType ] = toNoticeRecord( value );
+		payloadVisibility[ noticeId ] = records[ noticeId as NoticeIdType ].show;
+	}
+	const visibility = normalizeNoticesVisibility( payloadVisibility );
+	for ( const noticeId of Object.keys( visibility ) as NoticeIdType[] ) {
+		records[ noticeId ] = {
+			...( records[ noticeId ] ?? toNoticeRecord( false ) ),
+			show: visibility[ noticeId ],
+		};
+	}
+	return records;
+};
+
+export const toNoticesVisibility = ( records: NoticeRecords ): Notices => {
+	const visibility = { ...DEFAULT_NOTICES_VISIBILITY };
+	for ( const noticeId of Object.keys( records ) as NoticeIdType[] ) {
+		visibility[ noticeId ] = records[ noticeId ].show;
+	}
+	return visibility;
+};
+
+const queryNotices = async function ( siteId: number | null ): Promise< NoticeRecords > {
 	let payload;
 
 	try {
-		payload = await wpcom.req.get( {
-			method: 'GET',
-			apiNamespace: 'wpcom/v2',
-			path: `/sites/${ siteId }/jetpack-stats-dashboard/notices`,
-		} );
+		payload = await wpcom.req.get(
+			{
+				method: 'GET',
+				apiNamespace: 'wpcom/v2',
+				path: `/sites/${ siteId }/jetpack-stats-dashboard/notices`,
+			},
+			{ include_details: true }
+		);
 	} catch ( error ) {
-		return DEFAULT_NOTICES_VISIBILITY;
+		return normalizeNoticeRecords( DEFAULT_NOTICES_VISIBILITY );
 	}
 
-	return normalizeNoticesVisibility( payload );
+	return normalizeNoticeRecords( payload );
 };
+
+export const noticesVisibilityQueryKey = ( siteId: number | null ) => [
+	'stats',
+	'notices-visibility',
+	'raw',
+	siteId,
+];
 
 const useNoticesVisibilityQueryRaw = function < T >(
 	siteId: number | null,
-	select?: ( payload: Notices ) => T,
+	select?: ( payload: NoticeRecords ) => T,
 	enabled?: boolean
 ) {
 	return useQuery( {
 		...getDefaultQueryParams(),
-		queryKey: [ 'stats', 'notices-visibility', 'raw', siteId ],
+		queryKey: noticesVisibilityQueryKey( siteId ),
 		queryFn: () => queryNotices( siteId ),
 		select,
 		enabled: enabled !== false,
@@ -133,8 +198,8 @@ export function useNoticeVisibilityQuery(
 	noticeId: NoticeIdType,
 	enabled?: boolean
 ) {
-	const selectVisibilityForSingleNotice = ( payload: Notices ) => {
-		payload = processConflictNotices( payload );
+	const selectVisibilityForSingleNotice = ( records: NoticeRecords ) => {
+		const payload = processConflictNotices( toNoticesVisibility( records ) );
 		return !! payload?.[ noticeId ];
 	};
 	return useNoticesVisibilityQueryRaw< boolean >(
@@ -145,5 +210,10 @@ export function useNoticeVisibilityQuery(
 }
 
 export function useNoticesVisibilityQuery( siteId: number | null ) {
-	return useNoticesVisibilityQueryRaw< Notices >( siteId );
+	return useNoticesVisibilityQueryRaw< Notices >( siteId, toNoticesVisibility );
+}
+
+export function useNoticeRecordQuery( siteId: number | null, noticeId: NoticeIdType ) {
+	const selectRecord = ( records: NoticeRecords ) => records[ noticeId ];
+	return useNoticesVisibilityQueryRaw< NoticeRecord | undefined >( siteId, selectRecord );
 }

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -36,10 +36,11 @@ export const DEFAULT_NOTICES_VISIBILITY = {
 export type Notices = typeof DEFAULT_NOTICES_VISIBILITY;
 export type NoticeIdType = keyof Notices;
 
-export type NoticeStatus = 'dismissed' | 'postponed' | null;
+const NOTICE_DISMISS_STATUSES = [ 'dismissed', 'postponed' ] as const;
+export type NoticeDismissStatus = ( typeof NOTICE_DISMISS_STATUSES )[ number ];
 export interface NoticeRecord {
 	show: boolean;
-	status: NoticeStatus;
+	status: NoticeDismissStatus | null;
 	postponed_count: number;
 	next_show_at: number | null;
 }
@@ -110,39 +111,23 @@ export const normalizeNoticesVisibility = (
 const isNoticeRecord = ( value: unknown ): value is Partial< NoticeRecord > =>
 	typeof value === 'object' && value !== null;
 
+const isNoticeDismissStatus = ( value: unknown ): value is NoticeDismissStatus =>
+	NOTICE_DISMISS_STATUSES.includes( value as NoticeDismissStatus );
+
 /**
  * Both the flat map an older server answers with and a detail record land in one shape, so the
  * escalation fields read as "never postponed" wherever the server cannot say otherwise.
  */
-export const toNoticeRecord = ( value: unknown ): NoticeRecord => {
+const toNoticeRecord = ( value: unknown ): NoticeRecord => {
 	if ( ! isNoticeRecord( value ) ) {
 		return { show: !! value, status: null, postponed_count: 0, next_show_at: null };
 	}
 	return {
 		show: !! value.show,
-		status: value.status === 'dismissed' || value.status === 'postponed' ? value.status : null,
+		status: isNoticeDismissStatus( value.status ) ? value.status : null,
 		postponed_count: Number( value.postponed_count ) || 0,
 		next_show_at: typeof value.next_show_at === 'number' ? value.next_show_at : null,
 	};
-};
-
-export const normalizeNoticeRecords = (
-	payload: Record< string, unknown > | null | undefined
-): NoticeRecords => {
-	const records = {} as NoticeRecords;
-	const payloadVisibility: Record< string, boolean > = {};
-	for ( const [ noticeId, value ] of Object.entries( payload ?? {} ) ) {
-		records[ noticeId as NoticeIdType ] = toNoticeRecord( value );
-		payloadVisibility[ noticeId ] = records[ noticeId as NoticeIdType ].show;
-	}
-	const visibility = normalizeNoticesVisibility( payloadVisibility );
-	for ( const noticeId of Object.keys( visibility ) as NoticeIdType[] ) {
-		records[ noticeId ] = {
-			...( records[ noticeId ] ?? toNoticeRecord( false ) ),
-			show: visibility[ noticeId ],
-		};
-	}
-	return records;
 };
 
 export const toNoticesVisibility = ( records: NoticeRecords ): Notices => {
@@ -151,6 +136,23 @@ export const toNoticesVisibility = ( records: NoticeRecords ): Notices => {
 		visibility[ noticeId ] = records[ noticeId ].show;
 	}
 	return visibility;
+};
+
+export const normalizeNoticeRecords = (
+	payload: Record< string, unknown > | null | undefined
+): NoticeRecords => {
+	const records = {} as NoticeRecords;
+	for ( const [ noticeId, value ] of Object.entries( payload ?? {} ) ) {
+		records[ noticeId as NoticeIdType ] = toNoticeRecord( value );
+	}
+	const visibility = normalizeNoticesVisibility( toNoticesVisibility( records ) );
+	for ( const noticeId of Object.keys( visibility ) as NoticeIdType[] ) {
+		records[ noticeId ] = {
+			...( records[ noticeId ] ?? toNoticeRecord( false ) ),
+			show: visibility[ noticeId ],
+		};
+	}
+	return records;
 };
 
 const queryNotices = async function ( siteId: number | null ): Promise< NoticeRecords > {
@@ -182,24 +184,17 @@ export const noticesVisibilityQueryKey = ( siteId: number | null ) => [
 ];
 
 /**
- * Mark a notice hidden in the cache, from the record a write returned or the one already held.
+ * Mark a notice hidden in the cache, ahead of the refetch the write triggers.
  * A cache that was never filled is left alone; only a fetch may seed it.
  */
 export const setNoticeHidden = (
 	queryClient: QueryClient,
 	siteId: number | null,
-	noticeId: NoticeIdType,
-	record?: unknown
+	noticeId: NoticeIdType
 ) =>
 	queryClient.setQueryData< NoticeRecords >( noticesVisibilityQueryKey( siteId ), ( records ) =>
 		records
-			? {
-					...records,
-					[ noticeId ]: { ...toNoticeRecord( record ?? records[ noticeId ] ), show: false },
-					...( noticeId === 'do_you_love_jetpack_stats' || noticeId === 'commercial_site_upgrade'
-						? { free_site_upgrade: { ...records.free_site_upgrade, show: false } }
-						: {} ),
-			  }
+			? { ...records, [ noticeId ]: { ...toNoticeRecord( records[ noticeId ] ), show: false } }
 			: records
 	);
 
@@ -239,5 +234,5 @@ export function useNoticesVisibilityQuery( siteId: number | null ) {
 
 export function useNoticeRecordQuery( siteId: number | null, noticeId: NoticeIdType ) {
 	const selectRecord = ( records: NoticeRecords ) => records[ noticeId ];
-	return useNoticesVisibilityQueryRaw< NoticeRecord | undefined >( siteId, selectRecord );
+	return useNoticesVisibilityQueryRaw< NoticeRecord >( siteId, selectRecord );
 }

--- a/client/my-sites/stats/pricing-grid/hooks/test/use-dismiss-pricing-grid.test.tsx
+++ b/client/my-sites/stats/pricing-grid/hooks/test/use-dismiss-pricing-grid.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import {
+	normalizeNoticeRecords,
+	noticesVisibilityQueryKey,
+	useNoticeRecordQuery,
+	useNoticesVisibilityQuery,
+} from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import useDismissPricingGrid from '../use-dismiss-pricing-grid';
+
+const mockRecordDismissal = jest.fn();
+jest.mock( 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation', () => ( {
+	__esModule: true,
+	default: () => ( { mutateAsync: mockRecordDismissal } ),
+} ) );
+
+const SITE_ID = 1;
+
+describe( 'useDismissPricingGrid', () => {
+	let client: QueryClient;
+	const wrapper = ( { children }: { children: React.ReactNode } ) => (
+		<QueryClientProvider client={ client }>{ children }</QueryClientProvider>
+	);
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockRecordDismissal.mockReturnValue( new Promise( () => {} ) );
+		client = new QueryClient();
+		client.setQueryData(
+			noticesVisibilityQueryKey( SITE_ID ),
+			normalizeNoticeRecords( { pricing_grid: true, tier_upgrade: true } )
+		);
+	} );
+
+	/**
+	 * The cache holds records, and every reader relies on that shape. The patch that hides the
+	 * grid before the POST lands must keep it.
+	 */
+	it( 'hides the grid in the cache as a record, before the write lands', async () => {
+		const { result: dismiss } = renderHook( () => useDismissPricingGrid( SITE_ID ), { wrapper } );
+		const { result: all } = renderHook( () => useNoticesVisibilityQuery( SITE_ID ), { wrapper } );
+		const { result: record } = renderHook( () => useNoticeRecordQuery( SITE_ID, 'pricing_grid' ), {
+			wrapper,
+		} );
+
+		act( () => dismiss.current() );
+
+		expect( mockRecordDismissal ).toHaveBeenCalled();
+		await waitFor( () => expect( all.current.data?.pricing_grid ).toBe( false ) );
+		expect( all.current.data?.tier_upgrade ).toBe( true );
+		expect( record.current.data ).toEqual( {
+			show: false,
+			status: null,
+			postponed_count: 0,
+			next_show_at: null,
+		} );
+	} );
+} );

--- a/client/my-sites/stats/pricing-grid/hooks/test/use-dismiss-pricing-grid.test.tsx
+++ b/client/my-sites/stats/pricing-grid/hooks/test/use-dismiss-pricing-grid.test.tsx
@@ -35,10 +35,6 @@ describe( 'useDismissPricingGrid', () => {
 		);
 	} );
 
-	/**
-	 * The cache holds records, and every reader relies on that shape. The patch that hides the
-	 * grid before the POST lands must keep it.
-	 */
 	it( 'hides the grid in the cache as a record, before the write lands', async () => {
 		const { result: dismiss } = renderHook( () => useDismissPricingGrid( SITE_ID ), { wrapper } );
 		const { result: all } = renderHook( () => useNoticesVisibilityQuery( SITE_ID ), { wrapper } );

--- a/client/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid.ts
+++ b/client/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid.ts
@@ -1,7 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
-import type { Notices } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import { setNoticeHidden } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 
 /** The `from` value the pricing grid's paid CTA sends to the purchase page. */
 export const PRICING_GRID_REFERRER = 'jetpack-stats-pricing-grid';
@@ -38,9 +38,6 @@ export default function useDismissPricingGrid( siteId: number | null ) {
 
 	return useCallback( () => {
 		recordDismissal().catch( () => null );
-		queryClient.setQueryData(
-			[ 'stats', 'notices-visibility', 'raw', siteId ],
-			( notices: Notices | undefined ) => notices && { ...notices, pricing_grid: false }
-		);
+		setNoticeHidden( queryClient, siteId, 'pricing_grid' );
 	}, [ recordDismissal, queryClient, siteId ] );
 }

--- a/client/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid.ts
+++ b/client/my-sites/stats/pricing-grid/hooks/use-dismiss-pricing-grid.ts
@@ -18,7 +18,7 @@ export const PLAN_CHOSEN_QUERY_ARG = 'stats_plan_chosen';
  * Returns a function that records the pricing grid dismissal server-side and
  * patches the cached notices in place, so the gate sees the choice on SPA route
  * changes without waiting for a refetch. The patch can't cover every path — the
- * raw notices entry may be absent when the purchase page was reached directly —
+ * notices entry may be absent when the purchase page was reached directly —
  * but the round-trip needn't be awaited: the mutation invalidates the notices
  * query on success, so a gate that fetched pre-dismissal state self-corrects
  * once the POST lands. A rejection (after the mutation's own retry) is

--- a/client/my-sites/stats/stats-notices/premium-analytics-preview-notice.tsx
+++ b/client/my-sites/stats/stats-notices/premium-analytics-preview-notice.tsx
@@ -7,7 +7,9 @@ import { Button } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
+import useNoticeVisibilityMutation, {
+	NoticeUpdate,
+} from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
 import { useNoticeRecordQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import usePremiumAnalyticsStatusMutation from 'calypso/my-sites/stats/hooks/use-premium-analytics-status-mutation';
 import {
@@ -49,8 +51,8 @@ const PremiumAnalyticsPreviewNotice = ( {
 	const isOdyssey = config.isEnabled( 'is_odyssey' );
 	const { data: noticeRecord } = useNoticeRecordQuery( siteId, 'premium_analytics_preview' );
 	const postponedCount = noticeRecord?.postponed_count ?? 0;
-	// Read through a ref by the impression effect, so a record refreshed mid-mount does not
-	// count as a second showing.
+	// Read through a ref so the impression effect does not depend on the count: a record refreshed
+	// while mounted is not a second showing.
 	const postponedCountRef = useRef( postponedCount );
 	postponedCountRef.current = postponedCount;
 	const trackEvent = ( name: string, properties: Record< string, unknown > = {} ) =>
@@ -87,13 +89,16 @@ const PremiumAnalyticsPreviewNotice = ( {
 		trackEvent( 'dismissed', { postponed_count: postponedCount } );
 		setDismissedSiteId( siteId );
 
-		// Best-effort past the mutation's own retry: local state already hides it for this session,
-		// and a lost write only re-offers the same step on the next load, so nothing is surfaced.
-		recordDismissalAsync(
+		const update: NoticeUpdate =
 			postponedCount === 0
 				? { status: 'postponed', postponedFor: DISMISSAL_POSTPONEMENT }
-				: { status: 'dismissed' }
-		).catch( () => {} );
+				: { status: 'dismissed' };
+		// Best-effort past the mutation's own retry: local state already hides it for this session,
+		// and a lost write only re-offers the same step on the next load. The event is what tells a
+		// site that keeps failing apart from one that never got past its first sighting.
+		recordDismissalAsync( update ).catch( () =>
+			trackEvent( 'dismiss_failed', { postponed_count: postponedCount, status: update.status } )
+		);
 	};
 
 	// Neither the confirmation nor a failed attempt is a rejection, so closing those records
@@ -121,8 +126,9 @@ const PremiumAnalyticsPreviewNotice = ( {
 			// for saying yes.
 			//
 			// Deliberately no dismissal here. An enabled site already fails the eligibility rule, so
-			// the invitation is gone on the next load either way — and recording one marks the
-			// notice hidden, which unmounts this notice mid-sentence, taking the link with it.
+			// the invitation is gone on the next load either way — and recording one would refetch
+			// the notices, which now answers "dismissed" and unmounts this notice mid-sentence,
+			// taking the link with it.
 			setEnabledSiteId( siteId );
 		} catch {
 			shouldRestoreFocus.current = true;

--- a/client/my-sites/stats/stats-notices/premium-analytics-preview-notice.tsx
+++ b/client/my-sites/stats/stats-notices/premium-analytics-preview-notice.tsx
@@ -49,6 +49,10 @@ const PremiumAnalyticsPreviewNotice = ( {
 	const isOdyssey = config.isEnabled( 'is_odyssey' );
 	const { data: noticeRecord } = useNoticeRecordQuery( siteId, 'premium_analytics_preview' );
 	const postponedCount = noticeRecord?.postponed_count ?? 0;
+	// Read through a ref by the impression effect, so a record refreshed mid-mount does not
+	// count as a second showing.
+	const postponedCountRef = useRef( postponedCount );
+	postponedCountRef.current = postponedCount;
 	const trackEvent = ( name: string, properties: Record< string, unknown > = {} ) =>
 		trackPremiumAnalyticsPreviewEvent( 'notice', name, siteId, properties );
 	// Scoped to the site rather than held as a flag: the notices host reuses this component across
@@ -145,10 +149,10 @@ const PremiumAnalyticsPreviewNotice = ( {
 	useEffect( () => {
 		if ( ! noticeDismissed ) {
 			trackPremiumAnalyticsPreviewEvent( 'notice', 'viewed', siteId, {
-				postponed_count: postponedCount,
+				postponed_count: postponedCountRef.current,
 			} );
 		}
-	}, [ noticeDismissed, siteId, postponedCount ] );
+	}, [ noticeDismissed, siteId ] );
 
 	if ( noticeDismissed ) {
 		return null;

--- a/client/my-sites/stats/stats-notices/premium-analytics-preview-notice.tsx
+++ b/client/my-sites/stats/stats-notices/premium-analytics-preview-notice.tsx
@@ -8,6 +8,7 @@ import { Icon, external } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
+import { useNoticeRecordQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import usePremiumAnalyticsStatusMutation from 'calypso/my-sites/stats/hooks/use-premium-analytics-status-mutation';
 import {
 	PREMIUM_ANALYTICS_ENABLED_SETTING,
@@ -17,8 +18,8 @@ import { trackPremiumAnalyticsPreviewEvent } from '../premium-analytics-preview/
 import { StatsNoticeProps } from './types';
 
 const DAY_IN_SECONDS = 24 * 3600;
-// The notices endpoint decides when a postponed invitation stops coming back; the client only
-// says how long each one lasts.
+// The client owns the schedule: the server only counts postponements. The first dismissal holds
+// the invitation back for this long and it returns once; the next one is for good.
 const DISMISSAL_POSTPONEMENT = 30 * DAY_IN_SECONDS;
 
 const NoticeContainer = ( {
@@ -46,6 +47,8 @@ const PremiumAnalyticsPreviewNotice = ( {
 	// `is_running_in_jetpack_site` and false in a Simple site's wp-admin. That prop still decides
 	// where support lives, because it says which API the site answers on.
 	const isOdyssey = config.isEnabled( 'is_odyssey' );
+	const { data: noticeRecord } = useNoticeRecordQuery( siteId, 'premium_analytics_preview' );
+	const postponedCount = noticeRecord?.postponed_count ?? 0;
 	const trackEvent = ( name: string, properties: Record< string, unknown > = {} ) =>
 		trackPremiumAnalyticsPreviewEvent( 'notice', name, siteId, properties );
 	// Scoped to the site rather than held as a flag: the notices host reuses this component across
@@ -71,19 +74,22 @@ const PremiumAnalyticsPreviewNotice = ( {
 	const { mutateAsync: enablePreviewAsync, isPending: isEnabling } =
 		usePremiumAnalyticsStatusMutation( siteId );
 
-	const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
+	const { mutateAsync: recordDismissalAsync } = useNoticeVisibilityMutation(
 		siteId,
-		'premium_analytics_preview',
-		'postponed',
-		DISMISSAL_POSTPONEMENT
+		'premium_analytics_preview'
 	);
 
 	const dismissNotice = () => {
-		trackEvent( 'dismissed' );
+		trackEvent( 'dismissed', { postponed_count: postponedCount } );
 		setDismissedSiteId( siteId );
 
-		// Best-effort: the local state above already hides the notice for this session.
-		postponeNoticeAsync().catch( () => {} );
+		// Best-effort past the mutation's own retry: local state already hides it for this session,
+		// and a lost write only re-offers the same step on the next load, so nothing is surfaced.
+		recordDismissalAsync(
+			postponedCount === 0
+				? { status: 'postponed', postponedFor: DISMISSAL_POSTPONEMENT }
+				: { status: 'dismissed' }
+		).catch( () => {} );
 	};
 
 	// Neither the confirmation nor a failed attempt is a rejection, so closing those records
@@ -111,9 +117,8 @@ const PremiumAnalyticsPreviewNotice = ( {
 			// for saying yes.
 			//
 			// Deliberately no dismissal here. An enabled site already fails the eligibility rule, so
-			// the invitation is gone on the next load either way — and recording one would refetch
-			// the notices, which now answers "dismissed" and unmounts this notice mid-sentence,
-			// taking the link with it.
+			// the invitation is gone on the next load either way — and recording one marks the
+			// notice hidden, which unmounts this notice mid-sentence, taking the link with it.
 			setEnabledSiteId( siteId );
 		} catch {
 			shouldRestoreFocus.current = true;
@@ -139,9 +144,11 @@ const PremiumAnalyticsPreviewNotice = ( {
 
 	useEffect( () => {
 		if ( ! noticeDismissed ) {
-			trackPremiumAnalyticsPreviewEvent( 'notice', 'viewed', siteId );
+			trackPremiumAnalyticsPreviewEvent( 'notice', 'viewed', siteId, {
+				postponed_count: postponedCount,
+			} );
 		}
-	}, [ noticeDismissed, siteId ] );
+	}, [ noticeDismissed, siteId, postponedCount ] );
 
 	if ( noticeDismissed ) {
 		return null;

--- a/client/my-sites/stats/stats-notices/test/premium-analytics-preview-notice-endpoint.tsx
+++ b/client/my-sites/stats/stats-notices/test/premium-analytics-preview-notice-endpoint.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useNoticesVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import PremiumAnalyticsPreviewNotice from '../premium-analytics-preview-notice';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const isEnabled = () => false;
+	return { __esModule: true, default: { isEnabled }, isEnabled };
+} );
+
+jest.mock( '@automattic/calypso-analytics', () => ( { recordTracksEvent: jest.fn() } ) );
+
+const mockGet = jest.fn();
+const mockPost = jest.fn();
+jest.mock( 'calypso/lib/wp', () => ( {
+	__esModule: true,
+	default: {
+		req: {
+			get: ( ...args: unknown[] ) => mockGet( ...args ),
+			post: ( ...args: unknown[] ) => mockPost( ...args ),
+		},
+	},
+} ) );
+
+const SITE_ID = 123;
+const THIRTY_DAYS = 30 * 24 * 3600;
+
+// The notices host mounts the banner only once the query says so, which is what puts the record
+// in the cache before the banner's first render.
+const Host = () => {
+	const { data } = useNoticesVisibilityQuery( SITE_ID );
+	return data?.premium_analytics_preview === true ? (
+		<PremiumAnalyticsPreviewNotice
+			siteId={ SITE_ID }
+			isOdysseyStats={ false }
+			premiumAnalyticsDashboardUrl={ null }
+		/>
+	) : null;
+};
+
+const renderHost = () => {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	return render(
+		<QueryClientProvider client={ client }>
+			<Host />
+		</QueryClientProvider>
+	);
+};
+
+const closeNotice = async () =>
+	userEvent.click( await screen.findByRole( 'button', { name: 'close' } ) );
+
+describe( 'PremiumAnalyticsPreviewNotice against the notices endpoint', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockPost.mockResolvedValue( { updated: true } );
+	} );
+
+	it( 'keeps the single 30-day hold when an older server answers a flat map', async () => {
+		mockGet.mockResolvedValue( { premium_analytics_preview: true } );
+
+		renderHost();
+		await closeNotice();
+
+		expect( mockGet ).toHaveBeenCalledWith( expect.anything(), { include_details: true } );
+		expect( mockPost.mock.calls[ 0 ][ 0 ].body ).toEqual( {
+			id: 'premium_analytics_preview',
+			status: 'postponed',
+			postponed_for: THIRTY_DAYS,
+		} );
+	} );
+
+	it( 'dismisses for good once the record says the invitation already came back', async () => {
+		mockGet.mockResolvedValue( {
+			premium_analytics_preview: {
+				show: true,
+				status: 'postponed',
+				postponed_count: 1,
+				next_show_at: 1_700_000_000,
+			},
+		} );
+
+		renderHost();
+		await closeNotice();
+
+		expect( mockPost.mock.calls[ 0 ][ 0 ].body ).toEqual( {
+			id: 'premium_analytics_preview',
+			status: 'dismissed',
+			postponed_for: 0,
+		} );
+	} );
+} );

--- a/client/my-sites/stats/stats-notices/test/premium-analytics-preview-notice.tsx
+++ b/client/my-sites/stats/stats-notices/test/premium-analytics-preview-notice.tsx
@@ -344,6 +344,30 @@ describe( 'PremiumAnalyticsPreviewNotice', () => {
 		expect( screen.queryByText( 'Try the new Traffic tab' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'counts one impression per showing, however often the record is refreshed', () => {
+		const { rerender } = renderNotice();
+
+		mockPostponedCount = 1;
+		rerender(
+			<PremiumAnalyticsPreviewNotice
+				siteId={ 123 }
+				isOdysseyStats={ false }
+				premiumAnalyticsDashboardUrl={ DASHBOARD_URL }
+			/>
+		);
+
+		expect(
+			mockRecordTracksEvent.mock.calls.filter(
+				( [ name ] ) => name === 'calypso_stats_premium_analytics_preview_notice_viewed'
+			)
+		).toEqual( [
+			[
+				'calypso_stats_premium_analytics_preview_notice_viewed',
+				{ blog_id: 123, postponed_count: 0 },
+			],
+		] );
+	} );
+
 	it( 'does not hide the notice for a different site after a dismissal', async () => {
 		const { rerender } = renderNotice();
 

--- a/client/my-sites/stats/stats-notices/test/premium-analytics-preview-notice.tsx
+++ b/client/my-sites/stats/stats-notices/test/premium-analytics-preview-notice.tsx
@@ -28,14 +28,21 @@ jest.mock( '@automattic/calypso-analytics', () => ( {
 	recordTracksEvent: ( ...args: unknown[] ) => mockRecordTracksEvent( ...args ),
 } ) );
 
-const mockPostponeNotice = jest.fn();
+const mockRecordDismissal = jest.fn();
 const mockUseNoticeVisibilityMutation = jest.fn();
 jest.mock( 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation', () => ( {
 	__esModule: true,
 	default: ( ...args: unknown[] ) => {
 		mockUseNoticeVisibilityMutation( ...args );
-		return { mutateAsync: mockPostponeNotice };
+		return { mutateAsync: mockRecordDismissal };
 	},
+} ) );
+
+let mockPostponedCount = 0;
+jest.mock( 'calypso/my-sites/stats/hooks/use-notice-visibility-query', () => ( {
+	useNoticeRecordQuery: () => ( {
+		data: { show: true, status: null, postponed_count: mockPostponedCount, next_show_at: null },
+	} ),
 } ) );
 
 const mockEnablePreview = jest.fn();
@@ -63,9 +70,10 @@ describe( 'PremiumAnalyticsPreviewNotice', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		Object.keys( mockFlags() ).forEach( ( flag ) => delete mockFlags()[ flag ] );
-		mockPostponeNotice.mockResolvedValue( undefined );
+		mockRecordDismissal.mockResolvedValue( undefined );
 		mockEnablePreview.mockResolvedValue( true );
 		mockIsEnabling = false;
+		mockPostponedCount = 0;
 		Object.defineProperty( window, 'location', { value: { href: '' }, writable: true } );
 	} );
 
@@ -83,14 +91,21 @@ describe( 'PremiumAnalyticsPreviewNotice', () => {
 		);
 	} );
 
-	it( 'records exactly one impression', () => {
+	it( 'records exactly one impression, stamped with the showing it belongs to', () => {
+		mockPostponedCount = 1;
+
 		renderNotice();
 
 		expect(
 			mockRecordTracksEvent.mock.calls.filter(
 				( [ name ] ) => name === 'calypso_stats_premium_analytics_preview_notice_viewed'
 			)
-		).toHaveLength( 1 );
+		).toEqual( [
+			[
+				'calypso_stats_premium_analytics_preview_notice_viewed',
+				{ blog_id: 123, postponed_count: 1 },
+			],
+		] );
 	} );
 
 	it( 'enables the dashboard and offers a link into it, without navigating', async () => {
@@ -135,9 +150,9 @@ describe( 'PremiumAnalyticsPreviewNotice', () => {
 	} );
 
 	/**
-	 * Recording a dismissal refetches the notices, which then answers "dismissed" and unmounts this
-	 * notice - taking the link with it before anyone can follow it. An enabled site already fails
-	 * the eligibility rule, so the invitation is gone on the next load without one.
+	 * Recording a dismissal marks the notice hidden, which unmounts this notice - taking the link
+	 * with it before anyone can follow it. An enabled site already fails the eligibility rule, so
+	 * the invitation is gone on the next load without one.
 	 */
 	it( 'does not record a dismissal when the invitation is accepted', async () => {
 		renderNotice();
@@ -147,12 +162,12 @@ describe( 'PremiumAnalyticsPreviewNotice', () => {
 		expect(
 			await screen.findByRole( 'link', { name: 'Go to the new Traffic tab' } )
 		).toBeVisible();
-		expect( mockPostponeNotice ).not.toHaveBeenCalled();
+		expect( mockRecordDismissal ).not.toHaveBeenCalled();
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'close' } ) );
 
 		expect( screen.queryByText( 'The new Traffic tab is on' ) ).not.toBeInTheDocument();
-		expect( mockPostponeNotice ).not.toHaveBeenCalled();
+		expect( mockRecordDismissal ).not.toHaveBeenCalled();
 	} );
 
 	it( 'offers a retry and a way to reach support when the write fails', async () => {
@@ -202,7 +217,7 @@ describe( 'PremiumAnalyticsPreviewNotice', () => {
 		await userEvent.click( screen.getByRole( 'button', { name: 'close' } ) );
 
 		expect( screen.queryByRole( 'alert' ) ).not.toBeInTheDocument();
-		expect( mockPostponeNotice ).not.toHaveBeenCalled();
+		expect( mockRecordDismissal ).not.toHaveBeenCalled();
 	} );
 
 	it( 'records why an enable failed, so uptake can be told from breakage', async () => {
@@ -255,9 +270,9 @@ describe( 'PremiumAnalyticsPreviewNotice', () => {
 
 		expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
 			'jetpack_odyssey_stats_premium_analytics_preview_notice_dismissed',
-			{ blog_id: 123 }
+			{ blog_id: 123, postponed_count: 0 }
 		);
-		expect( mockPostponeNotice ).toHaveBeenCalled();
+		expect( mockRecordDismissal ).toHaveBeenCalled();
 	} );
 
 	it( 'keeps the Calypso container class out of wp-admin', () => {
@@ -269,25 +284,64 @@ describe( 'PremiumAnalyticsPreviewNotice', () => {
 	} );
 
 	/**
-	 * The client only says how long a dismissal lasts. Whether a repeat dismissal ends the invitation
-	 * for good is the notices endpoint's call, so there is no count kept here.
+	 * The client owns the schedule; the server only counts. A first dismissal is a 30-day hold, and
+	 * the one after the invitation has come back is for good.
 	 */
-	it( 'holds the invitation back for a month on dismissal', async () => {
+	it( 'holds the invitation back for a month on the first dismissal', async () => {
 		renderNotice();
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'close' } ) );
 
 		expect( mockUseNoticeVisibilityMutation ).toHaveBeenCalledWith(
 			123,
-			'premium_analytics_preview',
-			'postponed',
-			THIRTY_DAYS
+			'premium_analytics_preview'
 		);
-		expect( mockPostponeNotice ).toHaveBeenCalledTimes( 1 );
+		expect( mockRecordDismissal ).toHaveBeenCalledTimes( 1 );
+		expect( mockRecordDismissal ).toHaveBeenCalledWith( {
+			status: 'postponed',
+			postponedFor: THIRTY_DAYS,
+		} );
 		expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
 			'calypso_stats_premium_analytics_preview_notice_dismissed',
-			{ blog_id: 123 }
+			{ blog_id: 123, postponed_count: 0 }
 		);
+	} );
+
+	it( 'dismisses the invitation for good once it has already come back', async () => {
+		mockPostponedCount = 1;
+
+		renderNotice();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'close' } ) );
+
+		expect( mockRecordDismissal ).toHaveBeenCalledTimes( 1 );
+		expect( mockRecordDismissal ).toHaveBeenCalledWith( { status: 'dismissed' } );
+		expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_stats_premium_analytics_preview_notice_dismissed',
+			{ blog_id: 123, postponed_count: 1 }
+		);
+	} );
+
+	it( 'hides the invitation before the write is answered', async () => {
+		let settle: () => void = () => {};
+		mockRecordDismissal.mockReturnValue(
+			new Promise< void >( ( resolve ) => ( settle = resolve ) )
+		);
+
+		renderNotice();
+		await userEvent.click( screen.getByRole( 'button', { name: 'close' } ) );
+
+		expect( screen.queryByText( 'Try the new Traffic tab' ) ).not.toBeInTheDocument();
+		settle();
+	} );
+
+	it( 'stays hidden when the write fails', async () => {
+		mockRecordDismissal.mockRejectedValue( new Error( 'nope' ) );
+
+		renderNotice();
+		await userEvent.click( screen.getByRole( 'button', { name: 'close' } ) );
+
+		expect( screen.queryByText( 'Try the new Traffic tab' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'does not hide the notice for a different site after a dismissal', async () => {

--- a/client/my-sites/stats/stats-notices/test/premium-analytics-preview-notice.tsx
+++ b/client/my-sites/stats/stats-notices/test/premium-analytics-preview-notice.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PREMIUM_ANALYTICS_PAGE_PATH } from '../premium-analytics-preview-cohort';
 import PremiumAnalyticsPreviewNotice from '../premium-analytics-preview-notice';
@@ -283,10 +283,6 @@ describe( 'PremiumAnalyticsPreviewNotice', () => {
 		expect( container.querySelector( '.inner-notice-container--calypso' ) ).toBeNull();
 	} );
 
-	/**
-	 * The client owns the schedule; the server only counts. A first dismissal is a 30-day hold, and
-	 * the one after the invitation has come back is for good.
-	 */
 	it( 'holds the invitation back for a month on the first dismissal', async () => {
 		renderNotice();
 
@@ -307,20 +303,23 @@ describe( 'PremiumAnalyticsPreviewNotice', () => {
 		);
 	} );
 
-	it( 'dismisses the invitation for good once it has already come back', async () => {
-		mockPostponedCount = 1;
+	it.each( [ 1, 2, 5 ] )(
+		'dismisses the invitation for good once it has already come back (postponed %i times)',
+		async ( postponedCount ) => {
+			mockPostponedCount = postponedCount;
 
-		renderNotice();
+			renderNotice();
 
-		await userEvent.click( screen.getByRole( 'button', { name: 'close' } ) );
+			await userEvent.click( screen.getByRole( 'button', { name: 'close' } ) );
 
-		expect( mockRecordDismissal ).toHaveBeenCalledTimes( 1 );
-		expect( mockRecordDismissal ).toHaveBeenCalledWith( { status: 'dismissed' } );
-		expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
-			'calypso_stats_premium_analytics_preview_notice_dismissed',
-			{ blog_id: 123, postponed_count: 1 }
-		);
-	} );
+			expect( mockRecordDismissal ).toHaveBeenCalledTimes( 1 );
+			expect( mockRecordDismissal ).toHaveBeenCalledWith( { status: 'dismissed' } );
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_stats_premium_analytics_preview_notice_dismissed',
+				{ blog_id: 123, postponed_count: postponedCount }
+			);
+		}
+	);
 
 	it( 'hides the invitation before the write is answered', async () => {
 		let settle: () => void = () => {};
@@ -335,13 +334,20 @@ describe( 'PremiumAnalyticsPreviewNotice', () => {
 		settle();
 	} );
 
-	it( 'stays hidden when the write fails', async () => {
+	it( 'stays hidden when the write fails, and says so', async () => {
+		mockPostponedCount = 1;
 		mockRecordDismissal.mockRejectedValue( new Error( 'nope' ) );
 
 		renderNotice();
 		await userEvent.click( screen.getByRole( 'button', { name: 'close' } ) );
 
 		expect( screen.queryByText( 'Try the new Traffic tab' ) ).not.toBeInTheDocument();
+		await waitFor( () =>
+			expect( mockRecordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_stats_premium_analytics_preview_notice_dismiss_failed',
+				{ blog_id: 123, postponed_count: 1, status: 'dismissed' }
+			)
+		);
 	} );
 
 	it( 'counts one impression per showing, however often the record is refreshed', () => {


### PR DESCRIPTION
Part of STATS-474 (spec in STATS-461 / STATS-472). Server side: wpcom PR 239180 (deployed 2026-09-08) and Automattic/jetpack#52075 (STATS-473, merged 2026-09-10).

## Proposed Changes

Closing the "Try the new Traffic tab" banner used to send `postponed` for 30 days every time, so it came back every month for good. Now the first close postpones for 30 days and the banner returns once; the next close sends `dismissed` and it never returns.

- The notices GET asks for `include_details=true` and caches a record per notice. A server still answering `{ id: bool }` (older Jetpack `stats-admin`) reads as "never postponed", so the banner keeps today's single 30-day hold there.
- The banner picks the step from `postponed_count`: `0` sends `postponed` / `2592000`, anything else sends `dismissed`. The server only counts.
- `viewed` and `dismissed` Tracks events carry `postponed_count`. A write that still fails after the mutation's retry records `dismiss_failed` with the count and the status it tried to send.
- The query key gains a `details` segment: Calypso persists this cache for a week, and an older build's boolean map would otherwise be read as records.
- `useDismissPricingGrid` uses the same `setNoticeHidden` helper, so its optimistic patch keeps the record shape.


## Why are these changes being made?

STATS-461 asks that people who close the invitation twice stop seeing it, with one reminder for everyone else. The server became policy-stateless in STATS-472, so the schedule lives here. The comment above `DISMISSAL_POSTPONEMENT` claimed the opposite and is corrected. The swallowed write failure stays best-effort on top of the mutation's retry; the `dismiss_failed` event is what tells a site whose writes keep failing apart from one that never got past its first sighting, since both read as `postponed_count: 0` otherwise.

## Testing Instructions

Use a Simple site whose notice has never been dismissed: `postponed_count` cannot be reset, so a site that already reached `dismissed` will not show the banner again.

Setup tips (run in the browser console on Calypso; in development `window.wpcom` is the app's own client, so these calls use the same session):

- Site id: `(await wpcom.req.get('/sites/example.wordpress.com')).ID`
- Make the site eligible (the banner is hidden while the preview is on): `await wpcom.req.post({ apiNamespace: 'wp/v2', path: '/sites/<id>/settings', body: { jetpack_premium_analytics_enabled: false } })`. Switch it back on the same way afterwards, or from the settings in the new Traffic tab.
- Read the record: `await wpcom.req.get({ apiNamespace: 'wpcom/v2', path: '/sites/<id>/jetpack-stats-dashboard/notices' }, { include_details: true })` and look at `premium_analytics_preview`. Without the second argument you get the legacy `{ id: bool }` map.
- Watch what the banner sends: API calls go through the REST proxy iframe, so in DevTools Network filter by `jetpack-stats-dashboard` with all frames shown. Or log them: `const post = wpcom.req.post.bind(wpcom.req); wpcom.req.post = (p, ...r) => { if (/notices/.test(p.path)) console.log('POST', p.body); return post(p, ...r); }`
- See Tracks events: `localStorage.debug = 'calypso:analytics*'`, reload, and the console logs each `calypso_stats_premium_analytics_preview_notice_*` event with its props.

Steps:

1. Open `/stats/day/:site`. The banner shows and the record reads `show: true, postponed_count: 0`.
2. Close it. Expect POST `{ status: "postponed", postponed_for: 2592000 }`, the banner gone at once, and a follow-up GET. The record now reads `postponed_count: 1, show: false`.
3. Expire the hold without waiting 30 days: `await wpcom.req.post({ apiNamespace: 'wpcom/v2', path: '/sites/<id>/jetpack-stats-dashboard/notices', body: { id: 'premium_analytics_preview', status: 'postponed', postponed_for: 1 } })`. The count does not move while the notice is hidden. Reload after a second: the banner is back.
4. Close it again. Expect POST `{ status: "dismissed" }` and the `..._notice_dismissed` event with `postponed_count: 1`. Reload: the banner is gone for good.
5. Older server (flat map): wrap `wpcom.req.get` to turn each record into `!!record.show` for that route, wait 30s for the query to go stale, switch to Insights and back. The banner renders, closing sends the 30-day `postponed`, and there are no console errors.

| First sighting                                                                                                                                                 | Returned once                                                                                                                                                 | After the second close                                                                                                                                                |
| -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| ![banner visible, count 0](https://github.com/Automattic/wp-calypso/raw/screenshots/stats-preview-notice-escalating-dismiss/first-sighting-banner-visible.jpg) | ![banner back, count 1](https://github.com/Automattic/wp-calypso/raw/screenshots/stats-preview-notice-escalating-dismiss/returned-once-postponed-count-1.jpg) | ![banner gone after reload](https://github.com/Automattic/wp-calypso/raw/screenshots/stats-preview-notice-escalating-dismiss/after-permanent-dismiss-banner-gone.jpg) |

Only the banner's presence differs between the three.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
  - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

<!-- pr-draft
Verified: real environment (Simple site via sandbox) - first close, expiry, second close, flat-map fallback, no console errors; unit tests for normalizer, mutation cache write, banner escalation; typecheck 0 new errors
Fixed in review: mutateAsync() callers failed TS2554 (NoticeUpdate | void); persisted cache hydrated old boolean shape (versioned key); pricing-grid wrote a bare boolean into the records cache (shared setNoticeHidden); the response-patch path was dropped for a plain refetch (it only saved one GET and needed its own guards); failed writes were invisible (dismiss_failed event)
Skipped: Odyssey/wp-admin on a Jetpack site not driven; viewed event property only unit-tested; persisted-cache migration not exercised against a real old IndexedDB entry
Risk: Medium - changes a shared cache shape and key used by every Stats notice, verified end to end only on Simple
-->


