### PR TITLE
Stepper: report how the processing step came to mount on its wait heartbeat

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -1,6 +1,6 @@
 import { useSelect } from '@wordpress/data';
 import clsx from 'clsx';
-import { useEffect, type JSX } from 'react';
+import { useEffect, useState, type JSX } from 'react';
 import { useLoginUrlForFlow } from 'calypso/landing/stepper/hooks/use-login-url-for-flow';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
 import kebabCase from 'calypso/landing/stepper/utils/kebabCase';
@@ -8,6 +8,7 @@ import { StepperPerformanceTrackerStop } from 'calypso/landing/stepper/utils/per
 import SignupHeader from 'calypso/signup/signup-header';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { recordStepRouteMount } from '../../step-mount-registry';
 import { PRIVATE_STEPS } from '../../steps';
 import { useStepRouteTracking } from './hooks/use-step-route-tracking';
 import type { Flow, FlowV2, Navigate, StepperStep } from '../../types';
@@ -22,6 +23,9 @@ type StepRouteProps = {
 
 // TODO: Check we can move RenderStep function to here and remove the renderStep prop
 const StepRoute = ( { step, flow, renderStep, navigate }: StepRouteProps ) => {
+	// In render rather than an effect: a child's effects run before this component's, and the step
+	// reads this during its own first render.
+	useState( () => recordStepRouteMount( step.slug ) );
 	const userIsLoggedIn = useSelector( isUserLoggedIn );
 	const stepContent = renderStep( step );
 	const stepData = useSelect(

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/test/index.tsx
@@ -19,6 +19,7 @@ import {
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import StepRoute from '../';
+import { describeStepMount } from '../../../step-mount-registry';
 import type {
 	Flow,
 	StepperStep,
@@ -148,6 +149,30 @@ describe( 'StepRoute', () => {
 	} );
 
 	describe( 'tracking', () => {
+		it( 'records the route mount before the step reads it during its own first render', () => {
+			const now = jest.spyOn( performance, 'now' ).mockReturnValue( 1040 );
+			let seen: ReturnType< typeof describeStepMount > | undefined;
+			const ReadsMountOnRender: FC< StepProps > = ( { stepName } ) => {
+				seen = seen ?? describeStepMount( stepName );
+				return <div>Step Content</div>;
+			};
+
+			render( {
+				step: regularStep,
+				renderStep: ( step ) => (
+					<ReadsMountOnRender
+						navigation={ {} as NavigationControls }
+						flow={ fakeFlow.name }
+						stepName={ step.slug }
+						data={ {} }
+					/>
+				),
+			} );
+
+			expect( seen?.ms_since_route_mount ).toBe( 0 );
+			now.mockRestore();
+		} );
+
 		it( 'records a page view', async () => {
 			render( { step: regularStep } );
 

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -28,7 +28,7 @@ import { useFlowNavigation } from './hooks/use-flow-navigation';
 import { usePreloadSteps, lazyCache } from './hooks/use-preload-steps';
 import { useSignUpStartTracking } from './hooks/use-sign-up-start-tracking';
 import { useStepNavigationWithTracking } from './hooks/use-step-navigation-with-tracking';
-import { recordStepComponentType } from './step-mount-registry';
+import { componentTypeOf, recordStepComponentType } from './step-mount-registry';
 import { PRIVATE_STEPS } from './steps';
 import { AssertConditionState, FlowV2, StepProps, type Flow, type StepperStep } from './types';
 import type { StepperInternalSelect } from '@automattic/data-stores';
@@ -46,12 +46,7 @@ function flowStepComponent( flowStep: StepperStep | undefined ) {
 		);
 		lazyCache.set( flowStep.asyncComponent, lazyComponent );
 	}
-	recordStepComponentType(
-		flowStep.slug,
-		( lazyComponent as { $$typeof?: symbol } ).$$typeof === Symbol.for( 'react.lazy' )
-			? 'lazy'
-			: 'raw'
-	);
+	recordStepComponentType( flowStep.slug, componentTypeOf( lazyComponent ) );
 	return lazyComponent;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -28,6 +28,7 @@ import { useFlowNavigation } from './hooks/use-flow-navigation';
 import { usePreloadSteps, lazyCache } from './hooks/use-preload-steps';
 import { useSignUpStartTracking } from './hooks/use-sign-up-start-tracking';
 import { useStepNavigationWithTracking } from './hooks/use-step-navigation-with-tracking';
+import { recordStepComponentType } from './step-mount-registry';
 import { PRIVATE_STEPS } from './steps';
 import { AssertConditionState, FlowV2, StepProps, type Flow, type StepperStep } from './types';
 import type { StepperInternalSelect } from '@automattic/data-stores';
@@ -45,6 +46,12 @@ function flowStepComponent( flowStep: StepperStep | undefined ) {
 		);
 		lazyCache.set( flowStep.asyncComponent, lazyComponent );
 	}
+	recordStepComponentType(
+		flowStep.slug,
+		( lazyComponent as { $$typeof?: symbol } ).$$typeof === Symbol.for( 'react.lazy' )
+			? 'lazy'
+			: 'raw'
+	);
 	return lazyComponent;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/step-mount-registry.ts
+++ b/client/landing/stepper/declarative-flow/internals/step-mount-registry.ts
@@ -16,6 +16,12 @@ export type StepComponentType = 'lazy' | 'raw';
 const componentTypes = new Map< string, StepComponentType >();
 const routeMounts = new Map< string, number >();
 
+export function componentTypeOf( component: unknown ): StepComponentType {
+	return ( component as { $$typeof?: symbol } | null )?.$$typeof === Symbol.for( 'react.lazy' )
+		? 'lazy'
+		: 'raw';
+}
+
 export function recordStepComponentType( slug: string, type: StepComponentType ): void {
 	componentTypes.set( slug, type );
 }

--- a/client/landing/stepper/declarative-flow/internals/step-mount-registry.ts
+++ b/client/landing/stepper/declarative-flow/internals/step-mount-registry.ts
@@ -1,0 +1,37 @@
+/**
+ * How each step came to mount, for the wait heartbeat to report.
+ *
+ * The processing step is seen mounting twice for one signup in production, a second or less
+ * apart and only for translated locales, and the second mount reruns the pending action. Nothing
+ * in the events says what the second mount is. Two facts narrow it: which component type the
+ * renderer handed React for the step (`lazy()` wrapper or the raw component, since the preloader
+ * and the renderer share one cache and can disagree), and how long after the route mounted the
+ * step itself did (a remount inside a mounted route lands well after the route did).
+ *
+ * Module state rather than context because the renderer, the route, and the step are three
+ * components with nothing in common but the step slug.
+ */
+export type StepComponentType = 'lazy' | 'raw';
+
+const componentTypes = new Map< string, StepComponentType >();
+const routeMounts = new Map< string, number >();
+
+export function recordStepComponentType( slug: string, type: StepComponentType ): void {
+	componentTypes.set( slug, type );
+}
+
+export function recordStepRouteMount( slug: string ): void {
+	routeMounts.set( slug, performance.now() );
+}
+
+export function describeStepMount( slug: string ): {
+	step_component_type: StepComponentType | null;
+	ms_since_route_mount: number | null;
+} {
+	const mountedAt = routeMounts.get( slug );
+	return {
+		step_component_type: componentTypes.get( slug ) ?? null,
+		ms_since_route_mount:
+			mountedAt === undefined ? null : Math.round( performance.now() - mountedAt ),
+	};
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -26,6 +26,7 @@ import { useWaitHeartbeat } from 'calypso/lib/analytics/wait-heartbeat';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import useCaptureFlowException from '../../../../hooks/use-capture-flow-exception';
 import { shouldUseStepContainerV2 } from '../../../helpers/should-use-step-container-v2';
+import { describeStepMount } from '../../step-mount-registry';
 import { ProcessingResult } from './constants';
 import { useLoadingMessageIndex } from './hooks/use-loading-message-index';
 import { useProcessingLoadingMessages } from './hooks/use-processing-loading-messages';
@@ -154,10 +155,12 @@ const ProcessingStep: StepType< {
 	// How the wait ended is known only inside the callback that ends it, and that callback submits —
 	// navigating away in the same tick, with no render in between to carry the outcome. Mutating the
 	// object the heartbeat is already holding is what gets it onto the closing event.
+	// Read once per mount, so a second mount of this step reports its own arrival, not the first's.
 	const waitProperties = useRef< Record< string, unknown > >( {
 		flow,
 		previous_step: props.data?.previousStep ?? null,
 		outcome: null,
+		...describeStepMount( props.stepName ),
 	} ).current;
 	waitProperties.flow = flow;
 	waitProperties.previous_step = props.data?.previousStep ?? null;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/test/index.tsx
@@ -6,8 +6,10 @@ import { act, screen } from '@testing-library/react';
 import { dispatch } from '@wordpress/data';
 import React from 'react';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import ProcessingStep from '../';
+import { recordStepComponentType, recordStepRouteMount } from '../../../step-mount-registry';
 import { mockStepProps, renderStep } from '../../test/helpers/index';
 import type { OnboardActions } from '@automattic/data-stores';
 
@@ -72,6 +74,31 @@ describe( 'ProcessingStep', () => {
 			'/sites/example.wordpress.com'
 		);
 		jest.useRealTimers();
+	} );
+
+	// The processing step is seen mounting twice for one signup in production, a second or less
+	// apart, and only for translated locales. The wait heartbeat is the only event that fires once
+	// per mount, so it carries how this mount came about: which component type the renderer handed
+	// React for the step, and how long after the route mounted the step itself did.
+	it( 'reports how the step came to mount on the wait heartbeat', () => {
+		const now = jest.spyOn( performance, 'now' );
+		now.mockReturnValue( 5000 );
+		recordStepRouteMount( 'processing' );
+		recordStepComponentType( 'processing', 'lazy' );
+		now.mockReturnValue( 5040 );
+		onboardActions().setPendingAction( () => new Promise( () => {} ) );
+
+		render( { flow: ONBOARDING_FLOW, stepName: 'processing' } );
+
+		expect( recordTracksEvent ).toHaveBeenCalledWith(
+			'calypso_transfer_wait_started',
+			expect.objectContaining( {
+				surface: 'stepper_processing',
+				step_component_type: 'lazy',
+				ms_since_route_mount: 40,
+			} )
+		);
+		now.mockRestore();
 	} );
 
 	it( 'keeps the generic loading screen for other flows', () => {

--- a/client/landing/stepper/declarative-flow/internals/test/step-mount-registry.ts
+++ b/client/landing/stepper/declarative-flow/internals/test/step-mount-registry.ts
@@ -1,10 +1,18 @@
+import { lazy } from 'react';
 import {
+	componentTypeOf,
 	describeStepMount,
 	recordStepComponentType,
 	recordStepRouteMount,
 } from '../step-mount-registry';
 
 describe( 'step mount registry', () => {
+	it( 'tells a lazy() wrapper from the raw component the preloader swaps in', () => {
+		const Raw = () => null;
+		expect( componentTypeOf( lazy( () => Promise.resolve( { default: Raw } ) ) ) ).toBe( 'lazy' );
+		expect( componentTypeOf( Raw ) ).toBe( 'raw' );
+	} );
+
 	it( 'reports nothing for a step it has not seen', () => {
 		expect( describeStepMount( 'never-rendered' ) ).toEqual( {
 			step_component_type: null,

--- a/client/landing/stepper/declarative-flow/internals/test/step-mount-registry.ts
+++ b/client/landing/stepper/declarative-flow/internals/test/step-mount-registry.ts
@@ -1,0 +1,31 @@
+import {
+	describeStepMount,
+	recordStepComponentType,
+	recordStepRouteMount,
+} from '../step-mount-registry';
+
+describe( 'step mount registry', () => {
+	it( 'reports nothing for a step it has not seen', () => {
+		expect( describeStepMount( 'never-rendered' ) ).toEqual( {
+			step_component_type: null,
+			ms_since_route_mount: null,
+		} );
+	} );
+
+	it( 'reports the component type last handed to React and the time since the route mounted', () => {
+		const now = jest.spyOn( performance, 'now' );
+		now.mockReturnValue( 1000 );
+		recordStepRouteMount( 'processing' );
+		recordStepComponentType( 'processing', 'lazy' );
+		now.mockReturnValue( 1250 );
+
+		expect( describeStepMount( 'processing' ) ).toEqual( {
+			step_component_type: 'lazy',
+			ms_since_route_mount: 250,
+		} );
+
+		recordStepComponentType( 'processing', 'raw' );
+		expect( describeStepMount( 'processing' ).step_component_type ).toBe( 'raw' );
+		now.mockRestore();
+	} );
+} );


### PR DESCRIPTION
Related to #DOTCOM-18530

## Proposed changes

Two properties on `calypso_transfer_wait_started` from the processing step: `step_component_type`, the type the renderer last handed React for the step (`lazy` wrapper or `raw` component), and `ms_since_route_mount`, how long after the step's route mounted the step itself did. Both are read once per mount, so a second mount reports its own arrival. Nothing changes for the customer.

## Why are these changes being made?

Since 2026-08-18 the processing step mounts twice for about one non-English onboarding signup in eight, within a second, and the second mount reruns the pending action and sends a second `/sites/new`. The single-flight change in #114282 stops the second request. It does not explain the second mount, and eight instrumented browser runs across Chrome and Firefox today did not produce one.

The events cannot say what the second mount is. `calypso_signup_step_start` fires once for the route, and the heartbeat fires once per mount of the step inside it, so a remount within a mounted route and a route re-entry look the same in `prod_events`. These two properties tell them apart. `ms_since_route_mount` near zero on the second `wait_started` means the step remounted under a route that stayed put. `step_component_type` says whether that mount sits on the `lazy()` wrapper, which is what the step preloader can overwrite while a render is in flight, or on the raw component, which rules the preloader out.

Module state rather than context, because the renderer, the route, and the step share nothing but the slug.

## Testing Instructions

1. On the calypso.live build, run `/setup/onboarding` to the processing step with DevTools open on the Network tab, filter `t.gif`, and find the `calypso_transfer_wait_started` pixel.
2. Expect `step_component_type` set to `lazy` or `raw` and `ms_since_route_mount` set to a small integer in its query string.
3. After deploy, group `calypso_transfer_wait_started` with `previous_step=create-site` by user in `prod_events`. For users with two, the second event's two properties are the answer this PR exists for.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01PK9AQ5sWzrq5aqwf1GkCHJ
