### PR TITLE
Try: force the post-plan-selection email-verification arm (test-only, do not merge)

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-email-verification-gate.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/__user/use-email-verification-gate.ts
@@ -33,6 +33,13 @@ function useEmailVerificationVariant( flow: string ): {
 		isEligible: isOnboardingFlow( flow ),
 	} );
 
+	// TEST-ONLY STUB. DO NOT MERGE. Every onboarding signup on this build lands in Variant B so
+	// the signup-gate-repro skill can reach the post-plan-selection gate without an ExPlat
+	// assignment. The useExperiment call above stays so the hook order is unchanged.
+	if ( isOnboardingFlow( flow ) ) {
+		return { isLoading: false, variant: 'treatment_post_plan_selection' };
+	}
+
 	const variant = (
 		isLoading ? 'control' : assignment?.variationName ?? 'control'
 	) as EmailVerificationVariant;


### PR DESCRIPTION
Related to #DOTCOM-18530

**Do not merge.** This branch exists only to produce a `calypso.live` preview build.

## Proposed Changes

* `useEmailVerificationVariant()` returns `treatment_post_plan_selection` for every onboarding signup, so the post-plan-selection email-verification gate appears without an ExPlat assignment.

## Why are these changes being made?

The `authorization_required` failure on `/sites/new` after the verification gate (DOTCOM-18530) is reproduced by a browser-driven loop that needs a build where the gate always appears. The fix for that bug stacks on this branch for its preview build and is opened separately against trunk.

The control-arm cases in `__user/test/use-email-verification-gate.ts` fail on this branch by design.

## Testing Instructions

None. Preview build only.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01BebH9dsorME8g6aZxLW6yL