### PR TITLE
Onboarding: stop the email-verification gate creating a second site

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/onboarding.ts
@@ -579,7 +579,11 @@ const onboarding: FlowV2< typeof initialize > = {
 				}
 				case 'email-verification': {
 					const next = queryParams.get( 'next' ) || 'create-site';
-					return navigate( next as typeof currentStepSlug );
+					// Replaced rather than pushed, so a gate that has been passed leaves no history
+					// entry behind it. Pushed, Back off the destination lands here again, and the
+					// step advances on sight of a verified account without being asked — into site
+					// creation, under the name the site it just went back past already holds.
+					return navigate( next as typeof currentStepSlug, undefined, true );
 				}
 				case 'create-site':
 					return navigate( 'processing', undefined, true );

--- a/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-post-plan-selection-email-verification.ts
+++ b/client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-post-plan-selection-email-verification.ts
@@ -210,6 +210,10 @@ describe( 'onboarding post-plan-selection email verification (Variant B)', () =>
 		expect( navigate ).toHaveBeenCalledWith( 'create-site', undefined, false );
 	} );
 
+	// Both advances replace rather than push. A pushed gate stays in the history behind the step it
+	// advanced to, and it advances again the moment it renders against a verified account — so Back
+	// off the destination walks the customer forwards into site creation a second time, which
+	// /sites/new refuses as `blog_name_exists`.
 	it( 'advances the verification step to the target named in the next query param', async () => {
 		mockQueryParams = new URLSearchParams( 'next=post-checkout-onboarding' );
 		const navigate = jest.fn();
@@ -226,7 +230,7 @@ describe( 'onboarding post-plan-selection email verification (Variant B)', () =>
 			providedDependencies: {},
 		} as Parameters< NonNullable< typeof result.current.submit > >[ 0 ] );
 
-		expect( navigate ).toHaveBeenCalledWith( 'post-checkout-onboarding' );
+		expect( navigate ).toHaveBeenCalledWith( 'post-checkout-onboarding', undefined, true );
 	} );
 
 	// Without a `next`, the verification step falls back to site creation rather than a blank target.
@@ -245,7 +249,7 @@ describe( 'onboarding post-plan-selection email verification (Variant B)', () =>
 			providedDependencies: {},
 		} as Parameters< NonNullable< typeof result.current.submit > >[ 0 ] );
 
-		expect( navigate ).toHaveBeenCalledWith( 'create-site' );
+		expect( navigate ).toHaveBeenCalledWith( 'create-site', undefined, true );
 	} );
 
 	it( 'points a paid order back at the verification step on return from checkout', async () => {

--- a/client/landing/stepper/declarative-flow/internals/state-manager/stepper-state-manifest.ts
+++ b/client/landing/stepper/declarative-flow/internals/state-manager/stepper-state-manifest.ts
@@ -11,6 +11,21 @@ export type StepperMiscellaneousFields = Partial< {
 		entryPoint: string;
 	};
 	site: CreatedSite;
+	/**
+	 * The site the create-site step made, so reaching that step again adopts it rather than asking
+	 * /sites/new for a second one.
+	 *
+	 * Separate from `site`, which flows using `useCreateSite` write and `useSite` reads. This is
+	 * carried by the name the site was asked for, because a flow without
+	 * `__experimentalUseSessions` keys its state on the flow alone — nothing scopes the record to
+	 * one run, so a later run has to be able to tell that the site on file is not the one it is
+	 * asking for.
+	 */
+	createdSite: {
+		siteId: number;
+		siteSlug: string;
+		requestedName: string;
+	};
 } >;
 
 export type FlowStateManifest = StepperMiscellaneousFields & StepperStepsUnionedType;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/index.tsx
@@ -49,6 +49,7 @@ import { getCurrentUserName } from 'calypso/state/current-user/selectors';
 import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { useSimplifiedOnboarding } from '../../../../hooks/use-simplified-onboarding';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+import { useFlowState } from '../../state-manager/store';
 import { SESSION_KEY_FROM_PLAYGROUND_PUBLISH } from '../playground/lib/constants';
 import {
 	EARLY_PROVISION_TARGET_WPCOM_ATOMIC,
@@ -157,6 +158,7 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 	const username = useSelector( getCurrentUserName );
 
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
+	const flowState = useFlowState();
 
 	// when it's empty, the default WordPress theme will be used.
 	let theme = '';
@@ -325,34 +327,62 @@ const CreateSite: StepType = function CreateSite( { navigation, flow, data } ) {
 			? await resolveLaunchpadPersonalizationVariation( urlQueryParams.get( 'diy-launchpad' ) )
 			: 'control';
 
-		const site = await createSite(
-			flow,
-			theme,
-			siteVisibility,
-			urlData?.meta.title ?? selectedSiteTitle,
-			// We removed the color option during newsletter onboarding.
-			// But backend still expects/needs a value, so supplying the default.
-			// Ideally should remove this and update code downstream to handle this.
-			'#113AF5',
-			useThemeHeadstart,
-			username,
-			partnerBundle,
-			siteUrl,
-			domainItem,
-			sourceSlug,
-			siteIntent,
-			undefined, // siteGoals
-			gardenName,
-			gardenPartnerName,
-			urlQueryParams.get( 'spec_id' ),
-			isPlaygroundPublish ? 'playground-publish' : undefined,
-			undefined, // provisionTarget
-			launchpadPersonalizationVariation === 'ai_launchpad'
-		);
+		// A run creates one site. Arriving here again — Back onto a step that advances by itself, a
+		// reload, a second tab landing on the flow — has to adopt the site this run already made
+		// rather than ask for another. /sites/new is not idempotent, and the free-subdomain path
+		// sends `find_available_url: false`, so the same name asked for twice is refused outright
+		// as `blog_name_exists`. Everything below still runs against the adopted site, so follow-up
+		// work a re-entry interrupted is finished rather than skipped.
+		//
+		// Matched on the name being asked for, which is what `createSite` derives the blog name
+		// from. Nothing scopes this record to a single run, so a later signup must be able to tell
+		// that the site on file is not the one it is asking for — and an unnamed request, which
+		// /sites/new answers with a name of its own choosing, matches nothing.
+		const requestedName = siteUrl || domainItem?.domain_name || '';
+		const recordedSite = flowState.get( 'createdSite' );
+		const siteFromThisRun =
+			requestedName && recordedSite?.requestedName === requestedName ? recordedSite : undefined;
+
+		const site = siteFromThisRun
+			? { siteId: siteFromThisRun.siteId, siteSlug: siteFromThisRun.siteSlug }
+			: await createSite(
+					flow,
+					theme,
+					siteVisibility,
+					urlData?.meta.title ?? selectedSiteTitle,
+					// We removed the color option during newsletter onboarding.
+					// But backend still expects/needs a value, so supplying the default.
+					// Ideally should remove this and update code downstream to handle this.
+					'#113AF5',
+					useThemeHeadstart,
+					username,
+					partnerBundle,
+					siteUrl,
+					domainItem,
+					sourceSlug,
+					siteIntent,
+					undefined, // siteGoals
+					gardenName,
+					gardenPartnerName,
+					urlQueryParams.get( 'spec_id' ),
+					isPlaygroundPublish ? 'playground-publish' : undefined,
+					undefined, // provisionTarget
+					launchpadPersonalizationVariation === 'ai_launchpad'
+			  );
 
 		if ( ! site ) {
 			throw new Error( 'Failed to create site' );
 		}
+
+		// Recorded as soon as the site exists, ahead of the waits below rather than after them: the
+		// Atomic and garden polls run for minutes, and leaving during one is how someone comes back
+		// here with a site already made. The slug can still be the pre-transfer one, so the adopting
+		// run re-polls on the ID and settles it again.
+		flowState.set( 'createdSite', {
+			siteId: site.siteId,
+			siteSlug: site.siteSlug,
+			requestedName,
+		} );
 
 		if ( earlyProvisionTarget === EARLY_PROVISION_TARGET_WPCOM_ATOMIC ) {
 			const atomicSite = await pollForAtomicProvisioning( site.siteId );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/create-site/test/index.tsx
@@ -1,0 +1,180 @@
+/**
+ * @jest-environment jsdom
+ */
+import { createSite } from '@automattic/onboarding';
+import { render, waitFor } from '@testing-library/react';
+import { useFlowState } from '../../../state-manager/store';
+import CreateSite from '../index';
+
+// The action the step hands to the processing step, captured as it is set.
+let pendingAction: ( () => Promise< unknown > ) | undefined;
+let flowStateStore: Record< string, unknown >;
+
+jest.mock( '@automattic/calypso-products', () => ( { isEcommerce: () => false } ) );
+
+jest.mock( '@automattic/data-stores', () => ( {
+	Site: { Visibility: { PublicIndexed: 1, PublicNotIndexed: 0 } },
+	Onboard: { SiteIntent: { Sell: 'sell', Build: 'build' } },
+} ) );
+
+jest.mock( '@automattic/onboarding', () => ( {
+	AI_SITE_BUILDER_FLOW: 'ai-site-builder',
+	EDUCATION_FLOW: 'education',
+	ENTREPRENEUR_FLOW: 'entrepreneur',
+	StepContainer: () => null,
+	Step: { Loading: () => null },
+	addProductsToCart: jest.fn(),
+	createSite: jest.fn( async () => ( {
+		siteId: 111,
+		siteSlug: 'brand-new.wordpress.com',
+		domainItem: undefined,
+	} ) ),
+	setThemeOnSite: jest.fn(),
+	isAIBuilderOnboardingFlow: () => false,
+	isCopySiteFlow: () => false,
+	isEntrepreneurFlow: () => false,
+	isNewHostedSiteCreationFlow: () => false,
+	isNewsletterFlow: () => false,
+	isReadymadeFlow: () => false,
+	isWriteOnFlow: () => false,
+	isOnboardingFlow: ( flow: string ) => flow === 'onboarding',
+	isNewSiteMigrationFlow: () => false,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		setPendingAction: ( action: () => Promise< unknown > ) => {
+			pendingAction = action;
+		},
+	} ),
+	useSelect: () => ( {
+		domainItem: undefined,
+		domainCartItem: undefined,
+		domainCartItems: [],
+		planCartItem: null,
+		productCartItems: [],
+		selectedSiteTitle: 'My site',
+		siteUrl: 'my-site.wordpress.com',
+		progress: 0,
+		partnerBundle: null,
+		gardenName: null,
+		gardenPartnerName: null,
+	} ),
+} ) );
+
+jest.mock( '@wordpress/react-i18n', () => ( { useI18n: () => ( { __: ( s: string ) => s } ) } ) );
+
+jest.mock( 'calypso/components/data/document-head', () => () => null );
+jest.mock( 'calypso/components/loading', () => () => null );
+jest.mock( 'calypso/data/ecommerce/use-add-ecommerce-trial-mutation', () => () => ( {
+	mutateAsync: jest.fn(),
+} ) );
+jest.mock( 'calypso/landing/stepper/hooks/use-query', () => ( {
+	useQuery: () => new URLSearchParams( '' ),
+} ) );
+jest.mock( 'calypso/landing/stepper/stores', () => ( { ONBOARD_STORE: 'ONBOARD_STORE' } ) );
+jest.mock( 'calypso/landing/stepper/utils/wow-funnel', () => ( {
+	getWowFunnelArgs: () => ( {} ),
+	getWowFunnelFromWfm: () => false,
+	getWowFunnelSlug: () => '',
+	logWowFunnelEvent: jest.fn(),
+	wowFunnelSiteIsPaid: () => false,
+} ) );
+jest.mock( 'calypso/landing/stepper/utils/wow-funnel-site', () => ( {
+	startWowFunnelSite: jest.fn(),
+} ) );
+jest.mock( 'calypso/lib/ai-launchpad', () => ( {
+	resolveLaunchpadPersonalizationVariation: jest.fn( async () => 'control' ),
+} ) );
+jest.mock( 'calypso/lib/analytics/tracks', () => ( { recordTracksEvent: jest.fn() } ) );
+jest.mock( 'calypso/lib/wp', () => ( { req: { get: jest.fn(), post: jest.fn() } } ) );
+jest.mock( 'calypso/signup/storageUtils', () => ( {
+	retrieveSignupDestination: () => null,
+	getSignupCompleteFlowName: () => null,
+	wasSignupCheckoutPageUnloaded: () => false,
+	getSignupCompleteSlug: () => null,
+} ) );
+jest.mock( 'calypso/state', () => ( { useSelector: () => undefined } ) );
+jest.mock( 'calypso/state/imports/url-analyzer/selectors', () => ( { getUrlData: jest.fn() } ) );
+jest.mock( '../../../../../hooks/use-simplified-onboarding', () => ( {
+	useSimplifiedOnboarding: () => [ false, false ],
+} ) );
+jest.mock( '../../../../helpers/should-use-step-container-v2', () => ( {
+	shouldUseStepContainerV2: () => true,
+} ) );
+jest.mock( '../../../state-manager/store', () => ( { useFlowState: jest.fn() } ) );
+jest.mock( '../../playground/lib/constants', () => ( {
+	SESSION_KEY_FROM_PLAYGROUND_PUBLISH: 'from-playground-publish',
+} ) );
+jest.mock( '../early-provisioning', () => ( {
+	EARLY_PROVISION_TARGET_WPCOM_ATOMIC: 'wpcom-atomic',
+	getEarlyCreatedSiteId: () => null,
+	pollForAtomicProvisioning: jest.fn(),
+} ) );
+
+// Mounts the step and hands back the action it registered, which is what the processing step runs.
+const runStep = async () => {
+	const StepComponent = CreateSite as unknown as React.ComponentType< Record< string, unknown > >;
+	render( <StepComponent navigation={ { submit: jest.fn() } } flow="onboarding" /> );
+
+	await waitFor( () => expect( pendingAction ).toBeDefined() );
+
+	return pendingAction!();
+};
+
+describe( 'create-site', () => {
+	beforeEach( () => {
+		pendingAction = undefined;
+		flowStateStore = {};
+		jest.clearAllMocks();
+		( useFlowState as jest.Mock ).mockImplementation( () => ( {
+			get: ( key: string ) => flowStateStore[ key ],
+			set: ( key: string, value: unknown ) => {
+				flowStateStore[ key ] = value;
+			},
+		} ) );
+	} );
+
+	it( 'creates the site and records it against the name it asked for', async () => {
+		const result = await runStep();
+
+		expect( createSite ).toHaveBeenCalledTimes( 1 );
+		expect( result ).toMatchObject( { siteId: 111, siteSlug: 'brand-new.wordpress.com' } );
+		expect( flowStateStore.createdSite ).toEqual( {
+			siteId: 111,
+			siteSlug: 'brand-new.wordpress.com',
+			requestedName: 'my-site.wordpress.com',
+		} );
+	} );
+
+	// The whole point of the record: /sites/new is not idempotent, and the free-subdomain path asks
+	// for an exact name, so a second request under it comes back as `blog_name_exists`.
+	it( 'adopts the site the run already created instead of asking for a second one', async () => {
+		flowStateStore.createdSite = {
+			siteId: 222,
+			siteSlug: 'already-made.wordpress.com',
+			requestedName: 'my-site.wordpress.com',
+		};
+
+		const result = await runStep();
+
+		expect( createSite ).not.toHaveBeenCalled();
+		expect( result ).toMatchObject( { siteId: 222, siteSlug: 'already-made.wordpress.com' } );
+	} );
+
+	// Nothing scopes the record to one run — the onboarding flow doesn't declare
+	// `__experimentalUseSessions`, so its state is keyed on the flow alone and outlives the signup
+	// that wrote it. A later signup asking for a different site has to create one.
+	it( 'creates a new site when the record is for a different name', async () => {
+		flowStateStore.createdSite = {
+			siteId: 222,
+			siteSlug: 'from-a-previous-signup.wordpress.com',
+			requestedName: 'a-previous-name.wordpress.com',
+		};
+
+		const result = await runStep();
+
+		expect( createSite ).toHaveBeenCalledTimes( 1 );
+		expect( result ).toMatchObject( { siteId: 111, siteSlug: 'brand-new.wordpress.com' } );
+	} );
+} );


### PR DESCRIPTION
Part of DOTCOM-18229
Slack thread: p1789050114917329-slack-C04H4NY6STW

## Proposed Changes

* The onboarding flow's `email-verification` case advances with a **replace** instead of a push, so a gate that has been passed leaves no history entry behind it.
* `create-site` records the site it created (a new `createdSite` field on the Stepper state manifest) and **adopts** it on re-entry instead of asking for a second one.
* Tests for both.

## Why are these changes being made?

Under Variant B of `calypso_signup_onboarding_email_verification_202609` (`treatment_post_plan_selection`), a fully free order is sent to the verification gate before the site is created:

```
plans  →  email-verification?next=create-site  →  create-site  →  processing  →  destination
```

Two properties combine badly:

1. The gate is **pushed** onto the history (`navigate( next )`, no replace), and `create-site` replaces itself with `processing`, which the destination then replaces. So the gate is still sitting in the history right behind the finished run.
2. The gate **advances by itself** whenever it renders against a verified account — its effect submits on `isVerified` and the storage claim only decides which tab records the Tracks event, not whether to advance.

So Back off the new site's home lands on the gate, which immediately walks the customer forwards into site creation a second time. Under control the same Back lands on `plans` and does nothing.

`/sites/new` is not idempotent and nothing in `createSiteAction` recorded that the run had already made a site (the only bail-outs were `isManageSiteFlow` and `earlyCreatedSiteId`). The blog name comes from the selected domain, so the second request asks for the name the first one just took:

* **Free `.wordpress.com` subdomain** — `getBlogNameGenerationParams` sends `find_available_url: false`, so the API refuses outright and the customer is dropped on the error step with `blog_name_exists: Sorry, that site already exists!`
* **Paid domain** — `find_available_url` is `true`, so the duplicate is *not* refused; it quietly creates a second site.

The same double-create is what DOTCOM-18229 hit from the other direction (two tabs racing after the activation link). The record in `create-site` closes that class of bug at the point where the damage happens, independently of where the confirmation link is pointed.

The record is written as soon as the site exists, ahead of the Atomic and garden polls rather than after them — those run for minutes, and leaving during one is exactly how someone comes back with a site already made. Everything below the create still runs against the adopted site, so a run interrupted mid-wait finishes its follow-up work instead of skipping it.

### Why the record is carried by the requested name

The onboarding flow does not declare `__experimentalUseSessions`, so `useFlowState` keys on the flow alone (`[ 'stepper-state-item', 'onboarding', null, 'v1' ]`) and the record outlives the signup that wrote it — `resetOnboardStore()` and `clearStepPersistedState()` on flow entry both clear different stores. A bare "have we made a site?" flag would therefore make a customer's *second* signup silently adopt their first site.

So the record carries the name the site was asked for (`siteUrl || domainItem?.domain_name`, which is what `createSite` derives the blog name from), and is only adopted on an exact match. An unnamed request — where `/sites/new` picks a name itself, so a duplicate can't collide — matches nothing and always creates.

It is a separate manifest field from `site` deliberately: `site` is what `useCreateSite` writes and `useSite()` falls back to for a site ID, and writing it here would quietly change what `useSite()` resolves to in this flow.

## Testing Instructions

Needs the Variant B arm; force it with `?flags=...` or by stubbing `useIsPostPlanSelectionEmailVerification`.

1. Go to `/setup/onboarding`, create an account, pick a **free `.wordpress.com` subdomain**, and choose the **free plan**.
2. You land on **Verify your email**. Confirm the address; the flow creates the site and lands you on the new site's home.
3. Press **Back**.
4. Before: you bounce through "Creating your site" into the error step, with `blog_name_exists` in the console and a second `POST /rest/v1.1/sites/new` in the network tab. After: Back lands on the plans step, and no second `/sites/new` is sent.
5. Repeat with a **paid** domain + plan and confirm no second site is created (before this change a duplicate site was created silently).
6. Control arm regression check: a free order still goes straight to `create-site`, and a paid order still returns from checkout to `post-checkout-onboarding`.

Automated:

```
yarn test-client client/landing/stepper/declarative-flow/flows/onboarding/test/onboarding-post-plan-selection-email-verification.ts
yarn test-client client/landing/stepper/declarative-flow/internals/steps-repository/create-site
```

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HzWjRiqiEqGK57HinjAwL