### PR TITLE
Components: stop importing Calypso's z-index map from published styles

### DIFF
--- a/packages/components/src/dialog/style.scss
+++ b/packages/components/src/dialog/style.scss
@@ -1,7 +1,6 @@
-@import "calypso/assets/stylesheets/shared/functions/z-index";
-
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "../styles/z-index";
 
 .dialog__backdrop,
 .dialog__backdrop.card {
@@ -15,7 +14,7 @@
 	right: 0;
 	top: var(--masterbar-height, 0);
 	transition: background-color 0.2s ease-in;
-	z-index: z-index("root", ".dialog__backdrop"); // try to ensure that dialogs are on top of everything else
+	z-index: $dialog-backdrop-z-index;
 
 	// covers the masterbar as well
 	&.is-full-screen {

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -1,6 +1,5 @@
-@import "calypso/assets/stylesheets/shared/functions/z-index";
-
 @import "@automattic/typography/styles/fonts";
+@import "../styles/z-index";
 
 /**
  * "popover" theme for `component/tip`.
@@ -8,7 +7,7 @@
 
 .popover {
 	font-size: $font-body-extra-small;
-	z-index: z-index("root", ".popover");
+	z-index: $popover-z-index;
 	position: absolute;
 	top: 0;
 	left: 0 #{"/*rtl:ignore*/"};
@@ -29,7 +28,7 @@
 		line-height: 0;
 		position: absolute;
 		width: 0;
-		z-index: z-index(".popover", ".popover .popover__arrow");
+		z-index: 1;
 	}
 
 	&.fade {
@@ -134,6 +133,6 @@
 	}
 
 	&.is-dialog-visible {
-		z-index: z-index("root", "popover.is-dialog-visible"); /* Above .dialog */
+		z-index: $popover-over-dialog-z-index;
 	}
 }

--- a/packages/components/src/ribbon/style.scss
+++ b/packages/components/src/ribbon/style.scss
@@ -1,5 +1,3 @@
-@import "calypso/assets/stylesheets/shared/functions/z-index";
-
 @import "../styles/typography";
 
 .ribbon {
@@ -7,7 +5,7 @@
 	position: absolute;
 	right: -5px;
 	top: -5px;
-	z-index: z-index("root", ".ribbon");
+	z-index: 1;
 	overflow: hidden;
 	width: 75px;
 	height: 75px;
@@ -34,7 +32,7 @@
 	position: absolute;
 	left: 0;
 	top: 100%;
-	z-index: z-index(".ribbon", ".ribbon__title::before");
+	z-index: -1;
 	border-left: 3px solid var(--color-accent-dark);
 	border-right: 3px solid transparent;
 	border-bottom: 3px solid transparent;
@@ -45,7 +43,7 @@
 	position: absolute;
 	right: 0;
 	top: 100%;
-	z-index: z-index(".ribbon", ".ribbon__title::after");
+	z-index: -1;
 	border-left: 3px solid transparent;
 	border-right: 3px solid var(--color-accent-dark);
 	border-bottom: 3px solid transparent;

--- a/packages/components/src/screen-reader-text/style.scss
+++ b/packages/components/src/screen-reader-text/style.scss
@@ -1,6 +1,6 @@
 // Text meant only for screen readers
 
-@import "calypso/assets/stylesheets/shared/functions/z-index";
+@import "../styles/z-index";
 
 .screen-reader-text {
 	clip: rect(1px, 1px, 1px, 1px);
@@ -29,6 +29,6 @@
 		text-decoration: none;
 		top: 5px;
 		width: auto;
-		z-index: z-index("screen-reader-text-parent", ".screen-reader-text:focus"); // Above WP toolbar
+		z-index: $screen-reader-text-focus-z-index;
 	}
 }

--- a/packages/components/src/select-dropdown/style.scss
+++ b/packages/components/src/select-dropdown/style.scss
@@ -1,6 +1,5 @@
-@import "calypso/assets/stylesheets/shared/functions/z-index";
-
 @import "@automattic/typography/styles/variables";
+@import "../styles/z-index";
 
 /**
  * Select Dropdown
@@ -30,12 +29,12 @@ $compact-header-height: 35;
 	max-width: 100%;
 
 	.select-dropdown.is-open & {
-		z-index: z-index("root", ".select-dropdown.is-open .select-dropdown__container");
+		z-index: $select-dropdown-z-index;
 	}
 
 	.accessible-focus &:focus,
 	.accessible-focus .select-dropdown.is-open & {
-		z-index: z-index("root", ".accessible-focus .select-dropdown.is-open .select-dropdown__container");
+		z-index: $select-dropdown-z-index;
 		.select-dropdown__header {
 			border-color: var(--color-primary);
 		}

--- a/packages/components/src/styles/_z-index.scss
+++ b/packages/components/src/styles/_z-index.scss
@@ -4,6 +4,10 @@
 
 $select-dropdown-z-index: 170;
 $popover-z-index: 1000;
-$screen-reader-text-focus-z-index: 100000; // Above the WP toolbar.
+
+// Above the WP toolbar. apps/notifications still reads this one from the
+// registry, so the two have to stay in step.
+$screen-reader-text-focus-z-index: 100000;
+
 $dialog-backdrop-z-index: 100200;
 $popover-over-dialog-z-index: $dialog-backdrop-z-index + 100;

--- a/packages/components/src/styles/_z-index.scss
+++ b/packages/components/src/styles/_z-index.scss
@@ -1,0 +1,9 @@
+// Stacking positions that have to agree with Calypso's global z-index registry
+// (client/assets/stylesheets/shared/functions/_z-index.scss), because these
+// components render inside that app's chrome.
+
+$select-dropdown-z-index: 170;
+$popover-z-index: 1000;
+$screen-reader-text-focus-z-index: 100000; // Above the WP toolbar.
+$dialog-backdrop-z-index: 100200;
+$popover-over-dialog-z-index: $dialog-backdrop-z-index + 100;

--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -1,10 +1,11 @@
-@import "calypso/assets/stylesheets/shared/functions/z-index";
-
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "@automattic/typography/styles/fonts";
 
 $design-preview-sidebar-width: 311px;
+
+// Above the dialog backdrop in Calypso's global stacking order.
+$premium-badge-tooltip-z-index: 100300;
 
 .design-preview {
 	display: flex;
@@ -425,7 +426,7 @@ $design-preview-sidebar-width: 311px;
 }
 
 .design-picker__premium-badge-tooltip.popover {
-	z-index: z-index("root", ".design-picker__premium-badge-tooltip");
+	z-index: $premium-badge-tooltip-z-index;
 
 	&.is-top,
 	&.is-top-left,


### PR DESCRIPTION
## Proposed Changes

* Drop the `calypso/assets/stylesheets/shared/functions/z-index` import from six stylesheets in `@automattic/components` and `@automattic/design-preview`.
* Move the values that have to agree with Calypso's chrome into a package-local partial, and derive the popover-over-dialog offset from the dialog backdrop instead of restating the relationship in a comment. Values that are ordinary local stacking stay as literals.

## Why are these changes being made?

Six published stylesheets read their z-index from Calypso's registry via a `calypso/...` import. That resolves inside the monorepo, because `client/` is a workspace named `calypso`. But `copy-assets` ships SCSS verbatim into `dist/`, so the published packages carry an import that no consumer outside this repo can resolve.

It is also the wrong direction of dependency: a shared, publicly published package reaching into the app's private stylesheet tree means an app-side change can break the package.

With one exception the keys involved have no remaining reader anywhere in the repo, so the package becomes their only definition. The exception is the screen-reader-text value, which `apps/notifications` still reads from the registry; the partial notes that the two have to stay in step. The values themselves have not changed since 2022, when a stylelint autofix renormalised their quotes.

## Testing Instructions

* No visual change is expected anywhere — the emitted values are identical to trunk.
* Each of the six stylesheets now compiles standalone with only `node_modules` on the Sass load path, which it could not do before.
* Worth a look in passing: a dialog backdrop, a popover (including one opened over a dialog), a ribbon, an open select-dropdown, a focused skip link, and the design-preview premium badge tooltip should all stack exactly as they do on trunk.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages.
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
