### PR TITLE
Pricing differentiation: display the correct plan for the SEO upsell

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -1,9 +1,7 @@
 import {
 	FEATURE_ADVANCED_SEO,
 	FEATURE_SEO_PREVIEW_TOOLS,
-	PLAN_BUSINESS,
 	PLAN_PREMIUM,
-	TYPE_BUSINESS,
 	TYPE_PREMIUM,
 	findFirstSimilarPlanKey,
 	getPlan,
@@ -54,7 +52,6 @@ import {
 	isJetpackSite,
 	isRequestingSite,
 } from 'calypso/state/sites/selectors';
-import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -220,7 +217,6 @@ export class SiteSettingsFormSEO extends Component {
 	render() {
 		const {
 			conflictedSeoPlugin,
-			hasGatingFlag,
 			isFetchingSite,
 			siteId,
 			siteIsJetpack,
@@ -252,9 +248,6 @@ export class SiteSettingsFormSEO extends Component {
 
 		const generalTabUrl = getGeneralTabUrl( slug );
 
-		const upsellPlan = hasGatingFlag ? PLAN_PREMIUM : PLAN_BUSINESS;
-		const upsellPlanType = hasGatingFlag ? TYPE_PREMIUM : TYPE_BUSINESS;
-
 		const upsellProps =
 			siteIsJetpack && ! isAtomic
 				? {
@@ -265,13 +258,13 @@ export class SiteSettingsFormSEO extends Component {
 				: {
 						title: translate(
 							'Boost your search engine ranking with the powerful SEO tools in the %(planName)s plan',
-							{ args: { planName: getPlan( upsellPlan ).getTitle() } }
+							{ args: { planName: getPlan( PLAN_PREMIUM ).getTitle() } }
 						),
 						feature: FEATURE_ADVANCED_SEO,
 						plan:
 							selectedSite.plan &&
 							findFirstSimilarPlanKey( selectedSite.plan.product_slug, {
-								type: upsellPlanType,
+								type: TYPE_PREMIUM,
 							} ),
 				  };
 
@@ -465,7 +458,6 @@ const mapStateToProps = ( state ) => {
 		: null;
 	return {
 		conflictedSeoPlugin,
-		hasGatingFlag: !! getSiteOption( state, siteId, 'is_gating_business_q1' ),
 		isFetchingSite: isRequestingSite( state, siteId ),
 		siteId,
 		siteIsJetpack,

--- a/client/my-sites/site-settings/seo-settings/test/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/test/form.jsx
@@ -12,8 +12,6 @@ import {
 	PLAN_FREE,
 	PLAN_BLOGGER,
 	PLAN_BLOGGER_2_YEARS,
-	PLAN_BUSINESS,
-	PLAN_BUSINESS_2_YEARS,
 	PLAN_PREMIUM,
 	PLAN_PREMIUM_2_YEARS,
 	PLAN_PERSONAL,
@@ -147,8 +145,8 @@ describe( 'SeoForm basic tests', () => {
 } );
 
 describe( 'UpsellNudge should get appropriate plan constant', () => {
-	test.each( [ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL, PLAN_PREMIUM ] )(
-		`Business 1 year for (%s)`,
+	test.each( [ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL ] )(
+		`Premium 1 year for (%s)`,
 		( product_slug ) => {
 			render(
 				<SeoForm { ...props } siteIsJetpack={ false } selectedSite={ { plan: { product_slug } } } />
@@ -157,13 +155,13 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 			expect( nudge ).toBeVisible();
 			expect( UpsellNudge ).toHaveBeenCalled();
 			expect( UpsellNudge.mock.lastCall[ 0 ] ).toEqual(
-				expect.objectContaining( { plan: PLAN_BUSINESS } )
+				expect.objectContaining( { plan: PLAN_PREMIUM } )
 			);
 		}
 	);
 
-	test.each( [ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS, PLAN_PREMIUM_2_YEARS ] )(
-		`Business 2 year for (%s)`,
+	test.each( [ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS ] )(
+		`Premium 2 year for (%s)`,
 		( product_slug ) => {
 			render(
 				<SeoForm { ...props } siteIsJetpack={ false } selectedSite={ { plan: { product_slug } } } />
@@ -171,7 +169,7 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 			expect( screen.getByTestId( 'UpsellNudge' ) ).toBeVisible();
 			expect( UpsellNudge ).toHaveBeenCalled();
 			expect( UpsellNudge.mock.lastCall[ 0 ] ).toEqual(
-				expect.objectContaining( { plan: PLAN_BUSINESS_2_YEARS } )
+				expect.objectContaining( { plan: PLAN_PREMIUM_2_YEARS } )
 			);
 		}
 	);
@@ -186,50 +184,6 @@ describe( 'UpsellNudge should get appropriate plan constant', () => {
 				expect.objectContaining( {
 					href: expect.stringContaining( PLAN_JETPACK_SECURITY_DAILY ),
 				} )
-			);
-		}
-	);
-} );
-
-describe( 'UpsellNudge with gating flag should get Premium plan constant', () => {
-	afterEach( () => {
-		UpsellNudge.mockClear();
-	} );
-
-	test.each( [ PLAN_FREE, PLAN_BLOGGER, PLAN_PERSONAL ] )(
-		`Premium 1 year for (%s)`,
-		( product_slug ) => {
-			render(
-				<SeoForm
-					{ ...props }
-					siteIsJetpack={ false }
-					selectedSite={ { plan: { product_slug } } }
-					hasGatingFlag
-				/>
-			);
-			expect( screen.getByTestId( 'UpsellNudge' ) ).toBeVisible();
-			expect( UpsellNudge ).toHaveBeenCalled();
-			expect( UpsellNudge.mock.lastCall[ 0 ] ).toEqual(
-				expect.objectContaining( { plan: PLAN_PREMIUM } )
-			);
-		}
-	);
-
-	test.each( [ PLAN_BLOGGER_2_YEARS, PLAN_PERSONAL_2_YEARS ] )(
-		`Premium 2 year for (%s)`,
-		( product_slug ) => {
-			render(
-				<SeoForm
-					{ ...props }
-					siteIsJetpack={ false }
-					selectedSite={ { plan: { product_slug } } }
-					hasGatingFlag
-				/>
-			);
-			expect( screen.getByTestId( 'UpsellNudge' ) ).toBeVisible();
-			expect( UpsellNudge ).toHaveBeenCalled();
-			expect( UpsellNudge.mock.lastCall[ 0 ] ).toEqual(
-				expect.objectContaining( { plan: PLAN_PREMIUM_2_YEARS } )
 			);
 		}
 	);


### PR DESCRIPTION
<!--
Link a related GitHub/Linear issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword. Consider using "part of" instead.
-->

Fixes MARTECH-3024

## Proposed Changes

* Display "Premium" plan for the upsell to reflect the current state.

## Why are these changes being made?
<!--
It's easy to see what a PR does but much harder to find out why it was made,
particularly when researching old changes in history. Record an explanation of
the motivation behind this change and how it will help.
-->

* Advanced SEO is now available on the Premium plan for all sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to 'Jetpack->Traffic' on a free site without the gating-business-q1 sticker and with the sticker and confirm that the upsell shows 'Premium' in both cases.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
