### PR TITLE
Jetpack AI Logo Generator: upsell a WordPress.com plan on Simple sites and handle a plan upgrade still being applied

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -119,7 +119,13 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 			setNeedsMoreRequests( needsMoreRequests );
 
 			if ( ! feature?.hasFeature || needsMoreRequests ) {
-				setUpgradeURL( getUpgradeURL( { siteDetails, nextTierSlug: feature?.nextTier?.slug } ) );
+				setUpgradeURL(
+					getUpgradeURL( {
+						siteDetails,
+						nextTierSlug: feature?.nextTier?.slug,
+						reason: feature?.hasFeature ? 'requests' : 'feature',
+					} )
+				);
 				setLoadingState( null );
 				return;
 			}

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -119,13 +119,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 			setNeedsMoreRequests( needsMoreRequests );
 
 			if ( ! feature?.hasFeature || needsMoreRequests ) {
-				setUpgradeURL(
-					getUpgradeURL( {
-						siteDetails,
-						nextTierSlug: feature?.nextTier?.slug,
-						reason: feature?.hasFeature ? 'requests' : 'feature',
-					} )
-				);
+				setUpgradeURL( getUpgradeURL( { siteDetails, nextTierSlug: feature?.nextTier?.slug } ) );
 				setLoadingState( null );
 				return;
 			}

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -23,6 +23,7 @@ import {
 import useLogoGenerator from '../hooks/use-logo-generator';
 import useRequestErrors from '../hooks/use-request-errors';
 import { isLogoHistoryEmpty, clearDeletedMedia } from '../lib/logo-storage';
+import { getUpgradeURL } from '../lib/upgrade-url';
 import { STORE_NAME } from '../store';
 import { FeatureFetchFailureScreen } from './feature-fetch-failure-screen';
 import { FirstLoadScreen } from './first-load-screen';
@@ -118,11 +119,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 			setNeedsMoreRequests( needsMoreRequests );
 
 			if ( ! feature?.hasFeature || needsMoreRequests ) {
-				const upgradeURL = new URL(
-					`${ location.origin }/checkout/${ siteDetails?.domain }/${ feature?.nextTier?.slug }`
-				);
-				upgradeURL.searchParams.set( 'redirect_to', location.href );
-				setUpgradeURL( upgradeURL.toString() );
+				setUpgradeURL( getUpgradeURL( { siteDetails, nextTierSlug: feature?.nextTier?.slug } ) );
 				setLoadingState( null );
 				return;
 			}
@@ -143,7 +140,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 			debug( 'Error fetching feature', error );
 			setLoadingState( null );
 		}
-	}, [ getFeature, siteId, loadLogoHistory, generateFirstLogo, siteDetails?.domain ] );
+	}, [ getFeature, siteId, loadLogoHistory, generateFirstLogo, siteDetails ] );
 
 	const handleModalOpen = useCallback( async () => {
 		setContext( context );

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -30,6 +30,7 @@ import { FirstLoadScreen } from './first-load-screen';
 import { HistoryCarousel } from './history-carousel';
 import { LogoPresenter } from './logo-presenter';
 import { Prompt } from './prompt';
+import { UpgradePendingScreen } from './upgrade-pending-screen';
 import { UpgradeScreen } from './upgrade-screen';
 import { VisitSiteBanner } from './visit-site-banner';
 import './generator-modal.scss';
@@ -56,6 +57,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	const [ isFirstCallOnOpen, setIsFirstCallOnOpen ] = useState( true );
 	const [ needsFeature, setNeedsFeature ] = useState( false );
 	const [ needsMoreRequests, setNeedsMoreRequests ] = useState( false );
+	const [ isUpgradePending, setIsUpgradePending ] = useState( false );
 	const [ upgradeURL, setUpgradeURL ] = useState( '' );
 	const { selectedLogo, getAiAssistantFeature, generateFirstPrompt, generateLogo, setContext } =
 		useLogoGenerator();
@@ -99,6 +101,19 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		// First fetch the feature data so we have the most up-to-date info from the backend.
 		try {
 			const feature = await getFeature();
+
+			// Right after a plan purchase the endpoint can keep reporting the free tier for a
+			// while. Having the feature while still on the free tier only happens in that window.
+			const upgradePending = !! feature?.hasFeature && feature?.currentTier?.value === 0;
+
+			setIsUpgradePending( upgradePending );
+			if ( upgradePending ) {
+				setNeedsFeature( false );
+				setNeedsMoreRequests( false );
+				setLoadingState( null );
+				return;
+			}
+
 			const hasHistory = ! isLogoHistoryEmpty( String( siteId ) );
 			const logoCost = feature?.costs?.[ 'jetpack-ai-logo-generator' ]?.logo ?? DEFAULT_LOGO_COST;
 			const promptCreationCost = 1;
@@ -209,6 +224,8 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		body = <FirstLoadScreen state={ loadingState } />;
 	} else if ( featureFetchError || firstLogoPromptFetchError ) {
 		body = <FeatureFetchFailureScreen onCancel={ closeModal } onRetry={ initializeModal } />;
+	} else if ( isUpgradePending ) {
+		body = <UpgradePendingScreen onCancel={ closeModal } onRetry={ initializeModal } />;
 	} else if ( needsFeature || needsMoreRequests ) {
 		body = (
 			<UpgradeScreen
@@ -273,7 +290,11 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 					<div
 						className={ clsx( 'jetpack-ai-logo-generator-modal__body', {
 							'notice-modal':
-								needsFeature || needsMoreRequests || featureFetchError || firstLogoPromptFetchError,
+								needsFeature ||
+								needsMoreRequests ||
+								isUpgradePending ||
+								featureFetchError ||
+								firstLogoPromptFetchError,
 						} ) }
 					>
 						{ body }

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-pending-screen.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-pending-screen.tsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+/**
+ * Types
+ */
+import type React from 'react';
+
+export const UpgradePendingScreen: React.FC< {
+	onCancel: () => void;
+	onRetry: () => void;
+} > = ( { onCancel, onRetry } ) => {
+	const message = __(
+		'Your plan upgrade is still being applied. Please try again in a few minutes.',
+		'jetpack'
+	);
+
+	return (
+		<div className="jetpack-ai-logo-generator-modal__notice-message-wrapper">
+			<div className="jetpack-ai-logo-generator-modal__notice-message">
+				<span className="jetpack-ai-logo-generator-modal__loading-message">{ message }</span>
+			</div>
+			<div className="jetpack-ai-logo-generator-modal__notice-actions">
+				<Button variant="tertiary" onClick={ onCancel }>
+					{ __( 'Cancel', 'jetpack' ) }
+				</Button>
+				<Button variant="primary" onClick={ onRetry }>
+					{ __( 'Try again', 'jetpack' ) }
+				</Button>
+			</div>
+		</div>
+	);
+};

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
@@ -35,7 +35,7 @@ export const UpgradeScreen: React.FC< {
 
 	const upgradeMessageFeature = isWpcomSimpleSite( siteDetails )
 		? __(
-				'Upgrade your WordPress.com plan for access to exclusive Jetpack AI features, including logo generation. A paid plan also increases the amount of requests you can use in all AI-powered features.',
+				'Upgrade your WordPress.com plan for access to exclusive Jetpack AI features, including logo generation. A paid plan also gives you unlimited requests in all AI-powered features.',
 				'jetpack'
 		  )
 		: __(

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
@@ -5,16 +5,19 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenter } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
 import { EVENT_PLACEMENT_FREE_USER_SCREEN, EVENT_UPGRADE } from '../../constants';
 import useLogoGenerator from '../hooks/use-logo-generator';
+import { isWpcomSimpleSite } from '../lib/upgrade-url';
+import { STORE_NAME } from '../store';
 /**
  * Types
  */
+import type { Selectors } from '../store/types';
 import type React from 'react';
 
 const HELP_CENTER_STORE = HelpCenter.register();
@@ -25,16 +28,31 @@ export const UpgradeScreen: React.FC< {
 	reason: 'feature' | 'requests';
 } > = ( { onCancel, upgradeURL, reason } ) => {
 	const { setShowHelpCenter, setShowSupportDoc } = useDispatch( HELP_CENTER_STORE );
+	const siteDetails = useSelect( ( select ) => {
+		const selectors: Selectors = select( STORE_NAME );
+		return selectors.getSiteDetails();
+	}, [] );
 
-	const upgradeMessageFeature = __(
-		'Upgrade your Jetpack AI for access to exclusive features, including logo generation. This upgrade will also increase the amount of requests you can use in all AI-powered features.',
-		'jetpack'
-	);
+	// A Simple site upgrades its WordPress.com plan, not a Jetpack AI tier.
+	const upgradeMessageFeature = isWpcomSimpleSite( siteDetails )
+		? __(
+				'Upgrade your WordPress.com plan for access to exclusive Jetpack AI features, including logo generation. A paid plan also increases the amount of requests you can use in all AI-powered features.',
+				'jetpack'
+		  )
+		: __(
+				'Upgrade your Jetpack AI for access to exclusive features, including logo generation. This upgrade will also increase the amount of requests you can use in all AI-powered features.',
+				'jetpack'
+		  );
 
-	const upgradeMessageRequests = __(
-		'Not enough requests left to generate a logo. Upgrade your Jetpack AI to increase the amount of requests you can use in all AI-powered features.',
-		'jetpack'
-	);
+	const upgradeMessageRequests = isWpcomSimpleSite( siteDetails )
+		? __(
+				'Not enough requests left to generate a logo. Upgrade your WordPress.com plan to increase the amount of requests you can use in all AI-powered features.',
+				'jetpack'
+		  )
+		: __(
+				'Not enough requests left to generate a logo. Upgrade your Jetpack AI to increase the amount of requests you can use in all AI-powered features.',
+				'jetpack'
+		  );
 
 	const { context } = useLogoGenerator();
 

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { EVENT_PLACEMENT_FREE_USER_SCREEN, EVENT_UPGRADE } from '../../constants';
 import useLogoGenerator from '../hooks/use-logo-generator';
-import { isWpcomSimpleSite } from '../lib/upgrade-url';
+import { shouldUpgradePlan } from '../lib/upgrade-url';
 import { STORE_NAME } from '../store';
 /**
  * Types
@@ -33,8 +33,7 @@ export const UpgradeScreen: React.FC< {
 		return selectors.getSiteDetails();
 	}, [] );
 
-	// A Simple site upgrades its WordPress.com plan, not a Jetpack AI tier.
-	const upgradeMessageFeature = isWpcomSimpleSite( siteDetails )
+	const upgradeMessageFeature = shouldUpgradePlan( siteDetails, reason )
 		? __(
 				'Upgrade your WordPress.com plan for access to exclusive Jetpack AI features, including logo generation. A paid plan also increases the amount of requests you can use in all AI-powered features.',
 				'jetpack'
@@ -44,15 +43,10 @@ export const UpgradeScreen: React.FC< {
 				'jetpack'
 		  );
 
-	const upgradeMessageRequests = isWpcomSimpleSite( siteDetails )
-		? __(
-				'Not enough requests left to generate a logo. Upgrade your WordPress.com plan to increase the amount of requests you can use in all AI-powered features.',
-				'jetpack'
-		  )
-		: __(
-				'Not enough requests left to generate a logo. Upgrade your Jetpack AI to increase the amount of requests you can use in all AI-powered features.',
-				'jetpack'
-		  );
+	const upgradeMessageRequests = __(
+		'Not enough requests left to generate a logo. Upgrade your Jetpack AI to increase the amount of requests you can use in all AI-powered features.',
+		'jetpack'
+	);
 
 	const { context } = useLogoGenerator();
 

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
@@ -12,7 +12,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { EVENT_PLACEMENT_FREE_USER_SCREEN, EVENT_UPGRADE } from '../../constants';
 import useLogoGenerator from '../hooks/use-logo-generator';
-import { shouldUpgradePlan } from '../lib/upgrade-url';
+import { isWpcomSimpleSite } from '../lib/upgrade-url';
 import { STORE_NAME } from '../store';
 /**
  * Types
@@ -33,7 +33,7 @@ export const UpgradeScreen: React.FC< {
 		return selectors.getSiteDetails();
 	}, [] );
 
-	const upgradeMessageFeature = shouldUpgradePlan( siteDetails, reason )
+	const upgradeMessageFeature = isWpcomSimpleSite( siteDetails )
 		? __(
 				'Upgrade your WordPress.com plan for access to exclusive Jetpack AI features, including logo generation. A paid plan also increases the amount of requests you can use in all AI-powered features.',
 				'jetpack'

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-checkout.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-checkout.ts
@@ -6,7 +6,6 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
-import { getUpgradeURL } from '../lib/upgrade-url';
 import { STORE_NAME } from '../store';
 /**
  * Types
@@ -24,12 +23,15 @@ export const useCheckout = () => {
 		};
 	}, [] );
 
-	const upgradeURL = getUpgradeURL( { siteDetails, nextTierSlug: nextTier?.slug } );
+	const upgradeURL = new URL(
+		`${ location.origin }/checkout/${ siteDetails?.domain }/${ nextTier?.slug }`
+	);
+	upgradeURL.searchParams.set( 'redirect_to', location.href );
 
-	debug( 'Next tier checkout URL: ', upgradeURL );
+	debug( 'Next tier checkout URL: ', upgradeURL.toString() );
 
 	return {
-		nextTierCheckoutURL: upgradeURL,
+		nextTierCheckoutURL: upgradeURL.toString(),
 		hasNextTier: !! nextTier,
 	};
 };

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-checkout.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-checkout.ts
@@ -6,6 +6,7 @@ import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
+import { getUpgradeURL } from '../lib/upgrade-url';
 import { STORE_NAME } from '../store';
 /**
  * Types
@@ -23,15 +24,12 @@ export const useCheckout = () => {
 		};
 	}, [] );
 
-	const upgradeURL = new URL(
-		`${ location.origin }/checkout/${ siteDetails?.domain }/${ nextTier?.slug }`
-	);
-	upgradeURL.searchParams.set( 'redirect_to', location.href );
+	const upgradeURL = getUpgradeURL( { siteDetails, nextTierSlug: nextTier?.slug } );
 
-	debug( 'Next tier checkout URL: ', upgradeURL.toString() );
+	debug( 'Next tier checkout URL: ', upgradeURL );
 
 	return {
-		nextTierCheckoutURL: upgradeURL.toString(),
+		nextTierCheckoutURL: upgradeURL,
 		hasNextTier: !! nextTier,
 	};
 };

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/upgrade-url.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/upgrade-url.ts
@@ -1,0 +1,30 @@
+/**
+ * Types
+ */
+import type { SiteDetails } from '@automattic/data-stores';
+
+/**
+ * Jetpack AI tiers are only sold for Jetpack-connected sites. A WordPress.com
+ * Simple site gets Jetpack AI through a paid WordPress.com plan instead, so the
+ * upgrade path for it is the plans page rather than a Jetpack AI checkout.
+ */
+export const isWpcomSimpleSite = ( siteDetails?: SiteDetails ): boolean =>
+	!! siteDetails && ! siteDetails.jetpack;
+
+export const getUpgradeURL = ( {
+	siteDetails,
+	nextTierSlug,
+	redirectTo = location.href,
+}: {
+	siteDetails?: SiteDetails;
+	nextTierSlug?: string;
+	redirectTo?: string;
+} ): string => {
+	const upgradeURL = isWpcomSimpleSite( siteDetails )
+		? new URL( `${ location.origin }/plans/${ siteDetails?.slug }` )
+		: new URL( `${ location.origin }/checkout/${ siteDetails?.domain }/${ nextTierSlug }` );
+
+	upgradeURL.searchParams.set( 'redirect_to', redirectTo );
+
+	return upgradeURL.toString();
+};

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/upgrade-url.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/upgrade-url.ts
@@ -19,18 +19,16 @@ export const getUpgradeURL = ( {
 	siteDetails,
 	nextTierSlug,
 	reason,
-	redirectTo = location.href,
 }: {
 	siteDetails?: SiteDetails;
 	nextTierSlug?: string;
 	reason: UpgradeReason;
-	redirectTo?: string;
 } ): string => {
 	const upgradeURL = shouldUpgradePlan( siteDetails, reason )
 		? new URL( `${ location.origin }/plans/${ siteDetails?.slug }` )
 		: new URL( `${ location.origin }/checkout/${ siteDetails?.domain }/${ nextTierSlug }` );
 
-	upgradeURL.searchParams.set( 'redirect_to', redirectTo );
+	upgradeURL.searchParams.set( 'redirect_to', location.href );
 
 	return upgradeURL.toString();
 };

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/upgrade-url.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/upgrade-url.ts
@@ -3,24 +3,30 @@
  */
 import type { SiteDetails } from '@automattic/data-stores';
 
-/**
- * Jetpack AI tiers are only sold for Jetpack-connected sites. A WordPress.com
- * Simple site gets Jetpack AI through a paid WordPress.com plan instead, so the
- * upgrade path for it is the plans page rather than a Jetpack AI checkout.
- */
+export type UpgradeReason = 'feature' | 'requests';
+
 export const isWpcomSimpleSite = ( siteDetails?: SiteDetails ): boolean =>
 	!! siteDetails && ! siteDetails.jetpack;
+
+/**
+ * A WordPress.com Simple site without the feature gets Jetpack AI through a paid
+ * WordPress.com plan, not a Jetpack AI tier, so it upgrades on the plans page.
+ */
+export const shouldUpgradePlan = ( siteDetails?: SiteDetails, reason?: UpgradeReason ): boolean =>
+	reason === 'feature' && isWpcomSimpleSite( siteDetails );
 
 export const getUpgradeURL = ( {
 	siteDetails,
 	nextTierSlug,
+	reason,
 	redirectTo = location.href,
 }: {
 	siteDetails?: SiteDetails;
 	nextTierSlug?: string;
+	reason: UpgradeReason;
 	redirectTo?: string;
 } ): string => {
-	const upgradeURL = isWpcomSimpleSite( siteDetails )
+	const upgradeURL = shouldUpgradePlan( siteDetails, reason )
 		? new URL( `${ location.origin }/plans/${ siteDetails?.slug }` )
 		: new URL( `${ location.origin }/checkout/${ siteDetails?.domain }/${ nextTierSlug }` );
 

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/upgrade-url.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/upgrade-url.ts
@@ -3,28 +3,22 @@
  */
 import type { SiteDetails } from '@automattic/data-stores';
 
-export type UpgradeReason = 'feature' | 'requests';
-
+/**
+ * A WordPress.com Simple site gets Jetpack AI, with unlimited logo generation,
+ * through a paid WordPress.com plan rather than a Jetpack AI tier, so it upgrades
+ * on the plans page instead of the Jetpack AI checkout.
+ */
 export const isWpcomSimpleSite = ( siteDetails?: SiteDetails ): boolean =>
 	!! siteDetails && ! siteDetails.jetpack;
-
-/**
- * A WordPress.com Simple site without the feature gets Jetpack AI through a paid
- * WordPress.com plan, not a Jetpack AI tier, so it upgrades on the plans page.
- */
-export const shouldUpgradePlan = ( siteDetails?: SiteDetails, reason?: UpgradeReason ): boolean =>
-	reason === 'feature' && isWpcomSimpleSite( siteDetails );
 
 export const getUpgradeURL = ( {
 	siteDetails,
 	nextTierSlug,
-	reason,
 }: {
 	siteDetails?: SiteDetails;
 	nextTierSlug?: string;
-	reason: UpgradeReason;
 } ): string => {
-	const upgradeURL = shouldUpgradePlan( siteDetails, reason )
+	const upgradeURL = isWpcomSimpleSite( siteDetails )
 		? new URL( `${ location.origin }/plans/${ siteDetails?.slug }` )
 		: new URL( `${ location.origin }/checkout/${ siteDetails?.domain }/${ nextTierSlug }` );
 

--- a/packages/jetpack-ai-calypso/test/upgrade-url.ts
+++ b/packages/jetpack-ai-calypso/test/upgrade-url.ts
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getUpgradeURL, isWpcomSimpleSite } from '../src/logo-generator/lib/upgrade-url';
+/**
+ * Types
+ */
+import type { SiteDetails } from '@automattic/data-stores';
+
+const simpleSite = {
+	jetpack: false,
+	slug: 'simple.wordpress.com',
+	domain: 'simple.wordpress.com',
+} as SiteDetails;
+const jetpackSite = { jetpack: true, slug: 'example.com', domain: 'example.com' } as SiteDetails;
+
+describe( 'isWpcomSimpleSite', () => {
+	it( 'is true for a WordPress.com Simple site', () => {
+		expect( isWpcomSimpleSite( simpleSite ) ).toBe( true );
+	} );
+
+	it( 'is false for a Jetpack-connected site, which includes Atomic', () => {
+		expect( isWpcomSimpleSite( jetpackSite ) ).toBe( false );
+	} );
+
+	it( 'is false when there is no site', () => {
+		expect( isWpcomSimpleSite( undefined ) ).toBe( false );
+	} );
+} );
+
+describe( 'getUpgradeURL', () => {
+	it( 'sends a Simple site to the WordPress.com plans page', () => {
+		const url = new URL(
+			getUpgradeURL( {
+				siteDetails: simpleSite,
+				nextTierSlug: 'jetpack_ai_yearly',
+				redirectTo: 'http://localhost/home/simple.wordpress.com',
+			} )
+		);
+
+		expect( url.pathname ).toBe( '/plans/simple.wordpress.com' );
+		expect( url.searchParams.get( 'redirect_to' ) ).toBe(
+			'http://localhost/home/simple.wordpress.com'
+		);
+	} );
+
+	it( 'sends a Jetpack site to checkout for the next Jetpack AI tier', () => {
+		const url = new URL(
+			getUpgradeURL( {
+				siteDetails: jetpackSite,
+				nextTierSlug: 'jetpack_ai_yearly',
+				redirectTo: 'http://localhost/home/example.com',
+			} )
+		);
+
+		expect( url.pathname ).toBe( '/checkout/example.com/jetpack_ai_yearly' );
+		expect( url.searchParams.get( 'redirect_to' ) ).toBe( 'http://localhost/home/example.com' );
+	} );
+} );

--- a/packages/jetpack-ai-calypso/test/upgrade-url.ts
+++ b/packages/jetpack-ai-calypso/test/upgrade-url.ts
@@ -37,20 +37,17 @@ describe( 'shouldUpgradePlan', () => {
 } );
 
 describe( 'getUpgradeURL', () => {
-	const redirectTo = 'http://localhost/home/some-site';
-
 	it( 'sends a Simple site without the feature to the WordPress.com plans page', () => {
 		const url = new URL(
 			getUpgradeURL( {
 				siteDetails: simpleSite,
 				nextTierSlug: 'jetpack_ai_yearly',
 				reason: 'feature',
-				redirectTo,
 			} )
 		);
 
 		expect( url.pathname ).toBe( '/plans/simple.wordpress.com' );
-		expect( url.searchParams.get( 'redirect_to' ) ).toBe( redirectTo );
+		expect( url.searchParams.get( 'redirect_to' ) ).toBe( window.location.href );
 	} );
 
 	it( 'keeps the Jetpack AI tier checkout for a Simple site that ran out of requests', () => {
@@ -59,7 +56,6 @@ describe( 'getUpgradeURL', () => {
 				siteDetails: simpleSite,
 				nextTierSlug: 'jetpack_ai_yearly',
 				reason: 'requests',
-				redirectTo,
 			} )
 		);
 
@@ -72,11 +68,10 @@ describe( 'getUpgradeURL', () => {
 				siteDetails: jetpackSite,
 				nextTierSlug: 'jetpack_ai_yearly',
 				reason: 'feature',
-				redirectTo,
 			} )
 		);
 
 		expect( url.pathname ).toBe( '/checkout/example.com/jetpack_ai_yearly' );
-		expect( url.searchParams.get( 'redirect_to' ) ).toBe( redirectTo );
+		expect( url.searchParams.get( 'redirect_to' ) ).toBe( window.location.href );
 	} );
 } );

--- a/packages/jetpack-ai-calypso/test/upgrade-url.ts
+++ b/packages/jetpack-ai-calypso/test/upgrade-url.ts
@@ -5,7 +5,7 @@
 /**
  * Internal dependencies
  */
-import { getUpgradeURL, isWpcomSimpleSite } from '../src/logo-generator/lib/upgrade-url';
+import { getUpgradeURL, shouldUpgradePlan } from '../src/logo-generator/lib/upgrade-url';
 /**
  * Types
  */
@@ -18,34 +18,52 @@ const simpleSite = {
 } as SiteDetails;
 const jetpackSite = { jetpack: true, slug: 'example.com', domain: 'example.com' } as SiteDetails;
 
-describe( 'isWpcomSimpleSite', () => {
-	it( 'is true for a WordPress.com Simple site', () => {
-		expect( isWpcomSimpleSite( simpleSite ) ).toBe( true );
+describe( 'shouldUpgradePlan', () => {
+	it( 'is true for a Simple site that lacks the feature', () => {
+		expect( shouldUpgradePlan( simpleSite, 'feature' ) ).toBe( true );
+	} );
+
+	it( 'is false for a Simple site that only ran out of requests', () => {
+		expect( shouldUpgradePlan( simpleSite, 'requests' ) ).toBe( false );
 	} );
 
 	it( 'is false for a Jetpack-connected site, which includes Atomic', () => {
-		expect( isWpcomSimpleSite( jetpackSite ) ).toBe( false );
+		expect( shouldUpgradePlan( jetpackSite, 'feature' ) ).toBe( false );
 	} );
 
 	it( 'is false when there is no site', () => {
-		expect( isWpcomSimpleSite( undefined ) ).toBe( false );
+		expect( shouldUpgradePlan( undefined, 'feature' ) ).toBe( false );
 	} );
 } );
 
 describe( 'getUpgradeURL', () => {
-	it( 'sends a Simple site to the WordPress.com plans page', () => {
+	const redirectTo = 'http://localhost/home/some-site';
+
+	it( 'sends a Simple site without the feature to the WordPress.com plans page', () => {
 		const url = new URL(
 			getUpgradeURL( {
 				siteDetails: simpleSite,
 				nextTierSlug: 'jetpack_ai_yearly',
-				redirectTo: 'http://localhost/home/simple.wordpress.com',
+				reason: 'feature',
+				redirectTo,
 			} )
 		);
 
 		expect( url.pathname ).toBe( '/plans/simple.wordpress.com' );
-		expect( url.searchParams.get( 'redirect_to' ) ).toBe(
-			'http://localhost/home/simple.wordpress.com'
+		expect( url.searchParams.get( 'redirect_to' ) ).toBe( redirectTo );
+	} );
+
+	it( 'keeps the Jetpack AI tier checkout for a Simple site that ran out of requests', () => {
+		const url = new URL(
+			getUpgradeURL( {
+				siteDetails: simpleSite,
+				nextTierSlug: 'jetpack_ai_yearly',
+				reason: 'requests',
+				redirectTo,
+			} )
 		);
+
+		expect( url.pathname ).toBe( '/checkout/simple.wordpress.com/jetpack_ai_yearly' );
 	} );
 
 	it( 'sends a Jetpack site to checkout for the next Jetpack AI tier', () => {
@@ -53,11 +71,12 @@ describe( 'getUpgradeURL', () => {
 			getUpgradeURL( {
 				siteDetails: jetpackSite,
 				nextTierSlug: 'jetpack_ai_yearly',
-				redirectTo: 'http://localhost/home/example.com',
+				reason: 'feature',
+				redirectTo,
 			} )
 		);
 
 		expect( url.pathname ).toBe( '/checkout/example.com/jetpack_ai_yearly' );
-		expect( url.searchParams.get( 'redirect_to' ) ).toBe( 'http://localhost/home/example.com' );
+		expect( url.searchParams.get( 'redirect_to' ) ).toBe( redirectTo );
 	} );
 } );

--- a/packages/jetpack-ai-calypso/test/upgrade-url.ts
+++ b/packages/jetpack-ai-calypso/test/upgrade-url.ts
@@ -5,7 +5,7 @@
 /**
  * Internal dependencies
  */
-import { getUpgradeURL, shouldUpgradePlan } from '../src/logo-generator/lib/upgrade-url';
+import { getUpgradeURL, isWpcomSimpleSite } from '../src/logo-generator/lib/upgrade-url';
 /**
  * Types
  */
@@ -18,57 +18,33 @@ const simpleSite = {
 } as SiteDetails;
 const jetpackSite = { jetpack: true, slug: 'example.com', domain: 'example.com' } as SiteDetails;
 
-describe( 'shouldUpgradePlan', () => {
-	it( 'is true for a Simple site that lacks the feature', () => {
-		expect( shouldUpgradePlan( simpleSite, 'feature' ) ).toBe( true );
-	} );
-
-	it( 'is false for a Simple site that only ran out of requests', () => {
-		expect( shouldUpgradePlan( simpleSite, 'requests' ) ).toBe( false );
+describe( 'isWpcomSimpleSite', () => {
+	it( 'is true for a WordPress.com Simple site', () => {
+		expect( isWpcomSimpleSite( simpleSite ) ).toBe( true );
 	} );
 
 	it( 'is false for a Jetpack-connected site, which includes Atomic', () => {
-		expect( shouldUpgradePlan( jetpackSite, 'feature' ) ).toBe( false );
+		expect( isWpcomSimpleSite( jetpackSite ) ).toBe( false );
 	} );
 
 	it( 'is false when there is no site', () => {
-		expect( shouldUpgradePlan( undefined, 'feature' ) ).toBe( false );
+		expect( isWpcomSimpleSite( undefined ) ).toBe( false );
 	} );
 } );
 
 describe( 'getUpgradeURL', () => {
-	it( 'sends a Simple site without the feature to the WordPress.com plans page', () => {
+	it( 'sends a Simple site to the WordPress.com plans page', () => {
 		const url = new URL(
-			getUpgradeURL( {
-				siteDetails: simpleSite,
-				nextTierSlug: 'jetpack_ai_yearly',
-				reason: 'feature',
-			} )
+			getUpgradeURL( { siteDetails: simpleSite, nextTierSlug: 'jetpack_ai_yearly' } )
 		);
 
 		expect( url.pathname ).toBe( '/plans/simple.wordpress.com' );
 		expect( url.searchParams.get( 'redirect_to' ) ).toBe( window.location.href );
 	} );
 
-	it( 'keeps the Jetpack AI tier checkout for a Simple site that ran out of requests', () => {
-		const url = new URL(
-			getUpgradeURL( {
-				siteDetails: simpleSite,
-				nextTierSlug: 'jetpack_ai_yearly',
-				reason: 'requests',
-			} )
-		);
-
-		expect( url.pathname ).toBe( '/checkout/simple.wordpress.com/jetpack_ai_yearly' );
-	} );
-
 	it( 'sends a Jetpack site to checkout for the next Jetpack AI tier', () => {
 		const url = new URL(
-			getUpgradeURL( {
-				siteDetails: jetpackSite,
-				nextTierSlug: 'jetpack_ai_yearly',
-				reason: 'feature',
-			} )
+			getUpgradeURL( { siteDetails: jetpackSite, nextTierSlug: 'jetpack_ai_yearly' } )
 		);
 
 		expect( url.pathname ).toBe( '/checkout/example.com/jetpack_ai_yearly' );


### PR DESCRIPTION
Fixes DOTCOM-12778

## Proposed Changes

Send free Simple sites to the WordPress.com plans page from the Jetpack AI Logo Generator's `Upgrade` button, instead of to checkout with a Jetpack AI tier product, and adjust the modal copy to match.

## Why are these changes being made?

On a free WordPress.com site, My Home offers "Create a logo with Jetpack AI". The modal says "Upgrade your Jetpack AI…" and the `Upgrade` button goes to checkout for a Jetpack AI product. On WordPress.com, logo generation comes with any paid plan, so the right upsell is a plan.

## Testing Instructions
1. Use a Simple site on the Free plan
4. Open http://calypso.localhost:3000/home/<site>
5. In `Quick links`, click on `Create a logo with Jetpack AI`
6. Assert that the modal copy reads `Upgrade your WordPress.com plan for access to exclusive Jetpack AI features, including logo generation. A paid plan also gives you unlimited requests in all AI-powered features.` (Previously it was - "Upgrade your Jetpack AI for access to exclusive features…"):<br />
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="538" height="261" alt="Screenshot 2026-09-10 at 16 37 09" src="https://github.com/user-attachments/assets/7e0291ea-d121-45ad-8bb4-2d85c81932cb" />
<td><img width="539" height="260" alt="Screenshot 2026-09-10 at 17 45 23" src="https://github.com/user-attachments/assets/50a70c62-40cf-4751-ba48-d2637ec2ee2c" />
</tr>
</table>

7. Click on `Upgrade`
8. Assert that you are landed on `/plans/<site>` (Previously - Checkout page with `Jetpack AI Assistant` product)
9. Select for example Personal plan and complete checkout
11. Click on `Create a logo with Jetpack AI` again
12. Assert that you see `Your plan upgrade is still being applied.` and click on `Try again` (Note, there is a chance that backend handled everything quckly, so in this case you won't see it. It's just edge case which I decided to cover, to provide great UX):<br /><img width="538" height="242" alt="Screenshot 2026-09-10 at 17 52 08" src="https://github.com/user-attachments/assets/b04bf5df-8d41-4184-9605-57ba7d768c37" />
14. Assert that a logo is generated

## Pre-merge Checklist
- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?