### PR TITLE
Pricing grid: default to new feature gating for plan features

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-plan-differentiators-experiment.test.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-plan-differentiators-experiment.test.ts
@@ -13,9 +13,6 @@ const ELIGIBLE_RESULT = {
 };
 
 describe( 'usePlanDifferentiatorsExperiment', () => {
-	// The hook used to read `is_gating_business_q1` off the site and gate on it. The 2026 gating is
-	// now the server-side default, so the verdict is unconditional and the site context is ignored;
-	// these cases pin that it no longer varies by input.
 	test( 'is eligible in signup before a site exists', () => {
 		const { result } = renderHook( () =>
 			usePlanDifferentiatorsExperiment( { isInSignup: true, siteId: null } )

--- a/client/my-sites/plans-features-main/hooks/test/use-plan-differentiators-experiment.test.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-plan-differentiators-experiment.test.ts
@@ -2,12 +2,7 @@
  * @jest-environment jsdom
  */
 import { renderHook } from '@testing-library/react';
-import { useSelector } from 'calypso/state';
 import usePlanDifferentiatorsExperiment from '../use-plan-differentiators-experiment';
-
-jest.mock( 'calypso/state', () => ( {
-	useSelector: jest.fn(),
-} ) );
 
 const ELIGIBLE_RESULT = {
 	showDifferentiatorHeader: false,
@@ -17,92 +12,23 @@ const ELIGIBLE_RESULT = {
 	isExperimentVariant: true,
 };
 
-const INELIGIBLE_RESULT = {
-	showDifferentiatorHeader: false,
-	useVar42NoAiFeatures: false,
-	showPricingDifferentiationFeaturePills: false,
-	useFocusedNewCopyTaglines: false,
-	isExperimentVariant: false,
-};
-
-function mockSite( isGatingBusinessQ1: boolean | undefined ) {
-	( useSelector as jest.Mock ).mockImplementation( () =>
-		isGatingBusinessQ1 !== undefined
-			? { ID: 123, options: { is_gating_business_q1: isGatingBusinessQ1 } }
-			: null
-	);
-}
-
 describe( 'usePlanDifferentiatorsExperiment', () => {
-	beforeEach( () => jest.clearAllMocks() );
+	// The hook used to read `is_gating_business_q1` off the site and gate on it. The 2026 gating is
+	// now the server-side default, so the verdict is unconditional and the site context is ignored;
+	// these cases pin that it no longer varies by input.
+	test( 'is eligible in signup before a site exists', () => {
+		const { result } = renderHook( () =>
+			usePlanDifferentiatorsExperiment( { isInSignup: true, siteId: null } )
+		);
 
-	describe( 'signup flows (no siteId yet)', () => {
-		test( 'is eligible when isInSignup=true and siteId is null', () => {
-			mockSite( undefined );
-			const { result } = renderHook( () =>
-				usePlanDifferentiatorsExperiment( { isInSignup: true, siteId: null } )
-			);
-			expect( result.current ).toEqual( ELIGIBLE_RESULT );
-		} );
-
-		test( 'is eligible when isInSignup=true and siteId is undefined', () => {
-			mockSite( undefined );
-			const { result } = renderHook( () =>
-				usePlanDifferentiatorsExperiment( { isInSignup: true } )
-			);
-			expect( result.current ).toEqual( ELIGIBLE_RESULT );
-		} );
+		expect( result.current ).toEqual( ELIGIBLE_RESULT );
 	} );
 
-	describe( 'existing sites in signup flows', () => {
-		test( 'is not eligible when isInSignup=true but siteId is set and gating flag is absent', () => {
-			mockSite( false );
-			const { result } = renderHook( () =>
-				usePlanDifferentiatorsExperiment( { isInSignup: true, siteId: 123 } )
-			);
-			expect( result.current ).toEqual( INELIGIBLE_RESULT );
-		} );
+	test( 'is eligible for an existing site, whichever stickers it carries', () => {
+		const { result } = renderHook( () =>
+			usePlanDifferentiatorsExperiment( { isInSignup: false, siteId: 123 } )
+		);
 
-		test( 'is eligible when isInSignup=true, siteId is set, and gating flag is true', () => {
-			mockSite( true );
-			const { result } = renderHook( () =>
-				usePlanDifferentiatorsExperiment( { isInSignup: true, siteId: 123 } )
-			);
-			expect( result.current ).toEqual( ELIGIBLE_RESULT );
-		} );
-	} );
-
-	describe( 'logged-in flows (not in signup)', () => {
-		test( 'is eligible when site has the gating flag', () => {
-			mockSite( true );
-			const { result } = renderHook( () =>
-				usePlanDifferentiatorsExperiment( { isInSignup: false, siteId: 123 } )
-			);
-			expect( result.current ).toEqual( ELIGIBLE_RESULT );
-		} );
-
-		test( 'is not eligible when site does not have the gating flag', () => {
-			mockSite( false );
-			const { result } = renderHook( () =>
-				usePlanDifferentiatorsExperiment( { isInSignup: false, siteId: 123 } )
-			);
-			expect( result.current ).toEqual( INELIGIBLE_RESULT );
-		} );
-
-		test( 'is not eligible when site is not found', () => {
-			mockSite( undefined );
-			const { result } = renderHook( () =>
-				usePlanDifferentiatorsExperiment( { isInSignup: false, siteId: 123 } )
-			);
-			expect( result.current ).toEqual( INELIGIBLE_RESULT );
-		} );
-
-		test( 'is not eligible when there is no siteId', () => {
-			mockSite( undefined );
-			const { result } = renderHook( () =>
-				usePlanDifferentiatorsExperiment( { isInSignup: false } )
-			);
-			expect( result.current ).toEqual( INELIGIBLE_RESULT );
-		} );
+		expect( result.current ).toEqual( ELIGIBLE_RESULT );
 	} );
 } );

--- a/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-differentiators-experiment.ts
@@ -1,7 +1,3 @@
-import { useSelector } from 'calypso/state';
-import getSite from 'calypso/state/sites/selectors/get-site';
-import type { IAppState } from 'calypso/state/types';
-
 type PlanDifferentiatorsResult = {
 	/**
 	 * When true, show the differentiator header (3 bullet points). Currently disabled.
@@ -31,17 +27,11 @@ interface UsePlanDifferentiatorsParams {
 	siteId?: number | null;
 }
 
-function usePlanDifferentiatorsExperiment( {
-	isInSignup,
-	siteId,
-}: UsePlanDifferentiatorsParams ): PlanDifferentiatorsResult {
-	const site = useSelector( ( state: IAppState ) => getSite( state, siteId ) );
-
-	const hasGatingFlag = !! site?.options?.is_gating_business_q1;
-
-	// New-site signups (no siteId yet) are always eligible.
-	// Flows operating on an existing site are eligible only when the gating flag is set.
-	const isEligible = ( isInSignup && ! siteId ) || hasGatingFlag;
+function usePlanDifferentiatorsExperiment(
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	params: UsePlanDifferentiatorsParams
+): PlanDifferentiatorsResult {
+	const isEligible = true;
 
 	return {
 		showDifferentiatorHeader: false,

--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -25,6 +25,7 @@ import {
 	isPremiumPlan,
 	isFreePlan,
 	isPersonalPlan,
+	isWpComPlan,
 	planHasFeature,
 	getPlanClass,
 } from '@automattic/calypso-products';
@@ -418,11 +419,15 @@ const useGridPlans: UseGridPlansType = ( {
 		const isCurrentPlan = sitePlanSlug ? isSamePlan( sitePlanSlug, planSlug ) : false;
 
 		let tagline: TranslateResult = '';
+		let hasIntentSpecificTagline = false;
 		if ( 'plans-newsletter' === intent ) {
 			tagline = planConstantObj.getNewsletterTagLine?.() ?? '';
+			hasIntentSpecificTagline = !! tagline;
 		} else if ( 'plans-blog-onboarding' === intent ) {
 			tagline = planConstantObj.getBlogOnboardingTagLine?.() ?? '';
+			hasIntentSpecificTagline = !! tagline;
 		} else if ( 'plans-woo-hosting-solutions' === intent ) {
+			hasIntentSpecificTagline = true;
 			if ( isPersonalPlan( planSlug ) ) {
 				tagline = translate(
 					'Try out a store idea with low commitment. Custom domain and basic tools.'
@@ -441,12 +446,19 @@ const useGridPlans: UseGridPlansType = ( {
 				);
 			} else {
 				tagline = planConstantObj.getPlanTagline?.() ?? '';
+				hasIntentSpecificTagline = false;
 			}
 		} else {
 			tagline = planConstantObj.getPlanTagline?.() ?? '';
 		}
 
-		if ( useFocusedNewCopyTaglines ) {
+		/*
+		 * The focused copy is written for the standard WordPress.com plans, so it only replaces a
+		 * tagline that is not already specific to this surface: an intent that supplies its own
+		 * (newsletter, blog onboarding, Woo hosting solutions), or a plan outside the wpcom group
+		 * that overrides getPlanTagline -- P2 Free, which is TYPE_FREE but GROUP_P2, is the live case.
+		 */
+		if ( useFocusedNewCopyTaglines && ! hasIntentSpecificTagline && isWpComPlan( planSlug ) ) {
 			const existingTagline = tagline;
 			if ( isFreePlan( planSlug ) ) {
 				tagline =


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes MARTECH-3024

## Proposed Changes

* Make the new feature descriptions and the lists the default for WordPress.com plans

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Part of the rollout of the new feature packaging

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the /plans/{site} page for a site with legacy features and confirm that the features list matches the one displayed on /setup/onboarding/plans

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
