### PR TITLE
Stats: record when another notice hides the Traffic tab preview invitation

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -6,6 +6,7 @@ import { STATS_FEATURE_PAGE_TRAFFIC } from 'calypso/my-sites/stats/constants';
 import {
 	DEFAULT_NOTICES_VISIBILITY,
 	Notices,
+	NoticeIdType,
 	useNoticesVisibilityQuery,
 	processConflictNotices,
 } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
@@ -40,7 +41,8 @@ import './style.scss';
 const TEAM51_OWNER_ID = 70055110;
 const SIGNIFICANT_VIEWS_AMOUNT = 100;
 
-const ensureOnlyOneNoticeVisible = (
+/** Every notice that could show on its own, before the conflict groups pick one. */
+const calculateNoticesVisibility = (
 	serverNoticesVisibility: Notices,
 	noticeOptions: StatsNoticeProps
 ) => {
@@ -54,7 +56,26 @@ const ensureOnlyOneNoticeVisible = (
 				notice.isVisibleFunc( noticeOptions ) )
 	);
 
-	return processConflictNotices( calculatedNoticesVisibility );
+	return calculatedNoticesVisibility;
+};
+
+/**
+ * The notice that kept the preview invitation off the page, or null when the invitation was
+ * never in the running or is the one showing.
+ */
+const findPreviewSuppressor = (
+	noticesInTheRunning: Notices,
+	noticesVisibility: Notices
+): NoticeIdType | null => {
+	if (
+		! noticesInTheRunning.premium_analytics_preview ||
+		noticesVisibility.premium_analytics_preview
+	) {
+		return null;
+	}
+	return (
+		ALL_STATS_NOTICES.find( ( notice ) => noticesVisibility[ notice.noticeId ] )?.noticeId ?? null
+	);
 };
 
 /**
@@ -205,6 +226,12 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		// the modules menu and reports its fetch status to every observer, disabled ones included.
 		( shouldAskStatus && isLoadingPremiumAnalyticsStatus );
 
+	const noticesInTheRunning = calculateNoticesVisibility(
+		serverNoticesVisibility ?? DEFAULT_NOTICES_VISIBILITY,
+		noticeOptions
+	);
+	const calculatedNoticesVisibility = processConflictNotices( noticesInTheRunning );
+
 	usePremiumAnalyticsPreviewNotShownEvent( {
 		siteId,
 		isWpcom,
@@ -220,16 +247,12 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		isP2,
 		isPremiumAnalyticsEnabled,
 		isStatusError: isPremiumAnalyticsStatusError,
+		suppressedBy: findPreviewSuppressor( noticesInTheRunning, calculatedNoticesVisibility ),
 	} );
 
 	if ( isWaitingForNoticeInputs || isError ) {
 		return null;
 	}
-
-	const calculatedNoticesVisibility = ensureOnlyOneNoticeVisible(
-		serverNoticesVisibility ?? DEFAULT_NOTICES_VISIBILITY,
-		noticeOptions
-	);
 
 	const allNotices = ALL_STATS_NOTICES.map(
 		( notice ) =>

--- a/client/my-sites/stats/stats-notices/premium-analytics-preview-not-shown-event.ts
+++ b/client/my-sites/stats/stats-notices/premium-analytics-preview-not-shown-event.ts
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import { useEffect } from 'react';
 import { trackPremiumAnalyticsPreviewEvent } from '../premium-analytics-preview/track-event';
 import { PREMIUM_ANALYTICS_PREVIEW_FLAG } from './premium-analytics-preview-cohort';
+import type { NoticeIdType } from '../hooks/use-notice-visibility-query';
 
 type PreviewGateSignals = {
 	isServerVisible: boolean;
@@ -13,6 +14,8 @@ type PreviewGateSignals = {
 	isP2: boolean;
 	isPremiumAnalyticsEnabled?: boolean;
 	isStatusError: boolean;
+	/** The notice that won the conflict group over the invitation, when one did. */
+	suppressedBy?: NoticeIdType | null;
 };
 
 type NotShownSignals = PreviewGateSignals & {
@@ -48,6 +51,7 @@ const notShownReason = ( {
 	isP2,
 	isPremiumAnalyticsEnabled,
 	isStatusError,
+	suppressedBy,
 }: PreviewGateSignals ): string | null => {
 	if ( ! isServerVisible ) {
 		return 'server_hidden';
@@ -83,6 +87,11 @@ const notShownReason = ( {
 	if ( isPremiumAnalyticsEnabled === undefined ) {
 		return 'setting_unavailable';
 	}
+	// Every gate passed and another notice in the group outranked the invitation. Last, so the
+	// count is of sites that would otherwise have seen it.
+	if ( suppressedBy ) {
+		return 'suppressed';
+	}
 
 	return null;
 };
@@ -106,6 +115,7 @@ export default function usePremiumAnalyticsPreviewNotShownEvent( {
 	isP2,
 	isPremiumAnalyticsEnabled,
 	isStatusError,
+	suppressedBy,
 }: NotShownSignals ) {
 	useEffect( () => {
 		// The flag is off everywhere the preview has not reached yet, so counting those sites would
@@ -135,6 +145,7 @@ export default function usePremiumAnalyticsPreviewNotShownEvent( {
 			isP2,
 			isPremiumAnalyticsEnabled,
 			isStatusError,
+			suppressedBy,
 		} );
 
 		// Marked before the shown case returns, so a site that was offered the invitation stays out
@@ -145,7 +156,10 @@ export default function usePremiumAnalyticsPreviewNotShownEvent( {
 			return;
 		}
 
-		trackPremiumAnalyticsPreviewEvent( 'notice', 'not_shown', siteId, { reason } );
+		trackPremiumAnalyticsPreviewEvent( 'notice', 'not_shown', siteId, {
+			reason,
+			...( reason === 'suppressed' ? { by: suppressedBy } : {} ),
+		} );
 	}, [
 		siteId,
 		isWpcom,
@@ -159,5 +173,6 @@ export default function usePremiumAnalyticsPreviewNotShownEvent( {
 		isP2,
 		isPremiumAnalyticsEnabled,
 		isStatusError,
+		suppressedBy,
 	] );
 }

--- a/client/my-sites/stats/stats-notices/test/premium-analytics-preview-not-shown-event.tsx
+++ b/client/my-sites/stats/stats-notices/test/premium-analytics-preview-not-shown-event.tsx
@@ -28,7 +28,27 @@ jest.mock( 'calypso/state', () => ( {
 	useDispatch: () => jest.fn(),
 } ) );
 
-jest.mock( '../all-notice-definitions', () => ( { __esModule: true, default: [] } ) );
+// Empty by default so the gates alone decide; a case that needs the conflict group fills it in.
+jest.mock( '../all-notice-definitions', () => {
+	const definitions: unknown[] = [];
+	( globalThis as Record< string, unknown > ).__notShownEventTestNotices = definitions;
+	return { __esModule: true, default: definitions };
+} );
+
+const mockNoticeDefinitions = () =>
+	( globalThis as Record< string, unknown > ).__notShownEventTestNotices as Array< {
+		component: () => null;
+		noticeId: string;
+		isVisibleFunc: () => boolean;
+		disabled: boolean;
+	} >;
+
+const noticeDefinition = ( noticeId: string, isVisible = true ) => ( {
+	component: () => null,
+	noticeId,
+	isVisibleFunc: () => isVisible,
+	disabled: false,
+} );
 
 jest.mock( 'calypso/components/data/query-site-stats', () => ( {
 	__esModule: true,
@@ -188,6 +208,7 @@ describe( 'premium analytics preview "not shown" event', () => {
 		mockAdminUrl = 'https://example.com/wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin';
 		mockHasLoadedSiteFeatures = true;
 		mockIsStatsGated = false;
+		mockNoticeDefinitions().length = 0;
 		recordedSiteIds.clear();
 	} );
 
@@ -302,6 +323,55 @@ describe( 'premium analytics preview "not shown" event', () => {
 		renderNotices();
 
 		expect( notShownEvents() ).toEqual( [] );
+	} );
+
+	describe( 'with another notice in the conflict group', () => {
+		beforeEach( () => {
+			mockNoticeDefinitions().push(
+				noticeDefinition( 'gdpr_cookie_consent' ),
+				noticeDefinition( 'premium_analytics_preview' )
+			);
+		} );
+
+		it( 'records suppressed, naming the notice that outranked the invitation', () => {
+			mockNoticesVisibility.data = {
+				gdpr_cookie_consent: true,
+				premium_analytics_preview: true,
+			} as unknown as Notices;
+
+			renderNotices();
+
+			expect( notShownEvents() ).toEqual( [
+				[ EVENT_NAME, { blog_id: 123, reason: 'suppressed', by: 'gdpr_cookie_consent' } ],
+			] );
+		} );
+
+		it( 'stays quiet when the invitation wins the group', () => {
+			mockNoticesVisibility.data = {
+				gdpr_cookie_consent: false,
+				premium_analytics_preview: true,
+			} as unknown as Notices;
+
+			renderNotices();
+
+			expect( notShownEvents() ).toEqual( [] );
+		} );
+
+		// A gate failure is the reason a reader would reach first, and the site was never in the
+		// running for the group to suppress.
+		it( 'keeps the gate reason over suppressed', () => {
+			mockCanManageOptions = false;
+			mockNoticesVisibility.data = {
+				gdpr_cookie_consent: true,
+				premium_analytics_preview: true,
+			} as unknown as Notices;
+
+			renderNotices();
+
+			expect( notShownEvents() ).toEqual( [
+				[ EVENT_NAME, { blog_id: 123, reason: 'not_admin' } ],
+			] );
+		} );
 	} );
 
 	it( 'stays quiet for a site that was offered the invitation and then dismissed it', () => {


### PR DESCRIPTION
Part of STATS-461. Follows #114153.

## Proposed Changes

* The `stats_premium_analytics_preview_notice_not_shown` event gains a `suppressed` reason, with a `by` property naming the notice that outranked the invitation in the conflict group (in practice `gdpr_cookie_consent`).
* The notices host now resolves the conflict group before the not-shown hook runs, so the hook can tell "every gate passed but another notice won" apart from "shown". The render path is unchanged: the same post-conflict visibility drives what mounts.
* `suppressed` is checked last, after every gate, so a site that fails a gate keeps that reason and only sites that would otherwise have seen the banner are counted here.

## Why are these changes being made?

Classic Stats shows one notice at a time, and the preview invitation sits below the GDPR cookie consent notice and the two purchase-success notices in that group. The purchase-success ones are one-off, but a Complianz user in wp-admin keeps the GDPR notice until they postpone it, and the invitation stays hidden behind it.

The question raised on the launch thread was how many banners that actually costs. Today the answer is nothing: the banner's `viewed` event needs it to mount, and the not-shown event from #114153 resolves to "shown" once every gate passes, so a suppressed site records neither. With this, `suppressed / (suppressed + viewed)` is the share of eligible sites that had the banner hidden, and the `by` property says by what, which is enough to decide whether the invitation should outrank GDPR.

## Testing Instructions

The flag is on in development and on Calypso Live with `?flags=stats/premium-analytics-preview`. The GDPR notice only renders in wp-admin (Odyssey), so the suppressed case is easiest to force in Calypso by stubbing the server answer.

* On an eligible WordPress.com site (Simple or Atomic, Premium or higher, administrator, dashboard off), open `/stats/day/<site>` in Calypso with the flag and confirm the invitation banner shows and `calypso_stats_premium_analytics_preview_notice_viewed` fires, with no `_not_shown` event.
* In devtools, override the response of `jetpack-stats-dashboard/notices` so that `gdpr_cookie_consent` is `true` alongside `premium_analytics_preview: true`, and stub `isVisibleFunc` for `gdpr_cookie_consent` to return `true` (it is `isOdysseyStats` only). Reload: the GDPR notice shows instead of the banner, and one `_not_shown` event fires with `reason: 'suppressed', by: 'gdpr_cookie_consent'`. No `_viewed` event.
* Fail a gate on top of that (e.g. as a non-admin): the event carries the gate reason (`not_admin`), not `suppressed`.
* Alternatively, on an Atomic site running Complianz with its Jetpack integration blocking Stats, open wp-admin Stats with the flag once Odyssey is redeployed and check the `jetpack_odyssey_` prefixed event the same way.
* `yarn test-client client/my-sites/stats/stats-notices`

Verified in wp-admin on an Atomic site running Complianz, with a locally built Odyssey bundle and the flag on:

* With the GDPR notice showing, one `jetpack_odyssey_stats_premium_analytics_preview_notice_not_shown` fired with `reason: suppressed`, `by: gdpr_cookie_consent`, and no `_viewed`.

<img width="1412" height="788" alt="截圖 2026-09-10 下午4 48 05" src="https://github.com/user-attachments/assets/b0e1da90-c8a9-432c-b31f-626345cb69ad" />

* After dismissing the GDPR notice, the preview banner took its place and `..._notice_viewed` fired, with no `_not_shown`.

<img width="629" height="349" alt="截圖 2026-09-10 下午4 49 42" src="https://github.com/user-attachments/assets/2f17917b-d392-4ef8-91ae-7edc9a0225f5" />

<img width="1176" height="767" alt="截圖 2026-09-10 下午4 49 59" src="https://github.com/user-attachments/assets/146dd14b-22e1-493b-b065-7d64e6d23948" />

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyzLKskmKeCRc7GYv4gnZv

