### PR TITLE
Performance: align the classic tab's public-site check with the dashboard

### DIFF
--- a/client/hosting/performance/site-performance.tsx
+++ b/client/hosting/performance/site-performance.tsx
@@ -7,7 +7,6 @@ import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import { useEffect, useMemo, useState } from 'react';
-import { useSiteSettings } from 'calypso/blocks/plugins-scheduled-updates/hooks/use-site-settings';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PreLaunchSiteModal from 'calypso/components/pre-launch-site-modal';
@@ -57,9 +56,7 @@ const SitePerformanceContent = ( { path }: { path?: string } ) => {
 	const { activeTab, setActiveTab } = useDeviceTab();
 	const site = useSelector( getSelectedSite );
 	const siteId = site?.ID;
-	const { getSiteSetting } = useSiteSettings( site?.slug );
-	const blog_public = getSiteSetting( 'blog_public' );
-	const isSitePublic = site && blog_public === 1;
+	const isSitePublic = site && ! ( site.is_coming_soon || site.is_private );
 	const isSiteAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const isSiteFlex = useSelector( ( state ) => isWpcomFlexSite( state, siteId ) );
 


### PR DESCRIPTION
## Proposed Changes

* The classic Performance tab now treats a site as public unless it is coming soon or private, which is the check the multi-site dashboard uses, instead of requiring `blog_public` to be exactly `1`.
* Reading those flags off the site drops the last caller of `useSiteSettings` on this page, so that fetch goes with it.

## Why are these changes being made?

The two dashboards disagreed about one case: a public site with "Discourage search engines" on has `blog_public === 0`, so the dashboard measured its performance while the classic tab told the user to launch a site that is already launched. Aligning on the dashboard's check settles it, and the next person comparing the two screens finds one rule rather than two.

Worth knowing in review: this is a live behavior change for those sites, not only a refactor. They now get the performance report where they used to get the launch notice.

## Testing Instructions

**1. Public site that discourages search engines (the behavior change)**

1. Open a **public** site with `Settings → Reading → Discourage search engines` enabled.
2. Visit its Performance tab in the classic hosting dashboard. Confirm the report loads, where it previously showed the report-unavailable screen.
3. Set the same site to **Coming soon**, reload, and confirm the report-unavailable screen comes back.
4. Set it to **Private**, reload, and confirm it is still shown.
5. Return it to public and confirm the report loads.

**2. A4A development site launch flow (should be unchanged)**

1. Open an Automattic for Agencies development site and visit its Performance tab. Development sites are coming soon, so this path is untouched by the change.
2. Confirm the report-unavailable screen still appears, with the CTA reading `Prepare for launch` rather than `Launch your site`.
3. Click it. From A4A, confirm you land on the site's Site visibility settings; from the WordPress.com dashboard, confirm you land on that site's settings screen.
4. Launch the site from there, return to the Performance tab, and confirm the report now loads.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

---

*Generated by JK Bot, powered by Claude.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
