### PR TITLE
Color scheme: keep children mounted while a failed preferences query refetches

### DIFF
--- a/client/lib/color-scheme/query-provider.tsx
+++ b/client/lib/color-scheme/query-provider.tsx
@@ -17,7 +17,7 @@ export function ColorSchemeProvider( {
 	children: ReactNode;
 	enabled?: boolean;
 } ) {
-	const { data: savedColorScheme, isError } = useQuery( {
+	const { data: savedColorScheme, isFetched } = useQuery( {
 		...userPreferenceQuery( PREFERENCE_KEY ),
 		enabled,
 	} );
@@ -25,7 +25,7 @@ export function ColorSchemeProvider( {
 		userPreferenceOptimisticMutation( PREFERENCE_KEY )
 	);
 	const colorScheme = isColorScheme( savedColorScheme ) ? savedColorScheme : DEFAULT_SCHEME;
-	const isReady = savedColorScheme !== undefined || isError;
+	const isReady = savedColorScheme !== undefined || isFetched;
 
 	const setColorScheme = useCallback(
 		( scheme: ColorScheme, options?: { onSuccess?: () => void } ) => {

--- a/client/lib/color-scheme/test/query-provider.test.tsx
+++ b/client/lib/color-scheme/test/query-provider.test.tsx
@@ -7,6 +7,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
+import { useEffect } from 'react';
 import { ColorSchemeProvider, useColorScheme, withColorScheme } from 'calypso/lib/color-scheme';
 import type { ColorScheme } from 'calypso/lib/color-scheme';
 
@@ -17,6 +18,7 @@ const surfaceBodyClasses = [ 'is-reader-dark-mode', 'is-themes-dark-mode' ];
 
 const mockUpdatePreference = jest.fn();
 const mockOnSaveSuccess = jest.fn();
+const mockChildMount = jest.fn();
 
 function mockGetPreferences(
 	preferences: Record< string, unknown >,
@@ -64,6 +66,9 @@ function mockUpdateColorScheme(
 
 function CurrentScheme() {
 	const { colorScheme, setColorScheme } = useColorScheme();
+	useEffect( () => {
+		mockChildMount();
+	}, [] );
 	return (
 		<div>
 			<span data-testid="scheme">{ colorScheme }</span>
@@ -116,6 +121,7 @@ beforeEach( () => {
 	} );
 	mockUpdatePreference.mockClear();
 	mockOnSaveSuccess.mockClear();
+	mockChildMount.mockClear();
 	nock.cleanAll();
 	document.documentElement.removeAttribute( 'data-theme' );
 	removeSurfaceBodyClasses();
@@ -220,6 +226,22 @@ test( 'defaults to light when loading preferences fails without cached preferenc
 		expect( mockUpdatePreference ).not.toHaveBeenCalled();
 		expect( mockOnSaveSuccess ).not.toHaveBeenCalled();
 	} );
+} );
+
+test( 'keeps children mounted when a failed preferences query refetches', async () => {
+	mockGetPreferences( {}, { status: 500 } );
+
+	renderColorSchemeProvider();
+
+	await waitFor( () => expect( screen.getByTestId( 'scheme' ) ).toBeVisible() );
+	expect( mockChildMount ).toHaveBeenCalledTimes( 1 );
+
+	// A refetch resets the errored, data-less query back to a pending state.
+	mockGetPreferences( {}, { status: 500, delay: 20 } );
+	await queryClient.refetchQueries( { queryKey: [ 'me', 'preferences' ] } );
+
+	await waitFor( () => expect( screen.getByTestId( 'scheme' ) ).toBeVisible() );
+	expect( mockChildMount ).toHaveBeenCalledTimes( 1 );
 } );
 
 test( 'optimistically applies a user-initiated color scheme change', async () => {


### PR DESCRIPTION
Fixes DOTCOM-14911

## Proposed Changes

* When fetching colour scheme preference, treat as settled once it has been fetched at least once
* Add a test covering a refetch of a failed, data-less preferences query.

| Before | After |
| --- | --- |
| <img width="2876" height="1662" alt="CleanShot 2026-09-10 at 21 08 02@2x" src="https://github.com/user-attachments/assets/82591d6c-bb5c-4b78-95db-68b75c2f510f" /> | <img width="2872" height="1178" alt="CleanShot 2026-09-10 at 16 14 15@2x" src="https://github.com/user-attachments/assets/c3f865cf-3b1f-4c35-bf78-4fc5af37645e" /> |


## Why are these changes being made?

This _might_ be the reason behind p1789008659130119-slack-C08BWTSP7AS. But whether it's this specific issue or not, it's still a reproducible loading bug.

This was producing an infinite render loop which caused a WSOD in the MSD.

If the preference request in `ColorSchemeProvider` fails, the provider correctly falls back to the light scheme and renders its children (it doesn't want to block children rendering on error). But a child of `ColorSchemeProvider` is the router provider. The site list route needs to fetch the user preferences too, and since that last query was an error, it will try again. Because there's now a fetch in flight, `ColorSchemeProvider`'s `isError` check is now false (it's not in an error state, it's pending). That means `ColorSchemeProvider` immediately stops rendering children, unmounting the route provider.

So the loop is:
1. `ColorSchemeProvider` attempts to fetch preference (fetch A)
2. Fetch A fails
3. `ColorSchemeProvider` renders children, including `RouterProvider`
4. Site list route fetches preference (fetch B)
5. `ColorSchemeProvider` stops rendering children, unmounting `RouterProvider`
6. Fetch B fails
7. Loop back to 3

That's why `isFetched` is better than `isError`. The intention is that `ColorSchemeProvider` is meant to pause rendering while loading, but then unconditionally render children after that. That's why it was treating `isError` that way. However queries toggle in and out of the `isError` state. `isFetched` will be true after the first load is complete, regardless of whether it's in an error state or not.

## Testing Instructions

You need to something weird to get user permissions into this weird state where the preference request fails but the page still loads.

- Test in local dev
- Enable the `wpcom-user-bootstrap` flag
- Follow FG to get user bootstrapping working locally PCYsg-5YE-p2
- Be logged in to MSD
- Open dev tools and delete `wordpress_sec` cookie, but _not_ `wordpress_logged_in` cookie
- Refresh page

You should expect a non-WSOD experience. You should get a message telling you there's something wrong and you need to log out and in.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_018Zy8WnjcdA2Sx7ZsHFHVA4