### PR TITLE
Account defaults: let people choose which editor a daily writing prompt opens

### DIFF
--- a/client/dashboard/me/preferences-defaults/index.tsx
+++ b/client/dashboard/me/preferences-defaults/index.tsx
@@ -35,6 +35,12 @@ interface PrimarySiteFormData {
 	primarySiteId?: number;
 }
 
+type PreferredEditor = 'write-editor' | 'block-editor';
+
+interface PreferredEditorFormData {
+	preferredEditor: PreferredEditor;
+}
+
 function LandingPageCard() {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
@@ -290,6 +296,100 @@ function PrimarySiteCard() {
 	);
 }
 
+function WritingPromptEditorCard() {
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { recordTracksEvent } = useAnalytics();
+
+	// An unset or unrecognized value means no choice has been recorded, so the default applies.
+	const { data: savedEditor } = useSuspenseQuery( {
+		...userSettingsQuery(),
+		select: ( data ): PreferredEditor =>
+			data.preferred_editor === 'block-editor' ? 'block-editor' : 'write-editor',
+	} );
+
+	const { mutateAsync: saveUserSettings, isPending } = useMutation( userSettingsMutation() );
+
+	const [ formData, setFormData ] = useState< PreferredEditorFormData >( {
+		preferredEditor: savedEditor,
+	} );
+
+	const isDirty = savedEditor !== formData.preferredEditor;
+
+	const fields: Field< PreferredEditorFormData >[] = [
+		{
+			id: 'preferredEditor',
+			label: __( 'Editor' ),
+			Edit: 'radio',
+			elements: [
+				{ label: __( 'Write editor' ), value: 'write-editor' },
+				{ label: __( 'Block editor' ), value: 'block-editor' },
+			] satisfies { label: string; value: PreferredEditor }[],
+		},
+	];
+
+	const form = {
+		layout: { type: 'regular' as const },
+		fields: [ 'preferredEditor' ],
+	};
+
+	const handleSubmit = ( e: React.FormEvent ) => {
+		e.preventDefault();
+		saveUserSettings( {
+			preferred_editor: formData.preferredEditor,
+		} )
+			.then( () => {
+				recordTracksEvent( 'calypso_dashboard_preferences_defaults_preferred_editor_change', {
+					editor: formData.preferredEditor,
+					source: 'account_defaults',
+				} );
+				createSuccessNotice( __( 'Editor preference saved.' ), {
+					type: 'snackbar',
+				} );
+			} )
+			.catch( () => {
+				createErrorNotice( __( 'Failed to save editor preference.' ), {
+					type: 'snackbar',
+				} );
+			} );
+	};
+
+	return (
+		<Card>
+			<CardBody>
+				<form onSubmit={ handleSubmit } aria-label={ __( 'Daily writing prompts' ) }>
+					<VStack spacing={ 4 }>
+						<SectionHeader
+							level={ 3 }
+							title={ __( 'Daily writing prompts' ) }
+							description={ __( 'Choose which editor “Post your answer” opens.' ) }
+						/>
+						<NavigationBlocker shouldBlock={ isDirty } />
+						<DataForm< PreferredEditorFormData >
+							data={ formData }
+							fields={ fields }
+							form={ form }
+							onChange={ ( edits: Partial< PreferredEditorFormData > ) => {
+								setFormData( ( data ) => ( { ...data, ...edits } ) );
+							} }
+						/>
+						<ButtonStack>
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								type="submit"
+								isBusy={ isPending }
+								disabled={ isPending || ! isDirty }
+							>
+								{ __( 'Save' ) }
+							</Button>
+						</ButtonStack>
+					</VStack>
+				</form>
+			</CardBody>
+		</Card>
+	);
+}
+
 export default function PreferencesDefaults() {
 	return (
 		<PageLayout
@@ -305,6 +405,7 @@ export default function PreferencesDefaults() {
 			<VStack spacing={ 4 }>
 				<LandingPageCard />
 				<PrimarySiteCard />
+				<WritingPromptEditorCard />
 			</VStack>
 		</PageLayout>
 	);

--- a/client/dashboard/me/preferences-defaults/index.tsx
+++ b/client/dashboard/me/preferences-defaults/index.tsx
@@ -17,6 +17,7 @@ import { useAuth } from '../../app/auth';
 import Breadcrumbs from '../../app/breadcrumbs';
 import { useAppContext } from '../../app/context';
 import { NavigationBlocker } from '../../app/navigation-blocker';
+import { withSnackbar } from '../../app/snackbars/with-snackbar';
 import { ButtonStack } from '../../components/button-stack/';
 import { Card, CardBody } from '../../components/card';
 import { PageHeader } from '../../components/page-header';
@@ -297,7 +298,6 @@ function PrimarySiteCard() {
 }
 
 function WritingPromptEditorCard() {
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const { recordTracksEvent } = useAnalytics();
 
 	// An unset or unrecognized value means no choice has been recorded, so the default applies.
@@ -307,7 +307,12 @@ function WritingPromptEditorCard() {
 			data.preferred_editor === 'block-editor' ? 'block-editor' : 'write-editor',
 	} );
 
-	const { mutateAsync: saveUserSettings, isPending } = useMutation( userSettingsMutation() );
+	const { mutate: saveUserSettings, isPending } = useMutation(
+		withSnackbar( userSettingsMutation(), {
+			success: __( 'Editor preference saved.' ),
+			error: __( 'Failed to save editor preference.' ),
+		} )
+	);
 
 	const [ formData, setFormData ] = useState< PreferredEditorFormData >( {
 		preferredEditor: savedEditor,
@@ -334,23 +339,17 @@ function WritingPromptEditorCard() {
 
 	const handleSubmit = ( e: React.FormEvent ) => {
 		e.preventDefault();
-		saveUserSettings( {
-			preferred_editor: formData.preferredEditor,
-		} )
-			.then( () => {
-				recordTracksEvent( 'calypso_dashboard_preferences_defaults_preferred_editor_change', {
-					editor: formData.preferredEditor,
-					source: 'account_defaults',
-				} );
-				createSuccessNotice( __( 'Editor preference saved.' ), {
-					type: 'snackbar',
-				} );
-			} )
-			.catch( () => {
-				createErrorNotice( __( 'Failed to save editor preference.' ), {
-					type: 'snackbar',
-				} );
-			} );
+		saveUserSettings(
+			{ preferred_editor: formData.preferredEditor },
+			{
+				onSuccess: () => {
+					recordTracksEvent( 'calypso_dashboard_preferences_defaults_preferred_editor_change', {
+						editor: formData.preferredEditor,
+						source: 'account_defaults',
+					} );
+				},
+			}
+		);
 	};
 
 	return (

--- a/client/dashboard/me/preferences-defaults/test/index.test.tsx
+++ b/client/dashboard/me/preferences-defaults/test/index.test.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import { render } from '../../../test-utils';
 import PreferencesDefaults from '../index';
-import type { Site, User, UserPreferences } from '@automattic/api-core';
+import type { Site, User, UserPreferences, UserSettings } from '@automattic/api-core';
 
 // The suggestions list scrolls the highlighted option into view, which JSDOM lacks.
 Element.prototype.scrollIntoView = jest.fn();
@@ -39,11 +39,14 @@ function mockPreferences( preferences: Partial< UserPreferences > = {} ) {
 		.reply( 200, { calypso_preferences: preferences } );
 }
 
-function mockUserSettings( primarySiteId: number | null = PRIMARY_SITE_ID ) {
+function mockUserSettings(
+	primarySiteId: number | null = PRIMARY_SITE_ID,
+	settings: Partial< UserSettings > = {}
+) {
 	nock( 'https://public-api.wordpress.com' )
 		.get( '/rest/v1.1/me/settings' )
 		.query( true )
-		.reply( 200, { primary_site_ID: primarySiteId } );
+		.reply( 200, { primary_site_ID: primarySiteId, ...settings } );
 }
 
 function mockSites( sites: Site[] ) {
@@ -298,6 +301,99 @@ describe( '<PreferencesDefaults>', () => {
 			await waitFor( () => expect( saveRequest.isDone() ).toBe( true ) );
 			expect( recordTracksEvent ).not.toHaveBeenCalledWith(
 				'calypso_dashboard_preferences_defaults_homepage_toggle',
+				expect.anything()
+			);
+		} );
+	} );
+
+	describe( 'daily writing prompts', () => {
+		function mockPromptDefaults( settings: Partial< UserSettings > = {} ) {
+			mockPreferences();
+			mockUserSettings( PRIMARY_SITE_ID, settings );
+			mockSites( [ primarySite, otherSite ] );
+			mockSite( primarySite );
+		}
+
+		test( 'falls back to the Write editor when nothing is saved', async () => {
+			mockPromptDefaults();
+
+			renderPage();
+
+			await expect( screen.findByLabelText( 'Write editor' ) ).resolves.toBeChecked();
+			expect( screen.getByLabelText( 'Block editor' ) ).not.toBeChecked();
+		} );
+
+		test( 'treats an empty value as unset', async () => {
+			mockPromptDefaults( { preferred_editor: '' } );
+
+			renderPage();
+
+			await expect( screen.findByLabelText( 'Write editor' ) ).resolves.toBeChecked();
+		} );
+
+		test( 'preselects the block editor when it is saved', async () => {
+			mockPromptDefaults( { preferred_editor: 'block-editor' } );
+
+			renderPage();
+
+			await expect( screen.findByLabelText( 'Block editor' ) ).resolves.toBeChecked();
+		} );
+
+		test( 'save button is disabled until the selection changes', async () => {
+			const currentUser = userEvent.setup();
+			mockPromptDefaults();
+
+			renderPage();
+
+			await screen.findByRole( 'form', { name: 'Daily writing prompts' } );
+			const saveButton = saveButtonFor( 'Daily writing prompts' );
+			expect( saveButton ).toBeDisabled();
+
+			await currentUser.click( screen.getByLabelText( 'Block editor' ) );
+			expect( saveButton ).toBeEnabled();
+		} );
+
+		test( 'saves the selected editor to /me/settings', async () => {
+			const currentUser = userEvent.setup();
+			mockPromptDefaults();
+			let savedBody: Record< string, unknown > = {};
+			const saveRequest = nock( 'https://public-api.wordpress.com' )
+				.post( '/rest/v1.1/me/settings', ( body ) => {
+					savedBody = body;
+					return true;
+				} )
+				.reply( 200, { preferred_editor: 'block-editor' } );
+
+			const { recordTracksEvent } = renderPage();
+
+			await currentUser.click( await screen.findByLabelText( 'Block editor' ) );
+			await currentUser.click( saveButtonFor( 'Daily writing prompts' ) );
+
+			await waitFor( () => expect( saveRequest.isDone() ).toBe( true ) );
+			expect( savedBody ).toEqual( { preferred_editor: 'block-editor' } );
+			expect( recordTracksEvent ).toHaveBeenCalledWith(
+				'calypso_dashboard_preferences_defaults_preferred_editor_change',
+				{ editor: 'block-editor', source: 'account_defaults' }
+			);
+		} );
+
+		test( 'keeps the change when saving fails', async () => {
+			const currentUser = userEvent.setup();
+			mockPromptDefaults();
+			const saveRequest = nock( 'https://public-api.wordpress.com' )
+				.post( '/rest/v1.1/me/settings' )
+				.reply( 500 );
+
+			const { recordTracksEvent } = renderPage();
+
+			await currentUser.click( await screen.findByLabelText( 'Block editor' ) );
+			await currentUser.click( saveButtonFor( 'Daily writing prompts' ) );
+
+			await waitFor( () => expect( saveRequest.isDone() ).toBe( true ) );
+			expect( screen.getByLabelText( 'Block editor' ) ).toBeChecked();
+			await waitFor( () => expect( saveButtonFor( 'Daily writing prompts' ) ).toBeEnabled() );
+			expect( recordTracksEvent ).not.toHaveBeenCalledWith(
+				'calypso_dashboard_preferences_defaults_preferred_editor_change',
 				expect.anything()
 			);
 		} );

--- a/packages/api-core/src/me-settings/mutators.ts
+++ b/packages/api-core/src/me-settings/mutators.ts
@@ -36,6 +36,7 @@ export async function updateUserSettings(
 		'two_step_sms_phone_number',
 		'two_step_enhanced_security',
 		'primary_site_ID',
+		'preferred_editor',
 		'mcp_abilities',
 		'ai_assistant',
 		'user_email_change_pending',

--- a/packages/api-core/src/me-settings/types.ts
+++ b/packages/api-core/src/me-settings/types.ts
@@ -97,6 +97,8 @@ export interface UserSettings {
 	p2_disable_autofollow_on_comment: boolean;
 
 	primary_site_ID?: number;
+	/** Which editor a daily writing prompt opens. Empty or absent means no choice has been recorded. */
+	preferred_editor?: 'write-editor' | 'block-editor' | '' | null;
 	mcp_abilities?: McpAbilities;
 	/** When true, account-level AI assistant features are enabled (requires API support). */
 	ai_assistant?: boolean | null;


### PR DESCRIPTION
Fixes READ-730

## Proposed Changes

* Adds a "Daily writing prompts" card to `/me/preferences/defaults`, with a radio to pick the Write editor or the block editor. It saves to the wpcom `preferred_editor` user setting.
* Adds `preferred_editor` to the `UserSettings` type in `@automattic/api-core`, and to the `saveableKeys` allowlist in `updateUserSettings`. That allowlist filters the POST body, so without the entry the save would report success having sent nothing.
* An absent, empty, or unrecognized value means nobody has recorded a choice yet, so the card falls back to the Write editor.


<img width="728" height="246" alt="image" src="https://github.com/user-attachments/assets/4861a453-e024-479b-94ea-a8364d8050a5" />


## Why are these changes being made?

"Post your answer" on a daily writing prompt opens the Write editor. If someone leaves Write, through its first-visit note or the Tips panel, that choice gets recorded and they stop being sent there.

For a WordPress.com Simple user, this card is the only way back. The equivalent wp-admin toggle only exists on Atomic, since Simple sites don't use the Jetpack plugin's settings screens. That's why it should land alongside READ-729 rather than after it.

The value goes to wpcom `/me/settings` rather than the Calypso preferences blob, because the Jetpack plugin reads it server-side and can't see the blob.

Two things this deliberately doesn't do:

* There's no third "unset" radio. Once you save, the value is always an explicit `write-editor` or `block-editor`. That matches the design, since Write records a value on first open anyway. If we ever need unset to stay distinguishable from a deliberate `write-editor`, that's a third option to add later.
* The page description still reads "Set your starting point after you log in and primary site.", which doesn't cover the new card. It's the same translated string in two places, so I left it for a follow-up.

## Testing Instructions

This needs READ-728 deployed before it can be tested end to end. Until then `/me/settings` drops the unknown `preferred_editor` key, ends up with an empty payload, and returns `400 invalid_input` — "No settings were provided to the endpoint to set." The card handles that correctly: you get the "Failed to save editor preference." notice, your selection stays on screen, and Save stays enabled.

Of note, READ-728 and READ-729 both currently validate against `write` / `block`, and this uses `write-editor` / `block-editor`. Those two need the matching values before any of this works together — READ-728 rejects anything else with a 400, and READ-729 treats an unknown value as unset.

1. Go to `/me/preferences/defaults`. The third card is "Daily writing prompts", with the Write editor preselected.
2. Save stays disabled until you change the selection.
3. Pick "Block editor" and save. You should get an "Editor preference saved." snackbar, and Save should go back to disabled.
4. Reload the page. The block editor should still be selected.
5. Change the selection again and try to navigate away without saving. You should get the unsaved-changes prompt.

`yarn test-client client/dashboard/me/preferences-defaults` covers the fallback, the empty value, the preselection, the disabled Save, the request body, and a failed save keeping your change on screen.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
