### PR TITLE
Purchases: read the raw Purchase in the Redux leaf selectors

### DIFF
--- a/client/me/account-close/main.jsx
+++ b/client/me/account-close/main.jsx
@@ -178,8 +178,8 @@ const AccountSettingsClose = ( {
 									<ul className="account-close__theme-list">
 										{ purchasedPremiumThemes.map( ( purchasedPremiumTheme ) => {
 											return (
-												<li key={ purchasedPremiumTheme.id }>
-													{ purchasedPremiumTheme.productName }
+												<li key={ purchasedPremiumTheme.ID }>
+													{ purchasedPremiumTheme.product_name }
 												</li>
 											);
 										} ) }

--- a/client/state/purchases/selectors/get-raw-by-purchase-id.ts
+++ b/client/state/purchases/selectors/get-raw-by-purchase-id.ts
@@ -1,0 +1,11 @@
+import { getRawPurchases } from './get-raw-purchases';
+import type { Purchase } from '@automattic/api-core';
+import type { AppState } from 'calypso/types';
+
+import 'calypso/state/purchases/init';
+
+/**
+ * Returns a single purchase by id in the snake_case API shape.
+ */
+export const getRawByPurchaseId = ( state: AppState, purchaseId: number ): Purchase | undefined =>
+	getRawPurchases( state ).find( ( purchase ) => purchase.ID === purchaseId );

--- a/client/state/purchases/selectors/get-raw-purchases.ts
+++ b/client/state/purchases/selectors/get-raw-purchases.ts
@@ -1,0 +1,22 @@
+import { normalizePurchase } from '@automattic/api-core';
+import { createSelector } from '@automattic/state-utils';
+import type { Purchase } from '@automattic/api-core';
+import type { AppState } from 'calypso/types';
+
+import 'calypso/state/purchases/init';
+
+/**
+ * Returns every purchase in the state tree in the snake_case shape the API
+ * serves, rather than the camelCase shape `getPurchases` assembles.
+ *
+ * The Redux fetch thunks store the response body untouched, so ids may still
+ * arrive as numeric strings; `normalizePurchase` coerces them exactly the way
+ * `@automattic/api-queries` does, which keeps this list interchangeable with
+ * the one `userPurchasesQuery`/`sitePurchasesQuery` return. Once the thunks
+ * normalize at the fetch boundary this can become a plain state read.
+ */
+export const getRawPurchases = createSelector(
+	( state: AppState ): Purchase[] =>
+		Array.isArray( state.purchases.data ) ? state.purchases.data.map( normalizePurchase ) : [],
+	( state: AppState ) => [ state.purchases.data ]
+);

--- a/client/state/purchases/selectors/get-raw-site-purchases.ts
+++ b/client/state/purchases/selectors/get-raw-site-purchases.ts
@@ -1,0 +1,13 @@
+import { getRawPurchases } from './get-raw-purchases';
+import type { Purchase } from '@automattic/api-core';
+import type { AppState } from 'calypso/types';
+
+import 'calypso/state/purchases/init';
+
+/**
+ * Returns the purchases belonging to a site in the snake_case API shape.
+ */
+export const getRawSitePurchases = (
+	state: AppState,
+	siteId: number | null | undefined
+): Purchase[] => getRawPurchases( state ).filter( ( purchase ) => purchase.blog_id === siteId );

--- a/client/state/purchases/selectors/get-raw-user-purchases.ts
+++ b/client/state/purchases/selectors/get-raw-user-purchases.ts
@@ -1,0 +1,28 @@
+import { createSelector } from '@automattic/state-utils';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { hasLoadedUserPurchasesFromServer } from './fetching';
+import { getRawPurchases } from './get-raw-purchases';
+import type { Purchase } from '@automattic/api-core';
+import type { AppState } from 'calypso/types';
+
+import 'calypso/state/purchases/init';
+
+/**
+ * Returns the current user's purchases in the snake_case API shape, or `null`
+ * while the list has yet to load from the server.
+ */
+export const getRawUserPurchases = createSelector(
+	( state: AppState ): Purchase[] | null => {
+		if ( ! hasLoadedUserPurchasesFromServer( state ) ) {
+			return null;
+		}
+
+		const userId = getCurrentUserId( state );
+		return getRawPurchases( state ).filter( ( purchase ) => purchase.user_id === userId );
+	},
+	( state: AppState ) => [
+		hasLoadedUserPurchasesFromServer( state ),
+		getCurrentUserId( state ),
+		getRawPurchases( state ),
+	]
+);

--- a/client/state/purchases/selectors/index.js
+++ b/client/state/purchases/selectors/index.js
@@ -12,6 +12,10 @@ export { getDowngradePlanToMonthlyFromPurchase } from './get-downgrade-plan-to-m
 export { getIncludedDomainPurchase } from './get-included-domain-purchase';
 export { getPurchases } from './get-purchases';
 export { getPurchasesError } from './get-purchases-error';
+export { getRawByPurchaseId } from './get-raw-by-purchase-id';
+export { getRawPurchases } from './get-raw-purchases';
+export { getRawSitePurchases } from './get-raw-site-purchases';
+export { getRawUserPurchases } from './get-raw-user-purchases';
 export { getSitePurchases } from './get-site-purchases';
 export { getUserPurchases } from './get-user-purchases';
 export { isUserPaid } from './is-user-paid';

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -3,6 +3,9 @@ import {
 	getByPurchaseId,
 	getIncludedDomainPurchase,
 	getPurchases,
+	getRawByPurchaseId,
+	getRawSitePurchases,
+	getRawUserPurchases,
 	getSitePurchases,
 	isFetchingSitePurchases,
 	isFetchingUserPurchases,
@@ -139,6 +142,66 @@ describe( 'selectors', () => {
 			expect( result ).toHaveLength( 2 );
 			expect( result[ 0 ].siteId ).toBe( 1234 );
 			expect( result[ 1 ].siteId ).toBe( 1234 );
+		} );
+	} );
+
+	describe( 'raw selectors', () => {
+		// The Redux fetch thunks store the response body untouched, so ids can still
+		// arrive as numeric strings; the raw selectors have to match them anyway.
+		const state = {
+			currentUser: { id: 123 },
+			purchases: {
+				data: [
+					{ ID: '81414', blog_id: '1234', user_id: '123' },
+					{ ID: '82867', blog_id: '1234', user_id: '456' },
+					{ ID: '105103', blog_id: '123', user_id: '123' },
+				],
+				error: null,
+				isFetchingSitePurchases: false,
+				isFetchingUserPurchases: false,
+				hasLoadedSitePurchasesFromServer: true,
+				hasLoadedUserPurchasesFromServer: true,
+			},
+		};
+
+		describe( 'getRawSitePurchases', () => {
+			test( 'should return the snake_case purchases of a specific site', () => {
+				const result = getRawSitePurchases( state, 1234 );
+
+				expect( result ).toHaveLength( 2 );
+				expect( result.map( ( purchase ) => purchase.ID ) ).toEqual( [ 81414, 82867 ] );
+				expect( result[ 0 ].blog_id ).toBe( 1234 );
+			} );
+		} );
+
+		describe( 'getRawUserPurchases', () => {
+			test( 'should return the snake_case purchases of the current user', () => {
+				const result = getRawUserPurchases( state );
+
+				expect( result.map( ( purchase ) => purchase.ID ) ).toEqual( [ 81414, 105103 ] );
+			} );
+
+			test( 'should return null until the user purchases have loaded', () => {
+				expect(
+					getRawUserPurchases( {
+						...state,
+						purchases: { ...state.purchases, hasLoadedUserPurchasesFromServer: false },
+					} )
+				).toBeNull();
+			} );
+		} );
+
+		describe( 'getRawByPurchaseId', () => {
+			test( 'should return a snake_case purchase by its id', () => {
+				expect( getRawByPurchaseId( state, 82867 ) ).toMatchObject( {
+					ID: 82867,
+					blog_id: 1234,
+				} );
+			} );
+
+			test( 'should return undefined when no purchase matches', () => {
+				expect( getRawByPurchaseId( state, 999 ) ).toBeUndefined();
+			} );
 		} );
 	} );
 

--- a/client/state/selectors/can-upgrade-to-plan.ts
+++ b/client/state/selectors/can-upgrade-to-plan.ts
@@ -6,7 +6,7 @@ import {
 	isWpComEcommercePlan,
 	isFreePlan,
 } from '@automattic/calypso-products';
-import { getByPurchaseId } from 'calypso/state/purchases/selectors';
+import { getRawByPurchaseId } from 'calypso/state/purchases/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getCurrentPlan, getSitePlan } from 'calypso/state/sites/plans/selectors';
@@ -32,7 +32,7 @@ export default function canUpgradeToPlan(
 			? PLAN_JETPACK_FREE
 			: PLAN_FREE;
 	const plan = getCurrentPlan( state, siteId ) as SitePlanData | null;
-	const purchase = plan?.id ? getByPurchaseId( state, plan.id ) : null;
+	const purchase = plan?.id ? getRawByPurchaseId( state, plan.id ) : null;
 
 	// An expired (but still active) plan is treated as the free plan for upgrade
 	// purposes. `expired` comes from the endpoint's `is_expired` field.
@@ -41,7 +41,7 @@ export default function canUpgradeToPlan(
 	// Exception for upgrading Atomic v1 sites to eCommerce
 	const isAtomicV1 =
 		isSiteAutomatedTransfer( state, siteId ) && ! isSiteWpcomAtomic( state, siteId );
-	if ( ( isWpComEcommercePlan( planKey ) && isAtomicV1 ) || purchase?.isLocked ) {
+	if ( ( isWpComEcommercePlan( planKey ) && isAtomicV1 ) || purchase?.is_locked ) {
 		return false;
 	}
 

--- a/client/state/selectors/get-user-purchased-premium-themes.js
+++ b/client/state/selectors/get-user-purchased-premium-themes.js
@@ -1,4 +1,4 @@
-import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { getRawUserPurchases } from 'calypso/state/purchases/selectors';
 
 import 'calypso/state/purchases/init';
 
@@ -8,8 +8,8 @@ import 'calypso/state/purchases/init';
  * @returns {Array} Details of any premium themes the user has purchased
  */
 export const getUserPurchasedPremiumThemes = ( state ) => {
-	const purchases = getUserPurchases( state );
-	return purchases && purchases.filter( ( purchase ) => purchase.productType === 'theme' );
+	const purchases = getRawUserPurchases( state );
+	return purchases && purchases.filter( ( purchase ) => purchase.product_type === 'theme' );
 };
 
 export default getUserPurchasedPremiumThemes;

--- a/client/state/selectors/has-cancelable-site-purchases.js
+++ b/client/state/selectors/has-cancelable-site-purchases.js
@@ -1,4 +1,4 @@
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { getRawSitePurchases } from 'calypso/state/purchases/selectors';
 
 import 'calypso/state/purchases/init';
 
@@ -16,16 +16,16 @@ export const hasCancelableSitePurchases = ( state, siteId, userId = null ) => {
 		return false;
 	}
 
-	let purchases = getSitePurchases( state, siteId ).filter( ( purchase ) => {
-		if ( purchase.isRefundable ) {
+	let purchases = getRawSitePurchases( state, siteId ).filter( ( purchase ) => {
+		if ( purchase.is_refundable ) {
 			return true;
 		}
 
-		return purchase.productSlug !== 'premium_theme';
+		return purchase.product_slug !== 'premium_theme';
 	} );
 
 	if ( userId != null ) {
-		purchases = purchases.filter( ( purchase ) => Number( purchase.userId ) === userId );
+		purchases = purchases.filter( ( purchase ) => purchase.user_id === userId );
 	}
 
 	return purchases && purchases.length > 0;

--- a/client/state/selectors/has-cancelable-user-purchases.js
+++ b/client/state/selectors/has-cancelable-user-purchases.js
@@ -1,5 +1,5 @@
 import { getAllSubscriptions } from 'calypso/state/memberships/subscriptions/selectors';
-import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { getRawUserPurchases } from 'calypso/state/purchases/selectors';
 import 'calypso/state/purchases/init';
 
 /**
@@ -11,7 +11,7 @@ import 'calypso/state/purchases/init';
  * @returns {boolean} if the user currently has any purchases that can be canceled.
  */
 export const hasCancelableUserPurchases = ( state ) => {
-	const purchases = getUserPurchases( state );
+	const purchases = getRawUserPurchases( state );
 	const subscriptions = getAllSubscriptions( state );
 
 	if ( ! purchases || ! subscriptions ) {
@@ -19,7 +19,7 @@ export const hasCancelableUserPurchases = ( state ) => {
 	}
 
 	const hasRefundablePurchases = purchases.some(
-		( purchase ) => purchase.isRefundable || purchase.productSlug !== 'premium_theme'
+		( purchase ) => purchase.is_refundable || purchase.product_slug !== 'premium_theme'
 	);
 	const hasRenewableSubscriptions = subscriptions.some(
 		( subscription ) => subscription.status === 'active' && subscription.is_renewable

--- a/client/state/selectors/test/get-user-purchased-premium-themes.js
+++ b/client/state/selectors/test/get-user-purchased-premium-themes.js
@@ -70,11 +70,11 @@ describe( 'getUserPurchasedPremiumThemes', () => {
 		const purchasedPremiumThemes = getUserPurchasedPremiumThemes( state );
 		expect( purchasedPremiumThemes.length ).toBe( 1 );
 		expect( purchasedPremiumThemes[ 0 ] ).toMatchObject( {
-			id: 3,
-			productName: 'premium theme',
-			productSlug: 'premium_theme',
-			productType: 'theme',
-			userId: targetUserId,
+			ID: 3,
+			product_name: 'premium theme',
+			product_slug: 'premium_theme',
+			product_type: 'theme',
+			user_id: targetUserId,
 		} );
 	} );
 } );

--- a/client/state/themes/selectors/get-purchased-themes.js
+++ b/client/state/themes/selectors/get-purchased-themes.js
@@ -1,4 +1,4 @@
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { getRawSitePurchases } from 'calypso/state/purchases/selectors';
 
 import 'calypso/state/themes/init';
 
@@ -11,8 +11,8 @@ import 'calypso/state/themes/init';
  * @returns {Array}  Array of themeIds that have been purchased
  */
 export function getPurchasedThemes( state, siteId ) {
-	const sitePurchases = getSitePurchases( state, siteId );
+	const sitePurchases = getRawSitePurchases( state, siteId );
 	return sitePurchases
-		.filter( ( purchase ) => purchase?.productType === 'theme' )
+		.filter( ( purchase ) => purchase?.product_type === 'theme' )
 		.map( ( purchase ) => purchase.meta );
 }

--- a/client/state/themes/selectors/is-marketplace-theme-subscribed-by-user.ts
+++ b/client/state/themes/selectors/is-marketplace-theme-subscribed-by-user.ts
@@ -1,6 +1,6 @@
 import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
 import { getProductBillingSlugByThemeId } from 'calypso/state/products-list/selectors/get-product-billing-slug-by-theme-id';
-import { getUserPurchases } from 'calypso/state/purchases/selectors';
+import { getRawUserPurchases } from 'calypso/state/purchases/selectors';
 
 /**
  * Checks if the user has a subscription to the theme on any site.
@@ -13,13 +13,13 @@ export function isMarketplaceThemeSubscribedByUser( state = {}, themeId: string 
 		state,
 		getProductBillingSlugByThemeId( state, themeId )
 	);
-	const userPurchases = getUserPurchases( state );
+	const userPurchases = getRawUserPurchases( state );
 
 	return !! (
 		userPurchases &&
 		userPurchases.find( ( purchase ) => {
 			return (
-				products && products.find( ( product ) => purchase.productSlug === product.product_slug )
+				products && products.find( ( product ) => purchase.product_slug === product.product_slug )
 			);
 		} )
 	);

--- a/client/state/themes/selectors/is-marketplace-theme-subscribed.ts
+++ b/client/state/themes/selectors/is-marketplace-theme-subscribed.ts
@@ -1,6 +1,6 @@
 import { getProductsByBillingSlug } from 'calypso/state/products-list/selectors';
 import { getProductBillingSlugByThemeId } from 'calypso/state/products-list/selectors/get-product-billing-slug-by-theme-id';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { getRawSitePurchases } from 'calypso/state/purchases/selectors';
 
 /**
  * Checks if the site has a subscription to the theme.
@@ -15,13 +15,13 @@ export function isMarketplaceThemeSubscribed( state = {}, themeId: string, siteI
 		getProductBillingSlugByThemeId( state, themeId )
 	);
 
-	const sitePurchases = getSitePurchases( state, siteId );
+	const sitePurchases = getRawSitePurchases( state, siteId );
 
 	return !! (
 		sitePurchases &&
 		sitePurchases.find( ( purchase ) => {
 			return (
-				products && products.find( ( product ) => purchase.productSlug === product.product_slug )
+				products && products.find( ( product ) => purchase.product_slug === product.product_slug )
 			);
 		} )
 	);

--- a/client/state/themes/selectors/is-theme-purchased.ts
+++ b/client/state/themes/selectors/is-theme-purchased.ts
@@ -1,4 +1,4 @@
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { getRawSitePurchases } from 'calypso/state/purchases/selectors';
 import type { AppState } from 'calypso/types';
 
 import 'calypso/state/themes/init';
@@ -19,9 +19,9 @@ export function isThemePurchased(
 	themeId: string,
 	siteId: number | null
 ): boolean {
-	const sitePurchases = getSitePurchases( state, siteId );
+	const sitePurchases = getRawSitePurchases( state, siteId );
 
 	return !! sitePurchases.find(
-		( purchase ) => purchase.productType === 'theme' && purchase.meta === themeId
+		( purchase ) => purchase.product_type === 'theme' && purchase.meta === themeId
 	);
 }


### PR DESCRIPTION
Part of SHILL-2256.

## Proposed Changes

* Add raw counterparts to the four purchase selectors — `getRawPurchases`, `getRawSitePurchases`, `getRawUserPurchases`, `getRawByPurchaseId` — returning the snake_case `Purchase` from `@automattic/api-core` instead of the camelCase object `client/lib/purchases/assembler` builds.
* Move eight leaf selectors onto them. Every one returns a boolean or a string, so nothing downstream changes shape:
  * `state/themes/selectors/get-purchased-themes`
  * `state/themes/selectors/is-theme-purchased`
  * `state/themes/selectors/is-marketplace-theme-subscribed`
  * `state/themes/selectors/is-marketplace-theme-subscribed-by-user`
  * `state/selectors/has-cancelable-site-purchases`
  * `state/selectors/has-cancelable-user-purchases`
  * `state/selectors/can-upgrade-to-plan`
  * `state/selectors/get-user-purchased-premium-themes` — the only one that returns purchases, with a single consumer (`me/account-close`) updated alongside it (`productName` → `product_name`, `id` → `ID`).
* Drop the now-redundant `Number( purchase.userId )` coercion in `has-cancelable-site-purchases`.
* Add selector tests covering the three new lookups, including the numeric-string id case.

## Why are these changes being made?

This is the next slice of the assembler removal. App code has had zero `.rawPurchase` bridges since #114183; what remains is the files that read the camelCase shape through the Redux selectors.

The blocker for this particular group was that they are Redux selectors called from other selectors and from `mapStateToProps`, so they can't move to `useQuery` without converting their consumers first. But they don't need to: `state.purchases.data` is already raw, and `getPurchases` is the sole assembly point. A raw source selector makes each of these a field rename, and unblocks the rest of the Redux-shaped consumers (the Jetpack Stats `hasSupportedCommercialUse` / `shouldShowPaywall*` selectors and `state/marketplace/selectors.ts`) for later slices, without dragging their consumers along.

Two things worth flagging for reviewers:

* **The Redux path never normalized its response.** `fetchSitePurchases` / `fetchUserPurchases` in `state/purchases/actions.js` store the API body untouched, so ids can genuinely arrive as numeric strings — the pre-existing `getSitePurchases` test fixture uses `blog_id: '1234'` deliberately. The assembler's `Number()` calls were the only thing hiding that. `getRawPurchases` runs `normalizePurchase` from `@automattic/api-core`, the same coercion `api-queries` applies, which both removes the trap for every future consumer and makes the output interchangeable with what `sitePurchasesQuery` / `userPurchasesQuery` return. Once the fetch thunks normalize at the boundary instead, `getRawPurchases` can become a plain state read.
* **Typing these as `RawPurchase` would buy nothing.** `RawPurchase = Purchase & { ID: number | string }` intersects down to `ID: number`, so it does not actually widen the id types. They're typed as `Purchase`, consistent with the rest of the migration.

`getRawPurchases` and `getRawUserPurchases` are memoized with `createSelector` on the same dependants as their camelCase twins, so `useSelector` consumers keep referential stability.

Camel-case purchase-selector consumers in `client/`: 43 → 29.

## Testing Instructions

No user-visible change is intended — these selectors should return exactly what they returned before.

Automated:

```
yarn test-client client/state/purchases client/state/selectors client/state/themes client/me/account-close client/sites/settings client/my-sites/plans-features-main
yarn test-client client/my-sites/theme client/my-sites/themes client/blocks/inline-help client/my-sites/checkout/upsell-nudge client/my-sites/checkout/checkout-thank-you client/landing/stepper/hooks client/components/theme-tier client/lib/plans
```

Both pass (219 suites / 1196 tests, and 45 suites / 270 tests).

Manual spot checks, on a site with a premium or marketplace theme purchase:

* `/themes/:site` and a theme's detail page — a purchased premium theme still shows as purchased rather than offering to sell it again; a subscribed marketplace theme still shows its subscribed state.
* `/plans/:site` — upgrade options are unchanged, and a locked plan purchase still blocks the upgrade.
* `/me/account/close` — the close-account screen still lists purchased premium themes by name, and still warns about cancelable purchases.
* `/sites/:site/settings/administration` — Delete site / Leave site still reflect whether the site has cancelable purchases.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
