### PR TITLE
Unseen Posts: Allow a11n's to use mark as seen on all p2 posts even unsubscribed ones

### DIFF
--- a/client/blocks/reader-feed-header/follow.tsx
+++ b/client/blocks/reader-feed-header/follow.tsx
@@ -33,6 +33,7 @@ interface ReaderFeed {
 	subscription_id?: number;
 	blog_owner?: string;
 	name?: string;
+	organization_id?: number;
 }
 
 interface ReaderSite {
@@ -57,7 +58,11 @@ export default function ReaderFeedHeaderFollow( props: ReaderFeedHeaderFollowPro
 	const resolvedSiteId = siteId ?? resolvedFeed?.blog_ID;
 	const followFeedId = resolvedFeed?.feed_ID;
 	const reduxFollowing = useIsSubscribed( { feedUrl: followFeedUrl } );
-	const canMarkSeen = useCanMarkSeen( { feedId: followFeedId, blogId: resolvedSiteId } );
+	const canMarkSeen = useCanMarkSeen( {
+		feedId: followFeedId,
+		blogId: resolvedSiteId,
+		organizationId: resolvedFeed?.organization_id,
+	} );
 	const {
 		isRecommended,
 		isUpdating: isRecommendationPending,

--- a/client/reader/data/seen-posts/test/fixtures/index.tsx
+++ b/client/reader/data/seen-posts/test/fixtures/index.tsx
@@ -1,14 +1,13 @@
 import {
 	getSiteSubscriptionsQueryKey,
 	isAutomatticianQuery,
-	readFeedQuery,
 	readSubscribedListsQuery,
 } from '@automattic/api-queries';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import { AUTOMATTIC_ORG_ID, P2_ORG_ID } from 'calypso/state/reader/organizations/constants';
-import type { ReadFeedItem, SiteSubscriptionItem } from '@automattic/api-core';
+import type { SiteSubscriptionItem } from '@automattic/api-core';
 import type { ReactNode } from 'react';
 
 export const USER_ID = 10;
@@ -23,8 +22,6 @@ interface SeenPostsWrapperOptions {
 	isAutomattician?: boolean;
 	wpForTeamsBlogIds?: number[];
 	subscribedListFeedIds?: number[];
-	/** Feed records to seed, so an unsubscribed feed still resolves an organization. */
-	feedOrganizationIds?: Record< number, number >;
 	route?: string;
 }
 
@@ -36,7 +33,6 @@ export function createSeenPostsWrapper( {
 	isAutomattician = false,
 	wpForTeamsBlogIds = [],
 	subscribedListFeedIds = [],
-	feedOrganizationIds = {},
 	route,
 }: SeenPostsWrapperOptions = {} ) {
 	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
@@ -68,14 +64,6 @@ export function createSeenPostsWrapper( {
 				} ) ),
 			},
 		],
-	} );
-
-	Object.entries( feedOrganizationIds ).forEach( ( [ feedId, organizationId ] ) => {
-		queryClient.setQueryData( readFeedQuery( Number( feedId ) ).queryKey, {
-			feed_ID: String( feedId ),
-			blog_ID: String( BLOG_ID ),
-			organization_id: organizationId,
-		} as ReadFeedItem );
 	} );
 
 	const state = {

--- a/client/reader/data/seen-posts/test/use-can-mark-seen.test.tsx
+++ b/client/reader/data/seen-posts/test/use-can-mark-seen.test.tsx
@@ -15,9 +15,11 @@ import type { Subscription } from './fixtures';
 const a8cSubscription: Subscription = { ...subscription, organization_id: AUTOMATTIC_ORG_ID };
 const eligible = { subscriptions: [ a8cSubscription ] };
 
+const p2Post = { organization_id: AUTOMATTIC_ORG_ID };
+
 // An AFK post satisfies both halves of the wpcom `is_automattic_private()` guard.
 const afkPost = {
-	organization_id: AUTOMATTIC_ORG_ID,
+	...p2Post,
 	site_is_private: true,
 	tags: { afk: { slug: 'afk' } },
 };
@@ -32,7 +34,7 @@ describe( 'useCanMarkSeen', () => {
 	} );
 
 	it( 'returns true when the seen feature is available and the post is not an AFK post', () => {
-		const { result } = renderHook( () => useCanMarkSeen( { feedId: FEED_ID } ), {
+		const { result } = renderHook( () => useCanMarkSeen( { feedId: FEED_ID, post: p2Post } ), {
 			wrapper: createSeenPostsWrapper( eligible ),
 		} );
 

--- a/client/reader/data/seen-posts/test/use-can-mark-seen.test.tsx
+++ b/client/reader/data/seen-posts/test/use-can-mark-seen.test.tsx
@@ -12,13 +12,13 @@ import {
 } from './fixtures';
 import type { Subscription } from './fixtures';
 
-const AUTHOR = 'test_user';
 const a8cSubscription: Subscription = { ...subscription, organization_id: AUTOMATTIC_ORG_ID };
 const eligible = { subscriptions: [ a8cSubscription ] };
+
 // An AFK post satisfies both halves of the wpcom `is_automattic_private()` guard.
 const afkPost = {
+	organization_id: AUTOMATTIC_ORG_ID,
 	site_is_private: true,
-	author: { login: AUTHOR },
 	tags: { afk: { slug: 'afk' } },
 };
 
@@ -31,7 +31,15 @@ describe( 'useCanMarkSeen', () => {
 		expect( result.current ).toBe( false );
 	} );
 
-	it( 'returns false for an AFK post on A8C private blog', () => {
+	it( 'returns true when the seen feature is available and the post is not an AFK post', () => {
+		const { result } = renderHook( () => useCanMarkSeen( { feedId: FEED_ID } ), {
+			wrapper: createSeenPostsWrapper( eligible ),
+		} );
+
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'returns false for an AFK post on an Automattic-private blog', () => {
 		const { result } = renderHook( () => useCanMarkSeen( { feedId: FEED_ID, post: afkPost } ), {
 			wrapper: createSeenPostsWrapper( eligible ),
 		} );
@@ -44,15 +52,15 @@ describe( 'useCanMarkSeen', () => {
 			wrapper: createSeenPostsWrapper( {
 				isAutomattician: true,
 				wpForTeamsBlogIds: [ BLOG_ID ],
-				feedOrganizationIds: { [ FEED_ID ]: AUTOMATTIC_ORG_ID },
 			} ),
 		} );
 
 		expect( result.current ).toBe( false );
 	} );
 
-	it( 'returns true when seen feature is available and post is not an AFK post', () => {
-		const { result } = renderHook( () => useCanMarkSeen( { feedId: FEED_ID } ), {
+	it( 'returns true for an AFK post on a public Automattic blog', () => {
+		const post = { ...afkPost, site_is_private: false };
+		const { result } = renderHook( () => useCanMarkSeen( { feedId: FEED_ID, post } ), {
 			wrapper: createSeenPostsWrapper( eligible ),
 		} );
 

--- a/client/reader/data/seen-posts/test/use-is-seen-enabled.test.tsx
+++ b/client/reader/data/seen-posts/test/use-is-seen-enabled.test.tsx
@@ -6,6 +6,7 @@ import { useIsSeenEnabled } from '../use-is-seen-enabled';
 import {
 	BLOG_ID,
 	FEED_ID,
+	ORG_ID,
 	organizationSubscription,
 	createSeenPostsWrapper,
 	subscription,
@@ -13,17 +14,23 @@ import {
 
 describe( 'useIsSeenEnabled', () => {
 	it( 'returns true when user is subscribed to a feed', () => {
-		const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-			wrapper: createSeenPostsWrapper( { subscriptions: [ organizationSubscription ] } ),
-		} );
+		const { result } = renderHook(
+			() => useIsSeenEnabled( { feedId: FEED_ID, organizationId: ORG_ID } ),
+			{
+				wrapper: createSeenPostsWrapper( { subscriptions: [ subscription ] } ),
+			}
+		);
 
 		expect( result.current ).toBe( true );
 	} );
 
 	it( 'returns false when user is not subscribed to a feed', () => {
-		const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID + 1 } ), {
-			wrapper: createSeenPostsWrapper( { subscriptions: [ organizationSubscription ] } ),
-		} );
+		const { result } = renderHook(
+			() => useIsSeenEnabled( { feedId: FEED_ID + 1, organizationId: ORG_ID } ),
+			{
+				wrapper: createSeenPostsWrapper( { subscriptions: [ subscription ] } ),
+			}
+		);
 
 		expect( result.current ).toBe( false );
 	} );
@@ -60,19 +67,36 @@ describe( 'useIsSeenEnabled', () => {
 		} );
 
 		it( 'returns false for an organization feed the user no longer follows', () => {
-			const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-				wrapper: createSeenPostsWrapper( {
-					subscriptions: [ { ...organizationSubscription, is_following: false } ],
-				} ),
-			} );
+			const { result } = renderHook(
+				() => useIsSeenEnabled( { feedId: FEED_ID, organizationId: ORG_ID } ),
+				{
+					wrapper: createSeenPostsWrapper( {
+						subscriptions: [ { ...organizationSubscription, is_following: false } ],
+					} ),
+				}
+			);
 
 			expect( result.current ).toBe( false );
 		} );
 
 		it( 'returns true when user is subscribed to an organization feed', () => {
-			const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-				wrapper: createSeenPostsWrapper( { subscriptions: [ organizationSubscription ] } ),
-			} );
+			const { result } = renderHook(
+				() => useIsSeenEnabled( { feedId: FEED_ID, organizationId: ORG_ID } ),
+				{
+					wrapper: createSeenPostsWrapper( { subscriptions: [ organizationSubscription ] } ),
+				}
+			);
+
+			expect( result.current ).toBe( true );
+		} );
+
+		it( 'returns true when the post itself carries an organization id', () => {
+			const { result } = renderHook(
+				() => useIsSeenEnabled( { feedId: FEED_ID, post: { organization_id: ORG_ID } } ),
+				{
+					wrapper: createSeenPostsWrapper( { subscriptions: [ organizationSubscription ] } ),
+				}
+			);
 
 			expect( result.current ).toBe( true );
 		} );
@@ -102,12 +126,15 @@ describe( 'useIsSeenEnabled', () => {
 		} );
 
 		it( 'returns true when a user is not subscribed to an organization feed', () => {
-			const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-				wrapper: createSeenPostsWrapper( {
-					subscriptions: [ { ...organizationSubscription, is_following: false } ],
-					isAutomattician: true,
-				} ),
-			} );
+			const { result } = renderHook(
+				() => useIsSeenEnabled( { feedId: FEED_ID, organizationId: ORG_ID } ),
+				{
+					wrapper: createSeenPostsWrapper( {
+						subscriptions: [ { ...organizationSubscription, is_following: false } ],
+						isAutomattician: true,
+					} ),
+				}
+			);
 
 			expect( result.current ).toBe( true );
 		} );
@@ -180,7 +207,12 @@ describe( 'useIsSeenEnabled', () => {
 			'returns false on %s even when the post already carries the seen flag',
 			( route ) => {
 				const { result } = renderHook(
-					() => useIsSeenEnabled( { feedId: FEED_ID, post: { is_seen: true } } ),
+					() =>
+						useIsSeenEnabled( {
+							feedId: FEED_ID,
+							organizationId: ORG_ID,
+							post: { is_seen: true },
+						} ),
 					{ wrapper: createSeenPostsWrapper( { ...eligible, route } ) }
 				);
 
@@ -200,9 +232,12 @@ describe( 'useIsSeenEnabled', () => {
 		);
 
 		it( 'returns true on non-disabled route route when the user is otherwise eligible', () => {
-			const { result } = renderHook( () => useIsSeenEnabled( { feedId: FEED_ID } ), {
-				wrapper: createSeenPostsWrapper( { ...eligible, route: '/reader' } ),
-			} );
+			const { result } = renderHook(
+				() => useIsSeenEnabled( { feedId: FEED_ID, organizationId: ORG_ID } ),
+				{
+					wrapper: createSeenPostsWrapper( { ...eligible, route: '/reader' } ),
+				}
+			);
 
 			expect( result.current ).toBe( true );
 		} );

--- a/client/reader/data/seen-posts/test/use-is-seen-visible.test.tsx
+++ b/client/reader/data/seen-posts/test/use-is-seen-visible.test.tsx
@@ -6,12 +6,11 @@ import { useIsSeenVisible } from '../use-is-seen-visible';
 import { AUTOMATTIC_ORG_ID, FEED_ID, createSeenPostsWrapper, subscription } from './fixtures';
 import type { Subscription } from './fixtures';
 
-const AUTHOR = 'user_name';
 const a8cSubscription: Subscription = { ...subscription, organization_id: AUTOMATTIC_ORG_ID };
 const eligible = { subscriptions: [ a8cSubscription ] };
 const afkPost = {
+	organization_id: AUTOMATTIC_ORG_ID,
 	site_is_private: true,
-	author: { login: AUTHOR },
 	tags: { afk: { slug: 'afk' } },
 };
 

--- a/client/reader/data/seen-posts/test/use-is-seen-visible.test.tsx
+++ b/client/reader/data/seen-posts/test/use-is-seen-visible.test.tsx
@@ -8,8 +8,9 @@ import type { Subscription } from './fixtures';
 
 const a8cSubscription: Subscription = { ...subscription, organization_id: AUTOMATTIC_ORG_ID };
 const eligible = { subscriptions: [ a8cSubscription ] };
+const p2Post = { organization_id: AUTOMATTIC_ORG_ID };
 const afkPost = {
-	organization_id: AUTOMATTIC_ORG_ID,
+	...p2Post,
 	site_is_private: true,
 	tags: { afk: { slug: 'afk' } },
 };
@@ -26,7 +27,7 @@ describe( 'useIsSeenVisible', () => {
 
 	it( 'returns false for an unseen post', () => {
 		const { result } = renderHook(
-			() => useIsSeenVisible( { feedId: FEED_ID, post: { is_seen: false } } ),
+			() => useIsSeenVisible( { feedId: FEED_ID, post: { ...p2Post, is_seen: false } } ),
 			{ wrapper: createSeenPostsWrapper( eligible ) }
 		);
 
@@ -34,7 +35,7 @@ describe( 'useIsSeenVisible', () => {
 	} );
 
 	it( 'returns false when the post carries no seen flag', () => {
-		const { result } = renderHook( () => useIsSeenVisible( { feedId: FEED_ID } ), {
+		const { result } = renderHook( () => useIsSeenVisible( { feedId: FEED_ID, post: p2Post } ), {
 			wrapper: createSeenPostsWrapper( eligible ),
 		} );
 
@@ -43,7 +44,7 @@ describe( 'useIsSeenVisible', () => {
 
 	it( 'returns true for a post carrying the seen flag', () => {
 		const { result } = renderHook(
-			() => useIsSeenVisible( { feedId: FEED_ID, post: { is_seen: true } } ),
+			() => useIsSeenVisible( { feedId: FEED_ID, post: { ...p2Post, is_seen: true } } ),
 			{ wrapper: createSeenPostsWrapper( eligible ) }
 		);
 

--- a/client/reader/data/seen-posts/use-can-mark-seen.ts
+++ b/client/reader/data/seen-posts/use-can-mark-seen.ts
@@ -1,18 +1,16 @@
-import { useOrganizationId } from 'calypso/reader/data/site-subscriptions/use-follow-selectors';
 import { SeenArgs, useIsSeenEnabled, isPostAnAFKPost } from './use-is-seen-enabled';
 
 /**
  * Returns true if the user can mark a post as seen, false otherwise.
  */
 export function useCanMarkSeen( { feedId, blogId, post }: SeenArgs ): boolean {
-	const isSeenEnabled = useIsSeenEnabled( { feedId, blogId } );
-	const organizationId = useOrganizationId( feedId, blogId );
+	const isSeenEnabled = useIsSeenEnabled( { feedId, blogId, post } );
 
 	if ( ! isSeenEnabled ) {
 		return false;
 	}
 
-	if ( isPostAnAFKPost( organizationId, post ) ) {
+	if ( isPostAnAFKPost( post ) ) {
 		return false;
 	}
 

--- a/client/reader/data/seen-posts/use-is-seen-enabled.ts
+++ b/client/reader/data/seen-posts/use-is-seen-enabled.ts
@@ -1,7 +1,6 @@
 import { isAutomatticianQuery, readSubscribedListsQuery } from '@automattic/api-queries';
 import { useQuery } from '@tanstack/react-query';
 import { useIsSubscribed } from 'calypso/reader/data/site-subscriptions';
-import { useOrganizationId } from 'calypso/reader/data/site-subscriptions/use-follow-selectors';
 import { useSelector } from 'calypso/state';
 import { AUTOMATTIC_ORG_ID } from 'calypso/state/reader/organizations/constants';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -20,16 +19,16 @@ export interface SeenArgs {
 		is_seen?: boolean;
 		tags?: Record< string, { slug?: string } >;
 		site_is_private?: boolean;
+		organization_id?: number;
 	};
 }
 
 /**
  * Return true if the seen feature is enabled for the current user, false otherwise.
  */
-export function useIsSeenEnabled( { feedId, blogId }: SeenArgs ): boolean {
+export function useIsSeenEnabled( { feedId, blogId, post }: SeenArgs ): boolean {
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 	const isSubscribed = useIsSubscribed( { feedId, blogId } );
-	const organizationId = useOrganizationId( feedId, blogId );
 	const isWPForTeamsItem = useSelector( ( state ) => isSiteWPForTeams( state, Number( blogId ) ) );
 	const { data: subscribedLists } = useQuery( readSubscribedListsQuery() );
 	const currentRoute = useSelector( getCurrentRoute );
@@ -38,7 +37,7 @@ export function useIsSeenEnabled( { feedId, blogId }: SeenArgs ): boolean {
 		return false;
 	}
 
-	const isP2 = Boolean( organizationId ) || Boolean( isWPForTeamsItem );
+	const isP2 = Boolean( post?.organization_id ) || Boolean( isWPForTeamsItem );
 	const isInSubscribedList = !! subscribedLists?.lists.some( ( list ): boolean =>
 		list.feeds.some( ( feed ): boolean => feed.feed_id === Number( feedId ) )
 	);
@@ -51,15 +50,15 @@ export function useIsSeenEnabled( { feedId, blogId }: SeenArgs ): boolean {
 	);
 }
 
-export function isPostAnAFKPost( orgId: number, post: SeenArgs[ 'post' ] ): boolean {
+export function isPostAnAFKPost( post: SeenArgs[ 'post' ] ): boolean {
 	if ( ! post ) {
 		return false;
 	}
 
-	const isAutomatticPrivate = orgId === AUTOMATTIC_ORG_ID && !! post?.site_is_private;
+	const isA8CPrivate = post?.organization_id === AUTOMATTIC_ORG_ID && !! post?.site_is_private;
 	const isAFKPost = Object.entries( post.tags ?? {} ).some( ( [ name, tag ] ) => {
 		return ( tag.slug ?? name ).toLowerCase() === 'afk';
 	} );
 
-	return isAutomatticPrivate && isAFKPost;
+	return isA8CPrivate && isAFKPost;
 }

--- a/client/reader/data/seen-posts/use-is-seen-enabled.ts
+++ b/client/reader/data/seen-posts/use-is-seen-enabled.ts
@@ -13,8 +13,9 @@ const SEEN_DISABLED_ROUTES = [
 ];
 
 export interface SeenArgs {
-	feedId?: number | string; // Route params arrive as strings.
-	blogId?: number | string; // Route params arrive as strings.
+	feedId?: number | string;
+	blogId?: number | string;
+	organizationId?: number; // Organization ID from the feed or blog when no posts are available.
 	post?: {
 		is_seen?: boolean;
 		tags?: Record< string, { slug?: string } >;
@@ -26,7 +27,7 @@ export interface SeenArgs {
 /**
  * Return true if the seen feature is enabled for the current user, false otherwise.
  */
-export function useIsSeenEnabled( { feedId, blogId, post }: SeenArgs ): boolean {
+export function useIsSeenEnabled( { feedId, blogId, organizationId, post }: SeenArgs ): boolean {
 	const { data: isAutomattician } = useQuery( isAutomatticianQuery() );
 	const isSubscribed = useIsSubscribed( { feedId, blogId } );
 	const isWPForTeamsItem = useSelector( ( state ) => isSiteWPForTeams( state, Number( blogId ) ) );
@@ -37,7 +38,8 @@ export function useIsSeenEnabled( { feedId, blogId, post }: SeenArgs ): boolean 
 		return false;
 	}
 
-	const isP2 = Boolean( post?.organization_id ) || Boolean( isWPForTeamsItem );
+	const isP2 =
+		Boolean( post?.organization_id ) || Boolean( organizationId ) || Boolean( isWPForTeamsItem );
 	const isInSubscribedList = !! subscribedLists?.lists.some( ( list ): boolean =>
 		list.feeds.some( ( feed ): boolean => feed.feed_id === Number( feedId ) )
 	);

--- a/client/reader/data/seen-posts/use-is-seen-visible.ts
+++ b/client/reader/data/seen-posts/use-is-seen-visible.ts
@@ -1,4 +1,3 @@
-import { useOrganizationId } from 'calypso/reader/data/site-subscriptions/use-follow-selectors';
 import { SeenArgs, useIsSeenEnabled, isPostAnAFKPost } from './use-is-seen-enabled';
 
 /**
@@ -7,14 +6,13 @@ import { SeenArgs, useIsSeenEnabled, isPostAnAFKPost } from './use-is-seen-enabl
  * Mainly we need this because we want to show the seen state for AFK posts, but not allow users to mark them as seen.
  */
 export function useIsSeenVisible( { feedId, blogId, post }: SeenArgs ): boolean {
-	const isSeenEnabled = useIsSeenEnabled( { feedId, blogId } );
-	const organizationId = useOrganizationId( feedId, blogId );
+	const isSeenEnabled = useIsSeenEnabled( { feedId, blogId, post } );
 
 	if ( ! isSeenEnabled ) {
 		return false;
 	}
 
-	if ( isPostAnAFKPost( organizationId, post ) ) {
+	if ( isPostAnAFKPost( post ) ) {
 		return true;
 	}
 

--- a/client/reader/data/site-subscriptions/use-follow-selectors.ts
+++ b/client/reader/data/site-subscriptions/use-follow-selectors.ts
@@ -1,13 +1,11 @@
 import {
 	getAliasedSiteSubscriptionFeedUrl,
 	getIsSubscribedFromData,
-	getSiteSubscriptionByBlogIdFromData,
 	getSiteSubscriptionByFeedIdFromData,
 	getSubscribedSitesFromData,
 	getOrganizationSiteSubscriptionsFromData,
 } from '@automattic/api-queries';
 import { NO_ORG_ID } from 'calypso/state/reader/organizations/constants';
-import { useFeedQuery } from '../feed';
 import { useSiteSubscriptions } from './use-site-subscriptions';
 import type { SiteSubscriptionItem } from '@automattic/api-core';
 
@@ -87,32 +85,3 @@ export const useSubscribedFeedsInfo = () => {
 
 	return getFeedsInfo( sites );
 };
-
-export const useSiteSubscriptionOrganizationId = (
-	feedId?: FollowId,
-	blogId?: FollowId
-): number => {
-	const { data } = useSiteSubscriptions();
-	const feedFollow = hasId( feedId )
-		? getSiteSubscriptionByFeedIdFromData( data, feedId )
-		: undefined;
-	const follow =
-		feedFollow ??
-		( hasId( blogId ) ? getSiteSubscriptionByBlogIdFromData( data, blogId ) : undefined );
-
-	return follow?.organization_id ?? NO_ORG_ID;
-};
-
-/**
- * Resolve the organization owning a feed.
- *
- * `useSiteSubscriptionOrganizationId` only knows about feeds the viewer follows, so fall back to
- * the feed record. Without it an Automattician who does not follow an a8c P2 sees `NO_ORG_ID` and
- * the AFK guard never fires, even though the seen feature is enabled for them via WP For Teams.
- */
-export function useOrganizationId( feedId?: number | string, blogId?: number | string ): number {
-	const subscriptionOrganizationId = useSiteSubscriptionOrganizationId( feedId, blogId );
-	const { data: feed } = useFeedQuery( subscriptionOrganizationId ? null : feedId );
-
-	return subscriptionOrganizationId || feed?.organization_id || NO_ORG_ID;
-}

--- a/packages/api-queries/src/__tests__/read-follows.test.tsx
+++ b/packages/api-queries/src/__tests__/read-follows.test.tsx
@@ -11,7 +11,6 @@ import {
 	followSiteMutation,
 	siteSubscriptionsQuery,
 	getAliasedSiteSubscriptionFeedUrl,
-	getSiteSubscriptionByBlogIdFromData,
 	getSiteSubscriptionByFeedIdFromData,
 	getSubscribedSitesFromData,
 	getSiteSubscriptionsCountFromData,
@@ -341,7 +340,6 @@ describe( 'follow selectors and cache helpers', () => {
 
 		expect( getSiteSubscriptionsFromData( data ) ).toEqual( [ alpha, beta ] );
 		expect( getSiteSubscriptionsCountFromData( data ) ).toBe( 2 );
-		expect( getSiteSubscriptionByBlogIdFromData( data, 22 ) ).toBe( beta );
 		expect( getSiteSubscriptionByFeedIdFromData( data, 101 ) ).toBe( alpha );
 		expect( getSiteSubscriptionFromData( data, { feedUrl: 'https://alpha.example/feed/' } ) ).toBe(
 			alpha

--- a/packages/api-queries/src/read-follows.ts
+++ b/packages/api-queries/src/read-follows.ts
@@ -94,14 +94,6 @@ export const getSiteSubscriptionsCountFromData = (
 	return Math.max( totalCount, followingCount );
 };
 
-export const getSiteSubscriptionByBlogIdFromData = (
-	data: SiteSubscriptionsInfiniteData | undefined,
-	blogId: number | string
-): SiteSubscriptionItem | undefined =>
-	getSiteSubscriptionsFromData( data ).find(
-		( subscription ) => Number( subscription.blog_ID ) === Number( blogId )
-	);
-
 export const getSiteSubscriptionByFeedIdFromData = (
 	data: SiteSubscriptionsInfiniteData | undefined,
 	feedId: number | string


### PR DESCRIPTION
Related: https://linear.app/a8c/issue/READ-726

## Proposed Changes

* Read the organization from `post` object instead of looking it up from the viewer's subscriptions.
* Removed `useOrganizationId` and `useSiteSubscriptionOrganizationId`, plus the now-unused `getSiteSubscriptionByBlogIdFromData` selector.

## Why are these changes being made?

The organization was resolved from the viewer's subscription list, which returns nothing for a feed they don't follow. An Automattician viewing an unsubscribed P2 got `NO_ORG_ID`, so `isP2` was false and the post couldn't be marked as seen.

## Testing Instructions

As an Automattician:

1. Open a post on an a8c P2 you are **not** subscribed to.
2. Confirm the ellipsis menu shows "Mark as seen" and that clicking it works.
3. Confirm navigating to full post view auto marking the post as seen.
4. Verify AFK posts are working as expected i.e. no mark as seen available.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
