### PR TITLE
Dashboard: render snackbars above DataViews action modals

### DIFF
--- a/client/dashboard/app/snackbars/style.scss
+++ b/client/dashboard/app/snackbars/style.scss
@@ -6,6 +6,10 @@
 .dashboard-snackbars {
 	@include snackbar-container();
 
+	// Modals portal into <body> after the app root, so at the shared 100000
+	// they paint over the snackbars. `.dataviews-action-modal` goes to 1000001.
+	z-index: 1000002;
+
 	@include ui-mixins.when-dark-theme {
 		.components-snackbar {
 			background: var( --dashboard-surface__background-color );


### PR DESCRIPTION
## Proposed Changes

* Show dashboard snackbars above open modals.

## Why are these changes being made?

* Snackbars raised from inside a modal, such as the error shown when a new site address is unavailable, were dimmed behind the modal backdrop and hard to read.
* I discovered this issue while testing other PR: 239614-ghe-Automattic/wpcom

## Testing Instructions

1. Check out this branch and run `yarn start-dashboard-only`.
2. Open the Domains page for a site that still uses its free `.wordpress.com` address.
3. In the domain row, open the **Actions** menu and choose **Change site address**.
4. Enter a taken name such as `myawesomedomain` and click **Next**.
5. Before this change, the snackbar "Sorry, that site address is unavailable." shows dimmed under the modal backdrop. After this change, it renders on top of the backdrop in full contrast.
6. Regression: close the modal and trigger any other snackbar, for example saving a setting. It should still appear at the bottom center of the page as before.

| Before | After |
|--------|--------|
|  <img width="1550" height="1832" alt="CleanShot 2026-09-11 at 15 09 41@2x" src="https://github.com/user-attachments/assets/12287f6a-7fd2-4f46-be4c-47e8636a8db4" /> | <img width="1282" height="1688" alt="CleanShot 2026-09-11 at 15 08 40@2x" src="https://github.com/user-attachments/assets/82744a2b-9753-47df-a74e-691b036cbb4d" /> | 

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?