### PR TITLE
Emails: name the email plan in scheduled downgrade notices

### DIFF
--- a/client/dashboard/components/purchase-expiry-status/index.tsx
+++ b/client/dashboard/components/purchase-expiry-status/index.tsx
@@ -1,6 +1,6 @@
 import './style.scss';
 
-import { SubscriptionBillPeriod, getPlanNames } from '@automattic/api-core';
+import { SubscriptionBillPeriod } from '@automattic/api-core';
 import { formatCurrency } from '@automattic/number-formatters';
 import { Button, ExternalLink, Icon } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -12,6 +12,7 @@ import { useHelpCenter } from '../../app/help-center';
 import { useLocale } from '../../app/locale';
 import { Text } from '../../components/text';
 import { formatDate, getCalendarDaysUntil, getRelativeDayString } from '../../utils/datetime';
+import { getDowngradeTargetProductName } from '../../utils/downgrade-target-name';
 import {
 	EXPIRY_ERROR_DAYS,
 	EXPIRY_WARNING_DAYS,
@@ -318,9 +319,9 @@ export function PurchaseExpiryStatus( {
 	// renew at its current price — it changes to a lower-tier plan. Say so instead
 	// of the usual "Renews ... on <date>" line.
 	if ( isRenewingOnDate && purchase.is_delayed_downgrade_pending ) {
-		const slug = purchase.delayed_downgrade_to_product_slug;
-		const planNames = getPlanNames() as Record< string, string | undefined >;
-		const targetPlanName = slug ? planNames[ slug ] ?? null : null;
+		const targetPlanName = getDowngradeTargetProductName(
+			purchase.delayed_downgrade_to_product_slug
+		);
 		const renewalDate = formatDate( new Date( purchase.renew_date ?? '' ), locale, {
 			dateStyle: 'long',
 		} );

--- a/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
@@ -13,7 +13,7 @@ import poweredByTitanLogo from '../../resources/powered-by-titan-caps.svg';
 import { IntervalLength, MailboxProvider, TitanPlanTier } from '../../types';
 import { getTrialMonths } from '../../utils/get-trial-months';
 import { isEligibleForIntroductoryOffer } from '../../utils/is-eligible-for-introductory-offer';
-import { TITAN_TIER_ORDER } from '../../utils/titan-tiers';
+import { getTitanTierName, TITAN_TIER_ORDER } from '../../utils/titan-tiers';
 import type { Domain, EmailSubscription, Product } from '@automattic/api-core';
 
 interface TitanPlan {
@@ -24,17 +24,6 @@ interface TitanPlan {
 	isPopular: boolean;
 	everythingInName?: string;
 }
-
-const getTierName = ( tier: TitanPlanTier ): string => {
-	switch ( tier ) {
-		case TitanPlanTier.Pro:
-			return __( 'Pro' );
-		case TitanPlanTier.Premium:
-			return __( 'Premium' );
-		case TitanPlanTier.Ultra:
-			return __( 'Ultra' );
-	}
-};
 
 // Descriptions remain placeholder copy; feature lists reflect the tier
 // comparison from DOTEMP-111.
@@ -159,7 +148,7 @@ export function TitanPlanGrid( {
 			hasFreeTrial: hasFreeTrial( premiumProduct ),
 			trialMonths: getTrialMonths( premiumProduct ),
 			isPopular: true,
-			everythingInName: getTierName( TitanPlanTier.Pro ),
+			everythingInName: getTitanTierName( TitanPlanTier.Pro ),
 		},
 		{
 			tier: TitanPlanTier.Ultra,
@@ -167,7 +156,7 @@ export function TitanPlanGrid( {
 			hasFreeTrial: hasFreeTrial( ultraProduct ),
 			trialMonths: getTrialMonths( ultraProduct ),
 			isPopular: false,
-			everythingInName: getTierName( TitanPlanTier.Premium ),
+			everythingInName: getTitanTierName( TitanPlanTier.Premium ),
 		},
 	];
 
@@ -200,7 +189,7 @@ export function TitanPlanGrid( {
 	return (
 		<div className="email-providers">
 			{ plans.map( ( plan ) => {
-				const planName = getTierName( plan.tier );
+				const planName = getTitanTierName( plan.tier );
 				const details = getTierDetails( plan.tier );
 				const isCurrentPlan = plan.tier === currentTier;
 				const isDowngrade = isLowerTier( plan.tier );

--- a/client/dashboard/emails/utils/titan-tiers.ts
+++ b/client/dashboard/emails/utils/titan-tiers.ts
@@ -1,4 +1,5 @@
 import { TitanMailSlugs } from '@automattic/api-core';
+import { __ } from '@wordpress/i18n';
 import { IntervalLength, TitanPlanTier } from '../types';
 
 export const TITAN_TIER_SLUGS: Record< TitanPlanTier, Record< IntervalLength, string > > = {
@@ -25,6 +26,17 @@ export const TITAN_TIER_ORDER: TitanPlanTier[] = [
 
 export function isTitanPlanTier( value: unknown ): value is TitanPlanTier {
 	return Object.values( TitanPlanTier ).includes( value as TitanPlanTier );
+}
+
+export function getTitanTierName( tier: TitanPlanTier ): string {
+	switch ( tier ) {
+		case TitanPlanTier.Pro:
+			return __( 'Pro' );
+		case TitanPlanTier.Premium:
+			return __( 'Premium' );
+		case TitanPlanTier.Ultra:
+			return __( 'Ultra' );
+	}
 }
 
 // The highest tier has nothing to upgrade to.

--- a/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
+++ b/client/dashboard/me/billing-purchases/purchase-settings/purchase-notice.tsx
@@ -1,9 +1,4 @@
-import {
-	DomainProductSlugs,
-	DotcomPlans,
-	WooHostedPlans,
-	getPlanNames,
-} from '@automattic/api-core';
+import { DomainProductSlugs, DotcomPlans, WooHostedPlans } from '@automattic/api-core';
 import {
 	purchaseQuery,
 	sitePurchasesQuery,
@@ -33,6 +28,7 @@ import {
 	isEligibleForPlanExpiryNotice,
 } from '../../../components/plan-expiry-notice';
 import { formatDate } from '../../../utils/datetime';
+import { getDowngradeTargetProductName } from '../../../utils/downgrade-target-name';
 import { wpcomLink } from '../../../utils/link';
 import {
 	isExpiredOrRemoved,
@@ -224,9 +220,9 @@ export function PurchaseNotice( { purchase }: { purchase: Purchase } ) {
 
 	// Persistent warning notice when a delayed downgrade is pending.
 	if ( purchase.is_delayed_downgrade_pending ) {
-		const slug = purchase.delayed_downgrade_to_product_slug;
-		const planNames = getPlanNames() as Record< string, string | undefined >;
-		const targetPlanName = slug ? planNames[ slug ] ?? null : null;
+		const targetPlanName = getDowngradeTargetProductName(
+			purchase.delayed_downgrade_to_product_slug
+		);
 		// `renew_date` is the next auto-renewal attempt date, which for annual
 		// plans is up to 30 days before expiry. The downgrade takes effect on
 		// that renewal, so it's the accurate date to show the customer.

--- a/client/dashboard/utils/downgrade-target-name.ts
+++ b/client/dashboard/utils/downgrade-target-name.ts
@@ -1,0 +1,26 @@
+import { getPlanNames } from '@automattic/api-core';
+import { getTitanTierFromSlug, getTitanTierName } from '../emails/utils/titan-tiers';
+
+/**
+ * Display name for a scheduled downgrade's target product.
+ *
+ * `getPlanNames()` only covers site plans, so email tiers are resolved
+ * separately. Returns null when the slug is neither, so callers can fall back
+ * to a message without a product name.
+ *
+ * Kept out of `utils/purchase.ts`: that module is imported by tests which mock
+ * `@automattic/api-core`, and the email tier utils read an enum at module load.
+ */
+export function getDowngradeTargetProductName( productSlug?: string | null ): string | null {
+	if ( ! productSlug ) {
+		return null;
+	}
+
+	const planNames = getPlanNames() as Record< string, string | undefined >;
+	if ( planNames[ productSlug ] ) {
+		return planNames[ productSlug ];
+	}
+
+	const titanTier = getTitanTierFromSlug( productSlug );
+	return titanTier ? getTitanTierName( titanTier ) : null;
+}


### PR DESCRIPTION
Stacked on 114235.

## Proposed Changes

* Add `getDowngradeTargetProductName()`, which resolves a scheduled downgrade's target product name and falls back to the email tier name.
* Use it in the purchase page notice and the expiry status.
* Move `getTitanTierName()` out of the plan grid into the shared tier utils.

## Why are these changes being made?

Both places resolve the target name with `getPlanNames()`, which only covers site plans. A Professional Email tier fell through to a message with no product name.

## Testing Instructions

1. Run `yarn start` and sign in.
2. Regression check: on a site plan with a scheduled downgrade, open Upgrades > Billing > Active subscriptions and confirm the notice still names the target plan.
3. The email tier case needs a scheduled downgrade on a Professional Email subscription, which arrives with the downgrade PR later in this stack. With that PR applied, schedule a downgrade and confirm the notice reads "scheduled to downgrade to Pro" rather than omitting the name.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
