### PR TITLE
A4A: Add in-app announcement for the new A4A MCP

### DIFF
--- a/client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx
+++ b/client/a8c-for-agencies/sections/overview/dashboard-overview-body/index.tsx
@@ -6,6 +6,7 @@ import usePressableOfferEligibility from 'calypso/a8c-for-agencies/components/a4
 import { ONBOARDING_TOUR_HASH } from 'calypso/a8c-for-agencies/components/hoc/with-onboarding-tour/hooks/use-onboarding-tour';
 import {
 	A4A_AGENCY_TIER_LINK,
+	A4A_AI_MCP_LINK,
 	A4A_MARKETPLACE_PRODUCTS_LINK,
 	A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
 	A4A_REFERRALS_DASHBOARD,
@@ -71,6 +72,7 @@ function DashboardOverviewBodyContent( {
 				marketplace: A4A_MARKETPLACE_PRODUCTS_LINK,
 				partnerDirectory: A4A_PARTNER_DIRECTORY_DASHBOARD_LINK,
 				contactSupport: CONTACT_URL_HASH_FRAGMENT,
+				aiMcp: A4A_AI_MCP_LINK,
 				helpful: [
 					{
 						id: 'contact-support',

--- a/client/dashboard/agency/overview/constants.ts
+++ b/client/dashboard/agency/overview/constants.ts
@@ -21,6 +21,9 @@ export const PRESSABLE_EXPANSION_OFFER_TERMS_URL =
 // page exists, like the links in agency/marketplace/exclusive-offers.
 export const MARKETPLACE_HOSTING_PRESSABLE_PATH = '/marketplace/hosting/pressable';
 
+export const AI_MCP_ANNOUNCEMENT_BLOG_POST_URL =
+	'https://automattic.com/for-agencies/blog/our-new-mcp-brings-automattic-for-agencies-into-your-ai-workflow/';
+
 interface TierOverviewContent {
 	description: string;
 	hasPartnerManager: boolean;

--- a/client/dashboard/agency/overview/event-card.tsx
+++ b/client/dashboard/agency/overview/event-card.tsx
@@ -12,6 +12,7 @@ import {
 	FEATURED_EVENT,
 	PRESSABLE_EXPANSION_OFFER_EVENT,
 	PRESSABLE_INTRO_OFFER_EVENT,
+	getAiMcpAnnouncement,
 } from './events';
 import NewTabLabel from './new-tab-label';
 import type { FeaturedEvent } from './events';
@@ -20,6 +21,7 @@ import type { RecordTracksEvent } from '../tiers/types';
 interface EventCardProps {
 	isEligibleForPressableIntroOffer?: boolean;
 	isEligibleForPressableExpansionOffer?: boolean;
+	aiMcpHref: string;
 	recordTracksEvent?: RecordTracksEvent;
 }
 
@@ -91,6 +93,7 @@ function SingleEventCard( {
 export default function EventCard( {
 	isEligibleForPressableIntroOffer,
 	isEligibleForPressableExpansionOffer,
+	aiMcpHref,
 	recordTracksEvent,
 }: EventCardProps ) {
 	const now = new Date();
@@ -98,6 +101,7 @@ export default function EventCard( {
 		FEATURED_EVENT,
 		isEligibleForPressableIntroOffer ? PRESSABLE_INTRO_OFFER_EVENT : null,
 		isEligibleForPressableExpansionOffer ? PRESSABLE_EXPANSION_OFFER_EVENT : null,
+		getAiMcpAnnouncement( aiMcpHref ),
 	].filter( ( event ): event is FeaturedEvent => !! event && now < new Date( event.endsAt ) );
 
 	if ( ! events.length ) {

--- a/client/dashboard/agency/overview/events.ts
+++ b/client/dashboard/agency/overview/events.ts
@@ -1,6 +1,8 @@
 import { __ } from '@wordpress/i18n';
+import A4ALogo from 'calypso/assets/images/a8c-for-agencies/events/a4a-logo.svg';
 import PressableLogo from 'calypso/assets/images/a8c-for-agencies/events/pressable-logo.svg';
 import {
+	AI_MCP_ANNOUNCEMENT_BLOG_POST_URL,
 	MARKETPLACE_HOSTING_PRESSABLE_PATH,
 	PRESSABLE_EXPANSION_OFFER_TERMS_URL,
 	PRESSABLE_INTRODUCTORY_OFFER_TERMS_URL,
@@ -31,6 +33,7 @@ export interface FeaturedEvent {
 	 */
 	logo?: string;
 	logoAlt?: string;
+	/** Uppercase eyebrow above the title: a date for events, a label for announcements. */
 	when: string;
 	title: string;
 	subtitle: string;
@@ -149,3 +152,42 @@ export const PRESSABLE_EXPANSION_OFFER_EVENT: FeaturedEvent = {
 	],
 	endsAt: PRESSABLE_Q3_2026_OFFER_ENDS_AT,
 };
+
+/**
+ * The MCP launch announcement, shown to every agency below the Pressable promos.
+ *
+ * Takes the AI & MCP href because the two shells mount that screen at different
+ * paths (/resources-and-tools/ai-mcp in classic A4A, /resources/ai-mcp in the
+ * dashboard), so it arrives through AgencyOverviewLinks rather than a constant.
+ */
+export const getAiMcpAnnouncement = ( aiMcpHref: string ): FeaturedEvent => ( {
+	id: 'a4a-ai-mcp-announcement',
+	logo: A4ALogo,
+	logoAlt: __( 'Automattic for Agencies' ),
+	when: __( 'New · AI and MCP' ),
+	title: __( 'Bring Automattic for Agencies into your AI tools' ),
+	subtitle: __( 'Automattic for Agencies MCP' ),
+	description: [
+		__(
+			'Get answers about your agency without hunting through the dashboard. Ask about your tier, commissions, billing, or site health from Claude, ChatGPT, Cursor, or whatever AI tool your team already uses, and the answer comes back from your live account in seconds.'
+		),
+		__(
+			'Schedule a weekly digest to Slack, or build a custom dashboard your whole team can use. Our MCP is free and connects in minutes.'
+		),
+	],
+	ctas: [
+		{
+			id: 'enable-mcp',
+			label: __( 'Enable MCP' ),
+			url: aiMcpHref,
+			variant: 'primary',
+		},
+		{
+			id: 'see-how-it-works',
+			label: __( 'See how it works' ),
+			url: AI_MCP_ANNOUNCEMENT_BLOG_POST_URL,
+			isExternal: true,
+		},
+	],
+	endsAt: '2026-10-08',
+} );

--- a/client/dashboard/agency/overview/index.tsx
+++ b/client/dashboard/agency/overview/index.tsx
@@ -71,6 +71,7 @@ export default function AgencyOverview() {
 					marketplace: '/marketplace',
 					partnerDirectory: PARTNER_DIRECTORY_URL,
 					contactSupport: CONTACT_SUPPORT_URL,
+					aiMcp: '/resources/ai-mcp',
 					helpful: [
 						{
 							// TODO: wire up once the MSD dashboard has a contact-support entry

--- a/client/dashboard/agency/overview/overview-content.tsx
+++ b/client/dashboard/agency/overview/overview-content.tsx
@@ -24,6 +24,7 @@ export interface AgencyOverviewLinks {
 	marketplace: string;
 	partnerDirectory: string;
 	contactSupport: string;
+	aiMcp: string;
 	helpful: HelpfulLink[];
 }
 
@@ -133,6 +134,7 @@ export default function AgencyOverviewContent( {
 				<EventCard
 					isEligibleForPressableIntroOffer={ isEligibleForPressableIntroOffer }
 					isEligibleForPressableExpansionOffer={ isEligibleForPressableExpansionOffer }
+					aiMcpHref={ links.aiMcp }
 					recordTracksEvent={ recordTracksEvent }
 				/>
 			</VStack>


### PR DESCRIPTION
Fixes A4A-3348

## Proposed Changes

* Add an MCP announcement card to the agency Overview, below the Pressable promos, for all agencies. It stops rendering itself after October 7.
* Pass the AI & MCP screen's href through `AgencyOverviewLinks` so both shells that render the overview link to their own route.
<img width="1532" height="634" alt="Screenshot 2026-09-11 at 10 22 26 PM" src="https://github.com/user-attachments/assets/fe9ad648-41e1-4a2f-ba4a-ae50e0480ddd" />


## Why are these changes being made?

Our MCP is live and agencies need to hear about it where they already are. The overview's news column already renders a curated, self-expiring list of featured cards, so this is one more entry in that list rather than a new component.

The one non-obvious bit is the href. The two shells mount the MCP screen at different paths (`/resources-and-tools/ai-mcp` in classic A4A, `/resources/ai-mcp` in the dashboard), so a shared constant would have been a dead link in one of them. It goes through the `links` prop alongside `tiers`, `marketplace`, and the rest instead. Worth noting that the neighbouring `MARKETPLACE_HOSTING_PRESSABLE_PATH` still hardcodes a classic-only path, which looks like the same latent bug in the Pressable CTAs; left alone here.

Tracks came for free. `EventCard` already fires `calypso_a4a_overview_event_cta_click` with `event_id` and `cta_id`, so the two CTAs report as `a4a-ai-mcp-announcement` / `enable-mcp` and `see-how-it-works`.

## Testing Instructions

1. Go to the agency Overview page.
2. Confirm the "Bring Automattic for Agencies into your AI tools" card appears in the right-hand column, below the Pressable promo card if you are eligible for one.
3. Click **Enable MCP** and confirm it lands on the AI & MCP screen.
4. Click **See how it works** and confirm it opens the blog post in a new tab.
5. Confirm both clicks fire `calypso_a4a_overview_event_cta_click` with the right `cta_id`.
6. Check the card at phone width and in dark mode.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
