### PR TITLE
Onboarding: create the site through the shared wpcom client

### DIFF
--- a/packages/onboarding/src/cart/index.tsx
+++ b/packages/onboarding/src/cart/index.tsx
@@ -6,6 +6,7 @@ import { getTld, isFreeSubdomainQuery } from '@automattic/domain-search';
 import { guessTimezone, getLanguage } from '@automattic/i18n-utils';
 import debugFactory from 'debug';
 import { getLocaleSlug } from 'i18n-calypso';
+import wpcom from 'calypso/lib/wp'; // eslint-disable-line no-restricted-imports
 import {
 	setupSiteAfterCreation,
 	isTailoredSignupFlow,
@@ -216,11 +217,19 @@ export const createSite = async (
 	// This is the parameter that will contain the internal referral, e.g. a landing page.
 	const refParam = new URLSearchParams( document.location.search ).get( 'ref' );
 
-	const siteCreationResponse: NewSiteSuccessResponse = await wpcomRequest( {
-		path: '/sites/new',
-		apiVersion: '1.1',
-		method: 'POST',
-		body: {
+	// Through the shared client, never the bare proxy request. An account created in this session
+	// is signed in by a bearer token that only the shared client carries. A bare proxy request is
+	// authenticated by a JWT bound to the browser's login cookie instead, and any login, logout or
+	// second signup in the same browser invalidates that JWT while the token stays good. The gate
+	// polls /me through the shared client, so it reports the account verified right up to the
+	// moment this request answers authorization_required.
+	const siteCreationResponse: NewSiteSuccessResponse = await wpcom.req.post(
+		{
+			path: '/sites/new',
+			apiVersion: '1.1',
+		},
+		{},
+		{
 			...newSiteParams,
 			locale,
 			lang_id: getLanguage( locale as string )?.value,
@@ -253,8 +262,8 @@ export const createSite = async (
 						trigger_backend_build: false,
 					} ),
 			},
-		},
-	} );
+		}
+	);
 
 	if ( ! siteCreationResponse.success ) {
 		// TODO ebuccelli: Manage siteCreationResponse.errors

--- a/packages/onboarding/src/cart/test/index.ts
+++ b/packages/onboarding/src/cart/test/index.ts
@@ -1,6 +1,59 @@
 import { Visibility } from '@automattic/data-stores';
-import { getNewSiteParams } from '..';
+import wpcom from 'calypso/lib/wp'; // eslint-disable-line no-restricted-imports
+import { createSite, getNewSiteParams } from '..';
 import { HOSTING_LP_FLOW } from '../../utils/flows';
+import wpcomRequest from '../../wpcom-request';
+
+jest.mock( 'calypso/lib/wp', () => ( { req: { post: jest.fn() } } ), { virtual: true } );
+jest.mock( '../../wpcom-request', () => jest.fn() );
+jest.mock( '@automattic/calypso-config', () => {
+	const config = ( key: string ) => `config:${ key }`;
+	config.isEnabled = () => false;
+	return { __esModule: true, default: config, isEnabled: config.isEnabled };
+} );
+
+// The account this flow just created is signed in by a bearer token the shared wpcom client
+// carries. A bare proxy request has no token and is authenticated by a JWT bound to the browser's
+// login cookie instead, which any login, logout or second signup in the browser invalidates. So
+// site creation must go through the shared client, as the other site-creation paths do.
+describe( 'createSite', () => {
+	afterEach( () => jest.clearAllMocks() );
+
+	test( 'posts /sites/new through the shared wpcom client, not the bare proxy', async () => {
+		( wpcom.req.post as jest.Mock ).mockResolvedValue( {
+			success: true,
+			blog_details: { url: 'https://example.wordpress.com', blogid: 123 },
+		} );
+
+		const result = await createSite(
+			'onboarding',
+			'pub/twentytwentyfour',
+			Visibility.Private,
+			'Example',
+			'#113AF5',
+			false,
+			'exampleuser',
+			null,
+			'example'
+		);
+
+		expect( wpcomRequest ).not.toHaveBeenCalled();
+		expect( wpcom.req.post ).toHaveBeenCalledWith(
+			{ path: '/sites/new', apiVersion: '1.1' },
+			{},
+			expect.objectContaining( {
+				blog_name: 'example',
+				client_id: 'config:wpcom_signup_id',
+				client_secret: 'config:wpcom_signup_key',
+			} )
+		);
+		expect( result ).toEqual( {
+			siteId: 123,
+			siteSlug: 'example.wordpress.com',
+			domainItem: undefined,
+		} );
+	} );
+} );
 
 describe( 'getNewSiteParams', () => {
 	function testParams( partialParams: Partial< Parameters< typeof getNewSiteParams >[ 0 ] > = {} ) {

--- a/packages/onboarding/src/lib-wp.d.ts
+++ b/packages/onboarding/src/lib-wp.d.ts
@@ -1,0 +1,1 @@
+declare module 'calypso/lib/wp';


### PR DESCRIPTION
Related to #DOTCOM-18530

## Proposed Changes

* `createSite` in `@automattic/onboarding` posts `/sites/new` through the shared wpcom.js client instead of the bare `wpcomRequest`.
* A test that the request goes through the shared client and never the bare proxy.
* A `calypso/lib/wp` module declaration for the package, the same as `design-picker` carries.

## Why are these changes being made?

An account created in the onboarding flow is signed in by a bearer token that only the shared wpcom.js client carries. The gate's `/me` poll goes through that client, so it succeeds no matter what the browser's cookies say. `createSite` posted `/sites/new` through the bare proxy request with no token. The REST proxy authenticates that with a JWT bound to the browser's `wordpress_logged_in` cookie, and the API returns "no auth" rather than an error when the cookie no longer matches. Any login, logout or second signup in the same browser between account creation and site creation therefore produced `/me` 200 "verified" followed by `/sites/new` 403 `authorization_required`, which is the intermittent failure in DOTCOM-18530.

The two other Stepper site-creation paths (`use-create-site-hook.ts` and the legacy `step-actions`) already post through the shared client. This brings the onboarding helper in line with them.

Stepper installs a requester that would route every package request through the shared client, but only under `config.isEnabled( 'oauth' )`. Making that unconditional is the broader fix and is out of scope here.

## Testing Instructions

Automated:

```
yarn test-packages packages/onboarding/src/cart/test/index.ts
```

### Browser

The bug needs two builds: #114252 (forces the post-plan-selection email-verification arm, no fix) and #114254 (the same plus this PR). Each has its own `calypso.live` link on its PR. Use a Chrome profile that is logged out of WordPress.com and is not Incognito. Incognito blocks the cross-site cookies the REST proxy uses on `calypso.live`, which fakes the failure.

**Install the repro skill (Automatticians only).** Requirements: Claude Code, the [Claude in Chrome](https://claude.ai/chrome) browser extension installed and connected to the Claude Code session, and the `wpcom-dev` plugin from the `markbiek/mark-claude-plugins` marketplace on our internal GitHub Enterprise.

1. Install the Claude in Chrome extension and connect it to Claude Code.
2. `/plugin marketplace add <SSH URL of markbiek/mark-claude-plugins on internal GHE>`
3. `/plugin install wpcom-dev@mark-claude-plugins`
4. `/reload-plugins`

Already have `wpcom-dev` from that marketplace? Skip steps 2 and 3, and run `/plugin` → update, then `/reload-plugins`. The skill is at version 0.3.1 or later.

Before a run: grant the extension access to the `calypso.live` host of each build plus `wordpress.com` and `signup.wordpress.com`. The skill asks for the activation link twice per run.

**With the repro skill.** Two runs, one per build:

```
/wpcom-dev:signup-gate-repro <114252 live URL> --mode repro
/wpcom-dev:signup-gate-repro <114254 live URL> --mode verify
```

Each run does a control signup first, then the test signup. Expected verdicts: `REPRODUCED` on #114252 and `NOT REPRODUCED` on #114254.

**By hand.** Do this once on each build.

1. Open `<live URL>/setup/onboarding` in tab 1. Open DevTools on the Network tab and filter on `sites/new`.
2. Create an account with an email address whose inbox you can read. Do not use an Automattic address; those accounts cannot pass the gate.
3. Pick a free `.wordpress.com` subdomain and the free plan. You land on "Verify your email".
4. In tab 2, open `https://wordpress.com/wp-login.php?action=logout` and confirm the logout.
5. Open the activation link from the email in tab 2. It lands on a login page. That is expected.
6. Return to tab 1 and watch the `sites/new` request.

Expected on #114252: `POST /rest/v1.1/sites/new` returns 403 with `authorization_required`, and tab 1 shows the error step.

Expected on #114254: `POST /rest/v1.1/sites/new` returns 200, and tab 1 continues to the new site.

Step 4 is the trigger. Without it the site is created on both builds, which is the control case and proves the harness rather than the fix.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01BebH9dsorME8g6aZxLW6yL
