### PR TITLE
Blackbox: hold form submission until a submit-time challenge is solved

### DIFF
--- a/client/blocks/login/__mocks__/blackbox-challenge.jsx
+++ b/client/blocks/login/__mocks__/blackbox-challenge.jsx
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+// Stand-in widget that reports its blocking state to the host form. Set `blocked`
+// before rendering, or call `setBlocked` to raise a challenge mid-submit.
+export default function MockBlackboxChallenge( { onSubmitBlockedChange } ) {
+	const [ blocked, setBlocked ] = useState( MockBlackboxChallenge.blocked );
+	MockBlackboxChallenge.setBlocked = setBlocked;
+	useEffect( () => onSubmitBlockedChange?.( blocked ), [ blocked, onSubmitBlockedChange ] );
+	return null;
+}
+
+MockBlackboxChallenge.blocked = false;

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -343,6 +343,10 @@ export class LoginForm extends Component {
 	onSubmitForm = ( event ) => {
 		event.preventDefault();
 
+		if ( this.props.blackbox.isSubmitBlocked ) {
+			return;
+		}
+
 		if ( ! this.props.hasAccountTypeLoaded ) {
 			// Google Chrome on iOS will autofill without sending events, leading the user
 			// to see a filled box but getting an error. We fetch the value directly from

--- a/client/blocks/login/lost-password-form.jsx
+++ b/client/blocks/login/lost-password-form.jsx
@@ -88,6 +88,10 @@ const LostPasswordForm = ( {
 	const onSubmit = async ( event ) => {
 		event.preventDefault();
 
+		if ( blackbox.isSubmitBlocked ) {
+			return;
+		}
+
 		if ( isWooJPC ) {
 			const accountType = await getAuthAccountTypeRequest( userLogin );
 			if ( accountType?.passwordless === true ) {
@@ -174,6 +178,9 @@ const LostPasswordForm = ( {
 	};
 
 	const showError = !! error;
+	// A challenge raised by the submit's own collect holds the request until it is
+	// solved, so stop spinning while it is up.
+	const isSendingReset = isBusy && ! blackbox.isSubmitBlocked;
 	return (
 		<form
 			name="lostpasswordform"
@@ -212,10 +219,10 @@ const LostPasswordForm = ( {
 					variant="primary"
 					type="submit"
 					disabled={ userLogin.length === 0 || showError || isBusy || blackbox.isSubmitBlocked }
-					isBusy={ isBusy }
+					isBusy={ isSendingReset }
 					__next40pxDefaultSize
 				>
-					{ isBusy && isWoo ? <Spinner /> : translate( 'Reset my password' ) }
+					{ isSendingReset && isWoo ? <Spinner /> : translate( 'Reset my password' ) }
 				</Button>
 			</div>
 			<div className="login__form-help">

--- a/client/blocks/login/test/login-form.jsx
+++ b/client/blocks/login/test/login-form.jsx
@@ -5,6 +5,7 @@ import config from '@automattic/calypso-config';
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import cookie from 'cookie';
+import MockBlackboxChallenge from 'calypso/blocks/login/blackbox-challenge';
 import LoginForm from 'calypso/blocks/login/login-form';
 import { getBlackboxSessionId } from 'calypso/blocks/login/utils/get-blackbox-session-id';
 import loginReducer from 'calypso/state/login/reducer';
@@ -20,13 +21,7 @@ jest.mock( 'calypso/blocks/login/utils/get-blackbox-session-id', () => ( {
 	getBlackboxSessionId: jest.fn().mockResolvedValue( undefined ),
 } ) );
 
-jest.mock( 'calypso/blocks/login/blackbox-challenge', () => {
-	const { useEffect } = require( 'react' );
-	return ( { onSubmitBlockedChange } ) => {
-		useEffect( () => onSubmitBlockedChange?.( false ), [ onSubmitBlockedChange ] );
-		return null;
-	};
-} );
+jest.mock( 'calypso/blocks/login/blackbox-challenge' );
 
 const render = ( el, options ) =>
 	renderWithProvider( el, { ...options, reducers: { login: loginReducer, route: routeReducer } } );
@@ -275,6 +270,7 @@ describe( 'LoginForm', () => {
 			mockFetch.mockReset();
 			getBlackboxSessionId.mockReset();
 			getBlackboxSessionId.mockResolvedValue( undefined );
+			MockBlackboxChallenge.blocked = false;
 			delete window.Blackbox;
 		} );
 
@@ -324,6 +320,21 @@ describe( 'LoginForm', () => {
 			await userEvent.click( screen.getByRole( 'button', { name: /Log In/i } ) );
 
 			await waitFor( () => expect( window.Blackbox.reset ).toHaveBeenCalledTimes( 1 ) );
+		} );
+
+		test( 'sends no request when Enter submits while a challenge is blocking', async () => {
+			MockBlackboxChallenge.blocked = true;
+			getBlackboxSessionId.mockResolvedValue( 'ABCDEFGHIJKLMNOPQRSTuv' );
+
+			renderRegularLoginForm();
+
+			const form = document.querySelector( 'form[method="post"]' );
+			act( () => {
+				form.requestSubmit();
+			} );
+
+			await waitFor( () => expect( getBlackboxSessionId ).not.toHaveBeenCalled() );
+			expect( mockFetch ).not.toHaveBeenCalled();
 		} );
 
 		test( 'sends only one login request when the form is submitted twice', async () => {

--- a/client/blocks/login/test/lost-password-form.jsx
+++ b/client/blocks/login/test/lost-password-form.jsx
@@ -2,8 +2,9 @@
  * @jest-environment jsdom
  */
 import config from '@automattic/calypso-config';
-import { screen, render, waitFor } from '@testing-library/react';
+import { act, screen, render, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import MockBlackboxChallenge from 'calypso/blocks/login/blackbox-challenge';
 import LostPasswordForm from 'calypso/blocks/login/lost-password-form';
 import { getBlackboxSessionId } from 'calypso/blocks/login/utils/get-blackbox-session-id';
 
@@ -16,14 +17,7 @@ jest.mock( 'calypso/blocks/login/utils/get-blackbox-session-id', () => ( {
 	getBlackboxSessionId: jest.fn().mockResolvedValue( undefined ),
 } ) );
 
-jest.mock( 'calypso/blocks/login/blackbox-challenge', () => {
-	const { useEffect } = require( 'react' );
-	// Stand-in widget that reports "not blocking" so an enabled form stays submittable.
-	return ( { onSubmitBlockedChange } ) => {
-		useEffect( () => onSubmitBlockedChange?.( false ), [ onSubmitBlockedChange ] );
-		return null;
-	};
-} );
+jest.mock( 'calypso/blocks/login/blackbox-challenge' );
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
@@ -42,6 +36,7 @@ describe( 'LostPasswordForm', () => {
 		config.enable( 'blackbox-lost-password' );
 		getBlackboxSessionId.mockClear();
 		getBlackboxSessionId.mockResolvedValue( undefined );
+		MockBlackboxChallenge.blocked = false;
 		delete window.Blackbox;
 	} );
 
@@ -323,5 +318,44 @@ describe( 'LostPasswordForm', () => {
 		await waitFor( () => {
 			expect( window.Blackbox.reset ).toHaveBeenCalledTimes( 1 );
 		} );
+	} );
+
+	test( 'sends no request when Enter submits while a challenge is blocking', async () => {
+		MockBlackboxChallenge.blocked = true;
+		getBlackboxSessionId.mockResolvedValue( 'ABCDEFGHIJKLMNOPQRSTuv' );
+
+		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
+
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Email address or username' } ),
+			'user@example.com'
+		);
+
+		fireEvent.submit(
+			screen.getByRole( 'textbox', { name: 'Email address or username' } ).closest( 'form' )
+		);
+
+		await waitFor( () => expect( getBlackboxSessionId ).not.toHaveBeenCalled() );
+		expect( mockFetch ).not.toHaveBeenCalled();
+	} );
+
+	test( 'stops the submit button spinning when a challenge appears mid-submit', async () => {
+		getBlackboxSessionId.mockReturnValue( new Promise( () => {} ) );
+
+		render( <LostPasswordForm redirectToAfterLoginUrl="" oauth2ClientId="" locale="" /> );
+
+		await userEvent.type(
+			screen.getByRole( 'textbox', { name: 'Email address or username' } ),
+			'user@example.com'
+		);
+		await userEvent.click( screen.getByRole( 'button', { name: /Reset my password/i } ) );
+
+		const submitButton = screen.getByRole( 'button', { name: /Reset my password/i } );
+		expect( submitButton ).toHaveClass( 'is-busy' );
+
+		act( () => MockBlackboxChallenge.setBlocked( true ) );
+
+		expect( submitButton ).not.toHaveClass( 'is-busy' );
+		expect( submitButton ).toBeDisabled();
 	} );
 } );

--- a/client/blocks/login/utils/challenge-gate.js
+++ b/client/blocks/login/utils/challenge-gate.js
@@ -1,0 +1,39 @@
+// Tracked outside React because the SDK reports a challenge start synchronously
+// from inside collect(), before a state update could reach a caller already
+// awaiting its session id. Module state also reaches the checkout payment
+// processors, which run outside React and so cannot read a hook's return value.
+let pendingChallenge = null;
+
+/**
+ * Open or close the gate. Driven by the SDK's challenge callbacks.
+ * @param {boolean} running Whether a challenge is on screen.
+ */
+export function setChallengeRunning( running ) {
+	if ( ! running ) {
+		pendingChallenge?.resolve();
+		pendingChallenge = null;
+		return;
+	}
+
+	if ( ! pendingChallenge ) {
+		let resolve;
+		const promise = new Promise( ( r ) => {
+			resolve = r;
+		} );
+		pendingChallenge = { promise, resolve };
+	}
+}
+
+/**
+ * Resolves when no challenge is running.
+ *
+ * Deliberately unbounded, unlike the fail-open timeouts around the SDK itself: a
+ * session carrying an unsolved challenge is rejected by verify(), so giving up
+ * early would trade a wait for a guaranteed block. Every abandonment path —
+ * challenge failure, presentation error, container unmount, feature disable —
+ * closes the gate.
+ * @returns {Promise<void>}
+ */
+export function waitForChallengeSettled() {
+	return pendingChallenge?.promise ?? Promise.resolve();
+}

--- a/client/blocks/login/utils/get-blackbox-session-id.js
+++ b/client/blocks/login/utils/get-blackbox-session-id.js
@@ -1,4 +1,5 @@
 import { loadBlackboxSdk } from 'calypso/blocks/login/utils/blackbox-sdk';
+import { waitForChallengeSettled } from 'calypso/blocks/login/utils/challenge-gate';
 
 /**
  * Retrieve a Blackbox bot-detection session ID.
@@ -8,9 +9,9 @@ import { loadBlackboxSdk } from 'calypso/blocks/login/utils/blackbox-sdk';
  * This ensures the server-side session score reflects behavioral signals
  * before the login request fires — critical for enforcement via verify().
  *
- * collect() is safe to call at submit time because the login form's submit
- * button is disabled while Blackbox is loading or a challenge is active, so
- * this only fires when no challenge widget is in progress.
+ * collect() returns as soon as the response arrives, even when that response
+ * issued a challenge, so we hold the session here until the challenge settles.
+ * Verify rejects a session with an unsolved challenge outright.
  *
  * Blackbox returns BlackboxError instead of throwing, so the typeof check
  * filters those out. The try/catch is defense-in-depth.
@@ -36,6 +37,8 @@ export async function getBlackboxSessionId() {
 			window.Blackbox.collect(),
 			new Promise( ( resolve ) => setTimeout( resolve, 5000 ) ),
 		] );
+
+		await waitForChallengeSettled();
 
 		if ( typeof result === 'string' ) {
 			return result;

--- a/client/blocks/login/utils/test/get-blackbox-session-id.js
+++ b/client/blocks/login/utils/test/get-blackbox-session-id.js
@@ -7,10 +7,15 @@ jest.mock( '../blackbox-sdk', () => ( {
 } ) );
 
 import { loadBlackboxSdk } from '../blackbox-sdk';
+import { setChallengeRunning } from '../challenge-gate';
 import { getBlackboxSessionId } from '../get-blackbox-session-id';
+
+const flushMicrotasks = () => new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
 
 describe( 'getBlackboxSessionId', () => {
 	afterEach( () => {
+		// The gate is module state, so an open one would hang the next test.
+		setChallengeRunning( false );
 		delete window.Blackbox;
 		jest.clearAllMocks();
 	} );
@@ -48,5 +53,27 @@ describe( 'getBlackboxSessionId', () => {
 	test( 'returns undefined when collect throws', async () => {
 		window.Blackbox = { collect: jest.fn( () => Promise.reject( new Error( 'boom' ) ) ) };
 		await expect( getBlackboxSessionId() ).resolves.toBeUndefined();
+	} );
+
+	test( 'withholds the session until a challenge raised by its own collect settles', async () => {
+		window.Blackbox = {
+			collect: jest.fn( async () => {
+				setChallengeRunning( true );
+				return 'sid';
+			} ),
+		};
+
+		let sessionId;
+		const pending = getBlackboxSessionId().then( ( id ) => {
+			sessionId = id;
+		} );
+
+		await flushMicrotasks();
+		expect( sessionId ).toBeUndefined();
+
+		setChallengeRunning( false );
+		await pending;
+
+		expect( sessionId ).toBe( 'sid' );
 	} );
 } );

--- a/client/blocks/login/utils/test/use-blackbox.jsx
+++ b/client/blocks/login/utils/test/use-blackbox.jsx
@@ -5,6 +5,7 @@
 import { act, render, screen } from '@testing-library/react';
 import { useRef } from 'react';
 import { loadBlackboxSdk } from '../blackbox-sdk';
+import { waitForChallengeSettled } from '../challenge-gate';
 import { useBlackbox } from '../use-blackbox';
 
 jest.mock( '../blackbox-sdk', () => ( {
@@ -215,6 +216,71 @@ describe( 'useBlackbox', () => {
 		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
 	} );
 
+	test( 'waitForChallengeSettled resolves immediately when no challenge is active', async () => {
+		render( <TestComponent /> );
+
+		await act( async () => {} );
+
+		await expect( waitForChallengeSettled() ).resolves.toBeUndefined();
+	} );
+
+	test( 'waitForChallengeSettled stays pending until the challenge completes', async () => {
+		let callbacks;
+		window.Blackbox.configure.mockImplementationOnce( ( config ) => {
+			callbacks = config;
+		} );
+
+		render( <TestComponent /> );
+
+		await act( async () => {} );
+		act( () => callbacks.onChallengeStart() );
+
+		let settled = false;
+		const settledPromise = waitForChallengeSettled().then( () => {
+			settled = true;
+		} );
+
+		await act( async () => {} );
+		expect( settled ).toBe( false );
+
+		act( () => callbacks.onChallengeComplete() );
+		await act( async () => settledPromise );
+
+		expect( settled ).toBe( true );
+	} );
+
+	test( 'waitForChallengeSettled resolves when the challenge fails', async () => {
+		let callbacks;
+		window.Blackbox.configure.mockImplementationOnce( ( config ) => {
+			callbacks = config;
+		} );
+
+		render( <TestComponent /> );
+
+		await act( async () => {} );
+		act( () => callbacks.onChallengeStart() );
+
+		const settledPromise = waitForChallengeSettled();
+		act( () => callbacks.onChallengeFailure() );
+		await expect( settledPromise ).resolves.toBeUndefined();
+	} );
+
+	test( 'waitForChallengeSettled resolves when the SDK cannot present the challenge', async () => {
+		let callbacks;
+		window.Blackbox.configure.mockImplementationOnce( ( config ) => {
+			callbacks = config;
+		} );
+
+		render( <TestComponent /> );
+
+		await act( async () => {} );
+		act( () => callbacks.onChallengeStart() );
+
+		const settledPromise = waitForChallengeSettled();
+		act( () => callbacks.onError( { method: 'challenge' } ) );
+		await expect( settledPromise ).resolves.toBeUndefined();
+	} );
+
 	test( 'clears blocking state when disabled mid-challenge', async () => {
 		let callbacks;
 		window.Blackbox.configure.mockImplementationOnce( ( config ) => {
@@ -231,5 +297,6 @@ describe( 'useBlackbox', () => {
 		rerender( <TestComponent enabled={ false } /> );
 
 		expect( screen.getByTestId( 'blackbox-state' ) ).toHaveTextContent( 'ready/inactive/empty' );
+		await expect( waitForChallengeSettled() ).resolves.toBeUndefined();
 	} );
 } );

--- a/client/blocks/login/utils/use-blackbox.js
+++ b/client/blocks/login/utils/use-blackbox.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { getBlackboxApiKey, loadBlackboxSdk } from 'calypso/blocks/login/utils/blackbox-sdk';
+import { setChallengeRunning } from 'calypso/blocks/login/utils/challenge-gate';
 
 // Give the SDK a short window to synchronously or near-synchronously start a challenge
 // after configure(), avoiding a brief enabled submit button while the widget initializes.
@@ -46,11 +47,16 @@ export function useBlackbox( { containerRef, enabled } ) {
 	}, [ containerRef, isEnabled ] );
 
 	useEffect( () => {
+		const syncChallengeState = ( active ) => {
+			setChallengeRunning( active );
+			setIsChallengeActive( active );
+		};
+
 		if ( ! isEnabled ) {
 			// Covers the surface being suspended after a challenge appeared: drop
 			// all blocking state so the form isn't wedged when it re-enables.
 			setIsLoading( false );
-			setIsChallengeActive( false );
+			syncChallengeState( false );
 			setHasChallengeContent( false );
 			return;
 		}
@@ -105,14 +111,14 @@ export function useBlackbox( { containerRef, enabled } ) {
 					onError: ( error ) => {
 						if ( ! cancelled && error?.method === 'challenge' ) {
 							stopLoading();
-							setIsChallengeActive( false );
+							syncChallengeState( false );
 						}
 					},
 					onChallengeStart: () => {
 						if ( ! cancelled ) {
 							hasStartedChallenge = true;
 							stopLoading();
-							setIsChallengeActive( true );
+							syncChallengeState( true );
 						}
 					},
 					onChallengeComplete: () => {
@@ -120,7 +126,7 @@ export function useBlackbox( { containerRef, enabled } ) {
 							if ( hasStartedChallenge ) {
 								stopLoading();
 							}
-							setIsChallengeActive( false );
+							syncChallengeState( false );
 						}
 					},
 					onChallengeFailure: () => {
@@ -128,7 +134,7 @@ export function useBlackbox( { containerRef, enabled } ) {
 							if ( hasStartedChallenge ) {
 								stopLoading();
 							}
-							setIsChallengeActive( false );
+							syncChallengeState( false );
 						}
 					},
 				} );
@@ -151,6 +157,7 @@ export function useBlackbox( { containerRef, enabled } ) {
 		return () => {
 			cancelled = true;
 			clearPendingTimeouts();
+			setChallengeRunning( false );
 		};
 	}, [ containerRef, isEnabled ] );
 

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -71,6 +71,8 @@ class PasswordlessSignupForm extends Component {
 		errorMessages: null,
 	};
 
+	submitLock = false;
+
 	submitTracksEvent = ( isSuccessful, props ) => {
 		const tracksEventName = isSuccessful
 			? 'calypso_signup_actions_onboarding_passwordless_login_success'
@@ -83,7 +85,7 @@ class PasswordlessSignupForm extends Component {
 	onFormSubmit = async ( event ) => {
 		event.preventDefault();
 
-		if ( this.props.isSubmitBlocked ) {
+		if ( this.props.isSubmitBlocked || this.props.blackbox.isSubmitBlocked || this.submitLock ) {
 			return;
 		}
 
@@ -105,6 +107,8 @@ class PasswordlessSignupForm extends Component {
 			return;
 		}
 
+		this.submitLock = true;
+
 		if ( this.props.onUpdateEmail ) {
 			this.setState( { isSubmitting: true } );
 			try {
@@ -113,6 +117,7 @@ class PasswordlessSignupForm extends Component {
 				// The caller reports its own failures. This only keeps one it didn't from leaving
 				// the screen disabled with nothing to press.
 			} finally {
+				this.submitLock = false;
 				this.setState( { isSubmitting: false } );
 			}
 			return;
@@ -144,6 +149,7 @@ class PasswordlessSignupForm extends Component {
 					...( blackboxSessionId && { blackbox_session_id: blackboxSessionId } ),
 				},
 				( error ) => {
+					this.submitLock = false;
 					// The handed-off session was consumed by the parent's failed
 					// request; reset so a retry gets a verifiable one.
 					if ( error ) {
@@ -210,6 +216,7 @@ class PasswordlessSignupForm extends Component {
 	};
 
 	createAccountError = async ( error ) => {
+		this.submitLock = false;
 		this.submitTracksEvent( false, { action_message: error.message, error_code: error.error } );
 
 		// Reset Blackbox so the next signup attempt gets a fresh session.
@@ -402,13 +409,16 @@ class PasswordlessSignupForm extends Component {
 
 	formFooter() {
 		const { isSubmitting } = this.state;
+		// A challenge raised by the submit's own collect holds account creation until
+		// it is solved, so stop claiming the account is being created.
+		const isCreatingAccount = isSubmitting && ! this.props.blackbox.isSubmitBlocked;
 		const isPrimaryDisabled =
 			isSubmitting ||
 			!! this.props.disabled ||
 			!! this.props.disableSubmitButton ||
 			!! this.props.isSubmitBlocked ||
 			this.props.blackbox.isSubmitBlocked;
-		const submitButtonText = isSubmitting
+		const submitButtonText = isCreatingAccount
 			? this.props.submitButtonLoadingLabel || this.props.translate( 'Creating your account…' )
 			: this.props.submitButtonLabel || this.props.translate( 'Create your account' );
 
@@ -419,7 +429,7 @@ class PasswordlessSignupForm extends Component {
 						className="signup-form__action-buttons"
 						primaryLabel={ submitButtonText }
 						primaryType="submit"
-						primaryLoading={ isSubmitting }
+						primaryLoading={ isCreatingAccount }
 						primaryDisabled={ isPrimaryDisabled }
 					/>
 					{ this.props.secondaryFooterButton }
@@ -429,7 +439,7 @@ class PasswordlessSignupForm extends Component {
 
 		return (
 			<LoggedOutFormFooter>
-				<SignupSubmitButton isBusy={ isSubmitting } isDisabled={ isPrimaryDisabled }>
+				<SignupSubmitButton isBusy={ isCreatingAccount } isDisabled={ isPrimaryDisabled }>
 					{ submitButtonText }
 				</SignupSubmitButton>
 				{ this.props.secondaryFooterButton }

--- a/client/blocks/signup-form/test/passwordless.jsx
+++ b/client/blocks/signup-form/test/passwordless.jsx
@@ -3,12 +3,13 @@
  */
 
 import config from '@automattic/calypso-config';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { thunk } from 'redux-thunk';
+import MockBlackboxChallenge from 'calypso/blocks/login/blackbox-challenge';
 import { getBlackboxSessionId } from 'calypso/blocks/login/utils/get-blackbox-session-id';
 import PasswordlessSignupForm from '../passwordless';
 
@@ -16,14 +17,7 @@ jest.mock( 'calypso/blocks/login/utils/get-blackbox-session-id', () => ( {
 	getBlackboxSessionId: jest.fn().mockResolvedValue( undefined ),
 } ) );
 
-jest.mock( 'calypso/blocks/login/blackbox-challenge', () => {
-	const { useEffect } = require( 'react' );
-	// Stand-in widget that reports "not blocking" so an enabled form stays submittable.
-	return ( { onSubmitBlockedChange } ) => {
-		useEffect( () => onSubmitBlockedChange?.( false ), [ onSubmitBlockedChange ] );
-		return null;
-	};
-} );
+jest.mock( 'calypso/blocks/login/blackbox-challenge' );
 
 describe( 'createAccountError', () => {
 	const mockStore = configureStore( [ thunk ] );
@@ -301,6 +295,7 @@ describe( 'Blackbox integration', () => {
 		config.enable( 'blackbox-signup' );
 		getBlackboxSessionId.mockReset();
 		getBlackboxSessionId.mockResolvedValue( undefined );
+		MockBlackboxChallenge.blocked = false;
 		delete window.Blackbox;
 		nock.cleanAll();
 	} );
@@ -325,6 +320,54 @@ describe( 'Blackbox integration', () => {
 		await waitFor( () => expect( getRequestBody() ).toBeTruthy() );
 		expect( getRequestBody() ).not.toHaveProperty( 'blackbox_session_id' );
 		expect( getBlackboxSessionId ).not.toHaveBeenCalled();
+	} );
+
+	it( 'sends no request when Enter submits while a challenge is blocking', async () => {
+		MockBlackboxChallenge.blocked = true;
+		const getRequestBody = interceptUsersNew( 403, { error: 'throttled' } );
+
+		renderFormAndSubmit();
+		fireEvent.submit( screen.getByRole( 'textbox', { name: /email/i } ).closest( 'form' ) );
+
+		await waitFor( () => expect( getRequestBody() ).toBeUndefined() );
+		expect( getBlackboxSessionId ).not.toHaveBeenCalled();
+	} );
+
+	it( 'stops the submit button spinning when a challenge appears mid-submit', async () => {
+		getBlackboxSessionId.mockReturnValue( new Promise( () => {} ) );
+		interceptUsersNew( 403, { error: 'throttled' } );
+
+		renderFormAndSubmit();
+
+		const submitButton = await screen.findByRole( 'button', { name: /creating your account/i } );
+		expect( submitButton ).toHaveClass( 'is-busy' );
+
+		act( () => MockBlackboxChallenge.setBlocked( true ) );
+
+		const idleButton = screen.getByRole( 'button', { name: /create your account/i } );
+		expect( idleButton ).not.toHaveClass( 'is-busy' );
+		expect( idleButton ).toBeDisabled();
+	} );
+
+	it( 'does not start a second signup while the first is waiting on Blackbox', async () => {
+		getBlackboxSessionId.mockReturnValue( new Promise( () => {} ) );
+		interceptUsersNew( 403, { error: 'throttled' } );
+
+		const store = mockStore( {} );
+		render(
+			<Provider store={ store }>
+				<PasswordlessSignupForm flowName="onboarding" />
+			</Provider>
+		);
+		fireEvent.change( screen.getByRole( 'textbox', { name: /email/i } ), {
+			target: { value: 'test@example.com' },
+		} );
+
+		const form = screen.getByRole( 'textbox', { name: /email/i } ).closest( 'form' );
+		fireEvent.submit( form );
+		fireEvent.submit( form );
+
+		await waitFor( () => expect( getBlackboxSessionId ).toHaveBeenCalledTimes( 1 ) );
 	} );
 
 	it( 'resets Blackbox when the signup request fails', async () => {

--- a/test/e2e/lib/blackbox-test-key.ts
+++ b/test/e2e/lib/blackbox-test-key.ts
@@ -13,6 +13,12 @@ export const BLACKBOX_TEST_COLLECT_KEYS = {
 
 export type BlackboxTestCollectOutcome = keyof typeof BLACKBOX_TEST_COLLECT_KEYS;
 
+// Aborts the collect instead of keying it, leaving the SDK without a session.
+// The server only attaches a challenge to the collect that mints a session,
+// never to a recollect, so this is how a test arranges for the mint — and
+// therefore the challenge — to happen on the collect the submit fires.
+export type BlackboxTestCollectStep = BlackboxTestCollectOutcome | 'unavailable';
+
 export type BlackboxCollectBody = {
 	data?: { session_id?: string; challenge?: unknown };
 };
@@ -38,17 +44,25 @@ export function waitForCollectData( page: Page ): Promise< BlackboxCollectBody >
 
 export async function useBlackboxTestKeyForCollect(
 	page: Page,
-	outcome: BlackboxTestCollectOutcome = 'allow'
+	outcome: BlackboxTestCollectStep | BlackboxTestCollectStep[] = 'allow'
 ): Promise< void > {
-	const collectKey = BLACKBOX_TEST_COLLECT_KEYS[ outcome ];
+	// In a sequence, the last entry applies to every collect after it.
+	const outcomes = Array.isArray( outcome ) ? outcome : [ outcome ];
+	let collectsSeen = 0;
+	const currentStep = () => outcomes[ Math.min( collectsSeen, outcomes.length - 1 ) ];
 
 	await page.unroute( BLACKBOX_COLLECT_ROUTE );
 	await page.route( BLACKBOX_COLLECT_ROUTE, async ( route ) => {
 		const request = route.request();
+		const step = currentStep();
 
 		if ( request.method() === 'GET' ) {
+			if ( step === 'unavailable' ) {
+				await route.abort();
+				return;
+			}
 			const url = new URL( request.url() );
-			url.searchParams.set( 'apikey', collectKey );
+			url.searchParams.set( 'apikey', BLACKBOX_TEST_COLLECT_KEYS[ step ] );
 			await route.continue( { url: url.toString() } );
 			return;
 		}
@@ -58,10 +72,17 @@ export async function useBlackboxTestKeyForCollect(
 			return;
 		}
 
+		collectsSeen++;
+
+		if ( step === 'unavailable' ) {
+			await route.abort();
+			return;
+		}
+
 		await route.continue( {
 			headers: {
 				...request.headers(),
-				'x-blackbox-api-key': collectKey,
+				'x-blackbox-api-key': BLACKBOX_TEST_COLLECT_KEYS[ step ],
 			},
 		} );
 	} );

--- a/test/e2e/specs/authentication/authentication__blackbox-signup-start-account.spec.ts
+++ b/test/e2e/specs/authentication/authentication__blackbox-signup-start-account.spec.ts
@@ -31,10 +31,10 @@ test.describe( 'Signup: Blackbox /start/account', { tag: [ tags.AUTHENTICATION ]
 		}
 	} );
 
-	const waitForUsersNewRequest = ( page: Page ): Promise< Request > =>
+	const waitForUsersNewRequest = ( page: Page, timeout = 60 * 1000 ): Promise< Request > =>
 		page.waitForRequest(
 			( request ) => request.method() === 'POST' && /\/users\/new\?/.test( request.url() ),
-			{ timeout: 60 * 1000 }
+			{ timeout }
 		);
 
 	test( 'As a new user, I can sign up when Blackbox returns allow', async ( {
@@ -131,6 +131,88 @@ test.describe( 'Signup: Blackbox /start/account', { tag: [ tags.AUTHENTICATION ]
 			await expect(
 				page.locator( '.signup-form__passwordless-form-wrapper button[type="submit"]' )
 			).toBeDisabled();
+		} );
+	} );
+
+	test( 'As a new user, my signup waits when the submit itself starts a challenge', async ( {
+		page,
+	}, workerInfo ) => {
+		test.skip(
+			workerInfo.project.name !== 'authentication',
+			'The authentication project is the only one that has the right browser settings for authentication tests'
+		);
+
+		const testUser = DataHelper.getNewTestUser( { usernamePrefix: 'blackbox' } );
+		const signupPage = new UserSignupPage( page );
+
+		await test.step( 'Given the page mints no session, so the submit has to', async function () {
+			await useBlackboxTestKeyForCollect( page, [ 'unavailable', 'challenge' ] );
+
+			// Nothing should reach /users/new, but a regression creates a real
+			// account, so queue it for teardown instead of leaking it.
+			page.on( 'response', async ( response ) => {
+				if ( response.request().method() !== 'POST' || ! /\/users\/new\?/.test( response.url() ) ) {
+					return;
+				}
+				const body = ( await response.json().catch( () => null ) ) as NewUserResponse | null;
+				if ( body?.body?.user_id ) {
+					accountsToCleanup.push( {
+						user: body.body,
+						password: testUser.password,
+						email: testUser.email,
+					} );
+				}
+			} );
+		} );
+
+		await test.step( 'When I reveal the email form', async function () {
+			await signupPage.visit( { path: 'account' } );
+
+			const continueWithEmailButton = page.getByRole( 'button', {
+				name: /continue with email/i,
+			} );
+			await Promise.race( [
+				continueWithEmailButton.waitFor( { state: 'visible', timeout: 30 * 1000 } ),
+				page
+					.locator( 'input[name="email"]:visible' )
+					.first()
+					.waitFor( { state: 'visible', timeout: 30 * 1000 } ),
+			] );
+			if ( await continueWithEmailButton.isVisible() ) {
+				await continueWithEmailButton.click();
+			}
+		} );
+
+		const submitButton = page.locator(
+			'.signup-form__passwordless-form-wrapper button[type="submit"]'
+		);
+
+		// Registered before the click so a request sent the moment the submit-time
+		// collect resolves cannot slip past unobserved.
+		let heldRequest: Promise< Request | null >;
+
+		await test.step( 'And I submit my email while nothing is blocking it', async function () {
+			await expect(
+				page.locator( '.login__form-blackbox-challenge.has-visible-challenge' )
+			).toBeHidden();
+			await expect( submitButton ).toBeEnabled();
+			await signupPage.emailInput.fill( testUser.email );
+
+			heldRequest = waitForUsersNewRequest( page, 10 * 1000 ).catch( () => null );
+
+			await submitButton.click();
+		} );
+
+		await test.step( 'Then no account is created and the challenge is shown', async function () {
+			const request = await heldRequest;
+			// On a regression the account is real, so let its response land and
+			// reach the teardown listener before the assertion ends the test.
+			await request?.response();
+
+			expect( request ).toBeNull();
+			await expect(
+				page.locator( '.login__form-blackbox-challenge.has-visible-challenge' )
+			).toBeVisible();
 		} );
 	} );
 


### PR DESCRIPTION
`collect()` resolves as soon as the response arrives, even when that response asked for a challenge, so a form collecting at submit time posted a session whose challenge was still unsolved. The records added in BBOX-173, of sessions reaching verification with an unsolved challenge, are what surfaced it.

`challenge-gate.js` stays pending while a challenge is on screen and `getBlackboxSessionId` awaits it — there rather than in `useBlackboxProtection`, so callers that cannot read a hook (the checkout payment processors) are covered too.

This (eventually) belongs in the Blackbox SDK, where `collect()` would not resolve until a challenge it raised had settled. Rolling this out in Calypso first, to watch it on real traffic before changing the contract for every consumer.

Also guards the submit handlers (a disabled button does not stop Enter), adds `submitLock` to `passwordless.jsx`, and stops the buttons spinning while a challenge is up.