### PR TITLE
Domains: surface processing failures in the stepper domain flow

### DIFF
--- a/client/landing/stepper/declarative-flow/flows/domain/domain.ts
+++ b/client/landing/stepper/declarative-flow/flows/domain/domain.ts
@@ -45,6 +45,7 @@ function initialize() {
 		STEPS.UNIFIED_PLANS,
 		STEPS.SITE_CREATION_STEP,
 		STEPS.PROCESSING,
+		STEPS.ERROR,
 	];
 
 	return stepsWithRequiredLogin( steps );
@@ -478,8 +479,7 @@ const domain: FlowV2< typeof initialize > = {
 						// replace the location to delete processing step from history.
 						window.location.replace( destination );
 					} else {
-						// TODO: Handle errors
-						// navigate( 'error' );
+						return navigate( STEPS.ERROR.slug );
 					}
 					return;
 				}


### PR DESCRIPTION
## Proposed Changes

* Navigate to the error step when the stepper `domain` flow's processing step reports `ProcessingResult.FAILURE`, replacing the `// TODO: Handle errors` placeholder.
* Add `STEPS.ERROR` to the flow's step list so that navigation has a destination.

## Why are these changes being made?

Every path in the `domain` flow that sets a pending action funnels through the same processing handler, and that handler only acted on `ProcessingResult.SUCCESS`. When a pending action rejected — for example an `add-domain-mapping` request failing validation for a domain the user connects from `use-my-domain` — the processing step caught the rejection, stored the error and submitted `FAILURE`, but the flow did nothing with it. Since the processing screen has no error UI of its own and its final loading message has `duration: Infinity`, the user was left on a spinner indefinitely with no way forward.

The error step reads the error the processing step already stored via `setSiteSetupError()`, so the API error and the support card are now shown.

Routing a non-successful processing result to `STEPS.ERROR` is the established pattern in the stepper — every flow that handles the result does it this way, and this PR uses the same shape as the first group:

Same `else` of the `SUCCESS` check:

* `flows/onboarding/onboarding.ts:822`
* `flows/onboarding-unified/onboarding-unified.ts:154`

Equivalent `!== ProcessingResult.SUCCESS` guard:

* `flows/education/education.ts:162`
* `flows/direct-to-cart/direct-to-cart.ts:171`
* `flows/ai-site-builder-spec/ai-site-builder-spec.ts:96`

`=== ProcessingResult.FAILURE` guard:

* `flows/site-setup-flow/site-setup-flow.ts:241`
* `flows/ai-site-builder/ai-site-builder.ts:163`
* `flows/ai-site-builder-onboarding/ai-site-builder-onboarding.ts:218`
* `flows/entrepreneur-flow/entrepreneur-flow.ts:155`
* `flows/plugin-bundle-flow/plugin-bundle-flow.ts:188`
* `flows/readymade-template/readymade-template.tsx:114`
* `flows/transferring-hosted-site-flow/transferring-hosted-site-flow.ts:63`
* `flows/update-design/update-design.ts:78`
* `flows/update-options/update-options.ts:35`

All paths are relative to `client/landing/stepper/declarative-flow/`. Each of those flows also carries `STEPS.ERROR` in its step list, as this one now does.

## Testing Instructions

1. Start the dev server and open `/setup/domain/use-my-domain?siteSlug=<a site on a plan that includes domain mapping>`.
2. Connect a domain whose mapping the API will reject (or stub `POST /sites/<id>/add-domain-mapping` to return an error).
3. Before: the flow lands on `/setup/domain/processing` and the "Finishing up" animation runs forever, with `ProcessingStep failed:` logged to the console.
4. After: the flow lands on the error step, showing the error returned by the API along with the support card.
5. Confirm the success path is unaffected: connect a domain that maps successfully and check you are still redirected to the domain connection setup page.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

https://claude.ai/code/session_0177xrvZQh7RpqfKoUydGEVm
