### PR TITLE
Purchases: read the raw Purchase in eight leaf consumers

### DIFF
--- a/client/components/data/query-domain-owner-username/index.ts
+++ b/client/components/data/query-domain-owner-username/index.ts
@@ -1,7 +1,6 @@
-import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
+import { sitePurchasesQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import useUsersQuery from 'calypso/data/users/use-users-query';
-import { useSelector } from 'calypso/state';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { InfiniteData } from '@tanstack/react-query';
 import type { ResponseDomain } from 'calypso/lib/domains/types';
@@ -20,14 +19,16 @@ export function useDomainOwnerUserName(
 	selectedSite: SiteDetails | null | undefined,
 	domain: ResponseDomain | null | undefined
 ): string {
-	useQuerySitePurchases( selectedSite?.ID ?? -1 );
-
-	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
+	const siteId = selectedSite?.ID;
+	const { data: purchases } = useQuery( {
+		...sitePurchasesQuery( siteId ?? 0 ),
+		enabled: Boolean( siteId ),
+	} );
 
 	const selectedSubscriptionId = domain?.subscriptionId ?? '0';
 
-	const domainSubscription = purchases.find(
-		( purchase ) => purchase.id === parseInt( selectedSubscriptionId )
+	const domainSubscription = purchases?.find(
+		( purchase ) => purchase.ID === parseInt( selectedSubscriptionId )
 	);
 
 	const { data, isLoading } = useUsersQuery(
@@ -48,7 +49,7 @@ export function useDomainOwnerUserName(
 	//when Jetpack overrides this property, the original WordPress.com user Id
 	//ends stored as user.linked_user_ID, so in those cases, that's the ID we have to use.
 	const ownerUser = teams?.users?.find(
-		( user ) => ( user.linked_user_ID ?? user.ID ) === domainSubscription?.userId
+		( user ) => ( user.linked_user_ID ?? user.ID ) === domainSubscription.user_id
 	);
 
 	return ownerUser?.login ?? '';

--- a/client/components/data/query-email-owner-username/index.ts
+++ b/client/components/data/query-email-owner-username/index.ts
@@ -1,8 +1,7 @@
+import { sitePurchasesQuery } from '@automattic/api-queries';
 import { isTitanMail, isGoogleWorkspace } from '@automattic/calypso-products';
-import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
+import { useQuery } from '@tanstack/react-query';
 import useUsersQuery from 'calypso/data/users/use-users-query';
-import { useSelector } from 'calypso/state';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { InfiniteData } from '@tanstack/react-query';
 
@@ -20,11 +19,13 @@ export function useEmailOwnerUserName(
 	selectedSite: SiteDetails | null | undefined,
 	domainName: string
 ): string {
-	useQuerySitePurchases( selectedSite?.ID ?? -1 );
+	const siteId = selectedSite?.ID;
+	const { data: purchases } = useQuery( {
+		...sitePurchasesQuery( siteId ?? 0 ),
+		enabled: Boolean( siteId ),
+	} );
 
-	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
-
-	const emailSubscription = purchases.find(
+	const emailSubscription = purchases?.find(
 		( purchase ) =>
 			( isTitanMail( purchase ) || isGoogleWorkspace( purchase ) ) && purchase.meta === domainName
 	);
@@ -43,7 +44,7 @@ export function useEmailOwnerUserName(
 
 	const teams = data as InfiniteData< UsersData > & UsersData;
 	const ownerUser = teams?.users?.find(
-		( user ) => ( user.linked_user_ID ?? user.ID ) === emailSubscription?.userId
+		( user ) => ( user.linked_user_ID ?? user.ID ) === emailSubscription.user_id
 	);
 
 	return ownerUser?.login ?? '';

--- a/client/components/has-site-purchases-switch/index.tsx
+++ b/client/components/has-site-purchases-switch/index.tsx
@@ -1,14 +1,8 @@
-import { ReactNode, useCallback, useEffect, useState } from 'react';
+import { sitePurchasesQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
+import { ReactNode, useCallback } from 'react';
 import * as React from 'react';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import RenderSwitch from 'calypso/components/jetpack/render-switch';
-import { useSelector, useDispatch } from 'calypso/state';
-import { resetSiteState } from 'calypso/state/purchases/actions';
-import {
-	isFetchingSitePurchases,
-	hasLoadedSitePurchasesFromServer,
-	getSitePurchases,
-} from 'calypso/state/purchases/selectors';
 
 type Props = {
 	siteId: number;
@@ -23,28 +17,16 @@ const HasSitePurchasesSwitch: React.FC< Props > = ( {
 	falseComponent,
 	loadingComponent,
 } ) => {
-	const dispatch = useDispatch();
-	const [ currentSiteId, setCurrentSiteId ] = useState( siteId );
-	const isFetching = useSelector( isFetchingSitePurchases );
-	const hasLoaded = useSelector( hasLoadedSitePurchasesFromServer );
-	const purchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
+	const { data: purchases, isLoading } = useQuery( {
+		...sitePurchasesQuery( siteId ),
+		enabled: Boolean( siteId ),
+	} );
 
-	const loadingCondition = useCallback(
-		() => ! hasLoaded || isFetching,
-		[ hasLoaded, isFetching ]
-	);
-	const renderCondition = useCallback( () => purchases.length > 0, [ purchases ] );
-
-	useEffect( () => {
-		if ( siteId !== currentSiteId ) {
-			setCurrentSiteId( siteId );
-			dispatch( resetSiteState() );
-		}
-	}, [ siteId, currentSiteId, setCurrentSiteId, dispatch ] );
+	const loadingCondition = useCallback( () => isLoading, [ isLoading ] );
+	const renderCondition = useCallback( () => Boolean( purchases?.length ), [ purchases ] );
 
 	return (
 		<RenderSwitch
-			queryComponent={ <QuerySitePurchases siteId={ siteId } /> }
 			trueComponent={ trueComponent }
 			falseComponent={ falseComponent }
 			loadingComponent={ loadingComponent }

--- a/client/components/has-site-purchases-switch/test/index.jsx
+++ b/client/components/has-site-purchases-switch/test/index.jsx
@@ -1,73 +1,51 @@
 /**
  * @jest-environment jsdom
  */
-import { screen } from '@testing-library/react';
-import { reducer as purchases } from 'calypso/state/purchases/reducer';
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import HasSitePurchasesSwitch from '../index';
 
-jest.mock( 'calypso/components/data/query-site-purchases', () => () => <p>Query</p> );
-
 const siteId = 1;
-const trueComponent = <p>True</p>;
-const falseComponent = <p>False</p>;
-const loadingComponent = <p>Loading</p>;
 const props = {
 	siteId,
-	trueComponent,
-	falseComponent,
-	loadingComponent,
+	trueComponent: <p>True</p>,
+	falseComponent: <p>False</p>,
+	loadingComponent: <p>Loading</p>,
 };
 
-const getQueryElt = () => screen.getByText( /query/i );
-const getLoadingElt = () => screen.getByText( /loading/i );
-const getTrueElt = () => screen.getByText( /true/i );
-const getFalseElt = () => screen.getByText( /false/i );
-const render = ( el, options ) => renderWithProvider( el, { ...options, reducers: { purchases } } );
+const mockSitePurchases = ( purchases ) =>
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.2/upgrades' )
+		.query( true )
+		.reply( 200, purchases );
 
 describe( 'HasSitePurchasesSwitch', () => {
-	it( 'should render the loading state if data is being fetched', () => {
-		render( <HasSitePurchasesSwitch { ...props } />, {
-			initialState: {
-				purchases: {
-					isFetchingSitePurchases: true,
-				},
-			},
-		} );
-
-		expect( getLoadingElt() ).toBeInTheDocument();
+	afterEach( () => {
+		nock.cleanAll();
 	} );
 
-	it( 'should render the loading state and fetch data if data has not been loaded yet', () => {
-		render( <HasSitePurchasesSwitch { ...props } /> );
+	it( 'should render the loading state while the purchases are being fetched', () => {
+		mockSitePurchases( [] );
 
-		expect( getLoadingElt() ).toBeInTheDocument();
-		expect( getQueryElt() ).toBeInTheDocument();
+		renderWithProvider( <HasSitePurchasesSwitch { ...props } /> );
+
+		expect( screen.getByText( /loading/i ) ).toBeInTheDocument();
 	} );
 
-	it( 'should render the correct component if site has purchases', () => {
-		render( <HasSitePurchasesSwitch { ...props } />, {
-			initialState: {
-				purchases: {
-					hasLoadedSitePurchasesFromServer: true,
-					data: [ { blog_id: siteId } ],
-				},
-			},
-		} );
+	it( 'should render the correct component if site has purchases', async () => {
+		mockSitePurchases( [ { ID: 1, blog_id: siteId } ] );
 
-		expect( getTrueElt() ).toBeInTheDocument();
+		renderWithProvider( <HasSitePurchasesSwitch { ...props } /> );
+
+		await waitFor( () => expect( screen.getByText( /true/i ) ).toBeInTheDocument() );
 	} );
 
-	it( 'should render the correct component if site has no purchase', () => {
-		render( <HasSitePurchasesSwitch { ...props } />, {
-			initialState: {
-				purchases: {
-					hasLoadedSitePurchasesFromServer: true,
-					data: [],
-				},
-			},
-		} );
+	it( 'should render the correct component if site has no purchase', async () => {
+		mockSitePurchases( [] );
 
-		expect( getFalseElt() ).toBeInTheDocument();
+		renderWithProvider( <HasSitePurchasesSwitch { ...props } /> );
+
+		await waitFor( () => expect( screen.getByText( /false/i ) ).toBeInTheDocument() );
 	} );
 } );

--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -1,24 +1,20 @@
+import { userPurchasesQuery } from '@automattic/api-queries';
 import { WPCOM_FEATURES_COPY_SITE } from '@automattic/calypso-products';
 import { COPY_SITE_FLOW, addProductsToCart } from '@automattic/onboarding';
+import { useQuery } from '@tanstack/react-query';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useMemo, useCallback } from 'react';
-import { useQueryUserPurchases } from 'calypso/components/data/query-user-purchases';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { clearSignupDestinationCookie } from 'calypso/signup/storageUtils';
 import { useDispatch as useReduxDispatch, useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import {
-	hasLoadedUserPurchasesFromServer,
-	isFetchingUserPurchases,
-	getUserPurchases,
-} from 'calypso/state/purchases/selectors';
 import isRequestingSiteFeatures from 'calypso/state/selectors/is-requesting-site-features';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { fetchSiteFeatures } from 'calypso/state/sites/features/actions';
+import type { Purchase } from '@automattic/api-core';
 import type { SiteSelect } from '@automattic/data-stores';
 import type { SiteExcerptData } from '@automattic/sites';
-import type { Purchase } from 'calypso/lib/purchases/types';
 
 interface SiteCopyOptions {
 	enabled: boolean;
@@ -41,14 +37,14 @@ function useSafeSiteHasFeature( siteId: number | undefined, feature: string, ena
 	} );
 }
 
-function getMarketplaceProducts( purchases: Purchase[] | null, siteId: number ) {
-	return ( purchases || [] )
+function getMarketplaceProducts( purchases: Purchase[] | undefined, siteId: number ) {
+	return ( purchases ?? [] )
 		.filter(
 			( purchase ) =>
-				[ 'marketplace_plugin', 'marketplace_theme' ].includes( purchase.productType ) &&
-				purchase.siteId === siteId
+				[ 'marketplace_plugin', 'marketplace_theme' ].includes( purchase.product_type ) &&
+				purchase.blog_id === siteId
 		)
-		.map( ( purchase ) => ( { product_slug: purchase.productSlug } ) );
+		.map( ( purchase ) => ( { product_slug: purchase.product_slug } ) );
 }
 
 function getPlanProduct( plan: SiteExcerptData[ 'plan' ] ) {
@@ -76,12 +72,10 @@ export const useSiteCopy = (
 	const plan = site?.plan;
 	const isSiteOwner = site?.site_owner === userId;
 
-	useQueryUserPurchases( options.enabled );
-	const isLoadingPurchases = useSelector(
-		( state ) => isFetchingUserPurchases( state ) || ! hasLoadedUserPurchasesFromServer( state )
-	);
-
-	const purchases = useSelector( getUserPurchases );
+	const { data: purchases, isPending: isLoadingPurchases } = useQuery( {
+		...userPurchasesQuery(),
+		enabled: options.enabled,
+	} );
 
 	const { setPlanCartItem, setProductCartItems, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
@@ -140,15 +134,16 @@ export const useSiteCopy = (
 };
 
 export const withSiteCopy = createHigherOrderComponent(
-	( Wrapped ) => ( props ) => {
-		const { shouldShowSiteCopyItem, startSiteCopy } = useSiteCopy( props.site );
-		return (
-			<Wrapped
-				{ ...props }
-				shouldShowSiteCopyItem={ shouldShowSiteCopyItem }
-				startSiteCopy={ startSiteCopy }
-			/>
-		);
-	},
+	( Wrapped ) =>
+		function WithSiteCopy( props ) {
+			const { shouldShowSiteCopyItem, startSiteCopy } = useSiteCopy( props.site );
+			return (
+				<Wrapped
+					{ ...props }
+					shouldShowSiteCopyItem={ shouldShowSiteCopyItem }
+					startSiteCopy={ startSiteCopy }
+				/>
+			);
+		},
 	'withSiteCopy'
 );

--- a/client/lib/resurrected-users/test/use-resurrected-free-user-eligibility.test.tsx
+++ b/client/lib/resurrected-users/test/use-resurrected-free-user-eligibility.test.tsx
@@ -1,64 +1,47 @@
 /**
  * @jest-environment jsdom
  */
-import config from '@automattic/calypso-config';
+import { disable, enable } from '@automattic/calypso-config';
 import { waitFor } from '@testing-library/react';
+import nock from 'nock';
 import { useExperiment } from 'calypso/lib/explat';
-import { fetchUserPurchases } from 'calypso/state/purchases/actions';
 import userSettingsReducer from 'calypso/state/user-settings/reducer';
 import { renderHookWithProvider } from 'calypso/test-helpers/testing-library';
 import {
 	RESURRECTED_FREE_USERS_EXPERIMENT,
 	WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG,
+	WELCOME_BACK_MODAL_FORCE_FLAG,
 	WELCOME_BACK_VARIATION_MANUAL,
 	WELCOME_BACK_VARIATIONS,
 } from '../constants';
 import { useResurrectedFreeUserEligibility } from '../use-resurrected-free-user-eligibility';
 import type { ExperimentAssignment } from '@automattic/explat-client';
 
-const selectorsState = {
-	purchases: null as Array< { type: string; status: string } > | null,
-	hasLoaded: false,
-	isFetching: false,
-};
-
-jest.mock( '@automattic/calypso-config', () => {
-	const mockConfig = jest.fn() as jest.Mock & {
-		isEnabled: jest.Mock;
-	};
-	mockConfig.isEnabled = jest.fn().mockReturnValue( true );
-	return {
-		__esModule: true,
-		default: mockConfig,
-	};
-} );
-
 jest.mock( 'calypso/lib/explat', () => ( {
 	useExperiment: jest.fn(),
 } ) );
 
-jest.mock( 'calypso/state/purchases/selectors', () => ( {
-	getUserPurchases: () => selectorsState.purchases,
-	hasLoadedUserPurchasesFromServer: () => selectorsState.hasLoaded,
-	isFetchingUserPurchases: () => selectorsState.isFetching,
-} ) );
-
-jest.mock( 'calypso/lib/purchases', () => ( {
-	isSubscription: ( purchase: { type: string } ) => purchase.type === 'subscription',
-	isRenewingBeforeExpiration: ( purchase: { status: string } ) => purchase.status === 'active',
-} ) );
-
-jest.mock( 'calypso/state/purchases/actions', () => ( {
-	fetchUserPurchases: jest.fn( () => () => Promise.resolve( [] ) ),
-} ) );
-
-const mockFetchUserPurchases = fetchUserPurchases as jest.MockedFunction<
-	typeof fetchUserPurchases
->;
-const mockIsFeatureEnabled = config.isEnabled as jest.MockedFunction< typeof config.isEnabled >;
 const mockUseExperiment = useExperiment as jest.MockedFunction< typeof useExperiment >;
 
 const DAY_IN_SECONDS = 24 * 60 * 60;
+
+const mockPurchases = ( purchases: object[] = [] ) =>
+	nock( 'https://public-api.wordpress.com' )
+		.get( '/rest/v1.2/upgrades' )
+		.query( true )
+		.reply( 200, purchases );
+
+const activeSubscription = {
+	ID: 1,
+	ownership_id: 1,
+	product_id: 1,
+	product_slug: 'business-bundle',
+	blog_id: 1,
+	user_id: 1,
+	is_domain: false,
+	is_domain_registration: false,
+	expiry_status: 'auto-renewing',
+};
 
 const createExperimentAssignment = ( variationName: string ): ExperimentAssignment => ( {
 	experimentName: RESURRECTED_FREE_USERS_EXPERIMENT,
@@ -95,43 +78,42 @@ const createState = ( {
 	};
 };
 
+const renderEligibilityHook = ( initialState: object ) =>
+	renderHookWithProvider( () => useResurrectedFreeUserEligibility(), {
+		initialState,
+		reducers,
+	} );
+
 describe( 'useResurrectedFreeUserEligibility', () => {
 	beforeEach( () => {
-		selectorsState.purchases = null;
-		selectorsState.hasLoaded = false;
-		selectorsState.isFetching = false;
-		mockIsFeatureEnabled.mockReturnValue( false );
-		mockFetchUserPurchases.mockImplementation( () => () => Promise.resolve( [] ) );
-		mockFetchUserPurchases.mockClear();
+		disable( WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG );
+		disable( WELCOME_BACK_MODAL_FORCE_FLAG );
 		mockUseExperiment.mockReturnValue( [ false, null ] );
 		mockUseExperiment.mockClear();
 	} );
 
-	it( 'requests user purchases when they have not loaded yet', async () => {
-		const initialState = createState( { lastSeenOffsetDays: 200 } );
-
-		renderHookWithProvider( () => useResurrectedFreeUserEligibility(), {
-			initialState,
-			reducers,
-		} );
-
-		await waitFor( () =>
-			expect( fetchUserPurchases ).toHaveBeenCalledWith( initialState.currentUser.id )
-		);
+	afterEach( () => {
+		nock.cleanAll();
 	} );
 
-	it( 'does not mark the user as eligible when active subscriptions exist', () => {
-		selectorsState.purchases = [ { type: 'subscription', status: 'active' } ];
-		selectorsState.hasLoaded = true;
+	it( 'reports loading until the user purchases have been fetched', async () => {
+		mockPurchases();
 
-		const initialState = createState( { lastSeenOffsetDays: 400 } );
+		const { result } = renderEligibilityHook( createState( { lastSeenOffsetDays: 200 } ) );
 
-		const { result } = renderHookWithProvider( () => useResurrectedFreeUserEligibility(), {
-			initialState,
-			reducers,
-		} );
+		expect( result.current.isLoading ).toBe( true );
+		expect( result.current.hasActivePaidSubscription ).toBeNull();
 
-		expect( result.current.hasActivePaidSubscription ).toBe( true );
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+		expect( result.current.hasActivePaidSubscription ).toBe( false );
+	} );
+
+	it( 'does not mark the user as eligible when active subscriptions exist', async () => {
+		mockPurchases( [ activeSubscription ] );
+
+		const { result } = renderEligibilityHook( createState( { lastSeenOffsetDays: 400 } ) );
+
+		await waitFor( () => expect( result.current.hasActivePaidSubscription ).toBe( true ) );
 		expect( result.current.isEligible ).toBe( false );
 		expect( result.current.isForcedVariation ).toBe( false );
 		expect( mockUseExperiment ).toHaveBeenCalledWith( RESURRECTED_FREE_USERS_EXPERIMENT, {
@@ -139,21 +121,15 @@ describe( 'useResurrectedFreeUserEligibility', () => {
 		} );
 	} );
 
-	it( 'returns MANUAL variation when resurrected and free of active subscriptions', () => {
-		selectorsState.purchases = [];
-		selectorsState.hasLoaded = true;
+	it( 'returns MANUAL variation when resurrected and free of active subscriptions', async () => {
+		mockPurchases();
 
-		const initialState = createState( { lastSeenOffsetDays: 400 } );
+		const { result } = renderEligibilityHook( createState( { lastSeenOffsetDays: 400 } ) );
 
-		const { result } = renderHookWithProvider( () => useResurrectedFreeUserEligibility(), {
-			initialState,
-			reducers,
-		} );
-
+		await waitFor( () => expect( result.current.isEligible ).toBe( true ) );
 		expect( result.current.isResurrectedSixMonths ).toBe( true );
 		expect( result.current.isResurrectedThreeMonths ).toBe( true );
 		expect( result.current.hasActivePaidSubscription ).toBe( false );
-		expect( result.current.isEligible ).toBe( true );
 		expect( result.current.variationName ).toBe( WELCOME_BACK_VARIATION_MANUAL );
 		expect( result.current.isLoading ).toBe( false );
 		expect( result.current.isForcedVariation ).toBe( false );
@@ -162,82 +138,58 @@ describe( 'useResurrectedFreeUserEligibility', () => {
 		} );
 	} );
 
-	it( 'uses the 180-day threshold when 90-day eligibility is disabled', () => {
-		selectorsState.purchases = [];
-		selectorsState.hasLoaded = true;
+	it( 'uses the 180-day threshold when 90-day eligibility is disabled', async () => {
+		mockPurchases();
 
-		const { result } = renderHookWithProvider( () => useResurrectedFreeUserEligibility(), {
-			initialState: createState( { lastSeenOffsetDays: 100 } ),
-			reducers,
-		} );
+		const { result } = renderEligibilityHook( createState( { lastSeenOffsetDays: 100 } ) );
 
+		await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
 		expect( result.current.isResurrectedSixMonths ).toBe( false );
 		expect( result.current.isResurrectedThreeMonths ).toBe( true );
 		expect( result.current.isEligible ).toBe( false );
 	} );
 
-	it( 'uses the 90-day threshold when 90-day eligibility is enabled', () => {
-		mockIsFeatureEnabled.mockImplementation(
-			( flagName ) => flagName === WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG
-		);
-		selectorsState.purchases = [];
-		selectorsState.hasLoaded = true;
+	it( 'uses the 90-day threshold when 90-day eligibility is enabled', async () => {
+		enable( WELCOME_BACK_90_DAY_ELIGIBILITY_FLAG );
+		mockPurchases();
 
-		const { result } = renderHookWithProvider( () => useResurrectedFreeUserEligibility(), {
-			initialState: createState( { lastSeenOffsetDays: 100 } ),
-			reducers,
-		} );
+		const { result } = renderEligibilityHook( createState( { lastSeenOffsetDays: 100 } ) );
 
+		await waitFor( () => expect( result.current.isEligible ).toBe( true ) );
 		expect( result.current.isResurrectedSixMonths ).toBe( false );
 		expect( result.current.isResurrectedThreeMonths ).toBe( true );
-		expect( result.current.isEligible ).toBe( true );
 	} );
 
-	it( 'returns the assigned experiment variation for an eligible user', () => {
-		selectorsState.purchases = [];
-		selectorsState.hasLoaded = true;
+	it( 'returns the assigned experiment variation for an eligible user', async () => {
+		mockPurchases();
 		mockUseExperiment.mockReturnValue( [
 			false,
 			createExperimentAssignment( WELCOME_BACK_VARIATIONS.content ),
 		] );
 
-		const { result } = renderHookWithProvider( () => useResurrectedFreeUserEligibility(), {
-			initialState: createState( { lastSeenOffsetDays: 400 } ),
-			reducers,
-		} );
+		const { result } = renderEligibilityHook( createState( { lastSeenOffsetDays: 400 } ) );
 
-		expect( result.current.isEligible ).toBe( true );
+		await waitFor( () => expect( result.current.isEligible ).toBe( true ) );
 		expect( result.current.variationName ).toBe( WELCOME_BACK_VARIATIONS.content );
 		expect( result.current.isLoading ).toBe( false );
 	} );
 
-	it( 'waits for the experiment assignment for an eligible user', () => {
-		selectorsState.purchases = [];
-		selectorsState.hasLoaded = true;
+	it( 'waits for the experiment assignment for an eligible user', async () => {
+		mockPurchases();
 		mockUseExperiment.mockReturnValue( [ true, null ] );
 
-		const { result } = renderHookWithProvider( () => useResurrectedFreeUserEligibility(), {
-			initialState: createState( { lastSeenOffsetDays: 400 } ),
-			reducers,
-		} );
+		const { result } = renderEligibilityHook( createState( { lastSeenOffsetDays: 400 } ) );
 
+		await waitFor( () => expect( result.current.hasActivePaidSubscription ).toBe( false ) );
 		expect( result.current.isEligible ).toBe( false );
 		expect( result.current.isLoading ).toBe( true );
 	} );
 
 	it( 'forces eligibility when welcome-back-modal-manual flag is enabled', () => {
-		mockIsFeatureEnabled.mockImplementation(
-			( flagName ) => flagName === 'welcome-back-modal-manual'
-		);
-		selectorsState.purchases = null;
-		selectorsState.hasLoaded = false;
+		enable( WELCOME_BACK_MODAL_FORCE_FLAG );
+		mockPurchases();
 
-		const initialState = createState( { lastSeenOffsetDays: 30 } );
-
-		const { result } = renderHookWithProvider( () => useResurrectedFreeUserEligibility(), {
-			initialState,
-			reducers,
-		} );
+		const { result } = renderEligibilityHook( createState( { lastSeenOffsetDays: 30 } ) );
 
 		expect( result.current.isEligible ).toBe( true );
 		expect( result.current.isLoading ).toBe( false );

--- a/client/lib/resurrected-users/use-resurrected-free-user-eligibility.ts
+++ b/client/lib/resurrected-users/use-resurrected-free-user-eligibility.ts
@@ -1,15 +1,13 @@
+import { userPurchasesQuery } from '@automattic/api-queries';
 import config from '@automattic/calypso-config';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from '@wordpress/element';
 import { useExperiment } from 'calypso/lib/explat';
-import { isRenewingBeforeExpiration, isSubscription } from 'calypso/lib/purchases';
-import { useDispatch, useSelector } from 'calypso/state';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { fetchUserPurchases } from 'calypso/state/purchases/actions';
 import {
-	getUserPurchases,
-	hasLoadedUserPurchasesFromServer,
-	isFetchingUserPurchases,
-} from 'calypso/state/purchases/selectors';
+	isRenewingBeforeExpiration,
+	isSubscription,
+} from 'calypso/me/purchases/lib/raw-purchase-helpers';
+import { useSelector } from 'calypso/state';
 import getUserSettings from 'calypso/state/selectors/get-user-settings';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import {
@@ -21,7 +19,7 @@ import {
 	WELCOME_BACK_VARIATION_MANUAL,
 } from './constants';
 import { hasExceededDormancyThreshold } from './utils';
-import type { Purchase } from 'calypso/lib/purchases/types';
+import type { Purchase } from '@automattic/api-core';
 
 interface EligibilityResult {
 	isLoading: boolean;
@@ -33,8 +31,8 @@ interface EligibilityResult {
 	isForcedVariation: boolean;
 }
 
-function hasActivePaidSubscription( purchases: Purchase[] | null ): boolean | null {
-	if ( purchases === null ) {
+function hasActivePaidSubscription( purchases: Purchase[] | undefined ): boolean | null {
+	if ( ! purchases ) {
 		return null;
 	}
 
@@ -44,24 +42,10 @@ function hasActivePaidSubscription( purchases: Purchase[] | null ): boolean | nu
 }
 
 export function useResurrectedFreeUserEligibility(): EligibilityResult {
-	const dispatch = useDispatch();
 	const userSettings = useSelector( getUserSettings );
 	const isUserSettingsFetching = useSelector( isFetchingUserSettings );
-	const currentUserId = useSelector( getCurrentUserId );
 
-	const purchases = useSelector( getUserPurchases );
-	const hasLoadedPurchases = useSelector( hasLoadedUserPurchasesFromServer );
-	const isUserPurchasesFetching = useSelector( isFetchingUserPurchases );
-
-	const purchasesLoaded = purchases !== null || hasLoadedPurchases;
-
-	useEffect( () => {
-		if ( purchasesLoaded || isUserPurchasesFetching || ! currentUserId ) {
-			return;
-		}
-
-		dispatch( fetchUserPurchases( currentUserId ) );
-	}, [ purchasesLoaded, isUserPurchasesFetching, currentUserId, dispatch ] );
+	const { data: purchases, isPending: isLoadingPurchases } = useQuery( userPurchasesQuery() );
 
 	const rawLastSeen = userSettings?.last_admin_activity_timestamp;
 	let lastSeen: number | null = null;
@@ -115,10 +99,7 @@ export function useResurrectedFreeUserEligibility(): EligibilityResult {
 	}
 
 	const isLoading =
-		isUserSettingsFetching ||
-		! purchasesLoaded ||
-		isUserPurchasesFetching ||
-		( baseEligibility && isExperimentLoading );
+		isUserSettingsFetching || isLoadingPurchases || ( baseEligibility && isExperimentLoading );
 
 	return {
 		isLoading,

--- a/client/my-sites/customer-home/cards/tasks/renew/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/renew/index.jsx
@@ -1,25 +1,32 @@
+import { sitePurchasesQuery } from '@automattic/api-queries';
+import { useQuery } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import expiredIllustration from 'calypso/assets/images/customer-home/disconnected-dark.svg';
 import expiringIllustration from 'calypso/assets/images/customer-home/disconnected.svg';
 import { getRelativeDayString } from 'calypso/dashboard/utils/datetime';
 import { TASK_RENEW_EXPIRED_PLAN } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { getSitePurchases } from 'calypso/state/purchases/selectors/get-site-purchases';
+import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-const Renew = ( { card, purchases, site } ) => {
+const Renew = ( { card } ) => {
 	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const site = useSelector( ( state ) => getSite( state, siteId ) );
+	const { data: purchases } = useQuery( {
+		...sitePurchasesQuery( siteId ),
+		enabled: Boolean( siteId ),
+	} );
 	const hasExpired = card === TASK_RENEW_EXPIRED_PLAN;
 
-	const planPurchase = purchases.find(
-		( purchase ) => purchase.productId === site?.plan.product_id
+	const planPurchase = purchases?.find(
+		( purchase ) => purchase.product_id === site?.plan.product_id
 	);
 
 	const planName = site?.plan.product_name_short;
-	const expiryText = planPurchase?.expiryDate
-		? getRelativeDayString( new Date( planPurchase.expiryDate ), hasExpired ? 'past' : 'upcoming' )
+	const expiryText = planPurchase?.expiry_date
+		? getRelativeDayString( new Date( planPurchase.expiry_date ), hasExpired ? 'past' : 'upcoming' )
 		: '';
 	const isOwner = site?.plan.user_is_owner;
 
@@ -79,7 +86,7 @@ const Renew = ( { card, purchases, site } ) => {
 		);
 		actionText = translate( 'Got it' );
 	}
-	const actionUrl = isOwner ? `/checkout/renew/${ planPurchase?.id }` : null;
+	const actionUrl = isOwner ? `/checkout/renew/${ planPurchase?.ID }` : null;
 	const illustration = hasExpired ? expiredIllustration : expiringIllustration;
 
 	return (
@@ -98,13 +105,4 @@ const Renew = ( { card, purchases, site } ) => {
 	);
 };
 
-const mapStateToProps = ( state ) => {
-	const siteId = getSelectedSiteId( state );
-
-	return {
-		purchases: getSitePurchases( state, siteId ),
-		site: getSite( state, siteId ),
-	};
-};
-
-export default connect( mapStateToProps )( Renew );
+export default Renew;

--- a/client/my-sites/customer-home/cards/tasks/renew/index.tsx
+++ b/client/my-sites/customer-home/cards/tasks/renew/index.tsx
@@ -9,32 +9,33 @@ import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
 import { useSelector } from 'calypso/state';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import type { TranslateResult } from 'i18n-calypso';
 
-const Renew = ( { card } ) => {
+const Renew = ( { card }: { card: string } ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const site = useSelector( ( state ) => getSite( state, siteId ) );
 	const { data: purchases } = useQuery( {
-		...sitePurchasesQuery( siteId ),
+		...sitePurchasesQuery( siteId ?? 0 ),
 		enabled: Boolean( siteId ),
 	} );
 	const hasExpired = card === TASK_RENEW_EXPIRED_PLAN;
 
 	const planPurchase = purchases?.find(
-		( purchase ) => purchase.product_id === site?.plan.product_id
+		( purchase ) => purchase.product_id === site?.plan?.product_id
 	);
 
-	const planName = site?.plan.product_name_short;
+	const planName = site?.plan?.product_name_short ?? '';
 	const expiryText = planPurchase?.expiry_date
 		? getRelativeDayString( new Date( planPurchase.expiry_date ), hasExpired ? 'past' : 'upcoming' )
 		: '';
-	const isOwner = site?.plan.user_is_owner;
+	const isOwner = Boolean( site?.plan?.user_is_owner );
 
 	const title = hasExpired
 		? translate( 'Reactivate your %(planName)s plan', { args: { planName } } )
 		: translate( '%(planName)s plan expiring soon', { args: { planName } } );
-	let description;
-	let actionText;
+	let description: TranslateResult | undefined;
+	let actionText: TranslateResult | undefined;
 	if ( isOwner && hasExpired ) {
 		description = translate(
 			'Your %(planName)s plan expired %(timeSinceExpiry)s. Reactivate now to continue enjoying features such as increased storage space, access to expert support, and automatic removal of WordPress.com ads.',
@@ -86,7 +87,9 @@ const Renew = ( { card } ) => {
 		);
 		actionText = translate( 'Got it' );
 	}
-	const actionUrl = isOwner ? `/checkout/renew/${ planPurchase?.ID }` : null;
+	const actionProps = isOwner
+		? ( { hasAction: true, actionUrl: `/checkout/renew/${ planPurchase?.ID }` } as const )
+		: ( { hasAction: false } as const );
 	const illustration = hasExpired ? expiredIllustration : expiringIllustration;
 
 	return (
@@ -94,13 +97,12 @@ const Renew = ( { card } ) => {
 			title={ title }
 			description={ description }
 			actionText={ actionText }
-			actionUrl={ actionUrl }
 			badgeText={ translate( 'Action required' ) }
 			illustration={ illustration }
 			isLoading={ ! planPurchase }
 			isUrgent={ hasExpired }
-			hasAction={ isOwner }
 			taskId={ card }
+			{ ...actionProps }
 		/>
 	);
 };

--- a/client/my-sites/customer-home/cards/tasks/task.tsx
+++ b/client/my-sites/customer-home/cards/tasks/task.tsx
@@ -83,7 +83,7 @@ const Task = ( {
 	  }
 	| {
 			hasAction: true;
-			actionTarget: string;
+			actionTarget?: string;
 			actionText: ReactNode;
 			actionUrl: string;
 			actionButton?: ReactNode;

--- a/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-lite-in-progress.tsx
@@ -1,13 +1,14 @@
+import { sitePurchasesQuery } from '@automattic/api-queries';
 import { WPCOM_DIFM_LITE } from '@automattic/calypso-products';
 import { useFlowCustomOptions } from '@automattic/help-center/src/hooks';
 import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
 import { DIFM_FLOW } from '@automattic/onboarding';
+import { useQuery } from '@tanstack/react-query';
 import { Button } from '@wordpress/components';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
-import { useQuerySitePurchases } from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useCurrentRoute } from 'calypso/components/route';
@@ -17,7 +18,6 @@ import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getSitePurchases, isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import { useGetWebsiteContentQuery } from 'calypso/state/signup/steps/website-content/hooks/use-get-website-content-query';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
@@ -67,17 +67,20 @@ function SupportLink( { children }: { children?: JSX.Element } ) {
 
 function WebsiteContentSubmissionPending( { siteId, siteSlug }: Props ) {
 	const translate = useTranslate();
-	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
-	const difmPurchase = sitePurchases.find(
-		( purchase ) => WPCOM_DIFM_LITE === purchase.productSlug
+	const { data: sitePurchases } = useQuery( {
+		...sitePurchasesQuery( siteId ?? 0 ),
+		enabled: Boolean( siteId ),
+	} );
+	const difmPurchase = sitePurchases?.find(
+		( purchase ) => WPCOM_DIFM_LITE === purchase.product_slug
 	);
 
 	const moment = useLocalizedMoment();
 	let contentSubmissionDueDate: number | null = null;
-	if ( difmPurchase?.subscribedDate ) {
-		const subscribedDate = new Date( difmPurchase.subscribedDate );
+	if ( difmPurchase?.subscribed_date ) {
+		const subscribedDate = new Date( difmPurchase.subscribed_date );
 		contentSubmissionDueDate = subscribedDate.setDate(
-			subscribedDate.getDate() + difmPurchase.refundPeriodInDays
+			subscribedDate.getDate() + difmPurchase.refund_period_in_days
 		);
 		// Due dates in the past are invalid.
 		if ( contentSubmissionDueDate < Date.now() ) {
@@ -173,10 +176,7 @@ function WebsiteContentSubmitted( { primaryDomain, siteSlug }: Props ) {
 
 function DIFMLiteInProgress( { siteId }: DIFMLiteInProgressProps ) {
 	const siteSlug = useSelector( ( state: AppState ) => getSiteSlug( state, siteId ) );
-	useQuerySitePurchases( siteId );
-	const isLoadingSitePurchases = useSelector( ( state: AppState ) =>
-		isFetchingSitePurchases( state )
-	);
+	const { isLoading: isLoadingSitePurchases } = useQuery( sitePurchasesQuery( siteId ) );
 	const { isLoading: isLoadingWebsiteContent, data: websiteContentQueryResult } =
 		useGetWebsiteContentQuery( siteSlug );
 	const primaryDomain = useSelector( ( state: AppState ) =>

--- a/client/sites/settings/administration/tools/transfer-site/start-site-owner-transfer.tsx
+++ b/client/sites/settings/administration/tools/transfer-site/start-site-owner-transfer.tsx
@@ -1,19 +1,20 @@
+import { sitePurchasesQuery } from '@automattic/api-queries';
 import { Button, Gridicon } from '@automattic/components';
 import styled from '@emotion/styled';
+import { useQuery } from '@tanstack/react-query';
 import { ToggleControl } from '@wordpress/components';
 import { localize, useTranslate } from 'i18n-calypso';
 import { FormEvent, useState } from 'react';
-import { connect, useSelector } from 'react-redux';
+import { connect } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import { PanelCardHeading } from 'calypso/components/panel';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ResponseDomain } from 'calypso/lib/domains/types';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { IAppState } from 'calypso/state/types';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { useStartSiteOwnerTransfer } from './use-start-site-owner-transfer';
-import type { Purchase } from 'calypso/lib/purchases/types';
+import type { Purchase } from '@automattic/api-core';
 
 type Props = {
 	selectedSiteId: number | null;
@@ -131,12 +132,12 @@ const UpgradesCard = ( {
 	siteSlug,
 	siteOwner,
 }: {
-	purchases: Purchase[];
+	purchases: Purchase[] | undefined;
 	siteSlug: string | null;
 	siteOwner: string;
 } ) => {
 	const translate = useTranslate();
-	if ( purchases.length === 0 ) {
+	if ( ! purchases?.length ) {
 		return null;
 	}
 	return (
@@ -236,7 +237,10 @@ const StartSiteOwnerTransfer = ( {
 	const [ startSiteTransferError, setStartSiteTransferError ] = useState( '' );
 	const [ startSiteTransferSuccess, setStartSiteTransferSuccess ] = useState( false );
 
-	const purchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
+	const { data: purchases } = useQuery( {
+		...sitePurchasesQuery( selectedSiteId ?? 0 ),
+		enabled: Boolean( selectedSiteId ),
+	} );
 
 	const { startSiteOwnerTransfer, isPending: isStartingSiteTransfer } = useStartSiteOwnerTransfer(
 		selectedSiteId,
@@ -289,7 +293,7 @@ const StartSiteOwnerTransfer = ( {
 			<FormToggleControl
 				disabled={ false }
 				label={
-					purchases.length === 0
+					! purchases?.length
 						? translate( 'I want to transfer the ownership of the site.' )
 						: translate( 'I want to transfer ownership of the site and all my related upgrades.' )
 				}


### PR DESCRIPTION
Part of SHILL-2256

## Proposed Changes

Moves eight standalone purchase consumers off the Redux camelCase purchase selectors (`getSitePurchases`/`getUserPurchases`) onto `sitePurchasesQuery`/`userPurchasesQuery` from `@automattic/api-queries` plus the raw `Purchase` from `@automattic/api-core`. Each of these is a leaf — no shared purchase shape crosses a module boundary — so the slice is mechanical field renaming plus the usual fetch swap.

* `components/data/query-domain-owner-username` — `purchase.id` → `ID`, `userId` → `user_id`.
* `components/data/query-email-owner-username` — `userId` → `user_id`; the `isTitanMail`/`isGoogleWorkspace` predicates already accept both shapes.
* `components/has-site-purchases-switch` — only reads `purchases.length`; the query's own `isLoading` replaces the `isFetchingSitePurchases`/`hasLoadedSitePurchasesFromServer` pair.
* `lib/resurrected-users/use-resurrected-free-user-eligibility` — uses the raw `isSubscription`/`isRenewingBeforeExpiration` from `me/purchases/lib/raw-purchase-helpers`, which makes it a near-copy of its dashboard twin.
* `landing/stepper/hooks/use-site-copy` — `productType` → `product_type`, `siteId` → `blog_id`, `productSlug` → `product_slug`.
* `my-sites/customer-home/cards/tasks/renew` — `productId` → `product_id`, `expiryDate` → `expiry_date`, `purchase.id` → `ID`; drops `connect()` for `useSelector` since the component was already a function.
* `my-sites/marketing/do-it-for-me/difm-lite-in-progress` — `subscribedDate` → `subscribed_date`, `refundPeriodInDays` → `refund_period_in_days`.
* `sites/settings/administration/tools/transfer-site/start-site-owner-transfer` — only reads `purchases.length`.

Along the way:

* Drops four Redux purchase fetches: `useQuerySitePurchases` in the two owner-username hooks and in `difm-lite-in-progress`, `useQueryUserPurchases` in `use-site-copy`, plus the `<QuerySitePurchases />` and `resetSiteState()` effect in `has-site-purchases-switch` (the TanStack query is keyed by site id, so it needs no manual reset).
* Rewrites two test suites onto nock + TanStack Query: `has-site-purchases-switch` and `use-resurrected-free-user-eligibility`. The latter loses its wall of Redux mocks (`getUserPurchases`, the fetching selectors, `fetchUserPurchases` and `calypso/lib/purchases`) in favour of real raw-purchase fixtures, and swaps the `@automattic/calypso-config` module mock for `enable`/`disable`.
* Names the `withSiteCopy` inner component, since touching `use-site-copy.tsx` brings its pre-existing `react/display-name` error into lint range.

## Why are these changes being made?

Part of the ongoing removal of the `createPurchaseObject` assembler and the duplicate camelCase `Purchase` type, done a cluster at a time. With the payment-methods and domain-management slices landed, the camelCase shape survives only behind the `getPurchases` selector, and the remaining readers split into two groups: Redux selectors that can't use a hook until their callers move, and plain components and hooks that can convert today. This slice takes the whole second group where the purchase never leaves the file, which is why it spans directories that otherwise have nothing to do with each other.

Three of these files were also quietly relying on someone else's fetch. `renew` and `start-site-owner-transfer` read `getSitePurchases` with nothing on their route dispatching `fetchSitePurchases`, so they rendered against whatever happened to be in Redux — usually an empty array, which meant the renew card sat in its loading state and the transfer page's Upgrades card never appeared. Now each fetches what it reads.

The two loading gates also get more accurate. `difm-lite-in-progress` and `has-site-purchases-switch` both derived "loading" from the global `isFetchingSitePurchases` flag, which is false before the request is dispatched — so for a tick they treated "not fetched yet" as "no purchases". The per-query `isLoading` closes that window.

## Testing Instructions

TC:
```
yarn test-client client/lib/resurrected-users client/components/has-site-purchases-switch
```

The wider set of suites touching these files is also green:
```
yarn test-client client/components/data client/my-sites/email client/my-sites/customer-home client/sites/settings client/landing/stepper/hooks client/my-sites/marketing client/components/resurrected-welcome-modal
```

Manual testing (not yet done — this is browser-untested):
* **Renew card** — on a site whose plan is expiring or expired, open `/home/:site` and confirm the renew task shows the plan name, a relative expiry ("in 3 days" / "3 days ago"), and that **Renew now** links to `/checkout/renew/:purchaseId`.
* **Site owner transfer** — at `/sites/settings/administration/transfer-site/:site` on a site with paid upgrades, confirm the **Upgrades** card appears and the second toggle reads "…and all my related upgrades." On a site with no upgrades, confirm the card is hidden and the toggle reads "I want to transfer the ownership of the site."
* **Domain/email owner names** — as a user who is *not* the domain owner, open a domain's settings and an email plan on a multi-user site; the "owned by {username}" messaging should still name the right owner.
* **Site copy** — from the sites list on an Atomic site you own with a marketplace plugin or theme, use **Copy site** and confirm the destination cart picks up the plan plus each marketplace product.
* **DIFM in progress** — on a site with an in-flight Built By Express purchase, confirm the "provide the content" screen shows the submission due date, and that the placeholder (not a premature empty state) renders while purchases load.
* **Jetpack Cloud settings** — at `/settings/:site` for a Jetpack site with purchases, confirm the credentials/backup-schedule sections render rather than the "no purchases" message.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
