### PR TITLE
Unseen Posts: Fix seen state and api calls for AFK posts

### DIFF
--- a/client/blocks/reader-feed-header/follow.tsx
+++ b/client/blocks/reader-feed-header/follow.tsx
@@ -7,7 +7,7 @@ import SiteNotificationSettings from 'calypso/blocks/reader-site-notification-se
 import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
 import { useFeedRecommendationsMutation } from 'calypso/data/reader/use-feed-recommendations-mutation';
 import { useFeedQuery } from 'calypso/reader/data/feed';
-import { useIsSeenEnabled, useMarkAllAsSeenMutation } from 'calypso/reader/data/seen-posts';
+import { useCanMarkSeen, useMarkAllAsSeenMutation } from 'calypso/reader/data/seen-posts';
 import { useIsSubscribed } from 'calypso/reader/data/site-subscriptions';
 import ReaderFollowButton from 'calypso/reader/follow-button';
 import { getFeedUrl, getSiteUrl } from 'calypso/reader/get-helpers';
@@ -57,7 +57,7 @@ export default function ReaderFeedHeaderFollow( props: ReaderFeedHeaderFollowPro
 	const resolvedSiteId = siteId ?? resolvedFeed?.blog_ID;
 	const followFeedId = resolvedFeed?.feed_ID;
 	const reduxFollowing = useIsSubscribed( { feedUrl: followFeedUrl } );
-	const isSeenEnabled = useIsSeenEnabled( { feedId: followFeedId, blogId: resolvedSiteId } );
+	const canMarkSeen = useCanMarkSeen( { feedId: followFeedId, blogId: resolvedSiteId } );
 	const {
 		isRecommended,
 		isUpdating: isRecommendationPending,
@@ -157,7 +157,7 @@ export default function ReaderFeedHeaderFollow( props: ReaderFeedHeaderFollowPro
 					</div>
 				) }
 			</div>
-			{ isSeenEnabled && resolvedFeed && (
+			{ canMarkSeen && resolvedFeed && (
 				<button
 					onClick={ markAllAsSeen }
 					className="reader-feed-header__seen-button"

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -533,7 +533,7 @@ export class FullPostView extends Component {
 		}
 
 		if ( ! this.hasLoaded && post && post._state !== 'pending' ) {
-			if ( this.props.isSeenEnabled && ! post.is_seen ) {
+			if ( this.props.isSeenEnabled ) {
 				this.markAsSeen();
 			}
 

--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -32,7 +32,7 @@ import { usePostCommentsApiDisabled } from 'calypso/reader/data/comments';
 import { useFeedQuery } from 'calypso/reader/data/feed';
 import { usePost } from 'calypso/reader/data/post';
 import { withPostLikeActions } from 'calypso/reader/data/post/likes';
-import { useIsSeenEnabled, withSeenPostsMutations } from 'calypso/reader/data/seen-posts';
+import { useCanMarkSeen, withSeenPostsMutations } from 'calypso/reader/data/seen-posts';
 import { withSite } from 'calypso/reader/data/site';
 import { useSiteSubscriptionForFeed } from 'calypso/reader/data/site-subscriptions';
 import { getSiteName } from 'calypso/reader/get-helpers';
@@ -74,7 +74,7 @@ export class FullPostView extends Component {
 		onClose: PropTypes.func,
 		referralPost: PropTypes.object,
 		referralStream: PropTypes.string,
-		isSeenEnabled: PropTypes.bool,
+		canMarkSeen: PropTypes.bool,
 		layout: PropTypes.oneOf( [ 'default', 'recent' ] ),
 		currentPath: PropTypes.string,
 		commentsApiDisabled: PropTypes.bool,
@@ -533,7 +533,7 @@ export class FullPostView extends Component {
 		}
 
 		if ( ! this.hasLoaded && post && post._state !== 'pending' ) {
-			if ( this.props.isSeenEnabled ) {
+			if ( this.props.canMarkSeen && ! post.is_seen ) {
 				this.markAsSeen();
 			}
 
@@ -761,7 +761,7 @@ export class FullPostView extends Component {
 										post.discussion?.comment_count > 0
 									}
 									renderMarkAsSeenButton={
-										this.props.isSeenEnabled ? this.renderMarkAsSeenButton : null
+										this.props.canMarkSeen ? this.renderMarkAsSeenButton : null
 									}
 									feedUrl={ feedUrl }
 									siteUrl={ post.site_URL }
@@ -961,7 +961,7 @@ export const withFullPostNavigation = ( WrappedComponent ) =>
 
 		const { data: previousPost } = usePost( previousPostKey );
 		const { data: nextPost } = usePost( nextPostKey );
-		const isSeenEnabled = useIsSeenEnabled( {
+		const canMarkSeen = useCanMarkSeen( {
 			feedId: props.feedId,
 			blogId: props.blogId ?? props.feed?.blog_ID ?? post?.site_ID,
 			post,
@@ -987,7 +987,7 @@ export const withFullPostNavigation = ( WrappedComponent ) =>
 				nextPostKey={ nextPostKey }
 				post={ post }
 				referralPost={ referralPost }
-				isSeenEnabled={ isSeenEnabled }
+				canMarkSeen={ canMarkSeen }
 				commentsApiDisabled={ commentsApiDisabled }
 				previousPost={ previousPost }
 				nextPost={ nextPost }

--- a/client/blocks/reader-full-post/test/index.test.jsx
+++ b/client/blocks/reader-full-post/test/index.test.jsx
@@ -23,7 +23,7 @@ jest.mock( 'calypso/reader/stream/use-stream-post-key-selection', () => ( {
 
 // The seen gate reads React Query caches these tests don't provide.
 jest.mock( 'calypso/reader/data/seen-posts', () => ( {
-	useIsSeenEnabled: jest.fn( () => false ),
+	useCanMarkSeen: jest.fn( () => false ),
 	withSeenPostsMutations: ( WrappedComponent ) => WrappedComponent,
 } ) );
 
@@ -258,7 +258,7 @@ describe( 'FullPostView Comments API Disabled Logic', () => {
 
 describe( 'FullPostView automatic mark-as-seen on view', () => {
 	const baseProps = {
-		isSeenEnabled: true,
+		canMarkSeen: true,
 		teams: [],
 		referralStream: '',
 		setViewingFullPostKey: jest.fn(),
@@ -315,7 +315,7 @@ describe( 'FullPostView automatic mark-as-seen on view', () => {
 		const requestMarkAsSeenBlog = jest.fn();
 		const instance = new FullPostView( {
 			...baseProps,
-			isSeenEnabled: false,
+			canMarkSeen: false,
 			requestMarkAsSeen,
 			requestMarkAsSeenBlog,
 			post: { ...feedPost, is_seen: false },

--- a/client/blocks/reader-post-card/index.jsx
+++ b/client/blocks/reader-post-card/index.jsx
@@ -12,7 +12,7 @@ import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follow
 import { withReaderTeams } from 'calypso/components/data/with-reader-teams';
 import { useFeedQuery } from 'calypso/reader/data/feed';
 import DisplayTypes from 'calypso/reader/data/post/display-types';
-import { useIsSeenEnabled } from 'calypso/reader/data/seen-posts';
+import { useIsSeenVisible } from 'calypso/reader/data/seen-posts';
 import * as stats from 'calypso/reader/stats';
 import { expandCard as expandCardAction } from 'calypso/state/reader-ui/card-expansions/actions';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -42,7 +42,7 @@ class ReaderPostCard extends Component {
 		postKey: PropTypes.object,
 		compact: PropTypes.bool,
 		teams: PropTypes.array,
-		isSeenEnabled: PropTypes.bool,
+		isSeenVisible: PropTypes.bool,
 		fixedHeaderHeight: PropTypes.number,
 		streamKey: PropTypes.string,
 		commentsApiDisabled: PropTypes.bool,
@@ -179,7 +179,7 @@ class ReaderPostCard extends Component {
 			'is-photo': isPostPhoto,
 			'is-gallery': isGalleryPost,
 			'is-selected': isSelected,
-			'is-seen': this.props.isSeenEnabled && post?.is_seen,
+			'is-seen': this.props.isSeenVisible,
 			'is-expanded-video': isVideo && isExpanded,
 			'is-compact': compact,
 		} );
@@ -323,7 +323,7 @@ export default function ReaderPostCardContainer( props ) {
 	const { data: fetchedFeed } = useFeedQuery( feedId );
 	const feed = props.feed ?? fetchedFeed;
 	const blogId = props.postKey?.blogId ?? props.post?.site_ID ?? feed?.blog_ID;
-	const isSeenEnabled = useIsSeenEnabled( { feedId, blogId, post: props.post } );
+	const isSeenVisible = useIsSeenVisible( { feedId, blogId, post: props.post } );
 
-	return <ConnectedReaderPostCard { ...props } feed={ feed } isSeenEnabled={ isSeenEnabled } />;
+	return <ConnectedReaderPostCard { ...props } feed={ feed } isSeenVisible={ isSeenVisible } />;
 }

--- a/client/blocks/reader-post-card/style.scss
+++ b/client/blocks/reader-post-card/style.scss
@@ -97,7 +97,7 @@
 	}
 
 	&.is-seen {
-		opacity: 0.5;
+		opacity: 0.65;
 	}
 
 	&.has-thumbnail {

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -8,7 +8,7 @@ import ConversationFollowButton from 'calypso/blocks/conversation-follow-button'
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import ReaderFollowConversationIcon from 'calypso/reader/components/icons/follow-conversation-icon';
-import { useIsSeenEnabled, withSeenPostsMutations } from 'calypso/reader/data/seen-posts';
+import { useCanMarkSeen, withSeenPostsMutations } from 'calypso/reader/data/seen-posts';
 import ReaderFollowButton from 'calypso/reader/follow-button';
 import { READER_POST_OPTIONS_MENU } from 'calypso/reader/follow-sources';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
@@ -35,7 +35,7 @@ class ReaderPostEllipsisMenu extends Component {
 		showReportPost: PropTypes.bool,
 		showReportSite: PropTypes.bool,
 		teams: PropTypes.array,
-		isSeenEnabled: PropTypes.bool,
+		canMarkSeen: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -218,7 +218,7 @@ class ReaderPostEllipsisMenu extends Component {
 	stopPropagation = ( event ) => event.stopPropagation();
 
 	render() {
-		const { post, site, teams, translate, isLoggedIn, followSource, isSeenEnabled } = this.props;
+		const { post, site, teams, translate, isLoggedIn, followSource, canMarkSeen } = this.props;
 
 		const { ID: postId, site_ID: siteId, feed_ID: feedId } = post;
 
@@ -274,7 +274,7 @@ class ReaderPostEllipsisMenu extends Component {
 					/>
 				) }
 
-				{ isSeenEnabled && (
+				{ canMarkSeen && (
 					<PopoverMenuItem
 						onClick={ isSeen ? this.markAsUnSeen : this.markAsSeen }
 						icon={ isSeen ? unseen : seen }
@@ -352,7 +352,7 @@ const ConnectedPostEllipsisMenu = connect(
 export default function PostEllipsisMenuContainer( props ) {
 	const { feed_ID: feedId, is_external: isExternal, site_ID: siteId } = props.post ?? {};
 	const blogId = isExternal ? null : siteId;
-	const isSeenEnabled = useIsSeenEnabled( { feedId, blogId, post: props.post } );
+	const canMarkSeen = useCanMarkSeen( { feedId, blogId, post: props.post } );
 
-	return <ConnectedPostEllipsisMenu { ...props } isSeenEnabled={ isSeenEnabled } />;
+	return <ConnectedPostEllipsisMenu { ...props } canMarkSeen={ canMarkSeen } />;
 }

--- a/client/reader/data/seen-posts/index.ts
+++ b/client/reader/data/seen-posts/index.ts
@@ -1,3 +1,5 @@
 export * from './use-is-seen-enabled';
+export * from './use-can-mark-seen';
+export * from './use-is-seen-visible';
 export * from './use-mutations';
 export * from './with-seen-posts-mutations';

--- a/client/reader/data/seen-posts/test/fixtures/index.tsx
+++ b/client/reader/data/seen-posts/test/fixtures/index.tsx
@@ -1,13 +1,14 @@
 import {
 	getSiteSubscriptionsQueryKey,
 	isAutomatticianQuery,
+	readFeedQuery,
 	readSubscribedListsQuery,
 } from '@automattic/api-queries';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import { AUTOMATTIC_ORG_ID, P2_ORG_ID } from 'calypso/state/reader/organizations/constants';
-import type { SiteSubscriptionItem } from '@automattic/api-core';
+import type { ReadFeedItem, SiteSubscriptionItem } from '@automattic/api-core';
 import type { ReactNode } from 'react';
 
 export const USER_ID = 10;
@@ -22,6 +23,8 @@ interface SeenPostsWrapperOptions {
 	isAutomattician?: boolean;
 	wpForTeamsBlogIds?: number[];
 	subscribedListFeedIds?: number[];
+	/** Feed records to seed, so an unsubscribed feed still resolves an organization. */
+	feedOrganizationIds?: Record< number, number >;
 	route?: string;
 }
 
@@ -33,6 +36,7 @@ export function createSeenPostsWrapper( {
 	isAutomattician = false,
 	wpForTeamsBlogIds = [],
 	subscribedListFeedIds = [],
+	feedOrganizationIds = {},
 	route,
 }: SeenPostsWrapperOptions = {} ) {
 	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
@@ -64,6 +68,14 @@ export function createSeenPostsWrapper( {
 				} ) ),
 			},
 		],
+	} );
+
+	Object.entries( feedOrganizationIds ).forEach( ( [ feedId, organizationId ] ) => {
+		queryClient.setQueryData( readFeedQuery( Number( feedId ) ).queryKey, {
+			feed_ID: String( feedId ),
+			blog_ID: String( BLOG_ID ),
+			organization_id: organizationId,
+		} as ReadFeedItem );
 	} );
 
 	const state = {

--- a/client/reader/data/seen-posts/test/fixtures/index.tsx
+++ b/client/reader/data/seen-posts/test/fixtures/index.tsx
@@ -1,0 +1,100 @@
+import {
+	getSiteSubscriptionsQueryKey,
+	isAutomatticianQuery,
+	readSubscribedListsQuery,
+} from '@automattic/api-queries';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import { AUTOMATTIC_ORG_ID, P2_ORG_ID } from 'calypso/state/reader/organizations/constants';
+import type { SiteSubscriptionItem } from '@automattic/api-core';
+import type { ReactNode } from 'react';
+
+export const USER_ID = 10;
+export const FEED_ID = 200;
+export const BLOG_ID = 100;
+export const ORG_ID = P2_ORG_ID;
+
+export type Subscription = Partial< SiteSubscriptionItem >;
+
+interface SeenPostsWrapperOptions {
+	subscriptions?: Subscription[];
+	isAutomattician?: boolean;
+	wpForTeamsBlogIds?: number[];
+	subscribedListFeedIds?: number[];
+	route?: string;
+}
+
+/**
+ * Builds a `renderHook`/`render` wrapper with the React Query caches and Redux state for the seen-posts.
+ */
+export function createSeenPostsWrapper( {
+	subscriptions = [],
+	isAutomattician = false,
+	wpForTeamsBlogIds = [],
+	subscribedListFeedIds = [],
+	route,
+}: SeenPostsWrapperOptions = {} ) {
+	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+
+	// `isAutomatticianQuery` is `readTeamsQuery` plus a `select`, so this seeds both.
+	queryClient.setQueryData( isAutomatticianQuery().queryKey, {
+		number: isAutomattician ? 1 : 0,
+		teams: isAutomattician ? [ { slug: 'a8c', title: 'Automattic' } ] : [],
+	} );
+
+	queryClient.setQueryData( getSiteSubscriptionsQueryKey(), {
+		pages: [ { subscriptions, totalCount: subscriptions.length } ],
+		pageParams: [ 1 ],
+	} );
+
+	queryClient.setQueryData( readSubscribedListsQuery().queryKey, {
+		lists: [
+			{
+				ID: 1,
+				title: 'Test List',
+				slug: 'test-list',
+				description: 'A test list',
+				owner: 'test-user',
+				is_owner: false,
+				is_public: true,
+				feeds: subscribedListFeedIds.map( ( feed_id ) => ( {
+					feed_id,
+					unseen_count: 0,
+				} ) ),
+			},
+		],
+	} );
+
+	const state = {
+		currentUser: { id: USER_ID },
+		sites: {
+			items: Object.fromEntries(
+				wpForTeamsBlogIds.map( ( id ) => [ id, { options: { is_wpforteams_site: true } } ] )
+			),
+		},
+		route: { path: { current: route ?? null } },
+	};
+	const store = createStore( () => state );
+
+	return function Wrapper( { children }: { children: ReactNode } ) {
+		return (
+			<QueryClientProvider client={ queryClient }>
+				<Provider store={ store }>{ children }</Provider>
+			</QueryClientProvider>
+		);
+	};
+}
+
+export const subscription: Subscription = {
+	feed_ID: FEED_ID,
+	blog_ID: BLOG_ID,
+	is_following: true,
+};
+
+export const organizationSubscription: Subscription = {
+	...subscription,
+	organization_id: ORG_ID,
+};
+
+export { AUTOMATTIC_ORG_ID, P2_ORG_ID };

--- a/client/reader/data/seen-posts/test/use-can-mark-seen.test.tsx
+++ b/client/reader/data/seen-posts/test/use-can-mark-seen.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useCanMarkSeen } from '../use-can-mark-seen';
+import { AUTOMATTIC_ORG_ID, FEED_ID, createSeenPostsWrapper, subscription } from './fixtures';
+import type { Subscription } from './fixtures';
+
+const AUTHOR = 'test_user';
+const a8cSubscription: Subscription = { ...subscription, organization_id: AUTOMATTIC_ORG_ID };
+const eligible = { subscriptions: [ a8cSubscription ] };
+// An AFK post satisfies both halves of the wpcom `is_automattic_private()` guard.
+const afkPost = {
+	site_is_private: true,
+	author: { login: AUTHOR },
+	tags: { afk: {}, 'afk-vacation': {}, [ `afk-${ AUTHOR }` ]: {} },
+};
+
+describe( 'useCanMarkSeen', () => {
+	it( 'returns false when the seen feature is unavailable', () => {
+		const { result } = renderHook( () => useCanMarkSeen( { feedId: FEED_ID } ), {
+			wrapper: createSeenPostsWrapper(),
+		} );
+
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'returns false for an AFK post on A8C private blog', () => {
+		const { result } = renderHook( () => useCanMarkSeen( { feedId: FEED_ID, post: afkPost } ), {
+			wrapper: createSeenPostsWrapper( eligible ),
+		} );
+
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'returns true when seen feature is available and post is not an AFK post', () => {
+		const { result } = renderHook( () => useCanMarkSeen( { feedId: FEED_ID } ), {
+			wrapper: createSeenPostsWrapper( eligible ),
+		} );
+
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'returns true for a post with an unrelated tag', () => {
+		const post = { ...afkPost, tags: { 'p2-xpost': {} } };
+		const { result } = renderHook( () => useCanMarkSeen( { feedId: FEED_ID, post } ), {
+			wrapper: createSeenPostsWrapper( eligible ),
+		} );
+
+		expect( result.current ).toBe( true );
+	} );
+} );

--- a/client/reader/data/seen-posts/test/use-can-mark-seen.test.tsx
+++ b/client/reader/data/seen-posts/test/use-can-mark-seen.test.tsx
@@ -3,7 +3,13 @@
  */
 import { renderHook } from '@testing-library/react';
 import { useCanMarkSeen } from '../use-can-mark-seen';
-import { AUTOMATTIC_ORG_ID, FEED_ID, createSeenPostsWrapper, subscription } from './fixtures';
+import {
+	AUTOMATTIC_ORG_ID,
+	BLOG_ID,
+	FEED_ID,
+	createSeenPostsWrapper,
+	subscription,
+} from './fixtures';
 import type { Subscription } from './fixtures';
 
 const AUTHOR = 'test_user';
@@ -13,7 +19,7 @@ const eligible = { subscriptions: [ a8cSubscription ] };
 const afkPost = {
 	site_is_private: true,
 	author: { login: AUTHOR },
-	tags: { afk: {}, 'afk-vacation': {}, [ `afk-${ AUTHOR }` ]: {} },
+	tags: { afk: { slug: 'afk' } },
 };
 
 describe( 'useCanMarkSeen', () => {
@@ -33,6 +39,18 @@ describe( 'useCanMarkSeen', () => {
 		expect( result.current ).toBe( false );
 	} );
 
+	it( 'returns false for an AFK post the viewer does not follow', () => {
+		const { result } = renderHook( () => useCanMarkSeen( { feedId: FEED_ID, post: afkPost } ), {
+			wrapper: createSeenPostsWrapper( {
+				isAutomattician: true,
+				wpForTeamsBlogIds: [ BLOG_ID ],
+				feedOrganizationIds: { [ FEED_ID ]: AUTOMATTIC_ORG_ID },
+			} ),
+		} );
+
+		expect( result.current ).toBe( false );
+	} );
+
 	it( 'returns true when seen feature is available and post is not an AFK post', () => {
 		const { result } = renderHook( () => useCanMarkSeen( { feedId: FEED_ID } ), {
 			wrapper: createSeenPostsWrapper( eligible ),
@@ -42,7 +60,7 @@ describe( 'useCanMarkSeen', () => {
 	} );
 
 	it( 'returns true for a post with an unrelated tag', () => {
-		const post = { ...afkPost, tags: { 'p2-xpost': {} } };
+		const post = { ...afkPost, tags: { 'p2-xpost': { slug: 'p2-xpost' } } };
 		const { result } = renderHook( () => useCanMarkSeen( { feedId: FEED_ID, post } ), {
 			wrapper: createSeenPostsWrapper( eligible ),
 		} );

--- a/client/reader/data/seen-posts/test/use-is-seen-enabled.test.tsx
+++ b/client/reader/data/seen-posts/test/use-is-seen-enabled.test.tsx
@@ -1,107 +1,20 @@
 /**
  * @jest-environment jsdom
  */
-import {
-	getSiteSubscriptionsQueryKey,
-	isAutomatticianQuery,
-	readSubscribedListsQuery,
-} from '@automattic/api-queries';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react';
-import { Provider } from 'react-redux';
-import { createStore } from 'redux';
 import { useIsSeenEnabled } from '../use-is-seen-enabled';
-import type { SiteSubscriptionItem } from '@automattic/api-core';
-import type { ReactNode } from 'react';
-
-const USER_ID = 10;
-const FEED_ID = 200;
-const BLOG_ID = 100;
-const ORG_ID = 4;
-
-type Subscription = Partial< SiteSubscriptionItem >;
-
-interface SetUp {
-	subscriptions?: Subscription[];
-	isAutomattician?: boolean;
-	wpForTeamsBlogIds?: number[];
-	subscribedListFeedIds?: number[];
-	route?: string;
-}
-
-function setUp( {
-	subscriptions = [],
-	isAutomattician = false,
-	wpForTeamsBlogIds = [],
-	subscribedListFeedIds = [],
-	route,
-}: SetUp = {} ) {
-	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
-
-	// `isAutomatticianQuery` is `readTeamsQuery` plus a `select`, so this seeds both.
-	queryClient.setQueryData( isAutomatticianQuery().queryKey, {
-		number: isAutomattician ? 1 : 0,
-		teams: isAutomattician ? [ { slug: 'a8c', title: 'Automattic' } ] : [],
-	} );
-
-	queryClient.setQueryData( getSiteSubscriptionsQueryKey(), {
-		pages: [ { subscriptions, totalCount: subscriptions.length } ],
-		pageParams: [ 1 ],
-	} );
-
-	queryClient.setQueryData( readSubscribedListsQuery().queryKey, {
-		lists: [
-			{
-				ID: 1,
-				title: 'Test List',
-				slug: 'test-list',
-				description: 'A test list',
-				owner: 'test-user',
-				is_owner: false,
-				is_public: true,
-				feeds: subscribedListFeedIds.map( ( feed_id ) => ( {
-					feed_id,
-					unseen_count: 0,
-				} ) ),
-			},
-		],
-	} );
-
-	const state = {
-		currentUser: { id: USER_ID },
-		sites: {
-			items: Object.fromEntries(
-				wpForTeamsBlogIds.map( ( id ) => [ id, { options: { is_wpforteams_site: true } } ] )
-			),
-		},
-		route: { path: { current: route ?? null } },
-	};
-	const store = createStore( () => state );
-
-	return function Wrapper( { children }: { children: ReactNode } ) {
-		return (
-			<QueryClientProvider client={ queryClient }>
-				<Provider store={ store }>{ children }</Provider>
-			</QueryClientProvider>
-		);
-	};
-}
-
-const subscription: Subscription = {
-	feed_ID: FEED_ID,
-	blog_ID: BLOG_ID,
-	is_following: true,
-};
-
-const organizationSubscription: Subscription = {
-	...subscription,
-	organization_id: ORG_ID,
-};
+import {
+	BLOG_ID,
+	FEED_ID,
+	organizationSubscription,
+	createSeenPostsWrapper,
+	subscription,
+} from './fixtures';
 
 describe( 'useIsSeenEnabled', () => {
 	it( 'returns true when user is subscribed to a feed', () => {
 		const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-			wrapper: setUp( { subscriptions: [ organizationSubscription ] } ),
+			wrapper: createSeenPostsWrapper( { subscriptions: [ organizationSubscription ] } ),
 		} );
 
 		expect( result.current ).toBe( true );
@@ -109,7 +22,7 @@ describe( 'useIsSeenEnabled', () => {
 
 	it( 'returns false when user is not subscribed to a feed', () => {
 		const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID + 1 } ), {
-			wrapper: setUp( { subscriptions: [ organizationSubscription ] } ),
+			wrapper: createSeenPostsWrapper( { subscriptions: [ organizationSubscription ] } ),
 		} );
 
 		expect( result.current ).toBe( false );
@@ -118,7 +31,7 @@ describe( 'useIsSeenEnabled', () => {
 	describe( 'regular users', () => {
 		it( 'returns false when user is subscribed to a feed that is not a P2', () => {
 			const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-				wrapper: setUp( { subscriptions: [ subscription ] } ),
+				wrapper: createSeenPostsWrapper( { subscriptions: [ subscription ] } ),
 			} );
 
 			expect( result.current ).toBe( false );
@@ -126,7 +39,7 @@ describe( 'useIsSeenEnabled', () => {
 
 		it( 'returns false on a P2 the user does not subscribe to', () => {
 			const { result } = renderHook( () => useIsSeenEnabled( { blogId: BLOG_ID } ), {
-				wrapper: setUp( { wpForTeamsBlogIds: [ BLOG_ID ] } ),
+				wrapper: createSeenPostsWrapper( { wpForTeamsBlogIds: [ BLOG_ID ] } ),
 			} );
 
 			expect( result.current ).toBe( false );
@@ -136,7 +49,10 @@ describe( 'useIsSeenEnabled', () => {
 			const { result } = renderHook(
 				() => useIsSeenEnabled( { feedId: FEED_ID, blogId: BLOG_ID } ),
 				{
-					wrapper: setUp( { subscriptions: [ subscription ], wpForTeamsBlogIds: [ BLOG_ID ] } ),
+					wrapper: createSeenPostsWrapper( {
+						subscriptions: [ subscription ],
+						wpForTeamsBlogIds: [ BLOG_ID ],
+					} ),
 				}
 			);
 
@@ -145,7 +61,7 @@ describe( 'useIsSeenEnabled', () => {
 
 		it( 'returns false for an organization feed the user no longer follows', () => {
 			const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-				wrapper: setUp( {
+				wrapper: createSeenPostsWrapper( {
 					subscriptions: [ { ...organizationSubscription, is_following: false } ],
 				} ),
 			} );
@@ -155,7 +71,7 @@ describe( 'useIsSeenEnabled', () => {
 
 		it( 'returns true when user is subscribed to an organization feed', () => {
 			const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-				wrapper: setUp( { subscriptions: [ organizationSubscription ] } ),
+				wrapper: createSeenPostsWrapper( { subscriptions: [ organizationSubscription ] } ),
 			} );
 
 			expect( result.current ).toBe( true );
@@ -165,7 +81,10 @@ describe( 'useIsSeenEnabled', () => {
 	describe( 'Automatticians', () => {
 		it( 'returns true when user is subscribed to a feed that is not a P2', () => {
 			const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-				wrapper: setUp( { subscriptions: [ subscription ], isAutomattician: true } ),
+				wrapper: createSeenPostsWrapper( {
+					subscriptions: [ subscription ],
+					isAutomattician: true,
+				} ),
 			} );
 
 			expect( result.current ).toBe( true );
@@ -173,7 +92,10 @@ describe( 'useIsSeenEnabled', () => {
 
 		it( 'returns true when a user is not subscribed to a P2', () => {
 			const { result } = renderHook( () => useIsSeenEnabled( { blogId: BLOG_ID } ), {
-				wrapper: setUp( { wpForTeamsBlogIds: [ BLOG_ID ], isAutomattician: true } ),
+				wrapper: createSeenPostsWrapper( {
+					wpForTeamsBlogIds: [ BLOG_ID ],
+					isAutomattician: true,
+				} ),
 			} );
 
 			expect( result.current ).toBe( true );
@@ -181,7 +103,7 @@ describe( 'useIsSeenEnabled', () => {
 
 		it( 'returns true when a user is not subscribed to an organization feed', () => {
 			const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-				wrapper: setUp( {
+				wrapper: createSeenPostsWrapper( {
 					subscriptions: [ { ...organizationSubscription, is_following: false } ],
 					isAutomattician: true,
 				} ),
@@ -196,7 +118,7 @@ describe( 'useIsSeenEnabled', () => {
 			const { result } = renderHook(
 				() => useIsSeenEnabled( { feedId: FEED_ID, blogId: BLOG_ID } ),
 				{
-					wrapper: setUp( {
+					wrapper: createSeenPostsWrapper( {
 						wpForTeamsBlogIds: [ BLOG_ID ],
 						subscribedListFeedIds: [ FEED_ID + 1 ],
 					} ),
@@ -208,7 +130,7 @@ describe( 'useIsSeenEnabled', () => {
 
 		it( 'returns false for a non-P2 feed in a subscribed list for a regular user', () => {
 			const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-				wrapper: setUp( { subscribedListFeedIds: [ FEED_ID ] } ),
+				wrapper: createSeenPostsWrapper( { subscribedListFeedIds: [ FEED_ID ] } ),
 			} );
 
 			expect( result.current ).toBe( false );
@@ -218,7 +140,7 @@ describe( 'useIsSeenEnabled', () => {
 			const { result } = renderHook(
 				() => useIsSeenEnabled( { feedId: FEED_ID, blogId: BLOG_ID } ),
 				{
-					wrapper: setUp( {
+					wrapper: createSeenPostsWrapper( {
 						wpForTeamsBlogIds: [ BLOG_ID ],
 						subscribedListFeedIds: [ FEED_ID ],
 					} ),
@@ -230,7 +152,10 @@ describe( 'useIsSeenEnabled', () => {
 
 		it( 'returns false for an automattician on a feed not in any subscribed list', () => {
 			const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-				wrapper: setUp( { isAutomattician: true, subscribedListFeedIds: [ FEED_ID + 1 ] } ),
+				wrapper: createSeenPostsWrapper( {
+					isAutomattician: true,
+					subscribedListFeedIds: [ FEED_ID + 1 ],
+				} ),
 			} );
 
 			expect( result.current ).toBe( false );
@@ -238,30 +163,11 @@ describe( 'useIsSeenEnabled', () => {
 
 		it( 'returns true for an automattician on any feed in a subscribed list', () => {
 			const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-				wrapper: setUp( { isAutomattician: true, subscribedListFeedIds: [ FEED_ID ] } ),
+				wrapper: createSeenPostsWrapper( {
+					isAutomattician: true,
+					subscribedListFeedIds: [ FEED_ID ],
+				} ),
 			} );
-
-			expect( result.current ).toBe( true );
-		} );
-	} );
-
-	describe( 'post shape', () => {
-		const eligible = { subscriptions: [ organizationSubscription ] };
-
-		it( 'returns true for an usubscribed post carrying the seen flag', () => {
-			const { result } = renderHook(
-				() => useIsSeenEnabled( { feedId: FEED_ID, post: { is_seen: false } } ),
-				{ wrapper: setUp() }
-			);
-
-			expect( result.current ).toBe( false );
-		} );
-
-		it( 'returns true for a subscribed post carrying the seen flag', () => {
-			const { result } = renderHook(
-				() => useIsSeenEnabled( { feedId: FEED_ID, post: { is_seen: false } } ),
-				{ wrapper: setUp( eligible ) }
-			);
 
 			expect( result.current ).toBe( true );
 		} );
@@ -275,7 +181,7 @@ describe( 'useIsSeenEnabled', () => {
 			( route ) => {
 				const { result } = renderHook(
 					() => useIsSeenEnabled( { feedId: FEED_ID, post: { is_seen: true } } ),
-					{ wrapper: setUp( { ...eligible, route } ) }
+					{ wrapper: createSeenPostsWrapper( { ...eligible, route } ) }
 				);
 
 				expect( result.current ).toBe( false );
@@ -286,7 +192,7 @@ describe( 'useIsSeenEnabled', () => {
 			'returns false on %s for an automattician',
 			( route ) => {
 				const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-					wrapper: setUp( { isAutomattician: true, route } ),
+					wrapper: createSeenPostsWrapper( { isAutomattician: true, route } ),
 				} );
 
 				expect( result.current ).toBe( false );
@@ -295,7 +201,7 @@ describe( 'useIsSeenEnabled', () => {
 
 		it( 'returns true on non-disabled route route when the user is otherwise eligible', () => {
 			const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-				wrapper: setUp( { ...eligible, route: '/reader' } ),
+				wrapper: createSeenPostsWrapper( { ...eligible, route: '/reader' } ),
 			} );
 
 			expect( result.current ).toBe( true );

--- a/client/reader/data/seen-posts/test/use-is-seen-visible.test.tsx
+++ b/client/reader/data/seen-posts/test/use-is-seen-visible.test.tsx
@@ -12,7 +12,7 @@ const eligible = { subscriptions: [ a8cSubscription ] };
 const afkPost = {
 	site_is_private: true,
 	author: { login: AUTHOR },
-	tags: { afk: {}, 'afk-vacation': {}, [ `afk-${ AUTHOR }` ]: {} },
+	tags: { afk: { slug: 'afk' } },
 };
 
 describe( 'useIsSeenVisible', () => {

--- a/client/reader/data/seen-posts/test/use-is-seen-visible.test.tsx
+++ b/client/reader/data/seen-posts/test/use-is-seen-visible.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+import { useIsSeenVisible } from '../use-is-seen-visible';
+import { AUTOMATTIC_ORG_ID, FEED_ID, createSeenPostsWrapper, subscription } from './fixtures';
+import type { Subscription } from './fixtures';
+
+const AUTHOR = 'user_name';
+const a8cSubscription: Subscription = { ...subscription, organization_id: AUTOMATTIC_ORG_ID };
+const eligible = { subscriptions: [ a8cSubscription ] };
+const afkPost = {
+	site_is_private: true,
+	author: { login: AUTHOR },
+	tags: { afk: {}, 'afk-vacation': {}, [ `afk-${ AUTHOR }` ]: {} },
+};
+
+describe( 'useIsSeenVisible', () => {
+	it( 'returns false when the seen feature is unavailable', () => {
+		const { result } = renderHook(
+			() => useIsSeenVisible( { feedId: FEED_ID, post: { is_seen: true } } ),
+			{ wrapper: createSeenPostsWrapper() }
+		);
+
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'returns false for an unseen post', () => {
+		const { result } = renderHook(
+			() => useIsSeenVisible( { feedId: FEED_ID, post: { is_seen: false } } ),
+			{ wrapper: createSeenPostsWrapper( eligible ) }
+		);
+
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'returns false when the post carries no seen flag', () => {
+		const { result } = renderHook( () => useIsSeenVisible( { feedId: FEED_ID } ), {
+			wrapper: createSeenPostsWrapper( eligible ),
+		} );
+
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'returns true for a post carrying the seen flag', () => {
+		const { result } = renderHook(
+			() => useIsSeenVisible( { feedId: FEED_ID, post: { is_seen: true } } ),
+			{ wrapper: createSeenPostsWrapper( eligible ) }
+		);
+
+		expect( result.current ).toBe( true );
+	} );
+
+	describe( 'AFK posts', () => {
+		it( 'returns true for an AFK post even though it cannot be marked as seen', () => {
+			const { result } = renderHook( () => useIsSeenVisible( { feedId: FEED_ID, post: afkPost } ), {
+				wrapper: createSeenPostsWrapper( eligible ),
+			} );
+
+			expect( result.current ).toBe( true );
+		} );
+
+		it( 'defers to the seen flag for an AFK post on a public Automattic blog', () => {
+			const post = { ...afkPost, site_is_private: false, is_seen: false };
+			const { result } = renderHook( () => useIsSeenVisible( { feedId: FEED_ID, post } ), {
+				wrapper: createSeenPostsWrapper( eligible ),
+			} );
+
+			expect( result.current ).toBe( false );
+		} );
+	} );
+} );

--- a/client/reader/data/seen-posts/use-can-mark-seen.ts
+++ b/client/reader/data/seen-posts/use-can-mark-seen.ts
@@ -1,4 +1,4 @@
-import { useSiteSubscriptionOrganizationId } from 'calypso/reader/data/site-subscriptions';
+import { useOrganizationId } from 'calypso/reader/data/site-subscriptions/use-follow-selectors';
 import { SeenArgs, useIsSeenEnabled, isPostAnAFKPost } from './use-is-seen-enabled';
 
 /**
@@ -6,7 +6,7 @@ import { SeenArgs, useIsSeenEnabled, isPostAnAFKPost } from './use-is-seen-enabl
  */
 export function useCanMarkSeen( { feedId, blogId, post }: SeenArgs ): boolean {
 	const isSeenEnabled = useIsSeenEnabled( { feedId, blogId } );
-	const organizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
+	const organizationId = useOrganizationId( feedId, blogId );
 
 	if ( ! isSeenEnabled ) {
 		return false;

--- a/client/reader/data/seen-posts/use-can-mark-seen.ts
+++ b/client/reader/data/seen-posts/use-can-mark-seen.ts
@@ -1,0 +1,20 @@
+import { useSiteSubscriptionOrganizationId } from 'calypso/reader/data/site-subscriptions';
+import { SeenArgs, useIsSeenEnabled, isPostAnAFKPost } from './use-is-seen-enabled';
+
+/**
+ * Returns true if the user can mark a post as seen, false otherwise.
+ */
+export function useCanMarkSeen( { feedId, blogId, post }: SeenArgs ): boolean {
+	const isSeenEnabled = useIsSeenEnabled( { feedId, blogId } );
+	const organizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
+
+	if ( ! isSeenEnabled ) {
+		return false;
+	}
+
+	if ( isPostAnAFKPost( organizationId, post ) ) {
+		return false;
+	}
+
+	return true;
+}

--- a/client/reader/data/seen-posts/use-is-seen-enabled.ts
+++ b/client/reader/data/seen-posts/use-is-seen-enabled.ts
@@ -15,7 +15,7 @@ const SEEN_DISABLED_ROUTES = [
 	'/reader/conversations/a8c',
 ];
 
-interface SeenArgs {
+export interface SeenArgs {
 	feedId?: number | string; // Route params arrive as strings.
 	blogId?: number | string; // Route params arrive as strings.
 	post?: {
@@ -27,54 +27,9 @@ interface SeenArgs {
 }
 
 /**
- * Returns true if the user can mark a post as seen, false otherwise.
- */
-export function useCanMarkSeen( { feedId, blogId, post }: SeenArgs ): boolean {
-	const isSeenEnabled = useIsSeenEnabled( { feedId, blogId } );
-	const organizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
-
-	if ( ! isSeenEnabled ) {
-		return false;
-	}
-
-	if ( isPostAnAFKPost( organizationId, post ) ) {
-		return false;
-	}
-
-	return true;
-}
-
-/**
- * Returns true if the user can apply the seen state to a post, false otherwise.
- *
- * Mainly we need this because we want to show the seen state for AFK posts, but not allow users to mark them as seen.
- */
-export function useIsSeenVisible( { feedId, blogId, post }: SeenArgs ): boolean {
-	const isSeenEnabled = useIsSeenEnabled( { feedId, blogId } );
-	const organizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
-
-	if ( ! isSeenEnabled ) {
-		return false;
-	}
-
-	if ( isPostAnAFKPost( organizationId, post ) ) {
-		return true;
-	}
-
-	return Boolean( post?.is_seen );
-}
-
-function isPostAnAFKPost( orgId: number, post: SeenArgs[ 'post' ] ): boolean {
-	const isAutomatticPrivate = orgId === AUTOMATTIC_ORG_ID && !! post?.site_is_private;
-	const tags = post?.tags ?? {};
-
-	return isAutomatticPrivate && 'afk' in tags && `afk-${ post?.author?.login }` in tags;
-}
-
-/**
  * Return true if the seen feature is enabled for the current user, false otherwise.
  */
-function useIsSeenEnabled( { feedId, blogId }: SeenArgs ): boolean {
+export function useIsSeenEnabled( { feedId, blogId }: SeenArgs ): boolean {
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 	const isSubscribed = useIsSubscribed( { feedId, blogId } );
 	const organizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
@@ -97,4 +52,11 @@ function useIsSeenEnabled( { feedId, blogId }: SeenArgs ): boolean {
 		// Allow automatticians on all p2's regardless of subscription, or any feed they are subscribed to.
 		( Boolean( isAutomattician ) && ( isP2 || isSubscribed || isInSubscribedList ) )
 	);
+}
+
+export function isPostAnAFKPost( orgId: number, post: SeenArgs[ 'post' ] ): boolean {
+	const isAutomatticPrivate = orgId === AUTOMATTIC_ORG_ID && !! post?.site_is_private;
+	const tags = post?.tags ?? {};
+
+	return isAutomatticPrivate && 'afk' in tags && `afk-${ post?.author?.login }` in tags;
 }

--- a/client/reader/data/seen-posts/use-is-seen-enabled.ts
+++ b/client/reader/data/seen-posts/use-is-seen-enabled.ts
@@ -1,10 +1,11 @@
 import { isAutomatticianQuery, readSubscribedListsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import {
-	useHasSiteSubscriptionOrganization,
 	useIsSubscribed,
+	useSiteSubscriptionOrganizationId,
 } from 'calypso/reader/data/site-subscriptions';
 import { useSelector } from 'calypso/state';
+import { AUTOMATTIC_ORG_ID } from 'calypso/state/reader/organizations/constants';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 
@@ -14,19 +15,73 @@ const SEEN_DISABLED_ROUTES = [
 	'/reader/conversations/a8c',
 ];
 
-interface IsSeenEnabledArgs {
+interface SeenArgs {
 	feedId?: number | string; // Route params arrive as strings.
 	blogId?: number | string; // Route params arrive as strings.
-	post?: { is_seen?: boolean };
+	post?: {
+		is_seen?: boolean;
+		tags?: Record< string, unknown >;
+		author?: { login?: string };
+		site_is_private?: boolean;
+	};
 }
 
 /**
- * Returns true if the user can mark a post as seen.
+ * Returns true if the user can mark a post as seen, false otherwise.
  */
-export function useIsSeenEnabled( { feedId, blogId, post }: IsSeenEnabledArgs ): boolean {
+export function useIsSeenEnabled( { feedId, blogId, post }: SeenArgs ): boolean {
+	const isFeatureEnabled = useIsSeenFeatureEnabled( { feedId, blogId } );
+	const organizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
+
+	if ( ! isFeatureEnabled ) {
+		return false;
+	}
+
+	if ( isPostAnAFKPost( organizationId, post ) ) {
+		return false;
+	}
+
+	if ( post?.is_seen ) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Returns true if the user can apply the seen state to a post, false otherwise.
+ *
+ * Mainly we need this because we want to show the seen state for AFK posts, but not allow users to mark them as seen.
+ */
+export function useIsSeenVisible( { feedId, blogId, post }: SeenArgs ): boolean {
+	const isFeatureEnabled = useIsSeenFeatureEnabled( { feedId, blogId } );
+	const organizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
+
+	if ( ! isFeatureEnabled ) {
+		return false;
+	}
+
+	if ( isPostAnAFKPost( organizationId, post ) ) {
+		return true;
+	}
+
+	return Boolean( post?.is_seen );
+}
+
+function isPostAnAFKPost( orgId: number, post: SeenArgs[ 'post' ] ): boolean {
+	const isAutomatticPrivate = orgId === AUTOMATTIC_ORG_ID && !! post?.site_is_private;
+	const tags = post?.tags ?? {};
+
+	return isAutomatticPrivate && 'afk' in tags && `afk-${ post?.author?.login }` in tags;
+}
+
+/**
+ * Return true if the seen feature is enabled for the current user, false otherwise.
+ */
+export function useIsSeenFeatureEnabled( { feedId, blogId }: SeenArgs ): boolean {
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 	const isSubscribed = useIsSubscribed( { feedId, blogId } );
-	const hasOrganization = useHasSiteSubscriptionOrganization( feedId, blogId );
+	const organizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
 	const isWPForTeamsItem = useSelector( ( state ) => isSiteWPForTeams( state, Number( blogId ) ) );
 	const { data: subscribedLists } = useQuery( readSubscribedListsQuery() );
 	const currentRoute = useSelector( getCurrentRoute );
@@ -35,12 +90,7 @@ export function useIsSeenEnabled( { feedId, blogId, post }: IsSeenEnabledArgs ):
 		return false;
 	}
 
-	// If the post is already marked as seen, then prefer that over the subscription check.
-	if ( post?.is_seen ) {
-		return true;
-	}
-
-	const isP2 = hasOrganization || Boolean( isWPForTeamsItem );
+	const isP2 = Boolean( organizationId ) || Boolean( isWPForTeamsItem );
 	const isInSubscribedList = !! subscribedLists?.lists.some( ( list ): boolean =>
 		list.feeds.some( ( feed ): boolean => feed.feed_id === Number( feedId ) )
 	);

--- a/client/reader/data/seen-posts/use-is-seen-enabled.ts
+++ b/client/reader/data/seen-posts/use-is-seen-enabled.ts
@@ -1,9 +1,7 @@
 import { isAutomatticianQuery, readSubscribedListsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
-import {
-	useIsSubscribed,
-	useSiteSubscriptionOrganizationId,
-} from 'calypso/reader/data/site-subscriptions';
+import { useIsSubscribed } from 'calypso/reader/data/site-subscriptions';
+import { useOrganizationId } from 'calypso/reader/data/site-subscriptions/use-follow-selectors';
 import { useSelector } from 'calypso/state';
 import { AUTOMATTIC_ORG_ID } from 'calypso/state/reader/organizations/constants';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -20,8 +18,7 @@ export interface SeenArgs {
 	blogId?: number | string; // Route params arrive as strings.
 	post?: {
 		is_seen?: boolean;
-		tags?: Record< string, unknown >;
-		author?: { login?: string };
+		tags?: Record< string, { slug?: string } >;
 		site_is_private?: boolean;
 	};
 }
@@ -32,7 +29,7 @@ export interface SeenArgs {
 export function useIsSeenEnabled( { feedId, blogId }: SeenArgs ): boolean {
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 	const isSubscribed = useIsSubscribed( { feedId, blogId } );
-	const organizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
+	const organizationId = useOrganizationId( feedId, blogId );
 	const isWPForTeamsItem = useSelector( ( state ) => isSiteWPForTeams( state, Number( blogId ) ) );
 	const { data: subscribedLists } = useQuery( readSubscribedListsQuery() );
 	const currentRoute = useSelector( getCurrentRoute );
@@ -55,8 +52,14 @@ export function useIsSeenEnabled( { feedId, blogId }: SeenArgs ): boolean {
 }
 
 export function isPostAnAFKPost( orgId: number, post: SeenArgs[ 'post' ] ): boolean {
-	const isAutomatticPrivate = orgId === AUTOMATTIC_ORG_ID && !! post?.site_is_private;
-	const tags = post?.tags ?? {};
+	if ( ! post ) {
+		return false;
+	}
 
-	return isAutomatticPrivate && 'afk' in tags && `afk-${ post?.author?.login }` in tags;
+	const isAutomatticPrivate = orgId === AUTOMATTIC_ORG_ID && !! post?.site_is_private;
+	const isAFKPost = Object.entries( post.tags ?? {} ).some( ( [ name, tag ] ) => {
+		return ( tag.slug ?? name ).toLowerCase() === 'afk';
+	} );
+
+	return isAutomatticPrivate && isAFKPost;
 }

--- a/client/reader/data/seen-posts/use-is-seen-enabled.ts
+++ b/client/reader/data/seen-posts/use-is-seen-enabled.ts
@@ -29,19 +29,15 @@ interface SeenArgs {
 /**
  * Returns true if the user can mark a post as seen, false otherwise.
  */
-export function useIsSeenEnabled( { feedId, blogId, post }: SeenArgs ): boolean {
-	const isFeatureEnabled = useIsSeenFeatureEnabled( { feedId, blogId } );
+export function useCanMarkSeen( { feedId, blogId, post }: SeenArgs ): boolean {
+	const isSeenEnabled = useIsSeenEnabled( { feedId, blogId } );
 	const organizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
 
-	if ( ! isFeatureEnabled ) {
+	if ( ! isSeenEnabled ) {
 		return false;
 	}
 
 	if ( isPostAnAFKPost( organizationId, post ) ) {
-		return false;
-	}
-
-	if ( post?.is_seen ) {
 		return false;
 	}
 
@@ -54,10 +50,10 @@ export function useIsSeenEnabled( { feedId, blogId, post }: SeenArgs ): boolean 
  * Mainly we need this because we want to show the seen state for AFK posts, but not allow users to mark them as seen.
  */
 export function useIsSeenVisible( { feedId, blogId, post }: SeenArgs ): boolean {
-	const isFeatureEnabled = useIsSeenFeatureEnabled( { feedId, blogId } );
+	const isSeenEnabled = useIsSeenEnabled( { feedId, blogId } );
 	const organizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
 
-	if ( ! isFeatureEnabled ) {
+	if ( ! isSeenEnabled ) {
 		return false;
 	}
 
@@ -78,7 +74,7 @@ function isPostAnAFKPost( orgId: number, post: SeenArgs[ 'post' ] ): boolean {
 /**
  * Return true if the seen feature is enabled for the current user, false otherwise.
  */
-export function useIsSeenFeatureEnabled( { feedId, blogId }: SeenArgs ): boolean {
+function useIsSeenEnabled( { feedId, blogId }: SeenArgs ): boolean {
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 	const isSubscribed = useIsSubscribed( { feedId, blogId } );
 	const organizationId = useSiteSubscriptionOrganizationId( feedId, blogId );

--- a/client/reader/data/seen-posts/use-is-seen-visible.ts
+++ b/client/reader/data/seen-posts/use-is-seen-visible.ts
@@ -1,0 +1,22 @@
+import { useSiteSubscriptionOrganizationId } from 'calypso/reader/data/site-subscriptions';
+import { SeenArgs, useIsSeenEnabled, isPostAnAFKPost } from './use-is-seen-enabled';
+
+/**
+ * Returns true if the user can apply the seen state to a post, false otherwise.
+ *
+ * Mainly we need this because we want to show the seen state for AFK posts, but not allow users to mark them as seen.
+ */
+export function useIsSeenVisible( { feedId, blogId, post }: SeenArgs ): boolean {
+	const isSeenEnabled = useIsSeenEnabled( { feedId, blogId } );
+	const organizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
+
+	if ( ! isSeenEnabled ) {
+		return false;
+	}
+
+	if ( isPostAnAFKPost( organizationId, post ) ) {
+		return true;
+	}
+
+	return Boolean( post?.is_seen );
+}

--- a/client/reader/data/seen-posts/use-is-seen-visible.ts
+++ b/client/reader/data/seen-posts/use-is-seen-visible.ts
@@ -1,4 +1,4 @@
-import { useSiteSubscriptionOrganizationId } from 'calypso/reader/data/site-subscriptions';
+import { useOrganizationId } from 'calypso/reader/data/site-subscriptions/use-follow-selectors';
 import { SeenArgs, useIsSeenEnabled, isPostAnAFKPost } from './use-is-seen-enabled';
 
 /**
@@ -8,7 +8,7 @@ import { SeenArgs, useIsSeenEnabled, isPostAnAFKPost } from './use-is-seen-enabl
  */
 export function useIsSeenVisible( { feedId, blogId, post }: SeenArgs ): boolean {
 	const isSeenEnabled = useIsSeenEnabled( { feedId, blogId } );
-	const organizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
+	const organizationId = useOrganizationId( feedId, blogId );
 
 	if ( ! isSeenEnabled ) {
 		return false;

--- a/client/reader/data/site-subscriptions/use-follow-selectors.ts
+++ b/client/reader/data/site-subscriptions/use-follow-selectors.ts
@@ -87,7 +87,10 @@ export const useSubscribedFeedsInfo = () => {
 	return getFeedsInfo( sites );
 };
 
-export const useHasSiteSubscriptionOrganization = ( feedId?: FollowId, blogId?: FollowId ) => {
+export const useSiteSubscriptionOrganizationId = (
+	feedId?: FollowId,
+	blogId?: FollowId
+): number => {
 	const { data } = useSiteSubscriptions();
 	const feedFollow = hasId( feedId )
 		? getSiteSubscriptionByFeedIdFromData( data, feedId )
@@ -96,5 +99,5 @@ export const useHasSiteSubscriptionOrganization = ( feedId?: FollowId, blogId?: 
 		feedFollow ??
 		( hasId( blogId ) ? getSiteSubscriptionByBlogIdFromData( data, blogId ) : undefined );
 
-	return !! follow?.organization_id;
+	return follow?.organization_id ?? NO_ORG_ID;
 };

--- a/client/reader/data/site-subscriptions/use-follow-selectors.ts
+++ b/client/reader/data/site-subscriptions/use-follow-selectors.ts
@@ -7,6 +7,7 @@ import {
 	getOrganizationSiteSubscriptionsFromData,
 } from '@automattic/api-queries';
 import { NO_ORG_ID } from 'calypso/state/reader/organizations/constants';
+import { useFeedQuery } from '../feed';
 import { useSiteSubscriptions } from './use-site-subscriptions';
 import type { SiteSubscriptionItem } from '@automattic/api-core';
 
@@ -101,3 +102,17 @@ export const useSiteSubscriptionOrganizationId = (
 
 	return follow?.organization_id ?? NO_ORG_ID;
 };
+
+/**
+ * Resolve the organization owning a feed.
+ *
+ * `useSiteSubscriptionOrganizationId` only knows about feeds the viewer follows, so fall back to
+ * the feed record. Without it an Automattician who does not follow an a8c P2 sees `NO_ORG_ID` and
+ * the AFK guard never fires, even though the seen feature is enabled for them via WP For Teams.
+ */
+export function useOrganizationId( feedId?: number | string, blogId?: number | string ): number {
+	const subscriptionOrganizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
+	const { data: feed } = useFeedQuery( subscriptionOrganizationId ? null : feedId );
+
+	return subscriptionOrganizationId || feed?.organization_id || NO_ORG_ID;
+}

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -36,7 +36,7 @@
 	margin-bottom: 15px;
 
 	&.is-seen {
-		opacity: 0.5;
+		opacity: 0.65;
 	}
 
 	&.is-selected,

--- a/client/reader/stream/test/x-post.test.tsx
+++ b/client/reader/stream/test/x-post.test.tsx
@@ -24,7 +24,7 @@ describe( 'CrossPost', () => {
 			<CrossPost
 				post={ post }
 				postKey={ { feedId: 100, postId: 200 } }
-				isSeenEnabled
+				canMarkSeen
 				requestMarkAsSeen={ requestMarkAsSeen }
 				handleClick={ jest.fn() }
 			/>
@@ -39,5 +39,53 @@ describe( 'CrossPost', () => {
 			feedItemIds: [ 200 ],
 			globalIds: [ 'x-post-global-id' ],
 		} );
+	} );
+
+	it( 'does not mark the feed item as seen when marking is not allowed', async () => {
+		const user = userEvent.setup();
+		const requestMarkAsSeen = jest.fn();
+		const { container } = render(
+			<CrossPost
+				post={ post }
+				postKey={ { feedId: 100, postId: 200 } }
+				canMarkSeen={ false }
+				requestMarkAsSeen={ requestMarkAsSeen }
+				handleClick={ jest.fn() }
+			/>
+		);
+
+		await user.click( container.querySelector( 'article' )! );
+
+		expect( requestMarkAsSeen ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders the seen styling when isSeenVisible is true', () => {
+		const { container } = render(
+			<CrossPost
+				post={ post }
+				postKey={ { feedId: 100, postId: 200 } }
+				canMarkSeen={ false }
+				isSeenVisible
+				requestMarkAsSeen={ jest.fn() }
+				handleClick={ jest.fn() }
+			/>
+		);
+
+		expect( container.querySelector( 'article' ) ).toHaveClass( 'is-seen' );
+	} );
+
+	it( 'omits the seen styling when isSeenVisible is false', () => {
+		const { container } = render(
+			<CrossPost
+				post={ { ...post, is_seen: true } }
+				postKey={ { feedId: 100, postId: 200 } }
+				canMarkSeen
+				isSeenVisible={ false }
+				requestMarkAsSeen={ jest.fn() }
+				handleClick={ jest.fn() }
+			/>
+		);
+
+		expect( container.querySelector( 'article' ) ).not.toHaveClass( 'is-seen' );
 	} );
 } );

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -9,7 +9,7 @@ import { createRef, PureComponent } from 'react';
 import UserAvatar from 'calypso/blocks/user-avatar';
 import { useFeedQuery } from 'calypso/reader/data/feed';
 import {
-	useIsSeenEnabled,
+	useCanMarkSeen,
 	useIsSeenVisible,
 	useMarkAsSeenMutation,
 } from 'calypso/reader/data/seen-posts';
@@ -27,7 +27,7 @@ export class CrossPost extends PureComponent {
 		postKey: PropTypes.object,
 		site: PropTypes.object,
 		feed: PropTypes.object,
-		isSeenEnabled: PropTypes.bool,
+		canMarkSeen: PropTypes.bool,
 		isSeenVisible: PropTypes.bool,
 		requestMarkAsSeen: PropTypes.func.isRequired,
 	};
@@ -82,9 +82,9 @@ export class CrossPost extends PureComponent {
 	};
 
 	markAsSeen = () => {
-		const { isSeenEnabled, post, postKey, requestMarkAsSeen } = this.props;
+		const { canMarkSeen, post, postKey, requestMarkAsSeen } = this.props;
 		const feedId = postKey?.feedId || post.feed_ID;
-		if ( ! isSeenEnabled || ! feedId || ! post.feed_item_ID ) {
+		if ( ! canMarkSeen || post.is_seen || ! feedId || ! post.feed_item_ID ) {
 			return;
 		}
 
@@ -236,7 +236,7 @@ export default function CrossPostContainer( props ) {
 	const { data: feedFromSite } = useFeedQuery( feedFromKey ? undefined : resolvedFeedId );
 	const { mutate: requestMarkAsSeen } = useMarkAsSeenMutation();
 	const seenProps = { feedId: resolvedFeedId, blogId: siteId, post: props.post };
-	const isSeenEnabled = useIsSeenEnabled( seenProps );
+	const canMarkSeen = useCanMarkSeen( seenProps );
 	const isSeenVisible = useIsSeenVisible( seenProps );
 
 	return (
@@ -244,7 +244,7 @@ export default function CrossPostContainer( props ) {
 			{ ...props }
 			site={ site }
 			feed={ feedFromKey || feedFromSite }
-			isSeenEnabled={ isSeenEnabled }
+			canMarkSeen={ canMarkSeen }
 			isSeenVisible={ isSeenVisible }
 			requestMarkAsSeen={ requestMarkAsSeen }
 		/>

--- a/client/reader/stream/x-post.jsx
+++ b/client/reader/stream/x-post.jsx
@@ -8,7 +8,11 @@ import PropTypes from 'prop-types';
 import { createRef, PureComponent } from 'react';
 import UserAvatar from 'calypso/blocks/user-avatar';
 import { useFeedQuery } from 'calypso/reader/data/feed';
-import { useIsSeenEnabled, useMarkAsSeenMutation } from 'calypso/reader/data/seen-posts';
+import {
+	useIsSeenEnabled,
+	useIsSeenVisible,
+	useMarkAsSeenMutation,
+} from 'calypso/reader/data/seen-posts';
 import { useSite } from 'calypso/reader/data/site';
 
 /* eslint-disable wpcalypso/jsx-classname-namespace */
@@ -24,6 +28,7 @@ export class CrossPost extends PureComponent {
 		site: PropTypes.object,
 		feed: PropTypes.object,
 		isSeenEnabled: PropTypes.bool,
+		isSeenVisible: PropTypes.bool,
 		requestMarkAsSeen: PropTypes.func.isRequired,
 	};
 
@@ -79,7 +84,7 @@ export class CrossPost extends PureComponent {
 	markAsSeen = () => {
 		const { isSeenEnabled, post, postKey, requestMarkAsSeen } = this.props;
 		const feedId = postKey?.feedId || post.feed_ID;
-		if ( ! isSeenEnabled || post.is_seen || ! feedId || ! post.feed_item_ID ) {
+		if ( ! isSeenEnabled || ! feedId || ! post.feed_item_ID ) {
 			return;
 		}
 
@@ -177,7 +182,7 @@ export class CrossPost extends PureComponent {
 			reader__card: true,
 			'is-x-post': true,
 			'is-selected': this.props.isSelected,
-			'is-seen': this.props.isSeenEnabled && post?.is_seen,
+			'is-seen': this.props.isSeenVisible,
 		} );
 
 		// Remove the x-post text from the title.
@@ -230,11 +235,9 @@ export default function CrossPostContainer( props ) {
 	const resolvedFeedId = feedId || site?.feed_ID;
 	const { data: feedFromSite } = useFeedQuery( feedFromKey ? undefined : resolvedFeedId );
 	const { mutate: requestMarkAsSeen } = useMarkAsSeenMutation();
-	const isSeenEnabled = useIsSeenEnabled( {
-		feedId: resolvedFeedId,
-		blogId: siteId,
-		post: props.post,
-	} );
+	const seenProps = { feedId: resolvedFeedId, blogId: siteId, post: props.post };
+	const isSeenEnabled = useIsSeenEnabled( seenProps );
+	const isSeenVisible = useIsSeenVisible( seenProps );
 
 	return (
 		<LocalizedCrossPost
@@ -242,6 +245,7 @@ export default function CrossPostContainer( props ) {
 			site={ site }
 			feed={ feedFromKey || feedFromSite }
 			isSeenEnabled={ isSeenEnabled }
+			isSeenVisible={ isSeenVisible }
 			requestMarkAsSeen={ requestMarkAsSeen }
 		/>
 	);


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Closes: https://linear.app/a8c/issue/READ-725

## Proposed Changes

Updated `useIsSeenEnabled` hook to 2 hooks, `useIsSeenVisible` and `useCanMarkSeen`. `useIsSeenVisible` tell us when to apply seen styles while `useCanMarkSeen` tell us when can we mark the post as seen. It is mainly needed because for AFK posts we want to apply the seen state but do not call any API calls.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

- By default show AFK posts as seen else on all read feed AFK posts will appear as unread.
- Prevent marking AFK posts as seen else it will decrements the count on UI.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open any feed post.
- Verify on load it auto marks the post as seen.
- Verify seen icon is available on full view to change seen status.
- Verify "Mark as seen" option is available on ellipsis dropdown.
- Verify seen styles are applied based on seen status.
- Open any AFK post.
- Verify on load it doesn't mark the post as seen.
- Verify seen icon is not available on full view.
- Verify "Mark as seen" option is not available on ellipsis dropdown.
- Verify seen styles are always applied.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
