### PR TITLE
Remove unused @automattic/ui dependency from @automattic/components

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -52,7 +52,6 @@
 		"@automattic/material-design-icons": "workspace:^",
 		"@automattic/number-formatters": "^1.2.0",
 		"@automattic/typography": "workspace:^",
-		"@automattic/ui": "workspace:^",
 		"@automattic/viewport": "workspace:^",
 		"@automattic/viewport-react": "workspace:^",
 		"@emotion/css": "^11.11.2",

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -13,7 +13,6 @@
 		{ "path": "../calypso-analytics" },
 		{ "path": "../calypso-url" },
 		{ "path": "../i18n-utils" },
-		{ "path": "../js-utils" },
-		{ "path": "../ui" }
+		{ "path": "../js-utils" }
 	]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,7 +1017,6 @@ __metadata:
     "@automattic/material-design-icons": "workspace:^"
     "@automattic/number-formatters": "npm:^1.2.0"
     "@automattic/typography": "workspace:^"
-    "@automattic/ui": "workspace:^"
     "@automattic/viewport": "workspace:^"
     "@automattic/viewport-react": "workspace:^"
     "@emotion/css": "npm:^11.11.2"


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/wp-calypso/issues/113835

## Proposed Changes

* Remove the unused `@automattic/ui` dependency from `@automattic/components`.
* Drop the corresponding TypeScript project reference from `packages/components/tsconfig.json`.

## Why are these changes being made?

`SummaryButton` previously imported `Badge` from `@automattic/ui`, which is why the dependency was added. That import was later switched to `@wordpress/ui` (#111378), and nothing in `@automattic/components` imports `@automattic/ui` anymore. Keeping the unused dependency only adds package coupling.

## Testing Instructions

* Confirm `@automattic/components` still builds: `yarn workspace @automattic/components build`
* Optionally smoke-check that `SummaryButton` stories/tests still work, since that was the former consumer.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?