### PR TITLE
Emails: add "Manage your plan" action for the highest email tier

### DIFF
--- a/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
@@ -13,6 +13,7 @@ import poweredByTitanLogo from '../../resources/powered-by-titan-caps.svg';
 import { IntervalLength, MailboxProvider, TitanPlanTier } from '../../types';
 import { getTrialMonths } from '../../utils/get-trial-months';
 import { isEligibleForIntroductoryOffer } from '../../utils/is-eligible-for-introductory-offer';
+import { TITAN_TIER_ORDER } from '../../utils/titan-tiers';
 import type { Domain, EmailSubscription, Product } from '@automattic/api-core';
 
 interface TitanPlan {
@@ -100,14 +101,6 @@ const getTierDetails = ( tier: TitanPlanTier ): { description: string; features:
 	}
 };
 
-// Tiers ordered from lowest to highest, used to tell upgrades from downgrades
-// relative to the current tier.
-const TIER_ORDER: TitanPlanTier[] = [
-	TitanPlanTier.Pro,
-	TitanPlanTier.Premium,
-	TitanPlanTier.Ultra,
-];
-
 export function TitanPlanGrid( {
 	domain,
 	domainName,
@@ -181,7 +174,9 @@ export function TitanPlanGrid( {
 	// All tiers stay visible when upgrading; lower tiers render with a disabled
 	// button since this flow cannot downgrade.
 	const isLowerTier = ( tier: TitanPlanTier ) =>
-		currentTier ? TIER_ORDER.indexOf( tier ) < TIER_ORDER.indexOf( currentTier ) : false;
+		currentTier
+			? TITAN_TIER_ORDER.indexOf( tier ) < TITAN_TIER_ORDER.indexOf( currentTier )
+			: false;
 
 	// The tier that gets the emphasized (primary) button: the recommended plan when
 	// buying, or the recommended upgrade target when upgrading. The current and lower

--- a/client/dashboard/emails/utils/titan-tiers.ts
+++ b/client/dashboard/emails/utils/titan-tiers.ts
@@ -16,8 +16,20 @@ export const TITAN_TIER_SLUGS: Record< TitanPlanTier, Record< IntervalLength, st
 	},
 };
 
+// Tiers from cheapest to most expensive.
+export const TITAN_TIER_ORDER: TitanPlanTier[] = [
+	TitanPlanTier.Pro,
+	TitanPlanTier.Premium,
+	TitanPlanTier.Ultra,
+];
+
 export function isTitanPlanTier( value: unknown ): value is TitanPlanTier {
 	return Object.values( TitanPlanTier ).includes( value as TitanPlanTier );
+}
+
+// The highest tier has nothing to upgrade to.
+export function isHighestTitanTier( tier?: TitanPlanTier ): boolean {
+	return !! tier && tier === TITAN_TIER_ORDER[ TITAN_TIER_ORDER.length - 1 ];
 }
 
 export function getTitanTierFromSlug( productSlug?: string ): TitanPlanTier | undefined {

--- a/client/dashboard/me/billing-purchases/purchase-settings/email-plan.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/email-plan.tsx
@@ -8,12 +8,12 @@ import { Button } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { currencyDollar, envelope } from '@wordpress/icons';
 import { useAnalytics } from '../../../app/analytics';
-import { addMailboxRoute } from '../../../app/router/emails';
+import { addMailboxRoute, chooseEmailSolutionRoute } from '../../../app/router/emails';
 import { ActionList } from '../../../components/action-list';
 import OverviewCard from '../../../components/overview-card';
 import { IntervalLength, MailboxProvider, TitanPlanTier } from '../../../emails/types';
 import { isMonthlyEmailProduct } from '../../../emails/utils/is-monthly-email-product';
-import { getTitanTierFromSlug } from '../../../emails/utils/titan-tiers';
+import { getTitanTierFromSlug, isHighestTitanTier } from '../../../emails/utils/titan-tiers';
 import { isTitanMail } from '../../../utils/purchase';
 import type { Purchase } from '@automattic/api-core';
 
@@ -83,6 +83,50 @@ export function AddMailboxesActionItem( { purchase }: { purchase: Purchase } ) {
 			actions={
 				<Button variant="secondary" size="compact" onClick={ onAdd }>
 					{ __( 'Add' ) }
+				</Button>
+			}
+		/>
+	);
+}
+
+/**
+ * The highest email tier has nothing higher to upgrade to, so the generic
+ * upgrade action is hidden. In that case "Manage your plan" takes over as a
+ * neutral entry into the tier grid, where the user can still change their plan.
+ */
+export function isEmailPlanAtHighestTier( purchase: Purchase ): boolean {
+	return (
+		isEmailPlanManagementEnabled( purchase ) &&
+		isHighestTitanTier( getTitanTierFromSlug( purchase.product_slug ) )
+	);
+}
+
+function useManagePlanNavigation( purchase: Purchase ) {
+	const navigate = useNavigate();
+	const { recordTracksEvent } = useAnalytics();
+
+	return () => {
+		recordTracksEvent( 'calypso_purchases_email_manage_plan_click', {
+			product_slug: purchase.product_slug,
+		} );
+		navigate( {
+			to: chooseEmailSolutionRoute.to,
+			params: { domain: purchase.meta ?? '' },
+			search: { intent: 'upgrade' as const },
+		} );
+	};
+}
+
+export function ManageEmailPlanActionItem( { purchase }: { purchase: Purchase } ) {
+	const onManage = useManagePlanNavigation( purchase );
+
+	return (
+		<ActionList.ActionItem
+			title={ __( 'Manage your plan' ) }
+			description={ __( 'Review your plan and see other options.' ) }
+			actions={
+				<Button variant="secondary" size="compact" onClick={ onManage }>
+					{ __( 'Manage' ) }
 				</Button>
 			}
 		/>

--- a/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/index.tsx
@@ -123,6 +123,8 @@ import {
 	AddMailboxesActionItem,
 	EmailPlanMailboxCard,
 	EmailPlanPriceCard,
+	ManageEmailPlanActionItem,
+	isEmailPlanAtHighestTier,
 	isEmailPlanManagementEnabled,
 } from './email-plan';
 import { getCancelButtonCopy, getRemoveButtonCopy } from './get-cancel-remove-copy';
@@ -153,6 +155,11 @@ function getNonPlanUpgradeAction(
 	// Titan email upgrades route through the flag-gated tier grid; without the flag
 	// the upgrade URL would fall through to the wrong (site plan) page.
 	if ( isTitanMail( purchase ) && ! config.isEnabled( 'emails/titan-tiers' ) ) {
+		return undefined;
+	}
+	// The highest email tier has nothing to upgrade to; "Manage your plan"
+	// takes over so the user can still reach the plan grid.
+	if ( isEmailPlanAtHighestTier( purchase ) ) {
 		return undefined;
 	}
 	const href = getSitePurchaseUpgradeUrl( purchase, getUpgradedPurchaseRedirectUrl() );
@@ -814,6 +821,9 @@ function PurchaseSettingsActions( { purchase }: { purchase: Purchase } ) {
 				<ReinstallButton purchase={ purchase } />
 				<JetpackCRMDownloadsButton purchase={ purchase } />
 				<ProductChangeActionItem purchase={ purchase } />
+				{ ! isExpiredOrRemoved( purchase ) && isEmailPlanAtHighestTier( purchase ) && (
+					<ManageEmailPlanActionItem purchase={ purchase } />
+				) }
 				<StorageUpgradeActionButton purchase={ purchase } />
 				{ ! isExpiredOrRemoved( purchase ) && isEmailPlanManagementEnabled( purchase ) && (
 					<AddMailboxesActionItem purchase={ purchase } />


### PR DESCRIPTION
## Proposed Changes

* On the purchase page, show a "Manage your plan" action when a Professional Email plan is on the highest tier, where the generic Upgrade action is hidden.
* Add `TITAN_TIER_ORDER` and `isHighestTitanTier()` to the shared tier utils, and move the plan grid onto the shared tier order.

## Why are these changes being made?

The Upgrade action is hidden on the highest tier because there is nothing above it, which left no way to reach the plan grid from the purchase page.

## Testing Instructions

1. Run `yarn start` and sign in.
2. You need a domain with a Professional Email subscription on the **Ultra** tier. Lower tiers still show the normal Upgrade action.
3. Go to Upgrades > Billing > Active subscriptions and open that email subscription.
4. Confirm the actions list shows **Manage your plan** and no Upgrade action.
5. Click **Manage**. It opens the Professional Email plan grid.
6. Open a subscription on Pro or Premium and confirm the Upgrade action is unchanged.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
