### PR TITLE
Stats: hold the Traffic tab preview invitation on Atomic behind a flag

### DIFF
--- a/client/my-sites/stats/hooks/test/use-premium-analytics-preview-invitation.ts
+++ b/client/my-sites/stats/hooks/test/use-premium-analytics-preview-invitation.ts
@@ -25,11 +25,18 @@ jest.mock( 'calypso/state', () => ( {
 
 // An administrator on a WordPress.com site with commercial Stats and a wp-admin to land in.
 let mockIsWpcom = true;
+let mockIsAtomic = false;
 let mockCanManageOptions = true;
 let mockSiteFeatures: object | null = { active: [] };
 let mockIsGated = false;
 let mockAdminUrl: string | null =
 	'https://example.com/wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin';
+
+jest.mock( 'calypso/state/sites/selectors/is-jetpack-site', () => ( {
+	__esModule: true,
+	default: ( _state: unknown, _siteId: number, options: { treatAtomicAsJetpackSite: boolean } ) =>
+		mockIsAtomic && options.treatAtomicAsJetpackSite,
+} ) );
 
 jest.mock( 'calypso/state/selectors/is-site-wpcom', () => ( {
 	__esModule: true,
@@ -80,6 +87,8 @@ describe( 'usePremiumAnalyticsPreviewInvitation', () => {
 		jest.clearAllMocks();
 		mockFlags()[ 'stats/premium-analytics-preview' ] = true;
 		mockIsWpcom = true;
+		mockIsAtomic = false;
+		delete mockFlags()[ 'stats/premium-analytics-preview-atomic' ];
 		mockCanManageOptions = true;
 		mockSiteFeatures = { active: [] };
 		mockIsGated = false;
@@ -94,6 +103,19 @@ describe( 'usePremiumAnalyticsPreviewInvitation', () => {
 				'https://example.com/wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin',
 		} );
 		expect( mockUseStatusQuery ).toHaveBeenCalledWith( 123, true );
+	} );
+
+	it.each( [
+		[ true, false, false ],
+		[ true, true, true ],
+		[ false, false, true ],
+		[ false, true, true ],
+	] )( 'Atomic %s with flag %s requests status: %s', ( isAtomic, flag, expected ) => {
+		mockIsAtomic = isAtomic;
+		mockFlags()[ 'stats/premium-analytics-preview-atomic' ] = flag;
+
+		expect( invitation().isInvited ).toBe( expected );
+		expect( mockUseStatusQuery ).toHaveBeenCalledWith( 123, expected );
 	} );
 
 	it( 'does not invite a site that already has the dashboard', () => {

--- a/client/my-sites/stats/hooks/use-premium-analytics-preview-cohort.ts
+++ b/client/my-sites/stats/hooks/use-premium-analytics-preview-cohort.ts
@@ -13,6 +13,7 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
 import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 
 export type PremiumAnalyticsPreviewCohort = {
 	isWpcom: boolean;
@@ -37,6 +38,11 @@ export type PremiumAnalyticsPreviewCohort = {
 export default function usePremiumAnalyticsPreviewCohort(
 	siteId: number | null
 ): PremiumAnalyticsPreviewCohort {
+	const isAtomic = useSelector(
+		( state ) =>
+			!! isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: true } ) &&
+			! isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
+	);
 	const isWpcom = useSelector( ( state ) => !! isSiteWpcom( state, siteId ) );
 	// `is_vip` is not correctly placed in Odyssey, so we need to check `options.is_vip` as well.
 	const isVip = useSelector(
@@ -85,6 +91,7 @@ export default function usePremiumAnalyticsPreviewCohort(
 			config.isEnabled( PREMIUM_ANALYTICS_PREVIEW_FLAG ) &&
 			isPremiumAnalyticsPreviewCohort( {
 				isWpcom,
+				isAtomic,
 				isVip,
 				isP2,
 				canManageOptions,

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -96,6 +96,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 	const isSiteJetpack = useSelector(
 		( state ) => !! isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: true } )
 	);
+	const isAtomic = isSiteJetpack && ! isSiteJetpackNotAtomic;
 	const isOwnedByTeam51 = useSelector(
 		( state ) => getSelectedSite( state )?.site_owner === TEAM51_OWNER_ID
 	);
@@ -168,6 +169,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		isPremiumAnalyticsEnabled,
 		premiumAnalyticsDashboardUrl,
 		isWpcom,
+		isAtomic,
 		isVip,
 		isP2,
 		isOwnedByTeam51,
@@ -207,6 +209,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 
 	usePremiumAnalyticsPreviewNotShownEvent( {
 		siteId,
+		isAtomic,
 		isWpcom,
 		// The features are not among the notices' own inputs, so they are waited on here alone:
 		// reading the tier before they land answers "no" for every site.

--- a/client/my-sites/stats/stats-notices/premium-analytics-preview-cohort.ts
+++ b/client/my-sites/stats/stats-notices/premium-analytics-preview-cohort.ts
@@ -1,5 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { StatsNoticeProps } from './types';
 
+export const PREMIUM_ANALYTICS_PREVIEW_ATOMIC_FLAG = 'stats/premium-analytics-preview-atomic';
 export const PREMIUM_ANALYTICS_PREVIEW_FLAG = 'stats/premium-analytics-preview';
 
 /** The dashboard page, relative to the site's wp-admin. Where accepting the invitation lands. */
@@ -8,6 +10,7 @@ export const PREMIUM_ANALYTICS_PAGE_PATH = 'admin.php?page=jetpack-premium-analy
 type PreviewCohortSignals = Pick<
 	StatsNoticeProps,
 	| 'isWpcom'
+	| 'isAtomic'
 	| 'isVip'
 	| 'isP2'
 	| 'canManageOptions'
@@ -25,6 +28,8 @@ type PreviewCohortSignals = Pick<
  *
  * `isWpcom` is a rollout boundary rather than eligibility: Simple and Atomic go first, and
  * self-hosted Jetpack sites join by deleting that one clause.
+ * Atomic is held until 16.3-a.1 reaches WP Cloud, with the Atomic flag allowing
+ * Automatticians to test on Atomic meanwhile.
  *
  * `premiumAnalyticsDashboardUrl` is null when the site record carries no `admin_url`. Accepting
  * would then switch the dashboard on and drop the customer on a 404, so such a site is not
@@ -33,6 +38,7 @@ type PreviewCohortSignals = Pick<
  */
 export default function isPremiumAnalyticsPreviewCohort( {
 	isWpcom,
+	isAtomic,
 	isVip,
 	isP2,
 	canManageOptions,
@@ -45,6 +51,7 @@ export default function isPremiumAnalyticsPreviewCohort( {
 		hasCommercialStats &&
 		premiumAnalyticsDashboardUrl &&
 		! isVip &&
-		! isP2
+		! isP2 &&
+		( ! isAtomic || isEnabled( PREMIUM_ANALYTICS_PREVIEW_ATOMIC_FLAG ) )
 	);
 }

--- a/client/my-sites/stats/stats-notices/premium-analytics-preview-not-shown-event.ts
+++ b/client/my-sites/stats/stats-notices/premium-analytics-preview-not-shown-event.ts
@@ -1,7 +1,10 @@
 import config from '@automattic/calypso-config';
 import { useEffect } from 'react';
 import { trackPremiumAnalyticsPreviewEvent } from '../premium-analytics-preview/track-event';
-import { PREMIUM_ANALYTICS_PREVIEW_FLAG } from './premium-analytics-preview-cohort';
+import {
+	PREMIUM_ANALYTICS_PREVIEW_FLAG,
+	PREMIUM_ANALYTICS_PREVIEW_ATOMIC_FLAG,
+} from './premium-analytics-preview-cohort';
 
 type PreviewGateSignals = {
 	isServerVisible: boolean;
@@ -11,6 +14,7 @@ type PreviewGateSignals = {
 	premiumAnalyticsDashboardUrl?: string | null;
 	isVip: boolean;
 	isP2: boolean;
+	isAtomic: boolean;
 	isPremiumAnalyticsEnabled?: boolean;
 	isStatusError: boolean;
 };
@@ -46,6 +50,7 @@ const notShownReason = ( {
 	premiumAnalyticsDashboardUrl,
 	isVip,
 	isP2,
+	isAtomic,
 	isPremiumAnalyticsEnabled,
 	isStatusError,
 }: PreviewGateSignals ): string | null => {
@@ -71,6 +76,9 @@ const notShownReason = ( {
 	}
 	if ( isP2 ) {
 		return 'is_p2';
+	}
+	if ( isAtomic && ! config.isEnabled( PREMIUM_ANALYTICS_PREVIEW_ATOMIC_FLAG ) ) {
+		return 'atomic_hold';
 	}
 	if ( isPremiumAnalyticsEnabled === true ) {
 		return 'already_enabled';
@@ -104,6 +112,7 @@ export default function usePremiumAnalyticsPreviewNotShownEvent( {
 	premiumAnalyticsDashboardUrl,
 	isVip,
 	isP2,
+	isAtomic,
 	isPremiumAnalyticsEnabled,
 	isStatusError,
 }: NotShownSignals ) {
@@ -133,6 +142,7 @@ export default function usePremiumAnalyticsPreviewNotShownEvent( {
 			premiumAnalyticsDashboardUrl,
 			isVip,
 			isP2,
+			isAtomic,
 			isPremiumAnalyticsEnabled,
 			isStatusError,
 		} );
@@ -157,6 +167,7 @@ export default function usePremiumAnalyticsPreviewNotShownEvent( {
 		premiumAnalyticsDashboardUrl,
 		isVip,
 		isP2,
+		isAtomic,
 		isPremiumAnalyticsEnabled,
 		isStatusError,
 	] );

--- a/client/my-sites/stats/stats-notices/test/premium-analytics-preview-not-shown-event.tsx
+++ b/client/my-sites/stats/stats-notices/test/premium-analytics-preview-not-shown-event.tsx
@@ -150,9 +150,11 @@ jest.mock( 'calypso/state/sites/selectors/has-site-product-jetpack-stats-pwyw-on
 	__esModule: true,
 	default: () => false,
 } ) );
+let mockIsAtomic = false;
 jest.mock( 'calypso/state/sites/selectors/is-jetpack-site', () => ( {
 	__esModule: true,
-	default: () => false,
+	default: ( _state: unknown, _siteId: number, options: { treatAtomicAsJetpackSite: boolean } ) =>
+		mockIsAtomic && options.treatAtomicAsJetpackSite,
 } ) );
 jest.mock( 'calypso/state/stats/lists/selectors', () => ( {
 	getSiteStatsNormalizedData: () => ( {} ),
@@ -183,6 +185,7 @@ describe( 'premium analytics preview "not shown" event', () => {
 		mockCanManageOptions = true;
 		mockSiteFeatures = { active: [] };
 		mockIsWpcom = true;
+		mockIsAtomic = false;
 		mockIsP2 = false;
 		mockIsVip = false;
 		mockAdminUrl = 'https://example.com/wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin';
@@ -232,6 +235,13 @@ describe( 'premium analytics preview "not shown" event', () => {
 			'is_p2',
 			() => {
 				mockIsP2 = true;
+			},
+		],
+		[
+			'atomic_hold',
+			() => {
+				mockIsAtomic = true;
+				mockPremiumAnalyticsStatus = { data: undefined, isLoading: true, isError: false };
 			},
 		],
 		[
@@ -302,6 +312,35 @@ describe( 'premium analytics preview "not shown" event', () => {
 		renderNotices();
 
 		expect( notShownEvents() ).toEqual( [] );
+	} );
+
+	it.each( [ true, false ] )( 'does not hold Simple with Atomic flag %s', ( flag ) => {
+		mockFlags()[ 'stats/premium-analytics-preview-atomic' ] = flag;
+		renderNotices();
+		expect( notShownEvents() ).toEqual( [] );
+	} );
+
+	it( 'does not hold Atomic when its flag is on', () => {
+		mockIsAtomic = true;
+		mockFlags()[ 'stats/premium-analytics-preview-atomic' ] = true;
+		renderNotices();
+		expect( notShownEvents() ).toEqual( [] );
+	} );
+
+	it.each( [ true, undefined ] )( 'records atomic_hold before status %s', ( status ) => {
+		mockIsAtomic = true;
+		mockPremiumAnalyticsStatus.data = status;
+		renderNotices();
+		expect( notShownEvents() ).toEqual( [
+			[ EVENT_NAME, { blog_id: 123, reason: 'atomic_hold' } ],
+		] );
+	} );
+
+	it( 'records is_p2 before atomic_hold', () => {
+		mockIsAtomic = true;
+		mockIsP2 = true;
+		renderNotices();
+		expect( notShownEvents() ).toEqual( [ [ EVENT_NAME, { blog_id: 123, reason: 'is_p2' } ] ] );
 	} );
 
 	it( 'stays quiet for a site that was offered the invitation and then dismissed it', () => {

--- a/client/my-sites/stats/stats-notices/test/premium-analytics-preview-notice-visibility.ts
+++ b/client/my-sites/stats/stats-notices/test/premium-analytics-preview-notice-visibility.ts
@@ -3,7 +3,19 @@ import {
 	DEFAULT_NOTICES_VISIBILITY,
 } from '../../hooks/use-notice-visibility-query';
 import ALL_STATS_NOTICES from '../all-notice-definitions';
+import isPremiumAnalyticsPreviewCohort from '../premium-analytics-preview-cohort';
 import type { StatsNoticeProps } from '../types';
+
+jest.mock( '@automattic/calypso-config', () => {
+	const flags: Record< string, boolean > = { 'stats/premium-analytics-preview': true };
+	( globalThis as Record< string, unknown > ).__previewCohortTestFlags = flags;
+	const isEnabled = ( flag: string ) => !! flags[ flag ];
+	const config = jest.requireActual( '@automattic/calypso-config' );
+	return { __esModule: true, default: Object.assign( config, { isEnabled } ), isEnabled };
+} );
+
+const mockFlags = () =>
+	( globalThis as Record< string, unknown > ).__previewCohortTestFlags as Record< string, boolean >;
 
 const premiumAnalyticsPreviewNotice = ALL_STATS_NOTICES.find(
 	( notice ) => notice.noticeId === 'premium_analytics_preview'
@@ -15,6 +27,7 @@ const eligibleSite: StatsNoticeProps = {
 	siteId: 123,
 	isOdysseyStats: false,
 	isWpcom: true,
+	isAtomic: false,
 	canManageOptions: true,
 	hasCommercialStats: true,
 	isPremiumAnalyticsEnabled: false,
@@ -25,6 +38,19 @@ const eligibleSite: StatsNoticeProps = {
 };
 
 describe( 'premium_analytics_preview notice visibility', () => {
+	it.each( [
+		[ true, false, false ],
+		[ true, true, true ],
+		[ false, false, true ],
+		[ false, true, true ],
+	] )( 'Atomic %s with flag %s is in the cohort: %s', ( isAtomic, flag, expected ) => {
+		mockFlags()[ 'stats/premium-analytics-preview-atomic' ] = flag;
+		const options = { ...eligibleSite, isAtomic };
+
+		expect( isPremiumAnalyticsPreviewCohort( options ) ).toBe( expected );
+		expect( premiumAnalyticsPreviewNotice?.isVisibleFunc( options ) ).toBe( expected );
+	} );
+
 	it( 'is registered and enabled', () => {
 		expect( premiumAnalyticsPreviewNotice ).toBeDefined();
 		expect( premiumAnalyticsPreviewNotice?.disabled ).toBe( false );

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -10,6 +10,7 @@ export interface StatsNoticeProps {
 	onNoticeViewed?: () => void;
 	onNoticeDismissed?: () => void;
 	isWpcom?: boolean;
+	isAtomic?: boolean;
 	isVip?: boolean;
 	isP2?: boolean;
 	isOwnedByTeam51?: boolean;

--- a/config/client.json
+++ b/config/client.json
@@ -24,6 +24,7 @@
 	"stats/chart-library",
 	"stats/empty-module-traffic",
 	"stats/premium-analytics-preview",
+	"stats/premium-analytics-preview-atomic",
 	"stats/real-time-tab",
 	"wpcom_concierge_schedule_id",
 	"wpcom_signup_id",

--- a/config/development.json
+++ b/config/development.json
@@ -211,6 +211,7 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stats/premium-analytics-preview": true,
+		"stats/premium-analytics-preview-atomic": true,
 		"stats/real-time-tab": true,
 		"subscriber-importer": true,
 		"themes/block-theme-previews-premium-and-woo": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -131,6 +131,7 @@
 		"stats/empty-module-traffic": true,
 		"stats/paid-wpcom-v2": true,
 		"stats/premium-analytics-preview": false,
+		"stats/premium-analytics-preview-atomic": false,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
 		"themes/block-theme-previews-premium-and-woo": true,

--- a/config/production.json
+++ b/config/production.json
@@ -165,6 +165,7 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stats/premium-analytics-preview": false,
+		"stats/premium-analytics-preview-atomic": false,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
 		"themes/block-theme-previews-premium-and-woo": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -163,6 +163,7 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stats/premium-analytics-preview": false,
+		"stats/premium-analytics-preview-atomic": false,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
 		"themes/block-theme-previews-premium-and-woo": true,

--- a/config/test.json
+++ b/config/test.json
@@ -115,6 +115,7 @@
 		"stats/chart-library": true,
 		"stats/empty-module-traffic": true,
 		"stats/premium-analytics-preview": true,
+		"stats/premium-analytics-preview-atomic": true,
 		"themes/premium": true,
 		"themes/showcase-modern": true,
 		"upgrades/redirect-payments": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -165,6 +165,7 @@
 		"stats/paid-wpcom-v2": true,
 		"stats/paid-wpcom-v3": true,
 		"stats/premium-analytics-preview": true,
+		"stats/premium-analytics-preview-atomic": true,
 		"stats/real-time-tab": false,
 		"subscriber-importer": true,
 		"themes/block-theme-previews-premium-and-woo": true,


### PR DESCRIPTION
Related: #114075

## Proposed Changes

* Add `stats/premium-analytics-preview-atomic` wherever the preview flag is declared, enabled in development, wpcalypso and test, and disabled in horizon, stage and production.
* Gate Atomic in the shared invitation cohort so the banner and modules menu skip the settings request during the hold; Simple sites keep their existing behavior.
* Record `atomic_hold` after `is_p2` and before `already_enabled`, keeping held sites out of `setting_unavailable`.
* This PR and #114075 must both be in the Odyssey bundle before its next manual deploy.

Remove after: Flip production to true once 16.3-a.1 is on WP Cloud, then delete the flag and clause.

## Why are these changes being made?

Jetpack 16.2, rolling out to WP Cloud now, carries the September 8 dashboard snapshot, so Atomic sites do not yet have the dashboard changes merged since then.

Hold the invitation for one week until 16.3-a.1 reaches WP Cloud, while allowing Automatticians to test on real Atomic sites through the flag.

p1789025491735109-slack-C06FSDTSN82

## Testing Instructions

1. Use a real Atomic site as an administrator with commercial Stats, an available admin URL, and the new dashboard still disabled; the server must offer the preview notice and the base preview flag must be enabled by #114075.
2. In wp-admin Stats, confirm the invitation is held, no preview settings request is sent, and the not-shown event records `atomic_hold` rather than `setting_unavailable`.
3. Append `&flags=stats/premium-analytics-preview-atomic` to wp-admin Stats and reload: Odyssey honours URL flags in production, so the invitation and settings request should now be available.
4. For wordpress.com/stats, use wpcalypso, where the Atomic flag is already true.
5. Confirm Simple sites behave the same with the Atomic flag on or off.


## Already tested 


  | Checked | What happened | Status |
  | --- | --- | --- |
  | PR bundle, no URL flags | No banner, zero wp/v2/settings requests; notices still returns premium_analytics_preview: true | ✅ |
  | Tracks during the hold | notice_not_shown with reason=atomic_hold, not setting_unavailable | ✅ |
  | Modules menu during the hold | No "Try the new Traffic tab" entry | ✅ |
  | &flags=stats/premium-analytics-preview-atomic | Banner renders, one wp/v2/settings request, notice_viewed fires, menu entry appears | ✅ |
  | Merge base (+#114075), same site, no flags | Banner shows and settings is requested | ✅ |
  | Console on a fresh load | No errors | ✅ |

<img width="2300" height="1058" alt="Screenshot 2026-09-10 at 5 22 26 PM" src="https://github.com/user-attachments/assets/dd61c0f7-8d12-46e4-b8ee-d68933a51345" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?