### PR TITLE
Subscription Imports: grant comps without a Stripe plan mapping

### DIFF
--- a/client/data/paid-newsletter/test/use-set-comp-plan-mutation.tsx
+++ b/client/data/paid-newsletter/test/use-set-comp-plan-mutation.tsx
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSetCompPlanMutation } from '../use-set-comp-plan-mutation';
+import type { ReactNode } from 'react';
+
+const mockPost = jest.fn();
+jest.mock( 'calypso/lib/wp', () => ( {
+	__esModule: true,
+	default: {
+		req: {
+			post: ( ...args: unknown[] ) => mockPost( ...args ),
+		},
+	},
+} ) );
+
+describe( 'useSetCompPlanMutation', () => {
+	let queryClient: QueryClient;
+	let wrapper: ( props: { children: ReactNode } ) => JSX.Element;
+
+	beforeEach( () => {
+		mockPost.mockReset();
+		mockPost.mockResolvedValue( { current_step: 'subscribers' } );
+
+		queryClient = new QueryClient( {
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		} );
+
+		wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+	} );
+
+	it( 'grants comps against a WordPress.com tier rather than a Stripe plan', async () => {
+		const { result } = renderHook( () => useSetCompPlanMutation(), { wrapper } );
+
+		result.current.setCompPlan( 123, 'substack', 'subscribers', '10' );
+
+		await waitFor( () => expect( mockPost ).toHaveBeenCalled() );
+
+		const [ , body ] = mockPost.mock.calls[ 0 ];
+		expect( body ).toEqual( {
+			engine: 'substack',
+			current_step: 'subscribers',
+			comp_product_id: '10',
+		} );
+	} );
+
+	it( 'optimistically records the chosen tier so the import button unblocks', async () => {
+		// Hold the request open so the optimistic write is what we observe, not the response.
+		mockPost.mockReturnValue( new Promise( () => {} ) );
+		queryClient.setQueryData( [ 'paid-newsletter-importer', 123, 'substack' ], {
+			steps: { subscribers: { content: { comp_product_id: null } } },
+		} );
+
+		const { result } = renderHook( () => useSetCompPlanMutation(), { wrapper } );
+
+		result.current.setCompPlan( 123, 'substack', 'subscribers', '10' );
+
+		await waitFor( () => {
+			const cached = queryClient.getQueryData< {
+				steps: { subscribers: { content: { comp_product_id: number | null } } };
+			} >( [ 'paid-newsletter-importer', 123, 'substack' ] );
+			expect( cached?.steps.subscribers.content.comp_product_id ).toBe( 10 );
+		} );
+	} );
+
+	it( 'clears the selection when an empty tier is sent', async () => {
+		const { result } = renderHook( () => useSetCompPlanMutation(), { wrapper } );
+
+		result.current.setCompPlan( 123, 'substack', 'subscribers', '' );
+
+		await waitFor( () => expect( mockPost ).toHaveBeenCalled() );
+
+		const [ , body ] = mockPost.mock.calls[ 0 ];
+		expect( body.comp_product_id ).toBe( '' );
+	} );
+} );

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -28,12 +28,15 @@ export interface ContentStepContent {
 	};
 }
 
+export type CompSkipReason = 'no_tier' | 'multiple_tiers' | 'chosen_tier_gone';
+
 export interface SubscribersStepContent {
 	available_tiers?: Product[];
 	connect_url?: string;
 	is_connected_stripe: boolean;
 	map_plans?: Record< string, string >;
 	comp_stripe_plan_id?: string;
+	comp_product_id?: number | null;
 	account_display?: string;
 	plans?: Plan[];
 	meta?: {
@@ -53,6 +56,8 @@ export interface SubscribersStepContent {
 		comp_subscribed_count: string | null;
 		comp_already_subscribed_count: string | null;
 		comp_failed_subscribed_count: string | null;
+		comp_failed_emails?: string[];
+		comp_skip_reason?: CompSkipReason | null;
 		timestamp: string;
 	};
 }
@@ -63,6 +68,8 @@ export interface Product {
 	interval: string;
 	price: string;
 	title: string;
+	// The id of the monthly anchor this product belongs to, or 0 on an anchor itself.
+	tier?: number;
 }
 
 export interface Plan {
@@ -76,6 +83,7 @@ export interface Plan {
 	product_id: string;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface SummaryStepContent {}
 
 interface Step< T > {

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -60,7 +60,7 @@ export interface SubscribersStepContent {
 		comp_subscribed_count: string | null;
 		comp_already_subscribed_count: string | null;
 		comp_failed_subscribed_count: string | null;
-		comp_failed_emails?: string[];
+		comp_failed_emails?: { email: string; reason: string }[];
 		comp_skip_reason?: CompSkipReason | null;
 		timestamp: string;
 	};

--- a/client/data/paid-newsletter/use-paid-newsletter-query.ts
+++ b/client/data/paid-newsletter/use-paid-newsletter-query.ts
@@ -28,7 +28,11 @@ export interface ContentStepContent {
 	};
 }
 
-export type CompSkipReason = 'no_tier' | 'multiple_tiers' | 'chosen_tier_gone';
+export type CompSkipReason =
+	| 'no_tier'
+	| 'multiple_tiers'
+	| 'chosen_tier_gone'
+	| 'tier_lookup_failed';
 
 export interface SubscribersStepContent {
 	available_tiers?: Product[];

--- a/client/data/paid-newsletter/use-set-comp-plan-mutation.ts
+++ b/client/data/paid-newsletter/use-set-comp-plan-mutation.ts
@@ -11,7 +11,7 @@ interface MutationVariables {
 	siteId: number;
 	engine: string;
 	currentStep: string;
-	stripePlanId: string;
+	compProductId: string;
 }
 
 export const useSetCompPlanMutation = (
@@ -19,7 +19,7 @@ export const useSetCompPlanMutation = (
 ) => {
 	const queryClient = useQueryClient();
 	const mutation = useMutation( {
-		mutationFn: async ( { siteId, engine, currentStep, stripePlanId }: MutationVariables ) => {
+		mutationFn: async ( { siteId, engine, currentStep, compProductId }: MutationVariables ) => {
 			// Optimistically set the value.
 			queryClient.setQueryData(
 				[ 'paid-newsletter-importer', siteId, engine ],
@@ -27,7 +27,9 @@ export const useSetCompPlanMutation = (
 					if ( ! previous ) {
 						return previous;
 					}
-					previous.steps[ 'subscribers' ].content.comp_stripe_plan_id = stripePlanId;
+					previous.steps[ 'subscribers' ].content.comp_product_id = compProductId
+						? parseInt( compProductId )
+						: null;
 					return previous;
 				}
 			);
@@ -40,7 +42,7 @@ export const useSetCompPlanMutation = (
 				{
 					engine: engine,
 					current_step: currentStep,
-					comp_stripe_plan_id: stripePlanId,
+					comp_product_id: compProductId,
 				}
 			);
 
@@ -61,8 +63,8 @@ export const useSetCompPlanMutation = (
 	const { mutate } = mutation;
 
 	const setCompPlan = useCallback(
-		( siteId: number, engine: string, currentStep: string, stripePlanId: string ) =>
-			mutate( { siteId, engine, currentStep, stripePlanId } ),
+		( siteId: number, engine: string, currentStep: string, compProductId: string ) =>
+			mutate( { siteId, engine, currentStep, compProductId } ),
 		[ mutate ]
 	);
 

--- a/client/data/paid-newsletter/use-set-comp-plan-mutation.ts
+++ b/client/data/paid-newsletter/use-set-comp-plan-mutation.ts
@@ -14,11 +14,15 @@ interface MutationVariables {
 	compProductId: string;
 }
 
+// Lets a screen that does not own this mutation still tell whether a selection is in flight.
+export const setCompPlanMutationKey = [ 'paid-newsletter-set-comp-plan' ];
+
 export const useSetCompPlanMutation = (
 	options: UseMutationOptions< unknown, DefaultError, MutationVariables > = {}
 ) => {
 	const queryClient = useQueryClient();
 	const mutation = useMutation( {
+		mutationKey: setCompPlanMutationKey,
 		mutationFn: async ( { siteId, engine, currentStep, compProductId }: MutationVariables ) => {
 			// Optimistically set the value.
 			queryClient.setQueryData(

--- a/client/my-sites/importer/newsletter/style.scss
+++ b/client/my-sites/importer/newsletter/style.scss
@@ -76,6 +76,13 @@ $newsletter_importer_line-height: 20px;
 		line-height: $newsletter_importer_line-height;
 	}
 
+	.summary__comp-skip-reason {
+		margin-top: 12px;
+		font-size: $newsletter_importer_font-size;
+		line-height: $newsletter_importer_line-height;
+		color: var( --studio-gray-50 );
+	}
+
 	.summary__content-row {
 		display: flex;
 		flex-direction: row;

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/comp-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/comp-subscribers.tsx
@@ -12,17 +12,32 @@ import { MapCompPlan } from './map-comp-plan';
  * Newsletter tiers arrive as a monthly/yearly pair: the yearly entry points at the monthly
  * anchor through `tier`, and the anchor carries `tier: 0`. A comp attaches to the tier as a
  * whole, so collapse each pair into a single choice keyed on the anchor id.
+ *
+ * The endpoint returns `price` as a string, so its ids cannot be assumed to be numbers either.
+ * Everything is normalized to a number here so the grouping and the later selection lookup
+ * compare in the same representation.
  * @param availableTiers Tiers as returned by the importer endpoint.
  */
-export function groupCompTiers( availableTiers: Product[] = [] ): Product[] {
+export function groupCompTiers( availableTiers?: Product[] ): Product[] {
+	if ( ! Array.isArray( availableTiers ) ) {
+		return [];
+	}
+
 	const tiersByAnchor = new Map< number, Product >();
 
 	availableTiers.forEach( ( product ) => {
-		const anchorId = product.tier || product.id;
+		const tier = Number( product.tier ) || 0;
+		const anchorId = tier || Number( product.id );
+
+		if ( ! Number.isFinite( anchorId ) ) {
+			return;
+		}
+
 		const existing = tiersByAnchor.get( anchorId );
 
-		if ( ! existing || ( ! product.tier && existing.tier ) ) {
-			tiersByAnchor.set( anchorId, { ...product, id: anchorId } );
+		// Prefer the anchor, whichever order the pair arrives in, so the label and price are monthly.
+		if ( ! existing || ( tier === 0 && existing.tier !== 0 ) ) {
+			tiersByAnchor.set( anchorId, { ...product, id: anchorId, tier } );
 		}
 	} );
 

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/comp-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/comp-subscribers.tsx
@@ -1,0 +1,111 @@
+import { Notice } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import {
+	Product,
+	SubscribersStepContent,
+} from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import { useSetCompPlanMutation } from 'calypso/data/paid-newsletter/use-set-comp-plan-mutation';
+import { MapCompPlan } from './map-comp-plan';
+
+/**
+ * Newsletter tiers arrive as a monthly/yearly pair: the yearly entry points at the monthly
+ * anchor through `tier`, and the anchor carries `tier: 0`. A comp attaches to the tier as a
+ * whole, so collapse each pair into a single choice keyed on the anchor id.
+ * @param availableTiers Tiers as returned by the importer endpoint.
+ */
+export function groupCompTiers( availableTiers: Product[] = [] ): Product[] {
+	const tiersByAnchor = new Map< number, Product >();
+
+	availableTiers.forEach( ( product ) => {
+		const anchorId = product.tier || product.id;
+		const existing = tiersByAnchor.get( anchorId );
+
+		if ( ! existing || ( ! product.tier && existing.tier ) ) {
+			tiersByAnchor.set( anchorId, { ...product, id: anchorId } );
+		}
+	} );
+
+	return Array.from( tiersByAnchor.values() );
+}
+
+export function getCompCount( cardData?: SubscribersStepContent ): number {
+	return Number( cardData?.meta?.comp_count ?? 0 ) || 0;
+}
+
+/**
+ * The tier a comp will be granted against, as a string for the picker. Falls back to the only
+ * tier on the site, which is what the server grants against when nothing has been chosen.
+ * @param cardData The subscribers step content.
+ */
+export function getSelectedCompTierId( cardData?: SubscribersStepContent ): string {
+	const tiers = groupCompTiers( cardData?.available_tiers );
+	const selectedId = cardData?.comp_product_id;
+
+	if ( selectedId && tiers.some( ( tier ) => tier.id === Number( selectedId ) ) ) {
+		return selectedId.toString();
+	}
+
+	return tiers.length === 1 ? tiers[ 0 ].id.toString() : '';
+}
+
+/**
+ * Whether the import can go ahead as far as comped subscribers are concerned. A site with no
+ * tier at all is warned rather than blocked, since setting one up needs Stripe and free
+ * subscribers should still be importable.
+ * @param cardData The subscribers step content.
+ */
+export function isCompSelectionSatisfied( cardData?: SubscribersStepContent ): boolean {
+	if ( getCompCount( cardData ) === 0 ) {
+		return true;
+	}
+
+	if ( groupCompTiers( cardData?.available_tiers ).length === 0 ) {
+		return true;
+	}
+
+	return getSelectedCompTierId( cardData ) !== '';
+}
+
+type CompSubscribersProps = {
+	cardData: SubscribersStepContent;
+	siteId: number;
+	engine: string;
+};
+
+export default function CompSubscribers( { cardData, siteId, engine }: CompSubscribersProps ) {
+	const { _n } = useI18n();
+	const { setCompPlan } = useSetCompPlanMutation();
+
+	const compCount = getCompCount( cardData );
+	if ( compCount === 0 ) {
+		return null;
+	}
+
+	const tiers = groupCompTiers( cardData?.available_tiers );
+
+	if ( tiers.length === 0 ) {
+		return (
+			<Notice isDismissible={ false } status="warning">
+				{ sprintf(
+					// Translators: %d is number of complimentary subscribers
+					_n(
+						'%d subscriber won’t be comped unless you set up a paid tier.',
+						'%d subscribers won’t be comped unless you set up a paid tier.',
+						compCount
+					),
+					compCount
+				) }
+			</Notice>
+		);
+	}
+
+	return (
+		<MapCompPlan
+			compCount={ compCount }
+			tiers={ tiers }
+			selectedTierId={ getSelectedCompTierId( cardData ) }
+			onCompPlanSelect={ ( tierId ) => setCompPlan( siteId, engine, 'subscribers', tierId ) }
+		/>
+	);
+}

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/comp-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/comp-subscribers.tsx
@@ -53,19 +53,41 @@ export function getCompCount( cardData?: SubscribersStepContent ): number {
 }
 
 /**
- * The tier a comp will be granted against, as a string for the picker. Falls back to the only
- * tier on the site, which is what the server grants against when nothing has been chosen.
+ * The tier a comp will be granted against, as a string for the picker.
+ *
+ * A choice already made and a choice never made are different situations. With nothing chosen we
+ * fall back to the only tier, which is what the server grants against anyway. But a saved choice
+ * whose tier has since been deleted is left unresolved rather than quietly replaced: the server
+ * refuses to substitute, so showing another tier as selected would promise access nobody picked
+ * and the import would grant no comps at all.
  * @param cardData The subscribers step content.
  */
 export function getSelectedCompTierId( cardData?: SubscribersStepContent ): string {
 	const tiers = groupCompTiers( cardData?.available_tiers );
 	const selectedId = cardData?.comp_product_id;
 
-	if ( selectedId && tiers.some( ( tier ) => tier.id === Number( selectedId ) ) ) {
-		return selectedId.toString();
+	if ( selectedId ) {
+		return tiers.some( ( tier ) => tier.id === Number( selectedId ) ) ? selectedId.toString() : '';
 	}
 
 	return tiers.length === 1 ? tiers[ 0 ].id.toString() : '';
+}
+
+/**
+ * Whether a tier chosen in an earlier session has since been deleted. The selection outlives the
+ * import, so this can surface long after the choice was made.
+ * @param cardData The subscribers step content.
+ */
+export function isCompSelectionStale( cardData?: SubscribersStepContent ): boolean {
+	const selectedId = cardData?.comp_product_id;
+	if ( ! selectedId ) {
+		return false;
+	}
+
+	const tiers = groupCompTiers( cardData?.available_tiers );
+
+	// With no tiers at all the site-level warning already covers it.
+	return tiers.length > 0 && ! tiers.some( ( tier ) => tier.id === Number( selectedId ) );
 }
 
 /**
@@ -93,7 +115,7 @@ type CompSubscribersProps = {
 };
 
 export default function CompSubscribers( { cardData, siteId, engine }: CompSubscribersProps ) {
-	const { _n } = useI18n();
+	const { __, _n } = useI18n();
 	const { setCompPlan } = useSetCompPlanMutation();
 
 	const compCount = getCompCount( cardData );
@@ -120,11 +142,20 @@ export default function CompSubscribers( { cardData, siteId, engine }: CompSubsc
 	}
 
 	return (
-		<MapCompPlan
-			compCount={ compCount }
-			tiers={ tiers }
-			selectedTierId={ getSelectedCompTierId( cardData ) }
-			onCompPlanSelect={ ( tierId ) => setCompPlan( siteId, engine, 'subscribers', tierId ) }
-		/>
+		<>
+			{ isCompSelectionStale( cardData ) && (
+				<Notice isDismissible={ false } status="warning">
+					{ __(
+						'The paid tier you chose for comped subscribers no longer exists. Choose another one.'
+					) }
+				</Notice>
+			) }
+			<MapCompPlan
+				compCount={ compCount }
+				tiers={ tiers }
+				selectedTierId={ getSelectedCompTierId( cardData ) }
+				onCompPlanSelect={ ( tierId ) => setCompPlan( siteId, engine, 'subscribers', tierId ) }
+			/>
+		</>
 	);
 }

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/comp-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/comp-subscribers.tsx
@@ -24,10 +24,14 @@ export function groupCompTiers( availableTiers?: Product[] ): Product[] {
 	}
 
 	const tiersByAnchor = new Map< number, Product >();
+	// A deleted monthly anchor leaves its yearly half behind, still pointing at the id that went
+	// away, so the back-reference is only worth following when the anchor is still in the list.
+	// The server grants against the survivor's own id in that case.
+	const presentIds = new Set( availableTiers.map( ( product ) => Number( product.id ) ) );
 
 	availableTiers.forEach( ( product ) => {
 		const tier = Number( product.tier ) || 0;
-		const anchorId = tier || Number( product.id );
+		const anchorId = tier && presentIds.has( tier ) ? tier : Number( product.id );
 
 		if ( ! Number.isFinite( anchorId ) ) {
 			return;
@@ -36,7 +40,7 @@ export function groupCompTiers( availableTiers?: Product[] ): Product[] {
 		const existing = tiersByAnchor.get( anchorId );
 
 		// Prefer the anchor, whichever order the pair arrives in, so the label and price are monthly.
-		if ( ! existing || ( tier === 0 && existing.tier !== 0 ) ) {
+		if ( ! existing || ( anchorId === Number( product.id ) && existing.tier !== 0 ) ) {
 			tiersByAnchor.set( anchorId, { ...product, id: anchorId, tier } );
 		}
 	} );

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/comp-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/comp-subscribers.tsx
@@ -108,6 +108,16 @@ export function isCompSelectionSatisfied( cardData?: SubscribersStepContent ): b
 	return getSelectedCompTierId( cardData ) !== '';
 }
 
+/**
+ * Whether the import will actually grant complimentary access, which decides whether a button
+ * offering to continue "with free subscribers" would be telling the truth. Comps with no tier to
+ * grant against do arrive as plain free subscribers, so that case is still free-only.
+ * @param cardData The subscribers step content.
+ */
+export function willGrantComps( cardData?: SubscribersStepContent ): boolean {
+	return getCompCount( cardData ) > 0 && getSelectedCompTierId( cardData ) !== '';
+}
+
 type CompSubscribersProps = {
 	cardData: SubscribersStepContent;
 	siteId: number;

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
@@ -9,6 +9,7 @@ import ImporterActionButton from '../../../importer-action-buttons/action-button
 import ImporterActionButtonContainer from '../../../importer-action-buttons/container';
 import { SubscribersStepProps } from '../../types';
 import StartImportButton from '../start-import-button';
+import CompSubscribers from './comp-subscribers';
 import SuccessNotice from './success-notice';
 
 /**
@@ -61,6 +62,7 @@ export default function ConnectStripe( {
 					}
 				) }
 			</p>
+			<CompSubscribers cardData={ cardData } siteId={ selectedSite.ID } engine={ engine } />
 			<ImporterActionButtonContainer noSpacing>
 				<ImporterActionButton
 					primary

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
@@ -11,7 +11,7 @@ import ImporterActionButton from '../../../importer-action-buttons/action-button
 import ImporterActionButtonContainer from '../../../importer-action-buttons/container';
 import { SubscribersStepProps } from '../../types';
 import StartImportButton from '../start-import-button';
-import CompSubscribers, { isCompSelectionSatisfied } from './comp-subscribers';
+import CompSubscribers, { isCompSelectionSatisfied, willGrantComps } from './comp-subscribers';
 import SuccessNotice from './success-notice';
 
 /**
@@ -93,11 +93,13 @@ export default function ConnectStripe( {
 					disabled={ isImportDisabled }
 					navigate={ onStartImport }
 					label={
-						fixMe( {
-							text: 'Continue with free subscribers',
-							newCopy: __( 'Continue with free subscribers' ),
-							oldCopy: __( 'I have only free subscribers' ),
-						} ) as string
+						willGrantComps( cardData )
+							? __( 'Continue without paid subscribers' )
+							: ( fixMe( {
+									text: 'Continue with free subscribers',
+									newCopy: __( 'Continue with free subscribers' ),
+									oldCopy: __( 'I have only free subscribers' ),
+							  } ) as string )
 					}
 				/>
 			</ImporterActionButtonContainer>

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/connect-stripe.tsx
@@ -1,15 +1,17 @@
+import { useIsMutating } from '@tanstack/react-query';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { getQueryArg, addQueryArgs } from '@wordpress/url';
 import { QueryArgParsed } from '@wordpress/url/build-types/get-query-arg';
 import { fixMe } from 'i18n-calypso';
 import StripeLogoSvg from 'calypso/assets/images/jetpack/stripe-logo-white.svg';
+import { setCompPlanMutationKey } from 'calypso/data/paid-newsletter/use-set-comp-plan-mutation';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import ImporterActionButton from '../../../importer-action-buttons/action-button';
 import ImporterActionButtonContainer from '../../../importer-action-buttons/container';
 import { SubscribersStepProps } from '../../types';
 import StartImportButton from '../start-import-button';
-import CompSubscribers from './comp-subscribers';
+import CompSubscribers, { isCompSelectionSatisfied } from './comp-subscribers';
 import SuccessNotice from './success-notice';
 
 /**
@@ -41,12 +43,17 @@ export default function ConnectStripe( {
 	onStartImport,
 }: ConnectStripeProps ) {
 	const { __ } = useI18n();
+	const isSavingCompPlan = useIsMutating( { mutationKey: setCompPlanMutationKey } ) > 0;
+
 	if ( cardData?.connect_url === undefined ) {
 		return null;
 	}
 
 	const connectUrl = updateConnectUrl( cardData?.connect_url ?? '', fromSite, engine );
 	const allEmailsCount = parseInt( cardData?.meta?.email_count || '0' );
+	// Comps are dropped for good once the job runs, so an unresolved choice holds the import even
+	// here. A site with no tier to grant against resolves on its own, leaving the escape hatch open.
+	const isImportDisabled = ! isCompSelectionSatisfied( cardData ) || isSavingCompPlan;
 
 	return (
 		<>
@@ -83,6 +90,7 @@ export default function ConnectStripe( {
 					siteId={ selectedSite.ID }
 					step="subscribers"
 					primary={ false }
+					disabled={ isImportDisabled }
 					navigate={ onStartImport }
 					label={
 						fixMe( {

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-comp-plan.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-comp-plan.tsx
@@ -4,52 +4,48 @@ import { sprintf } from '@wordpress/i18n';
 import { chevronDown, Icon, arrowRight } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
-import { Plan } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import { Product } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+
+import './map-plan.scss';
 
 type MapCompPlanProps = {
 	compCount: number;
-	plans: Plan[];
-	selectedStripePlanId: string;
-	onCompPlanSelect: ( stripePlanId: string ) => void;
+	tiers: Product[];
+	selectedTierId: string;
+	onCompPlanSelect: ( tierId: string ) => void;
 };
 
-function displayPlan( plan?: Plan, fallback?: string ) {
-	if ( ! plan ) {
+function formatTierPrice( tier: Product ) {
+	return `${ formatCurrency( parseFloat( tier.price ), tier.currency ) }/${ tier.interval }`;
+}
+
+function displayTier( tier?: Product, fallback?: string ) {
+	if ( ! tier ) {
 		return fallback;
 	}
 
 	return (
 		<span>
-			<strong>{ plan.name }</strong>{ ' ' }
-			<span>
-				{ formatCurrency( plan.plan_amount_decimal, plan.plan_currency, {
-					isSmallestUnit: true,
-					stripZeros: true,
-				} ) }
-				/{ plan.plan_interval }
-			</span>
+			<strong>{ tier.title }</strong> <span>{ formatTierPrice( tier ) }</span>
 		</span>
 	);
 }
 
 export function MapCompPlan( {
 	compCount,
-	plans,
-	selectedStripePlanId,
+	tiers,
+	selectedTierId,
 	onCompPlanSelect,
 }: MapCompPlanProps ) {
 	const { __, _n } = useI18n();
 	const [ isOpen, setIsOpen ] = useState( false );
 
-	const selectedPlan = plans.find( ( plan ) => plan.product_id === selectedStripePlanId );
+	const selectedTier = tiers.find( ( tier ) => tier.id.toString() === selectedTierId );
 
-	const choices = plans.map( ( plan ) => ( {
-		info: `${ formatCurrency( plan.plan_amount_decimal, plan.plan_currency, {
-			isSmallestUnit: true,
-			stripZeros: true,
-		} ) } / ${ plan.plan_interval }`,
-		label: plan.name,
-		value: plan.product_id,
+	const choices = tiers.map( ( tier ) => ( {
+		info: formatTierPrice( tier ),
+		label: tier.title,
+		value: tier.id.toString(),
 	} ) );
 
 	return (
@@ -73,24 +69,24 @@ export function MapCompPlan( {
 					className="map-plan__selected"
 					onClick={ () => setIsOpen( ! isOpen ) }
 				>
-					{ displayPlan( selectedPlan, __( 'Select a plan' ) ) }
+					{ displayTier( selectedTier, __( 'Select a tier' ) ) }
 				</Button>
 				<DropdownMenu
 					onToggle={ ( openState: boolean ) => setIsOpen( openState ) }
 					icon={ chevronDown }
-					label={ __( 'Choose a plan for comped subscribers' ) }
+					label={ __( 'Choose a tier for comped subscribers' ) }
 					open={ isOpen }
 				>
 					{ ( { onClose }: { onClose: () => void } ) => (
 						<MenuGroup label={ __( 'Grant complimentary access to' ) }>
 							<MenuItemsChoice
 								choices={ choices }
-								onSelect={ ( stripePlanId ) => {
-									onCompPlanSelect( stripePlanId );
+								onSelect={ ( tierId ) => {
+									onCompPlanSelect( tierId );
 									onClose();
 								} }
 								onHover={ () => {} }
-								value={ selectedStripePlanId }
+								value={ selectedTierId }
 							/>
 						</MenuGroup>
 					) }

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-comp-plan.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-comp-plan.tsx
@@ -69,12 +69,12 @@ export function MapCompPlan( {
 					className="map-plan__selected"
 					onClick={ () => setIsOpen( ! isOpen ) }
 				>
-					{ displayTier( selectedTier, __( 'Select a tier' ) ) }
+					{ displayTier( selectedTier, __( 'Select a plan' ) ) }
 				</Button>
 				<DropdownMenu
 					onToggle={ ( openState: boolean ) => setIsOpen( openState ) }
 					icon={ chevronDown }
-					label={ __( 'Choose a tier for comped subscribers' ) }
+					label={ __( 'Choose a plan for comped subscribers' ) }
 					open={ isOpen }
 				>
 					{ ( { onClose }: { onClose: () => void } ) => (

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
@@ -1,9 +1,10 @@
 import { formatCurrency } from '@automattic/number-formatters';
-import { useQueryClient } from '@tanstack/react-query';
+import { useIsMutating, useQueryClient } from '@tanstack/react-query';
 import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, useRef } from 'react';
 import { useMapStripePlanToProductMutation } from 'calypso/data/paid-newsletter/use-map-stripe-plan-to-product-mutation';
+import { setCompPlanMutationKey } from 'calypso/data/paid-newsletter/use-set-comp-plan-mutation';
 import RecurringPaymentsPlanAddEditModal from 'calypso/my-sites/earn/components/add-edit-plan-modal';
 import {
 	PLAN_YEARLY_FREQUENCY,
@@ -74,6 +75,7 @@ export default function MapPlans( {
 	const currentStep = 'subscribers';
 
 	const queryClient = useQueryClient();
+	const isSavingCompPlan = useIsMutating( { mutationKey: setCompPlanMutationKey } ) > 0;
 
 	const newsletterTiers = useSelector( ( state ) =>
 		getProductsForSiteId( state, selectedSite.ID )
@@ -162,7 +164,10 @@ export default function MapPlans( {
 		},
 	};
 
-	const isImportButtonDisabled = ! shouldEnableImporting( cardData ) || isSavingPlanMapping;
+	// The comp selection is written optimistically, so without this the import can start before the
+	// choice reaches the server, which would then report that no tier was chosen.
+	const isImportButtonDisabled =
+		! shouldEnableImporting( cardData ) || isSavingPlanMapping || isSavingCompPlan;
 
 	const onProductSelect = ( stripePlanId: string, productId: string ) => {
 		mapStripePlanToProduct( selectedSite.ID, engine, currentStep, stripePlanId, productId );

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/map-plans.tsx
@@ -4,7 +4,6 @@ import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, useRef } from 'react';
 import { useMapStripePlanToProductMutation } from 'calypso/data/paid-newsletter/use-map-stripe-plan-to-product-mutation';
-import { useSetCompPlanMutation } from 'calypso/data/paid-newsletter/use-set-comp-plan-mutation';
 import RecurringPaymentsPlanAddEditModal from 'calypso/my-sites/earn/components/add-edit-plan-modal';
 import {
 	PLAN_YEARLY_FREQUENCY,
@@ -16,7 +15,7 @@ import { useSelector } from 'calypso/state';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
 import { SubscribersStepProps } from '../../types';
 import StartImportButton from './../start-import-button';
-import { MapCompPlan } from './map-comp-plan';
+import CompSubscribers, { isCompSelectionSatisfied } from './comp-subscribers';
 import { MapPlan, TierToAdd } from './map-plan';
 import NoPlans from './no-plans';
 import SuccessNotice from './success-notice';
@@ -45,24 +44,8 @@ function shouldEnableImporting( cardData: any ) {
 		return false;
 	}
 
-	// If there are comped subscribers, require a comp plan selection that still
-	// resolves to a known Stripe plan (guards against stale selections after a
-	// Stripe account reconnect or plan deletion).
-	const compCount = parseInt( cardData?.meta?.comp_count || '0' );
-	if ( compCount > 0 ) {
-		const compStripePlanId = cardData?.comp_stripe_plan_id;
-		if ( ! compStripePlanId ) {
-			return false;
-		}
-		const compPlanExists = ( plans as any[] ).some(
-			( item: any ) => item?.product_id === compStripePlanId
-		);
-		if ( ! compPlanExists ) {
-			return false;
-		}
-	}
-
-	return true;
+	// If there are comped subscribers, require a tier that still exists to grant against.
+	return isCompSelectionSatisfied( cardData );
 }
 
 function findNewProduct( currentProducts: Array< Product >, previousProducts: Array< Product > ) {
@@ -97,7 +80,6 @@ export default function MapPlans( {
 	);
 	const { mapStripePlanToProduct, isPending: isSavingPlanMapping } =
 		useMapStripePlanToProductMutation();
-	const { setCompPlan, isPending: isSavingCompPlan } = useSetCompPlanMutation();
 	const newsletterTiersRef = useRef( newsletterTiers );
 	const stripePlanRef = useRef( '' );
 
@@ -180,13 +162,7 @@ export default function MapPlans( {
 		},
 	};
 
-	const isImportButtonDisabled =
-		! shouldEnableImporting( cardData ) || isSavingPlanMapping || isSavingCompPlan;
-
-	const compCount = parseInt( cardData?.meta?.comp_count || '0' );
-	const onCompPlanSelect = ( stripePlanId: string ) => {
-		setCompPlan( selectedSite.ID, engine, currentStep, stripePlanId );
-	};
+	const isImportButtonDisabled = ! shouldEnableImporting( cardData ) || isSavingPlanMapping;
 
 	const onProductSelect = ( stripePlanId: string, productId: string ) => {
 		mapStripePlanToProduct( selectedSite.ID, engine, currentStep, stripePlanId, productId );
@@ -235,14 +211,7 @@ export default function MapPlans( {
 						/>
 					);
 				} ) }
-				{ compCount > 0 && (
-					<MapCompPlan
-						compCount={ compCount }
-						plans={ cardData.plans }
-						selectedStripePlanId={ cardData.comp_stripe_plan_id ?? '' }
-						onCompPlanSelect={ onCompPlanSelect }
-					/>
-				) }
+				<CompSubscribers cardData={ cardData } siteId={ selectedSite.ID } engine={ engine } />
 			</div>
 
 			<StartImportButton

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
@@ -11,7 +11,7 @@ import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-ac
 import { useDispatch } from 'calypso/state';
 import { requestDisconnectSiteStripeAccount } from 'calypso/state/memberships/settings/actions';
 import StartImportButton from './../start-import-button';
-import CompSubscribers, { isCompSelectionSatisfied } from './comp-subscribers';
+import CompSubscribers, { isCompSelectionSatisfied, willGrantComps } from './comp-subscribers';
 import type { SiteDetails } from '@automattic/data-stores';
 
 type NoPlansProps = {
@@ -93,7 +93,11 @@ export default function NoPlans( { cardData, selectedSite, engine, onStartImport
 					primary={ false }
 					step={ currentStep }
 					disabled={ isImportDisabled }
-					label={ __( 'Only import free subscribers' ) }
+					label={
+						willGrantComps( cardData )
+							? __( 'Import without paid subscribers' )
+							: __( 'Only import free subscribers' )
+					}
 					navigate={ onStartImport }
 				/>
 			</ImporterActionButtonContainer>

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
@@ -10,6 +10,7 @@ import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-ac
 import { useDispatch } from 'calypso/state';
 import { requestDisconnectSiteStripeAccount } from 'calypso/state/memberships/settings/actions';
 import StartImportButton from './../start-import-button';
+import CompSubscribers from './comp-subscribers';
 import type { SiteDetails } from '@automattic/data-stores';
 
 type NoPlansProps = {
@@ -75,6 +76,7 @@ export default function NoPlans( { cardData, selectedSite, engine, onStartImport
 					) }
 				</p>
 			</div>
+			<CompSubscribers cardData={ cardData } siteId={ selectedSite.ID } engine={ engine } />
 			<ImporterActionButtonContainer>
 				<ImporterActionButton onClick={ disconnectStripe } primary>
 					{ __( 'Try a different Stripe account' ) }

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/no-plans.tsx
@@ -1,16 +1,17 @@
 import { Dialog } from '@automattic/components';
-import { useQueryClient } from '@tanstack/react-query';
+import { useIsMutating, useQueryClient } from '@tanstack/react-query';
 import { Notice } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState, useEffect } from 'react';
 import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import { setCompPlanMutationKey } from 'calypso/data/paid-newsletter/use-set-comp-plan-mutation';
 import ImporterActionButton from 'calypso/my-sites/importer/importer-action-buttons/action-button';
 import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-action-buttons/container';
 import { useDispatch } from 'calypso/state';
 import { requestDisconnectSiteStripeAccount } from 'calypso/state/memberships/settings/actions';
 import StartImportButton from './../start-import-button';
-import CompSubscribers from './comp-subscribers';
+import CompSubscribers, { isCompSelectionSatisfied } from './comp-subscribers';
 import type { SiteDetails } from '@automattic/data-stores';
 
 type NoPlansProps = {
@@ -29,6 +30,10 @@ export default function NoPlans( { cardData, selectedSite, engine, onStartImport
 
 	const dispatch = useDispatch();
 	const queryClient = useQueryClient();
+	const isSavingCompPlan = useIsMutating( { mutationKey: setCompPlanMutationKey } ) > 0;
+	// Same reasoning as the Connect Stripe screen: an unresolved comp choice holds the import,
+	// while a site with nothing to grant against does not.
+	const isImportDisabled = ! isCompSelectionSatisfied( cardData ) || isSavingCompPlan;
 
 	const disconnectStripe = () => {
 		setShowDisconnectStripeDialog( true );
@@ -87,6 +92,7 @@ export default function NoPlans( { cardData, selectedSite, engine, onStartImport
 					siteId={ selectedSite.ID }
 					primary={ false }
 					step={ currentStep }
+					disabled={ isImportDisabled }
 					label={ __( 'Only import free subscribers' ) }
 					navigate={ onStartImport }
 				/>

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/comp-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/comp-subscribers.tsx
@@ -1,0 +1,178 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import CompSubscribers, {
+	groupCompTiers,
+	getSelectedCompTierId,
+	isCompSelectionSatisfied,
+} from '../comp-subscribers';
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	__esModule: true,
+	default: { req: { post: jest.fn() } },
+} ) );
+
+const monthlyAnchor = {
+	id: 10,
+	tier: 0,
+	title: 'Supporter',
+	price: '5',
+	currency: 'USD',
+	interval: '1 month',
+};
+const yearlyPair = {
+	id: 11,
+	tier: 10,
+	title: 'Supporter',
+	price: '50',
+	currency: 'USD',
+	interval: '1 year',
+};
+const secondTier = {
+	id: 20,
+	tier: 0,
+	title: 'Founding member',
+	price: '25',
+	currency: 'USD',
+	interval: '1 month',
+};
+
+function cardData( overrides: Partial< SubscribersStepContent > = {} ): SubscribersStepContent {
+	return {
+		is_connected_stripe: false,
+		available_tiers: [],
+		meta: { comp_count: 3 },
+		...overrides,
+	} as SubscribersStepContent;
+}
+
+function renderCompSubscribers( content: SubscribersStepContent ) {
+	return render(
+		<QueryClientProvider client={ new QueryClient() }>
+			<CompSubscribers cardData={ content } siteId={ 1 } engine="substack" />
+		</QueryClientProvider>
+	);
+}
+
+describe( 'groupCompTiers', () => {
+	it( 'collapses a monthly/yearly pair into one choice keyed on the monthly anchor', () => {
+		const tiers = groupCompTiers( [ monthlyAnchor, yearlyPair ] );
+
+		expect( tiers ).toHaveLength( 1 );
+		expect( tiers[ 0 ].id ).toBe( 10 );
+		expect( tiers[ 0 ].interval ).toBe( '1 month' );
+	} );
+
+	it( 'prefers the anchor even when the yearly entry comes first', () => {
+		const tiers = groupCompTiers( [ yearlyPair, monthlyAnchor ] );
+
+		expect( tiers ).toHaveLength( 1 );
+		expect( tiers[ 0 ].price ).toBe( '5' );
+	} );
+
+	it( 'keeps separate tiers apart', () => {
+		const tiers = groupCompTiers( [ monthlyAnchor, yearlyPair, secondTier ] );
+
+		expect( tiers.map( ( tier ) => tier.id ) ).toEqual( [ 10, 20 ] );
+	} );
+
+	it( 'returns nothing when the site has no tiers', () => {
+		expect( groupCompTiers( [] ) ).toEqual( [] );
+		expect( groupCompTiers() ).toEqual( [] );
+	} );
+} );
+
+describe( 'getSelectedCompTierId', () => {
+	it( 'uses the saved selection when the tier still exists', () => {
+		expect(
+			getSelectedCompTierId(
+				cardData( { available_tiers: [ monthlyAnchor, secondTier ], comp_product_id: 20 } )
+			)
+		).toBe( '20' );
+	} );
+
+	it( 'falls back to the only tier when nothing is saved', () => {
+		expect(
+			getSelectedCompTierId(
+				cardData( { available_tiers: [ monthlyAnchor, yearlyPair ], comp_product_id: null } )
+			)
+		).toBe( '10' );
+	} );
+
+	it( 'drops a selection whose tier has been deleted', () => {
+		expect(
+			getSelectedCompTierId(
+				cardData( { available_tiers: [ monthlyAnchor, secondTier ], comp_product_id: 99 } )
+			)
+		).toBe( '' );
+	} );
+
+	it( 'has no selection when several tiers are available and none is saved', () => {
+		expect(
+			getSelectedCompTierId( cardData( { available_tiers: [ monthlyAnchor, secondTier ] } ) )
+		).toBe( '' );
+	} );
+} );
+
+describe( 'isCompSelectionSatisfied', () => {
+	it( 'does not block an import that carries no comps', () => {
+		expect(
+			isCompSelectionSatisfied(
+				cardData( { meta: { comp_count: 0 } as SubscribersStepContent[ 'meta' ] } )
+			)
+		).toBe( true );
+	} );
+
+	it( 'does not block an import when the site has no tier to grant against', () => {
+		expect( isCompSelectionSatisfied( cardData( { available_tiers: [] } ) ) ).toBe( true );
+	} );
+
+	it( 'does not block when the single tier resolves on its own', () => {
+		expect(
+			isCompSelectionSatisfied( cardData( { available_tiers: [ monthlyAnchor, yearlyPair ] } ) )
+		).toBe( true );
+	} );
+
+	it( 'blocks while several tiers are available and none is chosen', () => {
+		expect(
+			isCompSelectionSatisfied( cardData( { available_tiers: [ monthlyAnchor, secondTier ] } ) )
+		).toBe( false );
+	} );
+} );
+
+describe( '<CompSubscribers>', () => {
+	it( 'warns instead of dropping comps silently when the site has no tier', () => {
+		renderCompSubscribers( cardData( { available_tiers: [] } ) );
+
+		expect(
+			screen.getAllByText( '3 subscribers won’t be comped unless you set up a paid tier.' )[ 0 ]
+		).toBeVisible();
+		expect( screen.queryByRole( 'button', { name: /Select a tier/ } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'offers the picker with a single tier pre-selected', () => {
+		renderCompSubscribers( cardData( { available_tiers: [ monthlyAnchor, yearlyPair ] } ) );
+
+		expect( screen.getByText( '3 complimentary subscribers' ) ).toBeVisible();
+		expect( screen.getByText( 'Supporter' ) ).toBeVisible();
+		expect( screen.queryByText( 'Select a tier' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'asks for a choice when several tiers are available', () => {
+		renderCompSubscribers( cardData( { available_tiers: [ monthlyAnchor, secondTier ] } ) );
+
+		expect( screen.getByText( 'Select a tier' ) ).toBeVisible();
+	} );
+
+	it( 'renders nothing when the import carries no comps', () => {
+		const { container } = renderCompSubscribers(
+			cardData( { meta: { comp_count: 0 } as SubscribersStepContent[ 'meta' ] } )
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/comp-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/comp-subscribers.tsx
@@ -4,7 +4,10 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import {
+	Product,
+	SubscribersStepContent,
+} from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
 import CompSubscribers, {
 	groupCompTiers,
 	getSelectedCompTierId,
@@ -84,6 +87,21 @@ describe( 'groupCompTiers', () => {
 		expect( groupCompTiers( [] ) ).toEqual( [] );
 		expect( groupCompTiers() ).toEqual( [] );
 	} );
+
+	it( 'collapses the pair when the endpoint stringifies the ids', () => {
+		// This endpoint already returns `price` as a string, so numerics cannot be assumed.
+		const tiers = groupCompTiers( [
+			{ ...monthlyAnchor, id: '10', tier: '0' },
+			{ ...yearlyPair, id: '11', tier: '10' },
+		] as unknown as Product[] );
+
+		expect( tiers ).toHaveLength( 1 );
+		expect( tiers[ 0 ].id ).toBe( 10 );
+	} );
+
+	it( 'survives a null tier list', () => {
+		expect( groupCompTiers( null as unknown as Product[] ) ).toEqual( [] );
+	} );
 } );
 
 describe( 'getSelectedCompTierId', () => {
@@ -109,6 +127,19 @@ describe( 'getSelectedCompTierId', () => {
 				cardData( { available_tiers: [ monthlyAnchor, secondTier ], comp_product_id: 99 } )
 			)
 		).toBe( '' );
+	} );
+
+	it( 'resolves a stringified selection against stringified tier ids', () => {
+		expect(
+			getSelectedCompTierId( {
+				...cardData(),
+				available_tiers: [
+					{ ...monthlyAnchor, id: '10', tier: '0' },
+					{ ...secondTier, id: '20', tier: '0' },
+				],
+				comp_product_id: '20',
+			} as unknown as SubscribersStepContent )
+		).toBe( '20' );
 	} );
 
 	it( 'has no selection when several tiers are available and none is saved', () => {
@@ -166,6 +197,17 @@ describe( '<CompSubscribers>', () => {
 		renderCompSubscribers( cardData( { available_tiers: [ monthlyAnchor, secondTier ] } ) );
 
 		expect( screen.getByText( 'Select a tier' ) ).toBeVisible();
+	} );
+
+	it( 'warns rather than crashing when the tier list comes back null', () => {
+		renderCompSubscribers( {
+			...cardData(),
+			available_tiers: null,
+		} as unknown as SubscribersStepContent );
+
+		expect(
+			screen.getAllByText( '3 subscribers won’t be comped unless you set up a paid tier.' )[ 0 ]
+		).toBeVisible();
 	} );
 
 	it( 'renders nothing when the import carries no comps', () => {

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/comp-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/comp-subscribers.tsx
@@ -99,6 +99,15 @@ describe( 'groupCompTiers', () => {
 		expect( tiers[ 0 ].id ).toBe( 10 );
 	} );
 
+	it( 'keeps a yearly tier whose monthly anchor has been deleted', () => {
+		// The server leaves the back-reference pointing at the deleted anchor, and grants against
+		// the survivor's own id, so following `tier` here would name a plan that no longer exists.
+		const tiers = groupCompTiers( [ yearlyPair ] );
+
+		expect( tiers ).toHaveLength( 1 );
+		expect( tiers[ 0 ].id ).toBe( 11 );
+	} );
+
 	it( 'survives a null tier list', () => {
 		expect( groupCompTiers( null as unknown as Product[] ) ).toEqual( [] );
 	} );

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/comp-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/comp-subscribers.tsx
@@ -12,6 +12,7 @@ import CompSubscribers, {
 	groupCompTiers,
 	getSelectedCompTierId,
 	isCompSelectionSatisfied,
+	isCompSelectionStale,
 } from '../comp-subscribers';
 
 jest.mock( 'calypso/lib/wp', () => ( {
@@ -151,10 +152,50 @@ describe( 'getSelectedCompTierId', () => {
 		).toBe( '20' );
 	} );
 
+	it( 'does not substitute another tier when the chosen one was deleted', () => {
+		// The server refuses to grant against a tier nobody chose, so pre-selecting the survivor
+		// would show access that will not be granted.
+		expect(
+			getSelectedCompTierId( cardData( { available_tiers: [ secondTier ], comp_product_id: 10 } ) )
+		).toBe( '' );
+	} );
+
+	it( 'auto-selects the only tier when no choice has been saved yet', () => {
+		expect(
+			getSelectedCompTierId(
+				cardData( { available_tiers: [ secondTier ], comp_product_id: null } )
+			)
+		).toBe( '20' );
+	} );
+
 	it( 'has no selection when several tiers are available and none is saved', () => {
 		expect(
 			getSelectedCompTierId( cardData( { available_tiers: [ monthlyAnchor, secondTier ] } ) )
 		).toBe( '' );
+	} );
+} );
+
+describe( 'isCompSelectionStale', () => {
+	it( 'reports a saved choice whose tier has been deleted', () => {
+		expect(
+			isCompSelectionStale( cardData( { available_tiers: [ secondTier ], comp_product_id: 10 } ) )
+		).toBe( true );
+	} );
+
+	it( 'is not stale when the saved choice still resolves', () => {
+		expect(
+			isCompSelectionStale( cardData( { available_tiers: [ secondTier ], comp_product_id: 20 } ) )
+		).toBe( false );
+	} );
+
+	it( 'is not stale when nothing has been chosen', () => {
+		expect( isCompSelectionStale( cardData( { available_tiers: [ secondTier ] } ) ) ).toBe( false );
+	} );
+
+	it( 'leaves the no-tier warning to speak for itself', () => {
+		expect( isCompSelectionStale( cardData( { available_tiers: [], comp_product_id: 10 } ) ) ).toBe(
+			false
+		);
 	} );
 } );
 
@@ -175,6 +216,14 @@ describe( 'isCompSelectionSatisfied', () => {
 		expect(
 			isCompSelectionSatisfied( cardData( { available_tiers: [ monthlyAnchor, yearlyPair ] } ) )
 		).toBe( true );
+	} );
+
+	it( 'blocks while the chosen tier is gone and only one other remains', () => {
+		expect(
+			isCompSelectionSatisfied(
+				cardData( { available_tiers: [ secondTier ], comp_product_id: 10 } )
+			)
+		).toBe( false );
 	} );
 
 	it( 'blocks while several tiers are available and none is chosen', () => {
@@ -217,6 +266,19 @@ describe( '<CompSubscribers>', () => {
 		expect(
 			screen.getAllByText( '3 subscribers won’t be comped unless you set up a paid tier.' )[ 0 ]
 		).toBeVisible();
+	} );
+
+	it( 'asks for a new choice when the chosen tier was deleted', () => {
+		renderCompSubscribers(
+			cardData( { available_tiers: [ monthlyAnchor, yearlyPair ], comp_product_id: 99 } )
+		);
+
+		expect(
+			screen.getAllByText(
+				'The paid tier you chose for comped subscribers no longer exists. Choose another one.'
+			)[ 0 ]
+		).toBeVisible();
+		expect( screen.getByText( 'Select a tier' ) ).toBeVisible();
 	} );
 
 	it( 'renders nothing when the import carries no comps', () => {

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/comp-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/comp-subscribers.tsx
@@ -26,7 +26,7 @@ const monthlyAnchor = {
 	title: 'Supporter',
 	price: '5',
 	currency: 'USD',
-	interval: '1 month',
+	interval: 'month',
 };
 const yearlyPair = {
 	id: 11,
@@ -34,7 +34,7 @@ const yearlyPair = {
 	title: 'Supporter',
 	price: '50',
 	currency: 'USD',
-	interval: '1 year',
+	interval: 'year',
 };
 const secondTier = {
 	id: 20,
@@ -42,7 +42,7 @@ const secondTier = {
 	title: 'Founding member',
 	price: '25',
 	currency: 'USD',
-	interval: '1 month',
+	interval: 'month',
 };
 
 function cardData( overrides: Partial< SubscribersStepContent > = {} ): SubscribersStepContent {
@@ -68,7 +68,7 @@ describe( 'groupCompTiers', () => {
 
 		expect( tiers ).toHaveLength( 1 );
 		expect( tiers[ 0 ].id ).toBe( 10 );
-		expect( tiers[ 0 ].interval ).toBe( '1 month' );
+		expect( tiers[ 0 ].interval ).toBe( 'month' );
 	} );
 
 	it( 'prefers the anchor even when the yearly entry comes first', () => {

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/comp-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/comp-subscribers.tsx
@@ -268,7 +268,7 @@ describe( '<CompSubscribers>', () => {
 		expect(
 			screen.getAllByText( '3 subscribers won’t be comped unless you set up a paid tier.' )[ 0 ]
 		).toBeVisible();
-		expect( screen.queryByRole( 'button', { name: /Select a tier/ } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: /Select a plan/ } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'offers the picker with a single tier pre-selected', () => {
@@ -276,13 +276,13 @@ describe( '<CompSubscribers>', () => {
 
 		expect( screen.getByText( '3 complimentary subscribers' ) ).toBeVisible();
 		expect( screen.getByText( 'Supporter' ) ).toBeVisible();
-		expect( screen.queryByText( 'Select a tier' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Select a plan' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'asks for a choice when several tiers are available', () => {
 		renderCompSubscribers( cardData( { available_tiers: [ monthlyAnchor, secondTier ] } ) );
 
-		expect( screen.getByText( 'Select a tier' ) ).toBeVisible();
+		expect( screen.getByText( 'Select a plan' ) ).toBeVisible();
 	} );
 
 	it( 'warns rather than crashing when the tier list comes back null', () => {
@@ -306,7 +306,7 @@ describe( '<CompSubscribers>', () => {
 				'The paid tier you chose for comped subscribers no longer exists. Choose another one.'
 			)[ 0 ]
 		).toBeVisible();
-		expect( screen.getByText( 'Select a tier' ) ).toBeVisible();
+		expect( screen.getByText( 'Select a plan' ) ).toBeVisible();
 	} );
 
 	it( 'renders nothing when the import carries no comps', () => {

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/comp-subscribers.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/comp-subscribers.tsx
@@ -13,6 +13,7 @@ import CompSubscribers, {
 	getSelectedCompTierId,
 	isCompSelectionSatisfied,
 	isCompSelectionStale,
+	willGrantComps,
 } from '../comp-subscribers';
 
 jest.mock( 'calypso/lib/wp', () => ( {
@@ -229,6 +230,33 @@ describe( 'isCompSelectionSatisfied', () => {
 	it( 'blocks while several tiers are available and none is chosen', () => {
 		expect(
 			isCompSelectionSatisfied( cardData( { available_tiers: [ monthlyAnchor, secondTier ] } ) )
+		).toBe( false );
+	} );
+} );
+
+describe( 'willGrantComps', () => {
+	it( 'is true once a tier resolves, so the button cannot claim free subscribers only', () => {
+		expect( willGrantComps( cardData( { available_tiers: [ secondTier ] } ) ) ).toBe( true );
+	} );
+
+	it( 'is false with no tier to grant against, where the comps do arrive as free', () => {
+		expect( willGrantComps( cardData( { available_tiers: [] } ) ) ).toBe( false );
+	} );
+
+	it( 'is false while several tiers are available and none is chosen', () => {
+		expect( willGrantComps( cardData( { available_tiers: [ monthlyAnchor, secondTier ] } ) ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'is false when the file carries no comps', () => {
+		expect(
+			willGrantComps(
+				cardData( {
+					available_tiers: [ secondTier ],
+					meta: { comp_count: 0 } as SubscribersStepContent[ 'meta' ],
+				} )
+			)
 		).toBe( false );
 	} );
 } );

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/connect-stripe.tsx
@@ -19,7 +19,7 @@ const tier = {
 	title: 'Supporter',
 	price: '5',
 	currency: 'USD',
-	interval: '1 month',
+	interval: 'month',
 };
 const secondTier = { ...tier, id: 20, title: 'Founding member', price: '25' };
 

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/connect-stripe.tsx
@@ -53,34 +53,63 @@ function renderConnectStripe( content: Partial< SubscribersStepContent > ) {
 	);
 }
 
-function freeSubscribersButton() {
-	return screen.getByRole( 'button', { name: /free subscribers/i } );
+// The label reads differently once a comp tier resolves, so match either wording.
+function continueButton() {
+	return screen.getByRole( 'button', { name: /free subscribers|without paid subscribers/i } );
 }
+
+describe( '<ConnectStripe> button label', () => {
+	it( 'does not claim free subscribers only when a comp tier will be granted', () => {
+		renderConnectStripe( { available_tiers: [ tier ], comp_product_id: 10 } );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Continue without paid subscribers' } )
+		).toBeVisible();
+	} );
+
+	it( 'keeps the free-subscribers wording when the comps have nowhere to go', () => {
+		renderConnectStripe( { available_tiers: [] } );
+
+		expect( screen.getByRole( 'button', { name: /free subscribers/i } ) ).toBeVisible();
+		expect(
+			screen.queryByRole( 'button', { name: 'Continue without paid subscribers' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps the free-subscribers wording when there are no comps at all', () => {
+		renderConnectStripe( {
+			available_tiers: [ tier ],
+			meta: { email_count: '8', comp_count: 0 } as SubscribersStepContent[ 'meta' ],
+		} );
+
+		expect( screen.getByRole( 'button', { name: /free subscribers/i } ) ).toBeVisible();
+	} );
+} );
 
 describe( '<ConnectStripe> comp gating', () => {
 	it( 'leaves the escape hatch open when there is no tier to grant against', () => {
 		renderConnectStripe( { available_tiers: [] } );
 
-		expect( freeSubscribersButton() ).toBeEnabled();
+		expect( continueButton() ).toBeEnabled();
 	} );
 
 	it( 'holds the import while the chosen tier is gone', () => {
 		// Importing here would drop every comp, which is the outcome this flow exists to prevent.
 		renderConnectStripe( { available_tiers: [ tier ], comp_product_id: 99 } );
 
-		expect( freeSubscribersButton() ).toBeDisabled();
+		expect( continueButton() ).toBeDisabled();
 	} );
 
 	it( 'holds the import while several tiers are available and none is chosen', () => {
 		renderConnectStripe( { available_tiers: [ tier, secondTier ] } );
 
-		expect( freeSubscribersButton() ).toBeDisabled();
+		expect( continueButton() ).toBeDisabled();
 	} );
 
 	it( 'allows the import once a tier resolves', () => {
 		renderConnectStripe( { available_tiers: [ tier ], comp_product_id: 10 } );
 
-		expect( freeSubscribersButton() ).toBeEnabled();
+		expect( continueButton() ).toBeEnabled();
 	} );
 
 	it( 'leaves the escape hatch open when the file carries no comps', () => {
@@ -89,6 +118,6 @@ describe( '<ConnectStripe> comp gating', () => {
 			meta: { email_count: '8', comp_count: 0 } as SubscribersStepContent[ 'meta' ],
 		} );
 
-		expect( freeSubscribersButton() ).toBeEnabled();
+		expect( continueButton() ).toBeEnabled();
 	} );
 } );

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/connect-stripe.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/connect-stripe.tsx
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import ConnectStripe from '../connect-stripe';
+import type { SiteDetails } from '@automattic/data-stores';
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	__esModule: true,
+	default: { req: { post: jest.fn(), get: jest.fn() } },
+} ) );
+
+const tier = {
+	id: 10,
+	tier: 0,
+	title: 'Supporter',
+	price: '5',
+	currency: 'USD',
+	interval: '1 month',
+};
+const secondTier = { ...tier, id: 20, title: 'Founding member', price: '25' };
+
+const connectUrl = `https://connect.stripe.com/oauth/authorize?state=${ btoa(
+	JSON.stringify( { blog_id: 1 } )
+) }`;
+
+function renderConnectStripe( content: Partial< SubscribersStepContent > ) {
+	return render(
+		<QueryClientProvider client={ new QueryClient() }>
+			<ConnectStripe
+				cardData={
+					{
+						is_connected_stripe: false,
+						connect_url: connectUrl,
+						available_tiers: [],
+						meta: { email_count: '8', comp_count: 2 },
+						...content,
+					} as SubscribersStepContent
+				}
+				status="initial"
+				engine="substack"
+				fromSite="https://example.substack.com"
+				selectedSite={ { ID: 1 } as SiteDetails }
+				setAutoFetchData={ () => {} }
+				siteSlug="example.wordpress.com"
+				skipNextStep={ () => {} }
+				onStartImport={ () => {} }
+			/>
+		</QueryClientProvider>
+	);
+}
+
+function freeSubscribersButton() {
+	return screen.getByRole( 'button', { name: /free subscribers/i } );
+}
+
+describe( '<ConnectStripe> comp gating', () => {
+	it( 'leaves the escape hatch open when there is no tier to grant against', () => {
+		renderConnectStripe( { available_tiers: [] } );
+
+		expect( freeSubscribersButton() ).toBeEnabled();
+	} );
+
+	it( 'holds the import while the chosen tier is gone', () => {
+		// Importing here would drop every comp, which is the outcome this flow exists to prevent.
+		renderConnectStripe( { available_tiers: [ tier ], comp_product_id: 99 } );
+
+		expect( freeSubscribersButton() ).toBeDisabled();
+	} );
+
+	it( 'holds the import while several tiers are available and none is chosen', () => {
+		renderConnectStripe( { available_tiers: [ tier, secondTier ] } );
+
+		expect( freeSubscribersButton() ).toBeDisabled();
+	} );
+
+	it( 'allows the import once a tier resolves', () => {
+		renderConnectStripe( { available_tiers: [ tier ], comp_product_id: 10 } );
+
+		expect( freeSubscribersButton() ).toBeEnabled();
+	} );
+
+	it( 'leaves the escape hatch open when the file carries no comps', () => {
+		renderConnectStripe( {
+			available_tiers: [ tier, secondTier ],
+			meta: { email_count: '8', comp_count: 0 } as SubscribersStepContent[ 'meta' ],
+		} );
+
+		expect( freeSubscribersButton() ).toBeEnabled();
+	} );
+} );

--- a/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/no-plans.tsx
+++ b/client/my-sites/importer/newsletter/subscribers/paid-subscribers/test/no-plans.tsx
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import NoPlans from '../no-plans';
+import type { SiteDetails } from '@automattic/data-stores';
+
+jest.mock( 'calypso/lib/wp', () => ( {
+	__esModule: true,
+	default: { req: { post: jest.fn(), get: jest.fn() } },
+} ) );
+
+const tier = {
+	id: 10,
+	tier: 0,
+	title: 'Supporter',
+	price: '5',
+	currency: 'USD',
+	interval: 'month',
+};
+const secondTier = { ...tier, id: 20, title: 'Founding member', price: '25' };
+
+function renderNoPlans( content: Partial< SubscribersStepContent > ) {
+	const store = configureStore()( { ui: { selectedSiteId: 1 } } );
+	return render(
+		<Provider store={ store }>
+			<QueryClientProvider client={ new QueryClient() }>
+				<NoPlans
+					cardData={
+						{
+							is_connected_stripe: true,
+							account_display: 'Test account',
+							available_tiers: [],
+							meta: { email_count: '8', comp_count: 2 },
+							...content,
+						} as SubscribersStepContent
+					}
+					selectedSite={ { ID: 1 } as SiteDetails }
+					engine="substack"
+					siteSlug="example.wordpress.com"
+					onStartImport={ () => {} }
+				/>
+			</QueryClientProvider>
+		</Provider>
+	);
+}
+
+function importButton() {
+	return screen.getByRole( 'button', { name: /free subscribers|without paid subscribers/i } );
+}
+
+describe( '<NoPlans>', () => {
+	it( 'does not claim free subscribers only when a comp tier will be granted', () => {
+		renderNoPlans( { available_tiers: [ tier ], comp_product_id: 10 } );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Import without paid subscribers' } )
+		).toBeVisible();
+	} );
+
+	it( 'keeps the free-subscribers wording when the comps have nowhere to go', () => {
+		renderNoPlans( { available_tiers: [] } );
+
+		expect( screen.getByRole( 'button', { name: 'Only import free subscribers' } ) ).toBeVisible();
+	} );
+
+	it( 'leaves the escape hatch open when there is no tier to grant against', () => {
+		renderNoPlans( { available_tiers: [] } );
+
+		expect( importButton() ).toBeEnabled();
+	} );
+
+	it( 'holds the import while several tiers are available and none is chosen', () => {
+		renderNoPlans( { available_tiers: [ tier, secondTier ] } );
+
+		expect( importButton() ).toBeDisabled();
+	} );
+} );

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -45,6 +45,10 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 				) }`;
 			case 'chosen_tier_gone':
 				return `${ addedAsFree } ${ __( 'The paid tier you chose no longer exists.' ) }`;
+			case 'tier_lookup_failed':
+				return `${ addedAsFree } ${ __(
+					'We couldn’t read your site’s paid tiers, so complimentary access wasn’t granted.'
+				) }`;
 			default:
 				// A reason we do not have copy for yet still tells them where the people went.
 				return addedAsFree;

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -74,12 +74,17 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 			parseInt( stepContent.meta?.already_subscribed_count || '0' ) +
 			parseInt( stepContent.meta?.paid_already_subscribed_count || '0' ) +
 			parseInt( stepContent.meta?.comp_already_subscribed_count || '0' );
+		const compSkipReason = stepContent.meta?.comp_skip_reason;
+		// Comps the server could not grant are counted as failed, but they still arrived as free
+		// subscribers, so counting them here too would both double-count them and contradict the
+		// explanation below.
+		const compFailed = compSkipReason
+			? 0
+			: parseInt( stepContent.meta?.comp_failed_subscribed_count || '0' );
 		const failedTotal =
 			parseInt( stepContent.meta?.failed_subscribed_count || '0' ) +
 			parseInt( stepContent.meta?.paid_failed_subscribed_count || '0' ) +
-			parseInt( stepContent.meta?.comp_failed_subscribed_count || '0' );
-
-		const compSkipReason = stepContent.meta?.comp_skip_reason;
+			compFailed;
 
 		return (
 			<>
@@ -97,7 +102,7 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 					{ addedPaid > 0 && (
 						<SummaryStat count={ addedPaid } label={ __( 'Paid Subscribers' ) } />
 					) }
-					{ compCount > 0 && (
+					{ addedComp > 0 && (
 						<SummaryStat count={ addedComp } label={ __( 'Comped Subscribers' ) } />
 					) }
 					{ existingTotal > 0 && (

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -47,7 +47,7 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 				return `${ addedAsFree } ${ __( 'The paid tier you chose no longer exists.' ) }`;
 			case 'tier_lookup_failed':
 				return `${ addedAsFree } ${ __(
-					'We couldn’t read your site’s paid tiers, so complimentary access wasn’t granted.'
+					'We couldn’t read your site’s paid tiers this time. Run the import again to grant them complimentary access.'
 				) }`;
 			default:
 				// A reason we do not have copy for yet still tells them where the people went.

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -24,11 +24,11 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 	 * @param count  How many comped subscribers the file carried.
 	 */
 	function getCompSkipMessage( reason: CompSkipReason, count: number ) {
-		const importedAsFree = sprintf(
+		const addedAsFree = sprintf(
 			// Translators: %d is number of complimentary subscribers
 			_n(
-				'%d comped subscriber was imported as a free subscriber.',
-				'%d comped subscribers were imported as free subscribers.',
+				'%d comped subscriber was added as a free subscriber.',
+				'%d comped subscribers were added as free subscribers.',
 				count
 			),
 			count
@@ -36,11 +36,15 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 
 		switch ( reason ) {
 			case 'no_tier':
-				return `${ importedAsFree } ${ __( 'There was no paid tier to grant against.' ) }`;
+				return `${ addedAsFree } ${ __(
+					'Set up a paid tier to give them complimentary access.'
+				) }`;
 			case 'multiple_tiers':
-				return `${ importedAsFree } ${ __( 'No tier was chosen to grant against.' ) }`;
+				return `${ addedAsFree } ${ __(
+					'Your site has more than one paid tier, so we didn’t know which one to use.'
+				) }`;
 			case 'chosen_tier_gone':
-				return `${ importedAsFree } ${ __( 'The chosen tier no longer exists.' ) }`;
+				return `${ addedAsFree } ${ __( 'The paid tier you chose no longer exists.' ) }`;
 		}
 	}
 

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -1,7 +1,9 @@
 import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 import { people } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import {
+	CompSkipReason,
 	SubscribersStepContent,
 	StepStatus,
 } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
@@ -13,7 +15,35 @@ interface SubscriberSummaryProps {
 }
 
 export default function SubscriberSummary( { stepContent, status }: SubscriberSummaryProps ) {
-	const { __ } = useI18n();
+	const { __, _n } = useI18n();
+
+	/**
+	 * Comped subscribers still arrive, as free subscribers, so say what happened to the
+	 * complimentary access rather than implying the people were lost.
+	 * @param reason Why the server could not grant the comps.
+	 * @param count  How many comped subscribers the file carried.
+	 */
+	function getCompSkipMessage( reason: CompSkipReason, count: number ) {
+		const importedAsFree = sprintf(
+			// Translators: %d is number of complimentary subscribers
+			_n(
+				'%d comped subscriber was imported as a free subscriber.',
+				'%d comped subscribers were imported as free subscribers.',
+				count
+			),
+			count
+		);
+
+		switch ( reason ) {
+			case 'no_tier':
+				return `${ importedAsFree } ${ __( 'There was no paid tier to grant against.' ) }`;
+			case 'multiple_tiers':
+				return `${ importedAsFree } ${ __( 'No tier was chosen to grant against.' ) }`;
+			case 'chosen_tier_gone':
+				return `${ importedAsFree } ${ __( 'The chosen tier no longer exists.' ) }`;
+		}
+	}
+
 	if ( status === 'skipped' ) {
 		return (
 			<p>
@@ -45,25 +75,40 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 			parseInt( stepContent.meta?.paid_failed_subscribed_count || '0' ) +
 			parseInt( stepContent.meta?.comp_failed_subscribed_count || '0' );
 
+		const compSkipReason = stepContent.meta?.comp_skip_reason;
+
 		return (
-			<div className="summary__content-stats">
-				{ subscribedCount > 0 && (
-					<SummaryStat
-						count={ subscribedCount }
-						icon={ people }
-						label={ __( 'Total Subscribers' ) }
-					/>
+			<>
+				<div className="summary__content-stats">
+					{ subscribedCount > 0 && (
+						<SummaryStat
+							count={ subscribedCount }
+							icon={ people }
+							label={ __( 'Total Subscribers' ) }
+						/>
+					) }
+					{ addedFree > 0 && (
+						<SummaryStat count={ addedFree } label={ __( 'Free Subscribers' ) } />
+					) }
+					{ addedPaid > 0 && (
+						<SummaryStat count={ addedPaid } label={ __( 'Paid Subscribers' ) } />
+					) }
+					{ compCount > 0 && (
+						<SummaryStat count={ addedComp } label={ __( 'Comped Subscribers' ) } />
+					) }
+					{ existingTotal > 0 && (
+						<SummaryStat count={ existingTotal } label={ __( 'Skipped (duplicate)' ) } />
+					) }
+					{ failedTotal > 0 && (
+						<SummaryStat count={ failedTotal } label={ __( 'Not imported' ) } />
+					) }
+				</div>
+				{ compCount > 0 && compSkipReason && (
+					<p className="summary__comp-skip-reason">
+						{ getCompSkipMessage( compSkipReason, compCount ) }
+					</p>
 				) }
-				{ addedFree > 0 && <SummaryStat count={ addedFree } label={ __( 'Free Subscribers' ) } /> }
-				{ addedPaid > 0 && <SummaryStat count={ addedPaid } label={ __( 'Paid Subscribers' ) } /> }
-				{ compCount > 0 && (
-					<SummaryStat count={ addedComp } label={ __( 'Comped Subscribers' ) } />
-				) }
-				{ existingTotal > 0 && (
-					<SummaryStat count={ existingTotal } label={ __( 'Skipped (duplicate)' ) } />
-				) }
-				{ failedTotal > 0 && <SummaryStat count={ failedTotal } label={ __( 'Not imported' ) } /> }
-			</div>
+			</>
 		);
 	}
 

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -45,6 +45,9 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 				) }`;
 			case 'chosen_tier_gone':
 				return `${ addedAsFree } ${ __( 'The paid tier you chose no longer exists.' ) }`;
+			default:
+				// A reason we do not have copy for yet still tells them where the people went.
+				return addedAsFree;
 		}
 	}
 

--- a/client/my-sites/importer/newsletter/summary/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/subscribers.tsx
@@ -82,16 +82,14 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 			parseInt( stepContent.meta?.paid_already_subscribed_count || '0' ) +
 			parseInt( stepContent.meta?.comp_already_subscribed_count || '0' );
 		const compSkipReason = stepContent.meta?.comp_skip_reason;
-		// Comps the server could not grant are counted as failed, but they still arrived as free
-		// subscribers, so counting them here too would both double-count them and contradict the
-		// explanation below.
-		const compFailed = compSkipReason
-			? 0
-			: parseInt( stepContent.meta?.comp_failed_subscribed_count || '0' );
+		// A comp that could not be granted, for any reason, is never added to the imported list, so
+		// the free pass subscribes that address anyway. These people arrived; they just arrived
+		// without complimentary access. Counting them as not imported would exceed the total and
+		// contradict what the rest of the summary says.
+		const notComped = parseInt( stepContent.meta?.comp_failed_subscribed_count || '0' );
 		const failedTotal =
 			parseInt( stepContent.meta?.failed_subscribed_count || '0' ) +
-			parseInt( stepContent.meta?.paid_failed_subscribed_count || '0' ) +
-			compFailed;
+			parseInt( stepContent.meta?.paid_failed_subscribed_count || '0' );
 
 		return (
 			<>
@@ -114,6 +112,9 @@ export default function SubscriberSummary( { stepContent, status }: SubscriberSu
 					) }
 					{ existingTotal > 0 && (
 						<SummaryStat count={ existingTotal } label={ __( 'Skipped (duplicate)' ) } />
+					) }
+					{ notComped > 0 && ! compSkipReason && (
+						<SummaryStat count={ notComped } label={ __( 'Not comped' ) } />
 					) }
 					{ failedTotal > 0 && (
 						<SummaryStat count={ failedTotal } label={ __( 'Not imported' ) } />

--- a/client/my-sites/importer/newsletter/summary/test/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/test/subscribers.tsx
@@ -98,6 +98,27 @@ describe( '<SubscriberSummary>', () => {
 		expect( screen.queryByText( 'Not imported' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'distinguishes a tier list we could not read from having no tier', () => {
+		render(
+			<SubscriberSummary
+				status="done"
+				stepContent={ stepContent( {
+					email_count: '3',
+					subscribed_count: '3',
+					comp_count: 1,
+					comp_failed_subscribed_count: '1',
+					comp_skip_reason: 'tier_lookup_failed',
+				} ) }
+			/>
+		);
+
+		expect(
+			screen.getByText(
+				'1 comped subscriber was added as a free subscriber. We couldn’t read your site’s paid tiers, so complimentary access wasn’t granted.'
+			)
+		).toBeVisible();
+	} );
+
 	it( 'still says what happened when the server sends an unfamiliar reason', () => {
 		const { container } = render(
 			<SubscriberSummary

--- a/client/my-sites/importer/newsletter/summary/test/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/test/subscribers.tsx
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import { SubscribersStepContent } from 'calypso/data/paid-newsletter/use-paid-newsletter-query';
+import SubscriberSummary from '../subscribers';
+
+type Meta = NonNullable< SubscribersStepContent[ 'meta' ] >;
+
+function stepContent( meta: Partial< Meta > ): SubscribersStepContent {
+	return {
+		is_connected_stripe: false,
+		meta: {
+			email_count: '0',
+			subscribed_count: '0',
+			already_subscribed_count: '0',
+			failed_subscribed_count: '0',
+			paid_subscribed_count: '0',
+			paid_already_subscribed_count: '0',
+			paid_failed_subscribed_count: '0',
+			comp_subscribed_count: '0',
+			comp_already_subscribed_count: '0',
+			comp_failed_subscribed_count: '0',
+			...meta,
+		} as Meta,
+	} as SubscribersStepContent;
+}
+
+function statFor( label: string ) {
+	const row = screen.getByText( label ).closest( '.summary__content-row' );
+	return row?.querySelector( '.summary__content-stats-count' )?.textContent;
+}
+
+describe( '<SubscriberSummary>', () => {
+	it( 'does not count comps the server could not grant as "Not imported"', () => {
+		// They arrived as free subscribers, so counting them again here would exceed the total.
+		render(
+			<SubscriberSummary
+				status="done"
+				stepContent={ stepContent( {
+					email_count: '8',
+					subscribed_count: '8',
+					comp_count: 2,
+					comp_failed_subscribed_count: '2',
+					comp_skip_reason: 'no_tier',
+				} ) }
+			/>
+		);
+
+		expect( statFor( 'Total Subscribers' ) ).toBe( '8' );
+		expect( statFor( 'Free Subscribers' ) ).toBe( '8' );
+		expect( screen.queryByText( 'Not imported' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Comped Subscribers' ) ).not.toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'2 comped subscribers were added as free subscribers. Set up a paid tier to give them complimentary access.'
+			)
+		).toBeVisible();
+	} );
+
+	it( 'still reports comps that failed for their own reasons', () => {
+		render(
+			<SubscriberSummary
+				status="done"
+				stepContent={ stepContent( {
+					email_count: '8',
+					subscribed_count: '6',
+					comp_count: 2,
+					comp_subscribed_count: '1',
+					comp_failed_subscribed_count: '1',
+				} ) }
+			/>
+		);
+
+		expect( statFor( 'Comped Subscribers' ) ).toBe( '1' );
+		expect( statFor( 'Not imported' ) ).toBe( '1' );
+	} );
+
+	it( 'counts comps that were already subscribed as duplicates', () => {
+		render(
+			<SubscriberSummary
+				status="done"
+				stepContent={ stepContent( {
+					email_count: '8',
+					subscribed_count: '6',
+					comp_count: 2,
+					comp_subscribed_count: '1',
+					comp_already_subscribed_count: '1',
+				} ) }
+			/>
+		);
+
+		expect( statFor( 'Total Subscribers' ) ).toBe( '8' );
+		expect( statFor( 'Free Subscribers' ) ).toBe( '6' );
+		expect( statFor( 'Comped Subscribers' ) ).toBe( '1' );
+		expect( statFor( 'Skipped (duplicate)' ) ).toBe( '1' );
+		expect( screen.queryByText( 'Not imported' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'explains a comp tier that disappeared before the import ran', () => {
+		render(
+			<SubscriberSummary
+				status="done"
+				stepContent={ stepContent( {
+					email_count: '3',
+					subscribed_count: '3',
+					comp_count: 1,
+					comp_failed_subscribed_count: '1',
+					comp_skip_reason: 'chosen_tier_gone',
+				} ) }
+			/>
+		);
+
+		expect(
+			screen.getByText(
+				'1 comped subscriber was added as a free subscriber. The paid tier you chose no longer exists.'
+			)
+		).toBeVisible();
+	} );
+} );

--- a/client/my-sites/importer/newsletter/summary/test/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/test/subscribers.tsx
@@ -98,6 +98,26 @@ describe( '<SubscriberSummary>', () => {
 		expect( screen.queryByText( 'Not imported' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'still says what happened when the server sends an unfamiliar reason', () => {
+		const { container } = render(
+			<SubscriberSummary
+				status="done"
+				stepContent={ stepContent( {
+					email_count: '3',
+					subscribed_count: '3',
+					comp_count: 1,
+					comp_failed_subscribed_count: '1',
+					comp_skip_reason: 'something_new' as Meta[ 'comp_skip_reason' ],
+				} ) }
+			/>
+		);
+
+		expect(
+			screen.getByText( '1 comped subscriber was added as a free subscriber.' )
+		).toBeVisible();
+		expect( container.querySelector( '.summary__comp-skip-reason' ) ).not.toBeEmptyDOMElement();
+	} );
+
 	it( 'explains a comp tier that disappeared before the import ran', () => {
 		render(
 			<SubscriberSummary

--- a/client/my-sites/importer/newsletter/summary/test/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/test/subscribers.tsx
@@ -59,13 +59,15 @@ describe( '<SubscriberSummary>', () => {
 		).toBeVisible();
 	} );
 
-	it( 'still reports comps that failed for their own reasons', () => {
+	it( 'reports a comp that failed on its own as imported but not comped', () => {
+		// A per-email comp failure is not added to the imported list, so the free pass subscribes
+		// that address anyway. Counting it as "Not imported" would contradict the total.
 		render(
 			<SubscriberSummary
 				status="done"
 				stepContent={ stepContent( {
 					email_count: '8',
-					subscribed_count: '6',
+					subscribed_count: '7',
 					comp_count: 2,
 					comp_subscribed_count: '1',
 					comp_failed_subscribed_count: '1',
@@ -73,8 +75,45 @@ describe( '<SubscriberSummary>', () => {
 			/>
 		);
 
+		expect( statFor( 'Total Subscribers' ) ).toBe( '8' );
+		expect( statFor( 'Free Subscribers' ) ).toBe( '7' );
 		expect( statFor( 'Comped Subscribers' ) ).toBe( '1' );
+		expect( statFor( 'Not comped' ) ).toBe( '1' );
+		expect( screen.queryByText( 'Not imported' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps genuine free-subscriber failures under "Not imported"', () => {
+		render(
+			<SubscriberSummary
+				status="done"
+				stepContent={ stepContent( {
+					email_count: '8',
+					subscribed_count: '7',
+					failed_subscribed_count: '1',
+				} ) }
+			/>
+		);
+
 		expect( statFor( 'Not imported' ) ).toBe( '1' );
+		expect( screen.queryByText( 'Not comped' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'leaves the explanation to speak for a whole batch that was skipped', () => {
+		render(
+			<SubscriberSummary
+				status="done"
+				stepContent={ stepContent( {
+					email_count: '8',
+					subscribed_count: '8',
+					comp_count: 2,
+					comp_failed_subscribed_count: '2',
+					comp_skip_reason: 'no_tier',
+				} ) }
+			/>
+		);
+
+		expect( screen.queryByText( 'Not comped' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Not imported' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'counts comps that were already subscribed as duplicates', () => {

--- a/client/my-sites/importer/newsletter/summary/test/subscribers.tsx
+++ b/client/my-sites/importer/newsletter/summary/test/subscribers.tsx
@@ -114,7 +114,7 @@ describe( '<SubscriberSummary>', () => {
 
 		expect(
 			screen.getByText(
-				'1 comped subscriber was added as a free subscriber. We couldn’t read your site’s paid tiers, so complimentary access wasn’t granted.'
+				'1 comped subscriber was added as a free subscriber. We couldn’t read your site’s paid tiers this time. Run the import again to grant them complimentary access.'
 			)
 		).toBeVisible();
 	} );


### PR DESCRIPTION
Fixes NL-898

## Proposed Changes

* Source the comped-subscriber picker from the site's own newsletter tiers (`available_tiers`) instead of the Stripe plans, collapsing each monthly/yearly pair into a single choice keyed on the monthly anchor, and save the selection as `comp_product_id`.
* Render the picker on the **Connect Stripe** and **No Plans** screens as well, not just on **Map Plans**, whenever the import carries comps and the site has at least one tier. A site with exactly one tier shows it pre-selected, matching what the server grants against on its own.
* When the import carries comps and the site has no tier at all, show a warning in place of the picker: "N subscribers won't be comped unless you set up a paid tier." Setting up a tier needs Stripe, so this is informational only.
* Leave the escape hatches alone: "Continue with free subscribers" and "Only import free subscribers" are never gated on a comp decision. Only the Map Plans screen still blocks, and only when several tiers exist and none has been chosen.
* On the import summary, surface the `comp_skip_reason` the server now records, saying the comps arrived as free subscribers and why complimentary access was not granted.
* Stop double-counting those comps in the summary. The server reports a skipped comp as failed, but the same person was also added as a free subscriber, so including them in "Not imported" counted them twice and contradicted the explanation directly below the stats. A summary of 8 subscribers was reading 8 free + 2 not imported.

<img width="939" height="619" alt="Screenshot 2026-09-10 at 11 38 53 AM" src="https://github.com/user-attachments/assets/e765619c-e262-4722-8b4a-e21fe3e9e44c" />
<img width="792" height="533" alt="Screenshot 2026-09-10 at 3 21 58 PM" src="https://github.com/user-attachments/assets/1c39de5f-9587-4a63-bfe3-a6719850b2b7" />

<img width="738" height="508" alt="Screenshot 2026-09-10 at 11 29 42 AM" src="https://github.com/user-attachments/assets/0c86e6d8-59cd-419f-b542-6e8128b46784" />

## Why are these changes being made?

A comp can only be granted against a WordPress.com tier. Previously that tier was only reachable through the Stripe plan mapping, and the picker only rendered inside `MapPlans`, which early-returns to `NoPlans` when Stripe returns no plans. An import with comped subscribers but no paid subscribers therefore never saw the picker, the comps were dropped, and the result reported zero imported, zero failed, with no explanation.

The server side landed separately in wpcom: comps now resolve without Stripe, `available_tiers` and `meta.comp_count` are returned on the disconnected path, `set-comp-plan` accepts `comp_product_id`, and the subscribers step records `comp_skip_reason`. This PR is the half the site owner can actually see: the choice beforehand, and the reason afterwards.

## Testing Instructions

Use a Substack export containing comped subscribers and no paid subscribers.

1. On a site with **no connected Stripe account and at least one newsletter tier**, start a Substack import and upload the file. On the "Do you have paid subscribers?" screen the comped-subscribers row should appear with a tier selected (pre-selected if the site has exactly one tier). Change it and confirm the choice persists across a reload.
3. On a site with **no connected Stripe account and no tier**, the same screen should show the warning instead of the picker, and the button should still be enabled.
6. Run the import and open the summary. When the server could not grant the comps, a line under the stats should explain that they were imported as free subscribers, and why.

Unit tests (23 across 3 suites): `yarn test-client client/data/paid-newsletter/test client/my-sites/importer/newsletter`

Covers the tier grouping and selection helpers, the picker/warning rendering, the `comp_product_id` payload, and the summary counters.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
