### PR TITLE
Emails: downgrade an active Professional Email subscription

### DIFF
--- a/client/dashboard/emails/choose-email-solution/components/test/titan-plan-grid.test.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/test/titan-plan-grid.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @jest-environment jsdom
+ */
+import { TitanMailSlugs } from '@automattic/api-core';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../../test-utils';
+import { IntervalLength, TitanPlanTier } from '../../../types';
+import { TitanPlanGrid } from '../titan-plan-grid';
+import type { Domain } from '@automattic/api-core';
+
+const DOMAIN_NAME = 'example.com';
+
+/**
+ * Shaped like a real `/products` entry: no `downgrade_paths`, because the wpcom
+ * endpoint allowlist drops that field. The grid has to work without it.
+ */
+function product( slug: string, productId: number ) {
+	return {
+		product_slug: slug,
+		product_id: productId,
+		product_name: slug,
+		cost: 60,
+		cost_smallest_unit: 6000,
+		currency_code: 'USD',
+		price_tier_list: [],
+		price_tier_usage_quantity: null,
+	};
+}
+
+function mockProducts() {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.1/products/' )
+		.query( true )
+		.reply( 200, {
+			[ TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG ]: product(
+				TitanMailSlugs.TITAN_MAIL_MONTHLY_SLUG,
+				400
+			),
+			[ TitanMailSlugs.TITAN_MAIL_PREMIUM_MONTHLY_SLUG ]: product(
+				TitanMailSlugs.TITAN_MAIL_PREMIUM_MONTHLY_SLUG,
+				402
+			),
+			[ TitanMailSlugs.TITAN_MAIL_ULTRA_MONTHLY_SLUG ]: product(
+				TitanMailSlugs.TITAN_MAIL_ULTRA_MONTHLY_SLUG,
+				404
+			),
+		} );
+}
+
+// No blog_id, so useEmailProduct reads the global products list mocked above.
+const domain = { domain: DOMAIN_NAME } as Domain;
+
+/**
+ * The grid renders before the products query settles, and an unloaded card
+ * looks exactly like one with no valid downgrade target. Wait for the loaded
+ * price (0 until then) so the button assertions read the settled state. At a
+ * monthly interval the card shows the full cost, so that is the '60' here.
+ */
+async function waitForProducts() {
+	await screen.findAllByText( '60' );
+}
+
+function renderGrid( props: Partial< React.ComponentProps< typeof TitanPlanGrid > > = {} ) {
+	return render(
+		<TitanPlanGrid
+			domain={ domain }
+			domainName={ DOMAIN_NAME }
+			interval={ IntervalLength.Monthly }
+			available
+			currentTier={ TitanPlanTier.Ultra }
+			canDowngrade
+			{ ...props }
+		/>
+	);
+}
+
+describe( '<TitanPlanGrid>', () => {
+	test( 'hands the caller the target product id instead of going to checkout', async () => {
+		mockProducts();
+		const onDowngrade = jest.fn();
+		const onUpgrade = jest.fn();
+		renderGrid( { onDowngrade, onUpgrade } );
+
+		await waitForProducts();
+
+		const downgradeButtons = screen.getAllByRole( 'button', { name: 'Downgrade' } );
+		expect( downgradeButtons ).toHaveLength( 2 );
+
+		await userEvent.click( downgradeButtons[ 1 ] );
+
+		expect( onDowngrade ).toHaveBeenCalledWith( TitanPlanTier.Premium, 402 );
+		// A downgrade is never a purchase, so the upgrade/checkout path stays untouched.
+		expect( onUpgrade ).not.toHaveBeenCalled();
+	} );
+
+	test( 'offers every strictly lower tier at the current term', async () => {
+		mockProducts();
+		renderGrid();
+
+		await waitForProducts();
+
+		// Ultra is current, so both Pro and Premium are downgrade targets.
+		for ( const button of screen.getAllByRole( 'button', { name: 'Downgrade' } ) ) {
+			expect( button ).toBeEnabled();
+		}
+	} );
+
+	test( 'offers no downgrade without a live subscription to downgrade', async () => {
+		mockProducts();
+		renderGrid( { canDowngrade: false } );
+
+		await waitForProducts();
+
+		for ( const button of screen.getAllByRole( 'button', { name: 'Downgrade' } ) ) {
+			expect( button ).toBeDisabled();
+		}
+	} );
+
+	test( 'offers to cancel a scheduled downgrade rather than repeating it', async () => {
+		mockProducts();
+		const onCancelScheduledDowngrade = jest.fn();
+		const onDowngrade = jest.fn();
+		renderGrid( {
+			pendingDowngradeTier: TitanPlanTier.Premium,
+			onCancelScheduledDowngrade,
+			onDowngrade,
+		} );
+
+		await waitForProducts();
+
+		const cancelButton = screen.getByRole( 'button', { name: 'Cancel scheduled change' } );
+		await userEvent.click( cancelButton );
+
+		expect( onCancelScheduledDowngrade ).toHaveBeenCalled();
+		expect( onDowngrade ).not.toHaveBeenCalled();
+
+		// Scheduling a second downgrade would silently replace the first.
+		expect( screen.getByRole( 'button', { name: 'Downgrade' } ) ).toBeDisabled();
+	} );
+
+	test( 'still sends a higher tier through the upgrade path', async () => {
+		mockProducts();
+		const onUpgrade = jest.fn();
+		const onDowngrade = jest.fn();
+		renderGrid( { currentTier: TitanPlanTier.Pro, onUpgrade, onDowngrade } );
+
+		await waitForProducts();
+
+		const upgradeButtons = screen.getAllByRole( 'button', { name: 'Upgrade' } );
+		await userEvent.click( upgradeButtons[ 0 ] );
+
+		expect( onUpgrade ).toHaveBeenCalledWith( TitanPlanTier.Premium );
+		expect( onDowngrade ).not.toHaveBeenCalled();
+	} );
+} );

--- a/client/dashboard/emails/choose-email-solution/components/test/titan-plan-grid.test.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/test/titan-plan-grid.test.tsx
@@ -123,6 +123,7 @@ describe( '<TitanPlanGrid>', () => {
 		const onCancelScheduledDowngrade = jest.fn();
 		const onDowngrade = jest.fn();
 		renderGrid( {
+			isDowngradePending: true,
 			pendingDowngradeTier: TitanPlanTier.Premium,
 			onCancelScheduledDowngrade,
 			onDowngrade,

--- a/client/dashboard/emails/choose-email-solution/components/titan-downgrade-modal.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-downgrade-modal.tsx
@@ -1,0 +1,115 @@
+import { formatCurrency } from '@automattic/number-formatters';
+import { __, sprintf } from '@wordpress/i18n';
+import { useIntlLocale } from '../../../app/locale';
+import ConfirmModal from '../../../components/confirm-modal';
+import { getTitanTierName } from '../../utils/titan-tiers';
+import type { TitanDowngradeMode } from '../../hooks/use-titan-downgrade';
+import type { TitanPlanTier } from '../../types';
+
+export interface PendingTitanDowngrade {
+	tier: TitanPlanTier;
+	toProductId: number;
+}
+
+export function TitanDowngradeModal( {
+	pendingDowngrade,
+	currentTier,
+	mode,
+	refundAmount,
+	currencyCode,
+	renewDate,
+	isBusy,
+	onCancel,
+	onConfirm,
+}: {
+	pendingDowngrade: PendingTitanDowngrade | null;
+	currentTier: TitanPlanTier;
+	mode: TitanDowngradeMode;
+	/** Refund for this target, in the currency's main unit. Zero when none applies. */
+	refundAmount: number;
+	currencyCode: string;
+	/** ISO date of the next renewal, when one is scheduled. */
+	renewDate?: string;
+	isBusy: boolean;
+	onCancel: () => void;
+	onConfirm: () => void;
+} ) {
+	const locale = useIntlLocale();
+
+	if ( ! pendingDowngrade ) {
+		return null;
+	}
+
+	const currentPlanName = getTitanTierName( currentTier );
+	const targetPlanName = getTitanTierName( pendingDowngrade.tier );
+	const isInstant = mode === 'instant';
+	const refundText =
+		refundAmount > 0 ? formatCurrency( refundAmount, currencyCode, { stripZeros: true } ) : null;
+	const renewalDate = renewDate
+		? new Intl.DateTimeFormat( locale, { dateStyle: 'long' } ).format( new Date( renewDate ) )
+		: null;
+
+	// Each message states what happens to the customer's money.
+	const description = ( () => {
+		if ( isInstant ) {
+			return refundText
+				? sprintf(
+						/* translators: %1$s is the current email plan name, %2$s the plan being switched to, %3$s a refunded amount such as "$18.00". */
+						__(
+							'Your plan will change from %1$s to %2$s right away, and you will be refunded %3$s.'
+						),
+						currentPlanName,
+						targetPlanName,
+						refundText
+				  )
+				: sprintf(
+						/* translators: %1$s is the current email plan name, %2$s the plan being switched to. */
+						__( 'Your plan will change from %1$s to %2$s right away.' ),
+						currentPlanName,
+						targetPlanName
+				  );
+		}
+
+		return renewalDate
+			? sprintf(
+					/* translators: %1$s is the current email plan name, %2$s the plan being switched to, %3$s a date such as "January 1, 2026". */
+					__(
+						'Your plan will change from %1$s to %2$s at your next renewal on %3$s. Until then you keep %1$s, and no refund or credit is issued.'
+					),
+					currentPlanName,
+					targetPlanName,
+					renewalDate
+			  )
+			: sprintf(
+					/* translators: %1$s is the current email plan name, %2$s the plan being switched to. */
+					__(
+						'Your plan will change from %1$s to %2$s at your next renewal. Until then you keep %1$s, and no refund or credit is issued.'
+					),
+					currentPlanName,
+					targetPlanName
+			  );
+	} )();
+
+	const confirmLabel =
+		isInstant && refundText
+			? sprintf(
+					/* translators: %s is a refunded amount, e.g. "$18.00". */
+					__( 'Change plan and refund %s' ),
+					refundText
+			  )
+			: __( 'Change plan' );
+
+	return (
+		<ConfirmModal
+			isOpen
+			__experimentalHideHeader={ false }
+			title={ isInstant ? __( 'Change your plan' ) : __( 'Schedule your plan change' ) }
+			cancelButtonText={ __( 'Keep current plan' ) }
+			confirmButtonProps={ { label: confirmLabel, isBusy, disabled: isBusy } }
+			onCancel={ onCancel }
+			onConfirm={ onConfirm }
+		>
+			{ description }
+		</ConfirmModal>
+	);
+}

--- a/client/dashboard/emails/choose-email-solution/components/titan-downgrade-modal.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-downgrade-modal.tsx
@@ -1,7 +1,8 @@
 import { formatCurrency } from '@automattic/number-formatters';
 import { __, sprintf } from '@wordpress/i18n';
-import { useIntlLocale } from '../../../app/locale';
+import { useLocale } from '../../../app/locale';
 import ConfirmModal from '../../../components/confirm-modal';
+import { formatDate } from '../../../utils/datetime';
 import { getTitanTierName } from '../../utils/titan-tiers';
 import type { TitanDowngradeMode } from '../../hooks/use-titan-downgrade';
 import type { TitanPlanTier } from '../../types';
@@ -34,7 +35,7 @@ export function TitanDowngradeModal( {
 	onCancel: () => void;
 	onConfirm: () => void;
 } ) {
-	const locale = useIntlLocale();
+	const locale = useLocale();
 
 	if ( ! pendingDowngrade ) {
 		return null;
@@ -46,7 +47,7 @@ export function TitanDowngradeModal( {
 	const refundText =
 		refundAmount > 0 ? formatCurrency( refundAmount, currencyCode, { stripZeros: true } ) : null;
 	const renewalDate = renewDate
-		? new Intl.DateTimeFormat( locale, { dateStyle: 'long' } ).format( new Date( renewDate ) )
+		? formatDate( new Date( renewDate ), locale, { dateStyle: 'long' } )
 		: null;
 
 	// Each message states what happens to the customer's money.
@@ -54,7 +55,7 @@ export function TitanDowngradeModal( {
 		if ( isInstant ) {
 			return refundText
 				? sprintf(
-						/* translators: %1$s is the current email plan name, %2$s the plan being switched to, %3$s a refunded amount such as "$18.00". */
+						/* translators: %1$s is the current email plan name, %2$s the plan being switched to, %3$s a refunded amount such as "$18". */
 						__(
 							'Your plan will change from %1$s to %2$s right away, and you will be refunded %3$s.'
 						),
@@ -93,7 +94,7 @@ export function TitanDowngradeModal( {
 	const confirmLabel =
 		isInstant && refundText
 			? sprintf(
-					/* translators: %s is a refunded amount, e.g. "$18.00". */
+					/* translators: %s is a refunded amount, e.g. "$18". */
 					__( 'Change plan and refund %s' ),
 					refundText
 			  )

--- a/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
@@ -13,7 +13,11 @@ import poweredByTitanLogo from '../../resources/powered-by-titan-caps.svg';
 import { IntervalLength, MailboxProvider, TitanPlanTier } from '../../types';
 import { getTrialMonths } from '../../utils/get-trial-months';
 import { isEligibleForIntroductoryOffer } from '../../utils/is-eligible-for-introductory-offer';
-import { getTitanTierName, TITAN_TIER_ORDER } from '../../utils/titan-tiers';
+import {
+	getTitanDowngradeTargetId,
+	getTitanTierName,
+	isLowerTitanTier,
+} from '../../utils/titan-tiers';
 import type { Domain, EmailSubscription, Product } from '@automattic/api-core';
 
 interface TitanPlan {
@@ -96,18 +100,32 @@ export function TitanPlanGrid( {
 	interval,
 	available,
 	currentTier,
+	canDowngrade = false,
+	pendingDowngradeTier,
+	isDowngradeBusy = false,
 	onUpgrade,
+	onDowngrade,
+	onCancelScheduledDowngrade,
 }: {
 	domain?: Domain;
 	domainName: string;
 	interval: IntervalLength;
 	available: boolean;
 	// The tier the user is currently subscribed to. When set, the grid is in
-	// upgrade mode: lower tiers are shown with a disabled button, the current
-	// tier is labeled, and higher tiers offer an upgrade.
+	// plan-change mode: the current tier is labeled, higher tiers offer an
+	// upgrade, and lower tiers offer a downgrade.
 	currentTier?: TitanPlanTier;
-	// Called when a higher tier is selected in upgrade mode (currentTier set).
+	// False when no live subscription backs the grid, which leaves lower tiers
+	// disabled instead of offering an action that would fail.
+	canDowngrade?: boolean;
+	// Tier a downgrade is already scheduled for. That card offers to cancel it.
+	pendingDowngradeTier?: TitanPlanTier;
+	isDowngradeBusy?: boolean;
+	// Upgrades are purchases, so this routes to checkout.
 	onUpgrade?: ( tier: TitanPlanTier ) => void;
+	// Downgrades are a direct API call, so this never goes to checkout.
+	onDowngrade?: ( tier: TitanPlanTier, toProductId: number ) => void;
+	onCancelScheduledDowngrade?: () => void;
 } ) {
 	const navigate = useNavigate();
 
@@ -160,16 +178,24 @@ export function TitanPlanGrid( {
 		},
 	];
 
-	// All tiers stay visible when upgrading; lower tiers render with a disabled
-	// button since this flow cannot downgrade.
-	const isLowerTier = ( tier: TitanPlanTier ) =>
-		currentTier
-			? TITAN_TIER_ORDER.indexOf( tier ) < TITAN_TIER_ORDER.indexOf( currentTier )
-			: false;
+	// All tiers stay visible when changing plan; lower tiers offer a downgrade.
+	const isLowerTier = ( tier: TitanPlanTier ) => isLowerTitanTier( tier, currentTier );
+
+	const productForTier = ( tier: TitanPlanTier ) =>
+		plans.find( ( plan ) => plan.tier === tier )?.product;
+
+	const getDowngradeTargetId = ( tier: TitanPlanTier ) =>
+		getTitanDowngradeTargetId( {
+			currentTier,
+			currentProduct: currentTier ? productForTier( currentTier ) : undefined,
+			targetTier: tier,
+			targetProduct: productForTier( tier ),
+			interval,
+		} );
 
 	// The tier that gets the emphasized (primary) button: the recommended plan when
 	// buying, or the recommended upgrade target when upgrading. The current and lower
-	// tiers are never emphasized because their buttons are disabled.
+	// tiers are never emphasized because upgrading is the encouraged action.
 	const primaryTier = ( () => {
 		const candidates = currentTier
 			? plans.filter( ( plan ) => plan.tier !== currentTier && ! isLowerTier( plan.tier ) )
@@ -193,12 +219,23 @@ export function TitanPlanGrid( {
 				const details = getTierDetails( plan.tier );
 				const isCurrentPlan = plan.tier === currentTier;
 				const isDowngrade = isLowerTier( plan.tier );
+				const downgradeTargetId = getDowngradeTargetId( plan.tier );
+				const isPendingDowngrade = Boolean(
+					pendingDowngradeTier && plan.tier === pendingDowngradeTier
+				);
+				// Scheduling a second downgrade would replace the first.
+				const isBlockedByPendingDowngrade =
+					Boolean( pendingDowngradeTier ) && isDowngrade && ! isPendingDowngrade;
+				const isDowngradeAvailable =
+					isDowngrade && canDowngrade && Boolean( downgradeTargetId ) && ! pendingDowngradeTier;
 
 				let actionLabel;
 				if ( isCurrentPlan ) {
 					actionLabel = __( 'Current plan' );
+				} else if ( isPendingDowngrade ) {
+					actionLabel = __( 'Cancel scheduled change' );
 				} else if ( isDowngrade ) {
-					actionLabel = __( 'Included in your plan' );
+					actionLabel = __( 'Downgrade' );
 				} else if ( currentTier ) {
 					actionLabel = __( 'Upgrade' );
 				} else if ( plan.hasFreeTrial ) {
@@ -210,6 +247,11 @@ export function TitanPlanGrid( {
 						planName
 					);
 				}
+
+				const isActionDisabled =
+					! available ||
+					isCurrentPlan ||
+					( isDowngrade && ! isPendingDowngrade && ! isDowngradeAvailable );
 
 				return (
 					<VStack
@@ -272,10 +314,18 @@ export function TitanPlanGrid( {
 							__next40pxDefaultSize
 							className="email-provider-action"
 							variant={ plan.tier === primaryTier ? 'primary' : 'secondary' }
-							disabled={ ! available || isCurrentPlan || isDowngrade }
+							disabled={ isActionDisabled || isDowngradeBusy }
+							isBusy={ isDowngradeBusy && ( isDowngrade || isPendingDowngrade ) }
 							onClick={ () => {
-								// Upgrade mode goes to checkout for the picked tier; otherwise the
-								// grid is buying a new plan, so collect mailboxes first.
+								if ( isPendingDowngrade ) {
+									onCancelScheduledDowngrade?.();
+									return;
+								}
+								// Downgrades call the API directly; only upgrades go to checkout.
+								if ( isDowngradeAvailable && downgradeTargetId ) {
+									onDowngrade?.( plan.tier, downgradeTargetId );
+									return;
+								}
 								if ( currentTier ) {
 									onUpgrade?.( plan.tier );
 									return;
@@ -293,6 +343,11 @@ export function TitanPlanGrid( {
 						>
 							{ actionLabel }
 						</Button>
+						{ isBlockedByPendingDowngrade && (
+							<Text variant="muted" className="email-titan-plan-downgrade-note">
+								{ __( 'Cancel your scheduled plan change to pick a different plan.' ) }
+							</Text>
+						) }
 						<VStack spacing={ 1 }>
 							<Text weight={ 600 } className="email-titan-plan-everything-in">
 								{ plan.everythingInName &&

--- a/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
+++ b/client/dashboard/emails/choose-email-solution/components/titan-plan-grid.tsx
@@ -100,9 +100,11 @@ export function TitanPlanGrid( {
 	interval,
 	available,
 	currentTier,
+	subscriptionInterval,
 	canDowngrade = false,
+	isDowngradePending = false,
 	pendingDowngradeTier,
-	isDowngradeBusy = false,
+	busyDowngradeTier,
 	onUpgrade,
 	onDowngrade,
 	onCancelScheduledDowngrade,
@@ -115,12 +117,19 @@ export function TitanPlanGrid( {
 	// plan-change mode: the current tier is labeled, higher tiers offer an
 	// upgrade, and lower tiers offer a downgrade.
 	currentTier?: TitanPlanTier;
+	// Billing term of the current subscription. A downgrade keeps that term, so
+	// lower tiers are only actionable while the selected interval matches it.
+	subscriptionInterval?: IntervalLength;
 	// False when no live subscription backs the grid, which leaves lower tiers
 	// disabled instead of offering an action that would fail.
 	canDowngrade?: boolean;
-	// Tier a downgrade is already scheduled for. That card offers to cancel it.
+	// Whether a downgrade is already scheduled.
+	isDowngradePending?: boolean;
+	// Tier that downgrade targets, when it maps to a known tier. Only labels
+	// which card offers to cancel it.
 	pendingDowngradeTier?: TitanPlanTier;
-	isDowngradeBusy?: boolean;
+	// Tier whose downgrade action is in flight.
+	busyDowngradeTier?: TitanPlanTier;
 	// Upgrades are purchases, so this routes to checkout.
 	onUpgrade?: ( tier: TitanPlanTier ) => void;
 	// Downgrades are a direct API call, so this never goes to checkout.
@@ -184,14 +193,21 @@ export function TitanPlanGrid( {
 	const productForTier = ( tier: TitanPlanTier ) =>
 		plans.find( ( plan ) => plan.tier === tier )?.product;
 
+	// The interval selector is still available to monthly subscribers so they can
+	// upgrade onto annual billing. Downgrades cannot change term, so they are
+	// offered only while the selected interval matches the subscription's.
+	const isSubscriptionInterval = ! subscriptionInterval || interval === subscriptionInterval;
+
 	const getDowngradeTargetId = ( tier: TitanPlanTier ) =>
-		getTitanDowngradeTargetId( {
-			currentTier,
-			currentProduct: currentTier ? productForTier( currentTier ) : undefined,
-			targetTier: tier,
-			targetProduct: productForTier( tier ),
-			interval,
-		} );
+		isSubscriptionInterval
+			? getTitanDowngradeTargetId( {
+					currentTier,
+					currentProduct: currentTier ? productForTier( currentTier ) : undefined,
+					targetTier: tier,
+					targetProduct: productForTier( tier ),
+					interval,
+			  } )
+			: undefined;
 
 	// The tier that gets the emphasized (primary) button: the recommended plan when
 	// buying, or the recommended upgrade target when upgrading. The current and lower
@@ -225,9 +241,10 @@ export function TitanPlanGrid( {
 				);
 				// Scheduling a second downgrade would replace the first.
 				const isBlockedByPendingDowngrade =
-					Boolean( pendingDowngradeTier ) && isDowngrade && ! isPendingDowngrade;
+					isDowngradePending && isDowngrade && ! isPendingDowngrade;
+				const isBlockedByInterval = isDowngrade && ! isSubscriptionInterval;
 				const isDowngradeAvailable =
-					isDowngrade && canDowngrade && Boolean( downgradeTargetId ) && ! pendingDowngradeTier;
+					isDowngrade && canDowngrade && Boolean( downgradeTargetId ) && ! isDowngradePending;
 
 				let actionLabel;
 				if ( isCurrentPlan ) {
@@ -314,8 +331,8 @@ export function TitanPlanGrid( {
 							__next40pxDefaultSize
 							className="email-provider-action"
 							variant={ plan.tier === primaryTier ? 'primary' : 'secondary' }
-							disabled={ isActionDisabled || isDowngradeBusy }
-							isBusy={ isDowngradeBusy && ( isDowngrade || isPendingDowngrade ) }
+							disabled={ isActionDisabled || Boolean( busyDowngradeTier ) }
+							isBusy={ busyDowngradeTier === plan.tier }
 							onClick={ () => {
 								if ( isPendingDowngrade ) {
 									onCancelScheduledDowngrade?.();
@@ -346,6 +363,11 @@ export function TitanPlanGrid( {
 						{ isBlockedByPendingDowngrade && (
 							<Text variant="muted" className="email-titan-plan-downgrade-note">
 								{ __( 'Cancel your scheduled plan change to pick a different plan.' ) }
+							</Text>
+						) }
+						{ isBlockedByInterval && (
+							<Text variant="muted" className="email-titan-plan-downgrade-note">
+								{ __( 'Switch back to your current billing period to downgrade.' ) }
 							</Text>
 						) }
 						<VStack spacing={ 1 }>

--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -31,6 +31,7 @@ import { EmailNonDomainOwnerNotice } from '../components/email-non-domain-owner-
 import { useAnnualSavings } from '../hooks/use-annual-savings';
 import { useDomainFromUrlParam } from '../hooks/use-domain-from-url-param';
 import { useEmailProduct } from '../hooks/use-email-product';
+import { useTitanDowngrade } from '../hooks/use-titan-downgrade';
 import poweredByTitanLogo from '../resources/powered-by-titan-caps.svg';
 import { IntervalLength, MailboxProvider, TitanPlanTier } from '../types';
 import { getTitanTierUpgradeUrl } from '../utils/get-tier-upgrade-url';
@@ -40,7 +41,9 @@ import { isMonthlyEmailProduct } from '../utils/is-monthly-email-product';
 import { getTitanTierFromSlug } from '../utils/titan-tiers';
 import { ExistingForwardsNotice } from './components/existing-forwards-notice';
 import { GoogleWorkspaceCard } from './components/google-workspace-card';
+import { TitanDowngradeModal } from './components/titan-downgrade-modal';
 import { TitanPlanGrid } from './components/titan-plan-grid';
+import type { PendingTitanDowngrade } from './components/titan-downgrade-modal';
 
 import './style.scss';
 
@@ -68,6 +71,31 @@ export default function ChooseEmailSolution() {
 	);
 
 	const { bestAnnualSavings } = useAnnualSavings( domain );
+
+	// The tier the subscription is on today, and therefore what every other card
+	// in the grid is an upgrade or a downgrade relative to.
+	const currentTier = isUpgradeIntent
+		? getTitanTierFromSlug( titanEmailSubscription?.product_slug )
+		: undefined;
+
+	const [ pendingDowngrade, setPendingDowngrade ] = useState< PendingTitanDowngrade | null >(
+		null
+	);
+	const {
+		purchase: titanPurchase,
+		mode: downgradeMode,
+		getRefundAmount,
+		downgrade,
+		cancelDowngrade,
+		pendingDowngradeTier,
+		isDowngrading,
+		isCancellingDowngrade,
+		canDowngrade,
+	} = useTitanDowngrade( {
+		domain,
+		domainName,
+		enabled: isTitanPlanSelectionEnabled && Boolean( currentTier ),
+	} );
 
 	const { product: googleProduct } = useEmailProduct(
 		MailboxProvider.Google,
@@ -155,6 +183,22 @@ export default function ChooseEmailSolution() {
 			tier,
 			interval: billingInterval,
 			quantity: getMaxTitanMailboxCount( domain ),
+		} );
+	};
+
+	// A downgrade is a direct call on the subscription, not a checkout: the
+	// backend rejects buying a lower tier while a subscription is active.
+	const handleTierDowngrade = ( tier: TitanPlanTier, toProductId: number ) => {
+		setPendingDowngrade( { tier, toProductId } );
+	};
+
+	const confirmDowngrade = () => {
+		if ( ! pendingDowngrade ) {
+			return;
+		}
+
+		downgrade( pendingDowngrade.toProductId, {
+			onSuccess: () => setPendingDowngrade( null ),
 		} );
 	};
 
@@ -282,12 +326,13 @@ export default function ChooseEmailSolution() {
 						domainName={ domainName }
 						interval={ billingInterval }
 						available={ isTitanAvailable }
-						currentTier={
-							isUpgradeIntent
-								? getTitanTierFromSlug( titanEmailSubscription?.product_slug )
-								: undefined
-						}
+						currentTier={ currentTier }
+						canDowngrade={ canDowngrade }
+						pendingDowngradeTier={ pendingDowngradeTier }
+						isDowngradeBusy={ isDowngrading || isCancellingDowngrade }
 						onUpgrade={ handleTierUpgrade }
+						onDowngrade={ handleTierDowngrade }
+						onCancelScheduledDowngrade={ cancelDowngrade }
 					/>
 					{ ! isUpgradeIntent && (
 						<GoogleWorkspaceCard
@@ -308,6 +353,20 @@ export default function ChooseEmailSolution() {
 						/>
 					) }
 				</VStack>
+			) }
+
+			{ currentTier && (
+				<TitanDowngradeModal
+					pendingDowngrade={ pendingDowngrade }
+					currentTier={ currentTier }
+					mode={ downgradeMode }
+					refundAmount={ pendingDowngrade ? getRefundAmount( pendingDowngrade.toProductId ) : 0 }
+					currencyCode={ titanPurchase?.currency_code ?? 'USD' }
+					renewDate={ titanPurchase?.renew_date }
+					isBusy={ isDowngrading }
+					onCancel={ () => setPendingDowngrade( null ) }
+					onConfirm={ confirmDowngrade }
+				/>
 			) }
 
 			{ /* Split card for providers */ }

--- a/client/dashboard/emails/choose-email-solution/index.tsx
+++ b/client/dashboard/emails/choose-email-solution/index.tsx
@@ -87,6 +87,7 @@ export default function ChooseEmailSolution() {
 		getRefundAmount,
 		downgrade,
 		cancelDowngrade,
+		isDowngradePending,
 		pendingDowngradeTier,
 		isDowngrading,
 		isCancellingDowngrade,
@@ -327,9 +328,19 @@ export default function ChooseEmailSolution() {
 						interval={ billingInterval }
 						available={ isTitanAvailable }
 						currentTier={ currentTier }
+						subscriptionInterval={
+							isMonthlyEmailProduct( titanEmailSubscription )
+								? IntervalLength.Monthly
+								: IntervalLength.Annually
+						}
 						canDowngrade={ canDowngrade }
+						isDowngradePending={ isDowngradePending }
 						pendingDowngradeTier={ pendingDowngradeTier }
-						isDowngradeBusy={ isDowngrading || isCancellingDowngrade }
+						busyDowngradeTier={
+							isDowngrading || isCancellingDowngrade
+								? pendingDowngrade?.tier ?? pendingDowngradeTier
+								: undefined
+						}
 						onUpgrade={ handleTierUpgrade }
 						onDowngrade={ handleTierDowngrade }
 						onCancelScheduledDowngrade={ cancelDowngrade }

--- a/client/dashboard/emails/hooks/test/use-titan-downgrade.tsx
+++ b/client/dashboard/emails/hooks/test/use-titan-downgrade.tsx
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment jsdom
+ */
+import { TitanMailSlugs } from '@automattic/api-core';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { render } from '../../../test-utils';
+import { useTitanDowngrade } from '../use-titan-downgrade';
+import type { Domain, Purchase } from '@automattic/api-core';
+
+const SITE_ID = 777;
+const DOMAIN_NAME = 'example.com';
+const PURCHASE_ID = 29102774;
+const PRO_MONTHLY_PRODUCT_ID = 400;
+
+const domain = { blog_id: SITE_ID } as Domain;
+
+function titanPurchase( overrides: Partial< Purchase > = {} ) {
+	return {
+		ID: PURCHASE_ID,
+		product_slug: TitanMailSlugs.TITAN_MAIL_PREMIUM_MONTHLY_SLUG,
+		meta: DOMAIN_NAME,
+		blog_id: SITE_ID,
+		currency_code: 'USD',
+		subscription_status: 'active',
+		expiry_status: 'auto-renewing',
+		is_instant_downgrade_available: false,
+		is_delayed_downgrade_pending: false,
+		...overrides,
+	};
+}
+
+function mockSitePurchases( ...purchases: object[] ) {
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.2/upgrades' )
+		.query( true )
+		.reply( 200, purchases );
+}
+
+function Harness() {
+	const { downgrade, cancelDowngrade, mode, canDowngrade, isDowngradePending } = useTitanDowngrade(
+		{ domain, domainName: DOMAIN_NAME }
+	);
+
+	return (
+		<>
+			<span>{ `mode:${ mode }` }</span>
+			<span>{ `canDowngrade:${ canDowngrade }` }</span>
+			<span>{ `pending:${ isDowngradePending }` }</span>
+			<button onClick={ () => downgrade( PRO_MONTHLY_PRODUCT_ID ) }>downgrade</button>
+			<button onClick={ () => cancelDowngrade() }>cancel</button>
+		</>
+	);
+}
+
+describe( 'useTitanDowngrade', () => {
+	test( 'schedules the downgrade for renewal when outside the refund window', async () => {
+		mockSitePurchases( titanPurchase() );
+		const scope = nock( 'https://public-api.wordpress.com' )
+			.post( `/rest/v1.1/upgrades/${ PURCHASE_ID }/delayed-downgrade`, {
+				enabled: true,
+				to_product_id: PRO_MONTHLY_PRODUCT_ID,
+			} )
+			.reply( 200, { success: true, delayed_downgrade: { is_pending: true } } );
+
+		render( <Harness /> );
+		await screen.findByText( 'canDowngrade:true' );
+		expect( screen.getByText( 'mode:delayed' ) ).toBeVisible();
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'downgrade' } ) );
+
+		await waitFor( () => expect( scope.isDone() ).toBe( true ) );
+	} );
+
+	test( 'downgrades immediately when inside the refund window', async () => {
+		mockSitePurchases(
+			titanPurchase( { is_instant_downgrade_available: true } as Partial< Purchase > )
+		);
+		const scope = nock( 'https://public-api.wordpress.com' )
+			.post( `/wpcom/v2/upgrades/${ PURCHASE_ID }/cancel`, {
+				type: 'downgrade',
+				to_product_id: PRO_MONTHLY_PRODUCT_ID,
+			} )
+			.reply( 200, { status: 'completed', message: 'ok' } );
+
+		render( <Harness /> );
+		await screen.findByText( 'mode:instant' );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'downgrade' } ) );
+
+		await waitFor( () => expect( scope.isDone() ).toBe( true ) );
+	} );
+
+	test( 'cancels a scheduled downgrade without a target product', async () => {
+		mockSitePurchases(
+			titanPurchase( { is_delayed_downgrade_pending: true } as Partial< Purchase > )
+		);
+		const scope = nock( 'https://public-api.wordpress.com' )
+			.post( `/rest/v1.1/upgrades/${ PURCHASE_ID }/delayed-downgrade`, { enabled: false } )
+			.reply( 200, { success: true, delayed_downgrade: { is_pending: false } } );
+
+		render( <Harness /> );
+		await screen.findByText( 'pending:true' );
+
+		await userEvent.click( screen.getByRole( 'button', { name: 'cancel' } ) );
+
+		await waitFor( () => expect( scope.isDone() ).toBe( true ) );
+	} );
+
+	test( 'offers no downgrade for an expired subscription', async () => {
+		mockSitePurchases( titanPurchase( { expiry_status: 'expired' } as Partial< Purchase > ) );
+
+		render( <Harness /> );
+
+		expect( await screen.findByText( 'canDowngrade:false' ) ).toBeVisible();
+	} );
+
+	test( 'offers no downgrade when the domain has no Titan subscription', async () => {
+		mockSitePurchases( titanPurchase( { meta: 'other-domain.com' } as Partial< Purchase > ) );
+
+		render( <Harness /> );
+
+		expect( await screen.findByText( 'canDowngrade:false' ) ).toBeVisible();
+	} );
+} );

--- a/client/dashboard/emails/hooks/use-titan-downgrade.ts
+++ b/client/dashboard/emails/hooks/use-titan-downgrade.ts
@@ -1,0 +1,145 @@
+import {
+	cancelAndRefundPurchaseMutation,
+	domainQuery,
+	setDelayedDowngradeMutation,
+	sitePurchasesQuery,
+} from '@automattic/api-queries';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import { useCallback } from 'react';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
+import { isExpiredOrRemoved, isTitanMail } from '../../utils/purchase';
+import { getTitanTierFromSlug } from '../utils/titan-tiers';
+import type { TitanPlanTier } from '../types';
+import type { Domain, Purchase } from '@automattic/api-core';
+
+/**
+ * Which downgrade endpoint applies, decided by the server:
+ *
+ * - `instant`: inside the refund window. Switches tier now and refunds the
+ *   difference.
+ * - `delayed`: outside it. Schedules the switch for the end of the current
+ *   term, with no refund or credit.
+ */
+export type TitanDowngradeMode = 'instant' | 'delayed';
+
+export function useTitanDowngrade( {
+	domain,
+	domainName,
+	enabled = true,
+}: {
+	domain: Domain | undefined;
+	domainName: string;
+	// False on the plain "buy email" visit, where there is no subscription to
+	// change and fetching the site's purchases would be a wasted request.
+	enabled?: boolean;
+} ) {
+	const queryClient = useQueryClient();
+	const siteId = domain?.blog_id;
+
+	const { data: sitePurchases } = useQuery( {
+		...sitePurchasesQuery( siteId ?? 0 ),
+		enabled: enabled && Boolean( siteId ),
+	} );
+
+	// Titan is one subscription per domain, and `meta` holds that domain.
+	const purchase: Purchase | undefined = sitePurchases?.find(
+		( sitePurchase ) => isTitanMail( sitePurchase ) && sitePurchase.meta === domainName
+	);
+
+	// is_instant_downgrade_available is true even when the refund is worth
+	// nothing (comped, 100%-off coupon, credits), so the mode comes from it
+	// rather than from refund_options, which is only read for the amount.
+	const mode: TitanDowngradeMode = purchase?.is_instant_downgrade_available ? 'instant' : 'delayed';
+
+	const getRefundAmount = useCallback(
+		( toProductId: number ) =>
+			purchase?.refund_options?.find( ( option ) => option.to_product_id === toProductId )
+				?.refund_amount ?? 0,
+		[ purchase ]
+	);
+
+	// The mutations only invalidate the user-wide purchases list. Refresh what
+	// this page reads: the site's purchases, and the domain, whose
+	// titan_mail_subscription slug gives the grid its current tier.
+	const invalidateAfterDowngrade = useCallback( () => {
+		if ( siteId ) {
+			queryClient.invalidateQueries( sitePurchasesQuery( siteId ) );
+		}
+		queryClient.invalidateQueries( domainQuery( domainName ) );
+	}, [ queryClient, siteId, domainName ] );
+
+	const { mutate: mutateInstantDowngrade, isPending: isInstantDowngradePending } = useMutation( {
+		...withSnackbar( cancelAndRefundPurchaseMutation(), {
+			success: __( 'Your plan has been changed.' ),
+			error: { source: 'server' },
+		} ),
+		onSuccess: invalidateAfterDowngrade,
+	} );
+
+	const { mutate: mutateDelayedDowngrade, isPending: isDelayedDowngradePending } = useMutation( {
+		...withSnackbar( setDelayedDowngradeMutation(), {
+			success: __( 'Your plan change has been scheduled.' ),
+			error: { source: 'server' },
+		} ),
+		onSuccess: invalidateAfterDowngrade,
+	} );
+
+	const { mutate: mutateCancelDowngrade, isPending: isCancelDowngradePending } = useMutation( {
+		...withSnackbar( setDelayedDowngradeMutation(), {
+			success: __( 'Your scheduled plan change has been cancelled.' ),
+			error: { source: 'server' },
+		} ),
+		onSuccess: invalidateAfterDowngrade,
+	} );
+
+	const downgrade = useCallback(
+		( toProductId: number, { onSuccess }: { onSuccess?: () => void } = {} ) => {
+			if ( ! purchase ) {
+				return;
+			}
+
+			if ( mode === 'instant' ) {
+				mutateInstantDowngrade(
+					{
+						purchaseId: purchase.ID,
+						options: { type: 'downgrade', to_product_id: toProductId },
+					},
+					{ onSuccess }
+				);
+				return;
+			}
+
+			mutateDelayedDowngrade(
+				{ purchaseId: purchase.ID, enabled: true, toProductId },
+				{ onSuccess }
+			);
+		},
+		[ purchase, mode, mutateInstantDowngrade, mutateDelayedDowngrade ]
+	);
+
+	const cancelDowngrade = useCallback( () => {
+		if ( purchase ) {
+			mutateCancelDowngrade( { purchaseId: purchase.ID, enabled: false } );
+		}
+	}, [ purchase, mutateCancelDowngrade ] );
+
+	// Stays set until the renewal applies the change, so the grid can offer to
+	// cancel it instead of repeating the downgrade.
+	const pendingDowngradeTier: TitanPlanTier | undefined = purchase?.is_delayed_downgrade_pending
+		? getTitanTierFromSlug( purchase.delayed_downgrade_to_product_slug ?? undefined )
+		: undefined;
+
+	return {
+		purchase,
+		mode,
+		getRefundAmount,
+		downgrade,
+		cancelDowngrade,
+		pendingDowngradeTier,
+		isDowngrading: isInstantDowngradePending || isDelayedDowngradePending,
+		isCancellingDowngrade: isCancelDowngradePending,
+		// An expired or removed subscription has nothing to downgrade.
+		canDowngrade: Boolean( purchase ) && ! ( purchase && isExpiredOrRemoved( purchase ) ),
+	};
+}

--- a/client/dashboard/emails/hooks/use-titan-downgrade.ts
+++ b/client/dashboard/emails/hooks/use-titan-downgrade.ts
@@ -59,9 +59,10 @@ export function useTitanDowngrade( {
 		[ purchase ]
 	);
 
-	// The mutations only invalidate the user-wide purchases list. Refresh what
+	// Runs alongside the invalidation the mutations already do, to refresh what
 	// this page reads: the site's purchases, and the domain, whose
-	// titan_mail_subscription slug gives the grid its current tier.
+	// titan_mail_subscription slug gives the grid its current tier. Passed per
+	// call, since an onSuccess on useMutation would replace the factory's own.
 	const invalidateAfterDowngrade = useCallback( () => {
 		if ( siteId ) {
 			queryClient.invalidateQueries( sitePurchasesQuery( siteId ) );
@@ -69,29 +70,26 @@ export function useTitanDowngrade( {
 		queryClient.invalidateQueries( domainQuery( domainName ) );
 	}, [ queryClient, siteId, domainName ] );
 
-	const { mutate: mutateInstantDowngrade, isPending: isInstantDowngradePending } = useMutation( {
-		...withSnackbar( cancelAndRefundPurchaseMutation(), {
+	const { mutate: mutateInstantDowngrade, isPending: isInstantDowngradePending } = useMutation(
+		withSnackbar( cancelAndRefundPurchaseMutation(), {
 			success: __( 'Your plan has been changed.' ),
 			error: { source: 'server' },
-		} ),
-		onSuccess: invalidateAfterDowngrade,
-	} );
+		} )
+	);
 
-	const { mutate: mutateDelayedDowngrade, isPending: isDelayedDowngradePending } = useMutation( {
-		...withSnackbar( setDelayedDowngradeMutation(), {
+	const { mutate: mutateDelayedDowngrade, isPending: isDelayedDowngradePending } = useMutation(
+		withSnackbar( setDelayedDowngradeMutation(), {
 			success: __( 'Your plan change has been scheduled.' ),
 			error: { source: 'server' },
-		} ),
-		onSuccess: invalidateAfterDowngrade,
-	} );
+		} )
+	);
 
-	const { mutate: mutateCancelDowngrade, isPending: isCancelDowngradePending } = useMutation( {
-		...withSnackbar( setDelayedDowngradeMutation(), {
+	const { mutate: mutateCancelDowngrade, isPending: isCancelDowngradePending } = useMutation(
+		withSnackbar( setDelayedDowngradeMutation(), {
 			success: __( 'Your scheduled plan change has been cancelled.' ),
 			error: { source: 'server' },
-		} ),
-		onSuccess: invalidateAfterDowngrade,
-	} );
+		} )
+	);
 
 	const downgrade = useCallback(
 		( toProductId: number, { onSuccess }: { onSuccess?: () => void } = {} ) => {
@@ -99,30 +97,38 @@ export function useTitanDowngrade( {
 				return;
 			}
 
+			const onDowngraded = () => {
+				invalidateAfterDowngrade();
+				onSuccess?.();
+			};
+
 			if ( mode === 'instant' ) {
 				mutateInstantDowngrade(
 					{
 						purchaseId: purchase.ID,
 						options: { type: 'downgrade', to_product_id: toProductId },
 					},
-					{ onSuccess }
+					{ onSuccess: onDowngraded }
 				);
 				return;
 			}
 
 			mutateDelayedDowngrade(
 				{ purchaseId: purchase.ID, enabled: true, toProductId },
-				{ onSuccess }
+				{ onSuccess: onDowngraded }
 			);
 		},
-		[ purchase, mode, mutateInstantDowngrade, mutateDelayedDowngrade ]
+		[ purchase, mode, invalidateAfterDowngrade, mutateInstantDowngrade, mutateDelayedDowngrade ]
 	);
 
 	const cancelDowngrade = useCallback( () => {
 		if ( purchase ) {
-			mutateCancelDowngrade( { purchaseId: purchase.ID, enabled: false } );
+			mutateCancelDowngrade(
+				{ purchaseId: purchase.ID, enabled: false },
+				{ onSuccess: invalidateAfterDowngrade }
+			);
 		}
-	}, [ purchase, mutateCancelDowngrade ] );
+	}, [ purchase, invalidateAfterDowngrade, mutateCancelDowngrade ] );
 
 	// Stays set until the renewal applies the change, so the grid can offer to
 	// cancel it instead of repeating the downgrade.

--- a/client/dashboard/emails/hooks/use-titan-downgrade.ts
+++ b/client/dashboard/emails/hooks/use-titan-downgrade.ts
@@ -59,16 +59,15 @@ export function useTitanDowngrade( {
 		[ purchase ]
 	);
 
-	// Runs alongside the invalidation the mutations already do, to refresh what
-	// this page reads: the site's purchases, and the domain, whose
-	// titan_mail_subscription slug gives the grid its current tier. Passed per
-	// call, since an onSuccess on useMutation would replace the factory's own.
-	const invalidateAfterDowngrade = useCallback( () => {
-		if ( siteId ) {
-			queryClient.invalidateQueries( sitePurchasesQuery( siteId ) );
-		}
-		queryClient.invalidateQueries( domainQuery( domainName ) );
-	}, [ queryClient, siteId, domainName ] );
+	// The mutations invalidate the [ 'upgrades' ] key, which covers every
+	// purchase query. The domain is not under that key and holds the
+	// titan_mail_subscription slug the grid reads its current tier from.
+	// Passed per call, since an onSuccess on useMutation would replace the
+	// factory's own.
+	const invalidateAfterDowngrade = useCallback(
+		() => queryClient.invalidateQueries( domainQuery( domainName ) ),
+		[ queryClient, domainName ]
+	);
 
 	const { mutate: mutateInstantDowngrade, isPending: isInstantDowngradePending } = useMutation(
 		withSnackbar( cancelAndRefundPurchaseMutation(), {
@@ -97,8 +96,8 @@ export function useTitanDowngrade( {
 				return;
 			}
 
-			const onDowngraded = () => {
-				invalidateAfterDowngrade();
+			const onDowngraded = async () => {
+				await invalidateAfterDowngrade();
 				onSuccess?.();
 			};
 
@@ -125,15 +124,17 @@ export function useTitanDowngrade( {
 		if ( purchase ) {
 			mutateCancelDowngrade(
 				{ purchaseId: purchase.ID, enabled: false },
-				{ onSuccess: invalidateAfterDowngrade }
+				{ onSuccess: () => invalidateAfterDowngrade() }
 			);
 		}
 	}, [ purchase, invalidateAfterDowngrade, mutateCancelDowngrade ] );
 
 	// Stays set until the renewal applies the change, so the grid can offer to
-	// cancel it instead of repeating the downgrade.
-	const pendingDowngradeTier: TitanPlanTier | undefined = purchase?.is_delayed_downgrade_pending
-		? getTitanTierFromSlug( purchase.delayed_downgrade_to_product_slug ?? undefined )
+	// cancel it instead of repeating the downgrade. The tier only labels which
+	// card shows that action; the flag is what says a downgrade is scheduled.
+	const isDowngradePending = Boolean( purchase?.is_delayed_downgrade_pending );
+	const pendingDowngradeTier: TitanPlanTier | undefined = isDowngradePending
+		? getTitanTierFromSlug( purchase?.delayed_downgrade_to_product_slug ?? undefined )
 		: undefined;
 
 	return {
@@ -142,10 +143,11 @@ export function useTitanDowngrade( {
 		getRefundAmount,
 		downgrade,
 		cancelDowngrade,
+		isDowngradePending,
 		pendingDowngradeTier,
 		isDowngrading: isInstantDowngradePending || isDelayedDowngradePending,
 		isCancellingDowngrade: isCancelDowngradePending,
 		// An expired or removed subscription has nothing to downgrade.
-		canDowngrade: Boolean( purchase ) && ! ( purchase && isExpiredOrRemoved( purchase ) ),
+		canDowngrade: Boolean( purchase && ! isExpiredOrRemoved( purchase ) ),
 	};
 }


### PR DESCRIPTION
Stacked on 114237.

## Proposed Changes

* Downgrade an active Professional Email subscription from the plan grid, using the subscription API instead of checkout.
* Pick the endpoint from the purchase's refund window:
  * inside it, `cancel` with `type=downgrade` switches the tier now and refunds the difference
  * outside it, `delayed-downgrade` schedules the switch for the next renewal, with no refund
* Add a confirmation modal stating which one applies, including the refund amount or the renewal date.
* Once a downgrade is scheduled, that tier offers to cancel it instead of repeating the downgrade.

## Why are these changes being made?

Lower tiers in the grid were routed to the tier checkout URL, the same one used for upgrades. The backend rejects that for an active subscription:

> Please specify another domain name as a Professional Email subscription already exists for 'example.com' with another provider.

Buying a lower tier in the cart is the post-expiry flow, valid only during the grace period after a subscription expires. Downgrading an active subscription is a direct API call.

Upgrades are unchanged and still go through checkout.

## Testing Instructions

1. Run `yarn start` and sign in. The `emails/titan-tiers` flag is already on in development.
2. You need a domain with an active Professional Email subscription on **Premium or Ultra**, and a payment method on that subscription.
3. Go to Upgrades > Billing > Active subscriptions, open that email subscription, and click **Upgrade** (or **Manage your plan** on Ultra) to reach the plan grid.
4. On a lower tier, confirm the button reads **Downgrade** and is enabled. Tiers above the current one still read Upgrade.
5. Click **Downgrade**. The modal states either an immediate change with a refund, or a change at the next renewal with no refund, depending on the refund window.
6. Confirm. Watch the network tab: it posts to `/upgrades/<id>/cancel` or `/upgrades/<id>/delayed-downgrade`. Nothing should navigate to checkout.
7. For a scheduled downgrade, reload the grid. That tier now reads **Cancel scheduled change** and the other lower tiers are disabled. Click it and confirm the downgrade is cancelled.
8. Confirm an upgrade still goes to checkout: click Upgrade on a higher tier.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
