### PR TITLE
Emails: resolve downgrade targets for Titan tiers

### DIFF
--- a/client/dashboard/emails/utils/test/titan-tiers.ts
+++ b/client/dashboard/emails/utils/test/titan-tiers.ts
@@ -1,0 +1,199 @@
+import { TitanMailSlugs } from '@automattic/api-core';
+import { IntervalLength, TitanPlanTier } from '../../types';
+import {
+	getTitanDowngradeTargetId,
+	getTitanTierFromSlug,
+	isHighestTitanTier,
+	isLowerTitanTier,
+} from '../titan-tiers';
+import type { PlanProductDowngrade, Product } from '@automattic/api-core';
+
+const PRODUCT_IDS: Record< string, number > = {
+	[ TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG ]: 400,
+	[ TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG ]: 401,
+	[ TitanMailSlugs.TITAN_MAIL_PREMIUM_MONTHLY_SLUG ]: 402,
+	[ TitanMailSlugs.TITAN_MAIL_PREMIUM_YEARLY_SLUG ]: 403,
+	[ TitanMailSlugs.TITAN_MAIL_ULTRA_MONTHLY_SLUG ]: 404,
+	[ TitanMailSlugs.TITAN_MAIL_ULTRA_YEARLY_SLUG ]: 405,
+};
+
+/**
+ * Products as the products endpoints actually return them today: no
+ * `downgrade_paths`, since the endpoint allowlist drops the field.
+ */
+function makeProduct( slug: string, downgradePaths?: PlanProductDowngrade[] ): Product {
+	return {
+		product_slug: slug,
+		product_id: PRODUCT_IDS[ slug ],
+		...( downgradePaths ? { downgrade_paths: downgradePaths } : {} ),
+	} as Product;
+}
+
+const ultraYearly = makeProduct( TitanMailSlugs.TITAN_MAIL_ULTRA_YEARLY_SLUG );
+const premiumYearly = makeProduct( TitanMailSlugs.TITAN_MAIL_PREMIUM_YEARLY_SLUG );
+const proYearly = makeProduct( TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG );
+const proMonthly = makeProduct( TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG );
+
+describe( 'getTitanDowngradeTargetId', () => {
+	// The fallback mirrors wpcom's Store::get_downgrade_paths() for Titan:
+	// Premium -> Pro, Ultra -> Pro/Premium, same term only.
+	describe( 'without server-declared downgrade paths', () => {
+		test( 'resolves every strictly lower tier at the same term', () => {
+			expect(
+				getTitanDowngradeTargetId( {
+					currentTier: TitanPlanTier.Ultra,
+					currentProduct: ultraYearly,
+					targetTier: TitanPlanTier.Premium,
+					targetProduct: premiumYearly,
+					interval: IntervalLength.Annually,
+				} )
+			).toBe( 403 );
+
+			expect(
+				getTitanDowngradeTargetId( {
+					currentTier: TitanPlanTier.Ultra,
+					currentProduct: ultraYearly,
+					targetTier: TitanPlanTier.Pro,
+					targetProduct: proYearly,
+					interval: IntervalLength.Annually,
+				} )
+			).toBe( 401 );
+		} );
+
+		test( 'refuses the current tier and any higher tier', () => {
+			expect(
+				getTitanDowngradeTargetId( {
+					currentTier: TitanPlanTier.Premium,
+					currentProduct: premiumYearly,
+					targetTier: TitanPlanTier.Premium,
+					targetProduct: premiumYearly,
+					interval: IntervalLength.Annually,
+				} )
+			).toBeUndefined();
+
+			expect(
+				getTitanDowngradeTargetId( {
+					currentTier: TitanPlanTier.Pro,
+					currentProduct: proYearly,
+					targetTier: TitanPlanTier.Ultra,
+					targetProduct: ultraYearly,
+					interval: IntervalLength.Annually,
+				} )
+			).toBeUndefined();
+		} );
+
+		// The server rejects a cross-term pair with bad_request, so a product
+		// loaded for the wrong term must never resolve as a target.
+		test( 'refuses a target product from a different billing term', () => {
+			expect(
+				getTitanDowngradeTargetId( {
+					currentTier: TitanPlanTier.Ultra,
+					currentProduct: ultraYearly,
+					targetTier: TitanPlanTier.Pro,
+					targetProduct: proMonthly,
+					interval: IntervalLength.Annually,
+				} )
+			).toBeUndefined();
+		} );
+
+		test( 'offers nothing when the target product has not loaded', () => {
+			expect(
+				getTitanDowngradeTargetId( {
+					currentTier: TitanPlanTier.Ultra,
+					currentProduct: ultraYearly,
+					targetTier: TitanPlanTier.Pro,
+					targetProduct: undefined,
+					interval: IntervalLength.Annually,
+				} )
+			).toBeUndefined();
+		} );
+
+		test( 'offers nothing when there is no current subscription tier', () => {
+			expect(
+				getTitanDowngradeTargetId( {
+					currentTier: undefined,
+					currentProduct: undefined,
+					targetTier: TitanPlanTier.Pro,
+					targetProduct: proYearly,
+					interval: IntervalLength.Annually,
+				} )
+			).toBeUndefined();
+		} );
+	} );
+
+	// If wpcom ever exposes the field, it takes over with no client change.
+	describe( 'with server-declared downgrade paths', () => {
+		const declaredProYearly: PlanProductDowngrade = {
+			product_id: 401,
+			bill_period: 365,
+			product_slug: TitanMailSlugs.TITAN_MAIL_YEARLY_SLUG,
+			product_name: 'Professional Email Pro',
+		};
+
+		test( 'uses the declared target id', () => {
+			expect(
+				getTitanDowngradeTargetId( {
+					currentTier: TitanPlanTier.Ultra,
+					currentProduct: makeProduct( TitanMailSlugs.TITAN_MAIL_ULTRA_YEARLY_SLUG, [
+						declaredProYearly,
+					] ),
+					targetTier: TitanPlanTier.Pro,
+					targetProduct: proYearly,
+					interval: IntervalLength.Annually,
+				} )
+			).toBe( 401 );
+		} );
+
+		// A declared list is exhaustive: an omitted tier is a refusal, so the
+		// fallback must not quietly re-allow it.
+		test( 'refuses a tier the declared list omits', () => {
+			expect(
+				getTitanDowngradeTargetId( {
+					currentTier: TitanPlanTier.Ultra,
+					currentProduct: makeProduct( TitanMailSlugs.TITAN_MAIL_ULTRA_YEARLY_SLUG, [
+						declaredProYearly,
+					] ),
+					targetTier: TitanPlanTier.Premium,
+					targetProduct: premiumYearly,
+					interval: IntervalLength.Annually,
+				} )
+			).toBeUndefined();
+		} );
+	} );
+} );
+
+describe( 'isLowerTitanTier', () => {
+	test( 'is true only for a strictly cheaper tier', () => {
+		expect( isLowerTitanTier( TitanPlanTier.Pro, TitanPlanTier.Ultra ) ).toBe( true );
+		expect( isLowerTitanTier( TitanPlanTier.Ultra, TitanPlanTier.Pro ) ).toBe( false );
+		expect( isLowerTitanTier( TitanPlanTier.Pro, TitanPlanTier.Pro ) ).toBe( false );
+		expect( isLowerTitanTier( TitanPlanTier.Pro, undefined ) ).toBe( false );
+	} );
+} );
+
+describe( 'getTitanTierFromSlug', () => {
+	test( 'maps every tier slug back to its tier', () => {
+		expect( getTitanTierFromSlug( TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG ) ).toBe(
+			TitanPlanTier.Pro
+		);
+		expect( getTitanTierFromSlug( TitanMailSlugs.TITAN_MAIL_PREMIUM_YEARLY_SLUG ) ).toBe(
+			TitanPlanTier.Premium
+		);
+		expect( getTitanTierFromSlug( TitanMailSlugs.TITAN_MAIL_ULTRA_MONTHLY_SLUG ) ).toBe(
+			TitanPlanTier.Ultra
+		);
+	} );
+
+	test( 'returns undefined for a non-Titan slug', () => {
+		expect( getTitanTierFromSlug( 'business-bundle' ) ).toBeUndefined();
+		expect( getTitanTierFromSlug( undefined ) ).toBeUndefined();
+	} );
+} );
+
+describe( 'isHighestTitanTier', () => {
+	test( 'is true only for the top tier', () => {
+		expect( isHighestTitanTier( TitanPlanTier.Ultra ) ).toBe( true );
+		expect( isHighestTitanTier( TitanPlanTier.Premium ) ).toBe( false );
+		expect( isHighestTitanTier( undefined ) ).toBe( false );
+	} );
+} );

--- a/client/dashboard/emails/utils/titan-tiers.ts
+++ b/client/dashboard/emails/utils/titan-tiers.ts
@@ -1,6 +1,7 @@
 import { TitanMailSlugs } from '@automattic/api-core';
 import { __ } from '@wordpress/i18n';
 import { IntervalLength, TitanPlanTier } from '../types';
+import type { Product } from '@automattic/api-core';
 
 export const TITAN_TIER_SLUGS: Record< TitanPlanTier, Record< IntervalLength, string > > = {
 	[ TitanPlanTier.Pro ]: {
@@ -42,6 +43,60 @@ export function getTitanTierName( tier: TitanPlanTier ): string {
 // The highest tier has nothing to upgrade to.
 export function isHighestTitanTier( tier?: TitanPlanTier ): boolean {
 	return !! tier && tier === TITAN_TIER_ORDER[ TITAN_TIER_ORDER.length - 1 ];
+}
+
+// A downgrade is a move to a strictly cheaper tier.
+export function isLowerTitanTier( tier: TitanPlanTier, currentTier?: TitanPlanTier ): boolean {
+	if ( ! currentTier ) {
+		return false;
+	}
+
+	return TITAN_TIER_ORDER.indexOf( tier ) < TITAN_TIER_ORDER.indexOf( currentTier );
+}
+
+/**
+ * Store product id to downgrade to, or undefined when the tier is not a valid
+ * target.
+ *
+ * `downgrade_paths` is the authoritative list, but no products endpoint returns
+ * it today, so the fallback mirrors the server rule: any strictly lower tier at
+ * the same billing term. The server validates every downgrade anyway, so a
+ * wrong target here fails as a bad request rather than charging incorrectly.
+ *
+ * When `downgrade_paths` is present it is used on its own, so this switches to
+ * server data if the field is ever exposed.
+ */
+export function getTitanDowngradeTargetId( {
+	currentTier,
+	currentProduct,
+	targetTier,
+	targetProduct,
+	interval,
+}: {
+	currentTier?: TitanPlanTier;
+	currentProduct?: Product;
+	targetTier: TitanPlanTier;
+	// The target tier's product at the current interval, which keeps the
+	// resolved id on the same billing term.
+	targetProduct?: Product;
+	interval: IntervalLength;
+} ): number | undefined {
+	if ( ! isLowerTitanTier( targetTier, currentTier ) ) {
+		return undefined;
+	}
+
+	const targetSlug = TITAN_TIER_SLUGS[ targetTier ]?.[ interval ];
+	if ( ! targetSlug ) {
+		return undefined;
+	}
+
+	if ( currentProduct?.downgrade_paths ) {
+		return currentProduct.downgrade_paths.find( ( path ) => path.product_slug === targetSlug )
+			?.product_id;
+	}
+
+	// Ignore a product loaded for another tier or billing term.
+	return targetProduct?.product_slug === targetSlug ? targetProduct.product_id : undefined;
 }
 
 export function getTitanTierFromSlug( productSlug?: string ): TitanPlanTier | undefined {

--- a/packages/api-core/src/products/types.ts
+++ b/packages/api-core/src/products/types.ts
@@ -1,3 +1,4 @@
+import type { PlanProductDowngrade } from '../plans';
 import type { PriceTierEntry } from '../upgrades';
 
 export type IntroductoryOfferTimeUnit = 'day' | 'week' | 'month' | 'year';
@@ -53,6 +54,15 @@ export interface Product {
 
 	// Introductory offer (conditional - when product has intro offer)
 	introductory_offer?: IntroductoryOffer;
+
+	/**
+	 * Products this one can be downgraded to, all on the same billing term.
+	 *
+	 * Not returned by any products endpoint today: wpcom builds it for plans
+	 * only, and the products endpoints filter it out. Declared here for when
+	 * that changes, so callers need a fallback. When present it is exhaustive.
+	 */
+	downgrade_paths?: PlanProductDowngrade[];
 
 	// Hundred year domain pricing (conditional - when hundred_year_slugs param is provided)
 	hundred_year_combined_cost_display?: string;


### PR DESCRIPTION
Stacked on 114236.

## Proposed Changes

* Add `getTitanDowngradeTargetId()`, which returns the store product id to downgrade to for a given tier, and `isLowerTitanTier()`.
* Declare `downgrade_paths` on `Product` in `@automattic/api-core`.
* Add unit tests for both branches of the resolver.

## Why are these changes being made?

A Professional Email downgrade is tier-only and same-term. `downgrade_paths` is the authoritative list of valid targets, but no products endpoint returns it: wpcom builds it for plans only, and the products endpoints filter it out.

The resolver mirrors the server rule instead: any strictly lower tier at the same billing term. The server validates every downgrade, so a wrong target fails as a bad request rather than charging incorrectly. When `downgrade_paths` is present it is used on its own, so this switches to server data if the field is ever exposed.

Nothing calls the resolver yet. The plan grid picks it up in the next PR in this stack.

## Testing Instructions

1. Run `yarn test-client client/dashboard/emails/utils/test/titan-tiers.ts` and confirm it passes.
2. Run `yarn typecheck-client` and confirm it passes.
3. No user-facing change: the plan grid behaves exactly as before. Open Upgrades > Emails, pick a domain, and confirm the plan grid still renders normally.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
