### PR TITLE
Purchases: read the raw Purchase in the Jetpack Stats selectors

### DIFF
--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -1,7 +1,6 @@
 import {
 	JETPACK_COMPLETE_PLANS,
 	JETPACK_GROWTH_PLANS,
-	JETPACK_SECURITY_PLANS,
 	JETPACK_VIDEOPRESS_PRODUCTS,
 	PLAN_JETPACK_BUSINESS,
 	PLAN_JETPACK_BUSINESS_MONTHLY,
@@ -82,20 +81,16 @@ const isVideoPressOwned = ( ownedPurchases: Purchase[] ) => {
 	return areProductsOwned( ownedPurchases, [ ...JETPACK_VIDEOPRESS_PRODUCTS ] );
 };
 
-export const hasBusinessPlan = ( ownedPurchases: Purchase[] ) => {
+const hasBusinessPlan = ( ownedPurchases: Purchase[] ) => {
 	return areProductsOwned( ownedPurchases, [ ...JETPACK_BUSINESS_PLANS ] );
 };
 
-export const hasCompletePlan = ( ownedPurchases: Purchase[] ) => {
+const hasCompletePlan = ( ownedPurchases: Purchase[] ) => {
 	return areProductsOwned( ownedPurchases, [ ...JETPACK_COMPLETE_PLANS ] );
 };
 
-export const hasGrowthPlan = ( ownedPurchases: Purchase[] ) => {
+const hasGrowthPlan = ( ownedPurchases: Purchase[] ) => {
 	return areProductsOwned( ownedPurchases, [ ...JETPACK_GROWTH_PLANS ] );
-};
-
-export const hasSecurityPlan = ( ownedPurchases: Purchase[] ) => {
-	return areProductsOwned( ownedPurchases, [ ...JETPACK_SECURITY_PLANS ] );
 };
 
 export const hasSupportedCommercialUse = ( state: object, siteId: number | null ) => {

--- a/client/my-sites/stats/hooks/use-stats-purchases.tsx
+++ b/client/my-sites/stats/hooks/use-stats-purchases.tsx
@@ -13,19 +13,19 @@ import {
 } from '@automattic/calypso-products';
 import { createSelector } from '@automattic/state-utils';
 import { ComponentClass, useMemo } from 'react';
-import { isRemoved } from 'calypso/lib/purchases';
+import { isRemoved } from 'calypso/dashboard/utils/purchase';
 import { useSelector } from 'calypso/state';
 import {
 	isFetchingSitePurchases,
-	getSitePurchases,
+	getRawSitePurchases,
 	hasLoadedSitePurchasesFromServer,
-	getPurchases,
+	getRawPurchases,
 } from 'calypso/state/purchases/selectors';
 import {
 	getShouldShowPaywallNotice,
 	getShouldShowPaywallAfterGracePeriod,
 } from 'calypso/state/stats/plan-usage/selectors';
-import type { Purchase } from 'calypso/lib/purchases/types';
+import type { Purchase } from '@automattic/api-core';
 
 const JETPACK_BUSINESS_PLANS = [ PLAN_JETPACK_BUSINESS, PLAN_JETPACK_BUSINESS_MONTHLY ];
 
@@ -49,7 +49,7 @@ const filterPurchasesByProducts = ( ownedPurchases: Purchase[], productSlugs: st
 
 	// Filter purchases by both slug and validity.
 	return ownedPurchases.filter(
-		( purchase ) => isPurchaseValid( purchase ) && productSlugs.includes( purchase.productSlug )
+		( purchase ) => isPurchaseValid( purchase ) && productSlugs.includes( purchase.product_slug )
 	);
 };
 
@@ -99,13 +99,13 @@ export const hasSecurityPlan = ( ownedPurchases: Purchase[] ) => {
 };
 
 export const hasSupportedCommercialUse = ( state: object, siteId: number | null ) => {
-	const sitePurchases = getSitePurchases( state, siteId );
+	const sitePurchases = getRawSitePurchases( state, siteId );
 
 	return supportCommercialPurchaseUse( sitePurchases );
 };
 
 export const hasSupportedVideoPressUse = ( state: object, siteId: number | null ) => {
-	const sitePurchases = getSitePurchases( state, siteId );
+	const sitePurchases = getRawSitePurchases( state, siteId );
 
 	return isVideoPressOwned( sitePurchases );
 };
@@ -130,8 +130,8 @@ export const shouldShowPaywallAfterGracePeriod = (
 };
 
 const getPurchasesBySiteId = createSelector(
-	( state, siteId ) => getSitePurchases( state, siteId ),
-	getPurchases
+	( state, siteId ) => getRawSitePurchases( state, siteId ),
+	getRawPurchases
 );
 
 export default function useStatsPurchases( siteId: number | null ) {

--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -12,7 +12,6 @@ import {
 	Product,
 } from './upsell-card/available-upsells';
 
-// TODO: Check usage of hasBusinessPlan, hasCompletePlan, hasSecurityPlan or delete
 const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 const CHECKOUT_URL_PREFIX = 'https://wordpress.com';

--- a/client/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only.ts
+++ b/client/state/sites/selectors/has-site-product-jetpack-stats-pwyw-only.ts
@@ -1,7 +1,7 @@
 import { camelOrSnakeSlug } from '@automattic/calypso-products';
 import { productHasStats } from 'calypso/blocks/jetpack-benefits/feature-checks';
-import { isRemoved } from 'calypso/lib/purchases';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { isRemoved } from 'calypso/dashboard/utils/purchase';
+import { getRawSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 
@@ -9,7 +9,7 @@ function hasSiteProductJetpackStatsPWYWOnly(
 	state: AppState,
 	siteId = getSelectedSiteId( state )
 ): boolean {
-	const sitePurchases = getSitePurchases( state, siteId );
+	const sitePurchases = getRawSitePurchases( state, siteId );
 
 	// Get listing of all plans that support stats in some way and qualify as "paid" plans.
 	const plansSupportingStats = sitePurchases?.filter(
@@ -22,7 +22,7 @@ function hasSiteProductJetpackStatsPWYWOnly(
 
 	// Check for one or more PWYW plans.
 	const plansPWYWStats = plansSupportingStats?.filter( ( product ) =>
-		product.productSlug.includes( 'pwyw' )
+		product.product_slug.includes( 'pwyw' )
 	);
 
 	// If the arrays are equal, the site has only PWYW stats.

--- a/client/state/sites/selectors/has-site-product-jetpack-stats.ts
+++ b/client/state/sites/selectors/has-site-product-jetpack-stats.ts
@@ -1,7 +1,7 @@
 import { camelOrSnakeSlug } from '@automattic/calypso-products';
 import { productHasStats } from 'calypso/blocks/jetpack-benefits/feature-checks';
-import { isRemoved } from 'calypso/lib/purchases';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
+import { isRemoved } from 'calypso/dashboard/utils/purchase';
+import { getRawSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
 import getSitePlan from './get-site-plan';
@@ -12,7 +12,7 @@ const hasSiteProductJetpackStats = (
 	onlyPaid = false,
 	siteId = getSelectedSiteId( state )
 ): boolean => {
-	const siteHasStatsProduct = getSitePurchases( state, siteId )?.some(
+	const siteHasStatsProduct = getRawSitePurchases( state, siteId )?.some(
 		( product ) =>
 			productHasStats( camelOrSnakeSlug( product ), onlyPaid ) && ! isRemoved( product )
 	);


### PR DESCRIPTION
Part of SHILL-2256

## Proposed Changes

* Move `useStatsPurchases` (`client/my-sites/stats/hooks/use-stats-purchases.tsx`) off `getSitePurchases`/`getPurchases` and onto `getRawSitePurchases`/`getRawPurchases`, so it reads the snake_case `Purchase` from `@automattic/api-core` instead of the assembled camelCase one.
* Same swap in `client/state/sites/selectors/has-site-product-jetpack-stats.ts` and `has-site-product-jetpack-stats-pwyw-only.ts` (and therefore in the `-paid`/`-free` selectors that wrap the first one).
* `isRemoved` now comes from `calypso/dashboard/utils/purchase` rather than `calypso/lib/purchases`; the two implementations are identical apart from the field casing.
* Field renames: `purchase.productSlug` → `purchase.product_slug` in the product filter and in the PWYW check.
* Second commit, a cleanup the first one surfaced: deletes `hasSecurityPlan`, which had no callers anywhere (and with it the `JETPACK_SECURITY_PLANS` import), and un-exports `hasBusinessPlan`/`hasCompletePlan`/`hasGrowthPlan`, whose only caller is the hook itself. That answers the `// TODO: Check usage of hasBusinessPlan, hasCompletePlan, hasSecurityPlan or delete` in `jetpack-upsell-section`, so the comment goes too.

No behavior change is intended.

## Why are these changes being made?

Continues the incremental removal of the `@automattic/data-stores` purchases assembler (`createPurchaseObject`/`createPurchasesArray`) and its duplicate camelCase `Purchase` type. Redux already stores the raw API body — the `getPurchases` selector is the only place assembly happens — so every consumer moved off it shrinks what the assembler has to keep supporting.

This cluster specifically had to wait for #114286. `hasSupportedCommercialUse`, `hasSupportedVideoPressUse`, `shouldShowPaywallNotice` and `shouldShowPaywallAfterGracePeriod` all take `state` and are called from `shouldGateStats`, which runs inside `mapStateToProps`. They can't be converted to the `useQuery` pattern the earlier slices used without first converting their consumers, so they needed raw *selectors*, which #114286 added.

The cluster is self-contained: every export of `use-stats-purchases` is a boolean, so no purchase shape crosses a module boundary and none of its ~15 consumers change. `camelOrSnakeSlug` accepts either casing, so the `productHasStats` calls needed no change. Checking the remaining exports for ripple is what turned up the dead ones in the second commit — note that the `hasBusinessPlan` in `lib/cart-values/cart-items.ts` is an unrelated function over a cart, not a caller.

## Testing Instructions

Best tested against a self-hosted Jetpack site, since that is where the Stats paywall applies.

1. On a Jetpack site with **no** paid Stats product, open Jetpack Stats. Advanced modules (UTM, Devices, Video plays, Search terms) should still be gated, and the date-control options should still be limited, exactly as on trunk.
2. On a Jetpack site that **does** own a commercial Stats product (or a Jetpack Complete/Growth/Business plan), confirm those same modules are ungated and no upgrade notice appears.
3. Visit `/stats/purchase/:site` and confirm the owned-product state is detected correctly (the page reads `isFreeOwned`/`isPWYWOwned`/`isCommercialOwned`/`supportCommercialUse` from this hook).
4. Confirm the Stats notices at the top of the traffic page render the same set as on trunk, including for a site with only a PWYW Stats subscription.
5. Check the browser console for React or TypeScript errors.

Automated coverage: `yarn test-client client/my-sites/stats client/state/sites client/state/purchases` — 78 suites / 788 tests green. The existing fixtures in `has-site-product-jetpack-stats.js` and both `commercial-paywall-kill-switch*` tests were already written in raw snake_case, since that is what lands in the store, so they pass unchanged — which is reasonable evidence the swap is behavior-preserving.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://github.com/Automattic/wp-calypso/blob/trunk/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] For UI changes, have you tested the affected components in [dark mode](https://github.com/Automattic/wp-calypso/blob/trunk/docs/dark-mode.md)?
- [ ] Have you tested accessibility for your changes? Ensure the feature remains usable with various user agents (e.g., browsers), interfaces (e.g., keyboard navigation), and assistive technologies (e.g., screen readers) (PCYsg-S3g-p2).
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
    - [ ] For UI changes, have we tested the change in various languages (for example, ES, PT, FR, or DE)? The length of text and words vary significantly between languages. 
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
